### PR TITLE
feat: Revised Search Tree

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,5 +1,5 @@
 [language-server.rust-analyzer.config]
-cargo.target = "wasm32-unknown-unknown"
+# cargo.target = "wasm32-unknown-unknown"
 cargo.features = ["integration-tests", "ucan"]
 
 # If you want all features enabled instead:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +307,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +406,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -541,6 +597,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +683,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -684,6 +809,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,9 +935,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base58",
  "blake3",
  "dialog-macros",
  "futures-util",
+ "getrandom 0.2.16",
+ "rand 0.8.5",
+ "rkyv",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -809,6 +952,8 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "web-time",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -950,6 +1095,38 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "url",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "dialog-search-tree"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base58",
+ "blake3",
+ "bytes",
+ "criterion",
+ "dashmap",
+ "dialog-common",
+ "dialog-macros",
+ "dialog-storage",
+ "futures-core",
+ "futures-util",
+ "getrandom 0.2.16",
+ "hashbrown 0.16.1",
+ "nonempty",
+ "parking_lot",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "sieve-cache",
+ "stable_deref_trait",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-test",
  "wasm-bindgen-test",
 ]
 
@@ -1243,6 +1420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1589,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,7 +1613,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1421,12 +1621,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex-simd"
@@ -1799,10 +2010,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2022,6 +2253,26 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "unsigned-varint",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2288,6 +2539,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2655,26 @@ checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
 dependencies = [
  "arbitrary",
  "proptest",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2474,6 +2773,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -2581,6 +2889,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,6 +2945,15 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -2689,6 +3026,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3385,6 +3752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +4050,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "rust/dialog-dbsp",
     "rust/dialog-encoding",
     "rust/dialog-prolly-tree",
+    "rust/dialog-search-tree",
     "rust/dialog-storage",
     "rust/dialog-s3-credentials",
     "rust/dialog-ucan",
@@ -37,6 +38,7 @@ resolver = "2"
 version = "0.1.0"
 authors = ["The Meiosys Project Authors"]
 license = "MPL-2.0"
+edition = "2024"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -56,10 +58,12 @@ clap_derive = "4"
 console_error_panic_hook = "0.1"
 convert_case = "0.6"
 csv-async = { version = "1", features = ["tokio"] }
+dashmap = "6"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
+hashbrown = "0.16"
 hmac = "0.12"
 http-body-util = "0.1"
 hyper = "1"
@@ -79,6 +83,7 @@ md5 = "0.8"
 nom = "7"
 nom-unicode = "0.3"
 nonempty = "0.11"
+parking_lot = "0.12"
 p256 = "0.13"
 p384 = "0.13"
 p521 = "0.13"
@@ -112,6 +117,7 @@ serde_json = "1"
 sha2 = "0.10"
 sieve-cache = "1"
 signature = "2.2"
+stable_deref_trait = "1"
 static_assertions = "1"
 syn = "2"
 tempfile = "3"
@@ -136,6 +142,7 @@ wasm-bindgen-test = "0.3"
 web-sys = "0.3"
 web-time = "1"
 zerocopy = "0.8"
+zerocopy-derive = "0.8"
 
 [workspace.dependencies.dialog-artifacts]
 path = "./rust/dialog-artifacts"

--- a/rust/dialog-common/Cargo.toml
+++ b/rust/dialog-common/Cargo.toml
@@ -9,28 +9,35 @@ license.workspace = true
 [features]
 default = []
 # Testing utilities (Provision, Provider traits, EnvGuard)
-helpers = ["dep:anyhow", "dep:serde_json", "dep:dialog-macros", "dep:async-trait"]
+helpers = ["dep:anyhow", "dep:serde_json", "dep:dialog-macros", "dep:async-trait", "dep:rand"]
 # Enable integration tests (tests with service provisioning)
 integration-tests = ["helpers"]
 # Enable web integration tests (implies integration-tests behavior)
 web-integration-tests = ["helpers"]
 
 [dependencies]
+base58 = { workspace = true }
 blake3 = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-web-time = { workspace = true }
-serde_bytes = { workspace = true }
-anyhow = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
-dialog-macros = { workspace = true, optional = true }
-async-trait = { workspace = true, optional = true }
 futures-util = { workspace = true }
+rkyv = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
 thiserror = { workspace = true }
+web-time = { workspace = true }
+zerocopy = { workspace = true }
+zerocopy-derive = { workspace = true }
+
+anyhow = { workspace = true, optional = true }
+async-trait = { workspace = true, optional = true }
+dialog-macros = { workspace = true, optional = true }
+rand = { workspace = true, features = ["min_const_gen"], optional = true }
+serde_json = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt", "sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
 tokio = { workspace = true, features = ["sync"] }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = ["console"] }

--- a/rust/dialog-common/src/hash.rs
+++ b/rust/dialog-common/src/hash.rs
@@ -1,5 +1,7 @@
-use serde::{Deserialize, Serialize};
+use base58::ToBase58;
+use rkyv::Archive;
 use thiserror::Error;
+use zerocopy_derive::{FromBytes, Immutable, KnownLayout};
 
 /// The size of a BLAKE3 hash in bytes.
 ///
@@ -20,9 +22,33 @@ pub const BLAKE3_HASH_SIZE: usize = 32;
 /// let data = b"hello world";
 /// let hash = Blake3Hash::hash(data);
 /// ```
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Hash,
+    Default,
+    Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+)]
 #[repr(transparent)]
 pub struct Blake3Hash([u8; 32]);
+
+impl ArchivedBlake3Hash {
+    /// Returns the hash bytes as a 32-byte array reference.
+    pub fn bytes(&self) -> &[u8; BLAKE3_HASH_SIZE] {
+        &self.0
+    }
+}
 
 impl Blake3Hash {
     /// Computes the BLAKE3 hash of the given bytes.
@@ -48,8 +74,25 @@ impl Blake3Hash {
     }
 
     /// Returns the hash as a byte slice.
-    pub fn as_bytes(&self) -> &[u8; 32] {
+    pub fn as_bytes(&self) -> &[u8; BLAKE3_HASH_SIZE] {
         &self.0
+    }
+
+    /// Computes the BLAKE3 hash of multiple byte slices.
+    pub fn hash_iter<'a, I>(bytes: I) -> Self
+    where
+        I: Iterator<Item = &'a [u8]>,
+    {
+        let mut hasher = blake3::Hasher::new();
+        for chunk in bytes {
+            hasher.update(chunk);
+        }
+        Self(hasher.finalize().into())
+    }
+
+    /// Checks if the hash of the given bytes matches this hash.
+    pub fn matches(&self, bytes: &[u8]) -> bool {
+        Self::hash(bytes) == *self
     }
 }
 
@@ -77,6 +120,18 @@ impl TryFrom<Vec<u8>> for Blake3Hash {
     }
 }
 
+impl std::fmt::Display for Blake3Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "blake3#{}", self.0.to_base58())
+    }
+}
+
+impl<'a> From<&'a ArchivedBlake3Hash> for &'a Blake3Hash {
+    fn from(value: &'a ArchivedBlake3Hash) -> Self {
+        zerocopy::transmute_ref!(value.bytes())
+    }
+}
+
 /// Error returned when trying to convert byte arry to a Blake3Hash.
 #[derive(Error, Debug, Clone)]
 pub enum ConversionError {
@@ -84,3 +139,8 @@ pub enum ConversionError {
     #[error("Expected {BLAKE3_HASH_SIZE} bytes, got {0}")]
     InvalidSize(usize),
 }
+
+/// A null hash consisting of all zero bytes.
+///
+/// This is used as a sentinel value to represent an empty or uninitialized state.
+pub const NULL_BLAKE3_HASH: &Blake3Hash = &Blake3Hash([0u8; 32]);

--- a/rust/dialog-search-tree/Cargo.toml
+++ b/rust/dialog-search-tree/Cargo.toml
@@ -1,0 +1,65 @@
+[package]
+name = "dialog-search-tree"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[features]
+default = []
+integration-tests = []
+web-integration-tests = []
+
+[dependencies]
+dialog-common = { workspace = true }
+dialog-macros = { workspace = true }
+dialog-storage = { workspace = true }
+anyhow = { workspace = true }
+
+async-trait = { workspace = true }
+async-stream = { workspace = true }
+base58 = { workspace = true }
+blake3 = { workspace = true }
+bytes = { workspace = true }
+dashmap = { workspace = true }
+futures-core = { workspace = true }
+hashbrown = { workspace = true }
+nonempty = { workspace = true, features = ["serialize"] }
+parking_lot = { workspace = true }
+rand = { workspace = true }
+rkyv = { workspace = true }
+serde = { workspace = true }
+sieve-cache = { workspace = true }
+stable_deref_trait = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+
+[dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
+dialog-storage = { workspace = true, features = ["helpers"] }
+futures-util = { workspace = true }
+tokio-test = { workspace = true }
+
+[[bench]]
+name = "insert"
+harness = false
+
+[[bench]]
+name = "get"
+harness = false
+
+[[bench]]
+name = "delete"
+harness = false
+
+[[bench]]
+name = "range_query"
+harness = false
+
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+getrandom = { workspace = true, features = ["js"] }
+wasm-bindgen-test = { workspace = true }

--- a/rust/dialog-search-tree/benches/delete.rs
+++ b/rust/dialog-search-tree/benches/delete.rs
@@ -1,0 +1,39 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_common::helpers::BenchData;
+use dialog_search_tree::{ContentAddressedStorage, Tree};
+use dialog_storage::MemoryStorageBackend;
+
+const BENCH_SEED: u64 = 42;
+
+fn bench_delete(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delete");
+    let mut data = BenchData::new(BENCH_SEED);
+
+    for size in [10, 100, 1000, 10000] {
+        let keys = data.random_buffers::<16>(size);
+        let values = data.random_buffers::<32>(size);
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            b.to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter(|| async {
+                    let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+                    let mut tree = Tree::<[u8; 16], Vec<u8>>::empty();
+
+                    // Insert all keys
+                    for (key, value) in keys.iter().zip(values.iter()) {
+                        tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+                    }
+
+                    // Delete half of them
+                    for key in keys.iter().take(size / 2) {
+                        tree = tree.delete(key, &storage).await.unwrap();
+                    }
+                });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_delete);
+criterion_main!(benches);

--- a/rust/dialog-search-tree/benches/get.rs
+++ b/rust/dialog-search-tree/benches/get.rs
@@ -1,0 +1,40 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_common::helpers::BenchData;
+use dialog_search_tree::{ContentAddressedStorage, Tree};
+use dialog_storage::MemoryStorageBackend;
+
+const BENCH_SEED: u64 = 42;
+
+fn bench_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get");
+    let mut data = BenchData::new(BENCH_SEED);
+
+    for size in [10, 100, 1000, 10000] {
+        let keys = data.random_buffers::<16>(size);
+        let values = data.random_buffers::<32>(size);
+
+        // Setup: create a tree with data
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let (tree, storage, keys) = runtime.block_on(async {
+            let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+            let mut tree = Tree::<[u8; 16], Vec<u8>>::empty();
+
+            for (key, value) in keys.iter().zip(values.iter()) {
+                tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+            }
+
+            (tree, storage, keys)
+        });
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            // Benchmark: get the first key
+            b.to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter(|| async { tree.get(&keys[0], &storage).await.unwrap() });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_get);
+criterion_main!(benches);

--- a/rust/dialog-search-tree/benches/insert.rs
+++ b/rust/dialog-search-tree/benches/insert.rs
@@ -1,0 +1,57 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_common::helpers::BenchData;
+use dialog_search_tree::{ContentAddressedStorage, Tree};
+use dialog_storage::MemoryStorageBackend;
+
+const BENCH_SEED: u64 = 42;
+
+fn bench_insert_sequential(c: &mut Criterion) {
+    let mut group = c.benchmark_group("insert_sequential");
+    let mut data = BenchData::new(BENCH_SEED);
+
+    for size in [10, 100, 1000, 10000] {
+        let keys = data.sequential_buffers::<16>(size);
+        let values = data.random_buffers::<32>(size);
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _size| {
+            b.to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter(|| async {
+                    let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+                    let mut tree = Tree::<[u8; 16], Vec<u8>>::empty();
+
+                    for (key, value) in keys.iter().zip(values.iter()) {
+                        tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+                    }
+                });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_insert_random(c: &mut Criterion) {
+    let mut group = c.benchmark_group("insert_random");
+    let mut data = BenchData::new(BENCH_SEED);
+
+    for size in [10, 100, 1000, 10000] {
+        let keys = data.random_buffers::<16>(size);
+        let values = data.random_buffers::<32>(size);
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, move |b, _size| {
+            b.to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter(|| async {
+                    let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+                    let mut tree = Tree::<[u8; 16], Vec<u8>>::empty();
+
+                    for (key, value) in keys.iter().zip(values.iter()) {
+                        tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+                    }
+                });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_insert_sequential, bench_insert_random);
+criterion_main!(benches);

--- a/rust/dialog-search-tree/benches/range_query.rs
+++ b/rust/dialog-search-tree/benches/range_query.rs
@@ -1,0 +1,63 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_common::helpers::BenchData;
+use dialog_search_tree::{ContentAddressedStorage, Tree};
+use dialog_storage::MemoryStorageBackend;
+use futures_util::StreamExt;
+
+const BENCH_SEED: u64 = 42;
+
+fn make_key(index: usize) -> [u8; 16] {
+    let mut key = [0; 16];
+    let index_bytes = (index as u32).to_le_bytes();
+    key[..index_bytes.len()].copy_from_slice(&index_bytes);
+    key
+}
+
+fn bench_range_query(c: &mut Criterion) {
+    let mut group = c.benchmark_group("range_query");
+    let mut data = BenchData::new(BENCH_SEED);
+
+    const TREE_SIZE: usize = 10100;
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let (tree, storage) = runtime.block_on(async {
+        let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 16], Vec<u8>>::empty();
+
+        let keys = data.random_buffers(TREE_SIZE);
+        let values = data.random_buffers::<32>(TREE_SIZE);
+
+        for (key, value) in keys.iter().zip(values.iter()) {
+            tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+        }
+
+        (tree, storage)
+    });
+
+    for range_size in [10usize, 100, 1000, 10000] {
+        let start = make_key(100);
+        let end = make_key(100 + range_size);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(range_size),
+            &range_size,
+            |b, _| {
+                b.to_async(tokio::runtime::Runtime::new().unwrap())
+                    .iter(|| async {
+                        let stream = tree.stream_range(start..end, &storage);
+                        futures_util::pin_mut!(stream);
+                        let mut count = 0;
+                        while let Some(result) = stream.next().await {
+                            result.unwrap();
+                            count += 1;
+                        }
+                        count
+                    });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_range_query);
+criterion_main!(benches);

--- a/rust/dialog-search-tree/src/body.rs
+++ b/rust/dialog-search-tree/src/body.rs
@@ -1,0 +1,171 @@
+use std::cmp::Ordering;
+
+use crate::{ArchivedEntry, DialogSearchTreeError, Entry, Key, Link, SymmetryWith, Value};
+use rkyv::{
+    Archive, Deserialize, Serialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    ser::{Serializer, allocator::ArenaHandle, sharing::Share},
+    util::AlignedVec,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+/// An index node containing links to child nodes.
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
+pub struct Index<Key> {
+    /// The child node links stored in this index.
+    pub links: Vec<Link<Key>>,
+}
+
+impl<Key> Index<Key>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+{
+    /// Creates a new [`Index`] containing a single link.
+    pub fn new(link: Link<Key>) -> Self {
+        Self { links: vec![link] }
+    }
+}
+
+impl<Key> ArchivedIndex<Key>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+{
+    /// Returns the upper bound key of the last link in this index.
+    pub fn upper_bound(&self) -> Option<&Key::Archived> {
+        self.links.last().map(|link| &link.upper_bound)
+    }
+}
+
+/// A leaf segment containing key-value entries.
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
+pub struct Segment<Key, Value> {
+    /// The key-value entries stored in this segment.
+    pub entries: Vec<Entry<Key, Value>>,
+}
+
+impl<Key, Value> Segment<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Value: self::Value,
+{
+    /// Creates a new [`Segment`] containing a single entry.
+    pub fn new(entry: Entry<Key, Value>) -> Self {
+        Self {
+            entries: vec![entry],
+        }
+    }
+}
+
+impl<Key, Value> ArchivedSegment<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Value: self::Value,
+{
+    /// Returns the key of the last entry in this segment.
+    pub fn upper_bound(&self) -> Option<&Key::Archived> {
+        self.entries.last().map(|entry| &entry.key)
+    }
+}
+
+/// The body of a tree node, either an index or a leaf segment.
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
+pub enum NodeBody<Key, Value> {
+    /// An index node containing links to child nodes.
+    Index(Index<Key>),
+    /// A leaf segment containing key-value entries.
+    Segment(Segment<Key, Value>),
+}
+
+impl<Key, Value> NodeBody<Key, Value>
+where
+    Key: self::Key
+        + for<'a> Serialize<
+            Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+        >,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Value: self::Value
+        + for<'a> Serialize<
+            Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+        >,
+{
+    /// Serializes this node body to bytes.
+    pub fn as_bytes(&self) -> Result<Vec<u8>, DialogSearchTreeError> {
+        rkyv::to_bytes(self)
+            .map_err(|error| DialogSearchTreeError::Encoding(format!("{error}")))
+            .map(|bytes| bytes.to_vec())
+    }
+}
+
+impl<Key, Value> TryFrom<Vec<Link<Key>>> for NodeBody<Key, Value> {
+    type Error = DialogSearchTreeError;
+
+    fn try_from(links: Vec<Link<Key>>) -> Result<Self, Self::Error> {
+        if links.is_empty() {
+            return Err(DialogSearchTreeError::Node(
+                "Attempted to create an index from zero links".into(),
+            ));
+        }
+        Ok(NodeBody::Index(Index { links }))
+    }
+}
+
+impl<Key, Value> TryFrom<Vec<Entry<Key, Value>>> for NodeBody<Key, Value> {
+    type Error = DialogSearchTreeError;
+
+    fn try_from(entries: Vec<Entry<Key, Value>>) -> Result<Self, Self::Error> {
+        if entries.is_empty() {
+            return Err(DialogSearchTreeError::Node(
+                "Attempted to create an index from zero links".into(),
+            ));
+        }
+        Ok(NodeBody::Segment(Segment { entries }))
+    }
+}
+
+impl<Key, Value> ArchivedNodeBody<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>
+        + PartialOrd<Key>
+        + PartialEq<Key>
+        + SymmetryWith<Key>
+        + Ord,
+    Value: self::Value,
+{
+    /// Returns the upper bound key of this node body.
+    pub fn upper_bound(&self) -> Result<&Key::Archived, DialogSearchTreeError> {
+        match self {
+            ArchivedNodeBody::Index(index) => index.upper_bound(),
+            ArchivedNodeBody::Segment(segment) => segment.upper_bound(),
+        }
+        .ok_or_else(|| DialogSearchTreeError::Node("Node was unexpectedly empty".into()))
+    }
+
+    /// Searches for an entry with the given key in this segment.
+    ///
+    /// Returns `Ok(None)` if this is an index node or if the key is not found.
+    pub fn find_entry(
+        &self,
+        key: &Key,
+    ) -> Result<Option<&ArchivedEntry<Key, Value>>, DialogSearchTreeError> {
+        match self {
+            ArchivedNodeBody::Index(_) => Err(DialogSearchTreeError::Access(
+                "Attempted to find an entry in an index node".into(),
+            )),
+            ArchivedNodeBody::Segment(segment) => Ok(segment
+                .entries
+                .binary_search_by(|entry| entry.key.partial_cmp(key).unwrap_or(Ordering::Less))
+                .map(|index| segment.entries.get(index))
+                .ok()
+                .and_then(|entry| entry)),
+        }
+    }
+}

--- a/rust/dialog-search-tree/src/buffer.rs
+++ b/rust/dialog-search-tree/src/buffer.rs
@@ -1,0 +1,30 @@
+use std::sync::{Arc, OnceLock};
+
+use dialog_common::Blake3Hash;
+
+/// A reference-counted buffer with lazy hash computation.
+///
+/// Buffers store serialized node data with efficient cloning
+/// and on-demand hash calculation.
+#[derive(Clone, Debug)]
+pub struct Buffer(Arc<(Vec<u8>, OnceLock<Blake3Hash>)>);
+
+impl Buffer {
+    /// Returns the [`Blake3Hash`] of this buffer's contents, computing it if
+    /// necessary.
+    pub fn blake3_hash(&self) -> &Blake3Hash {
+        self.0.1.get_or_init(|| Blake3Hash::hash(&self.0.0))
+    }
+}
+
+impl AsRef<[u8]> for Buffer {
+    fn as_ref(&self) -> &[u8] {
+        self.0.0.as_ref()
+    }
+}
+
+impl From<Vec<u8>> for Buffer {
+    fn from(value: Vec<u8>) -> Self {
+        Self(Arc::new((value, OnceLock::new())))
+    }
+}

--- a/rust/dialog-search-tree/src/cache.rs
+++ b/rust/dialog-search-tree/src/cache.rs
@@ -1,0 +1,111 @@
+use dialog_common::{ConditionalSend, ConditionalSync};
+
+#[cfg(not(target_arch = "wasm32"))]
+use sieve_cache::ShardedSieveCache as SieveCache;
+#[cfg(target_arch = "wasm32")]
+use sieve_cache::SieveCache;
+
+use std::hash::Hash;
+#[cfg(target_arch = "wasm32")]
+use std::{cell::RefCell, rc::Rc};
+
+const CACHE_CAPACITY: usize = 2048;
+
+/// A thread-safe cache for storing frequently accessed values.
+#[derive(Clone)]
+pub struct Cache<K, V>
+where
+    K: Eq + Hash + Clone + ConditionalSend + ConditionalSync,
+    V: Clone + ConditionalSend + ConditionalSync,
+{
+    #[cfg(not(target_arch = "wasm32"))]
+    cache: SieveCache<K, V>,
+
+    #[cfg(target_arch = "wasm32")]
+    cache: Rc<RefCell<SieveCache<K, V>>>,
+}
+
+impl<K, V> std::fmt::Debug for Cache<K, V>
+where
+    K: Eq + Hash + Clone + ConditionalSend + ConditionalSync,
+    V: Clone + ConditionalSend + ConditionalSync,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_struct = f.debug_struct("Cache");
+        #[cfg(not(target_arch = "wasm32"))]
+        let debug_struct = debug_struct.field("cache", &self.cache.len());
+
+        #[cfg(target_arch = "wasm32")]
+        let debug_struct = debug_struct.field("cache", &self.cache.borrow().len());
+
+        debug_struct.finish()
+    }
+}
+
+impl<K, V> Default for Cache<K, V>
+where
+    K: Eq + Hash + Clone + ConditionalSend + ConditionalSync,
+    V: Clone + ConditionalSend + ConditionalSync,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Cache<K, V>
+where
+    K: Eq + Hash + Clone + ConditionalSend + ConditionalSync,
+    V: Clone + ConditionalSend + ConditionalSync,
+{
+    /// Creates a new cache with a fixed capacity.
+    pub fn new() -> Self {
+        // SAFETY: `SieveCache` only returns an error if the cache capacity is 0.
+        let cache = SieveCache::new(CACHE_CAPACITY).unwrap();
+
+        Self {
+            #[cfg(not(target_arch = "wasm32"))]
+            cache,
+            #[cfg(target_arch = "wasm32")]
+            cache: Rc::new(RefCell::new(cache)),
+        }
+    }
+
+    /// Retrieves a value from the cache, or fetches it using the provided
+    /// function.
+    pub async fn get_or_fetch<F, E>(&self, key: &K, fetcher: F) -> Result<Option<V>, E>
+    where
+        F: AsyncFnOnce(&K) -> Result<Option<V>, E>,
+    {
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(value) = self.cache.get(key) {
+            return Ok(Some(value));
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        if let Some(value) = self.cache.borrow_mut().get(key) {
+            let value = value.clone();
+            return Ok(Some(value));
+        }
+
+        Ok(if let Some(value) = fetcher(key).await? {
+            #[cfg(not(target_arch = "wasm32"))]
+            self.cache.insert(key.clone(), value.clone());
+            #[cfg(target_arch = "wasm32")]
+            self.cache.borrow_mut().insert(key.clone(), value.clone());
+
+            Some(value)
+        } else {
+            None
+        })
+    }
+
+    /// Inserts a key-value pair into the cache.
+    pub fn insert(&self, key: K, value: V) -> bool {
+        #[cfg(not(target_arch = "wasm32"))]
+        let cache = &self.cache;
+        #[cfg(target_arch = "wasm32")]
+        let mut cache = self.cache.borrow_mut();
+
+        cache.insert(key, value)
+    }
+}

--- a/rust/dialog-search-tree/src/compare.rs
+++ b/rust/dialog-search-tree/src/compare.rs
@@ -1,0 +1,18 @@
+use std::cmp::Ordering;
+
+use rkyv::Archive;
+
+/// A trait for comparing archived and owned values symmetrically.
+pub trait SymmetryWith<T: ?Sized>: PartialOrd<T>
+where
+    T: Archive<Archived = Self> + Ord,
+{
+    /// Compares this archived value with an owned value.
+    fn cmp(&self, other: &T) -> Ordering {
+        // SAFETY: partial_cmp returns None only for incomparable values (e.g.,
+        // `0f32.cmp(f32::NAN)`). `<T as Archive>::Archived` is a code-generated
+        // derivative of `T` and should be byte-for-byte symmetrical to `T`
+        // (already known to be `Ord`).
+        self.partial_cmp(other).unwrap()
+    }
+}

--- a/rust/dialog-search-tree/src/delta.rs
+++ b/rust/dialog-search-tree/src/delta.rs
@@ -1,0 +1,403 @@
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+use hashbrown::HashMap;
+
+/// A thread-safe accumulator of pending changes to tree nodes.
+#[derive(Clone, Debug)]
+pub struct Delta<K, V> {
+    contents: Arc<Mutex<HashMap<K, V>>>,
+}
+
+impl<K, V> Delta<K, V>
+where
+    K: Clone + std::hash::Hash + PartialEq + Eq + std::fmt::Display,
+    V: Clone,
+{
+    /// Creates an empty delta with no pending changes.
+    pub fn zero() -> Self {
+        Self {
+            contents: Default::default(),
+        }
+    }
+
+    /// Creates a new delta that contains a copy of this delta's contents.
+    pub fn branch(&self) -> Self {
+        Self {
+            contents: Arc::new(Mutex::new(self.contents.lock().clone())),
+        }
+    }
+
+    /// Adds a key-value pair to this delta.
+    pub fn add(&mut self, key: K, value: V) {
+        let mut contents = self.contents.lock();
+        contents.insert(key.clone(), value);
+    }
+
+    /// Adds multiple key-value pairs to this delta.
+    pub fn add_all<Entries>(&mut self, entries: Entries)
+    where
+        Entries: Iterator<Item = (K, V)>,
+    {
+        let mut contents = self.contents.lock();
+        for (key, value) in entries {
+            contents.insert(key.clone(), value);
+        }
+    }
+
+    /// Removes a key from this delta.
+    pub fn subtract(&mut self, key: &K) {
+        let mut contents = self.contents.lock();
+        contents.remove(key);
+    }
+
+    /// Removes multiple keys from this delta.
+    pub fn subtract_all<'a, Keys>(&'a mut self, keys: Keys)
+    where
+        Keys: Iterator<Item = &'a K>,
+    {
+        let mut contents = self.contents.lock();
+        for key in keys {
+            contents.remove(key);
+        }
+    }
+
+    /// Retrieves the value associated with a key from this delta.
+    pub fn get(&self, key: &K) -> Option<V> {
+        let contents = self.contents.lock();
+        contents.get(key).cloned()
+    }
+
+    /// Drains all entries from this delta and returns them as an iterator.
+    pub fn flush(&mut self) -> impl Iterator<Item = (K, V)> {
+        std::mem::take(&mut *self.contents.lock()).into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use super::*;
+    use anyhow::Result;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[dialog_common::test]
+    async fn it_creates_an_empty_delta() -> Result<()> {
+        let delta = Delta::<u32, String>::zero();
+        assert_eq!(delta.get(&1), None);
+        assert_eq!(delta.get(&100), None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_adds_a_single_entry() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        delta.add(1, "value1".to_string());
+        assert_eq!(delta.get(&1), Some("value1".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_adds_multiple_entries() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        delta.add(1, "value1".to_string());
+        delta.add(2, "value2".to_string());
+        delta.add(3, "value3".to_string());
+
+        assert_eq!(delta.get(&1), Some("value1".to_string()));
+        assert_eq!(delta.get(&2), Some("value2".to_string()));
+        assert_eq!(delta.get(&3), Some("value3".to_string()));
+        assert_eq!(delta.get(&4), None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_overwrites_existing_entries() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        delta.add(1, "value1".to_string());
+        assert_eq!(delta.get(&1), Some("value1".to_string()));
+
+        delta.add(1, "updated".to_string());
+        assert_eq!(delta.get(&1), Some("updated".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_adds_all_entries_from_an_iterator() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        let entries = vec![
+            (1, "value1".to_string()),
+            (2, "value2".to_string()),
+            (3, "value3".to_string()),
+        ];
+
+        delta.add_all(entries.into_iter());
+
+        assert_eq!(delta.get(&1), Some("value1".to_string()));
+        assert_eq!(delta.get(&2), Some("value2".to_string()));
+        assert_eq!(delta.get(&3), Some("value3".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_subtracts_an_entry() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        delta.add(1, "value1".to_string());
+        delta.add(2, "value2".to_string());
+
+        assert_eq!(delta.get(&1), Some("value1".to_string()));
+        assert_eq!(delta.get(&2), Some("value2".to_string()));
+
+        delta.subtract(&1);
+
+        assert_eq!(delta.get(&1), None);
+        assert_eq!(delta.get(&2), Some("value2".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_subtracts_nonexistent_entry_without_error() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        delta.add(1, "value1".to_string());
+
+        // Subtracting non-existent key should not panic
+        delta.subtract(&999);
+
+        assert_eq!(delta.get(&1), Some("value1".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_subtracts_all_entries_from_an_iterator() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        delta.add(1, "value1".to_string());
+        delta.add(2, "value2".to_string());
+        delta.add(3, "value3".to_string());
+        delta.add(4, "value4".to_string());
+
+        let keys_to_remove = [1, 3];
+        delta.subtract_all(keys_to_remove.iter());
+
+        assert_eq!(delta.get(&1), None);
+        assert_eq!(delta.get(&2), Some("value2".to_string()));
+        assert_eq!(delta.get(&3), None);
+        assert_eq!(delta.get(&4), Some("value4".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_branches_to_create_independent_copy() -> Result<()> {
+        let mut delta1 = Delta::<u32, String>::zero();
+
+        delta1.add(1, "value1".to_string());
+        delta1.add(2, "value2".to_string());
+
+        let mut delta2 = delta1.branch();
+
+        // Verify delta2 has the same contents initially
+        assert_eq!(delta2.get(&1), Some("value1".to_string()));
+        assert_eq!(delta2.get(&2), Some("value2".to_string()));
+
+        // Modify delta2
+        delta2.add(3, "value3".to_string());
+        delta2.subtract(&1);
+
+        // Verify delta1 is unchanged
+        assert_eq!(delta1.get(&1), Some("value1".to_string()));
+        assert_eq!(delta1.get(&2), Some("value2".to_string()));
+        assert_eq!(delta1.get(&3), None);
+
+        // Verify delta2 has the changes
+        assert_eq!(delta2.get(&1), None);
+        assert_eq!(delta2.get(&2), Some("value2".to_string()));
+        assert_eq!(delta2.get(&3), Some("value3".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_flushes_all_entries() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        delta.add(1, "value1".to_string());
+        delta.add(2, "value2".to_string());
+        delta.add(3, "value3".to_string());
+
+        let entries: Vec<(u32, String)> = delta.flush().collect();
+
+        // Verify all entries were flushed
+        assert_eq!(entries.len(), 3);
+        assert!(entries.contains(&(1, "value1".to_string())));
+        assert!(entries.contains(&(2, "value2".to_string())));
+        assert!(entries.contains(&(3, "value3".to_string())));
+
+        // Verify delta is now empty
+        assert_eq!(delta.get(&1), None);
+        assert_eq!(delta.get(&2), None);
+        assert_eq!(delta.get(&3), None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_flushes_an_empty_delta() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        let entries: Vec<(u32, String)> = delta.flush().collect();
+
+        assert_eq!(entries.len(), 0);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_flushes_one_delta_without_affecting_branched_copy() -> Result<()> {
+        let mut delta1 = Delta::<u32, String>::zero();
+
+        delta1.add(1, "value1".to_string());
+        delta1.add(2, "value2".to_string());
+        delta1.add(3, "value3".to_string());
+
+        // Branch creates an independent copy
+        let delta2 = delta1.branch();
+
+        // Verify both have the same initial data
+        assert_eq!(delta1.get(&1), Some("value1".to_string()));
+        assert_eq!(delta1.get(&2), Some("value2".to_string()));
+        assert_eq!(delta1.get(&3), Some("value3".to_string()));
+
+        assert_eq!(delta2.get(&1), Some("value1".to_string()));
+        assert_eq!(delta2.get(&2), Some("value2".to_string()));
+        assert_eq!(delta2.get(&3), Some("value3".to_string()));
+
+        // Flush delta1
+        let entries: Vec<(u32, String)> = delta1.flush().collect();
+        assert_eq!(entries.len(), 3);
+
+        // Verify delta1 is now empty
+        assert_eq!(delta1.get(&1), None);
+        assert_eq!(delta1.get(&2), None);
+        assert_eq!(delta1.get(&3), None);
+
+        // Verify delta2 still has all its data (unaffected by flush)
+        assert_eq!(delta2.get(&1), Some("value1".to_string()));
+        assert_eq!(delta2.get(&2), Some("value2".to_string()));
+        assert_eq!(delta2.get(&3), Some("value3".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_mixed_operations() -> Result<()> {
+        let mut delta = Delta::<u32, String>::zero();
+
+        // Add some entries
+        delta.add(1, "value1".to_string());
+        delta.add(2, "value2".to_string());
+        delta.add(3, "value3".to_string());
+
+        // Update one
+        delta.add(2, "updated2".to_string());
+
+        // Remove one
+        delta.subtract(&1);
+
+        // Add more
+        delta.add(4, "value4".to_string());
+
+        // Verify final state
+        assert_eq!(delta.get(&1), None);
+        assert_eq!(delta.get(&2), Some("updated2".to_string()));
+        assert_eq!(delta.get(&3), Some("value3".to_string()));
+        assert_eq!(delta.get(&4), Some("value4".to_string()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_works_with_string_keys() -> Result<()> {
+        let mut delta = Delta::<String, Vec<u8>>::zero();
+
+        let key1 = "key1".to_string();
+        let key2 = "key2".to_string();
+        let value1 = vec![1, 2, 3, 4];
+        let value2 = vec![5, 6, 7, 8];
+
+        delta.add(key1.clone(), value1.clone());
+        delta.add(key2.clone(), value2.clone());
+
+        assert_eq!(delta.get(&key1), Some(value1));
+        assert_eq!(delta.get(&key2), Some(value2));
+
+        delta.subtract(&key1);
+        assert_eq!(delta.get(&key1), None);
+        assert_eq!(delta.get(&key2), Some(vec![5, 6, 7, 8]));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_large_number_of_entries() -> Result<()> {
+        let mut delta = Delta::<u32, u32>::zero();
+
+        // Add 1000 entries
+        for i in 0..1000 {
+            delta.add(i, i * 2);
+        }
+
+        // Verify some entries
+        assert_eq!(delta.get(&0), Some(0));
+        assert_eq!(delta.get(&500), Some(1000));
+        assert_eq!(delta.get(&999), Some(1998));
+
+        // Remove every other entry
+        for i in (0..1000).step_by(2) {
+            delta.subtract(&i);
+        }
+
+        // Verify removals
+        assert_eq!(delta.get(&0), None);
+        assert_eq!(delta.get(&1), Some(2));
+        assert_eq!(delta.get(&500), None);
+        assert_eq!(delta.get(&501), Some(1002));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_is_thread_safe_across_clones() -> Result<()> {
+        let mut delta1 = Delta::<u32, String>::zero();
+        delta1.add(1, "value1".to_string());
+
+        // Clone the delta (Arc is cloned, not the inner data)
+        let delta2 = delta1.clone();
+
+        // Both should see the same data
+        assert_eq!(delta1.get(&1), Some("value1".to_string()));
+        assert_eq!(delta2.get(&1), Some("value1".to_string()));
+
+        // Modifying one affects the other (shared Arc)
+        delta1.add(2, "value2".to_string());
+        assert_eq!(delta2.get(&2), Some("value2".to_string()));
+
+        Ok(())
+    }
+}

--- a/rust/dialog-search-tree/src/distribution.rs
+++ b/rust/dialog-search-tree/src/distribution.rs
@@ -1,0 +1,53 @@
+/// The rank of a node in the prolly tree.
+pub type Rank = u32;
+
+/// Geometric distribution for computing node ranks.
+pub mod geometric {
+    use dialog_common::Blake3Hash;
+
+    use super::Rank;
+
+    /// The branch factor of the [`Tree`]s that constitute [`Artifact`] indexes
+    pub const BRANCH_FACTOR: u32 = 254;
+
+    /// Computes the rank of a node from its hash using a geometric distribution.
+    pub fn rank(hash: &Blake3Hash) -> Rank {
+        compute_geometric_rank(hash, BRANCH_FACTOR)
+    }
+
+    pub(crate) fn compute_geometric_rank(hash: &Blake3Hash, m: u32) -> Rank {
+        // Convert the series of fair trials into a series with desired probability
+        // Since we start with a random 256-bit slice (which can be thought of as a
+        // series of 256 fair Bernoulli trials), we need to group these trials with
+        // p = 1 / 2 into trials with p = 1 / m.
+        //
+        // To simulate a trial with probability p = 1 / m, consider a group of k
+        // fair trials, where k is chosen such that 1 / 2^k ≈ 1 / m. The smallest k
+        // such that 2^k ≥ m will be k = ⌈log_2(m)⌉. Compute ⌈log_2(m)⌉ =
+        // ceil(log_2(m)).
+        let bytes = hash.as_bytes();
+
+        let k = (m + 1).ilog2();
+        // Number of batches  of k bits
+        let batch_count = 256 / k;
+        // Mask to extract k bits
+        let mask = (1u8 << k) - 1;
+        // For each batch of k bits, we treat the batch as a "success" if all bits
+        // are 0 (which happens with probability 1 / 2^k). The number of batches
+        // until the first "success" is the desired geometrically distributed random
+        // variable.
+        for i in 0..batch_count {
+            let byte_index = (k * i) / 8;
+            let bit_index = (k * i) % 8;
+            // Extract k bits
+            let batch = (bytes[byte_index as usize] >> bit_index) & mask;
+            // batch != 0 means we are looking for the failure probability 1 / m
+            // whereas batch == 0 means we are looking for the success probability
+            // 1 / m
+            if batch != 0 {
+                return i + 1; // +1 because geometric distribution starts at 1
+            }
+        }
+        batch_count + 1
+    }
+}

--- a/rust/dialog-search-tree/src/encoding.rs
+++ b/rust/dialog-search-tree/src/encoding.rs
@@ -1,0 +1,16 @@
+use rkyv::{Archive, Deserialize, de::Pool, rancor::Strategy};
+
+use crate::DialogSearchTreeError;
+
+/// Deserializes an archived value into an owned value.
+///
+/// The [`Archive::Archived`] type is a zero-copy representation that references
+/// serialized bytes directly in memory. This function deserializes it into a
+/// fully owned value that can be used independently of the original buffer.
+pub fn into_owned<T>(archived: &T::Archived) -> Result<T, DialogSearchTreeError>
+where
+    T: Archive,
+    T::Archived: Deserialize<T, Strategy<Pool, rkyv::rancor::Error>>,
+{
+    rkyv::deserialize(archived).map_err(|error| DialogSearchTreeError::Encoding(format!("{error}")))
+}

--- a/rust/dialog-search-tree/src/entry.rs
+++ b/rust/dialog-search-tree/src/entry.rs
@@ -1,0 +1,24 @@
+use crate::{Key, SymmetryWith, Value};
+use dialog_common::Blake3Hash;
+use rkyv::{Archive, Deserialize, Serialize};
+
+/// A key-value pair stored in the tree.
+#[derive(Clone, Debug, Archive, Deserialize, Serialize)]
+pub struct Entry<Key, Value> {
+    /// The key for this entry.
+    pub key: Key,
+    /// The value associated with the key.
+    pub value: Value,
+}
+
+impl<Key, Value> Entry<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Value: self::Value,
+{
+    /// Computes the [`Blake3Hash`] of the entry's key.
+    pub fn key_hash(&self) -> Blake3Hash {
+        Blake3Hash::hash(self.key.as_ref())
+    }
+}

--- a/rust/dialog-search-tree/src/error.rs
+++ b/rust/dialog-search-tree/src/error.rs
@@ -1,0 +1,40 @@
+use dialog_storage::DialogStorageError;
+use thiserror::Error;
+
+/// Errors that can occur when working with search trees.
+#[derive(Error, Debug)]
+pub enum DialogSearchTreeError {
+    /// An error that occurs when working with a tree entry.
+    #[error("Problem with tree entry: {0}")]
+    Entry(String),
+
+    /// An error that occurs when accessing a node.
+    #[error("Problem accessing node: {0}")]
+    Node(String),
+
+    /// An error from the storage backend.
+    #[error("{0}")]
+    Storage(DialogStorageError),
+
+    /// An error that occurs during a tree operation.
+    #[error("Failed to operate the tree: {0}")]
+    Operation(String),
+
+    /// An error that occurs when retrieving an item from the cache.
+    #[error("Failed to retrieve item in cache: {0}")]
+    Cache(String),
+
+    /// An error that occurs when accessing part of the tree.
+    #[error("Failed to access part of the tree: {0}")]
+    Access(String),
+
+    /// An error that occurs when interpreting bytes.
+    #[error("Failed to interpret bytes: {0}")]
+    Encoding(String),
+}
+
+impl From<DialogStorageError> for DialogSearchTreeError {
+    fn from(value: DialogStorageError) -> Self {
+        DialogSearchTreeError::Storage(value)
+    }
+}

--- a/rust/dialog-search-tree/src/kv.rs
+++ b/rust/dialog-search-tree/src/kv.rs
@@ -1,0 +1,44 @@
+use rkyv::Archive;
+use std::fmt::Debug;
+
+use crate::SymmetryWith;
+
+/// Trait for types that can be used as keys in a search tree.
+///
+/// Keys must be fixed-size, comparable, and serializable.
+pub trait Key:
+    Clone + Debug + Sized + AsRef<[u8]> + std::hash::Hash + PartialOrd + Ord + PartialEq + Eq + Archive
+where
+    Self: PartialOrd<Self::Archived>,
+    Self::Archived: PartialOrd<Self> + PartialEq<Self> + SymmetryWith<Self> + Ord,
+{
+    /// The fixed size of this key type in bytes.
+    const LENGTH: usize;
+
+    /// Returns the minimum possible value for this key type.
+    fn min() -> Self;
+
+    /// Returns the maximum possible value for this key type.
+    fn max() -> Self;
+}
+
+impl<const N: usize> Key for [u8; N] {
+    const LENGTH: usize = N;
+
+    fn min() -> Self {
+        [u8::MIN; N]
+    }
+
+    fn max() -> Self {
+        [u8::MAX; N]
+    }
+}
+
+impl<const N: usize> SymmetryWith<[u8; N]> for [u8; N] {}
+
+/// Trait for types that can be used as values in a search tree.
+///
+/// Values must be cloneable and serializable.
+pub trait Value: Clone + Debug + Sized + Archive {}
+
+impl Value for Vec<u8> {}

--- a/rust/dialog-search-tree/src/lib.rs
+++ b/rust/dialog-search-tree/src/lib.rs
@@ -1,0 +1,163 @@
+#![deny(missing_docs)]
+
+//! A content-addressed search tree implementation.
+//!
+//! This crate provides [`Tree`], a persistent key-value store backed by a
+//! prolly tree with content-addressed storage. Trees support efficient lookups,
+//! insertions, deletions, and range queries while maintaining structural
+//! sharing across versions.
+//!
+//! Trees are immutable data structures. Operations like [`Tree::insert`] and
+//! [`Tree::delete`] return a new [`Tree`] instance rather than modifying in
+//! place. This enables:
+//!
+//! - **Version History**: Keep multiple versions of the tree simultaneously
+//! - **Efficient Copying**: Trees share unchanged nodes through content
+//!   addressing
+//! - **Safe Concurrency**: Multiple readers can access different versions
+//!   without conflicts
+//!
+//! The tree uses a three-tier storage architecture:
+//!
+//! 1. **Delta Buffer**: Newly created or modified nodes are held in an
+//!    in-memory delta buffer. Reads will check the delta before accessing
+//!    storage.
+//!
+//! 2. **Node Cache**: Nodes retrieved from storage are cached in memory to
+//!    avoid redundant storage operations. The cache is shared across tree
+//!    versions.
+//!
+//! 3. **Content-Addressed Storage**: Persistent storage where nodes are keyed
+//!    by their [`Blake3Hash`]. Storage is only accessed when a node is not
+//!    found in the delta or cache.
+//!
+//! Tree modifications (insert, delete) accumulate in the delta buffer. You must
+//! call [`Tree::flush`] and store the returned buffers to persist changes.
+//! Unflushed changes remain queryable but are lost when the tree is dropped.
+//!
+//! Basic usage:
+//!
+//! ```
+//! # tokio_test::block_on(async {
+//! use dialog_search_tree::{Tree, ContentAddressedStorage};
+//! use dialog_storage::MemoryStorageBackend;
+//!
+//! let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+//! let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+//!
+//! // Insert entries
+//! tree = tree.insert([0, 0, 0, 1], vec![1, 2, 3], &storage).await.unwrap();
+//!
+//! // Retrieve entries
+//! let value = tree.get(&[0, 0, 0, 1], &storage).await.unwrap();
+//! assert_eq!(value, Some(vec![1, 2, 3]));
+//! # })
+//! ```
+//!
+//! Persisting changes with flush:
+//!
+//! ```
+//! # tokio_test::block_on(async {
+//! use dialog_search_tree::{Tree, ContentAddressedStorage};
+//! use dialog_storage::MemoryStorageBackend;
+//!
+//! let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+//! let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+//!
+//! // Make several modifications
+//! for i in 0..10u32 {
+//!     tree = tree.insert(i.to_le_bytes(), vec![i as u8], &storage).await.unwrap();
+//! }
+//!
+//! // Changes are queryable immediately, even before flushing
+//! assert_eq!(tree.get(&5u32.to_le_bytes(), &storage).await.unwrap(), Some(vec![5]));
+//!
+//! // Flush the delta to get buffers that need to be persisted
+//! let root_hash = tree.root().clone();
+//! for (hash, buffer) in tree.flush() {
+//!     storage.store(buffer.as_ref().to_vec(), &hash).await.unwrap();
+//! }
+//!
+//! // After flushing, the tree can be reconstructed from its root hash
+//! // by loading nodes from storage as needed
+//! let tree = Tree::<[u8; 4], Vec<u8>>::from_hash(root_hash);
+//! assert_eq!(tree.get(&5u32.to_le_bytes(), &storage).await.unwrap(), Some(vec![5]));
+//! assert_eq!(tree.get(&9u32.to_le_bytes(), &storage).await.unwrap(), Some(vec![9]));
+//! # })
+//! ```
+//!
+//! Working with multiple tree versions:
+//!
+//! ```
+//! # tokio_test::block_on(async {
+//! use dialog_search_tree::{Tree, ContentAddressedStorage};
+//! use dialog_storage::MemoryStorageBackend;
+//!
+//! let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+//! let tree_v1 = Tree::<[u8; 4], Vec<u8>>::empty();
+//!
+//! // Create version 1 with some data
+//! let tree_v1 = tree_v1.insert([0, 0, 0, 1], vec![1], &storage).await.unwrap();
+//! let tree_v1 = tree_v1.insert([0, 0, 0, 2], vec![2], &storage).await.unwrap();
+//!
+//! // Create version 2 by modifying version 1
+//! // Note: tree_v1 remains unchanged
+//! let tree_v2 = tree_v1.insert([0, 0, 0, 3], vec![3], &storage).await.unwrap();
+//!
+//! // Both versions can be queried independently
+//! assert_eq!(tree_v1.get(&[0, 0, 0, 3], &storage).await.unwrap(), None);
+//! assert_eq!(tree_v2.get(&[0, 0, 0, 3], &storage).await.unwrap(), Some(vec![3]));
+//!
+//! // Both versions see the shared data
+//! assert_eq!(tree_v1.get(&[0, 0, 0, 1], &storage).await.unwrap(), Some(vec![1]));
+//! assert_eq!(tree_v2.get(&[0, 0, 0, 1], &storage).await.unwrap(), Some(vec![1]));
+//! # })
+//! ```
+
+mod buffer;
+pub use buffer::*;
+
+mod kv;
+pub use kv::*;
+
+mod link;
+pub use link::*;
+
+mod entry;
+pub use entry::*;
+
+mod node;
+pub use node::*;
+
+mod body;
+pub use body::*;
+
+mod storage;
+pub use storage::*;
+
+mod tree;
+pub use tree::*;
+
+mod delta;
+pub use delta::*;
+
+mod cache;
+pub use cache::*;
+
+mod error;
+pub use error::*;
+
+mod distribution;
+pub use distribution::*;
+
+mod encoding;
+pub use encoding::*;
+
+mod walker;
+pub use walker::*;
+
+mod shaper;
+pub use shaper::*;
+
+mod compare;
+pub use compare::*;

--- a/rust/dialog-search-tree/src/link.rs
+++ b/rust/dialog-search-tree/src/link.rs
@@ -1,0 +1,14 @@
+use dialog_common::Blake3Hash;
+use rkyv::{Archive, Deserialize, Serialize};
+
+/// A reference to a child node in an index node.
+///
+/// Links connect index nodes to their children, storing the child's upper bound
+/// key and its content hash.
+#[derive(Clone, Debug, Archive, Serialize, Deserialize)]
+pub struct Link<Key> {
+    /// The maximum key contained in the referenced node's subtree.
+    pub upper_bound: Key,
+    /// The [`Blake3Hash`] of the referenced node.
+    pub node: Blake3Hash,
+}

--- a/rust/dialog-search-tree/src/node.rs
+++ b/rust/dialog-search-tree/src/node.rs
@@ -1,0 +1,126 @@
+use dialog_common::Blake3Hash;
+use rkyv::{
+    Deserialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+use crate::{
+    ArchivedIndex, ArchivedNodeBody, ArchivedSegment, Buffer, DialogSearchTreeError, Key, Link,
+    SymmetryWith, Value, into_owned,
+};
+use std::marker::PhantomData;
+
+/// A tree node containing either entries (segment) or links to children
+/// (index).
+///
+/// Nodes are content-addressed by their [`Blake3Hash`] and store serialized
+/// data in a [`Buffer`].
+#[derive(Clone, Debug)]
+pub struct Node<Key, Value> {
+    key: PhantomData<Key>,
+    value: PhantomData<Value>,
+
+    buffer: Buffer,
+}
+
+impl<Key, Value> Node<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>
+        + PartialOrd<Key>
+        + PartialEq<Key>
+        + SymmetryWith<Key>
+        + Ord,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+{
+    /// Creates a new node from a serialized buffer.
+    pub fn new(buffer: Buffer) -> Self {
+        Self {
+            buffer,
+            key: PhantomData,
+            value: PhantomData,
+        }
+    }
+
+    /// Returns the content hash of this node.
+    pub fn hash(&self) -> &Blake3Hash {
+        self.buffer.blake3_hash()
+    }
+
+    /// Returns the underlying buffer containing serialized node data.
+    pub fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
+
+    /// Converts this node into a [`Link`] referencing it.
+    pub fn to_link(&self) -> Result<Link<Key>, DialogSearchTreeError> {
+        let upper_bound: Key = self.body()?.upper_bound().and_then(into_owned)?;
+        let self_hash = self.buffer.blake3_hash().clone();
+
+        Ok(Link {
+            upper_bound,
+            node: self_hash,
+        })
+    }
+
+    /// Returns the upper bound key of this node, if it has one.
+    pub fn upper_bound(&self) -> Result<Option<&Key::Archived>, DialogSearchTreeError> {
+        self.body().map(|body| match body {
+            ArchivedNodeBody::Index(index) => index.upper_bound(),
+            ArchivedNodeBody::Segment(segment) => segment.upper_bound(),
+        })
+    }
+
+    /// Accesses the deserialized body of this node.
+    pub fn body(&self) -> Result<&ArchivedNodeBody<Key, Value>, DialogSearchTreeError> {
+        rkyv::access::<_, rkyv::rancor::Error>(self.buffer.as_ref())
+            .map_err(|error| DialogSearchTreeError::Access(format!("{error}")))
+    }
+
+    /// Interprets this node as an index node, returning an error if it's a
+    /// segment.
+    pub fn as_index(&self) -> Result<&ArchivedIndex<Key>, DialogSearchTreeError> {
+        self.body().and_then(|body| match body {
+            ArchivedNodeBody::Index(index) => Ok(index),
+            ArchivedNodeBody::Segment(_) => Err(DialogSearchTreeError::Access(
+                "Attempted to interpret a segment node as an index node".to_string(),
+            )),
+        })
+    }
+
+    /// Interprets this node as a segment node, returning an error if it's an
+    /// index.
+    pub fn as_segment(&self) -> Result<&ArchivedSegment<Key, Value>, DialogSearchTreeError> {
+        self.body().and_then(|body| match body {
+            ArchivedNodeBody::Segment(segment) => Ok(segment),
+            ArchivedNodeBody::Index(_) => Err(DialogSearchTreeError::Access(
+                "Attempted to interpret a index node as an segment node".to_string(),
+            )),
+        })
+    }
+
+    /// Finds the index of the child containing the given key.
+    pub fn get_child_index(
+        &self,
+        key: &Key::Archived,
+    ) -> Result<Option<usize>, DialogSearchTreeError> {
+        self.body().map(|body| match body {
+            ArchivedNodeBody::Index(index) => index
+                .links
+                .binary_search_by(|link| Ord::cmp(&link.upper_bound, key))
+                .ok(),
+            ArchivedNodeBody::Segment(segment) => segment
+                .entries
+                .binary_search_by(|entry| Ord::cmp(&entry.key, key))
+                .ok(),
+        })
+    }
+}

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -1,0 +1,517 @@
+//! Tree construction and modification logic.
+//!
+//! This module contains [`TreeShaper`], which encapsulates all the logic for
+//! building and modifying tree structures. By separating mutation operations
+//! from the read-only [`Tree`] interface, we achieve clearer separation of
+//! concerns and make the codebase more maintainable.
+
+use std::marker::PhantomData;
+
+use dialog_common::Blake3Hash;
+use nonempty::NonEmpty;
+use rkyv::{
+    Deserialize, Serialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    ser::{Serializer, allocator::ArenaHandle, sharing::Share},
+    util::AlignedVec,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+use crate::{
+    Buffer, Delta, DialogSearchTreeError, Entry, Key, Link, Node, NodeBody, Rank, SearchResult,
+    Segment, SymmetryWith, TreeLayer, Value, distribution, into_owned,
+};
+
+/// A collection of nodes with their ranks.
+type RankedNodes<Key, Value> = NonEmpty<(Node<Key, Value>, Rank)>;
+
+/// Handles tree construction and modification operations.
+///
+/// [`TreeShaper`] encapsulates the complex logic for building and modifying
+/// prolly trees, including:
+/// - Rank-based node collection and splitting
+/// - Path reconstruction after modifications
+/// - Delta management for structural changes
+///
+/// This struct holds the delta for a mutation operation and provides methods to
+/// perform tree modifications. Each instance is tied to a specific mutation and
+/// consumes itself when the operation completes.
+pub struct TreeShaper<Key, Value>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + crate::SymmetryWith<Key> + Ord,
+    Value: self::Value,
+{
+    root: Blake3Hash,
+    delta: Delta<Blake3Hash, Buffer>,
+    key: PhantomData<Key>,
+    value: PhantomData<Value>,
+}
+
+impl<Key, Value> TreeShaper<Key, Value>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + crate::SymmetryWith<Key> + Ord,
+    Key::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+    Key::Archived: Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Key: for<'a> Serialize<
+        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+    >,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: for<'a> Serialize<
+        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+    >,
+{
+    /// Creates a new [`TreeShaper`] with the given root and delta.
+    ///
+    /// The root represents the current root hash of the tree, and the delta
+    /// represents the current state of pending changes from the tree. It will
+    /// be branched internally as needed during mutation operations.
+    pub fn new(root: Blake3Hash, delta: Delta<Blake3Hash, Buffer>) -> Self {
+        Self {
+            root,
+            delta,
+            key: PhantomData,
+            value: PhantomData,
+        }
+    }
+
+    /// Inserts a new entry into the tree, returning the new root hash and
+    /// delta.
+    ///
+    /// This method takes an optional search result. If provided, it points to
+    /// the leaf segment where the entry should be inserted. If `None`, the tree
+    /// is empty and this will be the first entry.
+    ///
+    /// For existing trees, it:
+    /// 1. Extracts the entries from the segment
+    /// 2. Performs binary search to find insertion point or existing key
+    /// 3. Inserts the new entry or updates existing value
+    /// 4. Ranks all entries and distributes them into new nodes
+    /// 5. Rebuilds the tree path up to the root
+    ///
+    /// For empty trees, it simply creates a single-entry segment.
+    ///
+    /// If the key already exists, its value is updated. If it's new, it's
+    /// inserted in sorted order.
+    pub fn insert(
+        self,
+        new_entry: Entry<Key, Value>,
+        search_result: Option<SearchResult<Key, Value>>,
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        let (entries, search_result) = match search_result {
+            Some(search_result) => {
+                let key = new_entry.key.to_owned();
+                let segment = search_result.leaf.as_segment()?;
+
+                // Extract and modify entries
+                let mut entries: Vec<Entry<Key, Value>> =
+                    into_owned::<Segment<Key, Value>>(segment)?.entries;
+
+                match entries.binary_search_by(|probe| probe.key.cmp(&key)) {
+                    // Entry was found; update the value.
+                    Ok(index) => {
+                        let Some(previous_entry) = entries.get_mut(index) else {
+                            return Err(DialogSearchTreeError::Access(format!(
+                                "Entry at index {} not found",
+                                index,
+                            )));
+                        };
+                        previous_entry.value = new_entry.value;
+                    }
+                    // Entry was not found; insert at the provided index.
+                    Err(index) => {
+                        entries.insert(index, new_entry);
+                    }
+                };
+
+                let entries = NonEmpty::from_vec(entries).ok_or_else(|| {
+                    DialogSearchTreeError::Operation(
+                        "Segment has no entries after modification".into(),
+                    )
+                })?;
+
+                (entries, Some(search_result))
+            }
+            None => {
+                // Empty tree; just a single entry
+                (NonEmpty::singleton(new_entry), None)
+            }
+        };
+
+        // Rank the entries and distribute
+        let next_entries = entries
+            .into_iter()
+            .map(|entry| {
+                let rank = distribution::geometric::rank(&Blake3Hash::hash(entry.key.as_ref()));
+                (entry, rank)
+            })
+            .collect::<Vec<_>>();
+
+        let Some(next_entries) = NonEmpty::from_vec(next_entries) else {
+            return Err(DialogSearchTreeError::Operation(
+                "Insertion resulted in empty set of entries".into(),
+            ));
+        };
+
+        self.distribute(next_entries, search_result)
+    }
+
+    /// Removes an entry from the tree, returning the new root hash and delta.
+    ///
+    /// This method takes a search result pointing to the leaf segment
+    /// containing the key to remove. It handles three cases:
+    ///
+    /// 1. **Key doesn't exist in segment**: Returns the current root unchanged
+    ///    with the original delta (no-op).
+    ///
+    /// 2. **Segment still has entries after removal**: Creates a new segment
+    ///    with the remaining entries (no redistribution needed since ranks
+    ///    haven't changed), and updates the tree path with new hashes.
+    ///
+    /// 3. **Segment becomes empty**: Removes the empty segment by merging its
+    ///    siblings at the parent level, then rebuilds the tree upward.
+    pub fn delete(
+        self,
+        key: &Key,
+        search_result: SearchResult<Key, Value>,
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        let segment = search_result.leaf.as_segment()?;
+
+        let removal_index = match segment
+            .entries
+            .binary_search_by(|entry| SymmetryWith::cmp(&entry.key, key))
+        {
+            Ok(index) => index,
+            Err(_) => {
+                // Key not found; return unchanged state
+                return Ok((self.root, self.delta));
+            }
+        };
+
+        let mut segment = into_owned::<Segment<Key, Value>>(segment)?;
+        segment.entries.remove(removal_index);
+
+        if !segment.entries.is_empty() {
+            // Still have entries; create new segment and merge up the path
+            let new_segment_node = Node::<Key, Value>::new(Buffer::from(
+                NodeBody::try_from(segment.entries)?.as_bytes()?,
+            ));
+
+            let mut delta = self.delta.branch();
+            delta.subtract(search_result.leaf.hash());
+
+            Self::merge_with_path(
+                NonEmpty::singleton((new_segment_node, 1)),
+                search_result.path,
+                delta,
+            )
+        } else {
+            // Segment is now empty; remove it from parent
+            self.remove_from_path(search_result.path)
+        }
+    }
+
+    /// Distributes children into a new tree structure based on their ranks,
+    /// rebuilding the path from leaves to root.
+    ///
+    /// This is the core method for tree construction and modification. It takes
+    /// a collection of ranked children (either entries or links) and organizes
+    /// them into a tree hierarchy where node boundaries are determined by the
+    /// rank distribution.
+    ///
+    /// The algorithm proceeds in iterations:
+    /// 1. Collect children into nodes where ranks exceed the current minimum
+    /// 2. Convert nodes to links and merge with siblings from the search path
+    /// 3. Increment the minimum rank and repeat until a single root is formed
+    ///
+    /// When a search result is provided, the method reconstructs only the
+    /// affected path through the tree, merging new nodes with unchanged sibling
+    /// references. This enables efficient structural sharing where unmodified
+    /// portions of the tree remain unchanged.
+    ///
+    /// Returns the new root hash and a delta containing all newly created
+    /// nodes.
+    fn distribute<Child>(
+        self,
+        children: NonEmpty<(Child, Rank)>,
+        search_result: Option<SearchResult<Key, Value>>,
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError>
+    where
+        NodeBody<Key, Value>: TryFrom<Vec<Child>, Error = DialogSearchTreeError>,
+    {
+        let nodes = Self::collect(children, 1)?;
+
+        let mut delta = self.delta.branch();
+        let search_path = if let Some(search_result) = search_result {
+            delta.subtract(search_result.leaf.hash());
+            search_result.path
+        } else {
+            vec![]
+        };
+
+        Self::merge_with_path(nodes, search_path, delta)
+    }
+
+    /// Merges a collection of nodes with a search path, rebuilding from leaves
+    /// to root.
+    ///
+    /// This method takes an initial set of nodes (typically from modified leaf
+    /// segments) and propagates them up through the tree hierarchy. At each
+    /// level, it:
+    /// 1. Converts nodes to links and adds them to the delta
+    /// 2. Merges with left and right siblings from the search path
+    /// 3. Collects the merged links into new nodes based on rank
+    /// 4. Continues until a single root node is formed
+    ///
+    /// This is the shared path-reconstruction logic used by both insert (after
+    /// distributing entries) and delete (after modifying a segment).
+    pub fn merge_with_path(
+        mut nodes: NonEmpty<(Node<Key, Value>, Rank)>,
+        mut search_path: Vec<TreeLayer<Key, Value>>,
+        mut delta: Delta<Blake3Hash, Buffer>,
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        const MINIMUM_RANK: u32 = 2;
+        let mut minimum_rank = MINIMUM_RANK;
+
+        loop {
+            let links = {
+                delta.add_all(
+                    nodes
+                        .iter()
+                        .map(|(node, _)| (node.hash().clone(), node.buffer().clone())),
+                );
+
+                let ranked_links = nodes
+                    .into_iter()
+                    .map(|(node, rank)| node.to_link().map(|link| (link, rank)))
+                    .collect::<Result<Vec<(Link<Key>, Rank)>, DialogSearchTreeError>>()
+                    .and_then(|links| {
+                        NonEmpty::from_vec(links)
+                            .ok_or_else(|| DialogSearchTreeError::Node("Empty child list".into()))
+                    })?;
+
+                match search_path.pop() {
+                    Some(layer) => {
+                        delta.subtract(layer.host.hash());
+                        // TBD if we must recompute rank for siblings references
+                        // when building up the tree. Attempt to try setting
+                        // rank to `0` for references outside of the modified
+                        // path.
+                        let ranked_left_siblings = layer.left_siblings.map(into_ranked_links);
+                        let ranked_right_siblings = layer.right_siblings.map(into_ranked_links);
+
+                        match (ranked_left_siblings, ranked_right_siblings) {
+                            (None, None) => ranked_links,
+                            (Some(ranked_left_siblings), None) => {
+                                concat_nonempty(vec![ranked_left_siblings, ranked_links])?
+                            }
+                            (None, Some(ranked_right_siblings)) => {
+                                concat_nonempty(vec![ranked_links, ranked_right_siblings])?
+                            }
+                            (Some(ranked_left_siblings), Some(ranked_right_siblings)) => {
+                                concat_nonempty(vec![
+                                    ranked_left_siblings,
+                                    ranked_links,
+                                    ranked_right_siblings,
+                                ])?
+                            }
+                        }
+                    }
+                    None => ranked_links,
+                }
+            };
+
+            nodes = Self::collect::<Link<_>>(links, minimum_rank)?;
+
+            if search_path.is_empty() && nodes.len() == 1 {
+                break;
+            }
+
+            minimum_rank += 1;
+        }
+
+        delta.add_all(
+            nodes
+                .iter()
+                .map(|(node, _)| (node.hash().clone(), node.buffer().clone())),
+        );
+
+        Ok((nodes.head.0.hash().to_owned(), delta))
+    }
+
+    /// Removes a segment from the tree when it becomes empty after deletion.
+    ///
+    /// This method handles the case where deleting an entry leaves a segment
+    /// with no entries. It removes the segment by merging its left and right
+    /// siblings at the parent level, then rebuilds the tree upward.
+    ///
+    /// If the removed segment was the only child (no siblings), the removal
+    /// propagates upward. If it was the last segment in the entire tree, the
+    /// tree becomes empty.
+    fn remove_from_path(
+        self,
+        path: Vec<TreeLayer<Key, Value>>,
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        let delta = self.delta.branch();
+
+        Self::remove_from_path_with_delta(path, delta)
+    }
+
+    /// Internal helper for `remove_from_path` that works with a delta directly.
+    ///
+    /// This allows recursive calls to reuse the same delta without
+    /// re-branching.
+    fn remove_from_path_with_delta(
+        mut path: Vec<TreeLayer<Key, Value>>,
+        mut delta: Delta<Blake3Hash, Buffer>,
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        use dialog_common::NULL_BLAKE3_HASH;
+
+        // If there's no parent, the tree becomes empty
+        if path.is_empty() {
+            return Ok((NULL_BLAKE3_HASH.clone(), Delta::zero()));
+        }
+
+        let layer = path.remove(0); // Take the parent layer
+
+        delta.subtract(layer.host.hash());
+
+        // Collect left and right siblings, excluding the removed segment
+        let mut links = Vec::new();
+
+        if let Some(left_siblings) = layer.left_siblings {
+            links.extend(left_siblings);
+        }
+
+        // Note: we skip the removed segment's link here
+
+        if let Some(right_siblings) = layer.right_siblings {
+            links.extend(right_siblings);
+        }
+
+        // If no siblings remain, propagate the removal upward
+        if links.is_empty() {
+            return if path.is_empty() {
+                Ok((NULL_BLAKE3_HASH.clone(), delta))
+            } else {
+                // Continue removing up the path with the same delta
+                Self::remove_from_path_with_delta(path, delta)
+            };
+        }
+
+        // We have siblings; rebuild with them
+        let ranked_links = links
+            .into_iter()
+            .map(|link| {
+                let rank = distribution::geometric::rank(&link.node);
+                (link, rank)
+            })
+            .collect::<Vec<_>>();
+
+        let Some(ranked_links) = NonEmpty::from_vec(ranked_links) else {
+            return Err(DialogSearchTreeError::Node(
+                "Unexpectedly empty link list".into(),
+            ));
+        };
+
+        // Create nodes from the remaining links
+        let nodes = Self::collect::<Link<_>>(ranked_links, 1)?;
+
+        // Merge up the remaining path
+        Self::merge_with_path(nodes, path, delta)
+    }
+
+    /// Collects a sequence of ranked children into nodes based on a minimum
+    /// rank threshold.
+    ///
+    /// This method groups children into nodes by accumulating them until a
+    /// child with a rank exceeding the minimum threshold is encountered. When
+    /// such a child is found, the accumulated children (including the high-rank
+    /// child) are collected into a node, and accumulation begins anew.
+    ///
+    /// The algorithm:
+    /// 1. Accumulate children in a pending list
+    /// 2. When a child's rank > minimum_rank, create a node from pending
+    ///    children
+    /// 3. Continue until all children are processed
+    /// 4. Any remaining children form a final node with rank = minimum_rank
+    ///
+    /// This rank-based partitioning is what gives the prolly tree its
+    /// probabilistic splitting behavior, which in turn enables efficient
+    /// structural sharing and diff computation.
+    fn collect<Child>(
+        children: NonEmpty<(Child, Rank)>,
+        minimum_rank: Rank,
+    ) -> Result<RankedNodes<Key, Value>, DialogSearchTreeError>
+    where
+        NodeBody<Key, Value>: TryFrom<Vec<Child>, Error = DialogSearchTreeError>,
+    {
+        let mut output: Vec<(Node<Key, Value>, u32)> = vec![];
+        let mut pending = vec![];
+
+        for (child, rank) in children {
+            pending.push(child);
+            if rank > minimum_rank {
+                if pending.is_empty() {
+                    return Err(DialogSearchTreeError::Node(
+                        "Attempted to collect empty child list into index node".into(),
+                    ));
+                }
+                let node = Node::new(Buffer::from(
+                    NodeBody::try_from(std::mem::take(&mut pending))?.as_bytes()?,
+                ));
+
+                output.push((node, rank));
+            }
+        }
+
+        if !pending.is_empty() {
+            let node = Node::new(Buffer::from(NodeBody::try_from(pending)?.as_bytes()?));
+            output.push((node, minimum_rank));
+        }
+
+        NonEmpty::from_vec(output).ok_or_else(|| {
+            DialogSearchTreeError::Node("Node list was empty after collection".into())
+        })
+    }
+}
+
+/// Converts a collection of links into ranked links by computing each link's
+/// rank from its node hash.
+///
+/// This helper function is used when merging sibling references during tree
+/// reconstruction. The rank is computed using a geometric distribution over the
+/// node hash, ensuring consistent rank assignment for the same content.
+fn into_ranked_links<Key>(links: NonEmpty<Link<Key>>) -> NonEmpty<(Link<Key>, Rank)> {
+    links.map(|link| {
+        let rank = distribution::geometric::rank(&link.node);
+        (link, rank)
+    })
+}
+
+/// Concatenates multiple non-empty lists into a single non-empty list.
+///
+/// This utility function flattens a vector of [`NonEmpty`] collections into a
+/// single [`NonEmpty`] collection. Returns an error if the input vector is
+/// empty.
+///
+/// Used during tree reconstruction when merging left siblings, modified nodes,
+/// and right siblings into a single collection for the next level of the tree.
+///
+/// TODO: Improve. Possibly remove NonEmpty as it introduces some overhead
+/// compared to index comparison with slices.
+fn concat_nonempty<T>(list: Vec<NonEmpty<T>>) -> Result<NonEmpty<T>, DialogSearchTreeError> {
+    Ok(NonEmpty::flatten(NonEmpty::from_vec(list).ok_or(
+        DialogSearchTreeError::Node("Empty child list".into()),
+    )?))
+}

--- a/rust/dialog-search-tree/src/storage.rs
+++ b/rust/dialog-search-tree/src/storage.rs
@@ -1,0 +1,58 @@
+use dialog_common::Blake3Hash;
+
+use dialog_storage::{DialogStorageError, StorageBackend};
+
+/// Content-addressed storage wrapper for tree nodes.
+///
+/// Provides hash-verified storage and retrieval operations.
+pub struct ContentAddressedStorage<Backend>
+where
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+{
+    backend: Backend,
+}
+
+impl<Backend> ContentAddressedStorage<Backend>
+where
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+{
+    /// Creates a new content-addressed storage wrapper.
+    pub fn new(backend: Backend) -> Self {
+        Self { backend }
+    }
+
+    /// Stores bytes under their content hash, verifying the hash matches.
+    pub async fn store(
+        &mut self,
+        bytes: Vec<u8>,
+        expected_identity: &Blake3Hash,
+    ) -> Result<(), DialogStorageError> {
+        if !expected_identity.matches(&bytes) {
+            return Err(DialogStorageError::Verification(
+                "Cannot store the provided bytes".to_string(),
+            ));
+        }
+
+        self.backend.set(expected_identity.clone(), bytes).await?;
+
+        Ok(())
+    }
+
+    /// Retrieves bytes by their content hash, verifying the hash matches.
+    pub async fn retrieve(
+        &self,
+        identity: &Blake3Hash,
+    ) -> Result<Option<Vec<u8>>, DialogStorageError> {
+        if let Some(bytes) = self.backend.get(identity).await? {
+            if !identity.matches(&bytes) {
+                return Err(DialogStorageError::Verification(
+                    "Retrieved bytes did not match the provided hash".to_string(),
+                ));
+            }
+
+            Ok(Some(bytes))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -1,0 +1,1161 @@
+use std::{marker::PhantomData, ops::RangeBounds};
+
+use dialog_common::{Blake3Hash, NULL_BLAKE3_HASH};
+use dialog_storage::{DialogStorageError, StorageBackend};
+use futures_core::Stream;
+use rkyv::{
+    Deserialize, Serialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    ser::{Serializer, allocator::ArenaHandle, sharing::Share},
+    util::AlignedVec,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+use crate::{
+    Buffer, Cache, ContentAddressedStorage, Delta, DialogSearchTreeError, Entry, Key, Node,
+    SearchResult, SymmetryWith, TreeShaper, TreeWalker, Value, into_owned,
+};
+
+/// A key-value store backed by a ranked prolly tree with content-addressed
+/// storage.
+///
+/// The [`Tree`] represents an immutable, persistent data structure where each
+/// modification creates a new version while sharing unchanged nodes through
+/// structural sharing. The tree stores key-value pairs in sorted order and
+/// provides efficient lookups, insertions, and range queries.
+///
+/// Nodes are stored in content-addressed storage using [`Blake3Hash`] as
+/// identifiers, enabling deduplication and efficient versioning. The tree
+/// maintains a [`Delta`] of pending changes that can be flushed to storage in
+/// batches, and uses a [`Cache`] for frequently accessed nodes to minimize
+/// storage I/O operations.
+#[derive(Debug, Clone)]
+pub struct Tree<Key, Value>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Value: self::Value,
+{
+    key: PhantomData<Key>,
+    value: PhantomData<Value>,
+
+    root: Blake3Hash,
+    node_cache: Cache<Blake3Hash, Buffer>,
+
+    delta: Delta<Blake3Hash, Buffer>,
+}
+
+impl<Key, Value> Tree<Key, Value>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Key::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+    Key::Archived: Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Key: for<'a> Serialize<
+        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+    >,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: for<'a> Serialize<
+        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+    >,
+{
+    /// Returns the [`Blake3Hash`] of the root node of this tree.
+    ///
+    /// The root hash uniquely identifies this version of the tree and can be
+    /// used to reconstruct the tree from storage or to compare tree versions.
+    pub fn root(&self) -> &Blake3Hash {
+        &self.root
+    }
+
+    /// Creates a new empty [`Tree`] with no entries.
+    ///
+    /// The empty tree has a null root hash and contains no cached nodes or
+    /// pending changes in its delta.
+    pub fn empty() -> Self {
+        Self {
+            key: PhantomData,
+            value: PhantomData,
+            root: NULL_BLAKE3_HASH.clone(),
+            node_cache: Cache::new(),
+            delta: Delta::zero(),
+        }
+    }
+
+    /// Creates a [`Tree`] from a known root hash.
+    ///
+    /// This constructor is used to restore a tree to a previously persisted
+    /// version. The tree will lazily load nodes from storage as they are
+    /// accessed during operations.
+    pub fn from_hash(root: Blake3Hash) -> Self {
+        Self {
+            key: PhantomData,
+            value: PhantomData,
+            root,
+            node_cache: Cache::new(),
+            delta: Delta::zero(),
+        }
+    }
+
+    /// Retrieves the value associated with `key` from the tree.
+    ///
+    /// This method performs a binary search through the tree hierarchy to
+    /// locate the leaf segment containing the key, then searches within that
+    /// segment for the specific entry.
+    ///
+    /// Returns `Ok(Some(value))` if the key exists, `Ok(None)` if the key is
+    /// not found, or an error if the tree structure is invalid or storage
+    /// access fails.
+    pub async fn get<Backend>(
+        &self,
+        key: &Key,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Option<Value>, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+    {
+        if let Some(result) = self.search(key, storage).await? {
+            if let Some(entry) = result.leaf.body()?.find_entry(key)? {
+                into_owned(&entry.value).map(|value| Some(value))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Inserts a `key`/`value` pair into the tree, returning a new tree
+    /// version.
+    ///
+    /// If the key already exists, its value is updated. If the key is new, it
+    /// is inserted in sorted order within the appropriate leaf segment.
+    pub async fn insert<Backend>(
+        &self,
+        key: Key,
+        value: Value,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Self, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+    {
+        let search_result = self.search(&key, storage).await?;
+        let shaper = TreeShaper::new(self.root.clone(), self.delta.clone());
+        let (next_root, delta) = shaper.insert(Entry { key, value }, search_result)?;
+
+        Ok(self.advance(next_root, delta))
+    }
+
+    /// Removes the `key`/`value` pair associated with `key` from the tree.
+    ///
+    /// If the key does not exist, the operation completes successfully without
+    /// modification.
+    pub async fn delete<Backend>(
+        &mut self,
+        key: &Key,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Self, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+    {
+        if let Some(search_result) = self.search(key, storage).await? {
+            let shaper = TreeShaper::new(self.root.clone(), self.delta.clone());
+            let (next_root, delta) = shaper.delete(key, search_result)?;
+            Ok(self.advance(next_root, delta))
+        } else {
+            // Key not found in tree - nothing to delete
+            Ok(self.clone())
+        }
+    }
+
+    /// Returns an async stream over all entries in the tree.
+    ///
+    /// Entries are yielded in sorted order by key. This method traverses the
+    /// tree from the leftmost leaf to the rightmost, streaming entries as they
+    /// are encountered without loading the entire tree into memory.
+    ///
+    /// Internally, this calls [`stream_range`](Self::stream_range) with an
+    /// unbounded range covering all possible keys.
+    pub fn stream<'a, Backend>(
+        &'a self,
+        storage: &'a ContentAddressedStorage<Backend>,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + 'a
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+    {
+        self.stream_range(
+            <Key as self::Key>::min()..<Key as self::Key>::max(),
+            storage,
+        )
+    }
+
+    /// Returns an async stream over entries with keys within the provided
+    /// range.
+    ///
+    /// The range can be bounded or unbounded on either end, following Rust's
+    /// standard [`RangeBounds`] trait. Entries are yielded in sorted order.
+    pub fn stream_range<'a, R, Backend>(
+        &'a self,
+        range: R,
+        storage: &'a ContentAddressedStorage<Backend>,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + 'a
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+        R: RangeBounds<Key> + 'a,
+    {
+        TreeWalker::new(self.root.clone(), async |hash| {
+            self.get_node(hash, storage).await
+        })
+        .stream(range)
+    }
+
+    /// Flushes all pending changes, returning an iterator of nodes to be
+    /// written to storage.
+    ///
+    /// This method drains the accumulated delta and returns hash-buffer pairs
+    /// representing the new or modified nodes that need to be persisted to
+    /// storage. After flushing, the tree's delta is cleared.
+    ///
+    /// In cases where the caller wishes to access the modified tree in the
+    /// future, they should persist the flushed changes.
+    pub fn flush(&mut self) -> impl Iterator<Item = (Blake3Hash, Buffer)> {
+        self.delta.flush()
+    }
+
+    /// Creates a new tree version with an updated root hash and delta.
+    ///
+    /// This is an internal method used to produce a new tree state after
+    /// modifications. The new tree shares the same cache as the original,
+    /// enabling efficient structural sharing.
+    fn advance(&self, root: Blake3Hash, delta: Delta<Blake3Hash, Buffer>) -> Self {
+        Tree {
+            key: PhantomData,
+            value: PhantomData,
+            root,
+            node_cache: self.node_cache.clone(),
+            delta,
+        }
+    }
+
+    /// Retrieves a node from cache, delta, or storage.
+    ///
+    /// This method implements a multi-level lookup strategy:
+    /// 1. Check the node cache for a previously loaded node
+    /// 2. Check the delta for a recently created/modified node
+    /// 3. Fetch from persistent storage as a last resort
+    ///
+    /// Fetched nodes are automatically added to the cache for future access.
+    /// This layered approach minimizes expensive storage I/O operations.
+    async fn get_node<Backend>(
+        &self,
+        hash: &Blake3Hash,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Node<Key, Value>, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+    {
+        self.node_cache
+            .get_or_fetch(hash, async move |key| {
+                if let Some(buffer) = self.delta.get(hash) {
+                    Ok(Some(buffer))
+                } else {
+                    storage
+                        .retrieve(key)
+                        .await
+                        .map(|maybe_bytes| maybe_bytes.map(Buffer::from))
+                }
+            })
+            .await?
+            .ok_or_else(|| {
+                DialogSearchTreeError::Node(format!("Blob not found in storage: {}", hash))
+            })
+            .map(|buffer| Node::new(buffer))
+    }
+
+    /// Searches for the leaf segment that would contain `key`, recording the
+    /// path taken through the tree.
+    ///
+    /// This method traverses from the root to a leaf segment, following the
+    /// child references whose key ranges encompass the target key. The search
+    /// returns a [`SearchResult`] containing:
+    /// - The leaf segment where the key would be located
+    /// - The complete path from root to leaf, including sibling references
+    ///
+    /// The path information is essential for tree modification operations, as
+    /// it enables efficient reconstruction of the tree after changes.
+    ///
+    /// Returns `None` if the tree is empty.
+    async fn search<Backend>(
+        &self,
+        key: &Key,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Option<SearchResult<Key, Value>>, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+    {
+        TreeWalker::new(self.root.clone(), async |hash| {
+            self.get_node(hash, storage).await
+        })
+        .search(key)
+        .await
+    }
+}
+
+impl<Key, Value> From<Blake3Hash> for Tree<Key, Value>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Key::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+    Key::Archived: Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Key: for<'a> Serialize<
+        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+    >,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: for<'a> Serialize<
+        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+    >,
+{
+    fn from(root: Blake3Hash) -> Self {
+        Self::from_hash(root)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use anyhow::Result;
+    use dialog_storage::MemoryStorageBackend;
+
+    use crate::{ContentAddressedStorage, Tree};
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[dialog_common::test]
+    async fn it_retrieves_inserted_values() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert a range of values
+        for i in 0..100u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+
+        // Flush to storage
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify we can retrieve all inserted values
+        for i in 0..100u32 {
+            let value = tree.get(&i.to_le_bytes(), &storage).await?;
+            assert_eq!(value, Some(i.to_le_bytes().to_vec()));
+        }
+
+        // Verify non-existent keys return None
+        let missing = tree.get(&200u32.to_le_bytes(), &storage).await?;
+        assert_eq!(missing, None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_deletes_values() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert values
+        for i in 0..50u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+
+        // Flush to storage
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Delete some values
+        for i in (0..50u32).step_by(2) {
+            tree = tree.delete(&i.to_le_bytes(), &storage).await?;
+        }
+
+        // Flush deletions
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify deleted values are gone
+        for i in (0..50u32).step_by(2) {
+            let value = tree.get(&i.to_le_bytes(), &storage).await?;
+            assert_eq!(value, None, "Key {} should be deleted", i);
+        }
+
+        // Verify non-deleted values still exist
+        for i in (1..50u32).step_by(2) {
+            let value = tree.get(&i.to_le_bytes(), &storage).await?;
+            assert_eq!(
+                value,
+                Some(i.to_le_bytes().to_vec()),
+                "Key {} should exist",
+                i
+            );
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_entries_in_order() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert values in non-sequential order
+        let values = [5u32, 2, 8, 1, 9, 3, 7, 4, 6, 0];
+        for &i in &values {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+
+        // Flush to storage
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Stream all entries and verify they come out sorted
+        let stream = tree.stream(&storage);
+        futures_util::pin_mut!(stream);
+
+        let mut prev: Option<u32> = None;
+        let mut count = 0;
+
+        while let Some(entry) = stream.next().await {
+            let entry = entry?;
+            let key = u32::from_le_bytes(entry.key);
+            let value = u32::from_le_bytes(entry.value.as_slice().try_into()?);
+
+            assert_eq!(key, value);
+
+            if let Some(prev_key) = prev {
+                assert!(key > prev_key, "Keys should be in sorted order");
+            }
+
+            prev = Some(key);
+            count += 1;
+        }
+
+        assert_eq!(count, values.len());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_range_queries() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert values 0-99
+        for i in 0..100u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+
+        // Flush to storage
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Test inclusive range [10..20)
+        let stream = tree.stream_range(10u32.to_le_bytes()..20u32.to_le_bytes(), &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            let entry = entry?;
+            let key = u32::from_le_bytes(entry.key);
+            assert!(
+                (10..20).contains(&key),
+                "Key {} should be in range [10, 20)",
+                key
+            );
+            count += 1;
+        }
+        assert_eq!(count, 10, "Should have 10 entries in range");
+
+        // Test inclusive range [50..=54]
+        let stream = tree.stream_range(50u32.to_le_bytes()..=54u32.to_le_bytes(), &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut collected = Vec::new();
+        while let Some(entry) = stream.next().await {
+            let entry = entry?;
+            let key = u32::from_le_bytes(entry.key);
+            collected.push(key);
+        }
+        assert_eq!(collected, vec![50, 51, 52, 53, 54]);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_empty_range() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert values 0-9 and 90-99
+        for i in 0..10u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for i in 90..100u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+
+        // Flush to storage
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Query range with no entries [50..60)
+        let stream = tree.stream_range(50u32.to_le_bytes()..60u32.to_le_bytes(), &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+
+        assert_eq!(count, 0, "Empty range should yield no entries");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_empty_tree_operations() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Get on empty tree should return None
+        let value = tree.get(&1u32.to_le_bytes(), &storage).await?;
+        assert_eq!(value, None);
+
+        // Delete on empty tree should be no-op
+        let tree_after_delete = tree.delete(&1u32.to_le_bytes(), &storage).await?;
+        assert_eq!(tree_after_delete.root(), tree.root());
+
+        // Stream on empty tree should yield no entries
+        let stream = tree.stream(&storage);
+        futures_util::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 0);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_has_null_root_when_empty() -> Result<()> {
+        use dialog_common::NULL_BLAKE3_HASH;
+
+        let tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        assert_eq!(tree.root(), &NULL_BLAKE3_HASH.clone());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_updates_existing_keys() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert initial value
+        tree = tree
+            .insert(42u32.to_le_bytes(), vec![1, 2, 3], &storage)
+            .await?;
+
+        // Flush to storage
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify initial value
+        let value = tree.get(&42u32.to_le_bytes(), &storage).await?;
+        assert_eq!(value, Some(vec![1, 2, 3]));
+
+        // Update with new value
+        tree = tree
+            .insert(42u32.to_le_bytes(), vec![4, 5, 6, 7], &storage)
+            .await?;
+
+        // Flush update
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify updated value
+        let value = tree.get(&42u32.to_le_bytes(), &storage).await?;
+        assert_eq!(value, Some(vec![4, 5, 6, 7]));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_old_tree_after_insert() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree_v1 = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert into v1
+        tree_v1 = tree_v1
+            .insert(1u32.to_le_bytes(), vec![1], &storage)
+            .await?;
+
+        // Flush v1
+        for (key, value) in tree_v1.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        let v1_root = tree_v1.root().clone();
+
+        // Create v2 by inserting into v1
+        let mut tree_v2 = tree_v1
+            .insert(2u32.to_le_bytes(), vec![2], &storage)
+            .await?;
+
+        // Flush v2
+        for (key, value) in tree_v2.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify v1 is unchanged
+        assert_eq!(tree_v1.root(), &v1_root);
+        assert_eq!(
+            tree_v1.get(&1u32.to_le_bytes(), &storage).await?,
+            Some(vec![1])
+        );
+        assert_eq!(tree_v1.get(&2u32.to_le_bytes(), &storage).await?, None);
+
+        // Verify v2 has both entries
+        assert_ne!(tree_v2.root(), &v1_root);
+        assert_eq!(
+            tree_v2.get(&1u32.to_le_bytes(), &storage).await?,
+            Some(vec![1])
+        );
+        assert_eq!(
+            tree_v2.get(&2u32.to_le_bytes(), &storage).await?,
+            Some(vec![2])
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_independent_tree_versions() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut base = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert base data
+        for i in 0..10u32 {
+            base = base
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+
+        // Flush base
+        for (key, value) in base.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Create two independent branches
+        let mut branch_a = base
+            .insert(100u32.to_le_bytes(), vec![100], &storage)
+            .await?;
+        let mut branch_b = base
+            .insert(200u32.to_le_bytes(), vec![200], &storage)
+            .await?;
+
+        // Flush both branches
+        for (key, value) in branch_a.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+        for (key, value) in branch_b.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify branch A
+        assert_eq!(
+            branch_a.get(&100u32.to_le_bytes(), &storage).await?,
+            Some(vec![100])
+        );
+        assert_eq!(branch_a.get(&200u32.to_le_bytes(), &storage).await?, None);
+
+        // Verify branch B
+        assert_eq!(branch_b.get(&100u32.to_le_bytes(), &storage).await?, None);
+        assert_eq!(
+            branch_b.get(&200u32.to_le_bytes(), &storage).await?,
+            Some(vec![200])
+        );
+
+        // Verify base is still unchanged
+        assert_eq!(base.get(&100u32.to_le_bytes(), &storage).await?, None);
+        assert_eq!(base.get(&200u32.to_le_bytes(), &storage).await?, None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_changes_root_after_modification() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        let root_empty = tree.root().clone();
+
+        // Insert changes root
+        tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        let root_after_insert = tree.root().clone();
+        assert_ne!(root_after_insert, root_empty);
+
+        // Another insert changes root again
+        tree = tree.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        let root_after_second_insert = tree.root().clone();
+        assert_ne!(root_after_second_insert, root_after_insert);
+
+        // Delete changes root
+        tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        let root_after_delete = tree.root().clone();
+        assert_ne!(root_after_delete, root_after_second_insert);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_has_same_root_for_identical_trees() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        // Build tree A
+        let mut tree_a = Tree::<[u8; 4], Vec<u8>>::empty();
+        for i in 0..10u32 {
+            tree_a = tree_a
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree_a.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Build tree B with same data
+        let mut tree_b = Tree::<[u8; 4], Vec<u8>>::empty();
+        for i in 0..10u32 {
+            tree_b = tree_b
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree_b.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Trees with identical content should have same root (content-addressed)
+        assert_eq!(tree_a.root(), tree_b.root());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_unflushed_insertions() -> Result<()> {
+        let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert without flushing
+        tree = tree
+            .insert(1u32.to_le_bytes(), vec![1, 2, 3], &storage)
+            .await?;
+
+        // Should be able to read from delta
+        let value = tree.get(&1u32.to_le_bytes(), &storage).await?;
+        assert_eq!(value, Some(vec![1, 2, 3]));
+
+        // Insert more without flushing
+        tree = tree
+            .insert(2u32.to_le_bytes(), vec![4, 5, 6], &storage)
+            .await?;
+
+        // Should read both from delta
+        assert_eq!(
+            tree.get(&1u32.to_le_bytes(), &storage).await?,
+            Some(vec![1, 2, 3])
+        );
+        assert_eq!(
+            tree.get(&2u32.to_le_bytes(), &storage).await?,
+            Some(vec![4, 5, 6])
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_through_delta_and_storage() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert and flush first batch
+        for i in 0..5u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Insert second batch WITHOUT flushing
+        for i in 5..10u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+
+        // Should read 0-4 from storage and 5-9 from delta
+        for i in 0..10u32 {
+            let value = tree.get(&i.to_le_bytes(), &storage).await?;
+            assert_eq!(value, Some(vec![i as u8]));
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_single_entry_tree() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert single entry
+        tree = tree
+            .insert(42u32.to_le_bytes(), vec![1, 2, 3], &storage)
+            .await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Get should work
+        assert_eq!(
+            tree.get(&42u32.to_le_bytes(), &storage).await?,
+            Some(vec![1, 2, 3])
+        );
+
+        // Delete should work
+        tree = tree.delete(&42u32.to_le_bytes(), &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Should be empty again
+        assert_eq!(tree.get(&42u32.to_le_bytes(), &storage).await?, None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_deletes_nonexistent_key_in_empty_tree() -> Result<()> {
+        let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        let root_before = tree.root().clone();
+
+        // Delete from empty tree should be no-op
+        tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
+
+        // Root should be unchanged
+        assert_eq!(tree.root(), &root_before);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_deletes_nonexistent_key_in_populated_tree() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert some data
+        tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        let root_before = tree.root().clone();
+
+        // Delete non-existent key should be no-op
+        tree = tree.delete(&999u32.to_le_bytes(), &storage).await?;
+
+        // Root should be unchanged
+        assert_eq!(tree.root(), &root_before);
+
+        // Original data should still exist
+        assert_eq!(
+            tree.get(&1u32.to_le_bytes(), &storage).await?,
+            Some(vec![1])
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_mixed_operations() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert
+        tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        assert_eq!(
+            tree.get(&1u32.to_le_bytes(), &storage).await?,
+            Some(vec![1])
+        );
+
+        // Delete
+        tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        assert_eq!(tree.get(&1u32.to_le_bytes(), &storage).await?, None);
+
+        // Re-insert same key with different value
+        tree = tree
+            .insert(1u32.to_le_bytes(), vec![2, 3], &storage)
+            .await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        assert_eq!(
+            tree.get(&1u32.to_le_bytes(), &storage).await?,
+            Some(vec![2, 3])
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_has_same_root_regardless_of_insertion_order() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        // Build tree A with one insertion order
+        let mut tree_a = Tree::<[u8; 4], Vec<u8>>::empty();
+        tree_a = tree_a.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
+        tree_a = tree_a.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
+        tree_a = tree_a.insert(3u32.to_le_bytes(), vec![3], &storage).await?;
+
+        for (key, value) in tree_a.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Build tree B with different insertion order
+        let mut tree_b = Tree::<[u8; 4], Vec<u8>>::empty();
+        tree_b = tree_b.insert(3u32.to_le_bytes(), vec![3], &storage).await?;
+        tree_b = tree_b.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
+        tree_b = tree_b.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
+
+        for (key, value) in tree_b.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Different insertion orders should produce same root hash
+        assert_eq!(tree_a.root(), tree_b.root());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_to_null_root_after_deleting_all_entries() -> Result<()> {
+        use dialog_common::NULL_BLAKE3_HASH;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert some entries
+        tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
+        tree = tree.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
+        tree = tree.insert(3u32.to_le_bytes(), vec![3], &storage).await?;
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify tree is not empty
+        assert_ne!(tree.root(), &NULL_BLAKE3_HASH.clone());
+
+        // Delete all entries
+        tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        tree = tree.delete(&2u32.to_le_bytes(), &storage).await?;
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        tree = tree.delete(&3u32.to_le_bytes(), &storage).await?;
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Tree should be back to empty state with null root
+        assert_eq!(tree.root(), &NULL_BLAKE3_HASH.clone());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_out_of_bounds_range_queries() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert values 10-20
+        for i in 10..=20u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+
+        // Flush
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Query completely below range (0-5)
+        let stream = tree.stream_range(0u32.to_le_bytes()..5u32.to_le_bytes(), &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 0, "Range below all entries should yield nothing");
+
+        // Query completely above range (30-40)
+        let stream = tree.stream_range(30u32.to_le_bytes()..40u32.to_le_bytes(), &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 0, "Range above all entries should yield nothing");
+
+        // Query with only start out of bounds (25..)
+        let stream = tree.stream_range(25u32.to_le_bytes().., &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 0, "Start beyond all entries should yield nothing");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_larger_random_dataset() -> Result<()> {
+        use rand::{Rng, thread_rng};
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        let mut ledger = Vec::new();
+
+        // Generate and insert random data
+        for _ in 0..1024 {
+            let key = thread_rng().r#gen::<u32>().to_le_bytes();
+            let value = thread_rng().r#gen::<[u8; 16]>().to_vec();
+            ledger.push((key, value.clone()));
+            tree = tree.insert(key, value, &storage).await?;
+        }
+
+        // Flush to storage
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Verify all entries can be retrieved
+        for (key, expected_value) in ledger {
+            let value = tree.get(&key, &storage).await?;
+            assert_eq!(value, Some(expected_value));
+        }
+
+        Ok(())
+    }
+}

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -1,0 +1,293 @@
+use std::{
+    marker::PhantomData,
+    ops::{Bound, RangeBounds},
+};
+
+use async_stream::try_stream;
+use dialog_common::{Blake3Hash, NULL_BLAKE3_HASH};
+use futures_core::Stream;
+use nonempty::NonEmpty;
+use rkyv::{
+    Deserialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+use crate::{
+    ArchivedNodeBody, DialogSearchTreeError, Entry, Key, Link, Node, SymmetryWith, Value,
+    into_owned,
+};
+
+/// A traversal mechanism for walking through a tree structure.
+pub struct TreeWalker<Key, Value, GetNode>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+    GetNode: AsyncFn(&Blake3Hash) -> Result<Node<Key, Value>, DialogSearchTreeError>,
+{
+    root: Blake3Hash,
+    get_node: GetNode,
+
+    key: PhantomData<Key>,
+    value: PhantomData<Value>,
+}
+
+impl<Key, Value, GetNode> TreeWalker<Key, Value, GetNode>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Key::Archived: for<'b> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+    Key::Archived: Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: self::Value,
+    Value::Archived: for<'b> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+    Value::Archived: Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>,
+    GetNode: AsyncFn(&Blake3Hash) -> Result<Node<Key, Value>, DialogSearchTreeError>,
+{
+    /// Creates a new [`TreeWalker`] with the given root hash and node fetcher.
+    pub fn new(root: Blake3Hash, get_node: GetNode) -> Self {
+        Self {
+            root,
+            get_node,
+            key: PhantomData,
+            value: PhantomData,
+        }
+    }
+
+    /// Returns a stream of entries within the specified key range.
+    pub fn stream<'a, R>(
+        self,
+        range: R,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + 'a
+    where
+        Self: 'a,
+        R: RangeBounds<Key> + 'a,
+    {
+        try_stream! {
+            // Get the start key. Included/Excluded ranges are identical here,
+            // the check if key is in range is below, and this will at most read
+            // one unnecessary segment iff `Bound::Excluded(K)` and `K` is a
+            // boundary node.
+            let start_key = match range.start_bound() {
+                Bound::Included(start) => start.clone(),
+                Bound::Excluded(start) => start.clone(),
+                Bound::Unbounded => {
+                    return;
+                },
+            };
+            let Some(search_result) = self.search(&start_key).await? else {
+                return;
+            };
+            let mut search_path = search_result.into_indexed()?;
+            let mut entered_range = false;
+
+            while let Some((node, maybe_index)) = search_path.pop() {
+                match node.body()? {
+                    ArchivedNodeBody::Index(index) => {
+                        let child_index = if let Some(index) = maybe_index {
+                            index + 1
+                        } else {
+                            0
+                        };
+
+                        match index.links.get(child_index) {
+                            Some(link) => {
+                                let next_node = (self.get_node)(<&Blake3Hash>::from(&link.node)).await?;
+                                search_path.push((node, Some(child_index)));
+                                search_path.push((next_node, None));
+                            }
+                            None => {
+                                // Parent needs to check next sibling
+                                continue;
+                            }
+                        }
+
+                    },
+                    ArchivedNodeBody::Segment(segment) => {
+                        for entry in segment.entries.iter() {
+                            if range.contains(&entry.key) {
+                                entered_range = true;
+                                yield into_owned(entry)?;
+                            } else if entered_range {
+                                // We've surpassed the range; abort.
+                                break;
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    /// Searches for the leaf segment that would contain the given key.
+    pub async fn search(
+        &self,
+        key: &Key,
+    ) -> Result<Option<SearchResult<Key, Value>>, DialogSearchTreeError> {
+        if &self.root == NULL_BLAKE3_HASH {
+            return Ok(None);
+        }
+
+        // Depth scales logarithmically with number of entries, so 32 is truly
+        // overkill here
+        const MAXIMUM_TREE_DEPTH: usize = 32;
+
+        let mut next_node = self.root.clone();
+        let mut path = vec![];
+
+        loop {
+            if path.len() > MAXIMUM_TREE_DEPTH {
+                return Err(DialogSearchTreeError::Operation(format!(
+                    "Tree depth exceded the soft maximum ({MAXIMUM_TREE_DEPTH})"
+                )));
+            }
+
+            let node = (self.get_node)(&next_node).await?;
+
+            match node.body()? {
+                ArchivedNodeBody::Index(index) => {
+                    let mut left = vec![];
+                    let mut right = vec![];
+                    let mut next_descendant = None;
+
+                    for link in index.links.iter() {
+                        if next_descendant.is_some() {
+                            right.push(link);
+                        } else if key <= &link.upper_bound {
+                            next_descendant = Some(&link.node);
+                        } else {
+                            left.push(link);
+                        }
+                    }
+
+                    if next_descendant.is_none() {
+                        let last_candidate = left.pop().ok_or(DialogSearchTreeError::Operation(
+                            "No upper bound found".into(),
+                        ))?;
+
+                        next_descendant = Some(&last_candidate.node);
+                    }
+
+                    path.push(TreeLayer {
+                        host: node.clone(),
+                        left_siblings: NonEmpty::from_vec(
+                            left.into_iter()
+                                .map(into_owned)
+                                .collect::<Result<_, DialogSearchTreeError>>()?,
+                        ),
+                        right_siblings: NonEmpty::from_vec(
+                            right
+                                .into_iter()
+                                .map(into_owned)
+                                .collect::<Result<_, DialogSearchTreeError>>()?,
+                        ),
+                    });
+
+                    next_node = next_descendant
+                        .ok_or_else(|| {
+                            DialogSearchTreeError::Operation("Next node not found".into())
+                        })
+                        .and_then(into_owned)?;
+                }
+                ArchivedNodeBody::Segment(_) => {
+                    return Ok(Some(SearchResult { leaf: node, path }));
+                }
+            }
+        }
+    }
+}
+
+/// A layer in the tree traversal path, containing a node and its sibling links.
+pub struct TreeLayer<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+{
+    // pub host: Blake3Hash,
+    /// The node at this layer of the tree.
+    pub host: Node<Key, Value>,
+    /// Links to sibling nodes to the left of the current path.
+    pub left_siblings: Option<NonEmpty<Link<Key>>>,
+    /// Links to sibling nodes to the right of the current path.
+    pub right_siblings: Option<NonEmpty<Link<Key>>>,
+}
+
+/// The path taken from the root to a leaf during a tree search.
+pub type SearchPath<Key, Value> = Vec<TreeLayer<Key, Value>>;
+
+/// An indexed path with nodes and their child indices.
+pub type IndexedPath<Key, Value> = Vec<(Node<Key, Value>, Option<usize>)>;
+
+/// The result of a tree search, containing the leaf node and the path taken to
+/// reach it.
+pub struct SearchResult<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+{
+    /// The leaf node found by the search.
+    pub leaf: Node<Key, Value>,
+    /// The path from root to leaf.
+    pub path: SearchPath<Key, Value>,
+}
+
+impl<Key, Value> SearchResult<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>
+        + PartialOrd<Key>
+        + PartialEq<Key>
+        + SymmetryWith<Key>
+        + Ord,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+{
+    /// Converts this search result into a path with child indices.
+    pub fn into_indexed(mut self) -> Result<IndexedPath<Key, Value>, DialogSearchTreeError> {
+        let mut path = Vec::new();
+        let mut leaf = self.leaf;
+
+        path.push((leaf.clone(), None));
+
+        while let Some(layer) = self.path.pop() {
+            let Some(leaf_upper_bound) = leaf.upper_bound()? else {
+                return Err(DialogSearchTreeError::Node(
+                    "Could not discover child's upper bound".to_string(),
+                ));
+            };
+            let Some(index) = layer.host.get_child_index(leaf_upper_bound)? else {
+                return Err(DialogSearchTreeError::Node(
+                    "Could not find node's index relative to parent".to_string(),
+                ));
+            };
+
+            leaf = layer.host;
+            path.push((leaf.clone(), Some(index)));
+        }
+
+        path.reverse();
+
+        Ok(path)
+    }
+}

--- a/rust/dialog-storage/src/error.rs
+++ b/rust/dialog-storage/src/error.rs
@@ -14,4 +14,8 @@ pub enum DialogStorageError {
     /// An error that occurs when working with a storage backend
     #[error("Storage backend error: {0}")]
     StorageBackend(String),
+
+    /// An error that occurs when byte hash verification fails
+    #[error("Byte hash verification failed: {0}")]
+    Verification(String),
 }


### PR DESCRIPTION
This change represents a major revision to the search tree implementation in the existing crate `dialog-prolly-tree`. It is implemented as a new crate - `dialog-search-tree` - so that we can get it in and perform the replacement of the old tree as a follow-on exercise.

The main goal of this revised implementation is speed improvements. The previous tree was fast enough for certain demos, but it had some serious bottlenecks that hindered practical usage. In one notable case, performing many writes to the tree in one go was unacceptably slow (the time to import ~10,000 facts was measured in seconds).

The new tree applies the following optimizations:

- Tree nodes are (de)serialized using "total" zero-copy deserialization (via [`rkyv`](https://rkyv.org/))
  - There is [nearly zero deserialization cost for reads](https://rkyv.org/zero-copy-deserialization.html#total-zero-copy)
  - [Deserialization for writes is 3 ~ 4 x faster](https://github.com/djkoloski/rust_serialization_benchmark) than `serde_cbor` (used by `dialog-prolly-tree`)
- Node buffers are retained by the `Tree` in a cache that is shared by all branches from that `Tree`
- Node buffer hashes are computed at once most for a cached buffer
- `Storage` is _only_ used to populate cache when a node's block is otherwise not available in memory
  - The `Tree` _never_ writes to `Storage`
  - Instead, an internal buffer of new blocks needed to read the tree at the current state (relative to its base) is maintained and must be manually flushed to storage by the `Tree` user
    - In other words: the `Tree` user has full control over when (probably slow) writes happen, without compromising on the ability to read from a modified `Tree` 

Additionally, the new `Tree`:

- ...no longer supports arbitrary hashes
- ...no longer supports arbitrary branch factors
- ...depends on a simplified, in-crate `ContentAddressedStorage` wrapper over some `impl StorageBackend`
  - We should reconcile this trait with `dialog-storage` in a future change
- ...no longer owns a `Storage`
  - The user must bring their own `Storage` for each API interaction

### Abandoned Attempts

This change is the culmination of a few months of experimenting with a zero-copy tree that used the specialized encoding we landed in https://github.com/dialog-db/dialog-db/pull/95. All-told, I made five attempts to implement a satisfying tree that made use of `dialog-encoding` while also supporting fast, zero-copy reads. These attempts all ran aground against two constraints:

- Deserialization was always much slower than intended, dragged down by manually reassembling read-only structures from fragmented data
- Despite the deserialization overhead, it was not possible to modify the buffers in-place for efficient writes

My conclusion is that we need to revisit `dialog-encoding` with this experience in mind before we attempt another [Fressian](https://github.com/Datomic/fressian)-style (de)serialization scheme.

For now, `rkyv` is very fast for (de)serialization, and we can pair it with other compression schemes to get most of the benefits that we sought from `dialog-encoding`.

### Migration Outlook

In principle there should not be a reason why this new `Tree` is difficult to migrate to. The API embodies all the same verbs and semantics as the current one. However, there are some nuanced details related to `Storage` that need to be considered. The user of the `Tree` is now responsible for passing `Storage` to the `Tree` when reading and writing, and then also must handle persisting changes over time.

## Benchmark Results & Charts

As part of this change, I introduced some benchmarks to cover core API operations for `dialog-search-tree` (including backported analogous benchmarks for `dialog-prolly-tree`). I'm excited to report that  `dialog-search-tree` outperforms `dialog-prolly-tree` in all test scenarios. Here are the approximate speed improvements:

| Operation            | Change           |
|----------------------|------------------|
| Read (Single)        | 7 ~ 45 x faster  |
| Read (Range)         | 1.5 ~ 7 x faster  |
| Insert (Sequential)  | 2 ~ 4 x faster  |
| Insert (Random)      | 2 ~ 4 x faster  |
| Delete               | 2 ~ 5 x faster |


<details>
  <summary><strong><em>Read (Single)</em></strong></summary>

_N = size of tree_

| Size  | 🔵 Prolly Tree | 🟢 Search Tree | Speedup |
|-------|----------------|----------------|---------|
| 10    | 1.27 us        | 0.18 us        | 7.0x    |
| 100   | 3.61 us        | 0.31 us        | 11.7x   |
| 1000  | 36.91 us       | 0.81 us        | 45.7x   |
| 10000 | 54.00 us       | 1.29 us        | 41.8x   |

```mermaid
xychart-beta
    title "Read Performance (Single Key Lookup)"
    x-axis [10, 100, 1000, 10000]
    y-axis "Time (us, mean)" 0 --> 55
    line [1.27, 3.61, 36.91, 54.00]
    line [0.18, 0.31, 0.81, 1.29]
```
</details>

<details>
  <summary><strong><em>Read (Range)</em></strong></summary>

_N = number of entries streamed from 10100-sized tree_

_Note: I ran the benchmark a few times; I'm not sure why there is a spike in read time (in both crates) for N=100._

| Size  | 🔵 Prolly Tree | 🟢 Search Tree | Speedup |
|-------|----------------|----------------|---------|
| 10    | 92.34 us       | 25.28 us       | 3.7x    |
| 100   | 792.69 us      | 111.99 us      | 7.1x    |
| 1000  | 36.47 us       | 20.89 us       | 1.7x    |
| 10000 | 170.12 us      | 30.74 us       | 5.5x    |

```mermaid
xychart-beta
    title "Read Performance (Stream Key Range)"
    x-axis [10, 100, 1000, 10000]
    y-axis "Time (us, mean)" 0 --> 800
    line [92.34, 792.69, 36.47, 170.12]
    line [25.28, 111.99, 20.89, 30.74]
```
</details>

<details>
  <summary><strong><em>Insert (Sequential)</em></strong></summary>

_N = number of entries inserted to empty tree_

| Size  | 🔵 Prolly Tree | 🟢 Search Tree | Speedup |
|-------|----------------|----------------|---------|
| 10    | 0.04 ms        | 0.02 ms        | 2.3x    |
| 100   | 2.55 ms        | 0.73 ms        | 3.5x    |
| 1000  | 77.92 ms       | 19.01 ms       | 4.1x    |
| 10000 | 1143.91 ms     | 280.95 ms      | 4.1x    |

```mermaid
xychart-beta
    title "Insert Performance (Sequential Keys)"
    x-axis [10, 100, 1000, 10000]
    y-axis "Time (ms, mean)" 0 --> 1200
    line [0.04, 2.55, 77.92, 1143.91]
    line [0.02, 0.73, 19.01, 280.95]
```
</details>

<details>
  <summary><strong><em>Insert (Random)</em></strong></summary>

_N = number of entries inserted to empty tree_

| Size  | 🔵 Prolly Tree | 🟢 Search Tree | Speedup |
|-------|----------------|----------------|---------|
| 10    | 0.04 ms        | 0.02 ms        | 2.3x    |
| 100   | 2.34 ms        | 0.65 ms        | 3.6x    |
| 1000  | 88.95 ms       | 20.48 ms       | 4.3x    |
| 10000 | 1513.65 ms     | 335.78 ms      | 4.5x    |

```mermaid
xychart-beta
    title "Insert Performance (Random Keys)"
    x-axis [10, 100, 1000, 10000]
    y-axis "Time (ms, mean)" 0 --> 1600
    line [0.04, 2.34, 88.95, 1513.65]
    line [0.02, 0.65, 20.48, 335.78]
```
</details>

<details>
  <summary><strong><em>Delete</em></strong></summary>

_N = size of tree_

| Size  | 🔵 Prolly Tree | 🟢 Search Tree | Speedup |
|-------|----------------|----------------|---------|
| 10    | 0.07 ms        | 0.02 ms        | 2.9x    |
| 100   | 3.74 ms        | 0.88 ms        | 4.2x    |
| 1000  | 127.19 ms      | 25.09 ms       | 5.1x    |
| 10000 | 2191.91 ms     | 405.95 ms      | 5.4x    |

```mermaid
xychart-beta
    title "Delete Performance (Half the Keys)"
    x-axis [10, 100, 1000, 10000]
    y-axis "Time (ms, mean)" 0 --> 2200
    line [0.07, 3.74, 127.19, 2191.91]
    line [0.02, 0.88, 25.09, 405.95]
```
</details>


Data collected on a Framework 16 laptop:

- Ryzen 9 7940HS + Radeon RX 7700S, 64GB DDR5-5600 RAM
- rustc 1.91.1, x86_64-unknown-linux-gnu
- Linux kernel v6.12.59




