### PR TITLE
fix: Enable re-entrant selection of artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
-      - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/setup-nix
       - name: 'Run lints'
         shell: bash

--- a/flake.nix
+++ b/flake.nix
@@ -233,6 +233,7 @@
             cp -r ${dialog-experimental}/@dialog-db/experimental $out/@dialog-db
           '';
         };
+
       in
       {
         devShells = {

--- a/typescript/dialog-artifacts-web-tests/bindings.test.ts
+++ b/typescript/dialog-artifacts-web-tests/bindings.test.ts
@@ -1,5 +1,5 @@
 import init, { Artifacts, generateEntity, encode, Entity, InstructionType, ValueDataType, Artifact, ArtifactApi } from "./dialog-artifacts";
-import { expect } from "@open-wc/testing";
+import { assert, expect } from "@open-wc/testing";
 
 await init();
 
@@ -210,5 +210,52 @@ describe('artifacts', () => {
         }
 
         expect(count).to.be.eq(10);
+
+        for await (const _artifact of query) {
+            for await (const _artifact of query) {
+                count++;
+            }
+        }
+
+        expect(count).to.be.eql(35);
+
+        const otherQuery = artifacts.select({
+            is: {
+                type: ValueDataType.String,
+                value: "Acid Burn"
+            }
+        });
+
+        for await (const _artifact of query) {
+            for await (const _artifact of otherQuery) {
+                count++;
+            }
+        }
+
+        expect(count).to.be.eql(40);
     });
+
+    it('pins an iterator at the version where iteration began', async () => {
+        let artifacts = await Artifacts.open("test");
+        let entityMap = await populateWithHackers(artifacts);
+
+        let query = artifacts.select({
+            the: "profile/name"
+        });
+
+        let count = 0;
+
+        for await (const artifact of query) {
+            await populateWithHackers(artifacts);
+
+            let expectedHandle = entityMap.get(encode(artifact.of))?.name;
+            expect(expectedHandle).to.be.ok;
+            expect(artifact.is.value).to.be.eq(expectedHandle!)
+
+            count++;
+        }
+
+        expect(count).to.be.eql(5);
+    });
+
 });

--- a/typescript/dialog-artifacts-web-tests/web-test-runner.config.mjs
+++ b/typescript/dialog-artifacts-web-tests/web-test-runner.config.mjs
@@ -2,5 +2,11 @@ import { esbuildPlugin } from '@web/dev-server-esbuild';
 
 export default {
     plugins: [esbuildPlugin({ ts: true })],
-    testsFinishTimeout: 10000
+    testsFinishTimeout: 10000,
+    testFramework: {
+        config: {
+            ui: 'bdd',
+            timeout: '10000',
+        },
+    },
 };


### PR DESCRIPTION
This fixes an issue I ran into where certain access patterns would result in a deadlock.