### PR TITLE
2 ✅ feat: remove exclusivity constraint imposed by capability system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,7 @@ dependencies = [
  "ipld-core",
  "js-sys",
  "md5",
+ "parking_lot",
  "pidlock",
  "quick-xml",
  "rand 0.8.5",

--- a/rust/dialog-capability/src/authorized.rs
+++ b/rust/dialog-capability/src/authorized.rs
@@ -85,7 +85,7 @@ impl<Ok, E: Error, Fx: Effect<Output = Result<Ok, E>> + Constraint, A: Authoriza
 {
     /// Perform the invocation directly without authorization verification.
     /// For operations that require authorization, use `acquire` first.
-    pub async fn perform<Env>(self, env: &mut Env) -> Result<Ok, DialogCapabilityPerformError<E>>
+    pub async fn perform<Env>(self, env: &Env) -> Result<Ok, DialogCapabilityPerformError<E>>
     where
         Env: Provider<Self>
             + Authority<Signature = A::Signature>

--- a/rust/dialog-capability/src/capability.rs
+++ b/rust/dialog-capability/src/capability.rs
@@ -71,7 +71,7 @@ impl<T: Constraint> Capability<T> {
     /// capability with its authorization proof.
     pub async fn acquire<A: Access + Principal>(
         self,
-        access: &mut A,
+        access: &A,
     ) -> Result<Authorized<T, A::Authorization>, A::Error>
     where
         Self: ConditionalSend + Clone + 'static,
@@ -105,7 +105,7 @@ impl<T: Policy + Constraint> Capability<T> {
 impl<Fx: Effect> Capability<Fx> {
     /// Perform the invocation directly without authorization verification.
     /// For operations that require authorization, use `acquire` first.
-    pub async fn perform<Env>(self, env: &mut Env) -> Fx::Output
+    pub async fn perform<Env>(self, env: &Env) -> Fx::Output
     where
         Env: Provider<Fx>,
     {

--- a/rust/dialog-capability/src/constrained.rs
+++ b/rust/dialog-capability/src/constrained.rs
@@ -82,7 +82,7 @@ where
     ///
     /// Use this when the provider trusts the caller (e.g., local execution).
     /// For operations that require authorization, use `acquire` first.
-    pub async fn perform<Env>(self, env: &mut Env) -> Fx::Output
+    pub async fn perform<Env>(self, env: &Env) -> Fx::Output
     where
         Self: Into<Capability<Fx>>,
         Env: Provider<Fx>,

--- a/rust/dialog-capability/src/provider.rs
+++ b/rust/dialog-capability/src/provider.rs
@@ -29,7 +29,7 @@ use crate::Invocation;
 /// #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 /// #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 /// impl Provider<MyInvocation> for MyEnv {
-///     async fn execute(&mut self, input: String) -> usize {
+///     async fn execute(&self, input: String) -> usize {
 ///         input.len()
 ///     }
 /// }
@@ -38,5 +38,5 @@ use crate::Invocation;
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait Provider<I: Invocation> {
     /// Execute an invocation and return the output.
-    async fn execute(&mut self, input: I::Input) -> I::Output;
+    async fn execute(&self, input: I::Input) -> I::Output;
 }

--- a/rust/dialog-effects/src/remote.rs
+++ b/rust/dialog-effects/src/remote.rs
@@ -105,7 +105,7 @@ where
     Address: ConditionalSend,
 {
     /// Perform the remote invocation against a provider.
-    pub async fn perform<Env>(self, env: &mut Env) -> Fx::Output
+    pub async fn perform<Env>(self, env: &Env) -> Fx::Output
     where
         Env: Provider<RemoteInvocation<Fx, Address>>,
     {

--- a/rust/dialog-macros/src/router.rs
+++ b/rust/dialog-macros/src/router.rs
@@ -31,7 +31,7 @@
 //!     Router<s3::Address, s3::Connection<Issuer>>: ProviderRoute
 //!         + Provider<RemoteInvocation<Fx, <Router<s3::Address, s3::Connection<Issuer>> as ProviderRoute>::Address>>,
 //! {
-//!     async fn execute(&mut self, input: RemoteInvocation<Fx, ...>) -> Fx::Output {
+//!     async fn execute(&self, input: RemoteInvocation<Fx, ...>) -> Fx::Output {
 //!         self.s3.execute(input).await
 //!     }
 //! }
@@ -129,13 +129,13 @@ fn generate_router(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                     + ::dialog_capability::Provider<
                         ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>
                     > + ::dialog_common::ConditionalSend,
-                Self: ::dialog_common::ConditionalSend,
+                Self: ::dialog_common::ConditionalSend + ::dialog_common::ConditionalSync,
             {
                 async fn execute(
-                    &mut self,
+                    &self,
                     input: ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>,
                 ) -> __Fx::Output {
-                    ::dialog_capability::Provider::execute(&mut self.#field_name, input).await
+                    ::dialog_capability::Provider::execute(&self.#field_name, input).await
                 }
             }
         };

--- a/rust/dialog-prolly-tree/src/helpers.rs
+++ b/rust/dialog-prolly-tree/src/helpers.rs
@@ -9,13 +9,13 @@
 //! # Tree Specification Example
 //!
 //! ```no_run
-//! use dialog_prolly_tree::tree_spec;
-//! use dialog_storage::{Blake3Hash, CborEncoder, JournaledStorage, MemoryStorageBackend, Storage};
+//! use dialog_prolly_tree::{tree_spec, JournaledBackend, TestStorage, TreeSpec};
+//! use dialog_storage::{CborEncoder, MemoryStorageBackend, Storage};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! let storage = Storage {
+//! let storage: TestStorage = Storage {
 //!     encoder: CborEncoder,
-//!     backend: JournaledStorage::new(MemoryStorageBackend::default()),
+//!     backend: JournaledBackend::new(MemoryStorageBackend::default()),
 //! };
 //!
 //! let spec = tree_spec![
@@ -23,7 +23,7 @@
 //!     [..a, c..e, f..f, g..g, h..l]  // Height 0 (segment nodes/leaves)
 //! ];
 //!
-//! let tree_spec = spec.build(storage).await?;
+//! let tree_spec: TreeSpec = spec.build(storage).await?;
 //! let tree = tree_spec.tree();
 //! # Ok(())
 //! # }
@@ -35,11 +35,13 @@
 //! use dialog_prolly_tree::{Tree, GeometricDistribution, Traversable, TraversalOrder, TreeNodes};
 //! use dialog_storage::{Blake3Hash, CborEncoder, MemoryStorageBackend, Storage};
 //!
-//! # type TestTree = Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash,
-//! #     Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>>;
-//! # async fn example(tree: &TestTree) -> Result<(), Box<dyn std::error::Error>> {
+//! # type TestStorage = Storage<CborEncoder, MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
+//! # async fn example(
+//! #     tree: &Tree<GeometricDistribution, Vec<u8>, Vec<u8>, Blake3Hash>,
+//! #     storage: &TestStorage,
+//! # ) -> Result<(), Box<dyn std::error::Error>> {
 //! // Collect all node hashes for comparison
-//! let hashes = tree.traverse(TraversalOrder::DepthFirst).into_hash_set().await;
+//! let hashes = tree.traverse(TraversalOrder::DepthFirst, storage).into_hash_set().await;
 //! println!("Tree contains {} nodes", hashes.len());
 //! # Ok(())
 //! # }

--- a/rust/dialog-s3-credentials/src/capability.rs
+++ b/rust/dialog-s3-credentials/src/capability.rs
@@ -71,7 +71,7 @@
 //!
 //! ```ignore
 //! // With S3 credentials
-//! let result = get_capability.perform(&mut s3_credentials).await?;
+//! let result = get_capability.perform(&s3_credentials).await?;
 //!
 //! // Result is an AuthorizedRequest with presigned URL and headers
 //! println!("URL: {}", result.url);

--- a/rust/dialog-s3-credentials/src/credentials.rs
+++ b/rust/dialog-s3-credentials/src/credentials.rs
@@ -69,7 +69,7 @@ where
     Capability<Do>: ConditionalSend + S3Request,
 {
     async fn execute(
-        &mut self,
+        &self,
         authorized: Authorized<Do, Authorization>,
     ) -> Result<AuthorizedRequest, AccessError> {
         authorized

--- a/rust/dialog-s3-credentials/src/lib.rs
+++ b/rust/dialog-s3-credentials/src/lib.rs
@@ -30,7 +30,7 @@
 //! let subject = did!("key:zSubject");
 //!
 //! // Create credentials (public or private)
-//! let mut credentials = s3::Credentials::private(
+//! let credentials = s3::Credentials::private(
 //!     address,
 //!     "AKIAIOSFODNN7EXAMPLE",
 //!     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -44,7 +44,7 @@
 //!     .invoke(Get::new(b"my-key"));
 //!
 //! // Sign the capability to get a presigned URL
-//! let permission = capability.perform(&mut credentials).await?;
+//! let permission = capability.perform(&credentials).await?;
 
 //!
 //! println!("Presigned URL: {}", permission.url);

--- a/rust/dialog-s3-credentials/src/s3/provider.rs
+++ b/rust/dialog-s3-credentials/src/s3/provider.rs
@@ -39,10 +39,7 @@ where
     Do: Effect<Output = Result<AuthorizedRequest, AccessError>> + 'static,
     Capability<Do>: ConditionalSend + S3Request,
 {
-    async fn execute(
-        &mut self,
-        capability: Capability<Do>,
-    ) -> Result<AuthorizedRequest, AccessError> {
+    async fn execute(&self, capability: Capability<Do>) -> Result<AuthorizedRequest, AccessError> {
         self.grant(&capability).await
     }
 }
@@ -91,7 +88,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_url_for_storage_get() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let key = b"test-key";
 
         let capability = Subject::from(test_subject())
@@ -99,7 +96,7 @@ mod tests {
             .attenuate(storage::Store::new("index"))
             .invoke(storage::Get::new(key));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "GET");
         assert_eq!(
@@ -111,7 +108,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_binary_key_for_storage_get() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let binary_key: [u8; 32] = [
             0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
             0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -123,7 +120,7 @@ mod tests {
             .attenuate(storage::Store::new("blob"))
             .invoke(storage::Get::new(binary_key));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "GET");
         // Binary key should be base58 encoded in path
@@ -132,7 +129,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_url_and_checksum_for_storage_set() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let key = b"my-key";
         let checksum_bytes = [0x12u8; 32];
         let checksum = crate::Checksum::Sha256(checksum_bytes);
@@ -142,7 +139,7 @@ mod tests {
             .attenuate(storage::Store::new("blob"))
             .invoke(storage::Set::new(key, checksum));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "PUT");
         assert_eq!(
@@ -164,7 +161,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_url_for_storage_delete() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let key = b"key-to-delete";
 
         let capability = Subject::from(test_subject())
@@ -172,7 +169,7 @@ mod tests {
             .attenuate(storage::Store::new("index"))
             .invoke(storage::Delete::new(key));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "DELETE");
         assert_eq!(
@@ -183,14 +180,14 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_query_params_for_storage_list() {
-        let mut creds = public_creds();
+        let creds = public_creds();
 
         let capability = Subject::from(test_subject())
             .attenuate(storage::Storage)
             .attenuate(storage::Store::new("index"))
             .invoke(storage::List::new(None));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "GET");
 
@@ -212,7 +209,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_continuation_token_for_storage_list() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let token = "next-page-token-abc123";
 
         let capability = Subject::from(test_subject())
@@ -220,7 +217,7 @@ mod tests {
             .attenuate(storage::Store::new("data"))
             .invoke(storage::List::new(Some(token.to_string())));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         let query: Vec<(String, String)> = req
             .url
@@ -234,7 +231,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_url_for_memory_resolve() {
-        let mut creds = public_creds();
+        let creds = public_creds();
 
         let capability = Subject::from(test_subject())
             .attenuate(memory::Memory)
@@ -242,7 +239,7 @@ mod tests {
             .attenuate(memory::Cell::new("main"))
             .invoke(memory::Resolve);
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "GET");
         assert_eq!(
@@ -253,7 +250,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_publishes_memory_without_prior_edition() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let checksum = crate::Checksum::Sha256([0xab; 32]);
 
         let capability = Subject::from(test_subject())
@@ -265,7 +262,7 @@ mod tests {
                 when: None, // No prior edition - creating new cell
             });
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "PUT");
         assert_eq!(
@@ -283,7 +280,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_publishes_memory_with_prior_edition() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let checksum = crate::Checksum::Sha256([0xcd; 32]);
         let prior_etag = "abc123etag".to_string();
 
@@ -296,7 +293,7 @@ mod tests {
                 when: Some(prior_etag),
             });
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "PUT");
         assert!(
@@ -308,7 +305,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_url_for_memory_retract() {
-        let mut creds = public_creds();
+        let creds = public_creds();
 
         let capability = Subject::from(test_subject())
             .attenuate(memory::Memory)
@@ -316,7 +313,7 @@ mod tests {
             .attenuate(memory::Cell::new("temp"))
             .invoke(memory::Retract::new("etag-to-match"));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "DELETE");
         assert_eq!(
@@ -327,7 +324,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_url_for_archive_get() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let digest: [u8; 32] = [0x42; 32];
 
         let capability = Subject::from(test_subject())
@@ -335,7 +332,7 @@ mod tests {
             .attenuate(archive::Catalog::new("blobs"))
             .invoke(archive::Get::new(digest));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "GET");
         assert_eq!(
@@ -346,7 +343,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_correct_url_and_checksum_for_archive_put() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let digest: [u8; 32] = [0x99; 32];
         let checksum = crate::Checksum::Sha256([0x11; 32]);
 
@@ -355,7 +352,7 @@ mod tests {
             .attenuate(archive::Catalog::new("index"))
             .invoke(archive::Put::new(digest, checksum));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "PUT");
         assert_eq!(
@@ -371,7 +368,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_signed_url_for_get_with_private_creds() {
-        let mut creds = private_creds();
+        let creds = private_creds();
         let key = b"signed-key";
 
         let capability = Subject::from(test_subject())
@@ -379,7 +376,7 @@ mod tests {
             .attenuate(storage::Store::new("data"))
             .invoke(storage::Get::new(key));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "GET");
 
@@ -399,7 +396,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_signed_url_for_put_with_private_creds() {
-        let mut creds = private_creds();
+        let creds = private_creds();
         let key = b"upload-key";
         let checksum = crate::Checksum::Sha256([0xff; 32]);
 
@@ -408,7 +405,7 @@ mod tests {
             .attenuate(storage::Store::new("uploads"))
             .invoke(storage::Set::new(key, checksum));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "PUT");
 
@@ -430,14 +427,14 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_generates_signed_url_for_list_with_private_creds() {
-        let mut creds = private_creds();
+        let creds = private_creds();
 
         let capability = Subject::from(test_subject())
             .attenuate(storage::Storage)
             .attenuate(storage::Store::new("files"))
             .invoke(storage::List::new(None));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         assert_eq!(req.method, "GET");
 
@@ -457,14 +454,14 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_uses_virtual_hosted_style_for_aws() {
-        let mut creds = public_creds();
+        let creds = public_creds();
 
         let capability = Subject::from(test_subject())
             .attenuate(storage::Storage)
             .attenuate(storage::Store::new("test"))
             .invoke(storage::Get::new(b"key"));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         // Virtual hosted style: bucket is in the hostname
         assert!(req.url.host_str().unwrap().starts_with("my-bucket."));
@@ -472,14 +469,14 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_uses_path_style_for_localhost() {
-        let mut creds = localhost_creds();
+        let creds = localhost_creds();
 
         let capability = Subject::from(test_subject())
             .attenuate(storage::Storage)
             .attenuate(storage::Store::new("test"))
             .invoke(storage::Get::new(b"key"));
 
-        let req = capability.perform(&mut creds).await.unwrap();
+        let req = capability.perform(&creds).await.unwrap();
 
         // Path style: bucket is in the path
         assert_eq!(req.url.host_str().unwrap(), "localhost");
@@ -488,7 +485,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_supports_different_store_names() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let stores = ["index", "blob", "metadata", "cache", ""];
 
         for store_name in stores {
@@ -497,7 +494,7 @@ mod tests {
                 .attenuate(storage::Store::new(store_name))
                 .invoke(storage::Get::new(b"key"));
 
-            let req = capability.perform(&mut creds).await.unwrap();
+            let req = capability.perform(&creds).await.unwrap();
 
             if store_name.is_empty() {
                 assert!(req.url.path().contains(&format!("/{}/", TEST_SUBJECT)));
@@ -513,7 +510,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_supports_different_catalog_names() {
-        let mut creds = public_creds();
+        let creds = public_creds();
         let catalogs = ["blobs", "index", "refs"];
         let digest: [u8; 32] = [0x55; 32];
 
@@ -523,7 +520,7 @@ mod tests {
                 .attenuate(archive::Catalog::new(catalog_name))
                 .invoke(archive::Get::new(digest));
 
-            let req = capability.perform(&mut creds).await.unwrap();
+            let req = capability.perform(&creds).await.unwrap();
 
             assert!(
                 req.url

--- a/rust/dialog-s3-credentials/src/ucan/authorization.rs
+++ b/rust/dialog-s3-credentials/src/ucan/authorization.rs
@@ -311,10 +311,7 @@ where
     Do: Effect<Output = Result<AuthorizedRequest, AccessError>> + 'static,
     Capability<Do>: ConditionalSend + S3Request,
 {
-    async fn execute(
-        &mut self,
-        capability: Capability<Do>,
-    ) -> Result<AuthorizedRequest, AccessError> {
+    async fn execute(&self, capability: Capability<Do>) -> Result<AuthorizedRequest, AccessError> {
         self.grant(&capability).await
     }
 }

--- a/rust/dialog-s3-credentials/src/ucan/credentials.rs
+++ b/rust/dialog-s3-credentials/src/ucan/credentials.rs
@@ -163,7 +163,7 @@ where
     Capability<Do>: ConditionalSend + S3Request,
 {
     async fn execute(
-        &mut self,
+        &self,
         authorized: Authorized<Do, UcanAuthorization>,
     ) -> Result<AuthorizedRequest, AccessError> {
         authorized
@@ -265,7 +265,7 @@ pub mod tests {
             .invoke(archive::Get {
                 digest: Blake3Hash::hash(b"hello"),
             })
-            .acquire(&mut session.clone())
+            .acquire(&session.clone())
             .await?;
 
         let authorization = read.authorization().invoke(&session).await?;
@@ -320,7 +320,7 @@ pub mod tests {
             });
 
         // Acquire authorization - should return Owned since subject == audience
-        let authorized = capability.acquire(&mut session.clone()).await?;
+        let authorized = capability.acquire(&session.clone()).await?;
 
         // Verify it's an Owned authorization
         match authorized.authorization() {
@@ -366,7 +366,7 @@ pub mod tests {
                 digest: Blake3Hash::hash(b"hello"),
             });
 
-        let result = capability.acquire(&mut session.clone()).await;
+        let result = capability.acquire(&session.clone()).await;
 
         assert!(
             result.is_ok(),
@@ -398,7 +398,7 @@ pub mod tests {
             .invoke(archive::Get {
                 digest: Blake3Hash::hash(b"hello"),
             })
-            .acquire(&mut session.clone())
+            .acquire(&session.clone())
             .await?;
 
         // Invoke the authorization - should create an Invocation with empty proofs

--- a/rust/dialog-s3-credentials/src/ucan/provider.rs
+++ b/rust/dialog-s3-credentials/src/ucan/provider.rs
@@ -646,7 +646,7 @@ mod tests {
             test_delegation_chain(&operator, &operator, &["archive"]).await,
         );
 
-        let mut session = Session::open(credentials, &[0u8; 32]).await;
+        let session = Session::open(credentials, &[0u8; 32]).await;
 
         let read = Subject::from(session.did())
             .attenuate(archive::Archive)
@@ -656,7 +656,7 @@ mod tests {
             .invoke(archive::Get {
                 digest: Blake3Hash::hash(b"hello"),
             })
-            .acquire(&mut session)
+            .acquire(&session)
             .await?;
 
         let authorization = read.authorization().invoke(&session).await?;

--- a/rust/dialog-storage/Cargo.toml
+++ b/rust/dialog-storage/Cargo.toml
@@ -55,6 +55,7 @@ reqwest = { workspace = true, features = ["json"], optional = true }
 dialog-credentials = { workspace = true, optional = true }
 dialog-s3-credentials = { workspace = true, optional = true }
 quick-xml = { workspace = true, features = ["serde", "serialize"], optional = true }
+parking_lot = { workspace = true }
 s3s = { workspace = true, optional = true }
 sieve-cache = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/rust/dialog-storage/src/resource/pool.rs
+++ b/rust/dialog-storage/src/resource/pool.rs
@@ -1,8 +1,8 @@
 //! Caching pool for address-keyed resources.
 
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::sync::RwLock;
 
 /// A pool that caches resources by address.
 ///
@@ -10,13 +10,9 @@ use std::sync::RwLock;
 /// inserting them via [`Pool::insert`]. The pool provides thread-safe
 /// lookup and insertion through an internal `RwLock`.
 ///
-/// Uses `RwLock` for interior mutability so callers can check and
-/// insert through `&self`. All lock guards are short-lived and never
-/// held across `.await` points.
-///
-/// If the lock is poisoned (a thread panicked while holding it),
-/// methods recover by replacing the contents with an empty map since
-/// the pool is only a cache.
+/// Uses `parking_lot::RwLock` for interior mutability so callers can
+/// check and insert through `&self`. All lock guards are short-lived
+/// and never held across `.await` points.
 pub struct Pool<Address, R> {
     resources: RwLock<HashMap<Address, R>>,
 }
@@ -31,18 +27,12 @@ impl<Address, R> Pool<Address, R> {
 
     /// Get the number of cached resources.
     pub fn len(&self) -> usize {
-        self.resources
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .len()
+        self.resources.read().len()
     }
 
     /// Check if the pool has no cached resources.
     pub fn is_empty(&self) -> bool {
-        self.resources
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .is_empty()
+        self.resources.read().is_empty()
     }
 }
 
@@ -55,10 +45,7 @@ impl<Address, R> Default for Pool<Address, R> {
 impl<Address: Eq + Hash, R> Pool<Address, R> {
     /// Check whether the pool already contains a resource for the given address.
     pub fn contains(&self, address: &Address) -> bool {
-        self.resources
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .contains_key(address)
+        self.resources.read().contains_key(address)
     }
 
     /// Get a clone of the cached resource for the given address.
@@ -69,19 +56,12 @@ impl<Address: Eq + Hash, R> Pool<Address, R> {
     where
         R: Clone,
     {
-        self.resources
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(address)
-            .cloned()
+        self.resources.read().get(address).cloned()
     }
 
     /// Insert a resource for the given address, returning the old one if present.
     pub fn insert(&self, address: Address, resource: R) -> Option<R> {
-        self.resources
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(address, resource)
+        self.resources.write().insert(address, resource)
     }
 }
 

--- a/rust/dialog-storage/src/resource/pool.rs
+++ b/rust/dialog-storage/src/resource/pool.rs
@@ -2,34 +2,47 @@
 
 use std::collections::HashMap;
 use std::hash::Hash;
-
-use super::Resource;
+use std::sync::RwLock;
 
 /// A pool that caches resources by address.
 ///
-/// On first access to an address, the resource is opened via
-/// [`Resource::open`] and cached. Subsequent accesses return the
-/// cached instance.
+/// Callers are responsible for opening resources externally and
+/// inserting them via [`Pool::insert`]. The pool provides thread-safe
+/// lookup and insertion through an internal `RwLock`.
+///
+/// Uses `RwLock` for interior mutability so callers can check and
+/// insert through `&self`. All lock guards are short-lived and never
+/// held across `.await` points.
+///
+/// If the lock is poisoned (a thread panicked while holding it),
+/// methods recover by replacing the contents with an empty map since
+/// the pool is only a cache.
 pub struct Pool<Address, R> {
-    resources: HashMap<Address, R>,
+    resources: RwLock<HashMap<Address, R>>,
 }
 
 impl<Address, R> Pool<Address, R> {
     /// Create a new empty pool.
     pub fn new() -> Self {
         Self {
-            resources: HashMap::new(),
+            resources: RwLock::new(HashMap::new()),
         }
     }
 
     /// Get the number of cached resources.
     pub fn len(&self) -> usize {
-        self.resources.len()
+        self.resources
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
     }
 
     /// Check if the pool has no cached resources.
     pub fn is_empty(&self) -> bool {
-        self.resources.is_empty()
+        self.resources
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty()
     }
 }
 
@@ -39,99 +52,85 @@ impl<Address, R> Default for Pool<Address, R> {
     }
 }
 
-impl<Address, R> Pool<Address, R>
-where
-    Address: Eq + Hash + Clone,
-    R: Resource<Address>,
-{
-    /// Get a mutable reference to a resource for the given address,
-    /// opening it if not already cached.
-    pub async fn open(&mut self, address: &Address) -> Result<&mut R, R::Error> {
-        if !self.resources.contains_key(address) {
-            let resource = R::open(address).await?;
-            self.resources.insert(address.clone(), resource);
-        }
-        Ok(self.resources.get_mut(address).unwrap())
-    }
-}
-
 impl<Address: Eq + Hash, R> Pool<Address, R> {
-    /// Get a mutable reference to a cached resource, if it exists.
-    pub fn get_mut(&mut self, address: &Address) -> Option<&mut R> {
-        self.resources.get_mut(address)
+    /// Check whether the pool already contains a resource for the given address.
+    pub fn contains(&self, address: &Address) -> bool {
+        self.resources
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains_key(address)
+    }
+
+    /// Get a clone of the cached resource for the given address.
+    ///
+    /// Requires `R: Clone` so the value can be extracted without holding
+    /// the lock. When `R` is `Arc<T>`, this is a cheap reference-count bump.
+    pub fn get(&self, address: &Address) -> Option<R>
+    where
+        R: Clone,
+    {
+        self.resources
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(address)
+            .cloned()
     }
 
     /// Insert a resource for the given address, returning the old one if present.
-    pub fn insert(&mut self, address: Address, resource: R) -> Option<R> {
-        self.resources.insert(address, resource)
+    pub fn insert(&self, address: Address, resource: R) -> Option<R> {
+        self.resources
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(address, resource)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::Resource;
-    use std::collections::HashMap;
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     struct TestAddress(String);
 
-    struct MockConnection {
-        data: HashMap<String, Vec<u8>>,
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-    impl Resource<TestAddress> for MockConnection {
-        type Error = std::io::Error;
-
-        async fn open(_address: &TestAddress) -> Result<Self, Self::Error> {
-            Ok(MockConnection {
-                data: HashMap::new(),
-            })
-        }
-    }
-
-    #[dialog_common::test]
-    async fn it_opens_and_caches_resources() {
-        let mut pool: Pool<TestAddress, MockConnection> = Pool::new();
+    #[test]
+    fn it_starts_empty() {
+        let pool: Pool<TestAddress, String> = Pool::new();
         assert!(pool.is_empty());
         assert_eq!(pool.len(), 0);
-
-        let conn = pool.open(&TestAddress("a".into())).await.unwrap();
-        conn.data.insert("key".into(), b"value".to_vec());
-
-        assert!(!pool.is_empty());
-        assert_eq!(pool.len(), 1);
-
-        // Second open returns the cached connection with data intact
-        let conn = pool.open(&TestAddress("a".into())).await.unwrap();
-        assert_eq!(conn.data.get("key"), Some(&b"value".to_vec()));
-        assert_eq!(pool.len(), 1);
-    }
-
-    #[dialog_common::test]
-    async fn it_isolates_resources_by_address() {
-        let mut pool: Pool<TestAddress, MockConnection> = Pool::new();
-
-        pool.open(&TestAddress("a".into())).await.unwrap();
-        pool.open(&TestAddress("b".into())).await.unwrap();
-
-        assert_eq!(pool.len(), 2);
     }
 
     #[test]
-    fn it_inserts_and_retrieves_manually() {
-        let mut pool: Pool<TestAddress, MockConnection> = Pool::new();
+    fn it_inserts_and_checks_contains() {
+        let pool: Pool<TestAddress, String> = Pool::new();
 
-        pool.insert(
-            TestAddress("x".into()),
-            MockConnection {
-                data: HashMap::new(),
-            },
-        );
+        pool.insert(TestAddress("x".into()), "hello".into());
 
-        assert!(pool.get_mut(&TestAddress("x".into())).is_some());
-        assert!(pool.get_mut(&TestAddress("y".into())).is_none());
+        assert!(pool.contains(&TestAddress("x".into())));
+        assert!(!pool.contains(&TestAddress("y".into())));
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn it_replaces_existing_entry() {
+        let pool: Pool<TestAddress, String> = Pool::new();
+
+        let old = pool.insert(TestAddress("x".into()), "first".into());
+        assert!(old.is_none());
+
+        let old = pool.insert(TestAddress("x".into()), "second".into());
+        assert_eq!(old, Some("first".into()));
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn it_isolates_by_address() {
+        let pool: Pool<TestAddress, String> = Pool::new();
+
+        pool.insert(TestAddress("a".into()), "alpha".into());
+        pool.insert(TestAddress("b".into()), "beta".into());
+
+        assert_eq!(pool.len(), 2);
+        assert!(pool.contains(&TestAddress("a".into())));
+        assert!(pool.contains(&TestAddress("b".into())));
     }
 }

--- a/rust/dialog-storage/src/storage/backend/s3.rs
+++ b/rust/dialog-storage/src/storage/backend/s3.rs
@@ -26,7 +26,7 @@
 //!     "my-bucket",
 //! );
 //! let credentials = S3Credentials::public(address)?;
-//! let mut bucket = S3::from_s3(credentials, issuer);
+//! let bucket = S3::from_s3(credentials, issuer);
 //!
 //! let subject: dialog_capability::Did = "did:key:zMySubject".parse().unwrap();
 //! Subject::from(subject)
@@ -36,7 +36,7 @@
 //!         key: b"key".to_vec().into(),
 //!         value: b"value".to_vec().into(),
 //!     })
-//!     .perform(&mut bucket)
+//!     .perform(&bucket)
 //!     .await?;
 //! # Ok(())
 //! # }
@@ -60,7 +60,7 @@
 //!     std::env::var("AWS_SECRET_ACCESS_KEY")?,
 //! )?;
 //!
-//! let mut bucket = S3::from_s3(credentials, issuer);
+//! let bucket = S3::from_s3(credentials, issuer);
 //!
 //! let subject: dialog_capability::Did = "did:key:zMySubject".parse().unwrap();
 //! Subject::from(subject)
@@ -70,7 +70,7 @@
 //!         key: b"key".to_vec().into(),
 //!         value: b"value".to_vec().into(),
 //!     })
-//!     .perform(&mut bucket)
+//!     .perform(&bucket)
 //!     .await?;
 //! # Ok(())
 //! # }
@@ -329,7 +329,7 @@ where
     Capability<Do>: ConditionalSend + S3Request,
 {
     async fn execute(
-        &mut self,
+        &self,
         authorized: Authorized<Do, dialog_s3_credentials::Authorization>,
     ) -> Result<AuthorizedRequest, AccessError> {
         self.credentials.execute(authorized).await
@@ -349,7 +349,7 @@ where
 ///
 /// # async fn example(s3: S3<impl dialog_capability::Authority<Signature = dialog_varsig::eddsa::Ed25519Signature> + Clone + Send + Sync>) -> Result<(), Box<dyn std::error::Error>> {
 /// let subject: dialog_capability::Did = "did:key:zMySubject".parse().unwrap();
-/// let mut storage = Bucket::new(s3, subject, "my-store");
+/// let storage = Bucket::new(s3, subject, "my-store");
 /// storage.set(b"key".to_vec(), b"value".to_vec()).await?;
 /// let value = storage.get(&b"key".to_vec()).await?;
 /// # Ok(())
@@ -428,7 +428,7 @@ where
             .attenuate(storage::Store::new(&self.path))
             .invoke(storage::Delete { key: key.to_vec() });
 
-        Provider::<storage::Delete>::execute(&mut self.bucket, capability)
+        Provider::<storage::Delete>::execute(&self.bucket, capability)
             .await
             .map_err(|e| S3StorageError::ServiceError(e.to_string()))
     }
@@ -480,7 +480,7 @@ where
     Capability<Do>: ConditionalSend + S3Request,
 {
     async fn execute(
-        &mut self,
+        &self,
         authorized: Authorized<Do, dialog_s3_credentials::Authorization>,
     ) -> Result<AuthorizedRequest, AccessError> {
         self.bucket.execute(authorized).await
@@ -509,7 +509,7 @@ where
             });
 
         // Execute via Provider
-        Provider::<storage::Set>::execute(&mut self.bucket, capability)
+        Provider::<storage::Set>::execute(&self.bucket, capability)
             .await
             .map_err(|e| S3StorageError::ServiceError(e.to_string()))
     }
@@ -521,9 +521,8 @@ where
             .attenuate(storage::Store::new(&self.path))
             .invoke(storage::Get { key: key.clone() });
 
-        // We need a mutable reference for Provider, so clone the bucket
-        let mut bucket = self.bucket.clone();
-        Provider::<storage::Get>::execute(&mut bucket, capability)
+        let bucket = self.bucket.clone();
+        Provider::<storage::Get>::execute(&bucket, capability)
             .await
             .map(|opt| opt.map(|b| b.to_vec()))
             .map_err(|e| S3StorageError::ServiceError(e.to_string()))
@@ -557,7 +556,7 @@ where
             .invoke(memory::Resolve);
 
         // Execute via Provider
-        let result = Provider::<memory::Resolve>::execute(&mut self.bucket, capability)
+        let result = Provider::<memory::Resolve>::execute(&self.bucket, capability)
             .await
             .map_err(|e| S3StorageError::ServiceError(e.to_string()))?;
 
@@ -590,18 +589,17 @@ where
                         when: edition.map(|e| e.as_bytes().to_vec().into()),
                     });
 
-                let new_edition =
-                    Provider::<memory::Publish>::execute(&mut self.bucket, capability)
-                        .await
-                        .map_err(|e| match e {
-                            memory::MemoryError::EditionMismatch { .. } => {
-                                S3StorageError::EditionMismatch {
-                                    expected: edition.map(|e| e.to_string()),
-                                    actual: None,
-                                }
+                let new_edition = Provider::<memory::Publish>::execute(&self.bucket, capability)
+                    .await
+                    .map_err(|e| match e {
+                        memory::MemoryError::EditionMismatch { .. } => {
+                            S3StorageError::EditionMismatch {
+                                expected: edition.map(|e| e.to_string()),
+                                actual: None,
                             }
-                            e => S3StorageError::ServiceError(e.to_string()),
-                        })?;
+                        }
+                        e => S3StorageError::ServiceError(e.to_string()),
+                    })?;
 
                 Ok(Some(String::from_utf8_lossy(&new_edition).to_string()))
             }
@@ -619,7 +617,7 @@ where
                         when: when.as_bytes().to_vec(),
                     });
 
-                Provider::<memory::Retract>::execute(&mut self.bucket, capability)
+                Provider::<memory::Retract>::execute(&self.bucket, capability)
                     .await
                     .map_err(|e| match e {
                         memory::MemoryError::EditionMismatch { .. } => {
@@ -671,7 +669,7 @@ mod tests {
 
         #[dialog_common::test]
         async fn it_performs_storage_get_and_set(env: PublicS3Address) -> anyhow::Result<()> {
-            let mut bucket = create_test_bucket(&env);
+            let bucket = create_test_bucket(&env);
 
             // Create a storage Set capability
             let key = b"test-provider-key".to_vec();
@@ -685,7 +683,7 @@ mod tests {
                     key: key.clone(),
                     value: value.clone(),
                 })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
 
             // Execute the get operation using perform()
@@ -693,7 +691,7 @@ mod tests {
                 .attenuate(storage::Storage)
                 .attenuate(storage::Store::new("test"))
                 .invoke(storage::Get { key: key.clone() })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
 
             assert_eq!(result, Some(value));
@@ -703,7 +701,7 @@ mod tests {
 
         #[dialog_common::test]
         async fn it_performs_archive_get_and_put(env: PublicS3Address) -> anyhow::Result<()> {
-            let mut bucket = create_test_bucket(&env);
+            let bucket = create_test_bucket(&env);
 
             // Create content and compute its digest
             let content = b"test archive content".to_vec();
@@ -717,7 +715,7 @@ mod tests {
                     digest: digest.clone(),
                     content: content.clone(),
                 })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
 
             // Execute the get operation using perform()
@@ -727,7 +725,7 @@ mod tests {
                 .invoke(archive::Get {
                     digest: digest.clone(),
                 })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
 
             assert_eq!(result, Some(content));
@@ -776,7 +774,7 @@ mod tests {
             let subject_did = signer.did();
 
             // Create bucket with UCAN credentials
-            let mut bucket = create_ucan_bucket(&env, signer, delegation);
+            let bucket = create_ucan_bucket(&env, signer, delegation);
 
             // Create content and compute its digest
             let content = b"test ucan archive content".to_vec();
@@ -793,7 +791,7 @@ mod tests {
                     digest: digest.clone(),
                     content: content.clone(),
                 })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await;
 
             match &result {
@@ -809,7 +807,7 @@ mod tests {
                 .invoke(archive::Get {
                     digest: digest.clone(),
                 })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
 
             assert_eq!(result, Some(content));
@@ -1364,7 +1362,7 @@ mod tests {
                 DelegationChain::new(delegation)
             };
             let ucan_credentials = UcanCredentials::new(env.access_service_url.clone(), delegation);
-            let mut bucket = S3::new(Credentials::Ucan(ucan_credentials), signer);
+            let bucket = S3::new(Credentials::Ucan(ucan_credentials), signer);
 
             let store_name = "test-store";
             let key = b"ucan-delete-key".to_vec();
@@ -1378,7 +1376,7 @@ mod tests {
                     key: key.clone(),
                     value: value.clone(),
                 })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
 
             // Verify it exists
@@ -1386,7 +1384,7 @@ mod tests {
                 .attenuate(storage::Storage)
                 .attenuate(storage::Store::new(store_name))
                 .invoke(storage::Get { key: key.clone() })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
             assert_eq!(result, Some(value));
 
@@ -1395,7 +1393,7 @@ mod tests {
                 .attenuate(storage::Storage)
                 .attenuate(storage::Store::new(store_name))
                 .invoke(storage::Delete { key: key.clone() })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
 
             // Verify it's gone
@@ -1403,7 +1401,7 @@ mod tests {
                 .attenuate(storage::Storage)
                 .attenuate(storage::Store::new(store_name))
                 .invoke(storage::Get { key: key.clone() })
-                .perform(&mut bucket)
+                .perform(&bucket)
                 .await?;
             assert_eq!(result, None);
 

--- a/rust/dialog-storage/src/storage/backend/s3/archive.rs
+++ b/rust/dialog-storage/src/storage/backend/s3/archive.rs
@@ -19,7 +19,7 @@ impl<Issuer> Provider<Get> for S3<Issuer>
 where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
-    async fn execute(&mut self, input: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
+    async fn execute(&self, input: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
         // Build the authorization capability
         let capability = Subject::from(input.subject().clone())
             .attenuate(Archive)
@@ -69,7 +69,7 @@ impl<Issuer> Provider<Put> for S3<Issuer>
 where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
-    async fn execute(&mut self, input: Capability<Put>) -> Result<(), ArchiveError> {
+    async fn execute(&self, input: Capability<Put>) -> Result<(), ArchiveError> {
         let Put { content, digest } = Put::of(&input);
         let checksum = Hasher::Sha256.checksum(content);
 

--- a/rust/dialog-storage/src/storage/backend/s3/list.rs
+++ b/rust/dialog-storage/src/storage/backend/s3/list.rs
@@ -112,7 +112,7 @@ where
 
         // Execute the capability using the Provider trait
         let result = capability
-            .perform(&mut self.bucket.clone())
+            .perform(&self.bucket.clone())
             .await
             .map_err(|e| S3StorageError::ServiceError(e.to_string()))?;
 
@@ -132,7 +132,7 @@ where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
     async fn execute(
-        &mut self,
+        &self,
         input: Capability<storage::List>,
     ) -> Result<storage::ListResult, storage::StorageError> {
         // Build the authorization capability

--- a/rust/dialog-storage/src/storage/backend/s3/memory.rs
+++ b/rust/dialog-storage/src/storage/backend/s3/memory.rs
@@ -22,7 +22,7 @@ where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
     async fn execute(
-        &mut self,
+        &self,
         input: Capability<Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
         // Build the authorization capability
@@ -85,7 +85,7 @@ impl<Issuer> Provider<Publish> for S3<Issuer>
 where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
-    async fn execute(&mut self, input: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
+    async fn execute(&self, input: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
         let Publish { content, when } = Publish::of(&input);
         let when = when
             .as_ref()
@@ -151,7 +151,7 @@ impl<Issuer> Provider<Retract> for S3<Issuer>
 where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
-    async fn execute(&mut self, input: Capability<Retract>) -> Result<(), MemoryError> {
+    async fn execute(&self, input: Capability<Retract>) -> Result<(), MemoryError> {
         let Retract { when } = Retract::of(&input);
         let when = String::from_utf8_lossy(when).to_string();
 

--- a/rust/dialog-storage/src/storage/backend/s3/storage.rs
+++ b/rust/dialog-storage/src/storage/backend/s3/storage.rs
@@ -21,7 +21,7 @@ impl<Issuer> Provider<Get> for S3<Issuer>
 where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
-    async fn execute(&mut self, input: Capability<Get>) -> Result<Option<Vec<u8>>, StorageError> {
+    async fn execute(&self, input: Capability<Get>) -> Result<Option<Vec<u8>>, StorageError> {
         // Build the authorization capability
         let capability = Subject::from(input.subject().clone())
             .attenuate(Storage)
@@ -71,7 +71,7 @@ impl<Issuer> Provider<Set> for S3<Issuer>
 where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
-    async fn execute(&mut self, input: Capability<Set>) -> Result<(), StorageError> {
+    async fn execute(&self, input: Capability<Set>) -> Result<(), StorageError> {
         let Set { key, value } = Set::of(&input);
         let checksum = Hasher::Sha256.checksum(value);
 
@@ -119,7 +119,7 @@ impl<Issuer> Provider<Delete> for S3<Issuer>
 where
     Issuer: Authority<Signature = Ed25519Signature> + Clone + ConditionalSend + ConditionalSync,
 {
-    async fn execute(&mut self, input: Capability<Delete>) -> Result<(), StorageError> {
+    async fn execute(&self, input: Capability<Delete>) -> Result<(), StorageError> {
         // Build the authorization capability
         let capability = Subject::from(input.subject().clone())
             .attenuate(Storage)

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -29,7 +29,7 @@
 //! use std::path::PathBuf;
 //!
 //! # async fn example() -> anyhow::Result<()> {
-//! let mut provider = FileSystem::mount("file:///tmp/storage")?;
+//! let provider = FileSystem::mount("file:///tmp/storage")?;
 //! let digest = Blake3Hash::hash(b"hello");
 //!
 //! let effect = Subject::from(did!("key:z6Mk..."))
@@ -37,7 +37,7 @@
 //!     .attenuate(Catalog::new("index"))
 //!     .invoke(Get::new(digest));
 //!
-//! let result = effect.perform(&mut provider).await?;
+//! let result = effect.perform(&provider).await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/rust/dialog-storage/src/storage/provider/fs/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/archive.rs
@@ -18,7 +18,7 @@ impl From<FileSystemError> for ArchiveError {
 
 #[async_trait]
 impl Provider<Get> for FileSystem {
-    async fn execute(&mut self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
+    async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
         let subject = effect.subject().into();
         let catalog = effect.catalog();
         let digest = effect.digest();
@@ -39,7 +39,7 @@ impl Provider<Get> for FileSystem {
 
 #[async_trait]
 impl Provider<Put> for FileSystem {
-    async fn execute(&mut self, effect: Capability<Put>) -> Result<(), ArchiveError> {
+    async fn execute(&self, effect: Capability<Put>) -> Result<(), ArchiveError> {
         let subject = effect.subject().into();
         let catalog = effect.catalog();
         let digest = effect.digest();
@@ -106,7 +106,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_returns_none_for_missing_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-get-none");
         let digest = Blake3Hash::hash(b"nonexistent");
 
@@ -115,7 +115,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
 
-        let result = effect.perform(&mut provider).await?;
+        let result = effect.perform(&provider).await?;
         assert!(result.is_none());
 
         Ok(())
@@ -124,7 +124,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_stores_and_retrieves_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-put-get");
         let content = b"hello world".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -136,7 +136,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()));
 
-        put_effect.perform(&mut provider).await?;
+        put_effect.perform(&provider).await?;
 
         // Get content
         let get_effect = subject
@@ -144,7 +144,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
 
-        let result = get_effect.perform(&mut provider).await?;
+        let result = get_effect.perform(&provider).await?;
         assert_eq!(result, Some(content));
 
         Ok(())
@@ -153,7 +153,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_rejects_digest_mismatch() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-mismatch");
         let content = b"hello world".to_vec();
         let wrong_digest = Blake3Hash::hash(b"different content");
@@ -163,7 +163,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(wrong_digest, content));
 
-        let result = effect.perform(&mut provider).await;
+        let result = effect.perform(&provider).await;
         assert!(matches!(result, Err(ArchiveError::DigestMismatch { .. })));
 
         Ok(())
@@ -172,7 +172,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_different_catalogs() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-catalogs");
         let content1 = b"content for catalog 1".to_vec();
         let content2 = b"content for catalog 2".to_vec();
@@ -185,7 +185,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Put::new(digest1.clone(), content1.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -193,7 +193,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Put::new(digest2.clone(), content2.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Retrieve from catalog1
@@ -202,7 +202,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest1))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result1, Some(content1));
 
@@ -212,7 +212,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Get::new(digest2.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result2, Some(content2));
 
@@ -221,7 +221,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest2))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert!(cross.is_none());
 
@@ -231,7 +231,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_is_idempotent_for_same_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-idempotent");
         let content = b"idempotent content".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -242,7 +242,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -250,7 +250,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Should still be retrievable
@@ -258,7 +258,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
 
@@ -268,7 +268,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_empty_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-empty");
         let content = vec![];
         let digest = Blake3Hash::hash(&content);
@@ -278,14 +278,14 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let result = subject
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
 
@@ -295,7 +295,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_large_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-large");
         // 1MB content
         let content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
@@ -306,14 +306,14 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let result = subject
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
 

--- a/rust/dialog-storage/src/storage/provider/fs/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/memory.rs
@@ -112,7 +112,7 @@ impl Location {
 #[async_trait]
 impl Provider<Resolve> for FileSystem {
     async fn execute(
-        &mut self,
+        &self,
         effect: Capability<Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
         let subject = effect.subject().into();
@@ -141,7 +141,7 @@ impl Provider<Resolve> for FileSystem {
 
 #[async_trait]
 impl Provider<Publish> for FileSystem {
-    async fn execute(&mut self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
+    async fn execute(&self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
         let subject = effect.subject().into();
         let space = effect.space();
         let cell = effect.cell();
@@ -229,7 +229,7 @@ impl Provider<Publish> for FileSystem {
 
 #[async_trait]
 impl Provider<Retract> for FileSystem {
-    async fn execute(&mut self, effect: Capability<Retract>) -> Result<(), MemoryError> {
+    async fn execute(&self, effect: Capability<Retract>) -> Result<(), MemoryError> {
         let subject = effect.subject().into();
         let space = effect.space();
         let cell = effect.cell();
@@ -301,7 +301,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_resolves_non_existent_cell() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-resolve-none");
 
         let effect = subject
@@ -310,7 +310,7 @@ mod tests {
             .attenuate(Cell::new("missing"))
             .invoke(Resolve);
 
-        let result = effect.perform(&mut provider).await?;
+        let result = effect.perform(&provider).await?;
         assert!(result.is_none());
 
         Ok(())
@@ -319,7 +319,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_publishes_new_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-publish-new");
         let content = b"hello world".to_vec();
 
@@ -330,7 +330,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -341,7 +341,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -354,7 +354,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_updates_existing_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-publish-update");
 
         // Create initial content
@@ -364,7 +364,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Update with correct edition
@@ -374,7 +374,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"updated", Some(edition1.clone())))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert_ne!(edition1, edition2);
@@ -385,7 +385,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -397,7 +397,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_fails_on_edition_mismatch() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-mismatch");
 
         // Create initial content
@@ -407,7 +407,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to update with wrong edition
@@ -417,7 +417,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"updated", Some(wrong_edition)))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -428,7 +428,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_fails_creating_when_exists() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-create-exists");
 
         // Create initial content
@@ -438,7 +438,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to create again (when = None means expect empty)
@@ -447,7 +447,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"new", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -458,7 +458,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_retracts_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-retract");
 
         // Create content
@@ -468,7 +468,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"to be deleted", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Retract with correct edition
@@ -478,7 +478,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Retract::new(edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Verify deleted
@@ -487,7 +487,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(resolved.is_none());
@@ -498,7 +498,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_fails_retract_on_edition_mismatch() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-retract-mismatch");
 
         // Create content
@@ -508,7 +508,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"content", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to retract with wrong edition
@@ -518,7 +518,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Retract::new(wrong_edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -529,7 +529,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_different_spaces() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-spaces");
 
         // Publish to different spaces
@@ -539,7 +539,7 @@ mod tests {
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(b"content1", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -548,7 +548,7 @@ mod tests {
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(b"content2", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Resolve from space1
@@ -558,7 +558,7 @@ mod tests {
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result1.unwrap().content, b"content1".to_vec());
 
@@ -568,7 +568,7 @@ mod tests {
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result2.unwrap().content, b"content2".to_vec());
 
@@ -578,7 +578,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_succeeds_with_stale_edition_when_value_matches() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-stale-ok");
         let content = b"desired value".to_vec();
 
@@ -589,7 +589,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to publish same content with wrong edition - should succeed
@@ -599,7 +599,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), Some(wrong_edition)))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(result.is_ok());
@@ -614,7 +614,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_produces_deterministic_content_hash() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-deterministic-hash");
         let content = b"same content".to_vec();
 
@@ -625,7 +625,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell1"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Create same value at cell2
@@ -634,7 +634,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell2"))
             .invoke(Publish::new(content, None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Same content should produce same edition (content hash)
@@ -646,7 +646,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_succeeds_retracting_already_retracted() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-retract-already-retracted");
 
         // Try to retract non-existent cell - should succeed
@@ -656,7 +656,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("nonexistent"))
             .invoke(Retract::new(wrong_edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(result.is_ok());
@@ -667,7 +667,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_nested_spaces() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-nested-spaces");
         let content = b"nested content".to_vec();
 
@@ -678,7 +678,7 @@ mod tests {
             .attenuate(Space::new("parent/child/grandchild"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -689,7 +689,7 @@ mod tests {
             .attenuate(Space::new("parent/child/grandchild"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -701,7 +701,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_publishes_to_nested_cell() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-nested-cell");
         let content = b"nested cell content".to_vec();
 
@@ -713,7 +713,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("subdir/cell"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -723,7 +723,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("subdir/cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -735,7 +735,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_empty_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-empty");
         let content = vec![];
 
@@ -745,7 +745,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("empty"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -755,7 +755,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("empty"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -767,7 +767,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_large_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let mut provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-large");
         // 1MB content
         let content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
@@ -778,7 +778,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("large"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -788,7 +788,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("large"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -26,7 +26,7 @@
 //! use dialog_common::Blake3Hash;
 //!
 //! # async fn example() -> anyhow::Result<()> {
-//! let mut provider = IndexedDb::new();
+//! let provider = IndexedDb::new();
 //! let digest = Blake3Hash::hash(b"hello");
 //!
 //! let effect = Subject::from(did!("key:z6Mk..."))
@@ -34,7 +34,7 @@
 //!     .attenuate(Catalog::new("index"))
 //!     .invoke(Get::new(digest));
 //!
-//! let result = effect.perform(&mut provider).await?;
+//! let result = effect.perform(&provider).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -45,6 +45,7 @@ mod memory;
 use dialog_capability::Did;
 use js_sys::Uint8Array;
 use rexie::{ObjectStore, Rexie, RexieBuilder, TransactionMode};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 /// Convert bytes to a JS Uint8Array.
@@ -206,27 +207,52 @@ impl<'a> Store<'a> {
 ///
 /// Databases are opened lazily on first access and stores are created dynamically
 /// as needed.
+///
+/// Uses `RefCell` for interior mutability since this provider only targets
+/// wasm32 (single-threaded). This avoids the overhead and poisoning concerns
+/// of `RwLock`.
 pub struct IndexedDb {
     /// Cached database sessions keyed by subject DID.
-    sessions: HashMap<Did, Session>,
+    sessions: RefCell<HashMap<Did, Session>>,
 }
 
 impl IndexedDb {
     /// Creates a new IndexedDB provider.
     pub fn new() -> Self {
         Self {
-            sessions: HashMap::new(),
+            sessions: RefCell::new(HashMap::new()),
         }
     }
 
     /// Opens or returns an existing session for the given subject.
-    async fn open(&mut self, subject: &Did) -> Result<&mut Session, IndexedDbError> {
-        if !self.sessions.contains_key(subject) {
+    ///
+    /// Checks for an existing session via a short borrow, drops it before
+    /// any async work, then borrows mutably to insert a new session if needed.
+    async fn open(&self, subject: &Did) -> Result<(), IndexedDbError> {
+        let exists = self.sessions.borrow().contains_key(subject);
+        if !exists {
             let session = Session::open(subject.as_ref()).await?;
-            self.sessions.insert(subject.clone(), session);
+            self.sessions.borrow_mut().insert(subject.clone(), session);
         }
+        Ok(())
+    }
 
-        Ok(self.sessions.get_mut(subject).unwrap())
+    /// Temporarily removes a session from the cache for async operations.
+    ///
+    /// IndexedDB operations require `&mut Session` and are async, so we
+    /// cannot hold a `RefCell` borrow across `.await` points. Instead we
+    /// remove the session, perform the work, then re-insert it via
+    /// [`IndexedDb::return_session`].
+    fn take_session(&self, subject: &Did) -> Result<Session, IndexedDbError> {
+        self.sessions
+            .borrow_mut()
+            .remove(subject)
+            .ok_or_else(|| IndexedDbError::Database(format!("No session for {}", subject)))
+    }
+
+    /// Returns a session to the cache after async operations complete.
+    fn return_session(&self, subject: Did, session: Session) {
+        self.sessions.borrow_mut().insert(subject, session);
     }
 }
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
@@ -21,39 +21,46 @@ impl From<super::IndexedDbError> for ArchiveError {
 
 #[async_trait(?Send)]
 impl Provider<Get> for IndexedDb {
-    async fn execute(&mut self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
+    async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
         let subject = effect.subject().into();
         let catalog = effect.catalog();
         let digest = effect.digest();
 
-        let store = format!("archive/{}", catalog);
+        let store_path = format!("archive/{}", catalog);
         let key = JsValue::from_str(&digest.as_bytes().to_base58());
 
-        self.open(&subject)
-            .await?
-            .store(&store)
-            .await?
-            .query(|object_store| async move {
-                let value = object_store.get(key).await.map_err(storage_error)?;
+        self.open(&subject).await?;
+        let mut session = self.take_session(&subject)?;
 
-                let Some(value) = value else {
-                    return Ok(None);
-                };
+        let result = async {
+            let store = session.store(&store_path).await?;
+            store
+                .query(|object_store| async move {
+                    let value = object_store.get(key).await.map_err(storage_error)?;
 
-                let bytes = value
-                    .dyn_into::<Uint8Array>()
-                    .map_err(|_| ArchiveError::Storage("Value is not Uint8Array".to_string()))?
-                    .to_vec();
+                    let Some(value) = value else {
+                        return Ok(None);
+                    };
 
-                Ok(Some(bytes))
-            })
-            .await
+                    let bytes = value
+                        .dyn_into::<Uint8Array>()
+                        .map_err(|_| ArchiveError::Storage("Value is not Uint8Array".to_string()))?
+                        .to_vec();
+
+                    Ok(Some(bytes))
+                })
+                .await
+        }
+        .await;
+
+        self.return_session(subject, session);
+        result
     }
 }
 
 #[async_trait(?Send)]
 impl Provider<Put> for IndexedDb {
-    async fn execute(&mut self, effect: Capability<Put>) -> Result<(), ArchiveError> {
+    async fn execute(&self, effect: Capability<Put>) -> Result<(), ArchiveError> {
         let subject = effect.subject().into();
         let catalog = effect.catalog();
         let digest = effect.digest();
@@ -68,22 +75,29 @@ impl Provider<Put> for IndexedDb {
             });
         }
 
-        let store = format!("archive/{}", catalog);
+        let store_path = format!("archive/{}", catalog);
         let key = JsValue::from_str(&digest.as_bytes().to_base58());
         let value: JsValue = to_uint8array(content).into();
 
-        self.open(&subject)
-            .await?
-            .store(&store)
-            .await?
-            .transact(|object_store| async move {
-                object_store
-                    .put(&value, Some(&key))
-                    .await
-                    .map_err(storage_error)?;
-                Ok(())
-            })
-            .await
+        self.open(&subject).await?;
+        let mut session = self.take_session(&subject)?;
+
+        let result = async {
+            let store = session.store(&store_path).await?;
+            store
+                .transact(|object_store| async move {
+                    object_store
+                        .put(&value, Some(&key))
+                        .await
+                        .map_err(storage_error)?;
+                    Ok(())
+                })
+                .await
+        }
+        .await;
+
+        self.return_session(subject, session);
+        result
     }
 }
 
@@ -102,7 +116,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_returns_none_for_missing_content() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("archive-get-none");
         let digest = Blake3Hash::hash(b"nonexistent");
 
@@ -111,7 +125,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
 
-        let result = effect.perform(&mut provider).await?;
+        let result = effect.perform(&provider).await?;
         assert!(result.is_none());
 
         Ok(())
@@ -119,7 +133,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_stores_and_retrieves_content() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("archive-put-get");
         let content = b"hello world".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -131,7 +145,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()));
 
-        put_effect.perform(&mut provider).await?;
+        put_effect.perform(&provider).await?;
 
         // Get content
         let get_effect = subject
@@ -139,7 +153,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
 
-        let result = get_effect.perform(&mut provider).await?;
+        let result = get_effect.perform(&provider).await?;
         assert_eq!(result, Some(content));
 
         Ok(())
@@ -147,7 +161,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_rejects_digest_mismatch() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("archive-mismatch");
         let content = b"hello world".to_vec();
         let wrong_digest = Blake3Hash::hash(b"different content");
@@ -157,7 +171,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(wrong_digest, content));
 
-        let result = effect.perform(&mut provider).await;
+        let result = effect.perform(&provider).await;
         assert!(matches!(result, Err(ArchiveError::DigestMismatch { .. })));
 
         Ok(())
@@ -165,7 +179,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_different_catalogs() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("archive-catalogs");
         let content1 = b"content for catalog 1".to_vec();
         let content2 = b"content for catalog 2".to_vec();
@@ -178,7 +192,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Put::new(digest1.clone(), content1.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -186,7 +200,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Put::new(digest2.clone(), content2.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Retrieve from catalog1
@@ -195,7 +209,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest1))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result1, Some(content1));
 
@@ -205,7 +219,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Get::new(digest2.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result2, Some(content2));
 
@@ -214,7 +228,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest2))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert!(cross.is_none());
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/memory.rs
@@ -40,155 +40,183 @@ impl From<super::IndexedDbError> for MemoryError {
 #[async_trait(?Send)]
 impl Provider<Resolve> for IndexedDb {
     async fn execute(
-        &mut self,
+        &self,
         effect: Capability<Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
         let subject = effect.subject().into();
         let key = make_key(effect.space(), effect.cell());
 
-        let store = self.open(&subject).await?.store(MEMORY_STORE).await?;
+        self.open(&subject).await?;
+        let mut session = self.take_session(&subject)?;
 
-        store
-            .query(|object_store| async move {
-                let value = object_store.get(key).await.map_err(storage_error)?;
+        let result = async {
+            let store = session.store(MEMORY_STORE).await?;
+            store
+                .query(|object_store| async move {
+                    let value = object_store.get(key).await.map_err(storage_error)?;
 
-                let Some(value) = value else {
-                    return Ok(None);
-                };
+                    let Some(value) = value else {
+                        return Ok(None);
+                    };
 
-                let bytes = value
-                    .dyn_into::<Uint8Array>()
-                    .map_err(|_| MemoryError::Storage("Value is not Uint8Array".to_string()))?
-                    .to_vec();
+                    let bytes = value
+                        .dyn_into::<Uint8Array>()
+                        .map_err(|_| MemoryError::Storage("Value is not Uint8Array".to_string()))?
+                        .to_vec();
 
-                let edition = Blake3Hash::hash(&bytes);
+                    let edition = Blake3Hash::hash(&bytes);
 
-                Ok(Some(Publication {
-                    content: bytes,
-                    edition: edition.as_bytes().to_vec(),
-                }))
-            })
-            .await
+                    Ok(Some(Publication {
+                        content: bytes,
+                        edition: edition.as_bytes().to_vec(),
+                    }))
+                })
+                .await
+        }
+        .await;
+
+        self.return_session(subject, session);
+        result
     }
 }
 
 #[async_trait(?Send)]
 impl Provider<Publish> for IndexedDb {
-    async fn execute(&mut self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
+    async fn execute(&self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
         let subject = effect.subject().into();
         let key = make_key(effect.space(), effect.cell());
         let content = effect.content().to_vec();
         let expected_edition = effect.when().map(|e| e.to_vec());
 
-        let store = self.open(&subject).await?.store(MEMORY_STORE).await?;
+        self.open(&subject).await?;
+        let mut session = self.take_session(&subject)?;
 
-        store
-            .transact(|object_store| async move {
-                // Read current value to check CAS condition
-                let current = object_store.get(key.clone()).await.map_err(storage_error)?;
+        let result = async {
+            let store = session.store(MEMORY_STORE).await?;
+            store
+                .transact(|object_store| async move {
+                    // Read current value to check CAS condition
+                    let current = object_store.get(key.clone()).await.map_err(storage_error)?;
 
-                let current_edition = if let Some(value) = &current {
-                    let bytes = value
-                        .clone()
-                        .dyn_into::<Uint8Array>()
-                        .map_err(|_| MemoryError::Storage("Value is not Uint8Array".to_string()))?
-                        .to_vec();
-                    Some(Blake3Hash::hash(&bytes))
-                } else {
-                    None
-                };
+                    let current_edition = if let Some(value) = &current {
+                        let bytes = value
+                            .clone()
+                            .dyn_into::<Uint8Array>()
+                            .map_err(|_| {
+                                MemoryError::Storage("Value is not Uint8Array".to_string())
+                            })?
+                            .to_vec();
+                        Some(Blake3Hash::hash(&bytes))
+                    } else {
+                        None
+                    };
 
-                // Compute new edition
-                let new_edition = Blake3Hash::hash(&content);
+                    // Compute new edition
+                    let new_edition = Blake3Hash::hash(&content);
 
-                // If current value already matches desired value, succeed without writing
-                if current_edition.as_ref().map(|h| h.as_bytes()) == Some(new_edition.as_bytes()) {
-                    return Ok(new_edition.as_bytes().to_vec());
-                }
-
-                // Check CAS condition
-                match (expected_edition.as_deref(), &current_edition) {
-                    // Creating new: require cell doesn't exist
-                    (None, Some(_)) => {
-                        return Err(MemoryError::EditionMismatch {
-                            expected: None,
-                            actual: format_edition(
-                                current_edition.as_ref().map(|h| h.as_bytes().as_slice()),
-                            ),
-                        });
+                    // If current value already matches desired value, succeed without writing
+                    if current_edition.as_ref().map(|h| h.as_bytes())
+                        == Some(new_edition.as_bytes())
+                    {
+                        return Ok(new_edition.as_bytes().to_vec());
                     }
-                    // Updating existing: require edition matches
-                    (Some(expected), Some(current)) => {
-                        if expected != current.as_bytes() {
+
+                    // Check CAS condition
+                    match (expected_edition.as_deref(), &current_edition) {
+                        // Creating new: require cell doesn't exist
+                        (None, Some(_)) => {
                             return Err(MemoryError::EditionMismatch {
-                                expected: format_edition(Some(expected)),
-                                actual: format_edition(Some(current.as_bytes())),
+                                expected: None,
+                                actual: format_edition(
+                                    current_edition.as_ref().map(|h| h.as_bytes().as_slice()),
+                                ),
                             });
                         }
+                        // Updating existing: require edition matches
+                        (Some(expected), Some(current)) => {
+                            if expected != current.as_bytes() {
+                                return Err(MemoryError::EditionMismatch {
+                                    expected: format_edition(Some(expected)),
+                                    actual: format_edition(Some(current.as_bytes())),
+                                });
+                            }
+                        }
+                        // Updating non-existent: fail
+                        (Some(expected), None) => {
+                            return Err(MemoryError::EditionMismatch {
+                                expected: format_edition(Some(expected)),
+                                actual: None,
+                            });
+                        }
+                        // Creating new when cell doesn't exist: valid
+                        (None, None) => {}
                     }
-                    // Updating non-existent: fail
-                    (Some(expected), None) => {
-                        return Err(MemoryError::EditionMismatch {
-                            expected: format_edition(Some(expected)),
-                            actual: None,
-                        });
-                    }
-                    // Creating new when cell doesn't exist: valid
-                    (None, None) => {}
-                }
 
-                // Write the new value
-                let js_value: JsValue = to_uint8array(&content).into();
-                object_store
-                    .put(&js_value, Some(&key))
-                    .await
-                    .map_err(storage_error)?;
+                    // Write the new value
+                    let js_value: JsValue = to_uint8array(&content).into();
+                    object_store
+                        .put(&js_value, Some(&key))
+                        .await
+                        .map_err(storage_error)?;
 
-                Ok(new_edition.as_bytes().to_vec())
-            })
-            .await
+                    Ok(new_edition.as_bytes().to_vec())
+                })
+                .await
+        }
+        .await;
+
+        self.return_session(subject, session);
+        result
     }
 }
 
 #[async_trait(?Send)]
 impl Provider<Retract> for IndexedDb {
-    async fn execute(&mut self, effect: Capability<Retract>) -> Result<(), MemoryError> {
+    async fn execute(&self, effect: Capability<Retract>) -> Result<(), MemoryError> {
         let subject = effect.subject().into();
         let key = make_key(effect.space(), effect.cell());
         let expected_edition = effect.when().to_vec();
 
-        let store = self.open(&subject).await?.store(MEMORY_STORE).await?;
+        self.open(&subject).await?;
+        let mut session = self.take_session(&subject)?;
 
-        store
-            .transact(|object_store| async move {
-                // Read current value to check CAS condition
-                let current = object_store.get(key.clone()).await.map_err(storage_error)?;
+        let result = async {
+            let store = session.store(MEMORY_STORE).await?;
+            store
+                .transact(|object_store| async move {
+                    // Read current value to check CAS condition
+                    let current = object_store.get(key.clone()).await.map_err(storage_error)?;
 
-                // If already deleted, succeed
-                let Some(value) = current else {
-                    return Ok(());
-                };
+                    // If already deleted, succeed
+                    let Some(value) = current else {
+                        return Ok(());
+                    };
 
-                let bytes = value
-                    .dyn_into::<Uint8Array>()
-                    .map_err(|_| MemoryError::Storage("Value is not Uint8Array".to_string()))?
-                    .to_vec();
-                let current_edition = Blake3Hash::hash(&bytes);
+                    let bytes = value
+                        .dyn_into::<Uint8Array>()
+                        .map_err(|_| MemoryError::Storage("Value is not Uint8Array".to_string()))?
+                        .to_vec();
+                    let current_edition = Blake3Hash::hash(&bytes);
 
-                // Check CAS condition
-                if expected_edition != current_edition.as_bytes() {
-                    return Err(MemoryError::EditionMismatch {
-                        expected: format_edition(Some(&expected_edition)),
-                        actual: format_edition(Some(current_edition.as_bytes())),
-                    });
-                }
+                    // Check CAS condition
+                    if expected_edition != current_edition.as_bytes() {
+                        return Err(MemoryError::EditionMismatch {
+                            expected: format_edition(Some(&expected_edition)),
+                            actual: format_edition(Some(current_edition.as_bytes())),
+                        });
+                    }
 
-                // Delete the value
-                object_store.delete(key).await.map_err(storage_error)?;
+                    // Delete the value
+                    object_store.delete(key).await.map_err(storage_error)?;
 
-                Ok(())
-            })
-            .await
+                    Ok(())
+                })
+                .await
+        }
+        .await;
+
+        self.return_session(subject, session);
+        result
     }
 }
 
@@ -207,7 +235,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_resolves_non_existent_cell() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-resolve-none");
 
         let effect = subject
@@ -216,7 +244,7 @@ mod tests {
             .attenuate(Cell::new("missing"))
             .invoke(Resolve);
 
-        let result = effect.perform(&mut provider).await?;
+        let result = effect.perform(&provider).await?;
         assert!(result.is_none());
 
         Ok(())
@@ -224,7 +252,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_publishes_new_content() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-publish-new");
         let content = b"hello world".to_vec();
 
@@ -235,7 +263,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -246,7 +274,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -258,7 +286,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_updates_existing_content() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-publish-update");
 
         // Create initial content
@@ -268,7 +296,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Update with correct edition
@@ -278,7 +306,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"updated", Some(edition1.clone())))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert_ne!(edition1, edition2);
@@ -289,7 +317,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -300,7 +328,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_fails_on_edition_mismatch() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-mismatch");
 
         // Create initial content
@@ -310,7 +338,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to update with wrong edition
@@ -320,7 +348,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"updated", Some(wrong_edition)))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -330,7 +358,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_fails_creating_when_exists() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-create-exists");
 
         // Create initial content
@@ -340,7 +368,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to create again (when = None means expect empty)
@@ -349,7 +377,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"new", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -359,7 +387,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_retracts_content() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-retract");
 
         // Create content
@@ -369,7 +397,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"to be deleted", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Retract with correct edition
@@ -379,7 +407,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Retract::new(edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Verify deleted
@@ -388,7 +416,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(resolved.is_none());
@@ -398,7 +426,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_fails_retract_on_edition_mismatch() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-retract-mismatch");
 
         // Create content
@@ -408,7 +436,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"content", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to retract with wrong edition
@@ -418,7 +446,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Retract::new(wrong_edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -428,7 +456,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_different_spaces() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-spaces");
 
         // Publish to different spaces
@@ -438,7 +466,7 @@ mod tests {
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(b"content1", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -447,7 +475,7 @@ mod tests {
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(b"content2", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Resolve from space1
@@ -457,7 +485,7 @@ mod tests {
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result1.unwrap().content, b"content1".to_vec());
 
@@ -467,7 +495,7 @@ mod tests {
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result2.unwrap().content, b"content2".to_vec());
 
@@ -476,7 +504,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_succeeds_with_stale_edition_when_value_matches() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-stale-ok");
         let content = b"desired value".to_vec();
 
@@ -487,7 +515,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to publish same content with wrong edition - should succeed
@@ -497,7 +525,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), Some(wrong_edition)))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(result.is_ok());
@@ -511,7 +539,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_produces_deterministic_content_hash() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-deterministic-hash");
         let content = b"same content".to_vec();
 
@@ -522,7 +550,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell1"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Create same value at cell2
@@ -531,7 +559,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell2"))
             .invoke(Publish::new(content, None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Same content should produce same edition (content hash)
@@ -542,7 +570,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_succeeds_retracting_already_retracted() -> anyhow::Result<()> {
-        let mut provider = IndexedDb::new();
+        let provider = IndexedDb::new();
         let subject = unique_subject("memory-retract-already-retracted");
 
         // Try to retract non-existent cell - should succeed
@@ -552,7 +580,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("nonexistent"))
             .invoke(Retract::new(wrong_edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(result.is_ok());

--- a/rust/dialog-storage/src/storage/provider/network.rs
+++ b/rust/dialog-storage/src/storage/provider/network.rs
@@ -26,7 +26,7 @@
 //! # let did: Did = "did:key:z6Mk...".parse().unwrap();
 //! # let digest = Blake3Hash::hash(b"hello");
 //!
-//! let mut network = Network::new(issuer);
+//! let network = Network::new(issuer);
 //!
 //! let cap = Subject::from(did)
 //!     .attenuate(Archive)
@@ -39,7 +39,7 @@
 //! )
 //! .unwrap();
 //! RemoteInvocation::new(cap.clone(), s3_addr)
-//!     .perform(&mut network)
+//!     .perform(&network)
 //!     .await;
 //!
 //! // Route the same capability to a UCAN-delegated backend
@@ -48,7 +48,7 @@
 //!     delegation_chain,
 //! );
 //! RemoteInvocation::new(cap, ucan_addr)
-//!     .perform(&mut network)
+//!     .perform(&network)
 //!     .await;
 //! # }
 //! ```
@@ -126,7 +126,7 @@ mod archive_tests {
     async fn it_returns_none_for_missing_content(
         env: helpers::PublicS3Address,
     ) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let digest = Blake3Hash::hash(b"nonexistent");
 
@@ -136,7 +136,7 @@ mod archive_tests {
             .invoke(Get::new(digest));
 
         let result = RemoteInvocation::new(capability, addr)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert!(result.is_none());
 
@@ -145,7 +145,7 @@ mod archive_tests {
 
     #[dialog_common::test]
     async fn it_stores_and_retrieves_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = b"hello world".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -158,7 +158,7 @@ mod archive_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         // Get content
@@ -169,7 +169,7 @@ mod archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -178,7 +178,7 @@ mod archive_tests {
 
     #[dialog_common::test]
     async fn it_handles_different_catalogs(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content1 = b"content for catalog 1".to_vec();
         let content2 = b"content for catalog 2".to_vec();
@@ -193,7 +193,7 @@ mod archive_tests {
                 .invoke(Put::new(digest1.clone(), content1.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -203,7 +203,7 @@ mod archive_tests {
                 .invoke(Put::new(digest2.clone(), content2.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         // Retrieve from catalog1
@@ -214,7 +214,7 @@ mod archive_tests {
                 .invoke(Get::new(digest1)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result1, Some(content1));
 
@@ -226,7 +226,7 @@ mod archive_tests {
                 .invoke(Get::new(digest2.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result2, Some(content2));
 
@@ -238,7 +238,7 @@ mod archive_tests {
                 .invoke(Get::new(digest2)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert!(cross.is_none());
 
@@ -249,7 +249,7 @@ mod archive_tests {
     async fn it_is_idempotent_for_same_content(
         env: helpers::PublicS3Address,
     ) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = b"idempotent content".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -263,7 +263,7 @@ mod archive_tests {
                     .invoke(Put::new(digest.clone(), content.clone())),
                 addr.clone(),
             )
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         }
 
@@ -275,7 +275,7 @@ mod archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -284,7 +284,7 @@ mod archive_tests {
 
     #[dialog_common::test]
     async fn it_handles_empty_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = vec![];
         let digest = Blake3Hash::hash(&content);
@@ -296,7 +296,7 @@ mod archive_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result = RemoteInvocation::new(
@@ -306,7 +306,7 @@ mod archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -315,7 +315,7 @@ mod archive_tests {
 
     #[dialog_common::test]
     async fn it_handles_large_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         // 100KB content (matching S3 backend test size)
         let content: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
@@ -328,7 +328,7 @@ mod archive_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result = RemoteInvocation::new(
@@ -338,7 +338,7 @@ mod archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -349,7 +349,7 @@ mod archive_tests {
     async fn it_caches_connections_across_invocations(
         env: helpers::PublicS3Address,
     ) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = b"cached connection content".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -362,7 +362,7 @@ mod archive_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         // Get via second invocation (should reuse cached connection)
@@ -373,7 +373,7 @@ mod archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -382,7 +382,7 @@ mod archive_tests {
 
     #[dialog_common::test]
     async fn it_performs_multiple_operations(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         // Store 3 different blobs
@@ -402,7 +402,7 @@ mod archive_tests {
                     .invoke(Put::new(digest.clone(), content.clone())),
                 addr.clone(),
             )
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         }
 
@@ -415,7 +415,7 @@ mod archive_tests {
                     .invoke(Get::new(digest.clone())),
                 addr.clone(),
             )
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
             assert_eq!(result, Some(content.clone()));
         }
@@ -429,7 +429,7 @@ mod archive_tests {
                 .invoke(Get::new(missing_digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, None);
 
@@ -473,7 +473,7 @@ mod archive_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_returns_none_for_missing_content(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let digest = Blake3Hash::hash(b"nonexistent");
 
@@ -484,7 +484,7 @@ mod archive_signed_session_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert!(result.is_none());
 
@@ -493,7 +493,7 @@ mod archive_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_stores_and_retrieves_content(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = b"hello world signed".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -505,7 +505,7 @@ mod archive_signed_session_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result = RemoteInvocation::new(
@@ -515,7 +515,7 @@ mod archive_signed_session_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -524,7 +524,7 @@ mod archive_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_handles_different_catalogs(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content1 = b"signed catalog 1".to_vec();
         let content2 = b"signed catalog 2".to_vec();
@@ -538,7 +538,7 @@ mod archive_signed_session_tests {
                 .invoke(Put::new(digest1.clone(), content1.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -548,7 +548,7 @@ mod archive_signed_session_tests {
                 .invoke(Put::new(digest2.clone(), content2.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result1 = RemoteInvocation::new(
@@ -558,7 +558,7 @@ mod archive_signed_session_tests {
                 .invoke(Get::new(digest1)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result1, Some(content1));
 
@@ -569,7 +569,7 @@ mod archive_signed_session_tests {
                 .invoke(Get::new(digest2.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result2, Some(content2));
 
@@ -581,7 +581,7 @@ mod archive_signed_session_tests {
                 .invoke(Get::new(digest2)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert!(cross.is_none());
 
@@ -590,7 +590,7 @@ mod archive_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_fails_with_wrong_credentials(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider: Network<helpers::Session> =
+        let provider: Network<helpers::Session> =
             Network::new(helpers::Session::new(TEST_SUBJECT.parse::<Did>().unwrap()));
         let addr = s3::Credentials::private(
             Address::new(&env.endpoint, "us-east-1", &env.bucket),
@@ -610,7 +610,7 @@ mod archive_signed_session_tests {
                 .invoke(Put::new(digest, content)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await;
 
         assert!(
@@ -623,7 +623,7 @@ mod archive_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_handles_large_content(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
         let digest = Blake3Hash::hash(&content);
@@ -635,7 +635,7 @@ mod archive_signed_session_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result = RemoteInvocation::new(
@@ -645,7 +645,7 @@ mod archive_signed_session_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -698,7 +698,7 @@ mod ucan_archive_tests {
         env: helpers::UcanS3Address,
     ) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
         let digest = Blake3Hash::hash(b"nonexistent");
 
@@ -709,7 +709,7 @@ mod ucan_archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert!(result.is_none());
 
@@ -719,7 +719,7 @@ mod ucan_archive_tests {
     #[dialog_common::test]
     async fn it_stores_and_retrieves_content(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
         let content = b"hello world ucan".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -731,7 +731,7 @@ mod ucan_archive_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result = RemoteInvocation::new(
@@ -741,7 +741,7 @@ mod ucan_archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -751,7 +751,7 @@ mod ucan_archive_tests {
     #[dialog_common::test]
     async fn it_handles_different_catalogs(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
         let content1 = b"ucan catalog 1".to_vec();
         let content2 = b"ucan catalog 2".to_vec();
@@ -765,7 +765,7 @@ mod ucan_archive_tests {
                 .invoke(Put::new(digest1.clone(), content1.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -775,7 +775,7 @@ mod ucan_archive_tests {
                 .invoke(Put::new(digest2.clone(), content2.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result1 = RemoteInvocation::new(
@@ -785,7 +785,7 @@ mod ucan_archive_tests {
                 .invoke(Get::new(digest1)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result1, Some(content1));
 
@@ -796,7 +796,7 @@ mod ucan_archive_tests {
                 .invoke(Get::new(digest2.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result2, Some(content2));
 
@@ -808,7 +808,7 @@ mod ucan_archive_tests {
                 .invoke(Get::new(digest2)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert!(cross.is_none());
 
@@ -818,7 +818,7 @@ mod ucan_archive_tests {
     #[dialog_common::test]
     async fn it_is_idempotent_for_same_content(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
         let content = b"idempotent ucan content".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -831,7 +831,7 @@ mod ucan_archive_tests {
                     .invoke(Put::new(digest.clone(), content.clone())),
                 addr.clone(),
             )
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         }
 
@@ -842,7 +842,7 @@ mod ucan_archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -852,7 +852,7 @@ mod ucan_archive_tests {
     #[dialog_common::test]
     async fn it_handles_large_content(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
         let content: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
         let digest = Blake3Hash::hash(&content);
@@ -864,7 +864,7 @@ mod ucan_archive_tests {
                 .invoke(Put::new(digest.clone(), content.clone())),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result = RemoteInvocation::new(
@@ -874,7 +874,7 @@ mod ucan_archive_tests {
                 .invoke(Get::new(digest)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result, Some(content));
 
@@ -913,7 +913,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_resolves_non_existent_cell(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         let cap = test_subject()
@@ -922,9 +922,7 @@ mod transactional_memory_tests {
             .attenuate(Cell::new("missing"))
             .invoke(Resolve);
 
-        let result = RemoteInvocation::new(cap, addr)
-            .perform(&mut provider)
-            .await?;
+        let result = RemoteInvocation::new(cap, addr).perform(&provider).await?;
         assert!(result.is_none());
 
         Ok(())
@@ -932,7 +930,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_publishes_new_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = b"hello world".to_vec();
 
@@ -945,7 +943,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -959,7 +957,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -971,7 +969,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_updates_existing_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         // Create initial content
@@ -983,7 +981,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"initial", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         // Update with correct edition
@@ -995,7 +993,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"updated", Some(edition1.clone()))),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert_ne!(edition1, edition2);
@@ -1009,7 +1007,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1020,7 +1018,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_fails_on_edition_mismatch(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         RemoteInvocation::new(
@@ -1031,7 +1029,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"initial", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let wrong_edition = b"wrong-etag".to_vec();
@@ -1043,7 +1041,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"updated", Some(wrong_edition))),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -1053,7 +1051,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_fails_creating_when_exists(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         RemoteInvocation::new(
@@ -1064,7 +1062,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"initial", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result = RemoteInvocation::new(
@@ -1075,7 +1073,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"new", None)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -1085,7 +1083,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_retracts_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         // Create content
@@ -1097,7 +1095,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"to be deleted", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         // Retract with correct edition
@@ -1109,7 +1107,7 @@ mod transactional_memory_tests {
                 .invoke(Retract::new(edition)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         // Verify deleted
@@ -1121,7 +1119,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(resolved.is_none());
@@ -1131,7 +1129,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_handles_different_spaces(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         // Publish to different spaces
@@ -1143,7 +1141,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"content1", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -1154,7 +1152,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(b"content2", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         // Resolve from space1
@@ -1166,7 +1164,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result1.unwrap().content, b"content1".to_vec());
 
@@ -1179,7 +1177,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result2.unwrap().content, b"content2".to_vec());
 
@@ -1188,7 +1186,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_handles_nested_spaces(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = b"nested content".to_vec();
 
@@ -1201,7 +1199,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -1215,7 +1213,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1226,7 +1224,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_handles_empty_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = vec![];
 
@@ -1238,7 +1236,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -1251,7 +1249,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1262,7 +1260,7 @@ mod transactional_memory_tests {
 
     #[dialog_common::test]
     async fn it_handles_large_content(env: helpers::PublicS3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         // 100KB content (matching S3 backend test size)
         let content: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
@@ -1275,7 +1273,7 @@ mod transactional_memory_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -1288,7 +1286,7 @@ mod transactional_memory_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1301,7 +1299,7 @@ mod transactional_memory_tests {
     async fn it_succeeds_retracting_already_retracted(
         env: helpers::PublicS3Address,
     ) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         // Try to retract non-existent cell - should succeed
@@ -1314,7 +1312,7 @@ mod transactional_memory_tests {
                 .invoke(Retract::new(wrong_edition)),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await;
 
         assert!(result.is_ok());
@@ -1358,7 +1356,7 @@ mod memory_cell_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_resolves_non_existent_cell(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         let result = RemoteInvocation::new(
@@ -1369,7 +1367,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert!(result.is_none());
 
@@ -1378,7 +1376,7 @@ mod memory_cell_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_publishes_new_content(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content = b"signed memory content".to_vec();
 
@@ -1390,7 +1388,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -1403,7 +1401,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1415,7 +1413,7 @@ mod memory_cell_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_updates_existing_content(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         let edition1 = RemoteInvocation::new(
@@ -1426,7 +1424,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(b"initial", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let edition2 = RemoteInvocation::new(
@@ -1437,7 +1435,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(b"updated", Some(edition1.clone()))),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert_ne!(edition1, edition2);
@@ -1450,7 +1448,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1461,7 +1459,7 @@ mod memory_cell_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_fails_on_edition_mismatch(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         RemoteInvocation::new(
@@ -1472,7 +1470,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(b"initial", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let wrong_edition = b"wrong-etag".to_vec();
@@ -1484,7 +1482,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(b"updated", Some(wrong_edition))),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -1494,7 +1492,7 @@ mod memory_cell_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_retracts_content(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         let edition = RemoteInvocation::new(
@@ -1505,7 +1503,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(b"to be deleted", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -1516,7 +1514,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Retract::new(edition)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let resolved = RemoteInvocation::new(
@@ -1527,7 +1525,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(resolved.is_none());
@@ -1537,7 +1535,7 @@ mod memory_cell_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_handles_different_spaces(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
 
         RemoteInvocation::new(
@@ -1548,7 +1546,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(b"content1", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -1559,7 +1557,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(b"content2", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result1 = RemoteInvocation::new(
@@ -1570,7 +1568,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Resolve),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result1.unwrap().content, b"content1".to_vec());
 
@@ -1582,7 +1580,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result2.unwrap().content, b"content2".to_vec());
 
@@ -1591,7 +1589,7 @@ mod memory_cell_signed_session_tests {
 
     #[dialog_common::test]
     async fn it_handles_large_content(env: helpers::S3Address) -> anyhow::Result<()> {
-        let mut provider = create_network_provider(&env);
+        let provider = create_network_provider(&env);
         let addr = create_address(&env);
         let content: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
 
@@ -1603,7 +1601,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -1616,7 +1614,7 @@ mod memory_cell_signed_session_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1668,7 +1666,7 @@ mod ucan_memory_cell_tests {
     #[dialog_common::test]
     async fn it_resolves_non_existent_cell(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
 
         let result = RemoteInvocation::new(
@@ -1679,7 +1677,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert!(result.is_none());
 
@@ -1689,7 +1687,7 @@ mod ucan_memory_cell_tests {
     #[dialog_common::test]
     async fn it_publishes_new_content(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
         let content = b"ucan memory content".to_vec();
 
@@ -1701,7 +1699,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -1714,7 +1712,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1727,7 +1725,7 @@ mod ucan_memory_cell_tests {
     #[dialog_common::test]
     async fn it_updates_existing_content(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
 
         let edition1 = RemoteInvocation::new(
@@ -1738,7 +1736,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(b"initial", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let edition2 = RemoteInvocation::new(
@@ -1749,7 +1747,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(b"updated", Some(edition1.clone()))),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert_ne!(edition1, edition2);
@@ -1762,7 +1760,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");
@@ -1774,7 +1772,7 @@ mod ucan_memory_cell_tests {
     #[dialog_common::test]
     async fn it_fails_on_edition_mismatch(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
 
         RemoteInvocation::new(
@@ -1785,7 +1783,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(b"initial", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let wrong_edition = b"wrong-etag".to_vec();
@@ -1797,7 +1795,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(b"updated", Some(wrong_edition))),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -1808,7 +1806,7 @@ mod ucan_memory_cell_tests {
     #[dialog_common::test]
     async fn it_retracts_content(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
 
         let edition = RemoteInvocation::new(
@@ -1819,7 +1817,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(b"to be deleted", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -1830,7 +1828,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Retract::new(edition)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let resolved = RemoteInvocation::new(
@@ -1841,7 +1839,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(resolved.is_none());
@@ -1852,7 +1850,7 @@ mod ucan_memory_cell_tests {
     #[dialog_common::test]
     async fn it_handles_different_spaces(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
 
         RemoteInvocation::new(
@@ -1863,7 +1861,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(b"content1", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         RemoteInvocation::new(
@@ -1874,7 +1872,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(b"content2", None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let result1 = RemoteInvocation::new(
@@ -1885,7 +1883,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Resolve),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result1.unwrap().content, b"content1".to_vec());
 
@@ -1897,7 +1895,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
         assert_eq!(result2.unwrap().content, b"content2".to_vec());
 
@@ -1907,7 +1905,7 @@ mod ucan_memory_cell_tests {
     #[dialog_common::test]
     async fn it_handles_large_content(env: helpers::UcanS3Address) -> anyhow::Result<()> {
         let operator = Ed25519Signer::generate().await.unwrap();
-        let mut provider = create_network_provider(&operator);
+        let provider = create_network_provider(&operator);
         let addr = create_address(&env, &operator).await;
         let content: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
 
@@ -1919,7 +1917,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Publish::new(content.clone(), None)),
             addr.clone(),
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         assert!(!edition.is_empty());
@@ -1932,7 +1930,7 @@ mod ucan_memory_cell_tests {
                 .invoke(Resolve),
             addr,
         )
-        .perform(&mut provider)
+        .perform(&provider)
         .await?;
 
         let publication = resolved.expect("should have content");

--- a/rust/dialog-storage/src/storage/provider/network/emulator.rs
+++ b/rust/dialog-storage/src/storage/provider/network/emulator.rs
@@ -16,9 +16,10 @@ use async_trait::async_trait;
 use dialog_capability::{Capability, Constraint, Effect, Provider, ProviderRoute};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::remote::RemoteInvocation;
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 pub use crate::Emulator;
 use crate::provider::volatile::Volatile;
@@ -28,9 +29,10 @@ use crate::provider::volatile::Volatile;
 /// Each address gets its own independent `Volatile` instance, so data
 /// stored via one address is isolated from other addresses.
 ///
-/// Uses `RwLock` for interior mutability so `Provider::execute` can take
-/// `&self`. Connections are wrapped in `Arc` so they can be cloned out
-/// of the lock before any `.await` points.
+/// Uses `parking_lot::RwLock` for interior mutability so
+/// `Provider::execute` can take `&self`. Connections are wrapped in
+/// `Arc` so they can be cloned out of the lock before any `.await`
+/// points.
 ///
 /// Implements [`ProviderRoute`] so it can be used as a field in a
 /// `#[derive(Router)]` struct.
@@ -71,10 +73,8 @@ where
         let (capability, address) = input.into_parts();
 
         // Check the cache (read lock, dropped immediately).
-        // Recover from lock poisoning — emulator data may be
-        // inconsistent but we avoid panicking the current thread.
         let volatile = {
-            let cache = self.connections.read().unwrap_or_else(|e| e.into_inner());
+            let cache = self.connections.read();
             cache.get(&address).cloned()
         };
 
@@ -85,7 +85,6 @@ where
                 // Insert into cache (write lock, dropped immediately).
                 self.connections
                     .write()
-                    .unwrap_or_else(|e| e.into_inner())
                     .insert(address.clone(), new_volatile.clone());
                 new_volatile
             }

--- a/rust/dialog-storage/src/storage/provider/network/emulator.rs
+++ b/rust/dialog-storage/src/storage/provider/network/emulator.rs
@@ -18,6 +18,7 @@ use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::remote::RemoteInvocation;
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::sync::{Arc, RwLock};
 
 pub use crate::Emulator;
 use crate::provider::volatile::Volatile;
@@ -27,17 +28,21 @@ use crate::provider::volatile::Volatile;
 /// Each address gets its own independent `Volatile` instance, so data
 /// stored via one address is isolated from other addresses.
 ///
+/// Uses `RwLock` for interior mutability so `Provider::execute` can take
+/// `&self`. Connections are wrapped in `Arc` so they can be cloned out
+/// of the lock before any `.await` points.
+///
 /// Implements [`ProviderRoute`] so it can be used as a field in a
 /// `#[derive(Router)]` struct.
 pub struct Route<Address> {
-    connections: HashMap<Address, Volatile>,
+    connections: RwLock<HashMap<Address, Arc<Volatile>>>,
 }
 
 impl<Address> Route<Address> {
     /// Create a new emulated route with no cached connections.
     pub fn new() -> Self {
         Self {
-            connections: HashMap::new(),
+            connections: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -62,12 +67,31 @@ where
     Address: Eq + Hash + Clone + ConditionalSend + ConditionalSync + 'static,
     Volatile: Provider<Fx>,
 {
-    async fn execute(&mut self, input: RemoteInvocation<Fx, Address>) -> Fx::Output {
+    async fn execute(&self, input: RemoteInvocation<Fx, Address>) -> Fx::Output {
         let (capability, address) = input.into_parts();
-        if !self.connections.contains_key(&address) {
-            self.connections.insert(address.clone(), Volatile::new());
-        }
-        let volatile = self.connections.get_mut(&address).unwrap();
-        <Volatile as Provider<Fx>>::execute(volatile, capability).await
+
+        // Check the cache (read lock, dropped immediately).
+        // Recover from lock poisoning — emulator data may be
+        // inconsistent but we avoid panicking the current thread.
+        let volatile = {
+            let cache = self.connections.read().unwrap_or_else(|e| e.into_inner());
+            cache.get(&address).cloned()
+        };
+
+        let volatile = match volatile {
+            Some(v) => v,
+            None => {
+                let new_volatile = Arc::new(Volatile::new());
+                // Insert into cache (write lock, dropped immediately).
+                self.connections
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(address.clone(), new_volatile.clone());
+                new_volatile
+            }
+        };
+
+        // Execute on the Arc'd volatile — no lock held.
+        <Volatile as Provider<Fx>>::execute(&volatile, capability).await
     }
 }

--- a/rust/dialog-storage/src/storage/provider/network/route.rs
+++ b/rust/dialog-storage/src/storage/provider/network/route.rs
@@ -7,6 +7,7 @@
 
 use std::convert::Infallible;
 use std::hash::Hash;
+use std::sync::Arc;
 
 use crate::resource::{Pool, Resource};
 use dialog_capability::{Capability, Constraint, Effect, Provider, ProviderRoute};
@@ -22,10 +23,13 @@ use dialog_effects::remote::RemoteInvocation;
 /// The `Connection` type must implement `Resource<(Address, Issuer)>` so
 /// that new connections can be opened from the (address, issuer) pair.
 ///
+/// Connections are cached in `Arc` wrappers so they can be cloned out of the
+/// pool's `RwLock` before any `.await` points.
+///
 /// [`RemoteInvocation`]: dialog_effects::remote::RemoteInvocation
 pub struct Route<Issuer, Address, Connection> {
     issuer: Issuer,
-    connections: Pool<Address, Connection>,
+    connections: Pool<Address, Arc<Connection>>,
 }
 
 impl<Issuer, Address, Connection> Route<Issuer, Address, Connection> {
@@ -52,20 +56,33 @@ where
     Capability<Fx>: ConditionalSend,
     Issuer: Clone + ConditionalSend + ConditionalSync + 'static,
     Address: Clone + Eq + Hash + ConditionalSend + ConditionalSync + 'static,
-    Connection:
-        Resource<(Address, Issuer), Error = Infallible> + Provider<Fx> + ConditionalSend + 'static,
+    Connection: Resource<(Address, Issuer), Error = Infallible>
+        + Provider<Fx>
+        + ConditionalSend
+        + ConditionalSync
+        + 'static,
 {
-    async fn execute(&mut self, input: RemoteInvocation<Fx, Address>) -> Fx::Output {
+    async fn execute(&self, input: RemoteInvocation<Fx, Address>) -> Fx::Output {
         let (capability, address) = input.into_parts();
-        if self.connections.get_mut(&address).is_none() {
-            let connection = match Connection::open(&(address.clone(), self.issuer.clone())).await {
-                Ok(c) => c,
-                Err(error) => match error {},
-            };
-            self.connections.insert(address.clone(), connection);
-        }
-        let connection = self.connections.get_mut(&address).unwrap();
-        <Connection as Provider<Fx>>::execute(connection, capability).await
+
+        // Check the pool (read lock, dropped immediately).
+        let connection = match self.connections.get(&address) {
+            Some(conn) => conn,
+            None => {
+                // Open a new connection with no lock held during the await.
+                let new_conn = match Connection::open(&(address.clone(), self.issuer.clone())).await
+                {
+                    Ok(c) => Arc::new(c),
+                    Err(error) => match error {},
+                };
+                // Insert into pool (write lock, dropped immediately).
+                self.connections.insert(address.clone(), new_conn.clone());
+                new_conn
+            }
+        };
+
+        // Execute on the Arc'd connection — no lock held.
+        <Connection as Provider<Fx>>::execute(&connection, capability).await
     }
 }
 
@@ -104,7 +121,7 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     impl Provider<Get> for MockConnection {
-        async fn execute(&mut self, effect: Capability<Get>) -> Option<Vec<u8>> {
+        async fn execute(&self, effect: Capability<Get>) -> Option<Vec<u8>> {
             let get: &Get = effect.policy();
             self.data.get(&get.key).cloned()
         }
@@ -124,7 +141,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_routes_and_caches_connections() {
-        let mut route: Route<TestIssuer, TestCredentials, MockConnection> =
+        let route: Route<TestIssuer, TestCredentials, MockConnection> =
             Route::new(TestIssuer("issuer-1".into()));
 
         let creds = TestCredentials("site-a".into());
@@ -138,25 +155,24 @@ mod tests {
 
         // First invocation opens and caches the connection
         let remote = RemoteInvocation::new(capability, creds.clone());
-        let result = remote.perform(&mut route).await;
+        let result = remote.perform(&route).await;
         assert_eq!(result, None); // empty connection, no data
 
-        // Insert data into the cached connection directly
-        route
-            .connections
-            .get_mut(&creds)
-            .unwrap()
-            .data
-            .insert("my-key".into(), b"hello".to_vec());
+        // Pre-populate a connection with data and insert it
+        let mut conn = MockConnection {
+            data: HashMap::new(),
+        };
+        conn.data.insert("my-key".into(), b"hello".to_vec());
+        route.connections.insert(creds.clone(), Arc::new(conn));
 
-        // Second invocation reuses the cached connection
+        // Second invocation uses the newly inserted connection
         let capability = dialog_capability::Subject::from(did)
             .attenuate(Archive)
             .invoke(Get {
                 key: "my-key".into(),
             });
         let remote = RemoteInvocation::new(capability, creds);
-        let result = remote.perform(&mut route).await;
+        let result = remote.perform(&route).await;
         assert_eq!(result, Some(b"hello".to_vec()));
     }
 
@@ -195,7 +211,7 @@ mod tests {
         #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
         #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
         impl Provider<RemoteInvocation<Fetch, AlphaAddr>> for AlphaBackend {
-            async fn execute(&mut self, input: RemoteInvocation<Fetch, AlphaAddr>) -> String {
+            async fn execute(&self, input: RemoteInvocation<Fetch, AlphaAddr>) -> String {
                 let (cap, addr) = input.into_parts();
                 let fetch: &Fetch = cap.policy();
                 format!("alpha:{}:{}", addr.0, fetch.key)
@@ -211,7 +227,7 @@ mod tests {
         #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
         #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
         impl Provider<RemoteInvocation<Fetch, BetaAddr>> for BetaBackend {
-            async fn execute(&mut self, input: RemoteInvocation<Fetch, BetaAddr>) -> String {
+            async fn execute(&self, input: RemoteInvocation<Fetch, BetaAddr>) -> String {
                 let (cap, addr) = input.into_parts();
                 let fetch: &Fetch = cap.policy();
                 format!("beta:{}:{}", addr.0, fetch.key)
@@ -226,7 +242,7 @@ mod tests {
 
         #[dialog_common::test]
         async fn it_routes_via_derive_macro() {
-            let mut router = CompositeRouter {
+            let router = CompositeRouter {
                 alpha: AlphaBackend,
                 beta: BetaBackend,
             };
@@ -237,7 +253,7 @@ mod tests {
                     key: "doc-1".into(),
                 });
             let remote_a = RemoteInvocation::new(cap_a, AlphaAddr("site-a".into()));
-            let result_a = remote_a.perform(&mut router).await;
+            let result_a = remote_a.perform(&router).await;
             assert_eq!(result_a, "alpha:site-a:doc-1");
 
             let cap_b = Subject::from("did:key:zBeta".parse::<Did>().unwrap())
@@ -246,7 +262,7 @@ mod tests {
                     key: "doc-2".into(),
                 });
             let remote_b = RemoteInvocation::new(cap_b, BetaAddr("site-b".into()));
-            let result_b = remote_b.perform(&mut router).await;
+            let result_b = remote_b.perform(&router).await;
             assert_eq!(result_b, "beta:site-b:doc-2");
         }
     }

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -80,6 +80,15 @@ pub enum VolatileError {
     /// CAS condition failed.
     #[error("CAS condition failed: {0}")]
     Cas(String),
+    /// RwLock was poisoned by a panicking thread.
+    #[error("Lock poisoned: {0}")]
+    LockPoisoned(String),
+}
+
+impl<T> From<std::sync::PoisonError<T>> for VolatileError {
+    fn from(e: std::sync::PoisonError<T>) -> Self {
+        VolatileError::LockPoisoned(e.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -20,7 +20,7 @@
 //! use dialog_common::Blake3Hash;
 //!
 //! # async fn example() -> anyhow::Result<()> {
-//! let mut provider = Volatile::new();
+//! let provider = Volatile::new();
 //! let digest = Blake3Hash::hash(b"hello");
 //!
 //! let effect = Subject::from(did!("key:z6Mk..."))
@@ -28,7 +28,7 @@
 //!     .attenuate(Catalog::new("index"))
 //!     .invoke(Get::new(digest));
 //!
-//! let result = effect.perform(&mut provider).await?;
+//! let result = effect.perform(&provider).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -38,6 +38,7 @@ mod memory;
 
 use dialog_capability::Did;
 use std::collections::HashMap;
+use std::sync::RwLock;
 
 /// Archive key: (catalog, digest_base58)
 type ArchiveKey = (String, String);
@@ -58,20 +59,18 @@ struct Session {
 ///
 /// A simple provider that stores all data in memory. Each subject DID gets its
 /// own session with separate archive and memory storage. Data is not persisted.
+///
+/// Uses `RwLock` for interior mutability so that `Provider::execute` can take
+/// `&self`. All lock guards are dropped before any `.await` points.
 #[derive(Default, Debug)]
 pub struct Volatile {
-    sessions: HashMap<Did, Session>,
+    sessions: RwLock<HashMap<Did, Session>>,
 }
 
 impl Volatile {
     /// Creates a new volatile provider.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Gets or creates a session for the given subject.
-    fn session(&mut self, subject: &Did) -> &mut Session {
-        self.sessions.entry(subject.clone()).or_default()
     }
 }
 
@@ -93,53 +92,84 @@ mod tests {
     #[dialog_common::test]
     fn it_creates_new_provider() {
         let provider = Volatile::new();
-        assert!(provider.sessions.is_empty());
+        assert!(
+            provider
+                .sessions
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty()
+        );
     }
 
     #[dialog_common::test]
     fn it_creates_session_on_demand() {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = did!("test:subject1");
 
-        let _session = provider.session(&subject);
-        assert!(provider.sessions.contains_key(&subject));
+        provider
+            .sessions
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(subject.clone())
+            .or_default();
+        assert!(
+            provider
+                .sessions
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains_key(&subject)
+        );
     }
 
     #[dialog_common::test]
     fn it_reuses_existing_session() {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = did!("test:subject2");
 
         // First access creates session
         let digest = Blake3Hash::hash(b"test").as_bytes().to_base58();
         provider
-            .session(&subject)
+            .sessions
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(subject.clone())
+            .or_default()
             .archive
             .insert(("catalog".to_string(), digest), b"value".to_vec());
 
         // Second access should see the same data
-        let session = provider.session(&subject);
+        let sessions = provider.sessions.read().unwrap_or_else(|e| e.into_inner());
+        let session = sessions.get(&subject).unwrap();
         assert_eq!(session.archive.len(), 1);
     }
 
     #[dialog_common::test]
     fn it_isolates_sessions_by_subject() {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject1 = did!("test:subject-a");
         let subject2 = did!("test:subject-b");
 
         let digest = Blake3Hash::hash(b"test").as_bytes().to_base58();
         provider
-            .session(&subject1)
+            .sessions
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(subject1.clone())
+            .or_default()
             .archive
             .insert(("catalog".to_string(), digest.clone()), b"value1".to_vec());
 
         provider
-            .session(&subject2)
+            .sessions
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(subject2.clone())
+            .or_default()
             .archive
             .insert(("catalog".to_string(), digest), b"value2".to_vec());
 
-        assert_eq!(provider.session(&subject1).archive.len(), 1);
-        assert_eq!(provider.session(&subject2).archive.len(), 1);
+        let sessions = provider.sessions.read().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(sessions.get(&subject1).unwrap().archive.len(), 1);
+        assert_eq!(sessions.get(&subject2).unwrap().archive.len(), 1);
     }
 }

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -37,8 +37,8 @@ mod archive;
 mod memory;
 
 use dialog_capability::Did;
+use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::RwLock;
 
 /// Archive key: (catalog, digest_base58)
 type ArchiveKey = (String, String);
@@ -60,8 +60,10 @@ struct Session {
 /// A simple provider that stores all data in memory. Each subject DID gets its
 /// own session with separate archive and memory storage. Data is not persisted.
 ///
-/// Uses `RwLock` for interior mutability so that `Provider::execute` can take
-/// `&self`. All lock guards are dropped before any `.await` points.
+/// Uses `parking_lot::RwLock` for interior mutability so that
+/// `Provider::execute` can take `&self`. All lock guards are dropped before
+/// any `.await` points. Unlike `std::sync::RwLock`, `parking_lot` locks are
+/// infallible (no poisoning).
 #[derive(Default, Debug)]
 pub struct Volatile {
     sessions: RwLock<HashMap<Did, Session>>,
@@ -80,15 +82,6 @@ pub enum VolatileError {
     /// CAS condition failed.
     #[error("CAS condition failed: {0}")]
     Cas(String),
-    /// RwLock was poisoned by a panicking thread.
-    #[error("Lock poisoned: {0}")]
-    LockPoisoned(String),
-}
-
-impl<T> From<std::sync::PoisonError<T>> for VolatileError {
-    fn from(e: std::sync::PoisonError<T>) -> Self {
-        VolatileError::LockPoisoned(e.to_string())
-    }
 }
 
 #[cfg(test)]
@@ -101,13 +94,7 @@ mod tests {
     #[dialog_common::test]
     fn it_creates_new_provider() {
         let provider = Volatile::new();
-        assert!(
-            provider
-                .sessions
-                .read()
-                .unwrap_or_else(|e| e.into_inner())
-                .is_empty()
-        );
+        assert!(provider.sessions.read().is_empty());
     }
 
     #[dialog_common::test]
@@ -118,16 +105,9 @@ mod tests {
         provider
             .sessions
             .write()
-            .unwrap_or_else(|e| e.into_inner())
             .entry(subject.clone())
             .or_default();
-        assert!(
-            provider
-                .sessions
-                .read()
-                .unwrap_or_else(|e| e.into_inner())
-                .contains_key(&subject)
-        );
+        assert!(provider.sessions.read().contains_key(&subject));
     }
 
     #[dialog_common::test]
@@ -140,14 +120,13 @@ mod tests {
         provider
             .sessions
             .write()
-            .unwrap_or_else(|e| e.into_inner())
             .entry(subject.clone())
             .or_default()
             .archive
             .insert(("catalog".to_string(), digest), b"value".to_vec());
 
         // Second access should see the same data
-        let sessions = provider.sessions.read().unwrap_or_else(|e| e.into_inner());
+        let sessions = provider.sessions.read();
         let session = sessions.get(&subject).unwrap();
         assert_eq!(session.archive.len(), 1);
     }
@@ -162,7 +141,6 @@ mod tests {
         provider
             .sessions
             .write()
-            .unwrap_or_else(|e| e.into_inner())
             .entry(subject1.clone())
             .or_default()
             .archive
@@ -171,14 +149,63 @@ mod tests {
         provider
             .sessions
             .write()
-            .unwrap_or_else(|e| e.into_inner())
             .entry(subject2.clone())
             .or_default()
             .archive
             .insert(("catalog".to_string(), digest), b"value2".to_vec());
 
-        let sessions = provider.sessions.read().unwrap_or_else(|e| e.into_inner());
+        let sessions = provider.sessions.read();
         assert_eq!(sessions.get(&subject1).unwrap().archive.len(), 1);
         assert_eq!(sessions.get(&subject2).unwrap().archive.len(), 1);
+    }
+
+    /// Demonstrates that a provider can be shared across concurrent tasks,
+    /// which is the key motivation for `Provider::execute` taking `&self`
+    /// instead of `&mut self`.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_supports_concurrent_access() -> anyhow::Result<()> {
+        use dialog_capability::Subject;
+        use dialog_effects::archive::{Archive, Catalog, Get, Put};
+        use std::sync::Arc;
+
+        let provider = Arc::new(Volatile::new());
+
+        // Spawn multiple tasks that write to the same provider concurrently.
+        let mut handles = Vec::new();
+        for i in 0..10u8 {
+            let provider = provider.clone();
+            let handle = tokio::spawn(async move {
+                let subject = Subject::from(did!("test:concurrent"));
+                let content = vec![i; 64];
+                let digest = Blake3Hash::hash(&content);
+
+                subject
+                    .clone()
+                    .attenuate(Archive)
+                    .attenuate(Catalog::new("index"))
+                    .invoke(Put::new(digest.clone(), content))
+                    .perform(provider.as_ref())
+                    .await
+                    .unwrap();
+
+                let result = subject
+                    .attenuate(Archive)
+                    .attenuate(Catalog::new("index"))
+                    .invoke(Get::new(digest))
+                    .perform(provider.as_ref())
+                    .await
+                    .unwrap();
+
+                assert!(result.is_some());
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.await?;
+        }
+
+        Ok(())
     }
 }

--- a/rust/dialog-storage/src/storage/provider/volatile/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/archive.rs
@@ -16,21 +16,26 @@ impl From<VolatileError> for ArchiveError {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider<Get> for Volatile {
-    async fn execute(&mut self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
+    async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
         let subject = effect.subject().into();
         let catalog = effect.catalog();
         let digest = effect.digest();
 
         let key: ArchiveKey = (catalog.to_string(), digest.as_bytes().to_base58());
 
-        Ok(self.session(&subject).archive.get(&key).cloned())
+        // Recover from lock poisoning — session data may be
+        // inconsistent but we avoid panicking the current thread.
+        let sessions = self.sessions.read().unwrap_or_else(|e| e.into_inner());
+        Ok(sessions
+            .get(&subject)
+            .and_then(|session| session.archive.get(&key).cloned()))
     }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider<Put> for Volatile {
-    async fn execute(&mut self, effect: Capability<Put>) -> Result<(), ArchiveError> {
+    async fn execute(&self, effect: Capability<Put>) -> Result<(), ArchiveError> {
         let subject = effect.subject().into();
         let catalog = effect.catalog();
         let digest = effect.digest();
@@ -48,7 +53,9 @@ impl Provider<Put> for Volatile {
         let key: ArchiveKey = (catalog.to_string(), digest.as_bytes().to_base58());
 
         // Content-addressed storage is idempotent
-        self.session(&subject)
+        let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
+        let session = sessions.entry(subject).or_default();
+        session
             .archive
             .entry(key)
             .or_insert_with(|| content.to_vec());
@@ -79,7 +86,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_returns_none_for_missing_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("archive-get-none");
         let digest = Blake3Hash::hash(b"nonexistent");
 
@@ -88,7 +95,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
 
-        let result = effect.perform(&mut provider).await?;
+        let result = effect.perform(&provider).await?;
         assert!(result.is_none());
 
         Ok(())
@@ -96,7 +103,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_stores_and_retrieves_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("archive-put-get");
         let content = b"hello world".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -108,7 +115,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()));
 
-        put_effect.perform(&mut provider).await?;
+        put_effect.perform(&provider).await?;
 
         // Get content
         let get_effect = subject
@@ -116,7 +123,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
 
-        let result = get_effect.perform(&mut provider).await?;
+        let result = get_effect.perform(&provider).await?;
         assert_eq!(result, Some(content));
 
         Ok(())
@@ -124,7 +131,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_rejects_digest_mismatch() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("archive-mismatch");
         let content = b"hello world".to_vec();
         let wrong_digest = Blake3Hash::hash(b"different content");
@@ -134,7 +141,7 @@ mod tests {
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(wrong_digest, content));
 
-        let result = effect.perform(&mut provider).await;
+        let result = effect.perform(&provider).await;
         assert!(matches!(result, Err(ArchiveError::DigestMismatch { .. })));
 
         Ok(())
@@ -142,7 +149,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_different_catalogs() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("archive-catalogs");
         let content1 = b"content for catalog 1".to_vec();
         let content2 = b"content for catalog 2".to_vec();
@@ -155,7 +162,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Put::new(digest1.clone(), content1.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -163,7 +170,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Put::new(digest2.clone(), content2.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Retrieve from catalog1
@@ -172,7 +179,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest1))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result1, Some(content1));
 
@@ -182,7 +189,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Get::new(digest2.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result2, Some(content2));
 
@@ -191,7 +198,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest2))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert!(cross.is_none());
 
@@ -200,7 +207,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_is_idempotent_for_same_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("archive-idempotent");
         let content = b"idempotent content".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -211,7 +218,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -219,7 +226,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Should still be retrievable
@@ -227,7 +234,7 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
 
@@ -236,7 +243,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_empty_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("archive-empty");
         let content = vec![];
         let digest = Blake3Hash::hash(&content);
@@ -246,14 +253,14 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let result = subject
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
 
@@ -262,7 +269,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_large_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("archive-large");
         // 1MB content
         let content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
@@ -273,14 +280,14 @@ mod tests {
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(digest.clone(), content.clone()))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let result = subject
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
 

--- a/rust/dialog-storage/src/storage/provider/volatile/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/archive.rs
@@ -23,9 +23,10 @@ impl Provider<Get> for Volatile {
 
         let key: ArchiveKey = (catalog.to_string(), digest.as_bytes().to_base58());
 
-        // Recover from lock poisoning — session data may be
-        // inconsistent but we avoid panicking the current thread.
-        let sessions = self.sessions.read().unwrap_or_else(|e| e.into_inner());
+        let sessions = self
+            .sessions
+            .read()
+            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
         Ok(sessions
             .get(&subject)
             .and_then(|session| session.archive.get(&key).cloned()))
@@ -53,7 +54,10 @@ impl Provider<Put> for Volatile {
         let key: ArchiveKey = (catalog.to_string(), digest.as_bytes().to_base58());
 
         // Content-addressed storage is idempotent
-        let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
+        let mut sessions = self
+            .sessions
+            .write()
+            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
         let session = sessions.entry(subject).or_default();
         session
             .archive

--- a/rust/dialog-storage/src/storage/provider/volatile/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/archive.rs
@@ -23,10 +23,7 @@ impl Provider<Get> for Volatile {
 
         let key: ArchiveKey = (catalog.to_string(), digest.as_bytes().to_base58());
 
-        let sessions = self
-            .sessions
-            .read()
-            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
+        let sessions = self.sessions.read();
         Ok(sessions
             .get(&subject)
             .and_then(|session| session.archive.get(&key).cloned()))
@@ -54,10 +51,7 @@ impl Provider<Put> for Volatile {
         let key: ArchiveKey = (catalog.to_string(), digest.as_bytes().to_base58());
 
         // Content-addressed storage is idempotent
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
+        let mut sessions = self.sessions.write();
         let session = sessions.entry(subject).or_default();
         session
             .archive

--- a/rust/dialog-storage/src/storage/provider/volatile/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/memory.rs
@@ -36,9 +36,10 @@ impl Provider<Resolve> for Volatile {
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
 
-        // Recover from lock poisoning — session data may be
-        // inconsistent but we avoid panicking the current thread.
-        let sessions = self.sessions.read().unwrap_or_else(|e| e.into_inner());
+        let sessions = self
+            .sessions
+            .read()
+            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
         Ok(sessions
             .get(&subject)
             .and_then(|session| session.memory.get(&key))
@@ -63,9 +64,10 @@ impl Provider<Publish> for Volatile {
         let expected_edition = effect.when().map(|e| e.to_vec());
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
-        // Recover from lock poisoning — session data may be
-        // inconsistent but we avoid panicking the current thread.
-        let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
+        let mut sessions = self
+            .sessions
+            .write()
+            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
         let session = sessions.entry(subject).or_default();
 
         // Get current value and edition
@@ -128,9 +130,10 @@ impl Provider<Retract> for Volatile {
         let expected_edition = effect.when().to_vec();
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
-        // Recover from lock poisoning — session data may be
-        // inconsistent but we avoid panicking the current thread.
-        let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
+        let mut sessions = self
+            .sessions
+            .write()
+            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
         let session = sessions.entry(subject).or_default();
 
         // Get current value

--- a/rust/dialog-storage/src/storage/provider/volatile/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/memory.rs
@@ -27,7 +27,7 @@ fn format_edition(edition: Option<&[u8]>) -> Option<String> {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider<Resolve> for Volatile {
     async fn execute(
-        &mut self,
+        &self,
         effect: Capability<Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
         let subject = effect.subject().into();
@@ -36,20 +36,26 @@ impl Provider<Resolve> for Volatile {
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
 
-        Ok(self.session(&subject).memory.get(&key).map(|content| {
-            let edition = Blake3Hash::hash(content);
-            Publication {
-                content: content.clone(),
-                edition: edition.as_bytes().to_vec(),
-            }
-        }))
+        // Recover from lock poisoning — session data may be
+        // inconsistent but we avoid panicking the current thread.
+        let sessions = self.sessions.read().unwrap_or_else(|e| e.into_inner());
+        Ok(sessions
+            .get(&subject)
+            .and_then(|session| session.memory.get(&key))
+            .map(|content| {
+                let edition = Blake3Hash::hash(content);
+                Publication {
+                    content: content.clone(),
+                    edition: edition.as_bytes().to_vec(),
+                }
+            }))
     }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider<Publish> for Volatile {
-    async fn execute(&mut self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
+    async fn execute(&self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
         let subject = effect.subject().into();
         let space = effect.space();
         let cell = effect.cell();
@@ -57,7 +63,10 @@ impl Provider<Publish> for Volatile {
         let expected_edition = effect.when().map(|e| e.to_vec());
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
-        let session = self.session(&subject);
+        // Recover from lock poisoning — session data may be
+        // inconsistent but we avoid panicking the current thread.
+        let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
+        let session = sessions.entry(subject).or_default();
 
         // Get current value and edition
         let current_edition = session
@@ -112,14 +121,17 @@ impl Provider<Publish> for Volatile {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider<Retract> for Volatile {
-    async fn execute(&mut self, effect: Capability<Retract>) -> Result<(), MemoryError> {
+    async fn execute(&self, effect: Capability<Retract>) -> Result<(), MemoryError> {
         let subject = effect.subject().into();
         let space = effect.space();
         let cell = effect.cell();
         let expected_edition = effect.when().to_vec();
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
-        let session = self.session(&subject);
+        // Recover from lock poisoning — session data may be
+        // inconsistent but we avoid panicking the current thread.
+        let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
+        let session = sessions.entry(subject).or_default();
 
         // Get current value
         let Some(current_bytes) = session.memory.get(&key) else {
@@ -166,7 +178,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_resolves_non_existent_cell() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-resolve-none");
 
         let effect = subject
@@ -175,7 +187,7 @@ mod tests {
             .attenuate(Cell::new("missing"))
             .invoke(Resolve);
 
-        let result = effect.perform(&mut provider).await?;
+        let result = effect.perform(&provider).await?;
         assert!(result.is_none());
 
         Ok(())
@@ -183,7 +195,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_publishes_new_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-publish-new");
         let content = b"hello world".to_vec();
 
@@ -194,7 +206,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -205,7 +217,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -217,7 +229,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_updates_existing_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-publish-update");
 
         // Create initial content
@@ -227,7 +239,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Update with correct edition
@@ -237,7 +249,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"updated", Some(edition1.clone())))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert_ne!(edition1, edition2);
@@ -248,7 +260,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -259,7 +271,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_fails_on_edition_mismatch() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-mismatch");
 
         // Create initial content
@@ -269,7 +281,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to update with wrong edition
@@ -279,7 +291,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"updated", Some(wrong_edition)))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -289,7 +301,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_fails_creating_when_exists() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-create-exists");
 
         // Create initial content
@@ -299,7 +311,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"initial", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to create again (when = None means expect empty)
@@ -308,7 +320,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"new", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -318,7 +330,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_retracts_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-retract");
 
         // Create content
@@ -328,7 +340,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"to be deleted", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Retract with correct edition
@@ -338,7 +350,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Retract::new(edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Verify deleted
@@ -347,7 +359,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(resolved.is_none());
@@ -357,7 +369,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_fails_retract_on_edition_mismatch() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-retract-mismatch");
 
         // Create content
@@ -367,7 +379,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(b"content", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to retract with wrong edition
@@ -377,7 +389,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Retract::new(wrong_edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(matches!(result, Err(MemoryError::EditionMismatch { .. })));
@@ -387,7 +399,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_different_spaces() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-spaces");
 
         // Publish to different spaces
@@ -397,7 +409,7 @@ mod tests {
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(b"content1", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         subject
@@ -406,7 +418,7 @@ mod tests {
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(b"content2", None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Resolve from space1
@@ -416,7 +428,7 @@ mod tests {
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result1.unwrap().content, b"content1".to_vec());
 
@@ -426,7 +438,7 @@ mod tests {
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
         assert_eq!(result2.unwrap().content, b"content2".to_vec());
 
@@ -435,7 +447,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_succeeds_with_stale_edition_when_value_matches() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-stale-ok");
         let content = b"desired value".to_vec();
 
@@ -446,7 +458,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Try to publish same content with wrong edition - should succeed
@@ -456,7 +468,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
             .invoke(Publish::new(content.clone(), Some(wrong_edition)))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(result.is_ok());
@@ -470,7 +482,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_produces_deterministic_content_hash() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-deterministic-hash");
         let content = b"same content".to_vec();
 
@@ -481,7 +493,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell1"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Create same value at cell2
@@ -490,7 +502,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell2"))
             .invoke(Publish::new(content, None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         // Same content should produce same edition (content hash)
@@ -501,7 +513,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_succeeds_retracting_already_retracted() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-retract-already-retracted");
 
         // Try to retract non-existent cell - should succeed
@@ -511,7 +523,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("nonexistent"))
             .invoke(Retract::new(wrong_edition))
-            .perform(&mut provider)
+            .perform(&provider)
             .await;
 
         assert!(result.is_ok());
@@ -521,7 +533,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_nested_spaces() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-nested-spaces");
         let content = b"nested content".to_vec();
 
@@ -532,7 +544,7 @@ mod tests {
             .attenuate(Space::new("parent/child/grandchild"))
             .attenuate(Cell::new("cell"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -543,7 +555,7 @@ mod tests {
             .attenuate(Space::new("parent/child/grandchild"))
             .attenuate(Cell::new("cell"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -554,7 +566,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_empty_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-empty");
         let content = vec![];
 
@@ -564,7 +576,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("empty"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -574,7 +586,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("empty"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");
@@ -585,7 +597,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_handles_large_content() -> anyhow::Result<()> {
-        let mut provider = Volatile::new();
+        let provider = Volatile::new();
         let subject = unique_subject("memory-large");
         // 1MB content
         let content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
@@ -596,7 +608,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("large"))
             .invoke(Publish::new(content.clone(), None))
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         assert!(!edition.is_empty());
@@ -606,7 +618,7 @@ mod tests {
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("large"))
             .invoke(Resolve)
-            .perform(&mut provider)
+            .perform(&provider)
             .await?;
 
         let publication = resolved.expect("should have content");

--- a/rust/dialog-storage/src/storage/provider/volatile/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/memory.rs
@@ -36,10 +36,7 @@ impl Provider<Resolve> for Volatile {
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
 
-        let sessions = self
-            .sessions
-            .read()
-            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
+        let sessions = self.sessions.read();
         Ok(sessions
             .get(&subject)
             .and_then(|session| session.memory.get(&key))
@@ -64,10 +61,7 @@ impl Provider<Publish> for Volatile {
         let expected_edition = effect.when().map(|e| e.to_vec());
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
+        let mut sessions = self.sessions.write();
         let session = sessions.entry(subject).or_default();
 
         // Get current value and edition
@@ -130,10 +124,7 @@ impl Provider<Retract> for Volatile {
         let expected_edition = effect.when().to_vec();
 
         let key: MemoryKey = (space.to_string(), cell.to_string());
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| VolatileError::LockPoisoned("sessions".into()))?;
+        let mut sessions = self.sessions.write();
         let session = sessions.entry(subject).or_default();
 
         // Get current value


### PR DESCRIPTION
Design of capability system where `Effect::perform` is passed `&mut Env` was misguided, imposing two constraints:

- **Non-retention**: provider can't be kept beyond execution. This is a lifetime invariant.
- **Exclusivity**: no concurrent access.

Intention was to have 1st and not the 2nd, but I naively assumed `&mut` was more accurate reflected fact that provider often mutates state.

---

This pull request changes interface to use `&Env` which correctly retains 1st invariant removing the second one.