### PR TITLE
fix: outdated and invalid statements

### DIFF
--- a/notes/divergence-clock.md
+++ b/notes/divergence-clock.md
@@ -2,22 +2,22 @@
 
 ## Goal
 
-Supporting concurrent writes into database implies that multiple actors can create concurrent commits _(containing assertions / retractions)_ than need to be reconciled by all partial replicas. Reconciliation requirements following:
+Supporting concurrent writes into database implies that multiple actors can create concurrent commits _(containing assertions / retractions)_ that need to be reconciled by all partial replicas. Reconciliation requirements following:
 
 1. Identifying concurrent changes.
-2. Order all changes (including concurrent ones)
+2. Order all changes (including concurrent ones).
 
 To make this more concrete, when query reads set of facts we need to identify if some facts are conflicting - updated same state via concurrent changes. This would enable projecting concurrent states that consumer could choose from.
 
-Ordering changes would enable us to produce commit index so that we could perform reconciliation without having to replicate full commit history. Furthermore, we would like to index history such that reconiling query results would incur minimal reads, or more simply we would like to avoid following pointers to random parts of the tree.
+Ordering changes would enable us to produce commit index so that we could perform reconciliation without having to replicate full commit history. Furthermore, we would like to index history such that reconiling query results would incur minimal reads, or more simply we would like to avoid following pointers to random segments in the tree.
 
 ### Current Design
 
-Currnt design assumed that every causal triple `{ the, of, is, cause }` MUST have a `cause` that reference another causal triple with the same `{ the, of }` as the original. This constrained implied that all causal references would be colocated in the same subtree as selected facts and therefor require no extra reads to reconcile.
+Currnt design assumed that every causal triple `{ the, of, is, cause }` MUST have a `cause` that reference another causal triple with the same `{ the, of }` as the original. This constrained implied that all causal references would be colocated in the same subtree as selected facts and therefor require no additional reads to reconcile.
 
 ### Problem
 
-Limiting causal references to the same fact lineage has implications on the possible consistency guarantees possible. Specifically it becomes impossible to update multiple facts atomically. Below is an illstrutaion the problem, where two concurrent changes are made one updating `by` and `msg` attributes and another updating only `msg` attribute which ends up in a state in which `by` attribute is from one change and `msg` attribute is from another resulting in missatribution.
+Limiting causal references to the same fact lineage has implications on the possible consistency guarantees that are possible. Specifically it becomes impossible to update multiple facts atomically. Below is an illstrutaion the problem, where two concurrent changes are made one updating `by` and `msg` attributes and another updating only `msg` attribute which ends up in a state where `by` attribute is from one change and `msg` attribute is from another resulting in missatribution.
 
 Desired behavior would be to reconcile changes such that either only `msg` changes to `"Hi"` or both `msg` and `by` change.
 
@@ -37,7 +37,7 @@ stateDiagram-v2
   conflict --> after
 ```
 
-> 💭 I think this may actually be a problem with automerge and other popular CRDT implementations.
+> 💭 I believe this is a problem with automerge and other popular CRDT implementations.
 
 ## Idea
 
@@ -47,21 +47,19 @@ I think there are two potential ways we could address such limitation that I'll 
 
 We could lift imposed limitation on causal references e.g instead of requiring that all causal references share same `{ the, of }` we could require that all causal references share attribute namespace (slice of `the` before `/`).
 
-This approach would extend consistency guartees from fact to schema boundary, while still keeping relevant causal information in cousin branches so close by in the tree.
+This approach would extend consistency guarantees from fact granularity to a schema granularity, while still retaining relevant causal information nearby segments (same or the perhaps adjacent segment) of the tree.
 
 Main downside of this approach is that it introduces a very subtle nuance to what can and can not be updated with consistency guarantees. Furthermore, it undermines premise of open-ended cooperation model because it becomes impossible to retain any consistency guarantees across schemas and therefor creates incentive for centralizing around schemas
 
-> 💭 Such an incentive MAY actually be desired as it promotes some standardization effort, yet I still worry that transactional gurantees limited to namespace may prove error prone. Ideally we could avoid limit on transactional guarntees, while making gurantees within the namespace more optimal just like selects are.
+> 💭 Such an incentive MAY actually be a desired one as it promotes some standardization, yet I still worry that transactional guarantees limited to namespace may prove error prone. Ideally we could avoid limit on transactional guarantees, while making guarantees within the namespace more optimal just like queries are.
 
 ### Causal Index
 
-We could revisit design for causal references and model it more closely to datomic's (which transaction ID). We can not use datamic's approach directly as it assumes central authority. However, it should be possible to use a different [logical clock].
+We could revisit design for causal references and model it more closely to datomic's (with transaction ID). We can not use datamic's approach directly as it assumes central authority. However, it should be possible to use a different [logical clock].
 
 #### Vector Clock
 
-Popular CRDTs like Automerge use [vector clock]s which are effectively a par of `{ site, time }` where `site` is unique identifier and `time` is [lamport timestamp].
-
-This design implies additional state, specifically each `site` MUST be unique and `time` should only increase. Later requires tracking time of every origin and still does not help us identify if following two assertions are concurrent
+Popular CRDTs use [vector clock]s which are effectively a collection of `{ site, time }` pairs where `site` is unique process identifier and `time` is the max [lamport timestamp] across all sites it has observed.
 
 ```js
 {
@@ -69,8 +67,9 @@ This design implies additional state, specifically each `site` MUST be unique an
   of: 'uuid:ba1827ea-34f8-43f3-9a46-72ed0081cc59',
   is: 3,
   cause: {
-    time: 5,
-    site: "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi"
+   "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi": 10,
+   "did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob": 8,
+   "did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL": 3
   }
 }
 
@@ -78,16 +77,23 @@ This design implies additional state, specifically each `site` MUST be unique an
   the: "counter/count",
   of: 'uuid:ba1827ea-34f8-43f3-9a46-72ed0081cc59',
   is: 7,
-  cause: {
-    time: 2,
-    site: "did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob"
+  cause:{
+    "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi": 10,
+    "did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob": 4,
+    "did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL": 5
   }
 }
 ```
 
+Vectors clocks can be used to establish partial order across changes. If each time in one of the clocks is `>=` than in the other and it has at least one time that is `>` than other than that clock orders after the other, otherwise two are concurrent.
+
+Problem with this approach is that clock sizes grow with number of sites participating in the system. Although in practice production grade CRDTs like Automerge use clever encoding and essentially only encode time of the site. However doing this requires DAG traversal until divergence points are reached.
+
+This also does not necessarily fix our problem with consistency guarantees.
+
 #### Merkle Clocks
 
-Merkle clocks formalized by [Merkle CRDT] paper propose use of hash references instead, which removes a need from having to track sites. In fact our current design is more or less that except we impose single causal link and to the same lineage. We could change that instead use the `root` hash of the tree as a causeal reference.
+Merkle clocks formalized by [Merkle CRDT] paper propose use of hash references instead, which removes a need from having to track times at specific sites. In fact our current design is more or less that except we impose single causal link and to the same lineage. We could change that instead use the `root` hash of the tree as a causeal reference.
 
 However, given two assertions where `cause` fields are just some hashes would still not enable us to identify whether those assertions are concurrent. It would require traversing causal DAG until one is identified to be an ancestor of the other or common ancestor is found. Furthermore, to do traversal efficient we would need to device some indexing strategy.
 
@@ -108,13 +114,15 @@ I think we could synthesize ideas from various logical clocks that would offer t
 1. Ability to identify concurrent changes
 2. Ability to compare any two events (without having to read arbitrary tree branches)
 
-We could accomplish first goal we must capture synchronization points e.g. tree root a.k.a revision from where changes where made. This way if two changes have same a same revision they could be considered concurrent. However, since revision is a cryptogrphic hash we would not be able to compare two changes with different revisions as it would not be clear which one is older.
+We could accomplish first goal we must capture synchronization points e.g. tree revision from where changes where made. This way if two changes have same a same revision they could be considered concurrent. However, since revision is a cryptogrphic hash we would not be able to compare two changes with different revisions as it would not be clear which one is older.
 
-We can build upon this general idea but instead of using revision hash we could use monotonically growing tree size as synchronization point instead. Specifically we could use `{ since, drift, at }` tuple to represent our logical clock where:
+We can build upon this general idea but instead of using revision hash we could use monotonically growing time as synchronization point instead. Specifically we could use `{ since, drift, at }` tuple to represent our logical clock where:
 
-- `since` - Is count of commits in the database
-- `drift` - Is the number of commits made since updating `time`
+- `since` - Is an increment of the highest `since` across all commits in the shared tree (not local replica)
+- `drift` - Is the number of commits made since last synchronization with shared tree.
 - `at` - Is the unique identifier of the site that produced change
+
+The key insight is that `since` represents the shared convergence point - when two operations have the same `since` value but different `at` values, they diverged from the same tree state and are therefore concurrent.
 
 With such a time stamps we would be able to identify concurrent changes by comparing `since` and `at` fields. If `since` is same but `at` is different changes are concurrent. Any two timestamps could also be compared by replacing `at` with a hash of the change.
 
@@ -179,15 +187,48 @@ merge C tag: "8"
 | Commit | 4 | C | 1 |
 | Push | 7 | C |  |
 
-## Alternative Approach
+## Query-Driven Partial Replication
 
-Instead of trying to captureing complete commit history inside a tree we could take completely different approach and instead have upstream tree and local workspace tree for local changes between. Reconciliation can take place on-push by merging local changes into upstream tree. This way tree would represent reconciled merge state so at query time no reconciliation would be required.
+The divergence clock design enables efficient partial replication through query-driven segment loading. Since all queries in the datalog-based system reduce to range scans over indexed facts, the system can:
 
-This approach has a tradeoff making it impossible to surface conflicts at query time as they would need to be resolved before changes are pushed and once pushed information about prior conflict will be gone.
+1. **Identify Required Segments**: Based on query predicates
+`{ the, of, is }`
+2. **Replicate Relevant Subtrees**: Pull only tree segments containing facts that match the query constraints and index nodes leading to them.
+3. **Maintain Causality**: The lexicographic ordering of `${since}/${at}/${drift}` ensures causal relationships are preserved within replicated segments
+4. **Resolve Conflicts Locally**: Concurrent facts with same `since` values will be co-located in nearby tree segments, enabling local conflict resolution
 
-Perhaps there are more lessons here to learn from datomic, as far as I understand in datomic tree represents current state, yet history is persisted in it's own index from which everything could be recovered. In other words datomic is can be though of index over the transaction log which is persisted to optimized for querying current state.
+This approach allows querying without requiring full database replication, unlike traditional CRDTs.
 
-In other words we could probably consider hybrid approach where superseded entries are pruned from the tree and are moved into an archival subtree (that still can be queried).
+## Indexing Strategy with Divergence Clocks
+
+The system maintains multiple index trees where facts are indexed by different orderings with the divergence clock embedded in the key structure:
+
+```
+EAVT Index (Entity-Attribute-Value-Time):
+"user:123/name/Alice/5/A/1" -> { the: "name", of: "user:123", is: "Alice", cause: {since: 5, at: "A", drift: 1} }
+
+AEVT Index (Attribute-Entity-Value-Time):
+"name/user:123/Alice/5/A/1" -> { the: "name", of: "user:123", is: "Alice", cause: {since: 5, at: "A", drift: 1} }
+
+VEAT Index (Value-Entity-Attribute-Time):
+"Alice/user:123/name/5/A/1" -> { the: "name", of: "user:123", is: "Alice", cause: {since: 5, at: "A", drift: 1} }
+
+TEAV Index (Time-Entity-Attribute-Value):
+"5/A/1/user:123/name/Alice" -> { the: "name", of: "user:123", is: "Alice", cause: {since: 5, at: "A", drift: 1} }
+```
+
+This design ensures that:
+
+1. **Range Queries Work Efficiently**: Scanning for all facts about `user:123` in EAVT index co-locates related facts regardless of when they were created
+2. **Conflicts Are Discoverable**: Facts with the same entity/attribute/value but different cause values appear adjacent in each index
+3. **Temporal Queries Are Supported**: TEAV index enables efficient "as of" queries and total ordering of all operations
+4. **Partial Replication Is Preserved**: Tree segments contain related facts based on the primary index components, with temporal information encoded in the path
+
+## Convergence Preference
+
+It is important to observe that this design shares tradeoffs with "longest chain rule" in certain blockchains - that is sites that pull more frequently will increment `since` sooner and consequently supersede changes made by sites that pull less frequently and consequently have lower `since` values. This could be described as preference for convergence over divergence.
+
+It is also worth calling out that in practice nothing prevents sites that remained offline from rebasing their changes as opposed to just merging them as is. This would enable them to rewrite history such that their changes are not overridden by other active sites, however just like with git it comes with a cost of disturbing other sites (not as much as with git, but suddenly history that was agreed upon by certain sites may become disputed).
 
 [logical clock]:https://en.wikipedia.org/wiki/Logical_clock
 [vector clock]:https://en.wikipedia.org/wiki/Vector_clock


### PR DESCRIPTION
- Fix invalid description of vector clocks
- Describe `since` as counter as opposed to commit count.
- Add note about convergence preference