### PR TITLE
feat: backport system capabilities to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "dialog-macros",
  "futures-util",
  "serde",
+ "serde_bytes",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
@@ -800,6 +801,20 @@ dependencies = [
  "ratatui",
  "throbber-widgets-tui",
  "tokio",
+]
+
+[[package]]
+name = "dialog-effects"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dialog-capability",
+ "dialog-common",
+ "ipld-core",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.17",
+ "ucan",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "rust/dialog-artifacts",
     "rust/dialog-capability",
     "rust/dialog-common",
+    "rust/dialog-effects",
     "rust/dialog-macros",
     "rust/dialog-diagnose",
     "rust/dialog-dbsp",
@@ -73,6 +74,7 @@ rexie = "0.6"
 rkyv = "0.8"
 serde = "1"
 serde-big-array = "0.5"
+serde_bytes = "0.11"
 serde_ipld_dagcbor = "0.6"
 serde_json = "1"
 sieve-cache = "1"
@@ -108,6 +110,9 @@ path = "./rust/dialog-prolly-tree"
 
 [workspace.dependencies.dialog-storage]
 path = "./rust/dialog-storage"
+
+[workspace.dependencies.dialog-effects]
+path = "./rust/dialog-effects"
 
 [workspace.dependencies.dialog-macros]
 path = "./rust/dialog-macros"

--- a/rust/dialog-common/Cargo.toml
+++ b/rust/dialog-common/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [features]
 default = []
 # Testing utilities (Provision, Provider traits, EnvGuard)
-helpers = ["dep:anyhow", "dep:serde", "dep:serde_json", "dep:dialog-macros", "dep:async-trait"]
+helpers = ["dep:anyhow", "dep:serde_json", "dep:dialog-macros", "dep:async-trait"]
 # Enable integration tests (tests with service provisioning)
 integration-tests = ["helpers"]
 # Enable web integration tests (implies integration-tests behavior)
@@ -17,8 +17,9 @@ web-integration-tests = ["helpers"]
 
 [dependencies]
 blake3 = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
 anyhow = { workspace = true, optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 dialog-macros = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }

--- a/rust/dialog-common/src/as_bytes.rs
+++ b/rust/dialog-common/src/as_bytes.rs
@@ -1,0 +1,27 @@
+//! Generic serde helper for types that can be represented as bytes.
+//!
+//! Use with `#[serde(with = "dialog_common::as_bytes")]` for types that implement
+//! `AsRef<[u8]>` and `TryFrom<Vec<u8>>`.
+
+use serde::{Deserialize, Deserializer, Serializer};
+use std::fmt::Display;
+
+/// Serialize a value as raw bytes.
+pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: AsRef<[u8]>,
+    S: Serializer,
+{
+    serializer.serialize_bytes(value.as_ref())
+}
+
+/// Deserialize raw bytes into a value.
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: TryFrom<Vec<u8>>,
+    <T as TryFrom<Vec<u8>>>::Error: Display,
+    D: Deserializer<'de>,
+{
+    let buf: serde_bytes::ByteBuf = serde_bytes::ByteBuf::deserialize(deserializer)?;
+    T::try_from(buf.into_vec()).map_err(serde::de::Error::custom)
+}

--- a/rust/dialog-common/src/hash.rs
+++ b/rust/dialog-common/src/hash.rs
@@ -1,3 +1,6 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
 /// The size of a BLAKE3 hash in bytes.
 ///
 /// BLAKE3 produces 256-bit (32-byte) hashes by default.
@@ -17,7 +20,7 @@ pub const BLAKE3_HASH_SIZE: usize = 32;
 /// let data = b"hello world";
 /// let hash = Blake3Hash::hash(data);
 /// ```
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct Blake3Hash([u8; 32]);
 
@@ -43,4 +46,41 @@ impl Blake3Hash {
     pub fn hash(bytes: &[u8]) -> Self {
         Self(blake3::hash(bytes).into())
     }
+
+    /// Returns the hash as a byte slice.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Blake3Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for Blake3Hash {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Blake3Hash {
+    type Error = ConversionError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let len = bytes.len();
+        let arr: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| ConversionError::InvalidSize(len))?;
+        Ok(Self(arr))
+    }
+}
+
+/// Error returned when trying to convert byte arry to a Blake3Hash.
+#[derive(Error, Debug, Clone)]
+pub enum ConversionError {
+    /// Wrong number of bytes
+    #[error("Expected {BLAKE3_HASH_SIZE} bytes, got {0}")]
+    InvalidSize(usize),
 }

--- a/rust/dialog-common/src/lib.rs
+++ b/rust/dialog-common/src/lib.rs
@@ -10,6 +10,8 @@ extern crate self as dialog_common;
 mod sync;
 pub use sync::*;
 
+pub mod as_bytes;
+
 mod hash;
 pub use hash::*;
 

--- a/rust/dialog-effects/Cargo.toml
+++ b/rust/dialog-effects/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "dialog-effects"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[features]
+ucan = ["dep:ipld-core", "dep:ucan", "dialog-capability/ucan"]
+
+[dependencies]
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true }
+
+async-trait = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+thiserror = { workspace = true }
+
+# Optional UCAN support
+ipld-core = { workspace = true, optional = true }
+ucan = { workspace = true, optional = true }
+
+[dev-dependencies]
+ipld-core = { workspace = true }
+
+[lints.rust]
+missing_docs = "warn"

--- a/rust/dialog-effects/src/archive.rs
+++ b/rust/dialog-effects/src/archive.rs
@@ -1,0 +1,294 @@
+//! Archive capability hierarchy.
+//!
+//! Archive provides content-addressed blob storage organized into catalogs.
+//!
+//! # Capability Hierarchy
+//!
+//! ```text
+//! Subject (repository DID)
+//!   └── Archive (ability: /archive)
+//!         └── Catalog { catalog: String }
+//!               ├── Get { digest } → Effect → Result<Option<Bytes>, ArchiveError>
+//!               └── Put { digest, content } → Effect → Result<(), ArchiveError>
+//! ```
+
+use std::error::Error;
+
+pub use dialog_capability::{
+    Attenuation, Capability, DialogCapabilityPerformError, Effect, Policy, Subject,
+};
+pub use dialog_common::Blake3Hash;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Archive ability - restricts to archive operations.
+///
+/// Attaches to Subject and provides the `/archive` ability path segment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Archive;
+
+impl Attenuation for Archive {
+    type Of = Subject;
+}
+
+/// Catalog policy that scopes operations to a named catalog.
+///
+/// Does not add to ability path but constrains invocation arguments.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Catalog {
+    /// The catalog name (e.g., "index", "blobs").
+    pub catalog: String,
+}
+
+impl Catalog {
+    /// Create a new Catalog policy.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            catalog: name.into(),
+        }
+    }
+}
+
+impl Policy for Catalog {
+    type Of = Archive;
+}
+
+/// Get operation - retrieves content by digest.
+///
+/// Requires `Capability<Catalog>` access level.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Get {
+    /// The blake3 digest of the content to retrieve.
+    #[serde(with = "dialog_common::as_bytes")]
+    pub digest: Blake3Hash,
+}
+
+impl Get {
+    /// Create a new Get effect.
+    pub fn new(digest: impl Into<Blake3Hash>) -> Self {
+        Self {
+            digest: digest.into(),
+        }
+    }
+}
+
+impl Effect for Get {
+    type Of = Catalog;
+    type Output = Result<Option<Vec<u8>>, ArchiveError>;
+}
+
+/// Extension trait for `Capability<Get>` to access its fields.
+pub trait GetCapability {
+    /// Get the catalog name from the capability chain.
+    fn catalog(&self) -> &str;
+    /// Get the digest from the capability chain.
+    fn digest(&self) -> &Blake3Hash;
+}
+
+impl GetCapability for Capability<Get> {
+    fn catalog(&self) -> &str {
+        &Catalog::of(self).catalog
+    }
+
+    fn digest(&self) -> &Blake3Hash {
+        &Get::of(self).digest
+    }
+}
+
+/// Put operation - stores content by digest.
+///
+/// Requires `Capability<Catalog>` access level.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Put {
+    /// The blake3 digest of the content (must match hash of content).
+    #[serde(with = "dialog_common::as_bytes")]
+    pub digest: Blake3Hash,
+    /// The content to store.
+    #[serde(with = "serde_bytes")]
+    pub content: Vec<u8>,
+}
+
+impl Put {
+    /// Create a new Put effect.
+    pub fn new(digest: impl Into<Blake3Hash>, content: impl Into<Vec<u8>>) -> Self {
+        Self {
+            digest: digest.into(),
+            content: content.into(),
+        }
+    }
+}
+
+impl Effect for Put {
+    type Of = Catalog;
+    type Output = Result<(), ArchiveError>;
+}
+
+/// Extension trait for `Capability<Put>` to access its fields.
+pub trait PutCapability {
+    /// Get the catalog name from the capability chain.
+    fn catalog(&self) -> &str;
+    /// Get the digest from the capability chain.
+    fn digest(&self) -> &Blake3Hash;
+    /// Get the content from the capability chain.
+    fn content(&self) -> &[u8];
+}
+
+impl PutCapability for Capability<Put> {
+    fn catalog(&self) -> &str {
+        &Catalog::of(self).catalog
+    }
+
+    fn digest(&self) -> &Blake3Hash {
+        &Put::of(self).digest
+    }
+
+    fn content(&self) -> &[u8] {
+        &Put::of(self).content
+    }
+}
+
+/// Errors that can occur during archive operations.
+#[derive(Debug, Error)]
+pub enum ArchiveError {
+    /// Content digest mismatch.
+    #[error("Content digest mismatch: expected {expected}, got {actual}")]
+    DigestMismatch {
+        /// Expected digest.
+        expected: String,
+        /// Actual digest.
+        actual: String,
+    },
+
+    /// Authorization error occurred.
+    #[error("Unauthorized error: {0}")]
+    AuthorizationError(String),
+
+    /// Execution error occurred during operation.
+    #[error("Executions error: {0}")]
+    ExecutionError(String),
+
+    /// Storage backend error.
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    /// IO error.
+    #[error("IO error: {0}")]
+    Io(String),
+}
+
+impl From<dialog_capability::DialogCapabilityAuthorizationError> for ArchiveError {
+    fn from(value: dialog_capability::DialogCapabilityAuthorizationError) -> Self {
+        ArchiveError::AuthorizationError(value.to_string())
+    }
+}
+
+impl<E: Error> From<DialogCapabilityPerformError<E>> for ArchiveError {
+    fn from(value: DialogCapabilityPerformError<E>) -> Self {
+        match value {
+            DialogCapabilityPerformError::Authorization(error) => {
+                ArchiveError::AuthorizationError(error.to_string())
+            }
+            DialogCapabilityPerformError::Execution(error) => {
+                ArchiveError::ExecutionError(error.to_string())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_builds_archive_claim_path() {
+        let claim = Subject::from("did:key:zSpace").attenuate(Archive);
+
+        assert_eq!(claim.subject(), "did:key:zSpace");
+        assert_eq!(claim.ability(), "/archive");
+    }
+
+    #[test]
+    fn it_builds_catalog_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"));
+
+        assert_eq!(claim.subject(), "did:key:zSpace");
+        // Catalog is Policy, not Ability, so it doesn't add to path
+        assert_eq!(claim.ability(), "/archive");
+    }
+
+    #[test]
+    fn it_builds_get_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Get::new([0u8; 32]));
+
+        assert_eq!(claim.ability(), "/archive/get");
+    }
+
+    #[test]
+    fn it_builds_put_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Put::new([0u8; 32], Vec::new()));
+
+        assert_eq!(claim.ability(), "/archive/put");
+    }
+
+    #[cfg(feature = "ucan")]
+    mod parameters_tests {
+        use super::*;
+        use dialog_capability::ucan::parameters;
+        use ipld_core::ipld::Ipld;
+
+        #[test]
+        fn it_collects_archive_parameters() {
+            let cap = Subject::from("did:key:zSpace").attenuate(Archive);
+            let params = parameters(&cap);
+
+            // Archive is a unit struct, should produce empty map
+            assert!(params.is_empty());
+        }
+
+        #[test]
+        fn it_collects_catalog_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Archive)
+                .attenuate(Catalog::new("blobs"));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("catalog"), Some(&Ipld::String("blobs".into())));
+        }
+
+        #[test]
+        fn it_collects_get_parameters() {
+            let digest = Blake3Hash::from([1u8; 32]);
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Archive)
+                .attenuate(Catalog::new("index"))
+                .invoke(Get::new(digest));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("catalog"), Some(&Ipld::String("index".into())));
+            assert_eq!(params.get("digest"), Some(&Ipld::Bytes([1u8; 32].to_vec())));
+        }
+
+        #[test]
+        fn it_collects_put_parameters() {
+            let digest = Blake3Hash::from([2u8; 32]);
+            let content = b"hello world".to_vec();
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Archive)
+                .attenuate(Catalog::new("data"))
+                .invoke(Put::new(digest, content.clone()));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("catalog"), Some(&Ipld::String("data".into())));
+            assert_eq!(params.get("digest"), Some(&Ipld::Bytes([2u8; 32].to_vec())));
+            assert_eq!(params.get("content"), Some(&Ipld::Bytes(content)));
+        }
+    }
+}

--- a/rust/dialog-effects/src/lib.rs
+++ b/rust/dialog-effects/src/lib.rs
@@ -1,0 +1,35 @@
+//! Dialog effects - capability hierarchy types for storage operations.
+//!
+//! This crate defines the domain-specific capability hierarchies used by Dialog
+//! for storage operations. It provides the structural types (attenuations, policies,
+//! and effects) that form capability chains.
+//!
+//! # Capability Domains
+//!
+//! - [`storage`]: Key-value storage operations (`Storage`, `Store`, `Get`, `Set`, `Delete`, `List`)
+//! - [`memory`]: CAS memory cells (`Memory`, `Space`, `Cell`, `Resolve`, `Publish`, `Retract`)
+//! - [`archive`]: Content-addressed archive (`Archive`, `Catalog`, `Get`, `Put`)
+//!
+//! # Example
+//!
+//! ```
+//! use dialog_effects::storage::{Storage, Store, Get};
+//! use dialog_capability::Subject;
+//!
+//! let subject = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+//!
+//! // Build a capability to get a value from the "index" store
+//! let get_capability = Subject::from(subject)
+//!     .attenuate(Storage)              // Domain: storage operations
+//!     .attenuate(Store::new("index"))  // Policy: only the "index" store
+//!     .invoke(Get::new(b"my-key"));    // Effect: get this specific key
+//! ```
+
+#![warn(missing_docs)]
+
+pub mod archive;
+pub mod memory;
+pub mod storage;
+
+// Re-export capability primitives for convenience
+pub use dialog_capability::{Attenuation, Capability, Effect, Policy, Subject};

--- a/rust/dialog-effects/src/memory.rs
+++ b/rust/dialog-effects/src/memory.rs
@@ -1,0 +1,360 @@
+//! Memory capability hierarchy.
+//!
+//! Memory provides transactional cell storage with CAS (Compare-And-Swap) semantics.
+//!
+//! # Capability Hierarchy
+//!
+//! ```text
+//! Subject (repository DID)
+//!   └── Memory (ability: /memory)
+//!         └── Space { space: String }
+//!               └── Cell { cell: String }
+//!                     ├── Resolve → Effect → Result<Option<Publication>, MemoryError>
+//!                     ├── Publish { content, when } → Effect → Result<Bytes, MemoryError>
+//!                     └── Retract { when } → Effect → Result<(), MemoryError>
+//! ```
+
+pub use dialog_capability::{Attenuation, Capability, Effect, Policy, Subject};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Root attenuation for memory operations.
+///
+/// Attaches to Subject and provides the `/memory` ability path segment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Memory;
+
+impl Attenuation for Memory {
+    type Of = Subject;
+}
+
+/// Space policy that scopes operations to a memory space.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Space {
+    /// The space name (typically a DID).
+    pub space: String,
+}
+
+impl Space {
+    /// Create a new Space policy.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { space: name.into() }
+    }
+}
+
+impl Policy for Space {
+    type Of = Memory;
+}
+
+/// Cell policy that scopes operations to a specific cell within a space.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Cell {
+    /// The cell name.
+    pub cell: String,
+}
+
+impl Cell {
+    /// Create a new Cell policy.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { cell: name.into() }
+    }
+}
+
+impl Policy for Cell {
+    type Of = Space;
+}
+
+/// Edition identifier for CAS operations.
+pub type Edition = String;
+
+/// A cell's current state: content and its edition.
+///
+/// Returned by [`Resolve`] when the cell has content.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Publication {
+    /// The cell's current content.
+    #[serde(with = "serde_bytes")]
+    pub content: Vec<u8>,
+    /// The edition identifier for this content.
+    #[serde(with = "serde_bytes")]
+    pub edition: Vec<u8>,
+}
+
+/// Resolve operation - reads current cell content and edition.
+///
+/// Returns `None` if the cell has no content (empty/uninitialized).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Resolve;
+
+impl Effect for Resolve {
+    type Of = Cell;
+    type Output = Result<Option<Publication>, MemoryError>;
+}
+
+/// Extension trait for `Capability<Resolve>` to access its fields.
+pub trait ResolveCapability {
+    /// Get the space name from the capability chain.
+    fn space(&self) -> &str;
+    /// Get the cell name from the capability chain.
+    fn cell(&self) -> &str;
+}
+
+impl ResolveCapability for Capability<Resolve> {
+    fn space(&self) -> &str {
+        &Space::of(self).space
+    }
+
+    fn cell(&self) -> &str {
+        &Cell::of(self).cell
+    }
+}
+
+/// Publish operation - sets cell content with CAS semantics.
+///
+/// - If `when` is `None`, expects cell to be empty (first publish)
+/// - If `when` is `Some(edition)`, expects current edition to match
+/// - Returns new edition on success
+/// - Returns `MemoryError::EditionMismatch` if expectation doesn't match
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Publish {
+    /// The content to publish.
+    #[serde(with = "serde_bytes")]
+    pub content: Vec<u8>,
+    /// The expected current edition, or None if expecting empty cell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub when: Option<serde_bytes::ByteBuf>,
+}
+
+impl Publish {
+    /// Create a new Publish effect.
+    pub fn new(content: impl Into<Vec<u8>>, when: Option<Vec<u8>>) -> Self {
+        Self {
+            content: content.into(),
+            when: when.map(serde_bytes::ByteBuf::from),
+        }
+    }
+}
+
+impl Effect for Publish {
+    type Of = Cell;
+    type Output = Result<Vec<u8>, MemoryError>;
+}
+
+/// Extension trait for `Capability<Publish>` to access its fields.
+pub trait PublishCapability {
+    /// Get the space name from the capability chain.
+    fn space(&self) -> &str;
+    /// Get the cell name from the capability chain.
+    fn cell(&self) -> &str;
+    /// Get the content to publish.
+    fn content(&self) -> &[u8];
+    /// Get the expected edition (when condition).
+    fn when(&self) -> Option<&[u8]>;
+}
+
+impl PublishCapability for Capability<Publish> {
+    fn space(&self) -> &str {
+        &Space::of(self).space
+    }
+
+    fn cell(&self) -> &str {
+        &Cell::of(self).cell
+    }
+
+    fn content(&self) -> &[u8] {
+        &Publish::of(self).content
+    }
+
+    fn when(&self) -> Option<&[u8]> {
+        Publish::of(self).when.as_ref().map(|b| b.as_ref())
+    }
+}
+
+/// Retract operation - removes cell content with CAS semantics.
+///
+/// - Requires `when` to match current edition
+/// - Returns `MemoryError::EditionMismatch` if edition doesn't match
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Retract {
+    /// The expected current edition.
+    #[serde(with = "serde_bytes")]
+    pub when: Vec<u8>,
+}
+
+impl Retract {
+    /// Create a new Retract effect.
+    pub fn new(when: impl Into<Vec<u8>>) -> Self {
+        Self { when: when.into() }
+    }
+}
+
+impl Effect for Retract {
+    type Of = Cell;
+    type Output = Result<(), MemoryError>;
+}
+
+/// Extension trait for `Capability<Retract>` to access its fields.
+pub trait RetractCapability {
+    /// Get the space name from the capability chain.
+    fn space(&self) -> &str;
+    /// Get the cell name from the capability chain.
+    fn cell(&self) -> &str;
+    /// Get the expected edition (when condition).
+    fn when(&self) -> &[u8];
+}
+
+impl RetractCapability for Capability<Retract> {
+    fn space(&self) -> &str {
+        &Space::of(self).space
+    }
+
+    fn cell(&self) -> &str {
+        &Cell::of(self).cell
+    }
+
+    fn when(&self) -> &[u8] {
+        &Retract::of(self).when
+    }
+}
+
+/// Errors that can occur during memory operations.
+#[derive(Debug, Error)]
+pub enum MemoryError {
+    /// CAS edition mismatch.
+    #[error("Edition mismatch: expected {expected:?}, got {actual:?}")]
+    EditionMismatch {
+        /// The expected edition.
+        expected: Option<String>,
+        /// The actual edition found.
+        actual: Option<String>,
+    },
+
+    /// Storage backend error.
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    /// IO error.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_builds_memory_claim_path() {
+        let claim = Subject::from("did:key:zSpace").attenuate(Memory);
+
+        assert_eq!(claim.subject(), "did:key:zSpace");
+        assert_eq!(claim.ability(), "/memory");
+    }
+
+    #[test]
+    fn it_builds_space_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Memory)
+            .attenuate(Space::new("local"));
+
+        assert_eq!(claim.subject(), "did:key:zSpace");
+        // Space is Policy, not Ability, so it doesn't add to path
+        assert_eq!(claim.ability(), "/memory");
+    }
+
+    #[test]
+    fn it_builds_cell_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Memory)
+            .attenuate(Space::new("local"))
+            .attenuate(Cell::new("main"));
+
+        assert_eq!(claim.subject(), "did:key:zSpace");
+        // Cell is Policy, not Ability, so it doesn't add to path
+        assert_eq!(claim.ability(), "/memory");
+    }
+
+    #[test]
+    fn it_builds_resolve_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Memory)
+            .attenuate(Space::new("local"))
+            .attenuate(Cell::new("main"))
+            .invoke(Resolve);
+
+        assert_eq!(claim.ability(), "/memory/resolve");
+    }
+
+    #[test]
+    fn it_builds_publish_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Memory)
+            .attenuate(Space::new("local"))
+            .attenuate(Cell::new("main"))
+            .invoke(Publish::new(b"test", None));
+
+        assert_eq!(claim.ability(), "/memory/publish");
+    }
+
+    #[test]
+    fn it_builds_retract_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Memory)
+            .attenuate(Space::new("local"))
+            .attenuate(Cell::new("main"))
+            .invoke(Retract::new(b"v1"));
+
+        assert_eq!(claim.ability(), "/memory/retract");
+    }
+
+    #[cfg(feature = "ucan")]
+    mod parameters_tests {
+        use super::*;
+        use dialog_capability::ucan::parameters;
+        use ipld_core::ipld::Ipld;
+
+        #[test]
+        fn it_collects_resolve_capability_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Memory)
+                .attenuate(Space::new("remote"))
+                .attenuate(Cell::new("config"))
+                .invoke(Resolve);
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("space"), Some(&Ipld::String("remote".into())));
+            assert_eq!(params.get("cell"), Some(&Ipld::String("config".into())));
+        }
+
+        #[test]
+        fn it_collects_publish_capability_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Memory)
+                .attenuate(Space::new("local"))
+                .attenuate(Cell::new("main"))
+                .invoke(Publish {
+                    content: b"hello".to_vec(),
+                    when: Some(b"v1".to_vec().into()),
+                });
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("space"), Some(&Ipld::String("local".into())));
+            assert_eq!(params.get("cell"), Some(&Ipld::String("main".into())));
+            assert_eq!(params.get("content"), Some(&Ipld::Bytes(b"hello".to_vec())));
+            assert_eq!(params.get("when"), Some(&Ipld::Bytes(b"v1".to_vec())));
+        }
+
+        #[test]
+        fn it_collects_retract_capability_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Memory)
+                .attenuate(Space::new("local"))
+                .attenuate(Cell::new("main"))
+                .invoke(Retract::new(b"v1"));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("space"), Some(&Ipld::String("local".into())));
+            assert_eq!(params.get("cell"), Some(&Ipld::String("main".into())));
+            assert_eq!(params.get("when"), Some(&Ipld::Bytes(b"v1".to_vec())));
+        }
+    }
+}

--- a/rust/dialog-effects/src/storage.rs
+++ b/rust/dialog-effects/src/storage.rs
@@ -1,0 +1,347 @@
+//! Storage capability hierarchy.
+//!
+//! Storage provides key-value store operations.
+//!
+//! # Capability Hierarchy
+//!
+//! ```text
+//! Subject (repository DID)
+//!   └── Storage (ability: /storage)
+//!         └── Store { store: String }
+//!               ├── Get { key } → Effect → Result<Option<Bytes>, StorageError>
+//!               ├── Set { key, value } → Effect → Result<(), StorageError>
+//!               ├── Delete { key } → Effect → Result<(), StorageError>
+//!               └── List { continuation_token } → Effect → Result<ListResult, StorageError>
+//! ```
+
+pub use dialog_capability::{Attenuation, Capability, Effect, Policy, Subject};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Root attenuation for storage operations.
+///
+/// Attaches to Subject and provides the `/storage` ability path segment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Storage;
+
+impl Attenuation for Storage {
+    type Of = Subject;
+}
+
+/// Store policy that scopes operations to a named store.
+///
+/// This is a policy (not attenuation) so it doesn't contribute to the ability path.
+/// It restricts operations to a specific store (e.g., "index", "blob").
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Store {
+    /// The store name (e.g., "index", "blob").
+    pub store: String,
+}
+
+impl Store {
+    /// Create a new Store policy.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { store: name.into() }
+    }
+}
+
+impl Policy for Store {
+    type Of = Storage;
+}
+
+/// Get operation - retrieves a value by key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Get {
+    /// The key to look up.
+    #[serde(with = "serde_bytes")]
+    pub key: Vec<u8>,
+}
+
+impl Get {
+    /// Create a new Get effect.
+    pub fn new(key: impl Into<Vec<u8>>) -> Self {
+        Self { key: key.into() }
+    }
+}
+
+impl Effect for Get {
+    type Of = Store;
+    type Output = Result<Option<Vec<u8>>, StorageError>;
+}
+
+/// Extension trait for `Capability<Get>` to access its fields.
+pub trait GetCapability {
+    /// Get the store name from the capability chain.
+    fn store(&self) -> &str;
+    /// Get the key from the capability chain.
+    fn key(&self) -> &[u8];
+}
+
+impl GetCapability for Capability<Get> {
+    fn store(&self) -> &str {
+        &Store::of(self).store
+    }
+
+    fn key(&self) -> &[u8] {
+        &Get::of(self).key
+    }
+}
+
+/// Set operation - sets a value for a key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Set {
+    /// The key to update.
+    #[serde(with = "serde_bytes")]
+    pub key: Vec<u8>,
+    /// The value to set.
+    #[serde(with = "serde_bytes")]
+    pub value: Vec<u8>,
+}
+
+impl Set {
+    /// Create a new Set effect.
+    pub fn new(key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+impl Effect for Set {
+    type Of = Store;
+    type Output = Result<(), StorageError>;
+}
+
+/// Extension trait for `Capability<Set>` to access its fields.
+pub trait SetCapability {
+    /// Get the store name from the capability chain.
+    fn store(&self) -> &str;
+    /// Get the key from the capability chain.
+    fn key(&self) -> &[u8];
+    /// Get the value from the capability chain.
+    fn value(&self) -> &[u8];
+}
+
+impl SetCapability for Capability<Set> {
+    fn store(&self) -> &str {
+        &Store::of(self).store
+    }
+
+    fn key(&self) -> &[u8] {
+        &Set::of(self).key
+    }
+
+    fn value(&self) -> &[u8] {
+        &Set::of(self).value
+    }
+}
+
+/// Delete operation - removes a key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Delete {
+    /// The key to delete.
+    #[serde(with = "serde_bytes")]
+    pub key: Vec<u8>,
+}
+
+impl Delete {
+    /// Create a new Delete effect.
+    pub fn new(key: impl Into<Vec<u8>>) -> Self {
+        Self { key: key.into() }
+    }
+}
+
+impl Effect for Delete {
+    type Of = Store;
+    type Output = Result<(), StorageError>;
+}
+
+/// Extension trait for `Capability<Delete>` to access its fields.
+pub trait DeleteCapability {
+    /// Get the store name from the capability chain.
+    fn store(&self) -> &str;
+    /// Get the key from the capability chain.
+    fn key(&self) -> &[u8];
+}
+
+impl DeleteCapability for Capability<Delete> {
+    fn store(&self) -> &str {
+        &Store::of(self).store
+    }
+
+    fn key(&self) -> &[u8] {
+        &Delete::of(self).key
+    }
+}
+
+/// List operation - lists keys in a store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct List {
+    /// Continuation token for pagination.
+    pub continuation_token: Option<String>,
+}
+
+impl List {
+    /// Create a new List effect.
+    pub fn new(continuation_token: Option<String>) -> Self {
+        Self { continuation_token }
+    }
+}
+
+impl Effect for List {
+    type Of = Store;
+    type Output = Result<ListResult, StorageError>;
+}
+
+/// Result of a list operation.
+#[derive(Debug, Clone)]
+pub struct ListResult {
+    /// Object keys returned in this response.
+    pub keys: Vec<String>,
+    /// If true, there are more results to fetch.
+    pub is_truncated: bool,
+    /// Token to use for fetching the next page of results.
+    pub next_continuation_token: Option<String>,
+}
+
+/// Extension trait for `Capability<List>` to access its fields.
+pub trait ListCapability {
+    /// Get the store name from the capability chain.
+    fn store(&self) -> &str;
+    /// Get the continuation token from the capability chain.
+    fn continuation_token(&self) -> Option<&str>;
+}
+
+impl ListCapability for Capability<List> {
+    fn store(&self) -> &str {
+        &Store::of(self).store
+    }
+
+    fn continuation_token(&self) -> Option<&str> {
+        List::of(self).continuation_token.as_deref()
+    }
+}
+
+/// Errors that can occur during storage operations.
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// Storage backend error.
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    /// IO error.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_builds_storage_claim_path() {
+        let claim = Subject::from("did:key:zSpace").attenuate(Storage);
+
+        assert_eq!(claim.subject(), "did:key:zSpace");
+        assert_eq!(claim.ability(), "/storage");
+    }
+
+    #[test]
+    fn it_builds_store_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Storage)
+            .attenuate(Store::new("index"));
+
+        assert_eq!(claim.subject(), "did:key:zSpace");
+        // Store is Policy, not Ability, so it doesn't add to path
+        assert_eq!(claim.ability(), "/storage");
+    }
+
+    #[test]
+    fn it_builds_get_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Storage)
+            .attenuate(Store::new("index"))
+            .invoke(Get::new(vec![1, 2, 3]));
+
+        assert_eq!(claim.ability(), "/storage/get");
+    }
+
+    #[test]
+    fn it_builds_set_claim_path() {
+        let claim = Subject::from("did:key:zSpace")
+            .attenuate(Storage)
+            .attenuate(Store::new("index"))
+            .invoke(Set::new(vec![1, 2, 3], vec![4, 5, 6]));
+
+        assert_eq!(claim.ability(), "/storage/set");
+
+        // Use policy() method to extract nested constraints
+        assert_eq!(claim.policy::<Store, _>().store, "index");
+        assert_eq!(&claim.policy::<Set, _>().key[..], &[1, 2, 3]);
+    }
+
+    #[cfg(feature = "ucan")]
+    mod parameters_tests {
+        use super::*;
+        use dialog_capability::ucan::parameters;
+        use ipld_core::ipld::Ipld;
+
+        #[test]
+        fn it_collects_storage_parameters() {
+            let cap = Subject::from("did:key:zSpace").attenuate(Storage);
+            let params = parameters(&cap);
+
+            // Storage is a unit struct, should produce empty map
+            assert!(params.is_empty());
+        }
+
+        #[test]
+        fn it_collects_store_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Storage)
+                .attenuate(Store::new("index"));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("store"), Some(&Ipld::String("index".into())));
+        }
+
+        #[test]
+        fn it_collects_get_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Storage)
+                .attenuate(Store::new("index"))
+                .invoke(Get::new(vec![1, 2, 3]));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("store"), Some(&Ipld::String("index".into())));
+            assert_eq!(params.get("key"), Some(&Ipld::Bytes(vec![1, 2, 3])));
+        }
+
+        #[test]
+        fn it_collects_set_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Storage)
+                .attenuate(Store::new("mystore"))
+                .invoke(Set::new(vec![10, 20], vec![30, 40, 50]));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("store"), Some(&Ipld::String("mystore".into())));
+            assert_eq!(params.get("key"), Some(&Ipld::Bytes(vec![10, 20])));
+            assert_eq!(params.get("value"), Some(&Ipld::Bytes(vec![30, 40, 50])));
+        }
+
+        #[test]
+        fn it_collects_delete_parameters() {
+            let cap = Subject::from("did:key:zSpace")
+                .attenuate(Storage)
+                .attenuate(Store::new("trash"))
+                .invoke(Delete::new(vec![99]));
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("store"), Some(&Ipld::String("trash".into())));
+            assert_eq!(params.get("key"), Some(&Ipld::Bytes(vec![99])));
+        }
+    }
+}


### PR DESCRIPTION
Backports capability definitions from `tonk` branch into `main`. Intention is to lay groundwork for implementing repository & related abstractions on top requiring capability providers for effectful operations.

Fixes: #164