### PR TITLE
1 ✅ feat: use borrowed storage in a tree

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -60,8 +60,7 @@ use crate::{
 
 /// An alias type that describes the [`Tree`]-based prolly tree that is
 /// used for each index in [`Artifacts`]
-pub type Index<Key, Value, Backend> =
-    Tree<GeometricDistribution, Key, State<Value>, Blake3Hash, Storage<CborEncoder, Backend>>;
+pub type Index<Key, Value> = Tree<GeometricDistribution, Key, State<Value>, Blake3Hash>;
 
 /// [`Artifacts`] is an implementor of [`ArtifactStore`] and [`ArtifactStoreMut`].
 /// Internally, [`Artifacts`] maintains indexes built from [`Tree`]s (that is,
@@ -84,7 +83,7 @@ where
 {
     identifier: String,
     storage: Storage<CborEncoder, Backend>,
-    index: Arc<RwLock<Index<Key, Datum, Backend>>>,
+    index: Arc<RwLock<Index<Key, Datum>>>,
 }
 
 impl<Backend> Artifacts<Backend>
@@ -95,8 +94,14 @@ where
 {
     #[cfg(feature = "debug")]
     /// Get a reference-counted pointer to the internal entity index of the [`Artifacts`]
-    pub fn index(&self) -> Arc<RwLock<Index<Key, Datum, Backend>>> {
+    pub fn index(&self) -> Arc<RwLock<Index<Key, Datum>>> {
         self.index.clone()
+    }
+
+    #[cfg(feature = "debug")]
+    /// Get a clone of the storage used by this [`Artifacts`]
+    pub fn storage(&self) -> Storage<CborEncoder, Backend> {
+        self.storage.clone()
     }
 
     /// The name used to uniquely identify the data of this [`Artifacts`]
@@ -137,9 +142,9 @@ where
             };
 
             if let Some(revision) = revision {
-                Tree::from_hash(revision.index(), storage.clone()).await?
+                Tree::from_hash(revision.index(), &storage).await?
             } else {
-                Tree::new(storage.clone())
+                Tree::new()
             }
         };
 
@@ -179,7 +184,7 @@ where
         let index = self.index.read().await;
         let range = <EntityKey<Key> as KeyViewConstruct>::min().0
             ..<EntityKey<Key> as KeyViewConstruct>::max().0;
-        let entity_stream = index.stream_range(range);
+        let entity_stream = index.stream_range(range, &self.storage);
 
         tokio::pin!(entity_stream);
 
@@ -312,7 +317,7 @@ where
 
         // Finally update the index
         let mut index = self.index.write().await;
-        index.set_hash(index_version).await?;
+        index.set_hash(index_version, &self.storage).await?;
 
         Ok(())
     }
@@ -332,6 +337,7 @@ where
     ) -> impl Stream<Item = Result<Artifact, DialogArtifactsError>> + 'static + ConditionalSend
     {
         let index = self.index.clone();
+        let storage = self.storage.clone();
 
         try_stream! {
             // We clone to "pin" the indexes at a version for the lifetime of the stream
@@ -341,7 +347,7 @@ where
                 let start = <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
                 let end = <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
 
-                let stream = index.stream_range(Range { start, end });
+                let stream = index.stream_range(Range { start, end }, &storage);
 
                 tokio::pin!(stream);
 
@@ -358,7 +364,7 @@ where
                 let start = <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
                 let end = <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
 
-                let stream = index.stream_range(Range { start, end });
+                let stream = index.stream_range(Range { start, end }, &storage);
 
                 tokio::pin!(stream);
 
@@ -375,7 +381,7 @@ where
                 let start = <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
                 let end = <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
 
-                let stream = index.stream_range(Range { start, end });
+                let stream = index.stream_range(Range { start, end }, &storage);
 
                 tokio::pin!(stream);
 
@@ -437,7 +443,8 @@ where
                                     .set_attribute(entity_key.attribute())
                                     .into_key();
 
-                                let search_stream = index.stream_range(search_start..search_end);
+                                let search_stream =
+                                    index.stream_range(search_start..search_end, &self.storage);
 
                                 let mut ancestor_key = None;
 
@@ -466,20 +473,36 @@ where
                                 let attribute_key = AttributeKey::from_key(&entity_key);
 
                                 // TODO: Make it concurrent / parallel
-                                index.delete(&entity_key.into_key()).await?;
-                                index.delete(&value_key.into_key()).await?;
-                                index.delete(&attribute_key.into_key()).await?;
+                                index
+                                    .delete(&entity_key.into_key(), &mut self.storage)
+                                    .await?;
+                                index
+                                    .delete(&value_key.into_key(), &mut self.storage)
+                                    .await?;
+                                index
+                                    .delete(&attribute_key.into_key(), &mut self.storage)
+                                    .await?;
                             }
                         }
 
                         // TODO: Make it concurrent / parallel
                         index
-                            .set(entity_key.into_key(), State::Added(datum.clone()))
+                            .set(
+                                entity_key.into_key(),
+                                State::Added(datum.clone()),
+                                &mut self.storage,
+                            )
                             .await?;
                         index
-                            .set(attribute_key.into_key(), State::Added(datum.clone()))
+                            .set(
+                                attribute_key.into_key(),
+                                State::Added(datum.clone()),
+                                &mut self.storage,
+                            )
                             .await?;
-                        index.set(value_key.into_key(), State::Added(datum)).await?;
+                        index
+                            .set(value_key.into_key(), State::Added(datum), &mut self.storage)
+                            .await?;
                     }
                     Instruction::Retract(fact) => {
                         let entity_key = EntityKey::from(&fact);
@@ -487,9 +510,15 @@ where
                         let attribute_key = AttributeKey::from_key(&entity_key);
 
                         // TODO: Make it concurrent / parallel
-                        index.set(entity_key.into_key(), State::Removed).await?;
-                        index.set(attribute_key.into_key(), State::Removed).await?;
-                        index.set(value_key.into_key(), State::Removed).await?;
+                        index
+                            .set(entity_key.into_key(), State::Removed, &mut self.storage)
+                            .await?;
+                        index
+                            .set(attribute_key.into_key(), State::Removed, &mut self.storage)
+                            .await?;
+                        index
+                            .set(value_key.into_key(), State::Removed, &mut self.storage)
+                            .await?;
                     }
                 }
             }

--- a/rust/dialog-diagnose/src/state/analysis.rs
+++ b/rust/dialog-diagnose/src/state/analysis.rs
@@ -2,10 +2,12 @@
 
 use std::{collections::VecDeque, sync::mpsc::Sender};
 
-use dialog_artifacts::{Datum, DialogArtifactsError, Index, Key};
+use dialog_artifacts::{CborEncoder, Datum, DialogArtifactsError, Index, Key, Storage};
 use dialog_storage::{Blake3Hash, MemoryStorageBackend};
 
 use super::store::WorkerMessage;
+
+type DiagnoseStorage = Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
 
 /// Statistics about the structure and content of a prolly tree.
 ///
@@ -31,7 +33,9 @@ pub struct ArtifactsTreeStats {
 /// to compute various statistics about its structure and contents.
 pub struct ArtifactsTreeAnalysis {
     /// The prolly tree index to analyze
-    tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+    tree: Index<Key, Datum>,
+    /// The storage backend for tree operations
+    storage: DiagnoseStorage,
     /// Channel sender for worker messages
     tx: Sender<WorkerMessage>,
 }
@@ -42,12 +46,14 @@ impl ArtifactsTreeAnalysis {
     /// # Arguments
     ///
     /// * `tree` - The prolly tree index to analyze
+    /// * `storage` - The storage backend for tree operations
     /// * `tx` - Channel sender for worker messages
     pub fn new(
-        tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+        tree: Index<Key, Datum>,
+        storage: DiagnoseStorage,
         tx: Sender<WorkerMessage>,
     ) -> Self {
-        Self { tree, tx }
+        Self { tree, storage, tx }
     }
 
     /// Starts the background analysis task.
@@ -61,20 +67,20 @@ impl ArtifactsTreeAnalysis {
         };
 
         let root = root.clone();
-        let tree = self.tree.clone();
+        let storage = self.storage.clone();
         let tx = self.tx.clone();
 
         tokio::spawn(async move {
             let mut stats = ArtifactsTreeStats::default();
             let mut levels = VecDeque::from([vec![root.clone()]]);
-            let mut segment_sizes = vec![];
+            let mut segment_sizes: Vec<usize> = vec![];
 
             while let Some(level) = levels.pop_front() {
                 let mut next_level = vec![];
 
                 for node in level {
                     if node.is_branch() {
-                        let mut children = Vec::from(node.load_children(tree.storage()).await?);
+                        let mut children = Vec::from(node.load_children(&storage).await?);
                         next_level.append(&mut children);
                     } else {
                         let entries = node.into_entries()?;
@@ -93,13 +99,16 @@ impl ArtifactsTreeAnalysis {
             }
 
             let (minimum_segment_size, maximum_segment_size) =
-                segment_sizes.iter().fold((None, 0), |(min, max), value| {
-                    (
-                        min.or(Some(value)).map(|min| min.min(value)),
-                        max.max(*value),
-                    )
-                });
-            let minimum_segment_size = minimum_segment_size.copied().unwrap_or_default();
+                segment_sizes
+                    .iter()
+                    .copied()
+                    .fold((None, 0usize), |(min, max), value| {
+                        (
+                            Some(min.map_or(value, |m: usize| m.min(value))),
+                            max.max(value),
+                        )
+                    });
+            let minimum_segment_size = minimum_segment_size.unwrap_or_default();
             let segment_band_width =
                 maximum_segment_size.saturating_sub(minimum_segment_size) as f64 / 9.;
 

--- a/rust/dialog-diagnose/src/state/artifacts.rs
+++ b/rust/dialog-diagnose/src/state/artifacts.rs
@@ -5,12 +5,14 @@ use std::{
     sync::{Arc, mpsc::Sender},
 };
 
-use dialog_artifacts::{Datum, DialogArtifactsError, Index, Key};
+use dialog_artifacts::{CborEncoder, Datum, DialogArtifactsError, Index, Key, Storage};
 use dialog_storage::{Blake3Hash, MemoryStorageBackend};
 use futures_util::{Stream, TryStreamExt};
 use tokio::sync::Mutex;
 
 use super::store::WorkerMessage;
+
+type DiagnoseStorage = Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
 
 /// Internal state for the artifacts cursor.
 ///
@@ -33,7 +35,9 @@ pub struct ArtifactsCursor {
     /// Shared state for tracking cursor position
     state: Arc<Mutex<ArtifactsCursorState>>,
     /// The prolly tree index containing the facts
-    tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+    tree: Index<Key, Datum>,
+    /// The storage backend for tree operations
+    storage: DiagnoseStorage,
     /// Channel sender for worker messages
     tx: Sender<WorkerMessage>,
 }
@@ -44,14 +48,17 @@ impl ArtifactsCursor {
     /// # Arguments
     ///
     /// * `tree` - The prolly tree index containing facts data
+    /// * `storage` - The storage backend for tree operations
     /// * `tx` - Channel sender for worker messages
     pub fn new(
-        tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+        tree: Index<Key, Datum>,
+        storage: DiagnoseStorage,
         tx: Sender<WorkerMessage>,
     ) -> Self {
         Self {
             state: Default::default(),
             tree,
+            storage,
             tx,
         }
     }
@@ -69,6 +76,7 @@ impl ArtifactsCursor {
         let tx = self.tx.clone();
         let state = self.state.clone();
         let tree = self.tree.clone();
+        let storage = self.storage.clone();
 
         tokio::spawn(async move {
             let mut state = state.lock().await;
@@ -82,8 +90,8 @@ impl ArtifactsCursor {
             }
 
             let mut stream: Pin<Box<dyn Stream<Item = _> + Send>> = match state.last_key.clone() {
-                Some(key) => Box::pin(tree.stream_range(key..)),
-                None => Box::pin(tree.stream()),
+                Some(key) => Box::pin(tree.stream_range(key.., &storage)),
+                None => Box::pin(tree.stream(&storage)),
             };
 
             loop {

--- a/rust/dialog-diagnose/src/state/hierarchy.rs
+++ b/rust/dialog-diagnose/src/state/hierarchy.rs
@@ -2,11 +2,13 @@
 
 use std::sync::mpsc::Sender;
 
-use dialog_artifacts::{Datum, DialogArtifactsError, Index, Key, State};
+use dialog_artifacts::{CborEncoder, Datum, DialogArtifactsError, Key, State, Storage};
 use dialog_prolly_tree::{Block, Entry};
 use dialog_storage::{Blake3Hash, ContentAddressedStorage, MemoryStorageBackend};
 
 use super::store::WorkerMessage;
+
+type DiagnoseStorage = Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
 
 /// Represents a node in the prolly tree hierarchy.
 ///
@@ -33,8 +35,8 @@ pub enum TreeNode {
 /// This worker loads individual tree nodes on-demand as the UI navigates
 /// the prolly tree structure.
 pub struct ArtifactsHierarchy {
-    /// The prolly tree index to load nodes from
-    tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
+    /// The storage backend for tree operations
+    storage: DiagnoseStorage,
     /// Channel sender for worker messages
     tx: Sender<WorkerMessage>,
 }
@@ -46,11 +48,8 @@ impl ArtifactsHierarchy {
     ///
     /// * `tree` - The prolly tree index to load nodes from
     /// * `tx` - Channel sender for worker messages
-    pub fn new(
-        tree: Index<Key, Datum, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
-        tx: Sender<WorkerMessage>,
-    ) -> Self {
-        Self { tree, tx }
+    pub fn new(storage: DiagnoseStorage, tx: Sender<WorkerMessage>) -> Self {
+        Self { storage, tx }
     }
 
     /// Looks up a tree node by its hash, loading it in the background.
@@ -62,13 +61,13 @@ impl ArtifactsHierarchy {
     ///
     /// * `hash` - The hash of the node to look up
     pub fn lookup_node(&self, hash: &Blake3Hash) {
-        let tree = self.tree.clone();
+        let storage = self.storage.clone();
         let tx = self.tx.clone();
         let hash = hash.to_owned();
 
         tokio::spawn(async move {
             let Some(block): Option<Block<Key, State<Datum>, Blake3Hash>> =
-                tree.storage().read(&hash).await?
+                storage.read(&hash).await?
             else {
                 // TODO: This should be an error condition
                 return Ok(());

--- a/rust/dialog-diagnose/src/state/store.rs
+++ b/rust/dialog-diagnose/src/state/store.rs
@@ -77,11 +77,12 @@ impl DiagnoseStore {
     /// data loading and initializes the internal caches.
     pub async fn new(artifacts: Artifacts<MemoryStorageBackend<Blake3Hash, Vec<u8>>>) -> Self {
         let tree = artifacts.index().read().await.clone();
+        let storage = artifacts.storage();
 
         let (tx, message_rx) = channel();
-        let cursor = ArtifactsCursor::new(tree.clone(), tx.clone());
-        let analysis = ArtifactsTreeAnalysis::new(tree.clone(), tx.clone());
-        let hierarchy = ArtifactsHierarchy::new(tree, tx);
+        let cursor = ArtifactsCursor::new(tree.clone(), storage.clone(), tx.clone());
+        let analysis = ArtifactsTreeAnalysis::new(tree, storage.clone(), tx.clone());
+        let hierarchy = ArtifactsHierarchy::new(storage, tx);
 
         Self {
             message_rx,

--- a/rust/dialog-prolly-tree/src/differential.rs
+++ b/rust/dialog-prolly-tree/src/differential.rs
@@ -22,17 +22,17 @@
 //!
 //! ```text
 //! // Compute changes from tree_a to tree_b
-//! let changes = tree_a.differentiate(&tree_b);
+//! let changes = tree_a.differentiate(&tree_b, &storage, &storage);
 //!
 //! // Apply changes to another tree
-//! tree_c.integrate(changes).await?;
+//! tree_c.integrate(changes, &mut storage).await?;
 //! ```
 //!
 //! For sync/replication scenarios where you need to push novel nodes to a remote:
 //!
 //! ```text
 //! // Find nodes that local has but remote doesn't
-//! let diff = TreeDifference::compute(&remote_tree, &local_tree).await?;
+//! let diff = TreeDifference::compute(&remote_tree, &local_tree, storage, storage).await?;
 //! let novel = diff.novel_nodes();
 //! // Push each novel node to remote storage
 //! ```
@@ -511,11 +511,10 @@ where
 /// ```no_run
 /// # use dialog_prolly_tree::{TreeDifference, Tree, GeometricDistribution};
 /// # use dialog_storage::{Blake3Hash, CborEncoder, MemoryStorageBackend, Storage};
-/// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash,
-/// #     Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>>;
-/// # async fn example(source: &TestTree, target: &TestTree) -> Result<(), Box<dyn std::error::Error>> {
+/// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash>;
+/// # async fn example(source: &TestTree, target: &TestTree, storage: &Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>) -> Result<(), Box<dyn std::error::Error>> {
 /// // Compute the difference (includes expansion)
-/// let delta = TreeDifference::compute(&source, &target).await?;
+/// let delta = TreeDifference::compute(&source, &target, storage, storage).await?;
 ///
 /// // Option 1: Get entry-level changes (for replication/sync)
 /// let changes = delta.changes();
@@ -589,21 +588,22 @@ where
     /// ```no_run
     /// # use dialog_prolly_tree::{TreeDifference, Tree, GeometricDistribution};
     /// # use dialog_storage::{Blake3Hash, CborEncoder, MemoryStorageBackend, Storage};
-    /// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash,
-    /// #     Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>>;
-    /// # async fn example(remote_tree: &TestTree, local_tree: &TestTree) -> Result<(), Box<dyn std::error::Error>> {
-    /// let diff = TreeDifference::compute(&remote_tree, &local_tree).await?;
+    /// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash>;
+    /// # async fn example(remote_tree: &TestTree, local_tree: &TestTree, storage: &Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>) -> Result<(), Box<dyn std::error::Error>> {
+    /// let diff = TreeDifference::compute(&remote_tree, &local_tree, storage, storage).await?;
     /// // changes() produces transforms remote → local
     /// // novel_nodes() yields nodes local has that remote doesn't
     /// # Ok(())
     /// # }
     /// ```
     pub async fn compute<Distribution: crate::Distribution<Key, Hash>>(
-        source: &'a Tree<Distribution, Key, Value, Hash, Storage>,
-        target: &'a Tree<Distribution, Key, Value, Hash, Storage>,
+        source: &'a Tree<Distribution, Key, Value, Hash>,
+        target: &'a Tree<Distribution, Key, Value, Hash>,
+        source_storage: &'a Storage,
+        target_storage: &'a Storage,
     ) -> Result<Self, DialogProllyTreeError> {
         let mut source = SparseTree {
-            storage: source.storage(),
+            storage: source_storage,
             nodes: source
                 .root()
                 .map(|root| vec![SparseTreeNode::Node(root.clone())])
@@ -611,7 +611,7 @@ where
             expanded: vec![],
         };
         let mut target = SparseTree {
-            storage: target.storage(),
+            storage: target_storage,
             nodes: target
                 .root()
                 .map(|root| vec![SparseTreeNode::Node(root.clone())])
@@ -734,10 +734,9 @@ where
     /// # use dialog_prolly_tree::{TreeDifference, Tree, GeometricDistribution, Change};
     /// # use dialog_storage::{Blake3Hash, CborEncoder, MemoryStorageBackend, Storage};
     /// # use futures_util::{pin_mut, StreamExt};
-    /// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash,
-    /// #     Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>>;
-    /// # async fn example(old_tree: &TestTree, new_tree: &TestTree) -> Result<(), Box<dyn std::error::Error>> {
-    /// let diff = TreeDifference::compute(&old_tree, &new_tree).await?;
+    /// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash>;
+    /// # async fn example(old_tree: &TestTree, new_tree: &TestTree, storage: &Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>) -> Result<(), Box<dyn std::error::Error>> {
+    /// let diff = TreeDifference::compute(&old_tree, &new_tree, storage, storage).await?;
     /// let changes = diff.changes();
     /// pin_mut!(changes);
     /// while let Some(change) = changes.next().await {
@@ -830,10 +829,9 @@ where
     /// # use dialog_prolly_tree::{TreeDifference, Tree, GeometricDistribution};
     /// # use dialog_storage::{Blake3Hash, CborEncoder, MemoryStorageBackend, Storage};
     /// # use futures_util::{pin_mut, StreamExt};
-    /// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash,
-    /// #     Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>>;
-    /// # async fn example(remote_tree: &TestTree, local_tree: &TestTree) -> Result<(), Box<dyn std::error::Error>> {
-    /// let diff = TreeDifference::compute(&remote_tree, &local_tree).await?;
+    /// # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash>;
+    /// # async fn example(remote_tree: &TestTree, local_tree: &TestTree, storage: &Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>) -> Result<(), Box<dyn std::error::Error>> {
+    /// let diff = TreeDifference::compute(&remote_tree, &local_tree, storage, storage).await?;
     /// let nodes = diff.novel_nodes();
     /// pin_mut!(nodes);
     /// while let Some(node) = nodes.next().await {
@@ -874,13 +872,7 @@ mod tests {
     };
     use futures_util::{StreamExt, TryStreamExt, pin_mut, stream::iter};
 
-    type TestTree = Tree<
-        GeometricDistribution,
-        Vec<u8>,
-        Vec<u8>,
-        Blake3Hash,
-        Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>,
-    >;
+    type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash>;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_service_worker);
@@ -888,21 +880,19 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_identical_trees() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
-        tree1.set(vec![1], vec![10]).await.unwrap();
-        tree1.set(vec![2], vec![20]).await.unwrap();
-        tree2.set(vec![1], vec![10]).await.unwrap();
-        tree2.set(vec![2], vec![20]).await.unwrap();
+        tree1.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree1.set(vec![2], vec![20], &mut storage).await.unwrap();
+        tree2.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree2.set(vec![2], vec![20], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut count = 0;
         while changes.next().await.is_some() {
@@ -915,20 +905,18 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_added_entry() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
-        tree1.set(vec![1], vec![10]).await.unwrap();
-        tree1.set(vec![2], vec![20]).await.unwrap();
-        tree2.set(vec![1], vec![10]).await.unwrap();
+        tree1.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree1.set(vec![2], vec![20], &mut storage).await.unwrap();
+        tree2.set(vec![1], vec![10], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
         let mut removes = Vec::new();
@@ -949,20 +937,18 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_removed_entry() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
-        tree1.set(vec![1], vec![10]).await.unwrap();
-        tree2.set(vec![1], vec![10]).await.unwrap();
-        tree2.set(vec![2], vec![20]).await.unwrap();
+        tree1.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree2.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree2.set(vec![2], vec![20], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
         let mut removes = Vec::new();
@@ -983,21 +969,19 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_modified_entry() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
-        tree1.set(vec![1], vec![10]).await.unwrap();
-        tree1.set(vec![2], vec![30]).await.unwrap();
-        tree2.set(vec![1], vec![10]).await.unwrap();
-        tree2.set(vec![2], vec![20]).await.unwrap();
+        tree1.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree1.set(vec![2], vec![30], &mut storage).await.unwrap();
+        tree2.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree2.set(vec![2], vec![20], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
         let mut removes = Vec::new();
@@ -1020,19 +1004,17 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_empty_to_populated() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let tree2 = TestTree::new();
 
-        tree1.set(vec![1], vec![10]).await.unwrap();
-        tree1.set(vec![2], vec![20]).await.unwrap();
+        tree1.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree1.set(vec![2], vec![20], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
 
@@ -1049,19 +1031,17 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_populated_to_empty() {
         let backend = MemoryStorageBackend::default();
-        let tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
-        tree2.set(vec![1], vec![10]).await.unwrap();
-        tree2.set(vec![2], vec![20]).await.unwrap();
+        tree2.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree2.set(vec![2], vec![20], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut removes = Vec::new();
 
@@ -1078,25 +1058,23 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_large_tree() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
         // Create a larger tree to test branch handling
         for i in 0..100u8 {
-            tree1.set(vec![i], vec![i * 2]).await.unwrap();
+            tree1.set(vec![i], vec![i * 2], &mut storage).await.unwrap();
             if i != 50 {
                 // Skip one entry in tree2
-                tree2.set(vec![i], vec![i * 2]).await.unwrap();
+                tree2.set(vec![i], vec![i * 2], &mut storage).await.unwrap();
             }
         }
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
         let mut removes = Vec::new();
@@ -1116,35 +1094,37 @@ mod tests {
     #[dialog_common::test]
     async fn test_integrate_add_new_entry() {
         let backend = MemoryStorageBackend::default();
-        let mut tree = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
+        };
+        let mut tree = TestTree::new();
 
-        tree.set(vec![1], vec![10]).await.unwrap();
+        tree.set(vec![1], vec![10], &mut storage).await.unwrap();
 
         let changes = vec![Change::Add(Entry {
             key: vec![2],
             value: vec![20],
         })];
 
-        tree.integrate(iter(changes.into_iter().map(Ok)))
+        tree.integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
-        assert_eq!(tree.get(&vec![1]).await.unwrap(), Some(vec![10]));
-        assert_eq!(tree.get(&vec![2]).await.unwrap(), Some(vec![20]));
+        assert_eq!(tree.get(&vec![1], &storage).await.unwrap(), Some(vec![10]));
+        assert_eq!(tree.get(&vec![2], &storage).await.unwrap(), Some(vec![20]));
     }
 
     #[dialog_common::test]
     async fn test_integrate_add_idempotent() {
         let backend = MemoryStorageBackend::default();
-        let mut tree = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
+        };
+        let mut tree = TestTree::new();
 
-        tree.set(vec![1], vec![10]).await.unwrap();
+        tree.set(vec![1], vec![10], &mut storage).await.unwrap();
 
         // Add same entry - should be no-op
         let changes = vec![Change::Add(Entry {
@@ -1152,23 +1132,24 @@ mod tests {
             value: vec![10],
         })];
 
-        tree.integrate(iter(changes.into_iter().map(Ok)))
+        tree.integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
-        assert_eq!(tree.get(&vec![1]).await.unwrap(), Some(vec![10]));
+        assert_eq!(tree.get(&vec![1], &storage).await.unwrap(), Some(vec![10]));
     }
 
     #[dialog_common::test]
     async fn test_integrate_add_conflict_resolution() {
         let backend = MemoryStorageBackend::default();
-        let mut tree = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
+        };
+        let mut tree = TestTree::new();
 
         // Set initial value
-        tree.set(vec![1], vec![10]).await.unwrap();
+        tree.set(vec![1], vec![10], &mut storage).await.unwrap();
 
         // Try to add different value - conflict resolution by hash comparison
         let new_value = vec![20];
@@ -1179,56 +1160,60 @@ mod tests {
             value: new_value.clone(),
         })];
 
-        tree.integrate(iter(changes.into_iter().map(Ok)))
+        tree.integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
         // Check which value won based on hash comparison
         use dialog_storage::Encoder;
-        let storage = tree.storage();
         let (existing_hash, _) = storage.encode(&existing_value).await.unwrap();
         let (new_hash, _) = storage.encode(&new_value).await.unwrap();
 
         if new_hash.as_ref() > existing_hash.as_ref() {
-            assert_eq!(tree.get(&vec![1]).await.unwrap(), Some(new_value));
+            assert_eq!(tree.get(&vec![1], &storage).await.unwrap(), Some(new_value));
         } else {
-            assert_eq!(tree.get(&vec![1]).await.unwrap(), Some(existing_value));
+            assert_eq!(
+                tree.get(&vec![1], &storage).await.unwrap(),
+                Some(existing_value)
+            );
         }
     }
 
     #[dialog_common::test]
     async fn test_integrate_remove_existing() {
         let backend = MemoryStorageBackend::default();
-        let mut tree = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
+        };
+        let mut tree = TestTree::new();
 
-        tree.set(vec![1], vec![10]).await.unwrap();
-        tree.set(vec![2], vec![20]).await.unwrap();
+        tree.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree.set(vec![2], vec![20], &mut storage).await.unwrap();
 
         let changes = vec![Change::Remove(Entry {
             key: vec![1],
             value: vec![10],
         })];
 
-        tree.integrate(iter(changes.into_iter().map(Ok)))
+        tree.integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
-        assert_eq!(tree.get(&vec![1]).await.unwrap(), None);
-        assert_eq!(tree.get(&vec![2]).await.unwrap(), Some(vec![20]));
+        assert_eq!(tree.get(&vec![1], &storage).await.unwrap(), None);
+        assert_eq!(tree.get(&vec![2], &storage).await.unwrap(), Some(vec![20]));
     }
 
     #[dialog_common::test]
     async fn test_integrate_remove_nonexistent() {
         let backend = MemoryStorageBackend::default();
-        let mut tree = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
+        };
+        let mut tree = TestTree::new();
 
-        tree.set(vec![1], vec![10]).await.unwrap();
+        tree.set(vec![1], vec![10], &mut storage).await.unwrap();
 
         // Remove non-existent entry - should be no-op
         let changes = vec![Change::Remove(Entry {
@@ -1236,23 +1221,24 @@ mod tests {
             value: vec![20],
         })];
 
-        tree.integrate(iter(changes.into_iter().map(Ok)))
+        tree.integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
-        assert_eq!(tree.get(&vec![1]).await.unwrap(), Some(vec![10]));
-        assert_eq!(tree.get(&vec![2]).await.unwrap(), None);
+        assert_eq!(tree.get(&vec![1], &storage).await.unwrap(), Some(vec![10]));
+        assert_eq!(tree.get(&vec![2], &storage).await.unwrap(), None);
     }
 
     #[dialog_common::test]
     async fn test_integrate_remove_wrong_value() {
         let backend = MemoryStorageBackend::default();
-        let mut tree = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
+        };
+        let mut tree = TestTree::new();
 
-        tree.set(vec![1], vec![10]).await.unwrap();
+        tree.set(vec![1], vec![10], &mut storage).await.unwrap();
 
         // Try to remove with wrong value - should be no-op (concurrent update)
         let changes = vec![Change::Remove(Entry {
@@ -1260,61 +1246,69 @@ mod tests {
             value: vec![20], // Wrong value
         })];
 
-        tree.integrate(iter(changes.into_iter().map(Ok)))
+        tree.integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
         // Entry should still exist with original value
-        assert_eq!(tree.get(&vec![1]).await.unwrap(), Some(vec![10]));
+        assert_eq!(tree.get(&vec![1], &storage).await.unwrap(), Some(vec![10]));
     }
 
     #[dialog_common::test]
     async fn test_integrate_concurrent_updates() {
         let backend = MemoryStorageBackend::default();
+        let mut storage = Storage {
+            encoder: CborEncoder,
+            backend: backend.clone(),
+        };
 
         // Initial state - both replicas start with same value
-        let mut tree_a = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
-        let mut tree_b = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        let mut tree_a = TestTree::new();
+        let mut tree_b = TestTree::new();
 
-        tree_a.set(vec![1], vec![10]).await.unwrap();
-        tree_b.set(vec![1], vec![10]).await.unwrap();
+        tree_a.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree_b.set(vec![1], vec![10], &mut storage).await.unwrap();
 
         // Replica A updates to value_a
-        tree_a.set(vec![1], vec![20]).await.unwrap();
+        tree_a.set(vec![1], vec![20], &mut storage).await.unwrap();
 
         // Replica B updates to value_b
-        tree_b.set(vec![1], vec![30]).await.unwrap();
+        tree_b.set(vec![1], vec![30], &mut storage).await.unwrap();
 
         // Both replicas exchange their changes
-        let empty_tree = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        let empty_tree = TestTree::new();
 
         let host_a = tree_a.clone();
-        let changes_a = empty_tree.differentiate(&host_a);
+        let changes_a: Vec<_> = empty_tree
+            .differentiate(&host_a, &storage, &storage)
+            .try_collect()
+            .await
+            .unwrap();
         let host_b = tree_b.clone();
-        let changes_b = empty_tree.differentiate(&host_b);
+        let changes_b: Vec<_> = empty_tree
+            .differentiate(&host_b, &storage, &storage)
+            .try_collect()
+            .await
+            .unwrap();
 
         // Integrate changes
-        tree_a.integrate(changes_b).await.unwrap();
-        tree_b.integrate(changes_a).await.unwrap();
+        tree_a
+            .integrate(iter(changes_b.into_iter().map(Ok)), &mut storage)
+            .await
+            .unwrap();
+        tree_b
+            .integrate(iter(changes_a.into_iter().map(Ok)), &mut storage)
+            .await
+            .unwrap();
 
         // Both should converge to the same value (deterministic by hash)
-        let final_a = tree_a.get(&vec![1]).await.unwrap();
-        let final_b = tree_b.get(&vec![1]).await.unwrap();
+        let final_a = tree_a.get(&vec![1], &storage).await.unwrap();
+        let final_b = tree_b.get(&vec![1], &storage).await.unwrap();
 
         assert_eq!(final_a, final_b, "Trees should converge to same value");
 
         // Verify the winner is determined by hash
         use dialog_storage::Encoder;
-        let storage = tree_a.storage();
         let (hash_20, _) = storage.encode(&vec![20]).await.unwrap();
         let (hash_30, _) = storage.encode(&vec![30]).await.unwrap();
 
@@ -1329,25 +1323,23 @@ mod tests {
     #[dialog_common::test]
     async fn test_roundtrip_empty_to_populated() {
         let backend = MemoryStorageBackend::default();
-        let mut target = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut start = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut target = TestTree::new();
+        let mut start = TestTree::new();
 
         // Target has entries, start is empty
-        target.set(vec![1], vec![10]).await.unwrap();
-        target.set(vec![2], vec![20]).await.unwrap();
-        target.set(vec![3], vec![30]).await.unwrap();
+        target.set(vec![1], vec![10], &mut storage).await.unwrap();
+        target.set(vec![2], vec![20], &mut storage).await.unwrap();
+        target.set(vec![3], vec![30], &mut storage).await.unwrap();
 
         // Compute diff and integrate
         // Need to collect changes to avoid borrow checker issues
         // (diff holds immutable ref to start, but integrate needs mutable ref)
         let changes = {
-            let diff = start.differentiate(&target);
+            let diff = start.differentiate(&target, &storage, &storage);
             pin_mut!(diff);
             let mut changes = Vec::new();
             while let Some(result) = diff.next().await {
@@ -1356,38 +1348,36 @@ mod tests {
             changes
         };
         start
-            .integrate(iter(changes.into_iter().map(Ok)))
+            .integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
         // Verify start now matches target
-        assert_eq!(start.get(&vec![1]).await.unwrap(), Some(vec![10]));
-        assert_eq!(start.get(&vec![2]).await.unwrap(), Some(vec![20]));
-        assert_eq!(start.get(&vec![3]).await.unwrap(), Some(vec![30]));
+        assert_eq!(start.get(&vec![1], &storage).await.unwrap(), Some(vec![10]));
+        assert_eq!(start.get(&vec![2], &storage).await.unwrap(), Some(vec![20]));
+        assert_eq!(start.get(&vec![3], &storage).await.unwrap(), Some(vec![30]));
     }
 
     #[dialog_common::test]
     async fn test_roundtrip_populated_to_empty() {
         let backend = MemoryStorageBackend::default();
-        let target = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut start = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let target = TestTree::new();
+        let mut start = TestTree::new();
 
         // Start has entries, target is empty
-        start.set(vec![1], vec![10]).await.unwrap();
-        start.set(vec![2], vec![20]).await.unwrap();
-        start.set(vec![3], vec![30]).await.unwrap();
+        start.set(vec![1], vec![10], &mut storage).await.unwrap();
+        start.set(vec![2], vec![20], &mut storage).await.unwrap();
+        start.set(vec![3], vec![30], &mut storage).await.unwrap();
 
         // Compute diff and integrate
         // Need to collect changes to avoid borrow checker issues
         // (diff holds immutable ref to start, but integrate needs mutable ref)
         let changes = {
-            let diff = start.differentiate(&target);
+            let diff = start.differentiate(&target, &storage, &storage);
             pin_mut!(diff);
             let mut changes = Vec::new();
             while let Some(result) = diff.next().await {
@@ -1396,44 +1386,42 @@ mod tests {
             changes
         };
         start
-            .integrate(iter(changes.into_iter().map(Ok)))
+            .integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
         // Verify start is now empty
-        assert_eq!(start.get(&vec![1]).await.unwrap(), None);
-        assert_eq!(start.get(&vec![2]).await.unwrap(), None);
-        assert_eq!(start.get(&vec![3]).await.unwrap(), None);
+        assert_eq!(start.get(&vec![1], &storage).await.unwrap(), None);
+        assert_eq!(start.get(&vec![2], &storage).await.unwrap(), None);
+        assert_eq!(start.get(&vec![3], &storage).await.unwrap(), None);
     }
 
     #[dialog_common::test]
     async fn test_roundtrip_mixed_changes() {
         let backend = MemoryStorageBackend::default();
-        let mut target = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut start = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut target = TestTree::new();
+        let mut start = TestTree::new();
 
         // Start state: keys 1, 2, 3
-        start.set(vec![1], vec![10]).await.unwrap();
-        start.set(vec![2], vec![20]).await.unwrap();
-        start.set(vec![3], vec![30]).await.unwrap();
+        start.set(vec![1], vec![10], &mut storage).await.unwrap();
+        start.set(vec![2], vec![20], &mut storage).await.unwrap();
+        start.set(vec![3], vec![30], &mut storage).await.unwrap();
 
         // Target state: keys 2 (modified), 3, 4
-        target.set(vec![2], vec![22]).await.unwrap(); // Modified
-        target.set(vec![3], vec![30]).await.unwrap(); // Same
-        target.set(vec![4], vec![40]).await.unwrap(); // Added
+        target.set(vec![2], vec![22], &mut storage).await.unwrap(); // Modified
+        target.set(vec![3], vec![30], &mut storage).await.unwrap(); // Same
+        target.set(vec![4], vec![40], &mut storage).await.unwrap(); // Added
         // Key 1 removed
 
         // Compute diff and integrate
         // Need to collect changes to avoid borrow checker issues
         // (diff holds immutable ref to start, but integrate needs mutable ref)
         let changes = {
-            let diff = start.differentiate(&target);
+            let diff = start.differentiate(&target, &storage, &storage);
             pin_mut!(diff);
             let mut changes = Vec::new();
             while let Some(result) = diff.next().await {
@@ -1442,40 +1430,38 @@ mod tests {
             changes
         };
         start
-            .integrate(iter(changes.into_iter().map(Ok)))
+            .integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
         // Verify start now matches target
-        assert_eq!(start.get(&vec![1]).await.unwrap(), None);
-        assert_eq!(start.get(&vec![2]).await.unwrap(), Some(vec![22]));
-        assert_eq!(start.get(&vec![3]).await.unwrap(), Some(vec![30]));
-        assert_eq!(start.get(&vec![4]).await.unwrap(), Some(vec![40]));
+        assert_eq!(start.get(&vec![1], &storage).await.unwrap(), None);
+        assert_eq!(start.get(&vec![2], &storage).await.unwrap(), Some(vec![22]));
+        assert_eq!(start.get(&vec![3], &storage).await.unwrap(), Some(vec![30]));
+        assert_eq!(start.get(&vec![4], &storage).await.unwrap(), Some(vec![40]));
     }
 
     #[dialog_common::test]
     async fn test_roundtrip_large_tree() {
         let backend = MemoryStorageBackend::default();
-        let mut target = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut start = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut target = TestTree::new();
+        let mut start = TestTree::new();
 
         // Create large trees with many entries
         for i in 0u16..100 {
             start
-                .set(vec![i as u8], vec![(i * 10) as u8])
+                .set(vec![i as u8], vec![(i * 10) as u8], &mut storage)
                 .await
                 .unwrap();
         }
 
         for i in 50u16..150 {
             target
-                .set(vec![i as u8], vec![(i * 20) as u8])
+                .set(vec![i as u8], vec![(i * 20) as u8], &mut storage)
                 .await
                 .unwrap();
         }
@@ -1484,7 +1470,7 @@ mod tests {
         // Need to collect changes to avoid borrow checker issues
         // (diff holds immutable ref to start, but integrate needs mutable ref)
         let changes = {
-            let diff = start.differentiate(&target);
+            let diff = start.differentiate(&target, &storage, &storage);
             pin_mut!(diff);
             let mut changes = Vec::new();
             while let Some(result) = diff.next().await {
@@ -1493,17 +1479,17 @@ mod tests {
             changes
         };
         start
-            .integrate(iter(changes.into_iter().map(Ok)))
+            .integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
         // Verify start now matches target
         for i in 0u16..50 {
-            assert_eq!(start.get(&vec![i as u8]).await.unwrap(), None);
+            assert_eq!(start.get(&vec![i as u8], &storage).await.unwrap(), None);
         }
         for i in 50u16..150 {
             assert_eq!(
-                start.get(&vec![i as u8]).await.unwrap(),
+                start.get(&vec![i as u8], &storage).await.unwrap(),
                 Some(vec![(i * 20) as u8])
             );
         }
@@ -1514,16 +1500,14 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_both_empty() {
         let backend = MemoryStorageBackend::default();
-        let tree1 = TestTree::new(Storage {
+        let storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let tree1 = TestTree::new();
+        let tree2 = TestTree::new();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut count = 0;
         while changes.next().await.is_some() {
@@ -1536,19 +1520,17 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_single_entry_trees() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
-        tree1.set(vec![1], vec![10]).await.unwrap();
-        tree2.set(vec![1], vec![20]).await.unwrap();
+        tree1.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree2.set(vec![1], vec![20], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
         let mut removes = Vec::new();
@@ -1570,25 +1552,23 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_disjoint_trees() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
         // Completely disjoint key sets
-        tree1.set(vec![1], vec![10]).await.unwrap();
-        tree1.set(vec![3], vec![30]).await.unwrap();
-        tree1.set(vec![5], vec![50]).await.unwrap();
+        tree1.set(vec![1], vec![10], &mut storage).await.unwrap();
+        tree1.set(vec![3], vec![30], &mut storage).await.unwrap();
+        tree1.set(vec![5], vec![50], &mut storage).await.unwrap();
 
-        tree2.set(vec![2], vec![20]).await.unwrap();
-        tree2.set(vec![4], vec![40]).await.unwrap();
-        tree2.set(vec![6], vec![60]).await.unwrap();
+        tree2.set(vec![2], vec![20], &mut storage).await.unwrap();
+        tree2.set(vec![4], vec![40], &mut storage).await.unwrap();
+        tree2.set(vec![6], vec![60], &mut storage).await.unwrap();
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
         let mut removes = Vec::new();
@@ -1608,26 +1588,24 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_subset_superset() {
         let backend = MemoryStorageBackend::default();
-        let mut superset = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut subset = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut superset = TestTree::new();
+        let mut subset = TestTree::new();
 
         // Subset: keys 2, 3
-        subset.set(vec![2], vec![20]).await.unwrap();
-        subset.set(vec![3], vec![30]).await.unwrap();
+        subset.set(vec![2], vec![20], &mut storage).await.unwrap();
+        subset.set(vec![3], vec![30], &mut storage).await.unwrap();
 
         // Superset: keys 1, 2, 3, 4
-        superset.set(vec![1], vec![10]).await.unwrap();
-        superset.set(vec![2], vec![20]).await.unwrap();
-        superset.set(vec![3], vec![30]).await.unwrap();
-        superset.set(vec![4], vec![40]).await.unwrap();
+        superset.set(vec![1], vec![10], &mut storage).await.unwrap();
+        superset.set(vec![2], vec![20], &mut storage).await.unwrap();
+        superset.set(vec![3], vec![30], &mut storage).await.unwrap();
+        superset.set(vec![4], vec![40], &mut storage).await.unwrap();
 
-        let changes = subset.differentiate(&superset);
+        let changes = subset.differentiate(&superset, &storage, &storage);
         pin_mut!(changes);
         let mut adds = Vec::new();
         let mut removes = Vec::new();
@@ -1647,22 +1625,20 @@ mod tests {
     #[dialog_common::test]
     async fn test_differentiate_all_modified() {
         let backend = MemoryStorageBackend::default();
-        let mut tree1 = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut tree2 = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut tree1 = TestTree::new();
+        let mut tree2 = TestTree::new();
 
         // Same keys, all different values (except i=0 where both are [0])
         for i in 0u8..10 {
-            tree1.set(vec![i], vec![i * 2]).await.unwrap();
-            tree2.set(vec![i], vec![i]).await.unwrap();
+            tree1.set(vec![i], vec![i * 2], &mut storage).await.unwrap();
+            tree2.set(vec![i], vec![i], &mut storage).await.unwrap();
         }
 
-        let changes = tree2.differentiate(&tree1);
+        let changes = tree2.differentiate(&tree1, &storage, &storage);
         pin_mut!(changes);
         let mut count = 0;
 
@@ -1678,31 +1654,32 @@ mod tests {
     #[dialog_common::test]
     async fn test_roundtrip_preserves_hash() {
         let backend = MemoryStorageBackend::default();
-        let mut target = TestTree::new(Storage {
+        let mut storage = Storage {
             encoder: CborEncoder,
             backend: backend.clone(),
-        });
-        let mut start = TestTree::new(Storage {
-            encoder: CborEncoder,
-            backend: backend.clone(),
-        });
+        };
+        let mut target = TestTree::new();
+        let mut start = TestTree::new();
 
         // Set up target state
         for i in 0..20 {
-            target.set(vec![i], vec![i * 3]).await.unwrap();
+            target
+                .set(vec![i], vec![i * 3], &mut storage)
+                .await
+                .unwrap();
         }
         let target_hash = *target.hash().unwrap();
 
         // Set up different start state
         for i in 10..30 {
-            start.set(vec![i], vec![i * 5]).await.unwrap();
+            start.set(vec![i], vec![i * 5], &mut storage).await.unwrap();
         }
 
         // Compute diff and integrate
         // Need to collect changes to avoid borrow checker issues
         // (diff holds immutable ref to start, but integrate needs mutable ref)
         let changes = {
-            let diff = start.differentiate(&target);
+            let diff = start.differentiate(&target, &storage, &storage);
             pin_mut!(diff);
             let mut changes = Vec::new();
             while let Some(result) = diff.next().await {
@@ -1711,7 +1688,7 @@ mod tests {
             changes
         };
         start
-            .integrate(iter(changes.into_iter().map(Ok)))
+            .integrate(iter(changes.into_iter().map(Ok)), &mut storage)
             .await
             .unwrap();
 
@@ -1758,7 +1735,7 @@ mod tests {
 
         // Run differentiate (journal is automatically enabled after build)
         let host_b = spec_b.tree().clone();
-        let diff = host_b.differentiate(spec_a.tree());
+        let diff = host_b.differentiate(spec_a.tree(), spec_b.storage(), spec_a.storage());
         // consume so we actually perform reads
         let _: Vec<_> = diff.collect().await;
 
@@ -1796,7 +1773,7 @@ mod tests {
         .unwrap();
 
         let host_b = spec_b.tree().clone();
-        let diff = host_b.differentiate(spec_a.tree());
+        let diff = host_b.differentiate(spec_a.tree(), spec_b.storage(), spec_a.storage());
         let _: Vec<_> = diff.collect().await;
 
         spec_a.assert();
@@ -1841,7 +1818,7 @@ mod tests {
         .unwrap();
 
         let host_a = spec_a.tree().clone();
-        let diff = host_a.differentiate(spec_b.tree());
+        let diff = host_a.differentiate(spec_b.tree(), spec_a.storage(), spec_b.storage());
         let _: Vec<_> = diff.collect().await;
 
         spec_a.assert();
@@ -1887,7 +1864,7 @@ mod tests {
         .unwrap();
 
         let host_b = spec_b.tree().clone();
-        let diff = host_b.differentiate(spec_a.tree());
+        let diff = host_b.differentiate(spec_a.tree(), spec_b.storage(), spec_a.storage());
         let _: Vec<_> = diff.collect().await;
 
         spec_a.assert();
@@ -1931,7 +1908,7 @@ mod tests {
         .unwrap();
 
         let host_a = spec_a.tree().clone();
-        let diff = host_a.differentiate(spec_b.tree());
+        let diff = host_a.differentiate(spec_b.tree(), spec_a.storage(), spec_b.storage());
         let _: Vec<_> = diff.collect().await;
 
         spec_a.assert();
@@ -1977,7 +1954,7 @@ mod tests {
         // Differentiate B -> A (taller tree to shallow tree)
         // Still need to read all branches to discover remove changes
         let host_a = spec_a.tree().clone();
-        let diff = host_a.differentiate(spec_b.tree());
+        let diff = host_a.differentiate(spec_b.tree(), spec_a.storage(), spec_b.storage());
         let _: Vec<_> = diff.collect().await;
 
         spec_b.assert();
@@ -2019,9 +1996,14 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Verify that all target nodes were loaded (since source is empty)
@@ -2030,7 +2012,7 @@ mod tests {
         // All target nodes should be novel - traverse target tree to get all hashes
         let target_hashes = target
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), target.storage())
             .into_hash_set()
             .await;
         assert_eq!(
@@ -2066,9 +2048,14 @@ mod tests {
         // Empty target tree
         let target = tree_spec![].build(storage_target).await.unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Verify that no source nodes were loaded (since target is empty)
@@ -2097,9 +2084,14 @@ mod tests {
         let source = tree_spec![].build(storage_source).await.unwrap();
         let target = tree_spec![].build(storage_target).await.unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         assert!(
@@ -2143,9 +2135,14 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Verify no child nodes were loaded (identical trees detected at root)
@@ -2191,9 +2188,14 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Verify read patterns:
@@ -2205,12 +2207,12 @@ mod tests {
         // Novel nodes should be: target nodes - nodes shared with source
         let target_hashes = target
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), target.storage())
             .into_hash_set()
             .await;
         let source_hashes = source
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), source.storage())
             .into_hash_set()
             .await;
         let expected_novel: std::collections::HashSet<_> =
@@ -2257,9 +2259,14 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Verify read patterns - shared segment 'a' should NOT be loaded
@@ -2269,12 +2276,12 @@ mod tests {
         // Novel = target - shared
         let target_hashes = target
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), target.storage())
             .into_hash_set()
             .await;
         let source_hashes = source
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), source.storage())
             .into_hash_set()
             .await;
         let expected_novel: std::collections::HashSet<_> =
@@ -2326,20 +2333,25 @@ mod tests {
         // Because they share the same backend, identical content = identical hash
         let target = tree_spec![[(..a)]].build(storage_target).await.unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Target's 'a' segment should match source's 'a' segment (same hash)
         let target_hashes = target
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), target.storage())
             .into_hash_set()
             .await;
         let source_hashes = source
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), source.storage())
             .into_hash_set()
             .await;
         let expected_novel: std::collections::HashSet<_> =
@@ -2384,9 +2396,14 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Verify read patterns:
@@ -2398,7 +2415,7 @@ mod tests {
         // All target nodes should be novel (no overlap)
         let target_hashes = target
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), target.storage())
             .into_hash_set()
             .await;
         assert_eq!(
@@ -2441,9 +2458,14 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
 
         // Collect twice - as Vec (preserves duplicates) and HashSet (deduplicates)
         let all_nodes: Vec<_> = diff.novel_nodes().try_collect().await?;
@@ -2478,15 +2500,20 @@ mod tests {
         // Target: single segment 'b' (contains keys 'a', 'b' - different content)
         let target = tree_spec![[..b]].build(storage_target).await.unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // All target nodes should be novel (no overlap)
         let target_hashes = target
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), target.storage())
             .into_hash_set()
             .await;
 
@@ -2536,9 +2563,14 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = TreeDifference::compute(source.tree(), target.tree())
-            .await
-            .unwrap();
+        let diff = TreeDifference::compute(
+            source.tree(),
+            target.tree(),
+            source.storage(),
+            target.storage(),
+        )
+        .await
+        .unwrap();
         let novel_hashes = diff.novel_nodes().into_hash_set().await;
 
         // Verify left subtree was pruned (not loaded)
@@ -2548,12 +2580,12 @@ mod tests {
         // Novel nodes should be target - source (right subtree differs)
         let target_hashes = target
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), target.storage())
             .into_hash_set()
             .await;
         let source_hashes = source
             .tree()
-            .traverse(TraversalOrder::default())
+            .traverse(TraversalOrder::default(), source.storage())
             .into_hash_set()
             .await;
         let expected_novel: std::collections::HashSet<_> =

--- a/rust/dialog-prolly-tree/src/helpers.rs
+++ b/rust/dialog-prolly-tree/src/helpers.rs
@@ -141,27 +141,32 @@ where
     /// * `order` - The traversal order:
     ///   - `DepthFirst`: Visit children before siblings (pre-order)
     ///   - `BreadthFirst`: Visit all nodes at each level before going deeper
-    fn traverse(
-        &self,
+    fn traverse<'a, Storage>(
+        &'a self,
         order: TraversalOrder,
-    ) -> impl Stream<Item = Result<Node<Key, Value, Hash>, DialogProllyTreeError>>;
+        storage: &'a Storage,
+    ) -> impl Stream<Item = Result<Node<Key, Value, Hash>, DialogProllyTreeError>> + 'a
+    where
+        Storage: ContentAddressedStorage<Hash = Hash> + 'a;
 }
 
-impl<Distribution, Key, Value, Hash, Storage> Traversable<Key, Value, Hash>
-    for Tree<Distribution, Key, Value, Hash, Storage>
+impl<Distribution, Key, Value, Hash> Traversable<Key, Value, Hash>
+    for Tree<Distribution, Key, Value, Hash>
 where
     Distribution: crate::Distribution<Key, Hash>,
     Key: KeyType,
     Value: ValueType,
     Hash: HashType,
-    Storage: ContentAddressedStorage<Hash = Hash>,
 {
-    fn traverse(
-        &self,
+    fn traverse<'a, Storage>(
+        &'a self,
         order: TraversalOrder,
-    ) -> impl Stream<Item = Result<Node<Key, Value, Hash>, DialogProllyTreeError>> {
+        storage: &'a Storage,
+    ) -> impl Stream<Item = Result<Node<Key, Value, Hash>, DialogProllyTreeError>> + 'a
+    where
+        Storage: ContentAddressedStorage<Hash = Hash> + 'a,
+    {
         let root = self.root().cloned();
-        let storage = self.storage();
 
         try_stream! {
             if let Some(root) = root {
@@ -227,7 +232,7 @@ pub type TestStorage = dialog_storage::Storage<dialog_storage::CborEncoder, Jour
 
 /// Type alias for the tree type used in tree specs.
 pub type TestTree =
-    crate::Tree<DistributionSimulator, Vec<u8>, Vec<u8>, dialog_storage::Blake3Hash, TestStorage>;
+    crate::Tree<DistributionSimulator, Vec<u8>, Vec<u8>, dialog_storage::Blake3Hash>;
 
 /// A distribution that reads ranks directly from keys.
 /// Keys are encoded as: [actual_key_bytes, 0x00, rank_byte]
@@ -395,7 +400,7 @@ impl TreeDescriptor {
     /// for asserting read patterns during differential operations.
     pub async fn build(
         self,
-        storage: TestStorage,
+        mut storage: TestStorage,
     ) -> Result<TreeSpec, Box<dyn std::error::Error + Send + Sync>> {
         use std::collections::BTreeMap;
 
@@ -404,13 +409,7 @@ impl TreeDescriptor {
 
         // Handle empty tree case
         if self.0.is_empty() {
-            let tree = crate::Tree::<
-                DistributionSimulator,
-                Vec<u8>,
-                Vec<u8>,
-                dialog_storage::Blake3Hash,
-                _,
-            >::new(storage.clone());
+            let tree = TestTree::new();
             return Ok(TreeSpec {
                 spec: Vec::new(),
                 tree,
@@ -480,7 +479,7 @@ impl TreeDescriptor {
             btree_collection.insert(encoded_key, key.clone());
         }
 
-        let temp_tree = crate::Tree::from_collection(btree_collection, storage.clone()).await?;
+        let temp_tree = crate::Tree::from_collection(btree_collection, &mut storage).await?;
 
         // Now build NodeSpec levels from the actual tree
         let max_height = self.0.len() - 1;
@@ -508,7 +507,7 @@ impl TreeDescriptor {
 
         // Load tree from hash so root is freshly loaded (not from temp_tree)
         let tree = if let Some(hash) = root_hash {
-            crate::Tree::from_hash(&hash, storage.clone()).await?
+            crate::Tree::from_hash(&hash, &storage).await?
         } else {
             temp_tree
         };
@@ -650,6 +649,11 @@ impl TreeSpec {
     /// Get a reference to the compiled tree
     pub fn tree(&self) -> &TestTree {
         &self.tree
+    }
+
+    /// Get a reference to the storage backend
+    pub fn storage(&self) -> &TestStorage {
+        &self.storage
     }
 
     /// Visualize the full tree structure by loading all nodes

--- a/rust/dialog-prolly-tree/src/lib.rs
+++ b/rust/dialog-prolly-tree/src/lib.rs
@@ -14,16 +14,16 @@
 //! use dialog_prolly_tree::{Tree, GeometricDistribution};
 //! use dialog_storage::Blake3Hash;
 //!
-//! let storage = Storage {
+//! let mut storage = Storage {
 //!     encoder: CborEncoder,
 //!     backend: MemoryStorageBackend::default()
 //! };
 //!
 //! // Create a tree with geometric distribution (branch factor 254) and Blake3 hashes
-//! let mut tree = Tree::<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash, _>::new(storage);
+//! let mut tree = Tree::<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash>::new();
 //!
 //! // Store a key-value pair
-//! tree.set(vec![1, 2, 3], vec![4, 5, 6]).await?;
+//! tree.set(vec![1, 2, 3], vec![4, 5, 6], &mut storage).await?;
 //!
 //! // Get the hash of the tree root (if any)
 //! println!("{:?}", tree.hash());

--- a/rust/dialog-prolly-tree/src/tree.rs
+++ b/rust/dialog-prolly-tree/src/tree.rs
@@ -19,15 +19,13 @@ pub static EMPT_TREE_HASH: [u8; 32] = [0; 32];
 /// A key-value store backed by a Ranked Prolly Tree with configurable storage,
 /// encoding and rank distribution.
 #[derive(Debug, Clone)]
-pub struct Tree<Distribution, Key, Value, Hash, Storage>
+pub struct Tree<Distribution, Key, Value, Hash>
 where
     Distribution: crate::Distribution<Key, Hash>,
     Key: KeyType + 'static,
     Value: ValueType,
     Hash: HashType,
-    Storage: ContentAddressedStorage<Hash = Hash>,
 {
-    storage: Storage,
     root: Option<Node<Key, Value, Hash>>,
 
     distribution_type: PhantomData<Distribution>,
@@ -36,18 +34,16 @@ where
     hash_type: PhantomData<Hash>,
 }
 
-impl<Distribution, Key, Value, Hash, Storage> Tree<Distribution, Key, Value, Hash, Storage>
+impl<Distribution, Key, Value, Hash> Tree<Distribution, Key, Value, Hash>
 where
     Distribution: crate::Distribution<Key, Hash>,
     Key: KeyType,
     Value: ValueType,
     Hash: HashType,
-    Storage: ContentAddressedStorage<Hash = Hash>,
 {
-    /// Creates a new [`Tree`] with provided [`ContentAddressedStorage`].
-    pub fn new(storage: Storage) -> Self {
+    /// Creates a new empty [`Tree`].
+    pub fn new() -> Self {
         Self {
-            storage,
             root: None,
 
             distribution_type: PhantomData,
@@ -58,26 +54,26 @@ where
     }
 
     /// Hydrate a new [`Tree`] from a [`HashType`] that references a [`Node`].
-    pub async fn from_hash(hash: &Hash, storage: Storage) -> Result<Self, DialogProllyTreeError> {
+    pub async fn from_hash<Storage>(
+        hash: &Hash,
+        storage: &Storage,
+    ) -> Result<Self, DialogProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
         let root = if hash.as_ref() == EMPT_TREE_HASH {
             None
         } else {
-            Some(Node::from_hash(hash.clone(), &storage).await?)
+            Some(Node::from_hash(hash.clone(), storage).await?)
         };
 
         Ok(Self {
-            storage,
             root,
             distribution_type: PhantomData,
             key_type: PhantomData,
             value_type: PhantomData,
             hash_type: PhantomData,
         })
-    }
-
-    /// The [`ContentAddressedStorage`] used by this tree.
-    pub fn storage(&self) -> &Storage {
-        &self.storage
     }
 
     /// Returns the [`Node`] representing the root of this tree.
@@ -89,9 +85,16 @@ where
 
     /// Changes the root (revision) of the tree to the node identified by the
     /// given [`HashType`]
-    pub async fn set_hash(&mut self, hash: Option<Hash>) -> Result<(), DialogProllyTreeError> {
+    pub async fn set_hash<Storage>(
+        &mut self,
+        hash: Option<Hash>,
+        storage: &Storage,
+    ) -> Result<(), DialogProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
         self.root = if let Some(hash) = hash {
-            Some(Node::from_hash(hash, &self.storage).await?)
+            Some(Node::from_hash(hash, storage).await?)
         } else {
             None
         };
@@ -106,9 +109,16 @@ where
     }
 
     /// Retrieves the value associated with `key` from the tree.
-    pub async fn get(&self, key: &Key) -> Result<Option<Value>, DialogProllyTreeError> {
+    pub async fn get<Storage>(
+        &self,
+        key: &Key,
+        storage: &Storage,
+    ) -> Result<Option<Value>, DialogProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
         match &self.root {
-            Some(root) => match root.get_entry(key, &self.storage).await? {
+            Some(root) => match root.get_entry(key, storage).await? {
                 Some(entry) => Ok(Some(entry.value)),
                 None => Ok(None),
             },
@@ -117,17 +127,23 @@ where
     }
 
     /// Sets a `key`/`value` pair into the tree.
-    pub async fn set(&mut self, key: Key, value: Value) -> Result<(), DialogProllyTreeError> {
+    pub async fn set<Storage>(
+        &mut self,
+        key: Key,
+        value: Value,
+        storage: &mut Storage,
+    ) -> Result<(), DialogProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
         let entry = Entry { key, value };
         match &self.root {
             Some(root) => {
-                let new_root = root
-                    .insert::<Distribution, _>(entry, &mut self.storage)
-                    .await?;
+                let new_root = root.insert::<Distribution, _>(entry, storage).await?;
                 self.root = Some(new_root);
             }
             None => {
-                let segment = Entry::adopt(NonEmpty::singleton(entry), &mut self.storage).await?;
+                let segment = Entry::adopt(NonEmpty::singleton(entry), storage).await?;
                 self.root = Some(segment);
             }
         }
@@ -135,12 +151,17 @@ where
     }
 
     /// Remove the `key`/`value` pair associated with `key` (if it is present)
-    pub async fn delete(&mut self, key: &Key) -> Result<(), DialogProllyTreeError> {
+    pub async fn delete<Storage>(
+        &mut self,
+        key: &Key,
+        storage: &mut Storage,
+    ) -> Result<(), DialogProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
         match &self.root {
             Some(root) => {
-                self.root = root
-                    .remove::<Distribution, _>(key, &mut self.storage)
-                    .await?;
+                self.root = root.remove::<Distribution, _>(key, storage).await?;
                 Ok(())
             }
             None => Ok(()),
@@ -148,19 +169,25 @@ where
     }
 
     /// Returns an async stream over all entries.
-    pub fn stream(
-        &self,
-    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogProllyTreeError>> + '_ {
-        self.stream_range(..)
+    pub fn stream<'a, Storage>(
+        &'a self,
+        storage: &'a Storage,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogProllyTreeError>> + 'a
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
+        self.stream_range(.., storage)
     }
 
     /// Returns an async stream over entries with keys within the provided range.
-    pub fn stream_range<'a, R>(
+    pub fn stream_range<'a, R, Storage>(
         &'a self,
         range: R,
+        storage: &'a Storage,
     ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogProllyTreeError>> + 'a
     where
         R: RangeBounds<Key> + 'a,
+        Storage: ContentAddressedStorage<Hash = Hash>,
     {
         try_stream! {
             match (range.start_bound(), range.end_bound()) {
@@ -170,7 +197,7 @@ where
                     Bound::Included(start_key) | Bound::Excluded(start_key),
                     Bound::Included(end_key) | Bound::Excluded(end_key),
                 ) if start_key == end_key => {
-                    if let Some(value) = self.get(start_key).await? {
+                    if let Some(value) = self.get(start_key, storage).await? {
                         yield Entry {
                             key: start_key.clone(),
                             value,
@@ -179,7 +206,7 @@ where
                 }
                 _ => {
                     if let Some(root) = self.root.as_ref() {
-                        let stream = root.get_range(range, &self.storage);
+                        let stream = root.get_range(range, storage);
                         for await item in stream {
                             yield item?;
                         }
@@ -192,10 +219,13 @@ where
     /// Create a new [`Tree`] from a [`BTreeMap`].
     ///
     /// A more efficient method than iteratively adding values.
-    pub async fn from_collection(
+    pub async fn from_collection<Storage>(
         collection: BTreeMap<Key, Value>,
-        mut storage: Storage,
-    ) -> Result<Self, DialogProllyTreeError> {
+        storage: &mut Storage,
+    ) -> Result<Self, DialogProllyTreeError>
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
         let mut nodes = {
             let entries = collection
                 .into_iter()
@@ -210,18 +240,17 @@ where
                     "Tree must have at least one child".into(),
                 )
             })?;
-            Node::join_with_rank(entries, 1, &mut storage).await?
+            Node::join_with_rank(entries, 1, storage).await?
         };
         let mut minimum_rank = 2;
         loop {
-            nodes = Node::join_with_rank(nodes, minimum_rank, &mut storage).await?;
+            nodes = Node::join_with_rank(nodes, minimum_rank, storage).await?;
             if nodes.len() == 1 {
                 break;
             }
             minimum_rank += 1;
         }
         Ok(Tree {
-            storage,
             root: Some(nodes.head.0),
 
             distribution_type: PhantomData,
@@ -232,24 +261,40 @@ where
     }
 }
 
+impl<Distribution, Key, Value, Hash> Default for Tree<Distribution, Key, Value, Hash>
+where
+    Distribution: crate::Distribution<Key, Hash>,
+    Key: KeyType,
+    Value: ValueType,
+    Hash: HashType,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Impl block for methods that require Value: PartialEq
-impl<Distribution, Key, Value, Hash, Storage> Tree<Distribution, Key, Value, Hash, Storage>
+impl<Distribution, Key, Value, Hash> Tree<Distribution, Key, Value, Hash>
 where
     Distribution: crate::Distribution<Key, Hash>,
     Key: KeyType,
     Value: ValueType + PartialEq,
     Hash: HashType,
-    Storage: ContentAddressedStorage<Hash = Hash>,
 {
     /// Returns a differential that produces changes to transform `self` into `other`.
     ///
     /// Usage: `self.integrate(self.differentiate(other))` will result in `other`.
-    pub fn differentiate<'a>(
+    pub fn differentiate<'a, Storage>(
         &'a self,
         other: &'a Self,
-    ) -> impl crate::differential::Differential<Key, Value> + 'a {
+        self_storage: &'a Storage,
+        other_storage: &'a Storage,
+    ) -> impl crate::differential::Differential<Key, Value> + 'a
+    where
+        Storage: ContentAddressedStorage<Hash = Hash>,
+    {
         try_stream! {
-            let delta = TreeDifference::compute(self, other).await?;
+            let delta = TreeDifference::compute(self, other, self_storage, other_storage).await?;
             for await change in delta.changes() {
                 yield change?;
             }
@@ -258,13 +303,12 @@ where
 }
 
 // Impl block for methods that require Encoder
-impl<Distribution, Key, Value, Hash, Storage> Tree<Distribution, Key, Value, Hash, Storage>
+impl<Distribution, Key, Value, Hash> Tree<Distribution, Key, Value, Hash>
 where
     Distribution: crate::Distribution<Key, Hash>,
     Key: KeyType,
     Value: ValueType + PartialEq,
     Hash: HashType,
-    Storage: ContentAddressedStorage<Hash = Hash> + Encoder,
 {
     /// Integrates changes into this tree with deterministic conflict resolution.
     ///
@@ -277,11 +321,13 @@ where
     /// - **Remove**: Only removes if the exact entry (key+value) exists
     ///
     /// The operation is atomic - if any change fails, the entire integration is rolled back.
-    pub async fn integrate<Changes>(
+    pub async fn integrate<Storage, Changes>(
         &mut self,
         changes: Changes,
+        storage: &mut Storage,
     ) -> Result<(), DialogProllyTreeError>
     where
+        Storage: ContentAddressedStorage<Hash = Hash> + Encoder,
         Changes: crate::differential::Differential<Key, Value>,
     {
         // Copy root here in case we fail integration and need to revert
@@ -294,10 +340,10 @@ where
                 match change {
                     Change::Add(entry) => {
                         // Check if key already exists
-                        match self.get(&entry.key).await? {
+                        match self.get(&entry.key, storage).await? {
                             None => {
                                 // Key doesn't exist - insert it
-                                self.set(entry.key, entry.value).await?;
+                                self.set(entry.key, entry.value, storage).await?;
                             }
                             Some(existing_value) => {
                                 if existing_value == entry.value {
@@ -305,20 +351,16 @@ where
                                 } else {
                                     // Different values - resolve conflict by comparing hashes
 
-                                    let (existing_hash, _) = self
-                                        .storage()
+                                    let (existing_hash, _) = storage
                                         .encode(&existing_value)
                                         .await
                                         .map_err(|e| e.into())?;
-                                    let (new_hash, _) = self
-                                        .storage()
-                                        .encode(&entry.value)
-                                        .await
-                                        .map_err(|e| e.into())?;
+                                    let (new_hash, _) =
+                                        storage.encode(&entry.value).await.map_err(|e| e.into())?;
 
                                     if new_hash.as_ref() > existing_hash.as_ref() {
                                         // New value wins - update
-                                        self.set(entry.key, entry.value).await?;
+                                        self.set(entry.key, entry.value, storage).await?;
                                     }
                                     // Else: existing wins, no-op
                                 }
@@ -327,14 +369,14 @@ where
                     }
                     Change::Remove(entry) => {
                         // Check if key exists
-                        match self.get(&entry.key).await? {
+                        match self.get(&entry.key, storage).await? {
                             None => {
                                 // Key doesn't exist - no-op (already removed)
                             }
                             Some(existing_value) => {
                                 if existing_value == entry.value {
                                     // Same value - remove it
-                                    self.delete(&entry.key).await?;
+                                    self.delete(&entry.key, storage).await?;
                                 }
                                 // Else: different value - no-op (concurrent update)
                             }

--- a/rust/dialog-prolly-tree/tests/backend.rs
+++ b/rust/dialog-prolly-tree/tests/backend.rs
@@ -18,21 +18,21 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn platform_specific_storage() -> Result<()> {
     let (backend, _temp) = make_target_storage().await?;
-    let storage = Storage {
+    let mut storage = Storage {
         backend,
         encoder: CborEncoder,
     };
-    let mut tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage);
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::new();
 
     let mut ledger = vec![];
     for _ in 1..1024 {
         let key_value = (random(), random());
         ledger.push(key_value.clone());
-        tree.set(key_value.0, key_value.1).await?;
+        tree.set(key_value.0, key_value.1, &mut storage).await?;
     }
 
     for entry in ledger {
-        assert_eq!(tree.get(&entry.0).await?, Some(entry.1));
+        assert_eq!(tree.get(&entry.0, &storage).await?, Some(entry.1));
     }
     Ok(())
 }

--- a/rust/dialog-prolly-tree/tests/range.rs
+++ b/rust/dialog-prolly-tree/tests/range.rs
@@ -11,16 +11,11 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
 async fn create_test_tree(
     size: u32,
-) -> Result<
-    Tree<
-        GeometricDistribution,
-        Vec<u8>,
-        Vec<u8>,
-        [u8; 32],
-        Storage<CborEncoder, MemoryStorageBackend<[u8; 32], Vec<u8>>>,
-    >,
-> {
-    let storage = Storage {
+) -> Result<(
+    Tree<GeometricDistribution, Vec<u8>, Vec<u8>, [u8; 32]>,
+    Storage<CborEncoder, MemoryStorageBackend<[u8; 32], Vec<u8>>>,
+)> {
+    let mut storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
     };
@@ -30,14 +25,15 @@ async fn create_test_tree(
         let value = <[u8; 32] as From<blake3::Hash>>::from(blake3::hash(&key)).to_vec();
         collection.insert(key, value);
     }
-    Ok(Tree::from_collection(collection, storage).await?)
+    let tree = Tree::from_collection(collection, &mut storage).await?;
+    Ok((tree, storage))
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn gets_full_range() -> Result<()> {
-    let tree = create_test_tree(1024).await?;
-    let stream = tree.stream();
+    let (tree, storage) = create_test_tree(1024).await?;
+    let stream = tree.stream(&storage);
     tokio::pin!(stream);
     let mut i = 0u32;
     while (stream.try_next().await?).is_some() {
@@ -55,13 +51,13 @@ async fn stream_range_on_empty_trees() -> Result<()> {
         backend: MemoryStorageBackend::default(),
     };
 
-    let empty = Tree::<GeometricDistribution, Vec<u8>, Vec<u8>, _, _>::new(storage);
+    let empty = Tree::<GeometricDistribution, Vec<u8>, Vec<u8>, _>::new();
 
-    let stream = empty.stream_range(..);
+    let stream = empty.stream_range(.., &storage);
     tokio::pin!(stream);
     assert!(stream.try_next().await?.is_none());
 
-    let stream = empty.stream();
+    let stream = empty.stream(&storage);
     tokio::pin!(stream);
     assert!(stream.try_next().await?.is_none());
 
@@ -71,14 +67,14 @@ async fn stream_range_on_empty_trees() -> Result<()> {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn gets_range() -> Result<()> {
-    let tree = create_test_tree(1024).await?;
+    let (tree, storage) = create_test_tree(1024).await?;
 
     const OFFSET: u32 = 2;
     const MAX: u32 = 10;
 
     let start = OFFSET.to_be_bytes().to_vec();
     let end = MAX.to_be_bytes().to_vec();
-    let stream = tree.stream_range(start..end);
+    let stream = tree.stream_range(start..end, &storage);
     tokio::pin!(stream);
     let mut i = 0u32;
     while let Some(entry) = stream.try_next().await? {
@@ -96,24 +92,25 @@ async fn gets_range() -> Result<()> {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn request_out_of_range() -> Result<()> {
-    let tree = create_test_tree(1024).await?;
+    let (tree, storage) = create_test_tree(1024).await?;
     let start = 1_000_000u32.to_be_bytes().to_vec();
-    let stream = tree.stream_range(start..);
+    let stream = tree.stream_range(start.., &storage);
     tokio::pin!(stream);
     assert!(
         stream.try_next().await?.is_none(),
         "start range out of tree range yields no items"
     );
 
-    let storage = Storage {
+    let mut storage = Storage {
         encoder: CborEncoder,
         backend: MemoryStorageBackend::default(),
     };
-    let mut tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage);
-    tree.set(10u32.to_be_bytes().to_vec(), vec![1]).await?;
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::new();
+    tree.set(10u32.to_be_bytes().to_vec(), vec![1], &mut storage)
+        .await?;
     let start = 0u32.to_be_bytes().to_vec();
     let end = 5u32.to_be_bytes().to_vec();
-    let stream = tree.stream_range(start..end);
+    let stream = tree.stream_range(start..end, &storage);
     tokio::pin!(stream);
     assert!(
         stream.try_next().await?.is_none(),

--- a/rust/dialog-prolly-tree/tests/tree.rs
+++ b/rust/dialog-prolly-tree/tests/tree.rs
@@ -16,26 +16,41 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn basic_set_and_get() -> Result<()> {
-    let storage = Arc::new(Mutex::new(Storage {
+    let mut storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
-    }));
-    let mut tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage.clone());
+    };
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::new();
 
-    tree.set(bytes("foo1"), bytes("bar1")).await?;
-    tree.set(bytes("foo2"), bytes("bar2")).await?;
-    tree.set(bytes("foo3"), bytes("bar3")).await?;
+    tree.set(bytes("foo1"), bytes("bar1"), &mut storage).await?;
+    tree.set(bytes("foo2"), bytes("bar2"), &mut storage).await?;
+    tree.set(bytes("foo3"), bytes("bar3"), &mut storage).await?;
 
-    assert_eq!(tree.get(&bytes("bar")).await?, None);
-    assert_eq!(tree.get(&bytes("foo1")).await?, Some(bytes("bar1")));
-    assert_eq!(tree.get(&bytes("foo2")).await?, Some(bytes("bar2")));
-    assert_eq!(tree.get(&bytes("foo3")).await?, Some(bytes("bar3")));
+    assert_eq!(tree.get(&bytes("bar"), &storage).await?, None);
+    assert_eq!(
+        tree.get(&bytes("foo1"), &storage).await?,
+        Some(bytes("bar1"))
+    );
+    assert_eq!(
+        tree.get(&bytes("foo2"), &storage).await?,
+        Some(bytes("bar2"))
+    );
+    assert_eq!(
+        tree.get(&bytes("foo3"), &storage).await?,
+        Some(bytes("bar3"))
+    );
 
-    let mut inverse_tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage);
+    let mut inverse_tree = Tree::<GeometricDistribution, _, _, _>::new();
 
-    inverse_tree.set(bytes("foo3"), bytes("bar3")).await?;
-    inverse_tree.set(bytes("foo2"), bytes("bar2")).await?;
-    inverse_tree.set(bytes("foo1"), bytes("bar1")).await?;
+    inverse_tree
+        .set(bytes("foo3"), bytes("bar3"), &mut storage)
+        .await?;
+    inverse_tree
+        .set(bytes("foo2"), bytes("bar2"), &mut storage)
+        .await?;
+    inverse_tree
+        .set(bytes("foo1"), bytes("bar1"), &mut storage)
+        .await?;
 
     assert_eq!(
         tree.hash(),
@@ -49,26 +64,36 @@ async fn basic_set_and_get() -> Result<()> {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn basic_delete() -> Result<()> {
-    let storage = Arc::new(Mutex::new(Storage {
+    let mut storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
-    }));
-    let mut expected_tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage.clone());
+    };
+    let mut expected_tree = Tree::<GeometricDistribution, _, _, _>::new();
 
-    expected_tree.set(bytes("foo1"), bytes("bar1")).await?;
-    expected_tree.set(bytes("foo3"), bytes("bar3")).await?;
+    expected_tree
+        .set(bytes("foo1"), bytes("bar1"), &mut storage)
+        .await?;
+    expected_tree
+        .set(bytes("foo3"), bytes("bar3"), &mut storage)
+        .await?;
 
-    let mut tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage.clone());
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::new();
 
-    tree.set(bytes("foo1"), bytes("bar1")).await?;
-    tree.set(bytes("foo2"), bytes("bar2")).await?;
-    tree.set(bytes("foo3"), bytes("bar3")).await?;
+    tree.set(bytes("foo1"), bytes("bar1"), &mut storage).await?;
+    tree.set(bytes("foo2"), bytes("bar2"), &mut storage).await?;
+    tree.set(bytes("foo3"), bytes("bar3"), &mut storage).await?;
 
-    tree.delete(&bytes("foo2")).await?;
+    tree.delete(&bytes("foo2"), &mut storage).await?;
 
-    assert_eq!(tree.get(&bytes("foo1")).await?, Some(bytes("bar1")));
-    assert_eq!(tree.get(&bytes("foo2")).await?, None);
-    assert_eq!(tree.get(&bytes("foo3")).await?, Some(bytes("bar3")));
+    assert_eq!(
+        tree.get(&bytes("foo1"), &storage).await?,
+        Some(bytes("bar1"))
+    );
+    assert_eq!(tree.get(&bytes("foo2"), &storage).await?, None);
+    assert_eq!(
+        tree.get(&bytes("foo3"), &storage).await?,
+        Some(bytes("bar3"))
+    );
 
     assert_eq!(tree.hash(), expected_tree.hash());
 
@@ -78,18 +103,18 @@ async fn basic_delete() -> Result<()> {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn delete_from_tree_with_one_entry() -> Result<()> {
-    let storage = Arc::new(Mutex::new(Storage {
+    let mut storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
-    }));
+    };
 
-    let mut tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage.clone());
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::new();
 
-    tree.set(bytes("foo1"), bytes("bar1")).await?;
+    tree.set(bytes("foo1"), bytes("bar1"), &mut storage).await?;
 
-    tree.delete(&bytes("foo1")).await?;
+    tree.delete(&bytes("foo1"), &mut storage).await?;
 
-    assert_eq!(tree.get(&bytes("foo1")).await?, None);
+    assert_eq!(tree.get(&bytes("foo1"), &storage).await?, None);
     assert_eq!(tree.hash(), None);
 
     Ok(())
@@ -98,32 +123,37 @@ async fn delete_from_tree_with_one_entry() -> Result<()> {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn create_tree_from_set() -> Result<()> {
-    let iter_storage = Arc::new(Mutex::new(Storage {
+    let mut iter_storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
-    }));
-    let collection_storage = Arc::new(Mutex::new(Storage {
+    };
+    let mut collection_storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
-    }));
-    let mut iter_tree = Tree::<GeometricDistribution, _, _, _, _>::new(iter_storage.clone());
+    };
+    let mut iter_tree = Tree::<GeometricDistribution, _, _, _>::new();
     let mut collection = BTreeMap::default();
 
     for i in 0..=255 {
         let key = vec![i];
         let value = vec![255 - i];
         collection.insert(key.clone(), value.clone());
-        iter_tree.set(key, value).await?;
+        iter_tree.set(key, value, &mut iter_storage).await?;
     }
-    let collection_tree =
-        Tree::<GeometricDistribution, _, _, _, _>::from_collection(collection, collection_storage)
-            .await?;
+    let collection_tree = Tree::<GeometricDistribution, _, _, _>::from_collection(
+        collection,
+        &mut collection_storage,
+    )
+    .await?;
 
     for i in 0..=255 {
         let key = vec![i];
         let value = vec![255 - i];
-        assert_eq!(collection_tree.get(&key).await?, Some(value.clone()));
-        assert_eq!(iter_tree.get(&key).await?, Some(value));
+        assert_eq!(
+            collection_tree.get(&key, &collection_storage).await?,
+            Some(value.clone())
+        );
+        assert_eq!(iter_tree.get(&key, &iter_storage).await?, Some(value));
     }
 
     assert!(iter_tree.hash().is_some());
@@ -147,19 +177,19 @@ async fn larger_random_tree() -> Result<()> {
     }
 
     let mut ledger = vec![];
-    let storage = Storage {
+    let mut storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
     };
-    let mut tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage);
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::new();
     for _ in 1..1024 {
         let key_value = (random(), random());
         ledger.push(key_value.clone());
-        tree.set(key_value.0, key_value.1).await?;
+        tree.set(key_value.0, key_value.1, &mut storage).await?;
     }
 
     for entry in ledger {
-        assert_eq!(tree.get(&entry.0).await?, Some(entry.1));
+        assert_eq!(tree.get(&entry.0, &storage).await?, Some(entry.1));
     }
 
     Ok(())
@@ -168,23 +198,32 @@ async fn larger_random_tree() -> Result<()> {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn restores_tree_from_hash() -> Result<()> {
-    let storage = Arc::new(Mutex::new(Storage {
+    let mut storage = Storage {
         backend: MemoryStorageBackend::default(),
         encoder: CborEncoder,
-    }));
-    let mut tree = Tree::<GeometricDistribution, _, _, _, _>::new(storage.clone());
+    };
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::new();
 
-    tree.set(bytes("foo1"), bytes("bar1")).await?;
-    tree.set(bytes("foo2"), bytes("bar2")).await?;
-    tree.set(bytes("foo3"), bytes("bar3")).await?;
+    tree.set(bytes("foo1"), bytes("bar1"), &mut storage).await?;
+    tree.set(bytes("foo2"), bytes("bar2"), &mut storage).await?;
+    tree.set(bytes("foo3"), bytes("bar3"), &mut storage).await?;
 
     let root_hash = tree.hash().unwrap().to_owned();
 
-    let tree = Tree::<GeometricDistribution, _, _, _, _>::from_hash(&root_hash, storage).await?;
+    let tree = Tree::<GeometricDistribution, _, _, _>::from_hash(&root_hash, &storage).await?;
 
-    assert_eq!(tree.get(&bytes("foo1")).await?, Some(bytes("bar1")));
-    assert_eq!(tree.get(&bytes("foo2")).await?, Some(bytes("bar2")));
-    assert_eq!(tree.get(&bytes("foo3")).await?, Some(bytes("bar3")));
+    assert_eq!(
+        tree.get(&bytes("foo1"), &storage).await?,
+        Some(bytes("bar1"))
+    );
+    assert_eq!(
+        tree.get(&bytes("foo2"), &storage).await?,
+        Some(bytes("bar2"))
+    );
+    assert_eq!(
+        tree.get(&bytes("foo3"), &storage).await?,
+        Some(bytes("bar3"))
+    );
 
     Ok(())
 }
@@ -194,7 +233,7 @@ async fn restores_tree_from_hash() -> Result<()> {
 async fn lru_store_caches() -> Result<()> {
     let backend = MemoryStorageBackend::default();
     let root_hash = {
-        let storage = Storage {
+        let mut storage = Storage {
             backend: backend.clone(),
             encoder: CborEncoder,
         };
@@ -205,18 +244,18 @@ async fn lru_store_caches() -> Result<()> {
             collection.insert(key, value);
         }
         let tree =
-            Tree::<GeometricDistribution, _, _, _, _>::from_collection(collection, storage).await?;
+            Tree::<GeometricDistribution, _, _, _>::from_collection(collection, &mut storage)
+                .await?;
         tree.hash().unwrap().to_owned()
     };
 
     let tracking = Arc::new(Mutex::new(MeasuredStorage::new(backend)));
     let lru = StorageCache::new(tracking.clone(), 10)?;
-    let storage = Storage {
+    let mut storage = Storage {
         backend: lru,
         encoder: CborEncoder,
     };
-    let mut tree =
-        Tree::<GeometricDistribution, _, _, _, _>::from_hash(&root_hash, storage).await?;
+    let mut tree = Tree::<GeometricDistribution, _, _, _>::from_hash(&root_hash, &storage).await?;
 
     {
         let tracking = tracking.lock().await;
@@ -226,7 +265,7 @@ async fn lru_store_caches() -> Result<()> {
     }
 
     let key = 1023u32.to_be_bytes().to_vec();
-    let _ = tree.get(&key).await?;
+    let _ = tree.get(&key, &storage).await?;
 
     {
         let tracking = tracking.lock().await;
@@ -234,7 +273,7 @@ async fn lru_store_caches() -> Result<()> {
         assert_eq!(tracking.reads(), 4);
     }
 
-    let _ = tree.get(&key).await?;
+    let _ = tree.get(&key, &storage).await?;
 
     {
         let tracking = tracking.lock().await;
@@ -242,7 +281,7 @@ async fn lru_store_caches() -> Result<()> {
         assert_eq!(tracking.reads(), 4); // reads cached
     }
 
-    tree.set(key.to_vec(), vec![1]).await?;
+    tree.set(key.to_vec(), vec![1], &mut storage).await?;
 
     let tracking = tracking.lock().await;
     assert_eq!(tracking.writes(), 4); // writes on insertion

--- a/rust/dialog-storage/src/storage/content_addressed.rs
+++ b/rust/dialog-storage/src/storage/content_addressed.rs
@@ -15,7 +15,7 @@ use crate::{DialogStorageError, Encoder, HashType, StorageBackend};
 /// [Encoder] and [StorageBackend] in a compatible fashion.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait ContentAddressedStorage: ConditionalSync + 'static {
+pub trait ContentAddressedStorage: ConditionalSync {
     /// The type of hash that is produced by this [ContentAddressedStorage]
     type Hash: HashType + ConditionalSync;
     /// The type of error that is produced by this [ContentAddressedStorage]
@@ -41,8 +41,7 @@ where
     BackendError: Into<DialogStorageError>,
     U: Encoder<Bytes = Bytes, Hash = Hash, Error = EncoderError>
         + StorageBackend<Key = Hash, Value = Bytes, Error = BackendError>
-        + ConditionalSync
-        + 'static,
+        + ConditionalSync,
 {
     type Hash = Hash;
     type Error = DialogStorageError;
@@ -83,8 +82,7 @@ where
     BackendError: Into<DialogStorageError>,
     U: Encoder<Bytes = Bytes, Hash = Hash, Error = EncoderError>
         + StorageBackend<Key = Hash, Value = Bytes, Error = BackendError>
-        + ConditionalSync
-        + 'static,
+        + ConditionalSync,
 {
     type Hash = Hash;
     type Error = DialogStorageError;


### PR DESCRIPTION
This pull requests changes prolly-tree implementation to no longer own storage but instead to receive it as a reference in functions that perform read / write operations.

Goal is to enable integration with capability system which also pass capability provider as reference to effects.