### PR TITLE
feat: Port of ranked-prolly-tree crate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "rust-analyzer.cargo.target": null
+    "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +813,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "x-prolly-tree"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base58",
+ "blake3",
+ "futures-core",
+ "futures-util",
+ "getrandom",
+ "nonempty",
+ "rand",
+ "thiserror 2.0.12",
+ "tokio",
+ "wasm-bindgen-test",
+ "x-common",
+ "x-storage",
+]
+
+[[package]]
 name = "x-query"
 version = "0.1.0"
 dependencies = [
@@ -821,6 +848,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "ulid",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "x-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = ["rust/x-common", "rust/x-dbsp", "rust/x-query", "rust/x-storage"]
+members = [
+    "rust/x-common",
+    "rust/x-dbsp",
+    "rust/x-prolly-tree",
+    "rust/x-query",
+    "rust/x-storage",
+]
 
 resolver = "2"
 
@@ -10,6 +16,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 x-common = { path = "./rust/x-common" }
+x-prolly-tree = { path = "./rust/x-prolly-tree" }
 x-query = { path = "./rust/x-query" }
 x-storage = { path = "./rust/x-storage" }
 
@@ -22,6 +29,8 @@ futures-core = "0.3"
 futures-util = "0.3"
 getrandom = "0.3"
 js-sys = "0.3"
+nonempty = "0.11"
+rand = "0.9"
 rexie = "0.6"
 serde = "1"
 sieve-cache = "0.2"
@@ -30,6 +39,7 @@ thiserror = "2"
 tokio = "1"
 ulid = "1"
 wasm-bindgen = "=0.2.100"
+wasm-bindgen-futures = "0.4"
 wasm-bindgen-test = "0.3"
 web-sys = "0.3"
 

--- a/rust/x-common/src/sync.rs
+++ b/rust/x-common/src/sync.rs
@@ -3,6 +3,10 @@
 //! These traits support writing async code that may target both
 //! `wasm32-unknown-unknown` as well as native targets where it may be the case
 //! that an implementer will be shared across threads.
+//!
+//! On `wasm32-unknown-unknown` targets, the traits effectively represent no
+//! new bound. But, on other targets they represent `Send` or `Send + Sync`
+//! bounds (depending on which one is used).
 
 #[allow(missing_docs)]
 #[cfg(not(target_arch = "wasm32"))]

--- a/rust/x-prolly-tree/Cargo.toml
+++ b/rust/x-prolly-tree/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "x-prolly-tree"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+x-common = { workspace = true }
+x-storage = { workspace = true }
+
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+async-stream = { workspace = true }
+base58 = { workspace = true }
+blake3 = { workspace = true }
+futures-core = { workspace = true }
+rand = { workspace = true }
+
+nonempty = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+x-storage = { workspace = true, features = ["helpers"] }
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+futures-util = { workspace = true }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+wasm-bindgen-test = { workspace = true }

--- a/rust/x-prolly-tree/README.md
+++ b/rust/x-prolly-tree/README.md
@@ -1,0 +1,8 @@
+# x-prolly-tree
+
+This crate provides a key-value store implemented as a [prolly tree], utilizing
+a flexible content-addressed block storage backend. This prolly tree is designed
+to be the foundation of a passive database, providing on demand partial
+replication.
+
+[prolly tree]: https://www.dolthub.com/blog/2024-03-03-prolly-trees/

--- a/rust/x-prolly-tree/src/adopter.rs
+++ b/rust/x-prolly-tree/src/adopter.rs
@@ -1,0 +1,92 @@
+use crate::{Block, Entry, KeyType, Node, Reference, XProllyTreeError};
+use async_trait::async_trait;
+use nonempty::NonEmpty;
+use x_common::ConditionalSync;
+use x_storage::{ContentAddressedStorage, HashType};
+
+/// A helper trait implemented by [`Entry`], [`Reference`] and [`Node`] to
+/// create new [`Node`]s.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait Adopter<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Value, Hash>:
+    Sized
+where
+    Key: KeyType,
+    Value: Clone + ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+{
+    /// Adopt a collection of `children` into a new [`Node`]. Children data must
+    /// be ordered and follow rank rules.
+    async fn adopt(
+        children: NonEmpty<Self>,
+        storage: &mut impl ContentAddressedStorage<
+            HASH_SIZE,
+            Block = Block<HASH_SIZE, Key, Value, Hash>,
+            Hash = Hash,
+        >,
+    ) -> Result<Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>, XProllyTreeError>;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Value, Hash>
+    Adopter<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash> for Entry<Key, Value>
+where
+    Key: KeyType + 'static,
+    Value: Clone + ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+{
+    async fn adopt(
+        children: NonEmpty<Self>,
+        storage: &mut impl ContentAddressedStorage<
+            HASH_SIZE,
+            Block = Block<HASH_SIZE, Key, Value, Hash>,
+            Hash = Hash,
+        >,
+    ) -> Result<Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>, XProllyTreeError> {
+        Node::segment(children, storage).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Value, Hash>
+    Adopter<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash> for Reference<HASH_SIZE, Key, Hash>
+where
+    Key: KeyType + 'static,
+    Value: Clone + ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+{
+    async fn adopt(
+        children: NonEmpty<Self>,
+        storage: &mut impl ContentAddressedStorage<
+            HASH_SIZE,
+            Block = Block<HASH_SIZE, Key, Value, Hash>,
+            Hash = Hash,
+        >,
+    ) -> Result<Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>, XProllyTreeError> {
+        Node::branch(children, storage).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Value, Hash>
+    Adopter<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>
+    for Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>
+where
+    Key: KeyType + 'static,
+    Value: Clone + ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+{
+    async fn adopt(
+        children: NonEmpty<Self>,
+        storage: &mut impl ContentAddressedStorage<
+            HASH_SIZE,
+            Block = Block<HASH_SIZE, Key, Value, Hash>,
+            Hash = Hash,
+        >,
+    ) -> Result<Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>, XProllyTreeError> {
+        Node::branch(children.map(|node| node.reference().clone()), storage).await
+    }
+}

--- a/rust/x-prolly-tree/src/block.rs
+++ b/rust/x-prolly-tree/src/block.rs
@@ -1,0 +1,181 @@
+use nonempty::NonEmpty;
+use x_common::ConditionalSync;
+use x_storage::{HashType, XStorageError};
+
+use crate::{Entry, KeyType, ReadFrom, Reader, Reference, WriteInto, XProllyTreeError};
+
+/// The serializable construct representing a [`Node`].
+/// A [`Block`] is what is stored in a [`BlockStore`],
+/// used to hydrate and store nodes.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Block<const HASH_SIZE: usize, Key, Value, Hash>
+where
+    Key: KeyType,
+    Value: ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+{
+    /// A block representing a Branch.
+    Branch(NonEmpty<Reference<HASH_SIZE, Key, Hash>>),
+    /// A block representing a Segment.
+    Segment(NonEmpty<Entry<Key, Value>>),
+}
+
+impl<const HASH_SIZE: usize, Key, Value, Hash> Block<HASH_SIZE, Key, Value, Hash>
+where
+    Key: KeyType,
+    Value: ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+{
+    /// Create a new branch-type block.
+    pub fn branch(data: NonEmpty<Reference<HASH_SIZE, Key, Hash>>) -> Self {
+        Block::Branch(data)
+    }
+
+    /// Create a new segment-type block.
+    pub fn segment(data: NonEmpty<Entry<Key, Value>>) -> Self {
+        Block::Segment(data)
+    }
+
+    /// Whether this block is a branch.
+    pub fn is_branch(&self) -> bool {
+        match self {
+            Block::Branch(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Whether this block is a segment.
+    pub fn is_segment(&self) -> bool {
+        !self.is_branch()
+    }
+
+    /// Get the upper bounds that this block represents.
+    pub fn upper_bound(&self) -> &Key {
+        match self {
+            Block::Branch(data) => &data.last().upper_bound(),
+            Block::Segment(data) => &data.last().key,
+        }
+    }
+
+    /// Get children data as [`Reference`]s.
+    ///
+    /// The result is an error if this [`Node`] is a segment.
+    pub fn references(
+        &self,
+    ) -> Result<&NonEmpty<Reference<HASH_SIZE, Key, Hash>>, XProllyTreeError> {
+        match self {
+            Block::Branch(data) => Ok(&data),
+            Block::Segment(_) => Err(XProllyTreeError::IncorrectTreeAccess(
+                "Cannot read references from a segment".into(),
+            )),
+        }
+    }
+
+    /// Takes children data as [`Reference`]s.
+    ///
+    /// The result is an error if this [`Node`] is a segment.
+    pub fn into_references(
+        self,
+    ) -> Result<NonEmpty<Reference<HASH_SIZE, Key, Hash>>, XProllyTreeError> {
+        match self {
+            Block::Branch(data) => Ok(data),
+            Block::Segment(_) => Err(XProllyTreeError::IncorrectTreeAccess(
+                "Cannot take references from a segment".into(),
+            )),
+        }
+    }
+
+    /// Get children data as [`Entry`]s.
+    ///
+    /// The result is an error if this [`Node`] is a branch
+    pub fn entries(&self) -> Result<&NonEmpty<Entry<Key, Value>>, XProllyTreeError> {
+        match self {
+            Block::Branch(_) => Err(XProllyTreeError::IncorrectTreeAccess(
+                "Cannot read entries from a branch".into(),
+            )),
+            Block::Segment(data) => Ok(&data),
+        }
+    }
+
+    /// Take children data as [`Entry`]s.
+    ///
+    /// The result is an error if this [`Node`] is a branch
+    pub fn into_entries(self) -> Result<NonEmpty<Entry<Key, Value>>, XProllyTreeError> {
+        match self {
+            Block::Branch(_) => Err(XProllyTreeError::IncorrectTreeAccess(
+                "Cannot take entries from a branch".into(),
+            )),
+            Block::Segment(data) => Ok(data),
+        }
+    }
+}
+
+/// A [`BlockType`] contains variants that represent the kinds of blocks that
+/// may occur within a tree structure (either a branch or a segment)
+#[repr(u8)]
+#[derive(Clone, Copy)]
+pub enum BlockType {
+    /// A branch (non-leaf node)
+    Branch = 0,
+    /// A segment (leaf node)
+    Segment = 1,
+}
+
+impl<const HASH_SIZE: usize, Key, Value, Hash> From<&Block<HASH_SIZE, Key, Value, Hash>>
+    for BlockType
+where
+    Key: KeyType + 'static,
+    Value: ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+{
+    fn from(value: &Block<HASH_SIZE, Key, Value, Hash>) -> Self {
+        match value {
+            Block::Branch(_) => BlockType::Branch,
+            Block::Segment(_) => BlockType::Segment,
+        }
+    }
+}
+
+impl From<BlockType> for u8 {
+    fn from(value: BlockType) -> Self {
+        value as u8
+    }
+}
+
+impl TryFrom<u8> for BlockType {
+    type Error = XStorageError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => BlockType::Branch,
+            1 => BlockType::Segment,
+            _ => {
+                return Err(XStorageError::DecodeFailed(format!(
+                    "Byte does not represent a block type: {:x}",
+                    value
+                )));
+            }
+        })
+    }
+}
+
+impl WriteInto for BlockType {
+    type Error = XStorageError;
+
+    fn write_into(&self, writer: &mut crate::Writer) -> Result<(), Self::Error> {
+        writer.write_u8(u8::from(*self))
+    }
+}
+
+impl<'a> ReadFrom<'a> for BlockType {
+    type Error = XStorageError;
+
+    fn read_from<'r>(reader: &'r Reader<'a>) -> Result<BlockType, Self::Error>
+    where
+        'r: 'a,
+    {
+        reader.read_u8()?.try_into()
+    }
+}
+
+// use x_storage::Storage;

--- a/rust/x-prolly-tree/src/distribution.rs
+++ b/rust/x-prolly-tree/src/distribution.rs
@@ -1,0 +1,20 @@
+mod geometric;
+pub use geometric::*;
+use x_storage::HashType;
+
+use crate::KeyType;
+
+/// A rank determines how a tree's segments should be chunked
+pub type Rank = u32;
+
+/// A trait that may be implemented by any type that defines how to derive the
+/// [`Rank`] of a value in a tree
+pub trait Distribution<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Hash>
+where
+    Key: KeyType,
+    Hash: HashType<HASH_SIZE>,
+{
+    /// Compute the [`Rank`] of a value given its key
+    // TODO: support tree state e.g., fn rank(state: &TreeState, key: &Key) -> Rank;
+    fn rank(key: &Key) -> Rank;
+}

--- a/rust/x-prolly-tree/src/distribution/geometric.rs
+++ b/rust/x-prolly-tree/src/distribution/geometric.rs
@@ -1,0 +1,87 @@
+use x_storage::HashType;
+
+use crate::KeyType;
+
+use super::{Distribution, Rank};
+
+/// Simulate a geometric distribution with probability p = 1 - (1 / m) using a
+/// series of fair Bernoulli trials (p = 1 / 2). The number of trials is limited
+/// to 256 independent trials.
+///
+/// https://textile.notion.site/Flipping-bits-and-coins-with-hashes-205770b56418498fba4fef8cb037412d
+pub struct GeometricDistribution;
+
+impl<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Hash>
+    Distribution<BRANCH_FACTOR, HASH_SIZE, Key, Hash> for GeometricDistribution
+where
+    Key: KeyType,
+    Hash: HashType<HASH_SIZE>,
+{
+    fn rank(key: &Key) -> Rank {
+        let key_hash = blake3::hash(key.as_ref());
+        compute_geometric_rank(key_hash.as_bytes(), BRANCH_FACTOR)
+    }
+}
+
+pub(crate) fn compute_geometric_rank<const HASH_SIZE: usize>(
+    bytes: &[u8; HASH_SIZE],
+    m: u32,
+) -> Rank {
+    // Convert the series of fair trials into a series with desired probability
+    // Since we start with a random 256-bit slice (which can be thought of as a
+    // series of 256 fair Bernoulli trials), we need to group these trials with
+    // p = 1 / 2 into trials with p = 1 / m.
+    //
+    // To simulate a trial with probability p = 1 / m, consider a group of k
+    // fair trials, where k is chosen such that 1 / 2^k ≈ 1 / m. The smallest k
+    // such that 2^k ≥ m will be k = ⌈log_2(m)⌉. Compute ⌈log_2(m)⌉ =
+    // ceil(log_2(m)).
+
+    let k = (m + 1).ilog2();
+    // Number of batches  of k bits
+    let batch_count = 256 / k;
+    // Mask to extract k bits
+    let mask = (1u8 << k) - 1;
+    // For each batch of k bits, we treat the batch as a "success" if all bits
+    // are 0 (which happens with probability 1 / 2^k). The number of batches
+    // until the first "success" is the desired geometrically distributed random
+    // variable.
+    for i in 0..batch_count {
+        let byte_index = (k * i) / 8;
+        let bit_index = (k * i) % 8;
+        // Extract k bits
+        let batch = (bytes[byte_index as usize] >> bit_index) & mask;
+        // batch != 0 means we are looking for the failure probability 1 / m
+        // whereas batch == 0 means we are looking for the success probability
+        // 1 / m
+        if batch != 0 {
+            return i + 1; // +1 because geometric distribution starts at 1
+        }
+    }
+    batch_count + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_geometric_rank;
+    use rand::{Rng, rng};
+
+    #[test]
+    fn it_has_expected_distribution() {
+        let factor = 64;
+        let rounds = 500_000;
+
+        let mut sum = 0u32;
+        for _ in 0..rounds {
+            let mut buffer = [0u8; 32];
+            rng().fill(&mut buffer);
+            sum += compute_geometric_rank(&buffer, factor);
+        }
+        let average = f64::from(sum) / f64::from(rounds);
+        let probability = 1.0 - 1.0 / f64::from(factor);
+        let expected = 1.0 / probability;
+        println!("Average: {average}, expected: {expected}");
+
+        assert!((average - expected).abs() < 0.01)
+    }
+}

--- a/rust/x-prolly-tree/src/encoder.rs
+++ b/rust/x-prolly-tree/src/encoder.rs
@@ -1,0 +1,2 @@
+mod basic;
+pub use basic::*;

--- a/rust/x-prolly-tree/src/encoder/basic.rs
+++ b/rust/x-prolly-tree/src/encoder/basic.rs
@@ -1,0 +1,109 @@
+mod io;
+pub use io::*;
+
+use async_trait::async_trait;
+use nonempty::NonEmpty;
+use x_storage::{Encoder, XStorageError};
+
+use crate::{Block, BlockType, Entry, Reference};
+
+/// A [`BasicEncoder`] encodes blocks as a compact byte representation. It
+/// includes support for data structures that contain unsigned integers and byte
+/// arrays
+pub struct BasicEncoder;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Encoder<32> for BasicEncoder {
+    type Block = Block<32, Vec<u8>, Vec<u8>, Self::Hash>;
+    type Bytes = Vec<u8>;
+    type Hash = [u8; 32];
+    type Error = XStorageError;
+
+    async fn encode(&self, block: &Self::Block) -> Result<(Self::Hash, Self::Bytes), Self::Error> {
+        let mut writer = Writer::new();
+        let block_type = BlockType::from(block);
+        writer
+            .write(&block_type)
+            .map_err(|error| XStorageError::EncodeFailed(format!("{error}")))?;
+
+        match block_type {
+            BlockType::Branch => {
+                let refs = block.references()?;
+                writer.write_u32(
+                    refs.len()
+                        .try_into()
+                        .map_err(|error| XStorageError::EncodeFailed(format!("{error}")))?,
+                )?;
+                for node_ref in refs {
+                    writer.write(&node_ref.upper_bound().as_ref())?;
+                    writer.write::<&[u8]>(&node_ref.hash().as_ref())?;
+                }
+            }
+            BlockType::Segment => {
+                let entries = block.entries()?;
+                writer.write_u32(
+                    entries
+                        .len()
+                        .try_into()
+                        .map_err(|error| XStorageError::EncodeFailed(format!("{error}")))?,
+                )?;
+                for entry in entries {
+                    writer.write(&entry.key.as_ref())?;
+                    writer.write(&entry.value.as_ref())?;
+                }
+            }
+        }
+
+        let bytes = writer.into_inner();
+        let hash = blake3::hash(&bytes).as_bytes().to_owned();
+
+        Ok((hash, bytes))
+    }
+
+    /// Decode bytes into a `Block`.
+    async fn decode(&self, bytes: &[u8]) -> Result<Self::Block, Self::Error> {
+        let reader = Reader::new(bytes);
+        let block_type = reader.read::<BlockType>()?;
+        let child_count = reader.read_u32()?;
+
+        match block_type {
+            BlockType::Branch => {
+                let mut children = vec![];
+                for _ in 0..child_count {
+                    let boundary: Vec<u8> = reader
+                        .read::<Vec<u8>>()?
+                        .try_into()
+                        .map_err(|error| XStorageError::DecodeFailed(format!("{error}")))?;
+                    let hash: Self::Hash = reader.read::<Vec<u8>>()?.try_into().map_err(|_| {
+                        XStorageError::DecodeFailed(format!("Could not convert bytes to hash",))
+                    })?;
+                    children.push(Reference::new(boundary, hash))
+                }
+                let children = NonEmpty::from_vec(children).ok_or_else(|| {
+                    XStorageError::DecodeFailed("Branch seems to have zero children".into())
+                })?;
+
+                Ok(Block::branch(children))
+            }
+            BlockType::Segment => {
+                let mut children = vec![];
+                for _ in 0..child_count {
+                    let key: Vec<u8> = reader
+                        .read::<Vec<u8>>()?
+                        .try_into()
+                        .map_err(|error| XStorageError::DecodeFailed(format!("{error}")))?;
+                    let value: Vec<u8> = reader
+                        .read::<Vec<u8>>()?
+                        .try_into()
+                        .map_err(|error| XStorageError::DecodeFailed(format!("{error}")))?;
+                    children.push(Entry::new(key, value))
+                }
+                let children = NonEmpty::from_vec(children).ok_or_else(|| {
+                    XStorageError::DecodeFailed("Segment seems to have zero entries".into())
+                })?;
+                Ok(Block::segment(children))
+            }
+        }
+    }
+}

--- a/rust/x-prolly-tree/src/encoder/basic/io.rs
+++ b/rust/x-prolly-tree/src/encoder/basic/io.rs
@@ -1,0 +1,300 @@
+use std::{
+    cell::Cell,
+    io::{Cursor, Write},
+};
+use x_storage::XStorageError;
+
+/// Byte writer.
+pub struct Writer {
+    cursor: Cursor<Vec<u8>>,
+}
+
+impl Writer {
+    /// Create a new [`Writer`].
+    pub fn new() -> Self {
+        Self {
+            cursor: Cursor::new(vec![]),
+        }
+    }
+
+    /// Write a `u8` into the writer.
+    pub fn write_u8(&mut self, value: u8) -> Result<(), XStorageError> {
+        self.write_bytes(&[value])?;
+        Ok(())
+    }
+
+    /// Write a `u16` into the writer.
+    pub fn write_u16(&mut self, value: u16) -> Result<(), XStorageError> {
+        self.write_bytes(&value.to_le_bytes())?;
+        Ok(())
+    }
+
+    /// Write a `u32` into the writer.
+    pub fn write_u32(&mut self, value: u32) -> Result<(), XStorageError> {
+        self.write_bytes(&value.to_le_bytes())?;
+        Ok(())
+    }
+
+    /// Write a `u64` into the writer.
+    pub fn write_u64(&mut self, value: u64) -> Result<(), XStorageError> {
+        self.write_bytes(&value.to_le_bytes())?;
+        Ok(())
+    }
+
+    /// Write bytes into the writer.
+    pub fn write_bytes(&mut self, value: &[u8]) -> Result<(), XStorageError> {
+        let _ = self
+            .cursor
+            .write(value)
+            .map_err(|error| XStorageError::EncodeFailed(format!("{error}")))?;
+        Ok(())
+    }
+
+    /// Write a type implementing [`WriteInto`] into the writer.
+    pub fn write<W: WriteInto>(&mut self, target: &W) -> Result<(), XStorageError> {
+        target.write_into(self).map_err(|error| error.into())
+    }
+
+    /// Convert this writer into the bytes that were written.
+    pub fn into_inner(self) -> Vec<u8> {
+        self.cursor.into_inner()
+    }
+}
+
+/// Types implementing [`WriteInto`] define how they are written via a
+/// [`Writer`].
+pub trait WriteInto {
+    /// The error type produced by this [`WriteInto`]
+    type Error: Into<XStorageError>;
+
+    /// Write this struct into a [`Writer`].
+    fn write_into(&self, writer: &mut Writer) -> Result<(), Self::Error>;
+}
+
+impl WriteInto for &[u8] {
+    type Error = XStorageError;
+
+    fn write_into(&self, writer: &mut Writer) -> Result<(), Self::Error> {
+        writer
+            .write_u32(u32::try_from(self.len()).map_err(|error| {
+                XStorageError::EncodeFailed(format!("Slice too long: {error}"))
+            })?)?;
+        writer.write_bytes(self)
+    }
+}
+
+macro_rules! read_type {
+    ( $struct:ident, $fn_name:ident, $ty:ty, $size:expr ) => {
+        impl<'a> $struct<'a> {
+            #[doc = "Read a `"]
+            #[doc = stringify!($ty)]
+            #[doc = "` from the reader."]
+            pub fn $fn_name(&self) -> Result<$ty, XStorageError> {
+                const SIZE: usize = $size;
+                let (index, next) = self.check_indices(SIZE)?;
+                let mut buff = [0u8; SIZE];
+                buff.copy_from_slice(&self.bytes[index..next]);
+                let out = <$ty>::from_le_bytes(buff);
+                self.index.set(next);
+                Ok(out)
+            }
+        }
+    };
+}
+
+/// Read bytes as references from a source byte slice.
+pub struct Reader<'a> {
+    bytes: &'a [u8],
+    bytes_len: usize,
+    index: Cell<usize>,
+}
+
+impl<'a> Reader<'a> {
+    /// Create a new [`Reader`].
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Reader {
+            bytes,
+            bytes_len: bytes.len(),
+            index: 0.into(),
+        }
+    }
+
+    /// Read a `u8` from the reader.
+    pub fn read_u8(&self) -> Result<u8, XStorageError> {
+        let (index, next) = self.check_indices(1)?;
+        self.index.set(next);
+        Ok(self.bytes[index])
+    }
+
+    /// Read a sequence of `count` bytes from the reader.
+    pub fn read_bytes(&self, count: usize) -> Result<&[u8], XStorageError> {
+        let (index, next) = self.check_indices(count)?;
+        let out = &self.bytes[index..next];
+
+        self.index.set(next);
+        Ok(out)
+    }
+
+    /// Read `R` from the reader.
+    pub fn read<R: ReadFrom<'a>>(&'a self) -> Result<R, XStorageError> {
+        R::read_from(self).map_err(|error| error.into())
+    }
+
+    /// Skip forward `count` bytes.
+    pub fn skip(&self, count: usize) -> Result<(), XStorageError> {
+        let (_, next) = self.check_indices(count)?;
+        self.index.set(next);
+        Ok(())
+    }
+
+    fn check_indices(&self, size: usize) -> Result<(usize, usize), XStorageError> {
+        let index = self.index.get();
+        let next = index + size;
+        if next > self.bytes_len {
+            return Err(XStorageError::DecodeFailed(
+                "Attempted to read out of bounds".into(),
+            ));
+        }
+        Ok((index, next))
+    }
+}
+
+read_type!(Reader, read_u16, u16, 2);
+read_type!(Reader, read_u32, u32, 4);
+read_type!(Reader, read_u64, u64, 8);
+
+/// Types implementing [`ReadFrom`] define how they
+/// can be instantiated from a [`Reader`].
+pub trait ReadFrom<'a>: Sized {
+    /// The error type produced by this [`ReadFrom`]
+    type Error: Into<XStorageError>;
+
+    /// Instantiate `Self` from a [`Reader`].
+    fn read_from<'r>(reader: &'r Reader<'a>) -> Result<Self, Self::Error>
+    where
+        'r: 'a;
+}
+
+impl<'a> ReadFrom<'a> for &'a [u8] {
+    type Error = XStorageError;
+
+    fn read_from<'r>(reader: &'r Reader<'a>) -> Result<Self, XStorageError>
+    where
+        'r: 'a,
+    {
+        let length = reader.read_u32()?;
+        reader
+            .read_bytes(
+                length.try_into().map_err(|error| {
+                    XStorageError::DecodeFailed(format!("Slice too long: {error}"))
+                })?,
+            )
+            .map(|array| array.as_ref())
+    }
+}
+
+impl<'a> ReadFrom<'a> for Vec<u8> {
+    type Error = XStorageError;
+
+    fn read_from<'r>(reader: &'r Reader<'a>) -> Result<Self, Self::Error>
+    where
+        'r: 'a,
+    {
+        Ok(<&'a [u8] as ReadFrom<'a>>::read_from(reader)?.to_owned())
+    }
+}
+
+impl<'a, T> ReadFrom<'a> for Vec<T>
+where
+    T: ReadFrom<'a>,
+{
+    type Error = XStorageError;
+
+    fn read_from<'r>(reader: &'r Reader<'a>) -> Result<Self, Self::Error>
+    where
+        'r: 'a,
+    {
+        let length = reader.read_u32()?;
+        let mut collection = vec![];
+        for _ in 0..length {
+            collection.push(T::read_from(reader).map_err(|error| error.into())?);
+        }
+        Ok(collection)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use x_storage::XStorageError;
+
+    use crate::{ReadFrom, Reader, WriteInto, Writer};
+
+    #[test]
+    fn it_can_round_trip_complex_data() -> Result<()> {
+        #[derive(PartialEq, Debug)]
+        pub struct ComplexData {
+            bytes: [u8; 32],
+            value_8: u8,
+            pad_8: u8,
+            value_16: u16,
+            value_32: u32,
+        }
+
+        impl WriteInto for ComplexData {
+            type Error = XStorageError;
+
+            fn write_into(
+                &self,
+                writer: &mut super::Writer,
+            ) -> std::result::Result<(), Self::Error> {
+                writer.write_bytes(&self.bytes)?;
+                writer.write_u8(self.value_8)?;
+                writer.write_u8(self.pad_8)?;
+                writer.write_u16(self.value_16)?;
+                writer.write_u32(self.value_32)?;
+                Ok(())
+            }
+        }
+
+        impl<'a> ReadFrom<'a> for ComplexData {
+            type Error = XStorageError;
+
+            fn read_from<'r>(
+                reader: &'r super::Reader<'a>,
+            ) -> std::result::Result<Self, Self::Error>
+            where
+                'r: 'a,
+            {
+                Ok(Self {
+                    bytes: reader.read_bytes(32)?.try_into().unwrap(),
+                    value_8: reader.read_u8()?,
+                    pad_8: reader.read_u8()?,
+                    value_16: reader.read_u16()?,
+                    value_32: reader.read_u32()?,
+                })
+            }
+        }
+
+        let data = ComplexData {
+            bytes: blake3::hash(&vec![1, 2, 3]).as_bytes().to_owned(),
+            value_8: 123,
+            pad_8: 231,
+            value_16: 1024,
+            value_32: 64000,
+        };
+
+        let mut writer = Writer::new();
+        writer.write(&data)?;
+
+        let bytes = writer.into_inner();
+
+        let reader = Reader::new(&bytes);
+
+        let deserialized_data = reader.read::<ComplexData>()?;
+
+        assert_eq!(data, deserialized_data);
+
+        Ok(())
+    }
+}

--- a/rust/x-prolly-tree/src/entry.rs
+++ b/rust/x-prolly-tree/src/entry.rs
@@ -1,0 +1,23 @@
+use crate::KeyType;
+
+/// A key-value entry in a tree.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Entry<Key, Value>
+where
+    Key: KeyType,
+{
+    /// The key in this key/value pair.
+    pub key: Key,
+    /// The value in this key/value pair.
+    pub value: Value,
+}
+
+impl<Key, Value> Entry<Key, Value>
+where
+    Key: KeyType,
+{
+    /// Create a new [`Entry`].
+    pub fn new(key: Key, value: Value) -> Self {
+        Entry { key, value }
+    }
+}

--- a/rust/x-prolly-tree/src/error.rs
+++ b/rust/x-prolly-tree/src/error.rs
@@ -1,0 +1,40 @@
+use thiserror::Error;
+use x_storage::XStorageError;
+
+/// The common error type used by this crate
+#[derive(Error, Debug)]
+pub enum XProllyTreeError {
+    /// There was an attempt to access the tree in an incorrect way
+    #[error("Incorrect tree access: {0}")]
+    IncorrectTreeAccess(String),
+
+    /// The tree as constructed is not valid
+    #[error("Invalid tree construction: {0}")]
+    InvalidConstruction(String),
+
+    /// There was a problem when accessing storage
+    #[error("Storage error: {0}")]
+    Storage(XStorageError),
+
+    /// A required block is missing from storage
+    #[error("Block not found in storage: {0}")]
+    MissingBlock(String),
+
+    /// The tree did not match the expected shape
+    #[error("Tree did not match expected shape: {0}")]
+    UnexpectedTreeShape(String),
+}
+
+impl From<XStorageError> for XProllyTreeError {
+    fn from(value: XStorageError) -> Self {
+        XProllyTreeError::Storage(value)
+    }
+}
+
+// TODO: This is probably an overly-broad conversion
+impl From<XProllyTreeError> for XStorageError {
+    fn from(value: XProllyTreeError) -> Self {
+        XStorageError::EncodeFailed(format!("{value}"));
+        todo!();
+    }
+}

--- a/rust/x-prolly-tree/src/key.rs
+++ b/rust/x-prolly-tree/src/key.rs
@@ -1,0 +1,9 @@
+use x_common::ConditionalSync;
+
+/// A key used to reference values in a [Tree] or [Node].
+pub trait KeyType:
+    std::fmt::Debug + AsRef<[u8]> + ConditionalSync + Clone + PartialEq + Ord
+{
+}
+
+impl KeyType for Vec<u8> {}

--- a/rust/x-prolly-tree/src/lib.rs
+++ b/rust/x-prolly-tree/src/lib.rs
@@ -1,0 +1,55 @@
+#![warn(missing_docs)]
+
+//! This crate provides a key-value store implemented as a prolly tree,
+//! utilizing a flexible content-addressed block storage backend. This prolly
+//! tree is designed to be the foundation of a passive database, providing on
+//! demand partial replication.
+//!
+//! In order to use it, first construct a [`x_storage::Storage`] and then initialize
+//! a [`Tree`] with it:
+//!
+//! ```ignore
+//! use x_storage::{Storage, MemoryStorageBackend};
+//! use x_prolly_tree::{BasicEncoder, Tree};
+//!
+//! let storage = Storage {
+//!     encoder: BasicEncoder,
+//!     backend: MemoryStorageBackend::default()
+//! };
+//!
+//! let tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage);
+//!
+//! tree.set(vec![1, 2, 3], vec![4, 5, 6]).await?;
+//!
+//! println!("{:?}", tree.hash());
+//! ```
+
+mod encoder;
+pub use encoder::*;
+
+mod block;
+pub use block::*;
+
+mod entry;
+pub use entry::*;
+
+mod distribution;
+pub use distribution::*;
+
+mod key;
+pub use key::*;
+
+mod error;
+pub use error::*;
+
+mod node;
+pub use node::*;
+
+mod tree;
+pub use tree::*;
+
+mod reference;
+pub use reference::*;
+
+mod adopter;
+pub use adopter::*;

--- a/rust/x-prolly-tree/src/node.rs
+++ b/rust/x-prolly-tree/src/node.rs
@@ -1,0 +1,532 @@
+use std::ops::{Bound, RangeBounds};
+
+use async_stream::try_stream;
+use base58::ToBase58;
+use futures_core::Stream;
+use nonempty::NonEmpty;
+use x_common::ConditionalSync;
+use x_storage::{ContentAddressedStorage, HashType};
+
+use crate::{Block, Entry, KeyType, Rank, Reference, XProllyTreeError};
+
+/// Primary representation of tree nodes.
+///
+/// The common error type used by this crate Each [`Node`] stores its children
+/// in a [`ContentAddressedStorage`] as key/value pairs. Branches store a
+/// collection of children references as [`References`], and segments (leaf
+/// nodes) store their key-value [`Entry`] inline.
+#[derive(Clone, Debug)]
+pub struct Node<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Value, Hash>
+where
+    Key: KeyType + 'static,
+    Hash: HashType<HASH_SIZE>,
+    Value: Clone + ConditionalSync,
+{
+    block: Block<HASH_SIZE, Key, Value, Hash>,
+    /// A [`Reference`] that points to this [`Node`]s own [`Block`]
+    reference: Reference<HASH_SIZE, Key, Hash>,
+}
+
+impl<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Value, Hash>
+    Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>
+where
+    Key: KeyType,
+    Hash: HashType<HASH_SIZE>,
+    Value: Clone + ConditionalSync,
+{
+    /// Whether this node is a branch.
+    pub fn is_branch(&self) -> bool {
+        self.block.is_branch()
+    }
+
+    /// Whether this node is a segment.
+    pub fn is_segment(&self) -> bool {
+        self.block.is_segment()
+    }
+
+    /// Create a new branch [`Node`] given [`Reference`] children, storing
+    /// the new [`Node`] in the provided [`ContentAddressedStorage`]
+    pub async fn branch<Storage>(
+        children: NonEmpty<Reference<HASH_SIZE, Key, Hash>>,
+        storage: &mut Storage,
+    ) -> Result<Self, XProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        let block = Block::branch(children);
+        let bound = block.upper_bound().clone();
+        let hash = storage.write(&block).await.map_err(|error| error.into())?;
+        let reference = Reference::new(bound, hash);
+
+        Ok(Node { block, reference })
+    }
+
+    /// Create a new segment [`Node`] given [`Entry`] children, storing the new
+    /// [`Node`] in the provided [`ContentAddressedStorage`]
+    pub async fn segment<Storage>(
+        children: NonEmpty<Entry<Key, Value>>,
+        storage: &mut Storage,
+    ) -> Result<Self, XProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        let block = Block::segment(children);
+        let bound = block.upper_bound().clone();
+        let hash = storage.write(&block).await.map_err(|error| error.into())?;
+        let reference = Reference::new(bound, hash);
+
+        Ok(Node { block, reference })
+    }
+
+    /// Hydrates a [`Node`] from [`ContentAddressedStorage`] given a [`Reference`].
+    pub async fn from_reference<Storage>(
+        reference: Reference<HASH_SIZE, Key, Hash>,
+        storage: &Storage,
+    ) -> Result<Self, XProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        let Some(block) = storage
+            .read(reference.hash())
+            .await
+            .map_err(|error| error.into())?
+        else {
+            return Err(XProllyTreeError::MissingBlock(format!("{}", reference)));
+        };
+
+        Ok(Node { block, reference })
+    }
+
+    /// Hydrates a [`Node`] from [`ContentAddressedStorage`] given a [`HashType`].
+    pub async fn from_hash<Storage>(hash: Hash, storage: &Storage) -> Result<Self, XProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        let Some(block) = storage.read(&hash).await.map_err(|error| error.into())? else {
+            return Err(XProllyTreeError::MissingBlock(format!(
+                "#{}",
+                hash.bytes().to_base58()
+            )));
+        };
+        let reference = Reference::new(block.upper_bound().clone(), hash);
+
+        Ok(Node { block, reference })
+    }
+
+    /// Returns a [`Reference`] for this node.
+    pub fn reference(&self) -> &Reference<HASH_SIZE, Key, Hash> {
+        &self.reference
+    }
+
+    /// Returns the [`Hash`] for this [`Node`] used to retrieve from
+    /// [`ContentAddressedStorage`].
+    pub fn hash(&self) -> &Hash {
+        &self.reference.hash()
+    }
+
+    /// Return all [`Entry`]s from this [`Node`] into a [`Entry`] collection.
+    ///
+    /// The result is an error if this is not a segment [`Node`].
+    pub fn into_entries(self) -> Result<NonEmpty<Entry<Key, Value>>, XProllyTreeError> {
+        if !self.is_segment() {
+            return Err(XProllyTreeError::IncorrectTreeAccess(
+                "Cannot convert branch into entries".into(),
+            ));
+        }
+
+        self.block.into_entries()
+    }
+
+    /// Recursively descends the hierarchy, returning an [`Entry`] matching
+    /// `key` if found.
+    pub async fn get_entry<Storage>(
+        &self,
+        key: &Key,
+        storage: &Storage,
+    ) -> Result<Option<Entry<Key, Value>>, XProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        #[allow(unused_assignments)]
+        let mut current_node_holder: Option<Self> = None;
+        let mut current_node = self;
+
+        loop {
+            match current_node.is_branch() {
+                true => {
+                    let Some(node) = current_node.child_by_key(key, storage).await? else {
+                        return Ok(None);
+                    };
+                    current_node_holder = Some(node);
+                    current_node = current_node_holder.as_ref().unwrap();
+                }
+                false => return current_node.entry_by_key(key),
+            }
+        }
+    }
+
+    /// Inserts a new [`Entry`] into the hierarchy represented by this [`Node`]
+    /// as its root. If successful, returns the new root [`Node`] representing
+    /// the hierarchy.
+    pub async fn insert<Distribution, Storage>(
+        &self,
+        new_entry: Entry<Key, Value>,
+        storage: &mut Storage,
+    ) -> Result<Self, XProllyTreeError>
+    where
+        Distribution: crate::Distribution<BRANCH_FACTOR, HASH_SIZE, Key, Hash>,
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        let key = new_entry.key.to_owned();
+        let mut node = self.to_owned();
+        let mut branch_stack = vec![];
+        let all_entries: Option<NonEmpty<Entry<Key, Value>>>;
+
+        loop {
+            match node.is_branch() {
+                true => {
+                    let mut left = vec![];
+                    let mut right = vec![];
+                    let mut next = None;
+                    for child_reference in node.block.into_references()? {
+                        // If key may be contained within the child reference,
+                        // or if it's the largest boundary use the last child.
+                        if next.is_some() {
+                            right.push(child_reference);
+                        } else if &key <= child_reference.upper_bound() {
+                            next = Some(Node::from_reference(child_reference, storage).await?);
+                        } else {
+                            left.push(child_reference);
+                        }
+                    }
+                    // If key is greater than the greatest child, use the
+                    // greatest child.
+                    if next.is_none() {
+                        let last = left.pop().ok_or(XProllyTreeError::UnexpectedTreeShape(
+                            "No upper bound found".into(),
+                        ))?;
+                        next = Some(Node::from_reference(last, storage).await?);
+                    }
+                    branch_stack.push((NonEmpty::from_vec(left), NonEmpty::from_vec(right)));
+                    node = next.ok_or(XProllyTreeError::UnexpectedTreeShape(
+                        "Next node not found".into(),
+                    ))?;
+                }
+                false => {
+                    let mut entries = node.block.into_entries()?;
+                    match entries.binary_search_by(|probe| probe.key.cmp(&key)) {
+                        // Entry was found; update the value.
+                        Ok(index) => {
+                            let Some(previous_entry) = entries.get_mut(index) else {
+                                return Err(XProllyTreeError::UnexpectedTreeShape(format!(
+                                    "Entry at index {} not found",
+                                    index,
+                                )));
+                            };
+                            previous_entry.value = new_entry.value;
+                        }
+                        // Entry was not found; insert at the provided index.
+                        Err(index) => {
+                            entries.insert(index, new_entry);
+                        }
+                    };
+                    all_entries = Some(entries);
+                    break;
+                }
+            }
+        }
+        let mut nodes = {
+            let Some(entries) = all_entries else {
+                return Err(XProllyTreeError::UnexpectedTreeShape(
+                    "No entries found".into(),
+                ));
+            };
+            let entries = entries.map(|entry| {
+                let rank = Distribution::rank(&entry.key);
+                (entry, rank)
+            });
+            Node::join_with_rank(entries, 1, storage).await?
+        };
+        let mut min_rank = 2;
+        loop {
+            let references = {
+                let references = nodes.map(|(node, rank)| (node.reference().clone(), rank));
+                match branch_stack.pop() {
+                    Some(siblings) => {
+                        // TBD if we must recompute rank for siblings references
+                        // when building up the tree. Attempt to try setting
+                        // rank to `0` for references outside of the modified
+                        // path.
+                        let left = siblings.0.map(|left| {
+                            left.map(|reference| {
+                                let rank = Distribution::rank(reference.upper_bound());
+                                (reference, rank)
+                            })
+                        });
+                        let right = siblings.1.map(|right| {
+                            right.map(|reference| {
+                                let rank = Distribution::rank(reference.upper_bound());
+                                (reference, rank)
+                            })
+                        });
+                        match (left, right) {
+                            (None, None) => references,
+                            (Some(left), None) => concat_nonempty(vec![left, references])?,
+                            (None, Some(right)) => concat_nonempty(vec![references, right])?,
+                            (Some(left), Some(right)) => {
+                                concat_nonempty(vec![left, references, right])?
+                            }
+                        }
+                    }
+                    None => references,
+                }
+            };
+
+            nodes = Node::join_with_rank(references, min_rank, storage).await?;
+            if branch_stack.is_empty() && nodes.len() == 1 {
+                break;
+            }
+            min_rank += 1;
+        }
+        Ok(nodes.head.0)
+    }
+
+    /// Returns an async stream over entries with keys within the provided range.
+    pub fn get_range<'a, R, Storage>(
+        &'a self,
+        range: R,
+        storage: &'a Storage,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, XProllyTreeError>> + 'a
+    where
+        R: RangeBounds<Key> + 'a,
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        let get_child_index_by_key =
+            async |node: &Self,
+                   key: Option<&Key>,
+                   storage: &Storage|
+                   -> Result<Option<(Self, usize)>, XProllyTreeError> {
+                match key {
+                    Some(key) => {
+                        for (index, reference) in node.block.references()?.iter().enumerate() {
+                            if *key <= *reference.upper_bound() {
+                                return Ok(Some((
+                                    Node::from_reference(reference.to_owned(), storage).await?,
+                                    index,
+                                )));
+                            }
+                        }
+                        Ok(None)
+                    }
+                    // If no key provided, this was an unbounded range request; take
+                    // the left-most child.
+                    None => Ok(Some((
+                        Node::from_reference(node.block.references()?.first().to_owned(), storage)
+                            .await?,
+                        0,
+                    ))),
+                }
+            };
+
+        // Get the start key. Included/Excluded ranges are identical here, the
+        // check if key is in range is below, and this will at most read one
+        // unnecessary segment iff `Bound::Excluded(K)` and `K` is a boundary
+        // node.
+        let start_key = match range.start_bound() {
+            Bound::Included(start) => Some(start.clone()),
+            Bound::Excluded(start) => Some(start.clone()),
+            Bound::Unbounded => None,
+        };
+        // An entry was found matching the key range.
+        let mut matching = false;
+
+        // Track ancestor nodes and the index of the most recently visited child
+        let mut branch_stack = vec![TreeLocation {
+            node: self.to_owned(),
+            index: None,
+        }];
+
+        try_stream! {
+            loop {
+                let Some(current) = branch_stack.last_mut() else {
+                    return;
+                };
+                match current.node.is_branch() {
+                    true => {
+                        if !matching {
+                            let Some((next_node, next_index)) = get_child_index_by_key(&current.node, start_key.as_ref(), storage).await? else {
+                                // The start key is larger than any key stored in this tree.
+                                return;
+                            };
+                            current.index = Some(next_index);
+                            branch_stack.push(TreeLocation { node: next_node, index: None });
+                        } else {
+                            let next_index = match current.index {
+                                Some(visited_index) => visited_index + 1,
+                                None => 0
+                            };
+                            match current.node.block.references()?.get(next_index) {
+                                Some(reference) => {
+                                    let next_node = Node::from_reference(reference.to_owned(), storage).await?;
+                                    current.index = Some(next_index);
+                                    branch_stack.push(TreeLocation { node: next_node, index: None });
+                                }
+                                None => {
+                                    // Parent needs to check next sibling
+                                    branch_stack.pop();
+                                }
+                            }
+                        }
+                    }
+                    false => {
+                        let current = branch_stack.pop().ok_or_else(|| XProllyTreeError::UnexpectedTreeShape("Encountered segment with no ancestors".into()))?;
+                        for entry in current.node.into_entries()? {
+                            let entry_key = &entry.key;
+                            if range.contains(&entry_key) {
+                                if !matching {
+                                    matching = true;
+                                }
+                                yield entry;
+                            } else if matching {
+                                // We've surpassed the range; abort.
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns the decoded child [`Node`] that may contain `key` within its
+    /// descendants.
+    ///
+    /// The result is an error if this is a branch [`Node`].
+    async fn child_by_key<Storage>(
+        &self,
+        key: &Key,
+        storage: &Storage,
+    ) -> Result<Option<Self>, XProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        if !self.is_branch() {
+            return Err(XProllyTreeError::IncorrectTreeAccess(
+                "Cannot descend through segment".into(),
+            ));
+        }
+        for reference in self.block.references()? {
+            if *key <= *reference.upper_bound() {
+                return Ok(Some(
+                    Node::from_reference(reference.to_owned(), storage).await?,
+                ));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Returns this segment's [`Entry`] matching the provided `key`.
+    ///
+    /// The result is an error if this is not a segment [`Node`].
+    fn entry_by_key(&self, key: &Key) -> Result<Option<Entry<Key, Value>>, XProllyTreeError> {
+        if !self.is_segment() {
+            return Err(XProllyTreeError::IncorrectTreeAccess(
+                "Cannot read entries from a branch".into(),
+            ));
+        }
+        for entry in self.block.entries()? {
+            if *key == entry.key {
+                return Ok(Some(entry.to_owned()));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Joins a collection of sibling [`Adopter`]s into one or more parent
+    /// [`Node`]s, where branching is determined by rank.
+    pub(crate) async fn join_with_rank<Adopter, Storage>(
+        nodes: NonEmpty<(Adopter, Rank)>,
+        minimum_rank: Rank,
+        storage: &mut Storage,
+    ) -> Result<NonEmpty<(Self, Rank)>, XProllyTreeError>
+    where
+        Adopter: crate::Adopter<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>,
+        Storage: ContentAddressedStorage<
+                HASH_SIZE,
+                Block = Block<HASH_SIZE, Key, Value, Hash>,
+                Hash = Hash,
+            >,
+    {
+        let mut output = vec![];
+        let mut pending = vec![];
+        for (node, rank) in nodes {
+            pending.push(node);
+            if rank > minimum_rank {
+                let children = NonEmpty::from_vec(std::mem::replace(&mut pending, vec![])).ok_or(
+                    XProllyTreeError::InvalidConstruction(
+                        "Cannot adopt an empty child list".into(),
+                    ),
+                )?;
+                let node = Adopter::adopt(children, storage).await?;
+                output.push((node, rank));
+            }
+        }
+        if let Some(pending) = NonEmpty::from_vec(pending) {
+            let node = Adopter::adopt(pending, storage).await?;
+            output.push((node, minimum_rank));
+        }
+        NonEmpty::from_vec(output).ok_or(XProllyTreeError::InvalidConstruction(
+            "Empty node list".into(),
+        ))
+    }
+}
+
+struct TreeLocation<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Key, Value, Hash>
+where
+    Key: KeyType + 'static,
+    Hash: HashType<HASH_SIZE>,
+    Value: Clone + ConditionalSync,
+{
+    pub node: Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>,
+    pub index: Option<usize>,
+}
+
+/// TODO: Improve. Possibly remove NonEmpty as it introduces some overhead
+/// compared to index comparison with slices.
+fn concat_nonempty<T>(list: Vec<NonEmpty<T>>) -> Result<NonEmpty<T>, XProllyTreeError> {
+    Ok(NonEmpty::flatten(NonEmpty::from_vec(list).ok_or(
+        XProllyTreeError::InvalidConstruction("Empty child list".into()),
+    )?))
+}

--- a/rust/x-prolly-tree/src/reference.rs
+++ b/rust/x-prolly-tree/src/reference.rs
@@ -1,0 +1,48 @@
+use std::fmt::Display;
+
+use base58::ToBase58;
+use x_storage::HashType;
+
+use crate::KeyType;
+
+/// A serializable reference to a [`Node`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reference<const HASH_SIZE: usize, Key, Hash>
+where
+    Key: KeyType,
+    Hash: HashType<HASH_SIZE>,
+{
+    upper_bound: Key,
+    hash: Hash,
+}
+
+impl<const HASH_SIZE: usize, Key, Hash> Reference<HASH_SIZE, Key, Hash>
+where
+    Key: KeyType,
+    Hash: HashType<HASH_SIZE>,
+{
+    /// Create a new [`Reference`].
+    pub fn new(upper_bound: Key, hash: Hash) -> Self {
+        Reference { upper_bound, hash }
+    }
+
+    /// The hash for this [`Reference`].
+    pub fn hash(&self) -> &Hash {
+        &self.hash
+    }
+
+    /// The upper bounds as a key for this [`Reference`].
+    pub fn upper_bound(&self) -> &Key {
+        &self.upper_bound
+    }
+}
+
+impl<const HASH_SIZE: usize, Key, Hash> Display for Reference<HASH_SIZE, Key, Hash>
+where
+    Key: KeyType,
+    Hash: HashType<HASH_SIZE>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{}", self.hash().bytes().to_base58())
+    }
+}

--- a/rust/x-prolly-tree/src/tree.rs
+++ b/rust/x-prolly-tree/src/tree.rs
@@ -1,0 +1,188 @@
+use std::{collections::BTreeMap, marker::PhantomData, ops::RangeBounds};
+
+use async_stream::try_stream;
+use futures_core::Stream;
+use nonempty::NonEmpty;
+use x_common::ConditionalSync;
+use x_storage::{ContentAddressedStorage, HashType};
+
+use crate::{Adopter, Block, Entry, KeyType, Node, XProllyTreeError};
+
+/// A key-value store backed by a Ranked Prolly Tree with configurable storage,
+/// encoding and rank distribution.
+#[derive(Clone)]
+pub struct Tree<
+    const BRANCH_FACTOR: u32,
+    const HASH_SIZE: usize,
+    Distribution,
+    Key,
+    Value,
+    Hash,
+    Storage,
+> where
+    Distribution: crate::Distribution<BRANCH_FACTOR, HASH_SIZE, Key, Hash>,
+    Key: KeyType + 'static,
+    Value: Clone + ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+    Storage:
+        ContentAddressedStorage<HASH_SIZE, Block = Block<HASH_SIZE, Key, Value, Hash>, Hash = Hash>,
+{
+    storage: Storage,
+    root: Option<Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>>,
+
+    distribution_type: PhantomData<Distribution>,
+    key_type: PhantomData<Key>,
+    value_type: PhantomData<Value>,
+    hash_type: PhantomData<Hash>,
+}
+
+impl<const BRANCH_FACTOR: u32, const HASH_SIZE: usize, Distribution, Key, Value, Hash, Storage>
+    Tree<BRANCH_FACTOR, HASH_SIZE, Distribution, Key, Value, Hash, Storage>
+where
+    Distribution: crate::Distribution<BRANCH_FACTOR, HASH_SIZE, Key, Hash>,
+    Key: KeyType,
+    Value: Clone + ConditionalSync,
+    Hash: HashType<HASH_SIZE>,
+    Storage:
+        ContentAddressedStorage<HASH_SIZE, Block = Block<HASH_SIZE, Key, Value, Hash>, Hash = Hash>,
+{
+    /// Creates a new [`Tree`] with provided [`ContentAddressedStorage`].
+    pub fn new(storage: Storage) -> Self {
+        Self {
+            storage,
+            root: None,
+
+            distribution_type: PhantomData,
+            key_type: PhantomData,
+            value_type: PhantomData,
+            hash_type: PhantomData,
+        }
+    }
+
+    /// Hydrate a new [`Tree`] from a [`HashType`] that references a [`Node`].
+    pub async fn from_hash(hash: &Hash, storage: Storage) -> Result<Self, XProllyTreeError> {
+        let root = Node::from_hash(hash.clone(), &storage).await?;
+        Ok(Self {
+            storage,
+            root: Some(root),
+
+            distribution_type: PhantomData,
+            key_type: PhantomData,
+            value_type: PhantomData,
+            hash_type: PhantomData,
+        })
+    }
+
+    /// The [`ContentAddressedStorage`] used by this tree.
+    pub fn storage(&self) -> &Storage {
+        &self.storage
+    }
+
+    /// Returns the [`Node`] representing the root of this tree.
+    ///
+    /// Returns `None` if the tree is empty.
+    pub fn root(&self) -> Option<&Node<BRANCH_FACTOR, HASH_SIZE, Key, Value, Hash>> {
+        self.root.as_ref()
+    }
+
+    /// Returns the [`HashType`] representing the root of this tree.
+    ///
+    /// Returns `None` if the tree is empty.
+    pub fn hash(&self) -> Option<&Hash> {
+        self.root().map(|root| root.hash())
+    }
+
+    /// Retrieves the value associated with `key` from the tree.
+    pub async fn get(&self, key: &Key) -> Result<Option<Value>, XProllyTreeError> {
+        match &self.root {
+            Some(root) => match root.get_entry(key, &self.storage).await? {
+                Some(entry) => Ok(Some(entry.value)),
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
+    }
+
+    /// Sets a `key`/`value` pair into the tree.
+    pub async fn set(&mut self, key: Key, value: Value) -> Result<(), XProllyTreeError> {
+        let entry = Entry { key, value };
+        match &self.root {
+            Some(root) => {
+                let new_root = root
+                    .insert::<Distribution, _>(entry, &mut self.storage)
+                    .await?;
+                self.root = Some(new_root);
+            }
+            None => {
+                let segment = Entry::adopt(NonEmpty::singleton(entry), &mut self.storage).await?;
+                self.root = Some(segment);
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns an async stream over all entries.
+    pub fn stream<'a>(
+        &'a self,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, XProllyTreeError>> + 'a {
+        self.stream_range(..)
+    }
+
+    /// Returns an async stream over entries with keys within the provided range.
+    pub fn stream_range<'a, R>(
+        &'a self,
+        range: R,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, XProllyTreeError>> + 'a
+    where
+        R: RangeBounds<Key> + 'a,
+    {
+        try_stream! {
+            if let Some(root) = self.root.as_ref() {
+                let stream = root.get_range(range, &self.storage);
+                for await item in stream {
+                    yield item?;
+                }
+            }
+        }
+    }
+
+    /// Create a new [`Tree`] from a [`BTreeMap`].
+    ///
+    /// A more efficient method than iteratively adding values.
+    pub async fn from_collection(
+        collection: BTreeMap<Key, Value>,
+        mut storage: Storage,
+    ) -> Result<Self, XProllyTreeError> {
+        let mut nodes = {
+            let entries = collection
+                .into_iter()
+                .map(|(key, value)| {
+                    let node = Entry { key, value };
+                    let rank = Distribution::rank(&node.key);
+                    (node, rank)
+                })
+                .collect();
+            let entries = NonEmpty::from_vec(entries).ok_or_else(|| {
+                XProllyTreeError::InvalidConstruction("Tree must have at least one child".into())
+            })?;
+            Node::join_with_rank(entries, 1, &mut storage).await?
+        };
+        let mut minimum_rank = 2;
+        loop {
+            nodes = Node::join_with_rank(nodes, minimum_rank, &mut storage).await?;
+            if nodes.len() == 1 {
+                break;
+            }
+            minimum_rank += 1;
+        }
+        Ok(Tree {
+            storage,
+            root: Some(nodes.head.0),
+
+            distribution_type: PhantomData,
+            key_type: PhantomData,
+            value_type: PhantomData,
+            hash_type: PhantomData,
+        })
+    }
+}

--- a/rust/x-prolly-tree/tests/backend.rs
+++ b/rust/x-prolly-tree/tests/backend.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use rand::{Rng, rng};
+use x_prolly_tree::{BasicEncoder, GeometricDistribution, Tree};
+use x_storage::{Storage, make_target_storage};
+
+fn random() -> Vec<u8> {
+    let mut buffer = [0u8; 32];
+    rng().fill(&mut buffer[..]);
+    buffer.to_vec()
+}
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test;
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn platform_specific_storage() -> Result<()> {
+    let (backend, _temp) = make_target_storage().await?;
+    let storage = Storage {
+        backend,
+        encoder: BasicEncoder,
+    };
+    let mut tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage);
+
+    let mut ledger = vec![];
+    for _ in 1..1024 {
+        let key_value = (random(), random());
+        ledger.push(key_value.clone());
+        tree.set(key_value.0, key_value.1).await?;
+    }
+
+    for entry in ledger {
+        assert_eq!(tree.get(&entry.0).await?, Some(entry.1));
+    }
+    Ok(())
+}

--- a/rust/x-prolly-tree/tests/range.rs
+++ b/rust/x-prolly-tree/tests/range.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+use futures_util::TryStreamExt;
+use std::collections::BTreeMap;
+use x_prolly_tree::{BasicEncoder, GeometricDistribution, Tree};
+use x_storage::{MemoryStorageBackend, Storage};
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test;
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+async fn create_test_tree<const BRANCH_FACTOR: u32>(
+    size: u32,
+) -> Result<
+    Tree<
+        BRANCH_FACTOR,
+        32,
+        GeometricDistribution,
+        Vec<u8>,
+        Vec<u8>,
+        [u8; 32],
+        Storage<32, BasicEncoder, MemoryStorageBackend<[u8; 32], Vec<u8>>>,
+    >,
+> {
+    let storage = Storage {
+        backend: MemoryStorageBackend::default(),
+        encoder: BasicEncoder,
+    };
+    let mut collection = BTreeMap::default();
+    for i in 0..size {
+        let key = i.to_be_bytes().to_vec();
+        let value = <[u8; 32] as From<blake3::Hash>>::from(blake3::hash(&key)).to_vec();
+        collection.insert(key, value);
+    }
+    Ok(Tree::from_collection(collection, storage).await?)
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn gets_full_range() -> Result<()> {
+    let tree = create_test_tree::<32>(1024).await?;
+    let stream = tree.stream();
+    tokio::pin!(stream);
+    let mut i = 0u32;
+    while let Some(_) = stream.try_next().await? {
+        i += 1;
+    }
+    assert_eq!(i, 1024, "full range yields all nodes");
+    Ok(())
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn stream_range_on_empty_trees() -> Result<()> {
+    let storage = Storage {
+        encoder: BasicEncoder,
+        backend: MemoryStorageBackend::default(),
+    };
+
+    let empty = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage);
+
+    let stream = empty.stream_range(..);
+    tokio::pin!(stream);
+    assert!(stream.try_next().await?.is_none());
+
+    let stream = empty.stream();
+    tokio::pin!(stream);
+    assert!(stream.try_next().await?.is_none());
+
+    Ok(())
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn gets_range() -> Result<()> {
+    let tree = create_test_tree::<32>(1024).await?;
+
+    const OFFSET: u32 = 2;
+    const MAX: u32 = 10;
+
+    let start = OFFSET.to_be_bytes().to_vec();
+    let end = MAX.to_be_bytes().to_vec();
+    let stream = tree.stream_range(start..end);
+    tokio::pin!(stream);
+    let mut i = 0u32;
+    while let Some(entry) = stream.try_next().await? {
+        assert_eq!(entry.key, (i + OFFSET).to_be_bytes().to_vec());
+        assert_eq!(
+            entry.value,
+            <[u8; 32] as From<blake3::Hash>>::from(blake3::hash(&entry.key)).to_vec()
+        );
+        i += 1;
+    }
+    assert_eq!(i, MAX - OFFSET);
+    Ok(())
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn request_out_of_range() -> Result<()> {
+    let tree = create_test_tree::<32>(1024).await?;
+    let start = 1_000_000u32.to_be_bytes().to_vec();
+    let stream = tree.stream_range(start..);
+    tokio::pin!(stream);
+    assert!(
+        stream.try_next().await?.is_none(),
+        "start range out of tree range yields no items"
+    );
+
+    let storage = Storage {
+        encoder: BasicEncoder,
+        backend: MemoryStorageBackend::default(),
+    };
+    let mut tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage);
+    tree.set(10u32.to_be_bytes().to_vec(), vec![1]).await?;
+    let start = 0u32.to_be_bytes().to_vec();
+    let end = 5u32.to_be_bytes().to_vec();
+    let stream = tree.stream_range(start..end);
+    tokio::pin!(stream);
+    assert!(
+        stream.try_next().await?.is_none(),
+        "end range out of tree range yields no items"
+    );
+
+    Ok(())
+}

--- a/rust/x-prolly-tree/tests/tree.rs
+++ b/rust/x-prolly-tree/tests/tree.rs
@@ -1,0 +1,206 @@
+use anyhow::Result;
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::sync::Mutex;
+use x_prolly_tree::{BasicEncoder, GeometricDistribution, Tree};
+use x_storage::{CachedStorageBackend, MeasuredStorageBackend, MemoryStorageBackend, Storage};
+
+fn bytes(s: &str) -> Vec<u8> {
+    String::from(s).into_bytes()
+}
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test;
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn basic_set_and_get() -> Result<()> {
+    let storage = Arc::new(Mutex::new(Storage {
+        backend: MemoryStorageBackend::default(),
+        encoder: BasicEncoder,
+    }));
+    let mut tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage.clone());
+
+    tree.set(bytes("foo1"), bytes("bar1")).await?;
+    tree.set(bytes("foo2"), bytes("bar2")).await?;
+    tree.set(bytes("foo3"), bytes("bar3")).await?;
+
+    assert_eq!(tree.get(&bytes("bar")).await?, None);
+    assert_eq!(tree.get(&bytes("foo1")).await?, Some(bytes("bar1")));
+    assert_eq!(tree.get(&bytes("foo2")).await?, Some(bytes("bar2")));
+    assert_eq!(tree.get(&bytes("foo3")).await?, Some(bytes("bar3")));
+
+    let mut inverse_tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage);
+
+    inverse_tree.set(bytes("foo3"), bytes("bar3")).await?;
+    inverse_tree.set(bytes("foo2"), bytes("bar2")).await?;
+    inverse_tree.set(bytes("foo1"), bytes("bar1")).await?;
+
+    assert_eq!(
+        tree.hash(),
+        inverse_tree.hash(),
+        "alternate insertion order results in same hash"
+    );
+    Ok(())
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn create_tree_from_set() -> Result<()> {
+    let iter_storage = Arc::new(Mutex::new(Storage {
+        backend: MemoryStorageBackend::default(),
+        encoder: BasicEncoder,
+    }));
+    let collection_storage = Arc::new(Mutex::new(Storage {
+        backend: MemoryStorageBackend::default(),
+        encoder: BasicEncoder,
+    }));
+    let mut iter_tree =
+        Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(iter_storage.clone());
+    let mut collection = BTreeMap::default();
+
+    for i in 0..=255 {
+        let key = vec![i];
+        let value = vec![255 - i];
+        collection.insert(key.clone(), value.clone());
+        iter_tree.set(key, value).await?;
+    }
+    let collection_tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::from_collection(
+        collection,
+        collection_storage,
+    )
+    .await?;
+
+    for i in 0..=255 {
+        let key = vec![i];
+        let value = vec![255 - i];
+        assert_eq!(collection_tree.get(&key).await?, Some(value.clone()));
+        assert_eq!(iter_tree.get(&key).await?, Some(value));
+    }
+
+    assert!(iter_tree.hash().is_some());
+    assert_eq!(
+        iter_tree.hash(),
+        collection_tree.hash(),
+        "arrives at same root hash"
+    );
+    Ok(())
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn larger_random_tree() -> Result<()> {
+    use rand::{Rng, rng};
+
+    fn random() -> Vec<u8> {
+        let mut buffer = [0u8; 32];
+        rng().fill(&mut buffer[..]);
+        buffer.to_vec()
+    }
+
+    let mut ledger = vec![];
+    let storage = Storage {
+        backend: MemoryStorageBackend::default(),
+        encoder: BasicEncoder,
+    };
+    let mut tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage);
+    for _ in 1..1024 {
+        let key_value = (random(), random());
+        ledger.push(key_value.clone());
+        tree.set(key_value.0, key_value.1).await?;
+    }
+
+    for entry in ledger {
+        assert_eq!(tree.get(&entry.0).await?, Some(entry.1));
+    }
+    Ok(())
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn restores_tree_from_hash() -> Result<()> {
+    let storage = Arc::new(Mutex::new(Storage {
+        backend: MemoryStorageBackend::default(),
+        encoder: BasicEncoder,
+    }));
+    let mut tree = Tree::<32, 32, GeometricDistribution, _, _, _, _>::new(storage.clone());
+
+    tree.set(bytes("foo1"), bytes("bar1")).await?;
+    tree.set(bytes("foo2"), bytes("bar2")).await?;
+    tree.set(bytes("foo3"), bytes("bar3")).await?;
+
+    let root_hash = tree.hash().unwrap().to_owned();
+
+    let tree =
+        Tree::<32, 32, GeometricDistribution, _, _, _, _>::from_hash(&root_hash, storage).await?;
+
+    assert_eq!(tree.get(&bytes("foo1")).await?, Some(bytes("bar1")));
+    assert_eq!(tree.get(&bytes("foo2")).await?, Some(bytes("bar2")));
+    assert_eq!(tree.get(&bytes("foo3")).await?, Some(bytes("bar3")));
+
+    Ok(())
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn lru_store_caches() -> Result<()> {
+    let backend = MemoryStorageBackend::default();
+    let root_hash = {
+        let storage = Storage {
+            backend: backend.clone(),
+            encoder: BasicEncoder,
+        };
+        let mut collection = BTreeMap::default();
+        for i in 0..1024u32 {
+            let key = i.to_be_bytes().to_vec();
+            let value = <[u8; 32] as From<blake3::Hash>>::from(blake3::hash(&key)).to_vec();
+            collection.insert(key, value);
+        }
+        let tree =
+            Tree::<32, 32, GeometricDistribution, _, _, _, _>::from_collection(collection, storage)
+                .await?;
+        tree.hash().unwrap().to_owned()
+    };
+
+    let tracking = Arc::new(Mutex::new(MeasuredStorageBackend::new(backend)));
+    let lru = CachedStorageBackend::new(tracking.clone(), 10)?;
+    let storage = Storage {
+        backend: lru,
+        encoder: BasicEncoder,
+    };
+    let mut tree =
+        Tree::<32, 32, GeometricDistribution, _, _, _, _>::from_hash(&root_hash, storage).await?;
+
+    {
+        let tracking = tracking.lock().await;
+
+        assert_eq!(tracking.writes(), 0);
+        assert_eq!(tracking.reads(), 1); // read root hash
+    }
+
+    let key = 1023u32.to_be_bytes().to_vec();
+    let _ = tree.get(&key).await?;
+
+    {
+        let tracking = tracking.lock().await;
+        assert_eq!(tracking.writes(), 0);
+        assert_eq!(tracking.reads(), 3);
+    }
+
+    let _ = tree.get(&key).await?;
+
+    {
+        let tracking = tracking.lock().await;
+        assert_eq!(tracking.writes(), 0);
+        assert_eq!(tracking.reads(), 3); // reads cached
+    }
+
+    let _ = tree.set(key.to_vec(), vec![1]).await?;
+
+    let tracking = tracking.lock().await;
+    assert_eq!(tracking.writes(), 3); // 3 writes on insertion
+    assert_eq!(tracking.reads(), 3); // reads cached
+
+    Ok(())
+}

--- a/rust/x-query/Cargo.toml
+++ b/rust/x-query/Cargo.toml
@@ -19,6 +19,8 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 ulid = { workspace = true }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/rust/x-query/src/fact/store.rs
+++ b/rust/x-query/src/fact/store.rs
@@ -34,8 +34,8 @@ pub trait TripleStoreMut: TripleStore {
         value: V,
     ) -> Result<PrimaryKey, std::io::Error>
     where
-        A: Clone + ConditionalSend,
-        V: ConditionalSend,
+        A: Clone + Send,
+        V: Send,
         Attribute: From<A>,
         Value: From<V>,
     {
@@ -56,24 +56,22 @@ pub trait TripleStorePull: TripleStore {
     fn entities_with_attribute(
         &self,
         fragment: KeyPart,
-    ) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + ConditionalSend;
+    ) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + Send;
 
     /// Returns a stream that yields all entities that have a given value
     fn entities_with_value(
         &self,
         fragment: KeyPart,
-    ) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + ConditionalSend;
+    ) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + Send;
 
     /// Returns a stream that yields all attributes associated with a given entity
     fn attributes_of_entity(
         &self,
         fragment: KeyPart,
-    ) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + ConditionalSend;
+    ) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + Send;
 
     /// Returns a stream that yields all unique keys in the store
-    fn keys(
-        &self,
-    ) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + ConditionalSend;
+    fn keys(&self) -> impl TryStream<Item = Result<PrimaryKey, XQueryError>> + 'static + Send;
 }
 
 pub trait TripleStorePush: TripleStore {

--- a/rust/x-query/src/query/match.rs
+++ b/rust/x-query/src/query/match.rs
@@ -115,6 +115,11 @@ mod tests {
 
     use super::match_single;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_makes_a_literal_match() -> Result<()> {

--- a/rust/x-query/src/query/pull.rs
+++ b/rust/x-query/src/query/pull.rs
@@ -16,14 +16,14 @@ pub use rule::*;
 pub trait PullQuery: Query {
     fn stream<S, F>(self, store: S, frames: F) -> impl FrameStream
     where
-        S: TripleStorePull + 'static,
+        S: TripleStorePull + Send + 'static,
         F: FrameStream + 'static;
 }
 
 impl PullQuery for Pattern {
     fn stream<S, F>(self, store: S, frames: F) -> impl FrameStream
     where
-        S: TripleStorePull + 'static,
+        S: TripleStorePull + Send + 'static,
         F: FrameStream + 'static,
     {
         try_stream! {
@@ -50,6 +50,11 @@ mod tests {
     };
     use anyhow::Result;
     use futures_util::{TryStreamExt, stream};
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]

--- a/rust/x-query/src/query/pull/compound.rs
+++ b/rust/x-query/src/query/pull/compound.rs
@@ -30,12 +30,12 @@ where
 
 impl<L, R> PullQuery for And<L, R>
 where
-    L: PullQuery + 'static,
-    R: PullQuery + 'static,
+    L: PullQuery + Send + 'static,
+    R: PullQuery + Send + 'static,
 {
     fn stream<S, F>(self, store: S, frames: F) -> impl FrameStream
     where
-        S: TripleStorePull + 'static,
+        S: TripleStorePull + Send + 'static,
         F: FrameStream + 'static,
     {
         try_stream! {
@@ -76,12 +76,12 @@ where
 
 impl<L, R> PullQuery for Or<L, R>
 where
-    L: PullQuery + 'static,
-    R: PullQuery + 'static,
+    L: PullQuery + Send + 'static,
+    R: PullQuery + Send + 'static,
 {
     fn stream<S, F>(self, store: S, frames: F) -> impl FrameStream
     where
-        S: TripleStorePull + 'static,
+        S: TripleStorePull + Send + 'static,
         F: FrameStream + 'static,
     {
         try_stream! {
@@ -122,11 +122,11 @@ where
 
 impl<Q> PullQuery for Not<Q>
 where
-    Q: PullQuery + 'static,
+    Q: PullQuery + Send + 'static,
 {
     fn stream<S, F>(self, store: S, frames: F) -> impl FrameStream
     where
-        S: TripleStorePull + 'static,
+        S: TripleStorePull + Send + 'static,
         F: FrameStream + 'static,
     {
         try_stream! {

--- a/rust/x-query/src/query/pull/key.rs
+++ b/rust/x-query/src/query/pull/key.rs
@@ -4,7 +4,7 @@ use crate::{KeyPart, KeyStream, MatchableTerm, Pattern, TripleStorePull};
 
 pub fn key_stream<T>(store: T, pattern: &Pattern) -> impl KeyStream
 where
-    T: TripleStorePull + 'static,
+    T: TripleStorePull + Send + 'static,
 {
     let pattern = pattern.clone();
 

--- a/rust/x-query/src/query/pull/rule.rs
+++ b/rust/x-query/src/query/pull/rule.rs
@@ -47,6 +47,11 @@ mod tests {
     use anyhow::Result;
     use futures_util::{TryStreamExt, stream};
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_define_a_rule_and_use_it_in_a_query() -> Result<()> {

--- a/rust/x-storage/Cargo.toml
+++ b/rust/x-storage/Cargo.toml
@@ -5,15 +5,20 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[features]
+helpers = ["tempfile", "anyhow"]
+
 [dependencies]
 x-common = { workspace = true }
 
+anyhow = { workspace = true, optional = true }
 async-trait = { workspace = true }
 sieve-cache = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tempfile = { workspace = true, optional = true }
 base58 = { workspace = true }
 tokio = { workspace = true, features = ["sync", "fs"] }
 

--- a/rust/x-storage/src/hash.rs
+++ b/rust/x-storage/src/hash.rs
@@ -14,7 +14,7 @@ where
 {
     fn bytes(&self) -> [u8; SIZE] {
         let mut bytes = [0u8; SIZE];
-        bytes.copy_from_slice(self.as_ref());
+        bytes.copy_from_slice(&self.as_ref()[..SIZE.min(self.as_ref().len())]);
         bytes
     }
 }

--- a/rust/x-storage/src/helpers.rs
+++ b/rust/x-storage/src/helpers.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::FileSystemStorageBackend;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use crate::IndexedDbStorageBackend;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type MakeTargetStorageOutput<K> = (IndexedDbStorageBackend<K, Vec<u8>>, ());
+#[cfg(not(target_arch = "wasm32"))]
+type MakeTargetStorageOutput<K> = (FileSystemStorageBackend<K, Vec<u8>>, tempfile::TempDir);
+
+/// Creates a platform-specific persisted [`StorageBackend`], for use in tests
+pub async fn make_target_storage<K>() -> Result<MakeTargetStorageOutput<K>>
+where
+    K: AsRef<[u8]>,
+{
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    return Ok((
+        IndexedDbStorageBackend::<K, Vec<u8>>::new("test_db", "test_store").await?,
+        (),
+    ));
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let root = tempfile::tempdir()?;
+        let storage = FileSystemStorageBackend::<K, Vec<u8>>::new(root.path()).await?;
+        Ok((storage, root))
+    }
+}

--- a/rust/x-storage/src/lib.rs
+++ b/rust/x-storage/src/lib.rs
@@ -30,3 +30,8 @@ pub use storage::*;
 
 mod hash;
 pub use hash::*;
+
+#[cfg(any(test, feature = "helpers"))]
+mod helpers;
+#[cfg(any(test, feature = "helpers"))]
+pub use helpers::*;

--- a/rust/x-storage/src/storage/backend.rs
+++ b/rust/x-storage/src/storage/backend.rs
@@ -65,41 +65,15 @@ mod tests {
     use anyhow::Result;
     use tokio::sync::Mutex;
 
-    use crate::{CachedStorageBackend, MeasuredStorageBackend, StorageBackend};
-
-    #[cfg(not(target_arch = "wasm32"))]
-    use crate::FileSystemStorageBackend;
-
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    use crate::IndexedDbStorageBackend;
+    use crate::{
+        CachedStorageBackend, MeasuredStorageBackend, StorageBackend, make_target_storage,
+    };
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    type MakeTargetStorageOutput = (IndexedDbStorageBackend<Vec<u8>, Vec<u8>>, ());
-    #[cfg(not(target_arch = "wasm32"))]
-    type MakeTargetStorageOutput = (
-        FileSystemStorageBackend<Vec<u8>, Vec<u8>>,
-        tempfile::TempDir,
-    );
-
-    async fn make_target_storage() -> Result<MakeTargetStorageOutput> {
-        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-        return Ok((
-            IndexedDbStorageBackend::<Vec<u8>, Vec<u8>>::new("test_db", "test_store").await?,
-            (),
-        ));
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let root = tempfile::tempdir()?;
-            let storage = FileSystemStorageBackend::<Vec<u8>, Vec<u8>>::new(root.path()).await?;
-            Ok((storage, root))
-        }
-    }
 
     #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]

--- a/rust/x-storage/src/storage/backend/fs.rs
+++ b/rust/x-storage/src/storage/backend/fs.rs
@@ -28,7 +28,8 @@ where
     Key: AsRef<[u8]>,
     Value: AsRef<[u8]> + From<Vec<u8>>,
 {
-    /// Creates a new [`FileSystemStore`] stored in `root_dir`.
+    /// Creates a new [`FileSystemStorageBackend`] that stores files in
+    /// `root_dir`.
     pub async fn new<Pathlike>(root_dir: Pathlike) -> Result<Self, XStorageError>
     where
         Pathlike: AsRef<Path>,

--- a/rust/x-storage/src/storage/backend/memory.rs
+++ b/rust/x-storage/src/storage/backend/memory.rs
@@ -10,7 +10,7 @@ use super::StorageBackend;
 
 /// A trivial implementation of [StorageBackend] - backed by a [HashMap] - where
 /// all values are kept in memory and never persisted.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct MemoryStorageBackend<Key, Value>
 where
     Key: Eq + std::hash::Hash,


### PR DESCRIPTION
This change ports over the `ranked-prolly-tree` crate originally designed and implemented by @jsantell . Largely the design remains the same. The following substantive changes were made:

- `Tree` and `Node` make use of the refactored `x-storage` constructs
- `Tree` and `Node` are generic over their `Distribution`; `GeometricDistribution` is the only implementation, but others may be added in the future
- Some domain concepts are renamed (e.g., `NodeRef` -> `Reference`, `Adoptable` -> `Adopter`)
- Additional documentation and tests have been added

In addition to the port, the `x-query` crate has been revised to work under the `wasm32-unknown-unknown` target. All tests across the workspace now run and pass under both native and `wasm32-unknown-unknown` targets.