### PR TITLE
feat: Implement basic storage crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x-storage"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "blake3",
+ "thiserror",
+ "tokio",
+ "x-common",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["rust/x-common", "rust/x-dbsp", "rust/x-query"]
+members = ["rust/x-common", "rust/x-dbsp", "rust/x-query", "rust/x-storage"]
 
 resolver = "2"
 

--- a/rust/x-storage/Cargo.toml
+++ b/rust/x-storage/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "x-storage"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+x-common = { workspace = true }
+
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+blake3 = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }

--- a/rust/x-storage/README.md
+++ b/rust/x-storage/README.md
@@ -1,0 +1,4 @@
+# x-storage
+
+Generalized API for constructing content addressed storage from different
+backends and encoding schemes.

--- a/rust/x-storage/src/encoder.rs
+++ b/rust/x-storage/src/encoder.rs
@@ -1,0 +1,24 @@
+use async_trait::async_trait;
+use x_common::ConditionalSync;
+
+use crate::{HashType, XStorageError};
+
+/// An [Encoder] converts to and from content-addressable bytes
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait Encoder<const HASH_SIZE: usize> {
+    /// The in-memory representation of a block
+    type Block: ConditionalSync;
+    /// The encoded byte representation of a block
+    type Bytes: AsRef<[u8]> + 'static + ConditionalSync;
+    /// The hash type produced by this [Encoder]
+    type Hash: HashType<HASH_SIZE> + ConditionalSync;
+    /// The error type produced by this [Encoder]
+    type Error: Into<XStorageError>;
+
+    /// Encode a serializable item into its referencable [`Hash`] and its bytes.
+    async fn encode(&self, block: &Self::Block) -> Result<(Self::Hash, Self::Bytes), Self::Error>;
+
+    /// Decode bytes into a `Block`.
+    async fn decode(&self, bytes: &[u8]) -> Result<Self::Block, Self::Error>;
+}

--- a/rust/x-storage/src/error.rs
+++ b/rust/x-storage/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+/// The common error type used by this crate
+#[derive(Error, Debug)]
+pub enum XStorageError {
+    /// An error that occurs during block encoding
+    #[error("Failed to encode a block: {0}")]
+    EncodeFailed(String),
+
+    /// An error that occurs during block decoding
+    #[error("Failed to decode a block: {0}")]
+    DecodeFailed(String),
+}

--- a/rust/x-storage/src/hash.rs
+++ b/rust/x-storage/src/hash.rs
@@ -1,0 +1,20 @@
+use x_common::ConditionalSend;
+
+/// A trait that can be implemented for types that represent a hash. A blanket
+/// "unchecked" implementation is provided for any type that matches
+/// `AsRef<[u8]>` (this might be an antipattern; more investigation required).
+pub trait HashType<const SIZE: usize>: Clone + ConditionalSend {
+    /// Get the raw bytes of the hash
+    fn bytes(&self) -> [u8; SIZE];
+}
+
+impl<const SIZE: usize, T> HashType<SIZE> for T
+where
+    T: Clone + AsRef<[u8]> + ConditionalSend,
+{
+    fn bytes(&self) -> [u8; SIZE] {
+        let mut bytes = [0u8; SIZE];
+        bytes.copy_from_slice(self.as_ref());
+        bytes
+    }
+}

--- a/rust/x-storage/src/lib.rs
+++ b/rust/x-storage/src/lib.rs
@@ -1,0 +1,32 @@
+#![warn(missing_docs)]
+
+//! This crate contains generalized API for constructing content addressed
+//! storage from different backends and encoding schemes.
+//!
+//! In order to use it, first select or implement an [Encoder], and then select
+//! or implement a [StorageBackend]. When you have selected these things, you
+//! can construct a [Storage]:
+//!
+//! ```ignore
+//! let encoder = /* Some encoder */;
+//! let backend = /* Some storage backend */;
+//! let storage = Storage {
+//!     encoder,
+//!     backend
+//! };
+//! ```
+//!
+//! The prepared `storage` will automatically implement
+//! [ContentAddressedStorage] for bounds-matching encoders and storage backends.
+
+mod encoder;
+pub use encoder::*;
+
+mod error;
+pub use error::*;
+
+mod storage;
+pub use storage::*;
+
+mod hash;
+pub use hash::*;

--- a/rust/x-storage/src/storage.rs
+++ b/rust/x-storage/src/storage.rs
@@ -1,0 +1,126 @@
+use async_trait::async_trait;
+use x_common::ConditionalSync;
+
+use crate::Encoder;
+
+mod backend;
+pub use backend::*;
+
+mod content_addressed;
+pub use content_addressed::*;
+
+/// A universal envelope for all compatible combinations of [Encoder] and
+/// [StorageBackend] implementations. See the crate documentation for
+/// a practical example of usage.
+pub struct Storage<const HASH_SIZE: usize, E, S>
+where
+    E: Encoder<HASH_SIZE>,
+    S: StorageBackend,
+{
+    /// The [Encoder] used by the [Storage]
+    pub encoder: E,
+    /// The [StorageBackend] used by the [Storage]
+    pub backend: S,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<const HASH_SIZE: usize, E, S> Encoder<HASH_SIZE> for Storage<HASH_SIZE, E, S>
+where
+    E: Encoder<HASH_SIZE>,
+    S: StorageBackend,
+    Self: ConditionalSync,
+{
+    type Block = E::Block;
+    type Bytes = E::Bytes;
+    type Hash = E::Hash;
+    type Error = E::Error;
+
+    async fn encode(&self, block: &Self::Block) -> Result<(Self::Hash, Self::Bytes), Self::Error> {
+        self.encoder.encode(block).await
+    }
+
+    async fn decode(&self, bytes: &[u8]) -> Result<Self::Block, Self::Error> {
+        self.encoder.decode(bytes).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<const HASH_SIZE: usize, E, S> StorageBackend for Storage<HASH_SIZE, E, S>
+where
+    E: Encoder<HASH_SIZE>,
+    S: StorageBackend,
+    Self: ConditionalSync,
+{
+    type Key = S::Key;
+    type Value = S::Value;
+    type Error = S::Error;
+
+    async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
+        self.backend.set(key, value).await
+    }
+
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
+        self.backend.get(key).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ContentAddressedStorage, Encoder, MemoryStorageBackend, Storage};
+    use crate::XStorageError;
+    use anyhow::Result;
+    use async_trait::async_trait;
+
+    #[derive(PartialEq, Debug)]
+    struct TestBlock {
+        pub value: u32,
+    }
+
+    struct TestEncoder;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl Encoder<32> for TestEncoder {
+        type Block = TestBlock;
+        type Bytes = Vec<u8>;
+        type Hash = [u8; 32];
+        type Error = XStorageError;
+
+        async fn encode(
+            &self,
+            block: &Self::Block,
+        ) -> Result<(Self::Hash, Self::Bytes), Self::Error> {
+            let bytes = block.value.to_le_bytes().to_vec();
+            let hash = blake3::hash(&bytes).as_bytes().to_owned();
+
+            Ok((hash, bytes))
+        }
+
+        async fn decode(&self, bytes: &[u8]) -> Result<Self::Block, Self::Error> {
+            let value = u32::from_le_bytes(
+                bytes
+                    .try_into()
+                    .map_err(|error| XStorageError::DecodeFailed(format!("{error}")))?,
+            );
+            Ok(TestBlock { value })
+        }
+    }
+
+    #[tokio::test]
+    async fn it_manifests_content_addressed_storage_from_an_encoder_and_backend() -> Result<()> {
+        let mut storage = Storage {
+            encoder: TestEncoder,
+            backend: MemoryStorageBackend::<[u8; 32], Vec<u8>>::default(),
+        };
+
+        let hash = storage.write(&TestBlock { value: 123 }).await?;
+
+        let value = storage.read(&hash).await?;
+
+        assert_eq!(Some(TestBlock { value: 123 }), value);
+
+        Ok(())
+    }
+}

--- a/rust/x-storage/src/storage/backend.rs
+++ b/rust/x-storage/src/storage/backend.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+use x_common::{ConditionalSend, ConditionalSync};
+
+use crate::XStorageError;
+
+mod memory;
+pub use memory::*;
+
+/// A [StorageBackend] is a facade over some generalized storage substrate that
+/// is capable of storing and/or retrieving values by some key
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait StorageBackend {
+    /// The key type used by this [StorageBackend]
+    type Key: ConditionalSync;
+    /// The value type able to be stored by this [StorageBackend]
+    type Value: ConditionalSend;
+    /// The error type produced by this [StorageBackend]
+    type Error: Into<XStorageError>;
+
+    /// Store the given value against the given key
+    async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error>;
+    /// Retrieve a value (if any) stored against the given key
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error>;
+}

--- a/rust/x-storage/src/storage/backend/memory.rs
+++ b/rust/x-storage/src/storage/backend/memory.rs
@@ -1,0 +1,42 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use x_common::{ConditionalSend, ConditionalSync};
+
+use crate::XStorageError;
+
+use super::StorageBackend;
+
+/// A trivial implementation of [StorageBackend] - backed by a [HashMap] - where
+/// all values are kept in memory and never persisted.
+#[derive(Default)]
+pub struct MemoryStorageBackend<K, V>
+where
+    K: Eq + std::hash::Hash,
+    V: Clone,
+{
+    entries: Arc<Mutex<HashMap<K, V>>>,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<K, V> StorageBackend for MemoryStorageBackend<K, V>
+where
+    K: Eq + std::hash::Hash + ConditionalSync,
+    V: Clone + ConditionalSend,
+{
+    type Key = K;
+    type Value = V;
+    type Error = XStorageError;
+
+    async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
+        let mut entries = self.entries.lock().await;
+        entries.insert(key, value);
+        Ok(())
+    }
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
+        let entries = self.entries.lock().await;
+        Ok(entries.get(key).map(|value| value.clone()))
+    }
+}

--- a/rust/x-storage/src/storage/content_addressed.rs
+++ b/rust/x-storage/src/storage/content_addressed.rs
@@ -1,0 +1,63 @@
+use async_trait::async_trait;
+use x_common::ConditionalSync;
+
+use crate::{Encoder, HashType, StorageBackend, XStorageError};
+
+/// A [ContentAddressedStorage] is able to store and/or retrieve a value -
+/// called a block - by a self-evident, deterministically derivable value: its
+/// hash.
+///
+/// A blanket implementation is provided for all types that also implement
+/// [Encoder] and [StorageBackend] in a compatible fashion.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait ContentAddressedStorage<const HASH_SIZE: usize> {
+    /// The type of block that is able to be stored
+    type Block: ConditionalSync;
+    /// The type of hash that is produced by this [ContentAddressedStorage]
+    type Hash: HashType<HASH_SIZE> + ConditionalSync;
+    /// The type of error that is produced by this [ContentAddressedStorage]
+    type Error: Into<XStorageError>;
+
+    /// Retrieve a block by its hash
+    async fn read(&self, hash: &Self::Hash) -> Result<Option<Self::Block>, Self::Error>;
+    /// Store a block and receive its hash
+    async fn write(&mut self, block: &Self::Block) -> Result<Self::Hash, Self::Error>;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<const HASH_SIZE: usize, Bl, By, H, Ee, Es, T> ContentAddressedStorage<HASH_SIZE> for T
+where
+    H: HashType<HASH_SIZE> + ConditionalSync,
+    Bl: ConditionalSync,
+    By: AsRef<[u8]> + 'static + ConditionalSync,
+    Ee: Into<XStorageError>,
+    Es: Into<XStorageError>,
+    T: Encoder<HASH_SIZE, Block = Bl, Bytes = By, Hash = H, Error = Ee>
+        + StorageBackend<Key = H, Value = By, Error = Es>
+        + ConditionalSync,
+{
+    type Block = Bl;
+    type Hash = H;
+    type Error = XStorageError;
+
+    async fn read(&self, hash: &Self::Hash) -> Result<Option<Self::Block>, Self::Error> {
+        let Some(encoded_bytes) = self.get(hash).await.map_err(|error| error.into())? else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            self.decode(encoded_bytes.as_ref())
+                .await
+                .map_err(|error| error.into())?,
+        ))
+    }
+    async fn write(&mut self, block: &Self::Block) -> Result<Self::Hash, Self::Error> {
+        let (hash, encoded_bytes) = self.encode(&block).await.map_err(|error| error.into())?;
+        self.set(hash.clone(), encoded_bytes)
+            .await
+            .map_err(|error| error.into())?;
+        Ok(hash)
+    }
+}


### PR DESCRIPTION
This is the first PR to kick off the porting of @jsantell 's prolly tree implementation with an eye towards improvements we wish to make as sketched out in #4 .

This change carries over the basic storage facilities and factors them into their own crate. The design is very similar to @jsantell 's original design, except that the storage is made more generalized to arbitrary types (where the ancestor implementation was coupled to the prolly tree's notion of a block).

At a high-level, a `Storage` can be constructed with any combination `Encoder` and `StorageBackend`, and sufficiently compatible combinations will result in `Storage` expressing the `ContentAddressedStorage` API via a blanket trait implementation. This allows us to mix and match encoding strategies and raw storage backends rather easily.