### PR TITLE
feat: Universal index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -70,22 +70,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -157,7 +157,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -253,9 +253,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "shlex",
 ]
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -724,12 +724,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -899,9 +899,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -992,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64",
  "bytes",
@@ -1008,7 +1008,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1149,15 +1149,26 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1226,9 +1237,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1397,7 +1408,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1454,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1474,7 +1485,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1490,7 +1501,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1511,7 +1522,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1527,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1544,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -1613,18 +1624,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
@@ -1685,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1719,22 +1730,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring",
@@ -1756,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1767,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1850,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1918,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -1936,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1954,6 +1965,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2014,9 +2035,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2052,7 +2073,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -2133,18 +2154,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2483,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2522,12 +2545,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2536,7 +2565,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2545,14 +2583,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2562,10 +2617,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2574,10 +2641,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2586,10 +2665,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2598,10 +2689,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -2644,18 +2747,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2702,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -52,8 +52,9 @@ use futures_util::TryStreamExt;
 use async_stream::stream;
 
 use crate::{
-    AttributeKey, BRANCH_FACTOR, DialogArtifactsError, EntityKey, FromKey, HASH_SIZE, KeyView,
-    State, ValueKey, artifacts::selector::Constrained, make_reference,
+    AttributeKey, BRANCH_FACTOR, DialogArtifactsError, EntityKey, FromKey, HASH_SIZE, Key, KeyView,
+    KeyViewConstruct, KeyViewMut, State, ValueKey, artifacts::selector::Constrained,
+    make_reference,
 };
 
 /// An alias type that describes the [`Tree`]-based prolly tree that is
@@ -89,9 +90,7 @@ where
 {
     identifier: String,
     storage: Storage<HASH_SIZE, CborEncoder, Backend>,
-    entity_index: Arc<RwLock<Index<EntityKey, Datum, Backend>>>,
-    attribute_index: Arc<RwLock<Index<AttributeKey, Datum, Backend>>>,
-    value_index: Arc<RwLock<Index<ValueKey, Datum, Backend>>>,
+    index: Arc<RwLock<Index<Key, Datum, Backend>>>,
 }
 
 impl<Backend> Artifacts<Backend>
@@ -102,8 +101,8 @@ where
 {
     #[cfg(feature = "debug")]
     /// Get a reference-counted pointer to the internal entity index of the [`Artifacts`]
-    pub fn entity_index(&self) -> Arc<RwLock<Index<EntityKey, Datum, Backend>>> {
-        self.entity_index.clone()
+    pub fn index(&self) -> Arc<RwLock<Index<Key, Datum, Backend>>> {
+        self.index.clone()
     }
 
     /// The name used to uniquely identify the data of this [`Artifacts`]
@@ -122,7 +121,7 @@ where
         // TODO: We probably want to enforce some namespacing within storage so
         // that generic K/V storage can go e.g., in a different IDB store or a
         // different folder on the FS
-        let (entity_index, attribute_index, value_index) = {
+        let index = {
             let revision_block = storage.get(&make_reference(identifier.as_bytes())).await?;
             let revision = if let Some(revision_hash_bytes) = revision_block {
                 // Check if the revision is NULL_REVISION_HASH
@@ -144,26 +143,16 @@ where
             };
 
             if let Some(revision) = revision {
-                tokio::try_join!(
-                    Tree::from_hash(revision.entity_index(), storage.clone()),
-                    Tree::from_hash(revision.attribute_index(), storage.clone()),
-                    Tree::from_hash(revision.value_index(), storage.clone())
-                )?
+                Tree::from_hash(revision.index(), storage.clone()).await?
             } else {
-                (
-                    Tree::new(storage.clone()),
-                    Tree::new(storage.clone()),
-                    Tree::new(storage.clone()),
-                )
+                Tree::new(storage.clone())
             }
         };
 
         Ok(Self {
             identifier,
             storage,
-            entity_index: Arc::new(RwLock::new(entity_index)),
-            attribute_index: Arc::new(RwLock::new(attribute_index)),
-            value_index: Arc::new(RwLock::new(value_index)),
+            index: Arc::new(RwLock::new(index)),
         })
     }
 
@@ -189,10 +178,14 @@ where
     where
         Write: tokio::io::AsyncWrite + Unpin,
     {
+        use crate::{EntityKey, KeyViewConstruct};
+
         let mut csv = csv_async::AsyncSerializer::from_writer(write);
 
-        let entity_index = self.entity_index.read().await;
-        let entity_stream = entity_index.stream();
+        let index = self.index.read().await;
+        let range = <EntityKey<Key> as KeyViewConstruct>::min().0
+            ..<EntityKey<Key> as KeyViewConstruct>::max().0;
+        let entity_stream = index.stream_range(range);
 
         tokio::pin!(entity_stream);
 
@@ -243,30 +236,12 @@ where
 
     /// Get the hash that represents the [`ArtifactStore`] at its current version.
     pub async fn revision(&self) -> Result<Blake3Hash, DialogArtifactsError> {
-        let (entity_index, attribute_index, value_index) = tokio::join!(
-            self.entity_index.read(),
-            self.attribute_index.read(),
-            self.value_index.read()
-        );
+        let index = self.index.read().await;
 
-        Ok(
-            match (
-                entity_index.hash(),
-                attribute_index.hash(),
-                value_index.hash(),
-            ) {
-                (Some(entity_version), Some(attribute_version), Some(value_version)) => {
-                    Revision::from((
-                        entity_version.to_owned(),
-                        attribute_version.to_owned(),
-                        value_version.to_owned(),
-                    ))
-                    .as_reference()
-                    .await?
-                }
-                _ => NULL_REVISION_HASH,
-            },
-        )
+        Ok(match index.hash() {
+            Some(index_version) => Revision::new(index_version).as_reference().await?,
+            _ => NULL_REVISION_HASH,
+        })
     }
 
     /// Reset the root of the database to `revision_hash` if provided, or else reset
@@ -308,11 +283,11 @@ where
         };
 
         // Now get hashes for the indexes.
-        let (entity_version, attribute_version, value_version) =
+        let index_version =
             // The null revision does not actually exists it just represents
             // empty indexes so we set all versions to None's.
             if required_hash == NULL_REVISION_HASH {
-                (None, None, None)
+                None
             } else {
                 // Otherwise we hydrate revision info from the store.
                 let revision = self
@@ -325,11 +300,8 @@ where
                             required_hash.to_base58()
                         ))
                     })?;
-                (
-                    Some(revision.entity_index().to_owned()),
-                    Some(revision.attribute_index().to_owned()),
-                    Some(revision.value_index().to_owned()),
-                )
+
+                Some(revision.index().to_owned())
             };
 
         // Update storage to point to the revision hash only if it was
@@ -344,17 +316,9 @@ where
                 .await?;
         }
 
-        // Finally update all the indexes
-        let (mut entity_index, mut attribute_index, mut value_index) = tokio::join!(
-            self.entity_index.write(),
-            self.attribute_index.write(),
-            self.value_index.write()
-        );
-        tokio::try_join!(
-            entity_index.set_hash(entity_version),
-            attribute_index.set_hash(attribute_version),
-            value_index.set_hash(value_version),
-        )?;
+        // Finally update the index
+        let mut index = self.index.write().await;
+        index.set_hash(index_version).await?;
 
         Ok(())
     }
@@ -373,21 +337,17 @@ where
         selector: ArtifactSelector<Constrained>,
     ) -> impl Stream<Item = Result<Artifact, DialogArtifactsError>> + 'static + ConditionalSend
     {
-        let entity_index = self.entity_index.clone();
-        let attribute_index = self.attribute_index.clone();
-        let value_index = self.value_index.clone();
+        let index = self.index.clone();
 
         try_stream! {
             // We clone to "pin" the indexes at a version for the lifetime of the stream
-            let entity_index = entity_index.read().await.clone();
-            let attribute_index = attribute_index.read().await.clone();
-            let value_index = value_index.read().await.clone();
+            let index = index.read().await.clone();
 
             if selector.entity().is_some() {
-                let start = <EntityKey as KeyView>::min().apply_selector(&selector);
-                let end = <EntityKey as KeyView>::max().apply_selector(&selector);
+                let start = <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
+                let end = <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
 
-                let stream = entity_index.stream_range(Range { start, end });
+                let stream = index.stream_range(Range { start, end });
 
                 tokio::pin!(stream);
 
@@ -401,10 +361,10 @@ where
                     }
                 }
             } else if selector.value().is_some() {
-                let start = <ValueKey as KeyView>::min().apply_selector(&selector);
-                let end = <ValueKey as KeyView>::max().apply_selector(&selector);
+                let start = <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
+                let end = <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
 
-                let stream = value_index.stream_range(Range { start, end });
+                let stream = index.stream_range(Range { start, end });
 
                 tokio::pin!(stream);
 
@@ -418,10 +378,10 @@ where
                     }
                 }
             } else if selector.attribute().is_some() {
-                let start = <AttributeKey as KeyView>::min().apply_selector(&selector);
-                let end = <AttributeKey as KeyView>::max().apply_selector(&selector);
+                let start = <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
+                let end = <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
 
-                let stream = attribute_index.stream_range(Range { start, end });
+                let stream = index.stream_range(Range { start, end });
 
                 tokio::pin!(stream);
 
@@ -459,11 +419,7 @@ where
         let base_revision = self.revision().await?;
 
         let transaction_result = async {
-            let (mut entity_index, mut attribute_index, mut value_index) = tokio::join!(
-                self.entity_index.write(),
-                self.attribute_index.write(),
-                self.value_index.write()
-            );
+            let mut index = self.index.write().await;
 
             tokio::pin!(instructions);
 
@@ -478,15 +434,16 @@ where
 
                         if let Some(cause) = &datum.cause {
                             let ancestor_key = {
-                                let search_start = <EntityKey as KeyView>::min()
+                                let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
                                     .set_entity(entity_key.entity())
-                                    .set_attribute(entity_key.attribute());
-                                let search_end = <EntityKey as KeyView>::max()
+                                    .set_attribute(entity_key.attribute())
+                                    .into_key();
+                                let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
                                     .set_entity(entity_key.entity())
-                                    .set_attribute(entity_key.attribute());
+                                    .set_attribute(entity_key.attribute())
+                                    .into_key();
 
-                                let search_stream =
-                                    entity_index.stream_range(search_start..search_end);
+                                let search_stream = index.stream_range(search_start..search_end);
 
                                 let mut ancestor_key = None;
 
@@ -508,45 +465,42 @@ where
                                 ancestor_key
                             };
 
-                            if let Some(entity_key) = ancestor_key {
+                            if let Some(key) = ancestor_key {
                                 // Prune the old entry from the indexes
+                                let entity_key = EntityKey(key);
                                 let value_key = ValueKey::from_key(&entity_key);
                                 let attribute_key = AttributeKey::from_key(&entity_key);
 
-                                tokio::try_join!(
-                                    value_index.delete(&value_key),
-                                    attribute_index.delete(&attribute_key),
-                                    entity_index.delete(&entity_key),
-                                )?;
+                                // TODO: Make it concurrent / parallel
+                                index.delete(&entity_key.into_key()).await?;
+                                index.delete(&value_key.into_key()).await?;
+                                index.delete(&attribute_key.into_key()).await?;
                             }
                         }
 
-                        tokio::try_join!(
-                            attribute_index.set(attribute_key, State::Added(datum.clone())),
-                            value_index.set(value_key, State::Added(datum.clone())),
-                            entity_index.set(entity_key, State::Added(datum)),
-                        )?;
+                        // TODO: Make it concurrent / parallel
+                        index
+                            .set(entity_key.into_key(), State::Added(datum.clone()))
+                            .await?;
+                        index
+                            .set(attribute_key.into_key(), State::Added(datum.clone()))
+                            .await?;
+                        index.set(value_key.into_key(), State::Added(datum)).await?;
                     }
                     Instruction::Retract(fact) => {
-                        tokio::try_join!(
-                            entity_index.set(EntityKey::from(&fact), State::Removed,),
-                            attribute_index.set(AttributeKey::from(&fact), State::Removed),
-                            value_index.set(ValueKey::from(&fact), State::Removed),
-                        )?;
+                        let entity_key = EntityKey::from(&fact);
+                        let value_key = ValueKey::from_key(&entity_key);
+                        let attribute_key = AttributeKey::from_key(&entity_key);
+
+                        // TODO: Make it concurrent / parallel
+                        index.set(entity_key.into_key(), State::Removed).await?;
+                        index.set(attribute_key.into_key(), State::Removed).await?;
+                        index.set(value_key.into_key(), State::Removed).await?;
                     }
                 }
             }
 
-            let next_revision = match (
-                entity_index.hash(),
-                attribute_index.hash(),
-                value_index.hash(),
-            ) {
-                (Some(entity_index), Some(attribute_index), Some(value_index)) => Some(
-                    Revision::from((*entity_index, *attribute_index, *value_index)),
-                ),
-                _ => None,
-            };
+            let next_revision = index.hash().map(Revision::new);
 
             let revision_hash = if let Some(revision) = &next_revision {
                 self.storage.write(&revision).await?;
@@ -764,7 +718,7 @@ mod tests {
             )
         };
 
-        assert_eq!(net_reads, 1);
+        assert_eq!(net_reads, 2);
         assert_eq!(net_writes, 0);
 
         Ok(())
@@ -858,7 +812,7 @@ mod tests {
             )
         };
 
-        assert_eq!(net_reads, 2);
+        assert_eq!(net_reads, 4);
         assert_eq!(net_writes, 0);
 
         let fact_stream =
@@ -876,7 +830,7 @@ mod tests {
             )
         };
 
-        assert_eq!(net_reads, 9);
+        assert_eq!(net_reads, 11);
         assert_eq!(net_writes, 0);
 
         Ok(())

--- a/rust/dialog-artifacts/src/artifacts/artifact.rs
+++ b/rust/dialog-artifacts/src/artifacts/artifact.rs
@@ -1,3 +1,9 @@
+//! Artifact data structure representing semantic triples.
+//!
+//! This module defines the core [`Artifact`] type which represents a semantic triple
+//! (subject-predicate-object) in the Dialog database. Artifacts are the fundamental
+//! units of data storage and retrieval.
+
 use std::{fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Serialize};

--- a/rust/dialog-artifacts/src/artifacts/attribute.rs
+++ b/rust/dialog-artifacts/src/artifacts/attribute.rs
@@ -1,3 +1,9 @@
+//! Attribute types for semantic triple predicates.
+//!
+//! This module defines the [`Attribute`] type which represents the predicate part
+//! of semantic triples. Attributes must follow a namespace/predicate format and
+//! are limited to 64 bytes in length.
+
 use std::{fmt::Display, str::FromStr};
 
 use ::serde::{Deserialize, Serialize};
@@ -12,8 +18,10 @@ use crate::{ATTRIBUTE_LENGTH, DialogArtifactsError};
 pub struct Attribute(String, [u8; ATTRIBUTE_LENGTH]);
 
 impl Attribute {
-    /// A byte representation of this attribute in a format that is suitable for
-    /// use within a [`KeyType`].
+    /// Returns a byte representation of this attribute suitable for use within a key.
+    ///
+    /// The returned byte array is used for indexing and comparison operations
+    /// within the prolly tree structure.
     pub fn key_bytes(&self) -> &[u8; ATTRIBUTE_LENGTH] {
         &self.1
     }

--- a/rust/dialog-artifacts/src/artifacts/cause.rs
+++ b/rust/dialog-artifacts/src/artifacts/cause.rs
@@ -1,3 +1,9 @@
+//! Causal references for artifact versioning.
+//!
+//! This module defines the [`Cause`] type which represents causal relationships
+//! between artifacts, enabling proper versioning and update semantics in the
+//! triple store.
+
 use std::fmt::Display;
 
 use base58::ToBase58;

--- a/rust/dialog-artifacts/src/artifacts/data.rs
+++ b/rust/dialog-artifacts/src/artifacts/data.rs
@@ -1,3 +1,8 @@
+//! Internal data representation for storing artifacts in indexes.
+//!
+//! This module defines the [`Datum`] type which is the internal serializable
+//! representation of artifacts stored within the prolly tree indexes.
+
 use dialog_prolly_tree::ValueType;
 use dialog_storage::Blake3Hash;
 use serde::{Deserialize, Serialize};
@@ -23,7 +28,10 @@ pub struct Datum {
 }
 
 impl Datum {
-    /// The hash reference that corresponds to this [`Datum`]'s [`Value`]
+    /// Returns the hash reference that corresponds to this [`Datum`]'s [`Value`].
+    ///
+    /// This hash is used for indexing by value and enables efficient value-based
+    /// queries in the triple store.
     pub fn value_reference(&self) -> Blake3Hash {
         // TODO: Cache this
         make_reference(&self.value)

--- a/rust/dialog-artifacts/src/artifacts/entity.rs
+++ b/rust/dialog-artifacts/src/artifacts/entity.rs
@@ -1,3 +1,9 @@
+//! Entity types for semantic triple subjects.
+//!
+//! This module defines the [`Entity`] type which represents the subject part of
+//! semantic triples. Entities are based on URIs and provide unique identification
+//! for objects in the triple store.
+
 use std::{fmt::Display, ops::Deref, str::FromStr};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -10,6 +16,7 @@ use crate::{DialogArtifactsError, ENTITY_LENGTH, Uri};
 #[serde(into = "String", try_from = "String")]
 pub struct Entity(Uri, [u8; ENTITY_LENGTH]);
 
+/// Serializes an entity to UTF-8 format for CSV export.
 pub(crate) fn to_utf8<S>(entity: &Entity, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -17,6 +24,7 @@ where
     entity.0.serialize(serializer)
 }
 
+/// Deserializes an entity from UTF-8 format for CSV import.
 pub(crate) fn from_utf8<'de, D>(deserializer: D) -> Result<Entity, D::Error>
 where
     D: Deserializer<'de>,

--- a/rust/dialog-artifacts/src/artifacts/instruction.rs
+++ b/rust/dialog-artifacts/src/artifacts/instruction.rs
@@ -1,3 +1,8 @@
+//! Instructions for modifying artifacts in the store.
+//!
+//! This module defines the [`Instruction`] enum which represents operations
+//! that can be applied to artifacts during commit transactions.
+
 use crate::Artifact;
 
 #[cfg(doc)]

--- a/rust/dialog-artifacts/src/artifacts/match.rs
+++ b/rust/dialog-artifacts/src/artifacts/match.rs
@@ -1,9 +1,49 @@
+//! Pattern matching for artifacts against selectors.
+//!
+//! This module provides functionality for matching artifacts and index entries
+//! against artifact selectors during query operations.
+
 use dialog_prolly_tree::Entry;
 
 use crate::{
-    ArtifactSelector, AttributeKey, Datum, EntityKey, KeyView, State, ValueKey,
-    artifacts::selector::Constrained,
+    ATTRIBUTE_KEY_TAG, ArtifactSelector, AttributeKey, Datum, ENTITY_KEY_TAG, EntityKey, Key,
+    KeyView, State, VALUE_KEY_TAG, ValueKey, artifacts::selector::Constrained,
 };
+
+/// Checks if a key view matches the constraints in an artifact selector.
+///
+/// This function performs the actual matching logic between selector constraints
+/// and key components (entity, attribute, value type, value reference).
+fn match_selector_and_key_view<K>(selector: &ArtifactSelector<Constrained>, key: K) -> bool
+where
+    K: KeyView,
+{
+    if let Some(entity) = selector.entity() {
+        if entity.key_bytes() != key.entity().raw() {
+            return false;
+        }
+    }
+
+    if let Some(attribute) = selector.attribute() {
+        if attribute.key_bytes() != key.attribute().raw() {
+            return false;
+        }
+    }
+
+    if let Some(value) = selector.value() {
+        if value.data_type() != key.value_type() {
+            return false;
+        }
+    }
+
+    if let Some(value_reference) = selector.value_reference() {
+        if value_reference != key.value_reference().raw() {
+            return false;
+        }
+    }
+
+    true
+}
 
 /// A trait that may be implemented by anything that is able to be matched
 /// against an [`ArtifactSelector`]. In practice, this is implemented for the
@@ -13,101 +53,13 @@ pub trait MatchCandidate {
     fn matches_selector(&self, selector: &ArtifactSelector<Constrained>) -> bool;
 }
 
-impl MatchCandidate for Entry<EntityKey, State<Datum>> {
+impl MatchCandidate for Entry<Key, State<Datum>> {
     fn matches_selector(&self, selector: &ArtifactSelector<Constrained>) -> bool {
-        if let Some(entity) = selector.entity() {
-            if entity.key_bytes() != self.key.entity().raw() {
-                return false;
-            }
+        match self.key.tag() {
+            ENTITY_KEY_TAG => match_selector_and_key_view(selector, EntityKey(&self.key)),
+            ATTRIBUTE_KEY_TAG => match_selector_and_key_view(selector, AttributeKey(&self.key)),
+            VALUE_KEY_TAG => match_selector_and_key_view(selector, ValueKey(&self.key)),
+            _ => false,
         }
-
-        if let Some(attribute) = selector.attribute() {
-            if attribute.key_bytes() != self.key.attribute().raw() {
-                return false;
-            }
-        }
-
-        if let Some(value) = selector.value() {
-            if value.data_type() != self.key.value_type() {
-                return false;
-            }
-        }
-
-        if let Some(value_reference) = selector.value_reference() {
-            // TODO: Should we support comparing `State::Removed`?
-            if let State::Added(datum) = &self.value {
-                if value_reference != &datum.value_reference() {
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-}
-
-impl MatchCandidate for Entry<AttributeKey, State<Datum>> {
-    fn matches_selector(&self, selector: &ArtifactSelector<Constrained>) -> bool {
-        if let Some(entity) = selector.entity() {
-            if entity.key_bytes() != self.key.entity().raw() {
-                return false;
-            }
-        }
-
-        if let Some(attribute) = selector.attribute() {
-            if attribute.key_bytes() != self.key.attribute().raw() {
-                return false;
-            }
-        }
-
-        if let Some(value) = selector.value() {
-            if value.data_type() != self.key.value_type() {
-                return false;
-            }
-        }
-
-        if let Some(value_reference) = selector.value_reference() {
-            // TODO: Should we support comparing `State::Removed`?
-            if let State::Added(datum) = &self.value {
-                if value_reference != &datum.value_reference() {
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-}
-
-impl MatchCandidate for Entry<ValueKey, State<Datum>> {
-    fn matches_selector(&self, selector: &ArtifactSelector<Constrained>) -> bool {
-        if let Some(entity) = selector.entity() {
-            if entity.key_bytes() != self.key.entity().raw() {
-                return false;
-            }
-        }
-
-        if let Some(attribute) = selector.attribute() {
-            if attribute.key_bytes() != self.key.attribute().raw() {
-                return false;
-            }
-        }
-
-        if let Some(value) = selector.value() {
-            if value.data_type() != self.key.value_type() {
-                return false;
-            }
-        }
-
-        if let Some(value_reference) = selector.value_reference() {
-            // TODO: Should we support comparing `State::Removed`?
-            if let State::Added(datum) = &self.value {
-                if value_reference != &datum.value_reference() {
-                    return false;
-                }
-            }
-        }
-
-        true
     }
 }

--- a/rust/dialog-artifacts/src/artifacts/match.rs
+++ b/rust/dialog-artifacts/src/artifacts/match.rs
@@ -1,7 +1,7 @@
 use dialog_prolly_tree::Entry;
 
 use crate::{
-    ArtifactSelector, AttributeKey, Datum, EntityKey, State, ValueKey,
+    ArtifactSelector, AttributeKey, Datum, EntityKey, KeyView, State, ValueKey,
     artifacts::selector::Constrained,
 };
 

--- a/rust/dialog-artifacts/src/artifacts/revision.rs
+++ b/rust/dialog-artifacts/src/artifacts/revision.rs
@@ -12,25 +12,20 @@ pub static NULL_REVISION_HASH: Blake3Hash = [0; 32];
 /// A [`Revision`] represents the root of [`Artifacts`] for a given set of data.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Revision {
-    entity_index: Blake3Hash,
-    attribute_index: Blake3Hash,
-    value_index: Blake3Hash,
+    /// The hash of the prolly tree index root for this revision
+    index: Blake3Hash,
 }
 
 impl Revision {
+    /// Creates a new revision with the given index hash.
+    pub fn new(index: &Blake3Hash) -> Self {
+        Self {
+            index: index.to_owned(),
+        }
+    }
     /// The component of the [`Revision`] that corresponds to the [`Entity`] index
-    pub fn entity_index(&self) -> &Blake3Hash {
-        &self.entity_index
-    }
-
-    /// The component of the [`Revision`] that corresponds to the [`Attribute`] index
-    pub fn attribute_index(&self) -> &Blake3Hash {
-        &self.attribute_index
-    }
-
-    /// The component of the [`Revision`] that corresponds to the [`Value`] index
-    pub fn value_index(&self) -> &Blake3Hash {
-        &self.value_index
+    pub fn index(&self) -> &Blake3Hash {
+        &self.index
     }
 
     /// Encodes the [`Revision`] as IPLD-compatible CBOR and returns the raw
@@ -43,17 +38,5 @@ impl Revision {
     /// reference to the bytes
     pub async fn as_reference(&self) -> Result<Blake3Hash, DialogArtifactsError> {
         Ok(CborEncoder.encode(self).await?.0)
-    }
-}
-
-impl From<(Blake3Hash, Blake3Hash, Blake3Hash)> for Revision {
-    fn from(
-        (entity_index, attribute_index, value_index): (Blake3Hash, Blake3Hash, Blake3Hash),
-    ) -> Self {
-        Self {
-            entity_index,
-            attribute_index,
-            value_index,
-        }
     }
 }

--- a/rust/dialog-artifacts/src/artifacts/store.rs
+++ b/rust/dialog-artifacts/src/artifacts/store.rs
@@ -1,3 +1,9 @@
+//! Traits for artifact storage and querying.
+//!
+//! This module defines the core traits that enable querying and modification
+//! of artifacts in the triple store, providing both read-only and mutable
+//! interfaces.
+
 use async_trait::async_trait;
 use dialog_common::ConditionalSend;
 use dialog_storage::Blake3Hash;

--- a/rust/dialog-artifacts/src/artifacts/value.rs
+++ b/rust/dialog-artifacts/src/artifacts/value.rs
@@ -1,3 +1,9 @@
+//! Value types for semantic triple objects.
+//!
+//! This module defines the [`Value`] enum which represents all possible value
+//! types that can be stored as the object part of semantic triples, along with
+//! type information and serialization utilities.
+
 use std::{fmt::Display, str::FromStr};
 
 use crate::{Attribute, DialogArtifactsError, Entity, make_reference};

--- a/rust/dialog-artifacts/src/key.rs
+++ b/rust/dialog-artifacts/src/key.rs
@@ -1,5 +1,12 @@
+//! Key structures for indexing artifacts in prolly trees.
+//!
+//! This module provides the key layout and manipulation utilities for creating
+//! efficient indexes over semantic triples. Keys are structured to enable fast
+//! range queries over different access patterns (by entity, attribute, or value).
+
 use std::ops::{Deref, DerefMut};
 
+use dialog_prolly_tree::KeyType;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
 
@@ -15,6 +22,10 @@ pub use value::*;
 mod part;
 pub use part::*;
 
+/// Helper macro for creating mutable slices from byte arrays at compile time.
+///
+/// This macro is used internally for efficient manipulation of key byte layouts
+/// without runtime bounds checking.
 macro_rules! mutable_slice {
     ( $array:expr, $index:expr, $run:expr ) => {{
         const START: usize = $index;
@@ -25,14 +36,20 @@ macro_rules! mutable_slice {
 
 pub(crate) use mutable_slice;
 
-use crate::{ArtifactSelector, ValueDataType, selector::Constrained};
+use crate::{ArtifactSelector, DialogArtifactsError, ValueDataType, selector::Constrained};
 
+/// Length of the key tag field in bytes
 pub(crate) const TAG_LENGTH: usize = 1;
+/// Length of the entity field in key bytes
 pub(crate) const ENTITY_LENGTH: usize = 64;
+/// Length of the attribute field in key bytes
 pub(crate) const ATTRIBUTE_LENGTH: usize = 64;
+/// Length of the value data type field in key bytes
 pub(crate) const VALUE_DATA_TYPE_LENGTH: usize = 1;
+/// Length of the value reference field in key bytes
 pub(crate) const VALUE_REFERENCE_LENGTH: usize = 32;
 
+/// Total length of a complete key in bytes
 pub(crate) const KEY_LENGTH: usize =
     TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH;
 
@@ -48,11 +65,14 @@ pub(crate) const MINIMUM_VALUE_REFERENCE: [u8; VALUE_REFERENCE_LENGTH] =
 pub(crate) const MAXIMUM_VALUE_REFERENCE: [u8; VALUE_REFERENCE_LENGTH] =
     [u8::MAX; VALUE_REFERENCE_LENGTH];
 
+/// Type alias for the raw byte representation of a key
+pub type KeyBytes = [u8; KEY_LENGTH];
+
 /// An opaque, generic [`KeyType`] that is used when constructing the subtrees
 /// of an [`Artifacts`] index.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Key(#[serde(with = "BigArray")] [u8; KEY_LENGTH]);
+pub struct Key(#[serde(with = "BigArray")] KeyBytes);
 
 impl Key {
     /// Construct the lowest possible [`EntityKey`] (all bits are zero)
@@ -65,30 +85,51 @@ impl Key {
         Self(MAXIMUM_KEY)
     }
 
+    /// Returns the tag byte that identifies the key type (entity, attribute, or value)
     pub fn tag(&self) -> u8 {
         self.0[0]
     }
 
+    /// Sets the tag byte and returns the modified key
     pub fn set_tag(mut self, tag: u8) -> Self {
         self.0[0] = tag;
         self
     }
 }
 
-impl From<[u8; KEY_LENGTH]> for Key {
-    fn from(value: [u8; KEY_LENGTH]) -> Self {
+impl KeyType for Key {
+    fn bytes(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl TryFrom<Vec<u8>> for Key {
+    type Error = DialogArtifactsError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into().map_err(|value: Vec<u8>| {
+            DialogArtifactsError::InvalidKey(format!(
+                "Wrong byte length for entity key: {}",
+                value.len()
+            ))
+        })?))
+    }
+}
+
+impl From<KeyBytes> for Key {
+    fn from(value: KeyBytes) -> Self {
         Key(value)
     }
 }
 
-impl From<Key> for [u8; KEY_LENGTH] {
+impl From<Key> for KeyBytes {
     fn from(value: Key) -> Self {
         value.0
     }
 }
 
 impl Deref for Key {
-    type Target = [u8; KEY_LENGTH];
+    type Target = KeyBytes;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -101,13 +142,29 @@ impl DerefMut for Key {
     }
 }
 
-impl AsRef<[u8]> for Key {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
+impl AsRef<KeyBytes> for Key {
+    fn as_ref(&self) -> &KeyBytes {
+        &self.0
     }
 }
 
-pub trait KeyView: Sized + Clone + Default {
+impl AsMut<KeyBytes> for Key {
+    fn as_mut(&mut self) -> &mut KeyBytes {
+        &mut self.0
+    }
+}
+
+/// Trait for constructing key views with minimum and maximum values.
+///
+/// This trait enables the creation of key views for range-based queries, providing
+/// the ability to construct keys with boundary values for efficient prolly tree navigation.
+pub trait KeyViewConstruct: KeyViewMut + Default {
+    /// Construct the lowest possible [`KeyView`] (all non-tag bits are zero)
+    fn min() -> Self;
+
+    /// Construct the highest possible [`KeyView`] (all non-tag bits are one)
+    fn max() -> Self;
+
     /// Construct a [`KeyView`] from the provided component key parts.
     fn from_parts(
         entity: EntityKeyPart,
@@ -115,38 +172,23 @@ pub trait KeyView: Sized + Clone + Default {
         value_type: ValueDataType,
         value_reference: ValueReferenceKeyPart,
     ) -> Self;
+}
 
-    /// Construct the lowest possible [`KeyView`] (all non-tag bits are zero)
-    fn min() -> Self;
-
-    /// Construct the highest possible [`KeyView`] (all non-tag bits are one)
-    fn max() -> Self;
-
-    /// Get an [`EntityKeyPart`] that refers to the [`Entity`] part of this
-    /// [`KeyView`].
-    fn entity(&self) -> EntityKeyPart;
-
+/// Trait for mutably modifying key view components.
+///
+/// This trait provides methods to modify individual parts of a key view,
+/// enabling the construction of keys with specific entity, attribute, and value constraints.
+pub trait KeyViewMut: KeyView {
     /// Set the [`EntityKeyPart`], altering the [`Entity`] part of this
     /// [`KeyView`].
     fn set_entity(self, entity: EntityKeyPart) -> Self;
-
-    /// Get an [`AttributeKeyPart`] that refers to the [`Attribute`] part of
-    /// this [`KeyView`].
-    fn attribute(&self) -> AttributeKeyPart;
 
     /// Set the [`AttributeKeyPart`], altering the [`Attribute`] part of this
     /// [`KeyView`].
     fn set_attribute(self, attribute: AttributeKeyPart) -> Self;
 
-    /// Get the [`ValueDataType`] that is represented by this [`KeyView`].
-    fn value_type(&self) -> ValueDataType;
-
     /// Set the [`ValueDataType`] that is represented by this [`KeyView`].
     fn set_value_type(self, value_type: ValueDataType) -> Self;
-
-    /// Get a [`ValueReferenceKeyPart`] that refers to the [`Value`] part of
-    /// this [`KeyView`].
-    fn value_reference(&self) -> ValueReferenceKeyPart;
 
     /// Set the [`ValueReferenceKeyPart`], altering the [`Value`] part of this
     /// [`KeyView`].
@@ -177,25 +219,56 @@ pub trait KeyView: Sized + Clone + Default {
     }
 }
 
-pub trait FromSelector: KeyView {
+/// Trait for reading components from key views.
+///
+/// This trait provides read-only access to the individual parts of a key,
+/// enabling pattern matching and component extraction during query operations.
+pub trait KeyView: Sized + Clone {
+    /// Get an [`EntityKeyPart`] that refers to the [`Entity`] part of this
+    /// [`KeyView`].
+    fn entity(&self) -> EntityKeyPart;
+
+    /// Get an [`AttributeKeyPart`] that refers to the [`Attribute`] part of
+    /// this [`KeyView`].
+    fn attribute(&self) -> AttributeKeyPart;
+
+    /// Get the [`ValueDataType`] that is represented by this [`KeyView`].
+    fn value_type(&self) -> ValueDataType;
+
+    /// Get a [`ValueReferenceKeyPart`] that refers to the [`Value`] part of
+    /// this [`KeyView`].
+    fn value_reference(&self) -> ValueReferenceKeyPart;
+}
+
+/// Trait for constructing key views from artifact selectors.
+///
+/// This trait enables the creation of key views that match the constraints
+/// specified in an artifact selector, used during query range construction.
+pub trait FromSelector: KeyViewConstruct {
+    /// Creates a key view from an artifact selector's constraints.
     fn from_selector(selector: &ArtifactSelector<Constrained>) -> Self {
         Self::default().apply_selector(selector)
     }
 }
 
-impl<K> FromSelector for K where K: KeyView {}
+impl<K> FromSelector for K where K: KeyViewConstruct {}
 
+/// Trait for constructing key views from other key views.
+///
+/// This trait enables the conversion between different key view types,
+/// allowing transformation from one index type to another during query operations.
 pub trait FromKey<K>
 where
     K: KeyView,
 {
+    /// Creates a key view from another key view.
     fn from_key(key: &K) -> Self;
 }
 
 impl<Ka, Kb> FromKey<Ka> for Kb
 where
     Ka: KeyView,
-    Kb: KeyView,
+    Kb: KeyViewConstruct,
 {
     fn from_key(key: &Ka) -> Self {
         Kb::default()

--- a/rust/dialog-artifacts/src/key.rs
+++ b/rust/dialog-artifacts/src/key.rs
@@ -1,3 +1,8 @@
+use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
+
 mod attribute;
 pub use attribute::*;
 
@@ -20,19 +25,19 @@ macro_rules! mutable_slice {
 
 pub(crate) use mutable_slice;
 
+use crate::{ArtifactSelector, ValueDataType, selector::Constrained};
+
+pub(crate) const TAG_LENGTH: usize = 1;
 pub(crate) const ENTITY_LENGTH: usize = 64;
 pub(crate) const ATTRIBUTE_LENGTH: usize = 64;
 pub(crate) const VALUE_DATA_TYPE_LENGTH: usize = 1;
 pub(crate) const VALUE_REFERENCE_LENGTH: usize = 32;
 
-pub(crate) const ENTITY_KEY_LENGTH: usize =
-    ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH;
+pub(crate) const KEY_LENGTH: usize =
+    TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH;
 
-pub(crate) const ATTRIBUTE_KEY_LENGTH: usize =
-    ATTRIBUTE_LENGTH + ENTITY_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH;
-
-pub(crate) const VALUE_KEY_LENGTH: usize =
-    VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH + ATTRIBUTE_LENGTH + ENTITY_LENGTH;
+pub(crate) const MINIMUM_KEY: [u8; KEY_LENGTH] = [u8::MIN; KEY_LENGTH];
+pub(crate) const MAXIMUM_KEY: [u8; KEY_LENGTH] = [u8::MAX; KEY_LENGTH];
 
 pub(crate) const MINIMUM_ENTITY: [u8; ENTITY_LENGTH] = [u8::MIN; ENTITY_LENGTH];
 pub(crate) const MAXIMUM_ENTITY: [u8; ENTITY_LENGTH] = [u8::MAX; ENTITY_LENGTH];
@@ -42,3 +47,181 @@ pub(crate) const MINIMUM_VALUE_REFERENCE: [u8; VALUE_REFERENCE_LENGTH] =
     [u8::MIN; VALUE_REFERENCE_LENGTH];
 pub(crate) const MAXIMUM_VALUE_REFERENCE: [u8; VALUE_REFERENCE_LENGTH] =
     [u8::MAX; VALUE_REFERENCE_LENGTH];
+
+/// An opaque, generic [`KeyType`] that is used when constructing the subtrees
+/// of an [`Artifacts`] index.
+#[repr(transparent)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Key(#[serde(with = "BigArray")] [u8; KEY_LENGTH]);
+
+impl Key {
+    /// Construct the lowest possible [`EntityKey`] (all bits are zero)
+    pub fn min() -> Self {
+        Self(MINIMUM_KEY)
+    }
+
+    /// Construct the highest possible [`EntityKey`] (all bits are one)
+    pub fn max() -> Self {
+        Self(MAXIMUM_KEY)
+    }
+
+    pub fn tag(&self) -> u8 {
+        self.0[0]
+    }
+
+    pub fn set_tag(mut self, tag: u8) -> Self {
+        self.0[0] = tag;
+        self
+    }
+}
+
+impl From<[u8; KEY_LENGTH]> for Key {
+    fn from(value: [u8; KEY_LENGTH]) -> Self {
+        Key(value)
+    }
+}
+
+impl From<Key> for [u8; KEY_LENGTH] {
+    fn from(value: Key) -> Self {
+        value.0
+    }
+}
+
+impl Deref for Key {
+    type Target = [u8; KEY_LENGTH];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Key {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for Key {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+pub trait KeyView: Sized + Clone + Default {
+    /// Construct a [`KeyView`] from the provided component key parts.
+    fn from_parts(
+        entity: EntityKeyPart,
+        attribute: AttributeKeyPart,
+        value_type: ValueDataType,
+        value_reference: ValueReferenceKeyPart,
+    ) -> Self;
+
+    /// Construct the lowest possible [`KeyView`] (all non-tag bits are zero)
+    fn min() -> Self;
+
+    /// Construct the highest possible [`KeyView`] (all non-tag bits are one)
+    fn max() -> Self;
+
+    /// Get an [`EntityKeyPart`] that refers to the [`Entity`] part of this
+    /// [`KeyView`].
+    fn entity(&self) -> EntityKeyPart;
+
+    /// Set the [`EntityKeyPart`], altering the [`Entity`] part of this
+    /// [`KeyView`].
+    fn set_entity(self, entity: EntityKeyPart) -> Self;
+
+    /// Get an [`AttributeKeyPart`] that refers to the [`Attribute`] part of
+    /// this [`KeyView`].
+    fn attribute(&self) -> AttributeKeyPart;
+
+    /// Set the [`AttributeKeyPart`], altering the [`Attribute`] part of this
+    /// [`KeyView`].
+    fn set_attribute(self, attribute: AttributeKeyPart) -> Self;
+
+    /// Get the [`ValueDataType`] that is represented by this [`KeyView`].
+    fn value_type(&self) -> ValueDataType;
+
+    /// Set the [`ValueDataType`] that is represented by this [`KeyView`].
+    fn set_value_type(self, value_type: ValueDataType) -> Self;
+
+    /// Get a [`ValueReferenceKeyPart`] that refers to the [`Value`] part of
+    /// this [`KeyView`].
+    fn value_reference(&self) -> ValueReferenceKeyPart;
+
+    /// Set the [`ValueReferenceKeyPart`], altering the [`Value`] part of this
+    /// [`KeyView`].
+    fn set_value_reference(self, value_reference: ValueReferenceKeyPart) -> Self;
+
+    /// Sets the constrained parts of the given [`ArtifactSelector`] to the associated
+    /// components of this [`KeyView`]
+    fn apply_selector(self, selector: &ArtifactSelector<Constrained>) -> Self {
+        let mut key = self;
+
+        if let Some(entity) = selector.entity() {
+            key = key.set_entity(entity.into());
+        };
+
+        if let Some(attribute) = selector.attribute() {
+            key = key.set_attribute(attribute.into());
+        }
+
+        if let Some(value_type) = selector.value().map(|value| value.data_type()) {
+            key = key.set_value_type(value_type);
+        }
+
+        if let Some(value_reference) = selector.value_reference() {
+            key = key.set_value_reference(ValueReferenceKeyPart(value_reference));
+        }
+
+        key
+    }
+}
+
+pub trait FromSelector: KeyView {
+    fn from_selector(selector: &ArtifactSelector<Constrained>) -> Self {
+        Self::default().apply_selector(selector)
+    }
+}
+
+impl<K> FromSelector for K where K: KeyView {}
+
+pub trait FromKey<K>
+where
+    K: KeyView,
+{
+    fn from_key(key: &K) -> Self;
+}
+
+impl<Ka, Kb> FromKey<Ka> for Kb
+where
+    Ka: KeyView,
+    Kb: KeyView,
+{
+    fn from_key(key: &Ka) -> Self {
+        Kb::default()
+            .set_entity(key.entity())
+            .set_attribute(key.attribute())
+            .set_value_type(key.value_type())
+            .set_value_reference(key.value_reference())
+    }
+}
+
+// impl<T> Deref for T
+// where
+//     T: KeyView,
+// {
+//     type Target = <Key as Deref>::Target;
+
+//     fn deref(&self) -> &Self::Target {
+//         *self.0
+//     }
+// }
+
+// impl<T> Default for T
+// where
+//     T: KeyView,
+// {
+//     fn default() -> Self {
+//         Self::min()
+//     }
+// }

--- a/rust/dialog-artifacts/src/key/attribute.rs
+++ b/rust/dialog-artifacts/src/key/attribute.rs
@@ -3,35 +3,34 @@ use std::ops::Deref;
 use arrayref::array_ref;
 use dialog_prolly_tree::KeyType;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 
 use crate::{
-    ATTRIBUTE_KEY_LENGTH, ATTRIBUTE_LENGTH, Artifact, ArtifactSelector, AttributeKeyPart,
-    DialogArtifactsError, ENTITY_LENGTH, EntityKeyPart, VALUE_REFERENCE_LENGTH, ValueDataType,
-    mutable_slice, selector::Constrained,
+    ATTRIBUTE_LENGTH, Artifact, ArtifactSelector, AttributeKeyPart, DialogArtifactsError,
+    ENTITY_LENGTH, EntityKeyPart, TAG_LENGTH, VALUE_REFERENCE_LENGTH, ValueDataType, mutable_slice,
+    selector::Constrained,
 };
 
-use super::{EntityKey, VALUE_DATA_TYPE_LENGTH, ValueKey, ValueReferenceKeyPart};
+use super::{EntityKey, Key, KeyView, VALUE_DATA_TYPE_LENGTH, ValueKey, ValueReferenceKeyPart};
 
-const ATTRIBUTE_OFFSET: usize = 0;
-const ENTITY_OFFSET: usize = ATTRIBUTE_LENGTH;
-const VALUE_DATA_TYPE_OFFSET: usize = ENTITY_LENGTH + ATTRIBUTE_LENGTH;
-const VALUE_REFERENCE_OFFSET: usize = ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH;
+const TAG_OFFSET: usize = 0;
+const ATTRIBUTE_OFFSET: usize = TAG_LENGTH;
+const ENTITY_OFFSET: usize = TAG_LENGTH + ATTRIBUTE_LENGTH;
+const VALUE_DATA_TYPE_OFFSET: usize = TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH;
+const VALUE_REFERENCE_OFFSET: usize =
+    TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH;
 
-const MINIMUM_ATTRIBUTE_KEY: [u8; ATTRIBUTE_KEY_LENGTH] = [u8::MIN; ATTRIBUTE_KEY_LENGTH];
-const MAXIMUM_ATTRIBUTE_KEY: [u8; ATTRIBUTE_KEY_LENGTH] = [u8::MAX; ATTRIBUTE_KEY_LENGTH];
+pub const ATTRIBUTE_KEY_TAG: u8 = 1;
 
 /// A [`KeyType`] that is used when constructing an index of the [`Attribute`]s
 /// of [`Artifact`]s.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct AttributeKey(#[serde(with = "BigArray")] [u8; ATTRIBUTE_KEY_LENGTH]);
+pub struct AttributeKey(Key);
 
-impl AttributeKey {
-    /// Construct an [`AttributeKey`] from the provided component key parts.
-    pub fn from_parts(
-        attribute: AttributeKeyPart,
+impl KeyView for AttributeKey {
+    fn from_parts(
         entity: EntityKeyPart,
+        attribute: AttributeKeyPart,
         value_type: ValueDataType,
         value_reference: ValueReferenceKeyPart,
     ) -> Self {
@@ -42,59 +41,45 @@ impl AttributeKey {
             .set_value_reference(value_reference)
     }
 
-    /// Construct the lowest possible [`AttributeKey`] (all bits are zero)
-    pub fn min() -> Self {
-        Self(MINIMUM_ATTRIBUTE_KEY)
+    fn min() -> Self {
+        Self(Key::min().set_tag(ATTRIBUTE_KEY_TAG))
     }
 
-    /// Construct the highest possible [`AttributeKey`] (all bits are one)
-    pub fn max() -> Self {
-        Self(MAXIMUM_ATTRIBUTE_KEY)
+    fn max() -> Self {
+        Self(Key::max().set_tag(ATTRIBUTE_KEY_TAG))
     }
 
-    /// Get an [`AttributeKeyPart`] that refers to the [`Attribute`] part of
-    /// this [`AttributeKey`].
-    pub fn attribute(&self) -> AttributeKeyPart {
+    fn attribute(&self) -> AttributeKeyPart {
         AttributeKeyPart(array_ref![self.0, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH])
     }
 
-    /// Set the [`AttributeKeyPart`], altering the [`Attribute`] part of this
-    /// [`AttributeKey`].
-    pub fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
+    fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
         let mut inner = self.0;
         mutable_slice![inner, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH].copy_from_slice(attribute.0);
         Self(inner)
     }
 
-    /// Get an [`EntityKeyPart`] that refers to the [`Entity`] part of this
-    /// [`AttributeKey`].
-    pub fn entity(&self) -> EntityKeyPart {
+    fn entity(&self) -> EntityKeyPart {
         EntityKeyPart(array_ref![self.0, ENTITY_OFFSET, ENTITY_LENGTH])
     }
 
-    /// Set the [`EntityKeyPart`], altering the [`Entity`] part of this
-    /// [`AttributeKey`].
-    pub fn set_entity(self, entity: EntityKeyPart) -> Self {
+    fn set_entity(self, entity: EntityKeyPart) -> Self {
         let mut inner = self.0;
         mutable_slice![inner, ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
         Self(inner)
     }
 
-    /// Get the [`ValueDataType`] that is represented by this [`AttributeKey`].
-    pub fn value_type(&self) -> ValueDataType {
+    fn value_type(&self) -> ValueDataType {
         self.0[VALUE_DATA_TYPE_OFFSET].into()
     }
 
-    /// Set the [`ValueDataType`] that is represented by this [`AttributeKey`].
-    pub fn set_value_type(self, value_type: ValueDataType) -> Self {
+    fn set_value_type(self, value_type: ValueDataType) -> Self {
         let mut inner = self.0;
         inner[VALUE_DATA_TYPE_OFFSET] = value_type.into();
         Self(inner)
     }
 
-    /// Get a [`ValueReferenceKeyPart`] that refers to the [`Value`] part of
-    /// this [`AttributeKey`].
-    pub fn value_reference(&self) -> ValueReferenceKeyPart {
+    fn value_reference(&self) -> ValueReferenceKeyPart {
         ValueReferenceKeyPart(array_ref![
             self.0,
             VALUE_REFERENCE_OFFSET,
@@ -102,43 +87,17 @@ impl AttributeKey {
         ])
     }
 
-    /// Set the [`ValueReferenceKeyPart`], altering the [`Value`] part of this
-    /// [`AttributeKey`].
-    pub fn set_value_reference(self, value_reference: ValueReferenceKeyPart) -> Self {
+    fn set_value_reference(self, value_reference: ValueReferenceKeyPart) -> Self {
         let mut inner = self.0;
         mutable_slice!(inner, VALUE_REFERENCE_OFFSET, VALUE_REFERENCE_LENGTH)
             .copy_from_slice(value_reference.0);
         Self(inner)
     }
-
-    /// Sets the constrained parts of the given [`ArtifactSelector`] to the associated
-    /// components of this [`AttributeKey`]
-    pub fn apply_selector(self, selector: &ArtifactSelector<Constrained>) -> Self {
-        let mut key = self;
-
-        if let Some(entity) = selector.entity() {
-            key = key.set_entity(entity.into());
-        };
-
-        if let Some(attribute) = selector.attribute() {
-            key = key.set_attribute(attribute.into());
-        }
-
-        if let Some(value_type) = selector.value().map(|value| value.data_type()) {
-            key = key.set_value_type(value_type);
-        }
-
-        if let Some(value_reference) = selector.value_reference() {
-            key = key.set_value_reference(ValueReferenceKeyPart(value_reference));
-        }
-
-        key
-    }
 }
 
 impl Default for AttributeKey {
     fn default() -> Self {
-        Self::min()
+        <Self as KeyView>::min()
     }
 }
 
@@ -149,36 +108,10 @@ impl AsRef<[u8]> for AttributeKey {
 }
 
 impl Deref for AttributeKey {
-    type Target = [u8; ATTRIBUTE_KEY_LENGTH];
+    type Target = <Key as Deref>::Target;
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl From<&ArtifactSelector<Constrained>> for AttributeKey {
-    fn from(selector: &ArtifactSelector<Constrained>) -> Self {
-        AttributeKey::default().apply_selector(selector)
-    }
-}
-
-impl From<&ValueKey> for AttributeKey {
-    fn from(value: &ValueKey) -> Self {
-        AttributeKey::default()
-            .set_entity(value.entity())
-            .set_attribute(value.attribute())
-            .set_value_type(value.value_type())
-            .set_value_reference(value.value_reference())
-    }
-}
-
-impl From<&EntityKey> for AttributeKey {
-    fn from(value: &EntityKey) -> Self {
-        AttributeKey::default()
-            .set_entity(value.entity())
-            .set_attribute(value.attribute())
-            .set_value_type(value.value_type())
-            .set_value_reference(value.value_reference())
     }
 }
 
@@ -192,17 +125,17 @@ impl From<&Artifact> for AttributeKey {
     }
 }
 
+impl KeyType for AttributeKey {}
+
 impl TryFrom<Vec<u8>> for AttributeKey {
     type Error = DialogArtifactsError;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(Self(value.try_into().map_err(|value: Vec<u8>| {
+        Ok(Self(Key(value.try_into().map_err(|value: Vec<u8>| {
             DialogArtifactsError::InvalidKey(format!(
-                "Wrong byte length for attribute key: {}",
+                "Wrong byte length for entity key: {}",
                 value.len()
             ))
-        })?))
+        })?)))
     }
 }
-
-impl KeyType for AttributeKey {}

--- a/rust/dialog-artifacts/src/key/attribute.rs
+++ b/rust/dialog-artifacts/src/key/attribute.rs
@@ -5,29 +5,46 @@ use dialog_prolly_tree::KeyType;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ATTRIBUTE_LENGTH, Artifact, ArtifactSelector, AttributeKeyPart, DialogArtifactsError,
-    ENTITY_LENGTH, EntityKeyPart, TAG_LENGTH, VALUE_REFERENCE_LENGTH, ValueDataType, mutable_slice,
-    selector::Constrained,
+    ATTRIBUTE_LENGTH, Artifact, AttributeKeyPart, ENTITY_LENGTH, EntityKeyPart, TAG_LENGTH,
+    VALUE_REFERENCE_LENGTH, ValueDataType, mutable_slice,
 };
 
-use super::{EntityKey, Key, KeyView, VALUE_DATA_TYPE_LENGTH, ValueKey, ValueReferenceKeyPart};
+use super::{
+    Key, KeyBytes, KeyView, KeyViewConstruct, KeyViewMut, VALUE_DATA_TYPE_LENGTH,
+    ValueReferenceKeyPart,
+};
 
-const TAG_OFFSET: usize = 0;
 const ATTRIBUTE_OFFSET: usize = TAG_LENGTH;
 const ENTITY_OFFSET: usize = TAG_LENGTH + ATTRIBUTE_LENGTH;
 const VALUE_DATA_TYPE_OFFSET: usize = TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH;
 const VALUE_REFERENCE_OFFSET: usize =
     TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH;
 
+/// Tag byte that identifies attribute-based index keys
 pub const ATTRIBUTE_KEY_TAG: u8 = 1;
 
 /// A [`KeyType`] that is used when constructing an index of the [`Attribute`]s
 /// of [`Artifact`]s.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct AttributeKey(Key);
+pub struct AttributeKey<K>(pub K);
 
-impl KeyView for AttributeKey {
+impl AttributeKey<Key> {
+    /// Converts this attribute key into a generic key for storage in the prolly tree
+    pub fn into_key(self) -> Key {
+        self.0
+    }
+}
+
+impl KeyViewConstruct for AttributeKey<Key> {
+    fn min() -> Self {
+        Self(Key::min().set_tag(ATTRIBUTE_KEY_TAG))
+    }
+
+    fn max() -> Self {
+        Self(Key::max().set_tag(ATTRIBUTE_KEY_TAG))
+    }
+
     fn from_parts(
         entity: EntityKeyPart,
         attribute: AttributeKeyPart,
@@ -40,102 +57,120 @@ impl KeyView for AttributeKey {
             .set_value_type(value_type)
             .set_value_reference(value_reference)
     }
+}
 
-    fn min() -> Self {
-        Self(Key::min().set_tag(ATTRIBUTE_KEY_TAG))
-    }
-
-    fn max() -> Self {
-        Self(Key::max().set_tag(ATTRIBUTE_KEY_TAG))
+impl<K> KeyView for AttributeKey<K>
+where
+    K: AsRef<KeyBytes> + Clone,
+{
+    fn entity(&self) -> EntityKeyPart {
+        EntityKeyPart(array_ref![self.0.as_ref(), ENTITY_OFFSET, ENTITY_LENGTH])
     }
 
     fn attribute(&self) -> AttributeKeyPart {
-        AttributeKeyPart(array_ref![self.0, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH])
-    }
-
-    fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice![inner, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH].copy_from_slice(attribute.0);
-        Self(inner)
-    }
-
-    fn entity(&self) -> EntityKeyPart {
-        EntityKeyPart(array_ref![self.0, ENTITY_OFFSET, ENTITY_LENGTH])
-    }
-
-    fn set_entity(self, entity: EntityKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice![inner, ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
-        Self(inner)
+        AttributeKeyPart(array_ref![
+            self.0.as_ref(),
+            ATTRIBUTE_OFFSET,
+            ATTRIBUTE_LENGTH
+        ])
     }
 
     fn value_type(&self) -> ValueDataType {
-        self.0[VALUE_DATA_TYPE_OFFSET].into()
-    }
-
-    fn set_value_type(self, value_type: ValueDataType) -> Self {
-        let mut inner = self.0;
-        inner[VALUE_DATA_TYPE_OFFSET] = value_type.into();
-        Self(inner)
+        self.0.as_ref()[VALUE_DATA_TYPE_OFFSET].into()
     }
 
     fn value_reference(&self) -> ValueReferenceKeyPart {
         ValueReferenceKeyPart(array_ref![
-            self.0,
+            self.0.as_ref(),
             VALUE_REFERENCE_OFFSET,
             VALUE_REFERENCE_LENGTH
         ])
     }
+}
 
-    fn set_value_reference(self, value_reference: ValueReferenceKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice!(inner, VALUE_REFERENCE_OFFSET, VALUE_REFERENCE_LENGTH)
-            .copy_from_slice(value_reference.0);
-        Self(inner)
+impl<K> KeyViewMut for AttributeKey<K>
+where
+    K: AsRef<KeyBytes> + AsMut<KeyBytes> + Clone,
+{
+    fn set_entity(mut self, entity: EntityKeyPart) -> Self {
+        mutable_slice![self.0.as_mut(), ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
+        self
+    }
+
+    fn set_attribute(mut self, attribute: AttributeKeyPart) -> Self {
+        mutable_slice![self.0.as_mut(), ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH]
+            .copy_from_slice(attribute.0);
+        self
+    }
+
+    fn set_value_type(mut self, value_type: ValueDataType) -> Self {
+        self.0.as_mut()[VALUE_DATA_TYPE_OFFSET] = value_type.into();
+        self
+    }
+
+    fn set_value_reference(mut self, value_reference: ValueReferenceKeyPart) -> Self {
+        mutable_slice!(
+            self.0.as_mut(),
+            VALUE_REFERENCE_OFFSET,
+            VALUE_REFERENCE_LENGTH
+        )
+        .copy_from_slice(value_reference.0);
+        self
     }
 }
 
-impl Default for AttributeKey {
+impl Default for AttributeKey<Key> {
     fn default() -> Self {
-        <Self as KeyView>::min()
+        <Self as KeyViewConstruct>::min()
     }
 }
 
-impl AsRef<[u8]> for AttributeKey {
-    fn as_ref(&self) -> &[u8] {
+impl<K> AsRef<KeyBytes> for AttributeKey<K>
+where
+    K: AsRef<KeyBytes>,
+{
+    fn as_ref(&self) -> &KeyBytes {
         self.0.as_ref()
     }
 }
 
-impl Deref for AttributeKey {
-    type Target = <Key as Deref>::Target;
+impl<K> Deref for AttributeKey<K>
+where
+    K: Deref<Target = KeyBytes>,
+{
+    type Target = K::Target;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl From<&Artifact> for AttributeKey {
+impl From<&Artifact> for AttributeKey<Key> {
     fn from(fact: &Artifact) -> Self {
-        AttributeKey::default()
-            .set_attribute(AttributeKeyPart::from(&fact.the))
+        AttributeKey::<Key>::default()
             .set_entity(EntityKeyPart::from(&fact.of))
+            .set_attribute(AttributeKeyPart::from(&fact.the))
             .set_value_type(fact.is.data_type())
             .set_value_reference(ValueReferenceKeyPart(&fact.is.to_reference()))
     }
 }
 
-impl KeyType for AttributeKey {}
+impl<K> KeyType for AttributeKey<K>
+where
+    K: AsRef<KeyBytes> + AsMut<KeyBytes> + Clone + KeyType,
+{
+    fn bytes(&self) -> &[u8] {
+        self.as_ref().as_ref()
+    }
+}
 
-impl TryFrom<Vec<u8>> for AttributeKey {
-    type Error = DialogArtifactsError;
+impl<K> TryFrom<Vec<u8>> for AttributeKey<K>
+where
+    K: KeyType,
+{
+    type Error = <K as TryFrom<Vec<u8>>>::Error;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(Self(Key(value.try_into().map_err(|value: Vec<u8>| {
-            DialogArtifactsError::InvalidKey(format!(
-                "Wrong byte length for entity key: {}",
-                value.len()
-            ))
-        })?)))
+        Ok(AttributeKey(K::try_from(value)?))
     }
 }

--- a/rust/dialog-artifacts/src/key/entity.rs
+++ b/rust/dialog-artifacts/src/key/entity.rs
@@ -3,33 +3,31 @@ use std::ops::Deref;
 use arrayref::array_ref;
 use dialog_prolly_tree::KeyType;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 
 use crate::{
-    ATTRIBUTE_LENGTH, Artifact, ArtifactSelector, AttributeKeyPart, DialogArtifactsError,
-    ENTITY_KEY_LENGTH, ENTITY_LENGTH, EntityKeyPart, VALUE_REFERENCE_LENGTH, ValueDataType,
-    mutable_slice, selector::Constrained,
+    ATTRIBUTE_LENGTH, Artifact, AttributeKeyPart, DialogArtifactsError, ENTITY_LENGTH,
+    EntityKeyPart, TAG_LENGTH, VALUE_REFERENCE_LENGTH, ValueDataType, mutable_slice,
 };
 
-use super::{AttributeKey, VALUE_DATA_TYPE_LENGTH, ValueKey, ValueReferenceKeyPart};
+use super::{Key, KeyView, VALUE_DATA_TYPE_LENGTH, ValueReferenceKeyPart};
 
-const ENTITY_OFFSET: usize = 0;
-const ATTRIBUTE_OFFSET: usize = ENTITY_LENGTH;
-const VALUE_DATA_TYPE_OFFSET: usize = ENTITY_LENGTH + ATTRIBUTE_LENGTH;
-const VALUE_REFERENCE_OFFSET: usize = ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH;
+const TAG_OFFSET: usize = 0;
+const ENTITY_OFFSET: usize = TAG_LENGTH;
+const ATTRIBUTE_OFFSET: usize = TAG_LENGTH + ENTITY_LENGTH;
+const VALUE_DATA_TYPE_OFFSET: usize = TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH;
+const VALUE_REFERENCE_OFFSET: usize =
+    TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH;
 
-const MINIMUM_ENTITY_KEY: [u8; ENTITY_KEY_LENGTH] = [u8::MIN; ENTITY_KEY_LENGTH];
-const MAXIMUM_ENTITY_KEY: [u8; ENTITY_KEY_LENGTH] = [u8::MAX; ENTITY_KEY_LENGTH];
+pub const ENTITY_KEY_TAG: u8 = 0;
 
 /// A [`KeyType`] that is used when constructing an index of the [`Entity`]s
 /// of [`Artifact`]s.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct EntityKey(#[serde(with = "BigArray")] [u8; ENTITY_KEY_LENGTH]);
+pub struct EntityKey(Key);
 
-impl EntityKey {
-    /// Construct an [`EntityKey`] from the provided component key parts.
-    pub fn from_parts(
+impl KeyView for EntityKey {
+    fn from_parts(
         entity: EntityKeyPart,
         attribute: AttributeKeyPart,
         value_type: ValueDataType,
@@ -42,117 +40,77 @@ impl EntityKey {
             .set_value_reference(value_reference)
     }
 
-    /// Construct the lowest possible [`EntityKey`] (all bits are zero)
-    pub fn min() -> Self {
-        Self(MINIMUM_ENTITY_KEY)
+    fn min() -> Self {
+        Self(Key::min().set_tag(ENTITY_KEY_TAG))
     }
 
-    /// Construct the highest possible [`EntityKey`] (all bits are one)
-    pub fn max() -> Self {
-        Self(MAXIMUM_ENTITY_KEY)
+    fn max() -> Self {
+        Self(Key::max().set_tag(ENTITY_KEY_TAG))
     }
 
-    /// Get an [`EntityKeyPart`] that refers to the [`Entity`] part of this
-    /// [`EntityKey`].
-    pub fn entity(&self) -> EntityKeyPart {
-        EntityKeyPart(array_ref![self.0, ENTITY_OFFSET, ENTITY_LENGTH])
+    fn entity(&self) -> EntityKeyPart {
+        EntityKeyPart(array_ref![*self.0, ENTITY_OFFSET, ENTITY_LENGTH])
     }
 
-    /// Set the [`EntityKeyPart`], altering the [`Entity`] part of this
-    /// [`EntityKey`].
-    pub fn set_entity(self, entity: EntityKeyPart) -> Self {
+    fn set_entity(self, entity: EntityKeyPart) -> Self {
         let mut inner = self.0;
-        mutable_slice![inner, ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
+        mutable_slice![*inner, ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
         Self(inner)
     }
 
-    /// Get an [`AttributeKeyPart`] that refers to the [`Attribute`] part of
-    /// this [`EntityKey`].
-    pub fn attribute(&self) -> AttributeKeyPart {
-        AttributeKeyPart(array_ref![self.0, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH])
+    fn attribute(&self) -> AttributeKeyPart {
+        AttributeKeyPart(array_ref![*self.0, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH])
     }
 
-    /// Set the [`AttributeKeyPart`], altering the [`Attribute`] part of this
-    /// [`EntityKey`].
-    pub fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
+    fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
         let mut inner = self.0;
-        mutable_slice![inner, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH].copy_from_slice(attribute.0);
+        mutable_slice![*inner, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH].copy_from_slice(attribute.0);
         Self(inner)
     }
 
-    /// Get the [`ValueDataType`] that is represented by this [`EntityKey`].
-    pub fn value_type(&self) -> ValueDataType {
-        self.0[VALUE_DATA_TYPE_OFFSET].into()
+    fn value_type(&self) -> ValueDataType {
+        (*self.0)[VALUE_DATA_TYPE_OFFSET].into()
     }
 
-    /// Set the [`ValueDataType`] that is represented by this [`EntityKey`].
-    pub fn set_value_type(self, value_type: ValueDataType) -> Self {
+    fn set_value_type(self, value_type: ValueDataType) -> Self {
         let mut inner = self.0;
-        inner[VALUE_DATA_TYPE_OFFSET] = value_type.into();
+        (*inner)[VALUE_DATA_TYPE_OFFSET] = value_type.into();
         Self(inner)
     }
 
-    /// Get a [`ValueReferenceKeyPart`] that refers to the [`Value`] part of
-    /// this [`EntityKey`].
-    pub fn value_reference(&self) -> ValueReferenceKeyPart {
+    fn value_reference(&self) -> ValueReferenceKeyPart {
         ValueReferenceKeyPart(array_ref![
-            self.0,
+            *self.0,
             VALUE_REFERENCE_OFFSET,
             VALUE_REFERENCE_LENGTH
         ])
     }
 
-    /// Set the [`ValueReferenceKeyPart`], altering the [`Value`] part of this
-    /// [`EntityKey`].
-    pub fn set_value_reference(self, value_reference: ValueReferenceKeyPart) -> Self {
+    fn set_value_reference(self, value_reference: ValueReferenceKeyPart) -> Self {
         let mut inner = self.0;
-        mutable_slice!(inner, VALUE_REFERENCE_OFFSET, VALUE_REFERENCE_LENGTH)
+        mutable_slice!(*inner, VALUE_REFERENCE_OFFSET, VALUE_REFERENCE_LENGTH)
             .copy_from_slice(value_reference.0);
         Self(inner)
     }
+}
 
-    /// Sets the constrained parts of the given [`ArtifactSelector`] to the associated
-    /// components of this [`EntityKey`]
-    pub fn apply_selector(self, selector: &ArtifactSelector<Constrained>) -> Self {
-        let mut key = self;
-
-        if let Some(entity) = selector.entity() {
-            key = key.set_entity(entity.into());
-        };
-
-        if let Some(attribute) = selector.attribute() {
-            key = key.set_attribute(attribute.into());
-        }
-
-        if let Some(value_type) = selector.value().map(|value| value.data_type()) {
-            key = key.set_value_type(value_type);
-        }
-
-        if let Some(value_reference) = selector.value_reference() {
-            key = key.set_value_reference(ValueReferenceKeyPart(value_reference));
-        }
-
-        key
+impl Default for EntityKey {
+    fn default() -> Self {
+        <Self as KeyView>::min()
     }
 }
 
-impl From<&AttributeKey> for EntityKey {
-    fn from(value: &AttributeKey) -> Self {
-        EntityKey::default()
-            .set_entity(value.entity())
-            .set_attribute(value.attribute())
-            .set_value_type(value.value_type())
-            .set_value_reference(value.value_reference())
+impl AsRef<[u8]> for EntityKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 
-impl From<&ValueKey> for EntityKey {
-    fn from(value: &ValueKey) -> Self {
-        EntityKey::default()
-            .set_entity(value.entity())
-            .set_attribute(value.attribute())
-            .set_value_type(value.value_type())
-            .set_value_reference(value.value_reference())
+impl Deref for EntityKey {
+    type Target = <Key as Deref>::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
     }
 }
 
@@ -166,43 +124,17 @@ impl From<&Artifact> for EntityKey {
     }
 }
 
-impl From<&ArtifactSelector<Constrained>> for EntityKey {
-    fn from(selector: &ArtifactSelector<Constrained>) -> Self {
-        EntityKey::default().apply_selector(selector)
-    }
-}
-
-impl Default for EntityKey {
-    fn default() -> Self {
-        Self(MINIMUM_ENTITY_KEY)
-    }
-}
-
-impl AsRef<[u8]> for EntityKey {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl Deref for EntityKey {
-    type Target = [u8; ENTITY_KEY_LENGTH];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl KeyType for EntityKey {}
 
 impl TryFrom<Vec<u8>> for EntityKey {
     type Error = DialogArtifactsError;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(Self(value.try_into().map_err(|value: Vec<u8>| {
+        Ok(Self(Key(value.try_into().map_err(|value: Vec<u8>| {
             DialogArtifactsError::InvalidKey(format!(
                 "Wrong byte length for entity key: {}",
                 value.len()
             ))
-        })?))
+        })?)))
     }
 }
-
-impl KeyType for EntityKey {}

--- a/rust/dialog-artifacts/src/key/entity.rs
+++ b/rust/dialog-artifacts/src/key/entity.rs
@@ -5,28 +5,46 @@ use dialog_prolly_tree::KeyType;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ATTRIBUTE_LENGTH, Artifact, AttributeKeyPart, DialogArtifactsError, ENTITY_LENGTH,
-    EntityKeyPart, TAG_LENGTH, VALUE_REFERENCE_LENGTH, ValueDataType, mutable_slice,
+    ATTRIBUTE_LENGTH, Artifact, AttributeKeyPart, ENTITY_LENGTH, EntityKeyPart, TAG_LENGTH,
+    VALUE_REFERENCE_LENGTH, ValueDataType, mutable_slice,
 };
 
-use super::{Key, KeyView, VALUE_DATA_TYPE_LENGTH, ValueReferenceKeyPart};
+use super::{
+    Key, KeyBytes, KeyView, KeyViewConstruct, KeyViewMut, VALUE_DATA_TYPE_LENGTH,
+    ValueReferenceKeyPart,
+};
 
-const TAG_OFFSET: usize = 0;
 const ENTITY_OFFSET: usize = TAG_LENGTH;
 const ATTRIBUTE_OFFSET: usize = TAG_LENGTH + ENTITY_LENGTH;
 const VALUE_DATA_TYPE_OFFSET: usize = TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH;
 const VALUE_REFERENCE_OFFSET: usize =
     TAG_LENGTH + ENTITY_LENGTH + ATTRIBUTE_LENGTH + VALUE_DATA_TYPE_LENGTH;
 
+/// Tag byte that identifies entity-based index keys
 pub const ENTITY_KEY_TAG: u8 = 0;
 
 /// A [`KeyType`] that is used when constructing an index of the [`Entity`]s
 /// of [`Artifact`]s.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct EntityKey(Key);
+pub struct EntityKey<K>(pub K);
 
-impl KeyView for EntityKey {
+impl EntityKey<Key> {
+    /// Converts this entity key into a generic key for storage in the prolly tree
+    pub fn into_key(self) -> Key {
+        self.0
+    }
+}
+
+impl KeyViewConstruct for EntityKey<Key> {
+    fn min() -> Self {
+        Self(Key::min().set_tag(ENTITY_KEY_TAG))
+    }
+
+    fn max() -> Self {
+        Self(Key::max().set_tag(ENTITY_KEY_TAG))
+    }
+
     fn from_parts(
         entity: EntityKeyPart,
         attribute: AttributeKeyPart,
@@ -39,84 +57,97 @@ impl KeyView for EntityKey {
             .set_value_type(value_type)
             .set_value_reference(value_reference)
     }
+}
 
-    fn min() -> Self {
-        Self(Key::min().set_tag(ENTITY_KEY_TAG))
-    }
-
-    fn max() -> Self {
-        Self(Key::max().set_tag(ENTITY_KEY_TAG))
-    }
-
+impl<K> KeyView for EntityKey<K>
+where
+    K: AsRef<KeyBytes> + Clone,
+{
     fn entity(&self) -> EntityKeyPart {
-        EntityKeyPart(array_ref![*self.0, ENTITY_OFFSET, ENTITY_LENGTH])
-    }
-
-    fn set_entity(self, entity: EntityKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice![*inner, ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
-        Self(inner)
+        EntityKeyPart(array_ref![self.0.as_ref(), ENTITY_OFFSET, ENTITY_LENGTH])
     }
 
     fn attribute(&self) -> AttributeKeyPart {
-        AttributeKeyPart(array_ref![*self.0, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH])
-    }
-
-    fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice![*inner, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH].copy_from_slice(attribute.0);
-        Self(inner)
+        AttributeKeyPart(array_ref![
+            self.0.as_ref(),
+            ATTRIBUTE_OFFSET,
+            ATTRIBUTE_LENGTH
+        ])
     }
 
     fn value_type(&self) -> ValueDataType {
-        (*self.0)[VALUE_DATA_TYPE_OFFSET].into()
-    }
-
-    fn set_value_type(self, value_type: ValueDataType) -> Self {
-        let mut inner = self.0;
-        (*inner)[VALUE_DATA_TYPE_OFFSET] = value_type.into();
-        Self(inner)
+        self.0.as_ref()[VALUE_DATA_TYPE_OFFSET].into()
     }
 
     fn value_reference(&self) -> ValueReferenceKeyPart {
         ValueReferenceKeyPart(array_ref![
-            *self.0,
+            self.0.as_ref(),
             VALUE_REFERENCE_OFFSET,
             VALUE_REFERENCE_LENGTH
         ])
     }
+}
 
-    fn set_value_reference(self, value_reference: ValueReferenceKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice!(*inner, VALUE_REFERENCE_OFFSET, VALUE_REFERENCE_LENGTH)
-            .copy_from_slice(value_reference.0);
-        Self(inner)
+impl<K> KeyViewMut for EntityKey<K>
+where
+    K: AsRef<KeyBytes> + AsMut<KeyBytes> + Clone,
+{
+    fn set_entity(mut self, entity: EntityKeyPart) -> Self {
+        mutable_slice![self.0.as_mut(), ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
+        self
+    }
+
+    fn set_attribute(mut self, attribute: AttributeKeyPart) -> Self {
+        mutable_slice![self.0.as_mut(), ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH]
+            .copy_from_slice(attribute.0);
+        self
+    }
+
+    fn set_value_type(mut self, value_type: ValueDataType) -> Self {
+        self.0.as_mut()[VALUE_DATA_TYPE_OFFSET] = value_type.into();
+        self
+    }
+
+    fn set_value_reference(mut self, value_reference: ValueReferenceKeyPart) -> Self {
+        mutable_slice!(
+            self.0.as_mut(),
+            VALUE_REFERENCE_OFFSET,
+            VALUE_REFERENCE_LENGTH
+        )
+        .copy_from_slice(value_reference.0);
+        self
     }
 }
 
-impl Default for EntityKey {
+impl Default for EntityKey<Key> {
     fn default() -> Self {
-        <Self as KeyView>::min()
+        <Self as KeyViewConstruct>::min()
     }
 }
 
-impl AsRef<[u8]> for EntityKey {
-    fn as_ref(&self) -> &[u8] {
+impl<K> AsRef<KeyBytes> for EntityKey<K>
+where
+    K: AsRef<KeyBytes>,
+{
+    fn as_ref(&self) -> &KeyBytes {
         self.0.as_ref()
     }
 }
 
-impl Deref for EntityKey {
-    type Target = <Key as Deref>::Target;
+impl<K> Deref for EntityKey<K>
+where
+    K: Deref<Target = KeyBytes>,
+{
+    type Target = K::Target;
 
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 
-impl From<&Artifact> for EntityKey {
+impl From<&Artifact> for EntityKey<Key> {
     fn from(fact: &Artifact) -> Self {
-        EntityKey::default()
+        EntityKey::<Key>::default()
             .set_entity(EntityKeyPart::from(&fact.of))
             .set_attribute(AttributeKeyPart::from(&fact.the))
             .set_value_type(fact.is.data_type())
@@ -124,17 +155,22 @@ impl From<&Artifact> for EntityKey {
     }
 }
 
-impl KeyType for EntityKey {}
+impl<K> KeyType for EntityKey<K>
+where
+    K: AsRef<KeyBytes> + AsMut<KeyBytes> + Clone + KeyType,
+{
+    fn bytes(&self) -> &[u8] {
+        self.as_ref().as_ref()
+    }
+}
 
-impl TryFrom<Vec<u8>> for EntityKey {
-    type Error = DialogArtifactsError;
+impl<K> TryFrom<Vec<u8>> for EntityKey<K>
+where
+    K: KeyType,
+{
+    type Error = <K as TryFrom<Vec<u8>>>::Error;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(Self(Key(value.try_into().map_err(|value: Vec<u8>| {
-            DialogArtifactsError::InvalidKey(format!(
-                "Wrong byte length for entity key: {}",
-                value.len()
-            ))
-        })?)))
+        Ok(EntityKey(K::try_from(value)?))
     }
 }

--- a/rust/dialog-artifacts/src/key/value.rs
+++ b/rust/dialog-artifacts/src/key/value.rs
@@ -3,38 +3,36 @@ use std::ops::Deref;
 use arrayref::array_ref;
 use dialog_prolly_tree::KeyType;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 
 use crate::{
-    ATTRIBUTE_LENGTH, Artifact, ArtifactSelector, AttributeKeyPart, DialogArtifactsError,
-    ENTITY_LENGTH, VALUE_DATA_TYPE_LENGTH, VALUE_KEY_LENGTH, VALUE_REFERENCE_LENGTH, ValueDataType,
-    ValueReferenceKeyPart, mutable_slice, selector::Constrained,
+    ATTRIBUTE_LENGTH, Artifact, AttributeKeyPart, DialogArtifactsError, ENTITY_LENGTH, TAG_LENGTH,
+    VALUE_DATA_TYPE_LENGTH, VALUE_REFERENCE_LENGTH, ValueDataType, ValueReferenceKeyPart,
+    mutable_slice,
 };
 
-use super::{AttributeKey, EntityKey, EntityKeyPart};
+use super::{EntityKeyPart, Key, KeyView};
 
-const VALUE_KEY_VALUE_DATA_TYPE_OFFSET: usize = 0;
-const VALUE_KEY_VALUE_REFERENCE_OFFSET: usize = VALUE_DATA_TYPE_LENGTH;
-const VALUE_KEY_ATTRIBUTE_OFFSET: usize = VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH;
-const VALUE_KEY_ENTITY_OFFSET: usize =
-    VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH + ATTRIBUTE_LENGTH;
+const TAG_OFFSET: usize = 0;
+const VALUE_DATA_TYPE_OFFSET: usize = TAG_LENGTH;
+const VALUE_REFERENCE_OFFSET: usize = TAG_LENGTH + VALUE_DATA_TYPE_LENGTH;
+const ATTRIBUTE_OFFSET: usize = TAG_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH;
+const ENTITY_OFFSET: usize =
+    TAG_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH + ATTRIBUTE_LENGTH;
 
-const MINIMUM_VALUE_KEY: [u8; VALUE_KEY_LENGTH] = [u8::MIN; VALUE_KEY_LENGTH];
-const MAXIMUM_VALUE_KEY: [u8; VALUE_KEY_LENGTH] = [u8::MAX; VALUE_KEY_LENGTH];
+pub const VALUE_KEY_TAG: u8 = 2;
 
 /// A [`KeyType`] that is used when constructing an index of the [`Value`]s
 /// of [`Artifact`]s.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct ValueKey(#[serde(with = "BigArray")] [u8; VALUE_KEY_LENGTH]);
+pub struct ValueKey(Key);
 
-impl ValueKey {
-    /// Construct a [`ValueKey`] from the provided component key parts.
-    pub fn from_parts(
+impl KeyView for ValueKey {
+    fn from_parts(
+        entity: EntityKeyPart,
+        attribute: AttributeKeyPart,
         value_type: ValueDataType,
         value_reference: ValueReferenceKeyPart,
-        attribute: AttributeKeyPart,
-        entity: EntityKeyPart,
     ) -> Self {
         Self::default()
             .set_entity(entity)
@@ -43,112 +41,63 @@ impl ValueKey {
             .set_value_reference(value_reference)
     }
 
-    /// Construct the lowest possible [`ValueKey`] (all bits are zero)
-    pub fn min() -> Self {
-        Self(MINIMUM_VALUE_KEY)
+    fn min() -> Self {
+        Self(Key::min().set_tag(VALUE_KEY_TAG))
     }
 
-    /// Construct the highest possible [`ValueKey`] (all bits are one)
-    pub fn max() -> Self {
-        Self(MAXIMUM_VALUE_KEY)
+    fn max() -> Self {
+        Self(Key::max().set_tag(VALUE_KEY_TAG))
     }
 
-    /// Get an [`AttributeKeyPart`] that refers to the [`Attribute`] part of
-    /// this [`ValueKey`].
-    pub fn attribute(&self) -> AttributeKeyPart {
-        AttributeKeyPart(array_ref![
-            self.0,
-            VALUE_KEY_ATTRIBUTE_OFFSET,
-            ATTRIBUTE_LENGTH
-        ])
+    fn attribute(&self) -> AttributeKeyPart {
+        AttributeKeyPart(array_ref![self.0, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH])
     }
 
-    /// Get an [`EntityKeyPart`] that refers to the [`Entity`] part of this
-    /// [`ValueKey`]
-    pub fn entity(&self) -> EntityKeyPart {
-        EntityKeyPart(array_ref![self.0, VALUE_KEY_ENTITY_OFFSET, ENTITY_LENGTH])
+    fn entity(&self) -> EntityKeyPart {
+        EntityKeyPart(array_ref![self.0, ENTITY_OFFSET, ENTITY_LENGTH])
     }
 
-    /// Set the [`AttributeKeyPart`], altering the [`Attribute`] part of this
-    /// [`ValueKey`].
-    pub fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
+    fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
         let mut inner = self.0;
-        mutable_slice![inner, VALUE_KEY_ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH]
-            .copy_from_slice(attribute.0);
+        mutable_slice![inner, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH].copy_from_slice(attribute.0);
         Self(inner)
     }
 
-    /// Set the [`EntityKeyPart`], altering the [`Entity`] part of this
-    /// [`ValueKey`].
-    pub fn set_entity(self, entity: EntityKeyPart) -> Self {
+    fn set_entity(self, entity: EntityKeyPart) -> Self {
         let mut inner = self.0;
-        mutable_slice![inner, VALUE_KEY_ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
+        mutable_slice![inner, ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
         Self(inner)
     }
 
-    /// Get a [`ValueReferenceKeyPart`] that refers to the [`Value`] part of
-    /// this [`ValueKey`].
-    pub fn value_reference(&self) -> ValueReferenceKeyPart {
+    fn value_reference(&self) -> ValueReferenceKeyPart {
         ValueReferenceKeyPart(array_ref![
             self.0,
-            VALUE_KEY_VALUE_REFERENCE_OFFSET,
+            VALUE_REFERENCE_OFFSET,
             VALUE_REFERENCE_LENGTH
         ])
     }
 
-    /// Set the [`ValueReferenceKeyPart`], altering the [`Value`] part of this
-    /// [`ValueKey`].
-    pub fn set_value_reference(self, value: ValueReferenceKeyPart) -> Self {
+    fn set_value_reference(self, value: ValueReferenceKeyPart) -> Self {
         let mut inner = self.0;
-        mutable_slice!(
-            inner,
-            VALUE_KEY_VALUE_REFERENCE_OFFSET,
-            VALUE_REFERENCE_LENGTH
-        )
-        .copy_from_slice(value.0);
+        mutable_slice!(inner, VALUE_REFERENCE_OFFSET, VALUE_REFERENCE_LENGTH)
+            .copy_from_slice(value.0);
         Self(inner)
     }
 
-    /// Get the [`ValueDataType`] that is represented by this [`ValueKey`].
-    pub fn value_type(&self) -> ValueDataType {
-        self.0[VALUE_KEY_VALUE_DATA_TYPE_OFFSET].into()
+    fn value_type(&self) -> ValueDataType {
+        self.0[VALUE_DATA_TYPE_OFFSET].into()
     }
 
-    /// Set the [`ValueDataType`] that is represented by this [`ValueKey`].
-    pub fn set_value_type(self, value_type: ValueDataType) -> Self {
+    fn set_value_type(self, value_type: ValueDataType) -> Self {
         let mut inner = self.0;
-        inner[VALUE_KEY_VALUE_DATA_TYPE_OFFSET] = value_type.into();
+        inner[VALUE_DATA_TYPE_OFFSET] = value_type.into();
         Self(inner)
-    }
-
-    /// Sets the constrained parts of the given [`ArtifactSelector`] to the associated
-    /// components of this [`ValueKey`]
-    pub fn apply_selector(self, selector: &ArtifactSelector<Constrained>) -> Self {
-        let mut key = self;
-
-        if let Some(entity) = selector.entity() {
-            key = key.set_entity(entity.into());
-        };
-
-        if let Some(attribute) = selector.attribute() {
-            key = key.set_attribute(attribute.into());
-        }
-
-        if let Some(value_type) = selector.value().map(|value| value.data_type()) {
-            key = key.set_value_type(value_type);
-        }
-
-        if let Some(value_reference) = selector.value_reference() {
-            key = key.set_value_reference(ValueReferenceKeyPart(value_reference));
-        }
-
-        key
     }
 }
 
 impl Default for ValueKey {
     fn default() -> Self {
-        Self::min()
+        <Self as KeyView>::min()
     }
 }
 
@@ -159,36 +108,10 @@ impl AsRef<[u8]> for ValueKey {
 }
 
 impl Deref for ValueKey {
-    type Target = [u8; VALUE_KEY_LENGTH];
+    type Target = <Key as Deref>::Target;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<&ArtifactSelector<Constrained>> for ValueKey {
-    fn from(selector: &ArtifactSelector<Constrained>) -> Self {
-        ValueKey::default().apply_selector(selector)
-    }
-}
-
-impl From<&AttributeKey> for ValueKey {
-    fn from(value: &AttributeKey) -> Self {
-        ValueKey::default()
-            .set_entity(value.entity())
-            .set_attribute(value.attribute())
-            .set_value_type(value.value_type())
-            .set_value_reference(value.value_reference())
-    }
-}
-
-impl From<&EntityKey> for ValueKey {
-    fn from(value: &EntityKey) -> Self {
-        ValueKey::default()
-            .set_entity(value.entity())
-            .set_attribute(value.attribute())
-            .set_value_type(value.value_type())
-            .set_value_reference(value.value_reference())
+        &*self.0
     }
 }
 
@@ -203,17 +126,17 @@ impl From<&Artifact> for ValueKey {
     }
 }
 
+impl KeyType for ValueKey {}
+
 impl TryFrom<Vec<u8>> for ValueKey {
     type Error = DialogArtifactsError;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(Self(value.try_into().map_err(|value: Vec<u8>| {
+        Ok(Self(Key(value.try_into().map_err(|value: Vec<u8>| {
             DialogArtifactsError::InvalidKey(format!(
-                "Wrong byte length for value key: {}",
+                "Wrong byte length for entity key: {}",
                 value.len()
             ))
-        })?))
+        })?)))
     }
 }
-
-impl KeyType for ValueKey {}

--- a/rust/dialog-artifacts/src/key/value.rs
+++ b/rust/dialog-artifacts/src/key/value.rs
@@ -5,29 +5,44 @@ use dialog_prolly_tree::KeyType;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ATTRIBUTE_LENGTH, Artifact, AttributeKeyPart, DialogArtifactsError, ENTITY_LENGTH, TAG_LENGTH,
+    ATTRIBUTE_LENGTH, Artifact, AttributeKeyPart, ENTITY_LENGTH, TAG_LENGTH,
     VALUE_DATA_TYPE_LENGTH, VALUE_REFERENCE_LENGTH, ValueDataType, ValueReferenceKeyPart,
     mutable_slice,
 };
 
-use super::{EntityKeyPart, Key, KeyView};
+use super::{EntityKeyPart, Key, KeyBytes, KeyView, KeyViewConstruct, KeyViewMut};
 
-const TAG_OFFSET: usize = 0;
 const VALUE_DATA_TYPE_OFFSET: usize = TAG_LENGTH;
 const VALUE_REFERENCE_OFFSET: usize = TAG_LENGTH + VALUE_DATA_TYPE_LENGTH;
 const ATTRIBUTE_OFFSET: usize = TAG_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH;
 const ENTITY_OFFSET: usize =
     TAG_LENGTH + VALUE_DATA_TYPE_LENGTH + VALUE_REFERENCE_LENGTH + ATTRIBUTE_LENGTH;
 
+/// Tag byte that identifies value-based index keys
 pub const VALUE_KEY_TAG: u8 = 2;
 
 /// A [`KeyType`] that is used when constructing an index of the [`Value`]s
 /// of [`Artifact`]s.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct ValueKey(Key);
+pub struct ValueKey<K>(pub K);
 
-impl KeyView for ValueKey {
+impl ValueKey<Key> {
+    /// Converts this value key into a generic key for storage in the prolly tree
+    pub fn into_key(self) -> Key {
+        self.0
+    }
+}
+
+impl KeyViewConstruct for ValueKey<Key> {
+    fn min() -> Self {
+        Self(Key::min().set_tag(VALUE_KEY_TAG))
+    }
+
+    fn max() -> Self {
+        Self(Key::max().set_tag(VALUE_KEY_TAG))
+    }
+
     fn from_parts(
         entity: EntityKeyPart,
         attribute: AttributeKeyPart,
@@ -40,103 +55,120 @@ impl KeyView for ValueKey {
             .set_value_type(value_type)
             .set_value_reference(value_reference)
     }
+}
 
-    fn min() -> Self {
-        Self(Key::min().set_tag(VALUE_KEY_TAG))
-    }
-
-    fn max() -> Self {
-        Self(Key::max().set_tag(VALUE_KEY_TAG))
+impl<K> KeyView for ValueKey<K>
+where
+    K: AsRef<KeyBytes> + Clone,
+{
+    fn entity(&self) -> EntityKeyPart {
+        EntityKeyPart(array_ref![self.0.as_ref(), ENTITY_OFFSET, ENTITY_LENGTH])
     }
 
     fn attribute(&self) -> AttributeKeyPart {
-        AttributeKeyPart(array_ref![self.0, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH])
+        AttributeKeyPart(array_ref![
+            self.0.as_ref(),
+            ATTRIBUTE_OFFSET,
+            ATTRIBUTE_LENGTH
+        ])
     }
 
-    fn entity(&self) -> EntityKeyPart {
-        EntityKeyPart(array_ref![self.0, ENTITY_OFFSET, ENTITY_LENGTH])
-    }
-
-    fn set_attribute(self, attribute: AttributeKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice![inner, ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH].copy_from_slice(attribute.0);
-        Self(inner)
-    }
-
-    fn set_entity(self, entity: EntityKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice![inner, ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
-        Self(inner)
+    fn value_type(&self) -> ValueDataType {
+        self.0.as_ref()[VALUE_DATA_TYPE_OFFSET].into()
     }
 
     fn value_reference(&self) -> ValueReferenceKeyPart {
         ValueReferenceKeyPart(array_ref![
-            self.0,
+            self.0.as_ref(),
             VALUE_REFERENCE_OFFSET,
             VALUE_REFERENCE_LENGTH
         ])
     }
+}
 
-    fn set_value_reference(self, value: ValueReferenceKeyPart) -> Self {
-        let mut inner = self.0;
-        mutable_slice!(inner, VALUE_REFERENCE_OFFSET, VALUE_REFERENCE_LENGTH)
-            .copy_from_slice(value.0);
-        Self(inner)
+impl<K> KeyViewMut for ValueKey<K>
+where
+    K: AsRef<KeyBytes> + AsMut<KeyBytes> + Clone,
+{
+    fn set_entity(mut self, entity: EntityKeyPart) -> Self {
+        mutable_slice![self.0.as_mut(), ENTITY_OFFSET, ENTITY_LENGTH].copy_from_slice(entity.0);
+        self
     }
 
-    fn value_type(&self) -> ValueDataType {
-        self.0[VALUE_DATA_TYPE_OFFSET].into()
+    fn set_attribute(mut self, attribute: AttributeKeyPart) -> Self {
+        mutable_slice![self.0.as_mut(), ATTRIBUTE_OFFSET, ATTRIBUTE_LENGTH]
+            .copy_from_slice(attribute.0);
+        self
     }
 
-    fn set_value_type(self, value_type: ValueDataType) -> Self {
-        let mut inner = self.0;
-        inner[VALUE_DATA_TYPE_OFFSET] = value_type.into();
-        Self(inner)
+    fn set_value_type(mut self, value_type: ValueDataType) -> Self {
+        self.0.as_mut()[VALUE_DATA_TYPE_OFFSET] = value_type.into();
+        self
+    }
+
+    fn set_value_reference(mut self, value_reference: ValueReferenceKeyPart) -> Self {
+        mutable_slice!(
+            self.0.as_mut(),
+            VALUE_REFERENCE_OFFSET,
+            VALUE_REFERENCE_LENGTH
+        )
+        .copy_from_slice(value_reference.0);
+        self
     }
 }
 
-impl Default for ValueKey {
+impl Default for ValueKey<Key> {
     fn default() -> Self {
-        <Self as KeyView>::min()
+        <Self as KeyViewConstruct>::min()
     }
 }
 
-impl AsRef<[u8]> for ValueKey {
-    fn as_ref(&self) -> &[u8] {
+impl<K> AsRef<KeyBytes> for ValueKey<K>
+where
+    K: AsRef<KeyBytes>,
+{
+    fn as_ref(&self) -> &KeyBytes {
         self.0.as_ref()
     }
 }
 
-impl Deref for ValueKey {
-    type Target = <Key as Deref>::Target;
+impl<K> Deref for ValueKey<K>
+where
+    K: Deref<Target = KeyBytes>,
+{
+    type Target = K::Target;
 
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 
-impl From<&Artifact> for ValueKey {
+impl From<&Artifact> for ValueKey<Key> {
     fn from(fact: &Artifact) -> Self {
-        let value_reference = fact.is.to_reference();
-        ValueKey::default()
-            .set_value_type(fact.is.data_type())
-            .set_value_reference(ValueReferenceKeyPart(&value_reference))
-            .set_attribute(AttributeKeyPart::from(&fact.the))
+        ValueKey::<Key>::default()
             .set_entity(EntityKeyPart::from(&fact.of))
+            .set_attribute(AttributeKeyPart::from(&fact.the))
+            .set_value_type(fact.is.data_type())
+            .set_value_reference(ValueReferenceKeyPart(&fact.is.to_reference()))
     }
 }
 
-impl KeyType for ValueKey {}
+impl<K> KeyType for ValueKey<K>
+where
+    K: AsRef<KeyBytes> + AsMut<KeyBytes> + Clone + KeyType,
+{
+    fn bytes(&self) -> &[u8] {
+        self.as_ref().as_ref()
+    }
+}
 
-impl TryFrom<Vec<u8>> for ValueKey {
-    type Error = DialogArtifactsError;
+impl<K> TryFrom<Vec<u8>> for ValueKey<K>
+where
+    K: KeyType,
+{
+    type Error = <K as TryFrom<Vec<u8>>>::Error;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(Self(Key(value.try_into().map_err(|value: Vec<u8>| {
-            DialogArtifactsError::InvalidKey(format!(
-                "Wrong byte length for entity key: {}",
-                value.len()
-            ))
-        })?)))
+        Ok(ValueKey(K::try_from(value)?))
     }
 }

--- a/rust/dialog-diagnose/src/state.rs
+++ b/rust/dialog-diagnose/src/state.rs
@@ -52,6 +52,9 @@ pub struct TreeState {
     pub selected_entry: Option<usize>,
     /// Set of node hashes that are currently expanded in the tree view
     pub expanded: BTreeSet<Blake3Hash>,
+
+    /// Vertical scroll offset for the tree view to handle large trees
+    pub scroll_offset: usize,
 }
 
 impl TreeState {
@@ -180,7 +183,7 @@ impl DiagnoseState {
     /// to start at the root of the prolly tree.
     pub async fn new(artifacts: Artifacts<MemoryStorageBackend<[u8; 32], Vec<u8>>>) -> Self {
         let root_hash = artifacts
-            .entity_index()
+            .index()
             .read()
             .await
             .hash()
@@ -196,6 +199,7 @@ impl DiagnoseState {
                 selected_node: root_hash,
                 selected_entry: None,
                 expanded: Default::default(),
+                scroll_offset: 0,
             },
         }
     }

--- a/rust/dialog-diagnose/src/state/analysis.rs
+++ b/rust/dialog-diagnose/src/state/analysis.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::VecDeque, sync::mpsc::Sender};
 
-use dialog_artifacts::{Datum, DialogArtifactsError, EntityKey, Index};
+use dialog_artifacts::{Datum, DialogArtifactsError, Index, Key};
 use dialog_storage::{Blake3Hash, MemoryStorageBackend};
 
 use super::store::WorkerMessage;
@@ -31,7 +31,7 @@ pub struct ArtifactsTreeStats {
 /// to compute various statistics about its structure and contents.
 pub struct ArtifactsTreeAnalysis {
     /// The prolly tree index to analyze
-    tree: Index<EntityKey, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+    tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
     /// Channel sender for worker messages
     tx: Sender<WorkerMessage>,
 }
@@ -44,7 +44,7 @@ impl ArtifactsTreeAnalysis {
     /// * `tree` - The prolly tree index to analyze
     /// * `tx` - Channel sender for worker messages
     pub fn new(
-        tree: Index<EntityKey, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+        tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
         tx: Sender<WorkerMessage>,
     ) -> Self {
         Self { tree, tx }

--- a/rust/dialog-diagnose/src/state/artifacts.rs
+++ b/rust/dialog-diagnose/src/state/artifacts.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, mpsc::Sender},
 };
 
-use dialog_artifacts::{Datum, DialogArtifactsError, EntityKey, Index};
+use dialog_artifacts::{Datum, DialogArtifactsError, Index, Key};
 use dialog_storage::{Blake3Hash, MemoryStorageBackend};
 use futures_util::{Stream, TryStreamExt};
 use tokio::sync::Mutex;
@@ -20,7 +20,7 @@ pub struct ArtifactsCursorState {
     /// Index of the next item to fetch
     next_index: usize,
     /// Last key processed (for resuming streams)
-    last_key: Option<EntityKey>,
+    last_key: Option<Key>,
     /// Whether the stream has finished
     finished: bool,
 }
@@ -33,7 +33,7 @@ pub struct ArtifactsCursor {
     /// Shared state for tracking cursor position
     state: Arc<Mutex<ArtifactsCursorState>>,
     /// The prolly tree index containing the facts
-    tree: Index<EntityKey, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+    tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
     /// Channel sender for worker messages
     tx: Sender<WorkerMessage>,
 }
@@ -46,7 +46,7 @@ impl ArtifactsCursor {
     /// * `tree` - The prolly tree index containing facts data
     /// * `tx` - Channel sender for worker messages
     pub fn new(
-        tree: Index<EntityKey, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+        tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
         tx: Sender<WorkerMessage>,
     ) -> Self {
         Self {

--- a/rust/dialog-diagnose/src/state/hierarchy.rs
+++ b/rust/dialog-diagnose/src/state/hierarchy.rs
@@ -2,7 +2,7 @@
 
 use std::sync::mpsc::Sender;
 
-use dialog_artifacts::{Datum, DialogArtifactsError, EntityKey, HASH_SIZE, Index, State};
+use dialog_artifacts::{Datum, DialogArtifactsError, HASH_SIZE, Index, Key, State};
 use dialog_prolly_tree::{Block, Entry};
 use dialog_storage::{Blake3Hash, ContentAddressedStorage, MemoryStorageBackend};
 
@@ -17,12 +17,12 @@ pub enum TreeNode {
     /// A leaf segment containing actual data entries
     Segment {
         /// The entries stored in this leaf segment
-        entries: Vec<Entry<EntityKey, State<Datum>>>,
+        entries: Vec<Entry<Key, State<Datum>>>,
     },
     /// A branch node containing references to child nodes
     Branch {
         /// The upper bound key for this branch
-        upper_bound: EntityKey,
+        upper_bound: Key,
         /// Hashes of child nodes
         children: Vec<Blake3Hash>,
     },
@@ -34,7 +34,7 @@ pub enum TreeNode {
 /// the prolly tree structure.
 pub struct ArtifactsHierarchy {
     /// The prolly tree index to load nodes from
-    tree: Index<EntityKey, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+    tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
     /// Channel sender for worker messages
     tx: Sender<WorkerMessage>,
 }
@@ -47,7 +47,7 @@ impl ArtifactsHierarchy {
     /// * `tree` - The prolly tree index to load nodes from
     /// * `tx` - Channel sender for worker messages
     pub fn new(
-        tree: Index<EntityKey, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+        tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
         tx: Sender<WorkerMessage>,
     ) -> Self {
         Self { tree, tx }
@@ -67,7 +67,7 @@ impl ArtifactsHierarchy {
         let hash = hash.to_owned();
 
         tokio::spawn(async move {
-            let Some(block): Option<Block<HASH_SIZE, EntityKey, State<Datum>, Blake3Hash>> =
+            let Some(block): Option<Block<HASH_SIZE, Key, State<Datum>, Blake3Hash>> =
                 tree.storage().read(&hash).await?
             else {
                 // TODO: This should be an error condition

--- a/rust/dialog-diagnose/src/state/store.rs
+++ b/rust/dialog-diagnose/src/state/store.rs
@@ -76,7 +76,7 @@ impl DiagnoseStore {
     /// This sets up all the background workers and channels for asynchronous
     /// data loading and initializes the internal caches.
     pub async fn new(artifacts: Artifacts<MemoryStorageBackend<Blake3Hash, Vec<u8>>>) -> Self {
-        let tree = artifacts.entity_index().read().await.clone();
+        let tree = artifacts.index().read().await.clone();
 
         let (tx, message_rx) = channel();
         let cursor = ArtifactsCursor::new(tree.clone(), tx.clone());

--- a/rust/dialog-prolly-tree/src/distribution/geometric.rs
+++ b/rust/dialog-prolly-tree/src/distribution/geometric.rs
@@ -19,7 +19,7 @@ where
     Hash: HashType<HASH_SIZE>,
 {
     fn rank(key: &Key) -> Rank {
-        let key_hash = blake3::hash(key.as_ref());
+        let key_hash = blake3::hash(key.bytes());
         compute_geometric_rank(key_hash.as_bytes(), BRANCH_FACTOR)
     }
 }

--- a/rust/dialog-prolly-tree/src/key.rs
+++ b/rust/dialog-prolly-tree/src/key.rs
@@ -4,7 +4,6 @@ use serde::{Serialize, de::DeserializeOwned};
 /// A key used to reference values in a [Tree] or [Node].
 pub trait KeyType:
     std::fmt::Debug
-    + AsRef<[u8]>
     + TryFrom<Vec<u8>>
     + ConditionalSync
     + Clone
@@ -13,9 +12,15 @@ pub trait KeyType:
     + Serialize
     + DeserializeOwned
 {
+    /// Get the raw bytes of this [`KeyType`]
+    fn bytes(&self) -> &[u8];
 }
 
-impl KeyType for Vec<u8> {}
+impl KeyType for Vec<u8> {
+    fn bytes(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
 
 /// A value that may be stored within a [Tree]
 pub trait ValueType:

--- a/typescript/dialog-experimental/src/session.ts
+++ b/typescript/dialog-experimental/src/session.ts
@@ -44,7 +44,7 @@ export type DID = `did:${string}:${string}`
  * Change that retracts set of facts, which is usually a set corresponding to
  * one relation model.
  */
-export interface Retraction extends Iterable<{ retract: Fact }> { }
+export interface Retraction extends Iterable<{ retract: Fact }> {}
 
 /**
  * Change is either assertion or a rtercation.
@@ -54,7 +54,7 @@ export type Change = Assertion | Retraction
 /**
  * Changes are set of changes that can be transacted atomically.
  */
-export interface Changes extends Iterable<Change> { }
+export interface Changes extends Iterable<Change> {}
 
 /**
  * Represents a database revision using via IPLD link formatted as string.
@@ -441,7 +441,7 @@ const fromIterable = async (iterable: ArtifactIterable) => {
   return selection
 }
 
-const select = async (connection: Artifacts, selector: ArtifactSelector) => { }
+const select = async (connection: Artifacts, selector: ArtifactSelector) => {}
 /**
  * Convert a link to an entity
  * @param link The link to convert
@@ -477,8 +477,8 @@ const toTyped = (
     case 'number': {
       return (
         Number.isInteger(value) ? { value, type: ValueDataType.SignedInt }
-          : Number.isFinite(value) ? { value, type: ValueDataType.Float }
-            : unreachable(`Number ${value} can not be inferred`)
+        : Number.isFinite(value) ? { value, type: ValueDataType.Float }
+        : unreachable(`Number ${value} can not be inferred`)
       )
     }
     case 'bigint': {

--- a/typescript/dialog-experimental/src/session.ts
+++ b/typescript/dialog-experimental/src/session.ts
@@ -44,7 +44,7 @@ export type DID = `did:${string}:${string}`
  * Change that retracts set of facts, which is usually a set corresponding to
  * one relation model.
  */
-export interface Retraction extends Iterable<{ retract: Fact }> {}
+export interface Retraction extends Iterable<{ retract: Fact }> { }
 
 /**
  * Change is either assertion or a rtercation.
@@ -54,7 +54,7 @@ export type Change = Assertion | Retraction
 /**
  * Changes are set of changes that can be transacted atomically.
  */
-export interface Changes extends Iterable<Change> {}
+export interface Changes extends Iterable<Change> { }
 
 /**
  * Represents a database revision using via IPLD link formatted as string.
@@ -441,7 +441,7 @@ const fromIterable = async (iterable: ArtifactIterable) => {
   return selection
 }
 
-const select = async (connection: Artifacts, selector: ArtifactSelector) => {}
+const select = async (connection: Artifacts, selector: ArtifactSelector) => { }
 /**
  * Convert a link to an entity
  * @param link The link to convert
@@ -477,8 +477,8 @@ const toTyped = (
     case 'number': {
       return (
         Number.isInteger(value) ? { value, type: ValueDataType.SignedInt }
-        : Number.isFinite(value) ? { value, type: ValueDataType.Float }
-        : unreachable(`Number ${value} can not be inferred`)
+          : Number.isFinite(value) ? { value, type: ValueDataType.Float }
+            : unreachable(`Number ${value} can not be inferred`)
       )
     }
     case 'bigint': {


### PR DESCRIPTION
This change switches us from using three distinct indexes to using a single, universal index with tagged keys. The observation was made that by tagging the keys, a single prolly tree may naturally balance segments by key type. One trade-off is that some segments that embody index boundaries will likely cut across two (or more, for small data) indexes.

Additionally, `diagnose` has been refined with:

- Tree level indicator
- Scrolling for tree view
- Highlighting for key bytes

[Screencast From 2025-06-27 23-02-54.webm](https://github.com/user-attachments/assets/829f22bb-f000-45d0-b34e-0680d6c01c97)
