### PR TITLE
feat: Optimized bulk storage transfer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "rust-analyzer.cargo.target": null,
+    "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
     "rust-analyzer.procMacro.ignored": {
         "async-trait": [
             "async_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,10 +212,12 @@ name = "dialog-storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "base58",
  "blake3",
  "dialog-common",
+ "futures-util",
  "getrandom",
  "js-sys",
  "rexie",

--- a/rust/dialog-artifacts/src/state.rs
+++ b/rust/dialog-artifacts/src/state.rs
@@ -5,16 +5,16 @@ use crate::DialogArtifactsError;
 #[cfg(doc)]
 use crate::{Artifact, ArtifactStore};
 
-/// A [`State`] represents the presence or absence of a [`Artifact`] within a
+/// A [`State`] represents the presence or absence of an [`Artifact`] within a
 /// [`ArtifactStore`]
 #[derive(Clone, Debug)]
 pub enum State<Datum>
 where
     Datum: ValueType,
 {
-    /// A [`Artifact`] that has been asserted
+    /// An [`Artifact`] that has been asserted
     Added(Datum),
-    /// A [`Artifact`] that has been retracted
+    /// An [`Artifact`] that has been retracted
     Removed,
 }
 

--- a/rust/dialog-storage/Cargo.toml
+++ b/rust/dialog-storage/Cargo.toml
@@ -12,7 +12,9 @@ helpers = ["tempfile", "anyhow"]
 dialog-common = { workspace = true }
 
 anyhow = { workspace = true, optional = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
+futures-util = { workspace = true }
 sieve-cache = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/rust/dialog-storage/src/storage.rs
+++ b/rust/dialog-storage/src/storage.rs
@@ -10,6 +10,9 @@ pub use cache::*;
 mod measure;
 pub use measure::*;
 
+mod transfer;
+pub use transfer::*;
+
 mod content_addressed;
 pub use content_addressed::*;
 

--- a/rust/dialog-storage/src/storage/backend/memory.rs
+++ b/rust/dialog-storage/src/storage/backend/memory.rs
@@ -1,10 +1,12 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, ops::DerefMut, sync::Arc};
 
+use async_stream::try_stream;
 use async_trait::async_trait;
-use dialog_common::{ConditionalSend, ConditionalSync};
-use tokio::sync::Mutex;
+use dialog_common::ConditionalSync;
+use futures_util::Stream;
+use tokio::sync::RwLock;
 
-use crate::DialogStorageError;
+use crate::{DialogStorageError, StorageSource};
 
 use super::StorageBackend;
 
@@ -16,7 +18,7 @@ where
     Key: Eq + std::hash::Hash,
     Value: Clone,
 {
-    entries: Arc<Mutex<HashMap<Key, Value>>>,
+    entries: Arc<RwLock<HashMap<Key, Value>>>,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -24,19 +26,64 @@ where
 impl<Key, Value> StorageBackend for MemoryStorageBackend<Key, Value>
 where
     Key: Clone + Eq + std::hash::Hash + ConditionalSync,
-    Value: Clone + ConditionalSend,
+    Value: Clone + ConditionalSync,
 {
     type Key = Key;
     type Value = Value;
     type Error = DialogStorageError;
 
     async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
-        let mut entries = self.entries.lock().await;
+        let mut entries = self.entries.write().await;
         entries.insert(key, value);
         Ok(())
     }
     async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
-        let entries = self.entries.lock().await;
+        let entries = self.entries.read().await;
         Ok(entries.get(key).cloned())
+    }
+}
+
+impl<Key, Value> StorageSource for MemoryStorageBackend<Key, Value>
+where
+    Key: Clone + Eq + std::hash::Hash + ConditionalSync,
+    Value: Clone + ConditionalSync,
+{
+    fn read(
+        &self,
+    ) -> impl Stream<
+        Item = Result<
+            (
+                <Self as StorageBackend>::Key,
+                <Self as StorageBackend>::Value,
+            ),
+            <Self as StorageBackend>::Error,
+        >,
+    > {
+        try_stream! {
+            let entries = self.entries.read().await;
+            for (key, value) in entries.iter() {
+                yield (key.clone(), value.clone());
+            }
+        }
+    }
+
+    fn drain(
+        &mut self,
+    ) -> impl Stream<
+        Item = Result<
+            (
+                <Self as StorageBackend>::Key,
+                <Self as StorageBackend>::Value,
+            ),
+            <Self as StorageBackend>::Error,
+        >,
+    > {
+        try_stream! {
+            let entries = std::mem::take(self.entries.write().await.deref_mut());
+
+            for (key, value) in entries.into_iter() {
+                yield (key, value);
+            }
+        }
     }
 }

--- a/rust/dialog-storage/src/storage/transfer.rs
+++ b/rust/dialog-storage/src/storage/transfer.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+use dialog_common::ConditionalSend;
+use futures_util::Stream;
+
+use crate::StorageBackend;
+
+/// A trait that may be implemented by any [`StorageBackend`] that has the
+/// ability to efficiently stream its contents in their entirely (as compared to
+/// reading keys individually).
+pub trait StorageSource: StorageBackend {
+    /// Stream a copy of the contents of the [`StorageBackend`]
+    fn read(
+        &self,
+    ) -> impl Stream<
+        Item = Result<
+            (
+                <Self as StorageBackend>::Key,
+                <Self as StorageBackend>::Value,
+            ),
+            <Self as StorageBackend>::Error,
+        >,
+    >;
+
+    /// Stream the contents of the [`StorageBackend`], removing it from the
+    /// [`StorageSource`] by the time that the [`Stream`] is fully consumed.
+    fn drain(
+        &mut self,
+    ) -> impl Stream<
+        Item = Result<
+            (
+                <Self as StorageBackend>::Key,
+                <Self as StorageBackend>::Value,
+            ),
+            <Self as StorageBackend>::Error,
+        >,
+    >;
+}
+
+/// A trait that may be implemented by any [`StorageBackend`] that has the
+/// ability to efficiently persist contents when provided in bulk (as compared
+/// to writing entries individually).
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait StorageSink: StorageBackend {
+    /// Consume a [`Stream`] of entries, persisting them to the
+    /// [`StorageBackend`]
+    async fn write<EntryStream>(
+        &mut self,
+        stream: EntryStream,
+    ) -> Result<(), <Self as StorageBackend>::Error>
+    where
+        EntryStream: Stream<
+                Item = Result<
+                    (
+                        <Self as StorageBackend>::Key,
+                        <Self as StorageBackend>::Value,
+                    ),
+                    <Self as StorageBackend>::Error,
+                >,
+            > + ConditionalSend;
+}


### PR DESCRIPTION
This change implements an extension for `StorageBackend`s that enables relatively efficient bulk transfer from some places to other places.

This capability is a precursor to work on the WAL. The idea is that before the WAL changes are considered persisted, we write to a layer of storage in memory that is an overlay of the actual persisted storage. Then, when we persist the transaction, we take the fast path to drain the in-memory part of the storage into persisted storage.

This has the added benefit of making most writes seem to take as long as writing to `MemoryStorageBackend` without delaying reads. Persistence can happen in the background.