### PR TITLE
3 ✅ feat: gen router address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ name = "dialog-macros"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",

--- a/rust/dialog-capability/src/router.rs
+++ b/rust/dialog-capability/src/router.rs
@@ -1,9 +1,20 @@
-/// Marker trait for composite types that route remote invocations to
-/// per-address-type fields.
+use crate::ProviderRoute;
+
+/// Derive macro that generates [`Router`] impl and
+/// `Provider<RemoteInvocation<Fx, Address>>` impls for composite structs whose
+/// fields each route to a different address type.
+pub use dialog_macros::Router;
+
+/// Trait for composite types that route remote invocations to
+/// per-address-type fields via a unified address enum.
 ///
-/// Implemented automatically by the [`Router`](derive@Router) derive macro.
+/// Implemented automatically by the [`Router`](derive@Router) derive macro,
+/// which generates a `{StructName}Address` enum from the routable fields
+/// and implements dispatch logic.
+///
 /// Each field must implement [`ProviderRoute`](crate::ProviderRoute) so the macro
-/// can determine the address type via the associated `Address` type.
+/// can determine the per-field address type. The generated unified address
+/// enum combines all field addresses into a single type.
 ///
 /// Fields annotated with `#[route(skip)]` are excluded from routing.
 ///
@@ -17,10 +28,15 @@
 ///     #[cfg(feature = "ucan")]
 ///     ucan: ucan::Route<Issuer>,
 /// }
+/// // Generates: NetworkAddress enum, Router impl, ProviderRoute blanket,
+/// // and Provider<RemoteInvocation<Fx, NetworkAddress>> dispatch.
 /// ```
-pub trait Router {}
+pub trait Router {
+    /// The unified address type for this router, typically a generated enum.
+    type Address;
+}
 
-/// Derive macro that generates [`Router`] impl and
-/// `Provider<RemoteInvocation<Fx, Address>>` impls for composite structs whose
-/// fields each route to a different address type.
-pub use dialog_macros::Router;
+/// Blanket impl: any `Router` automatically satisfies `ProviderRoute`.
+impl<T: Router> ProviderRoute for T {
+    type Address = <T as Router>::Address;
+}

--- a/rust/dialog-macros/Cargo.toml
+++ b/rust/dialog-macros/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 
 [dependencies]
 blake3 = { workspace = true }
+convert_case = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full", "parsing"] }

--- a/rust/dialog-macros/src/router.rs
+++ b/rust/dialog-macros/src/router.rs
@@ -27,6 +27,7 @@
 //! Generates per-field `Provider<RemoteInvocation<Fx, FieldAddress>>` impls,
 //! plus a unified `NetworkAddress` enum and dispatch impl.
 
+use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{DeriveInput, parse_macro_input};
@@ -46,22 +47,6 @@ struct RoutableField<'a> {
     field_ty: &'a syn::Type,
     cfg_attrs: Vec<&'a syn::Attribute>,
     variant_name: syn::Ident,
-}
-
-/// Convert a snake_case identifier to PascalCase.
-fn to_pascal_case(s: &str) -> String {
-    s.split('_')
-        .map(|segment| {
-            let mut chars = segment.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(c) => {
-                    let upper: String = c.to_uppercase().collect();
-                    upper + chars.as_str()
-                }
-            }
-        })
-        .collect()
 }
 
 /// Extract bare generic param identifiers (without bounds) for use in
@@ -154,7 +139,7 @@ fn generate_router(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 .iter()
                 .filter(|attr| attr.path().is_ident("cfg"))
                 .collect();
-            let variant_name = format_ident!("{}", to_pascal_case(&field_name.to_string()));
+            let variant_name = format_ident!("{}", field_name.to_string().to_case(Case::Pascal));
 
             Some(RoutableField {
                 field_name,
@@ -381,18 +366,4 @@ fn generate_router(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         #(#from_impls)*
         #unified_provider_impl
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::to_pascal_case;
-
-    #[test]
-    fn pascal_case_simple() {
-        assert_eq!(to_pascal_case("s3"), "S3");
-        assert_eq!(to_pascal_case("ucan"), "Ucan");
-        assert_eq!(to_pascal_case("my_field"), "MyField");
-        assert_eq!(to_pascal_case("a_b_c"), "ABC");
-        assert_eq!(to_pascal_case("hello_world"), "HelloWorld");
-    }
 }

--- a/rust/dialog-macros/src/router.rs
+++ b/rust/dialog-macros/src/router.rs
@@ -8,37 +8,27 @@
 //! types don't implement `ProviderRoute` are silently skipped (the where clause
 //! is unsatisfied).
 //!
+//! Additionally generates a unified `{StructName}Address` enum that combines
+//! all routable field addresses into a single type, along with a
+//! `ProviderRoute` impl on the struct and a unified `Provider` dispatch impl.
+//!
 //! # Example
 //!
 //! ```rust,ignore
 //! #[derive(Router)]
-//! pub struct Network<Issuer> {
-//!     issuer: Issuer,
+//! pub struct Network<Issuer: Clone> {
 //!     #[cfg(feature = "s3")]
-//!     s3: Router<s3::Address, s3::Connection<Issuer>>,
+//!     s3: Route<Issuer, s3::Credentials, s3::Connection<Issuer>>,
 //!     #[cfg(feature = "ucan")]
-//!     ucan: Router<ucan::Address, ucan::Connection<Issuer>>,
+//!     ucan: Route<Issuer, ucan::Credentials, ucan::Connection<Issuer>>,
 //! }
 //! ```
 //!
-//! Generates (for each field):
-//!
-//! ```rust,ignore
-//! #[cfg(feature = "s3")]
-//! impl<Fx, Issuer> Provider<RemoteInvocation<Fx, <Router<s3::Address, s3::Connection<Issuer>> as ProviderRoute>::Address>>
-//!     for Network<Issuer>
-//! where
-//!     Router<s3::Address, s3::Connection<Issuer>>: ProviderRoute
-//!         + Provider<RemoteInvocation<Fx, <Router<s3::Address, s3::Connection<Issuer>> as ProviderRoute>::Address>>,
-//! {
-//!     async fn execute(&self, input: RemoteInvocation<Fx, ...>) -> Fx::Output {
-//!         self.s3.execute(input).await
-//!     }
-//! }
-//! ```
+//! Generates per-field `Provider<RemoteInvocation<Fx, FieldAddress>>` impls,
+//! plus a unified `NetworkAddress` enum and dispatch impl.
 
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{DeriveInput, parse_macro_input};
 
 /// Implementation used by `#[derive(Router)]`.
@@ -50,11 +40,71 @@ pub fn generate(input: TokenStream) -> TokenStream {
     }
 }
 
+/// A routable field extracted from the struct.
+struct RoutableField<'a> {
+    field_name: &'a syn::Ident,
+    field_ty: &'a syn::Type,
+    cfg_attrs: Vec<&'a syn::Attribute>,
+    variant_name: syn::Ident,
+}
+
+/// Convert a snake_case identifier to PascalCase.
+fn to_pascal_case(s: &str) -> String {
+    s.split('_')
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(c) => {
+                    let upper: String = c.to_uppercase().collect();
+                    upper + chars.as_str()
+                }
+            }
+        })
+        .collect()
+}
+
+/// Extract bare generic param identifiers (without bounds) for use in
+/// type positions like `PhantomData<(Issuer,)>`. `Issuer: Clone` → `Issuer`.
+fn bare_generics(
+    generics: &syn::Generics,
+) -> (Vec<proc_macro2::TokenStream>, proc_macro2::TokenStream) {
+    let bare: Vec<_> = generics
+        .params
+        .iter()
+        .map(|p| match p {
+            syn::GenericParam::Type(tp) => {
+                let ident = &tp.ident;
+                quote! { #ident }
+            }
+            syn::GenericParam::Lifetime(lp) => {
+                let lt = &lp.lifetime;
+                quote! { #lt }
+            }
+            syn::GenericParam::Const(cp) => {
+                let ident = &cp.ident;
+                quote! { #ident }
+            }
+        })
+        .collect();
+
+    let bare_ty_generics = if bare.is_empty() {
+        quote! {}
+    } else {
+        quote! { < #(#bare),* > }
+    };
+
+    (bare, bare_ty_generics)
+}
+
 fn generate_router(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let struct_name = &input.ident;
+    let vis = &input.vis;
     let (_impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let generic_params = &input.generics.params;
+    let (bare_params, bare_ty_generics) = bare_generics(&input.generics);
+    let has_generics = !generic_params.is_empty();
 
     let fields = match &input.data {
         syn::Data::Struct(data) => match &data.fields {
@@ -81,77 +131,268 @@ fn generate_router(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         })
         .unwrap_or_default();
 
-    let mut impls = Vec::new();
-
-    for field in fields {
-        // Skip fields annotated with #[route(skip)]
-        let has_skip = field.attrs.iter().any(|attr| {
-            if attr.path().is_ident("route")
-                && let Ok(meta) = attr.parse_args::<syn::Ident>()
-            {
-                return meta == "skip";
+    // Collect routable fields (non-skipped)
+    let routable_fields: Vec<RoutableField> = fields
+        .iter()
+        .filter_map(|field| {
+            let has_skip = field.attrs.iter().any(|attr| {
+                if attr.path().is_ident("route")
+                    && let Ok(meta) = attr.parse_args::<syn::Ident>()
+                {
+                    return meta == "skip";
+                }
+                false
+            });
+            if has_skip {
+                return None;
             }
-            false
-        });
-        if has_skip {
-            continue;
-        }
 
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
+            let field_name = field.ident.as_ref().unwrap();
+            let field_ty = &field.ty;
+            let cfg_attrs: Vec<_> = field
+                .attrs
+                .iter()
+                .filter(|attr| attr.path().is_ident("cfg"))
+                .collect();
+            let variant_name = format_ident!("{}", to_pascal_case(&field_name.to_string()));
 
-        // Collect #[cfg(...)] attributes from the field
-        let cfg_attrs: Vec<_> = field
-            .attrs
-            .iter()
-            .filter(|attr| attr.path().is_ident("cfg"))
-            .collect();
+            Some(RoutableField {
+                field_name,
+                field_ty,
+                cfg_attrs,
+                variant_name,
+            })
+        })
+        .collect();
 
-        // The address type is derived from the ProviderRoute trait
-        let address_projection =
-            quote! { <#field_ty as ::dialog_capability::ProviderRoute>::Address };
+    // Per-field Provider impls (existing behavior)
+    let per_field_impls: Vec<_> = routable_fields
+        .iter()
+        .map(|rf| {
+            let field_name = rf.field_name;
+            let field_ty = rf.field_ty;
+            let cfg_attrs = &rf.cfg_attrs;
+            let address_projection =
+                quote! { <#field_ty as ::dialog_capability::ProviderRoute>::Address };
 
-        let impl_block = quote! {
-            #(#cfg_attrs)*
-            #[cfg_attr(not(target_arch = "wasm32"), ::async_trait::async_trait)]
-            #[cfg_attr(target_arch = "wasm32", ::async_trait::async_trait(?Send))]
-            impl<__Fx, #generic_params>
-                ::dialog_capability::Provider<
-                    ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>
-                >
-                for #struct_name #ty_generics
-            where
-                #existing_predicates
-                __Fx: ::dialog_capability::Effect + ::dialog_common::ConditionalSend + 'static,
-                <__Fx as ::dialog_capability::Constraint>::Capability: ::dialog_common::ConditionalSend + 'static,
-                #address_projection: ::dialog_common::ConditionalSend + 'static,
-                #field_ty: ::dialog_capability::ProviderRoute
-                    + ::dialog_capability::Provider<
+            quote! {
+                #(#cfg_attrs)*
+                #[cfg_attr(not(target_arch = "wasm32"), ::async_trait::async_trait)]
+                #[cfg_attr(target_arch = "wasm32", ::async_trait::async_trait(?Send))]
+                impl<__Fx, #generic_params>
+                    ::dialog_capability::Provider<
                         ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>
-                    > + ::dialog_common::ConditionalSend,
-                Self: ::dialog_common::ConditionalSend + ::dialog_common::ConditionalSync,
-            {
-                async fn execute(
-                    &self,
-                    input: ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>,
-                ) -> __Fx::Output {
-                    ::dialog_capability::Provider::execute(&self.#field_name, input).await
+                    >
+                    for #struct_name #ty_generics
+                where
+                    #existing_predicates
+                    __Fx: ::dialog_capability::Effect + ::dialog_common::ConditionalSend + 'static,
+                    <__Fx as ::dialog_capability::Constraint>::Capability: ::dialog_common::ConditionalSend + 'static,
+                    #address_projection: ::dialog_common::ConditionalSend + 'static,
+                    #field_ty: ::dialog_capability::ProviderRoute
+                        + ::dialog_capability::Provider<
+                            ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>
+                        > + ::dialog_common::ConditionalSend,
+                    Self: ::dialog_common::ConditionalSend + ::dialog_common::ConditionalSync,
+                {
+                    async fn execute(
+                        &self,
+                        input: ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>,
+                    ) -> __Fx::Output {
+                        ::dialog_capability::Provider::execute(&self.#field_name, input).await
+                    }
                 }
             }
-        };
+        })
+        .collect();
 
-        impls.push(impl_block);
-    }
+    // Unified address enum name
+    let address_enum_name = format_ident!("{}Address", struct_name);
 
+    // Router trait impl with unified Address type
     let router_impl = quote! {
         impl<#generic_params> ::dialog_capability::Router for #struct_name #ty_generics
         where
             #existing_predicates
-        {}
+        {
+            type Address = #address_enum_name #bare_ty_generics;
+        }
+    };
+
+    let enum_variants: Vec<_> = routable_fields
+        .iter()
+        .map(|rf| {
+            let variant_name = &rf.variant_name;
+            let field_ty = rf.field_ty;
+            let cfg_attrs = &rf.cfg_attrs;
+            let address_projection =
+                quote! { <#field_ty as ::dialog_capability::ProviderRoute>::Address };
+
+            quote! {
+                #(#cfg_attrs)*
+                #variant_name(#address_projection)
+            }
+        })
+        .collect();
+
+    // PhantomData variant to suppress unused type parameter warnings
+    // when all real variants are cfg'd out.
+    let phantom_variant = if has_generics {
+        quote! {
+            #[doc(hidden)]
+            #[serde(skip)]
+            __Phantom(::core::marker::PhantomData<(#(#bare_params),*)>),
+        }
+    } else {
+        quote! {}
+    };
+
+    let phantom_match_arm = if has_generics {
+        quote! {
+            #address_enum_name::__Phantom(_) => unreachable!(),
+        }
+    } else {
+        quote! {}
+    };
+
+    // The enum definition uses bare generics (no bounds).
+    // Where clause from the struct propagates for associated type resolution.
+    let enum_where = if existing_predicates.is_empty() {
+        quote! {}
+    } else {
+        quote! { where #existing_predicates }
+    };
+
+    let serde_bound_attr = if has_generics {
+        quote! { #[serde(bound = "")] }
+    } else {
+        quote! {}
+    };
+
+    let address_enum = quote! {
+        #[derive(
+            Debug, Clone, PartialEq, Eq, Hash,
+            ::serde::Serialize, ::serde::Deserialize,
+        )]
+        #serde_bound_attr
+        #[allow(non_camel_case_types, missing_docs)]
+        #vis enum #address_enum_name #bare_ty_generics #enum_where {
+            #(#enum_variants,)*
+            #phantom_variant
+        }
+    };
+
+    // From impls for each variant
+    let from_impls: Vec<_> = routable_fields
+        .iter()
+        .map(|rf| {
+            let variant_name = &rf.variant_name;
+            let field_ty = rf.field_ty;
+            let cfg_attrs = &rf.cfg_attrs;
+            let address_projection =
+                quote! { <#field_ty as ::dialog_capability::ProviderRoute>::Address };
+
+            quote! {
+                #(#cfg_attrs)*
+                impl<#generic_params> From<#address_projection>
+                    for #address_enum_name #bare_ty_generics
+                where
+                    #existing_predicates
+                    #field_ty: ::dialog_capability::ProviderRoute,
+                {
+                    fn from(address: #address_projection) -> Self {
+                        Self::#variant_name(address)
+                    }
+                }
+            }
+        })
+        .collect();
+
+    // Unified Provider dispatch impl
+    let per_field_where_clauses: Vec<_> = routable_fields
+        .iter()
+        .map(|rf| {
+            let field_ty = rf.field_ty;
+            let address_projection =
+                quote! { <#field_ty as ::dialog_capability::ProviderRoute>::Address };
+
+            quote! {
+                #field_ty: ::dialog_capability::ProviderRoute
+                    + ::dialog_capability::Provider<
+                        ::dialog_effects::remote::RemoteInvocation<__Fx, #address_projection>
+                    > + ::dialog_common::ConditionalSend,
+                #address_projection: ::dialog_common::ConditionalSend + 'static,
+            }
+        })
+        .collect();
+
+    let match_arms: Vec<_> = routable_fields
+        .iter()
+        .map(|rf| {
+            let variant_name = &rf.variant_name;
+            let field_name = rf.field_name;
+            let cfg_attrs = &rf.cfg_attrs;
+
+            quote! {
+                #(#cfg_attrs)*
+                #address_enum_name::#variant_name(inner) => {
+                    ::dialog_capability::Provider::execute(
+                        &self.#field_name,
+                        ::dialog_effects::remote::RemoteInvocation::new(capability, inner),
+                    ).await
+                }
+            }
+        })
+        .collect();
+
+    let unified_provider_impl = quote! {
+        #[cfg_attr(not(target_arch = "wasm32"), ::async_trait::async_trait)]
+        #[cfg_attr(target_arch = "wasm32", ::async_trait::async_trait(?Send))]
+        impl<__Fx, #generic_params>
+            ::dialog_capability::Provider<
+                ::dialog_effects::remote::RemoteInvocation<__Fx, #address_enum_name #bare_ty_generics>
+            >
+            for #struct_name #ty_generics
+        where
+            #existing_predicates
+            __Fx: ::dialog_capability::Effect + ::dialog_common::ConditionalSend + 'static,
+            <__Fx as ::dialog_capability::Constraint>::Capability: ::dialog_common::ConditionalSend + 'static,
+            #(#per_field_where_clauses)*
+            #address_enum_name #bare_ty_generics: ::dialog_common::ConditionalSend + 'static,
+            Self: ::dialog_common::ConditionalSend + ::dialog_common::ConditionalSync,
+        {
+            async fn execute(
+                &self,
+                input: ::dialog_effects::remote::RemoteInvocation<__Fx, #address_enum_name #bare_ty_generics>,
+            ) -> __Fx::Output {
+                let (capability, address) = input.into_parts();
+                match address {
+                    #(#match_arms)*
+                    #phantom_match_arm
+                }
+            }
+        }
     };
 
     Ok(quote! {
         #router_impl
-        #(#impls)*
+        #(#per_field_impls)*
+        #address_enum
+        #(#from_impls)*
+        #unified_provider_impl
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_pascal_case;
+
+    #[test]
+    fn pascal_case_simple() {
+        assert_eq!(to_pascal_case("s3"), "S3");
+        assert_eq!(to_pascal_case("ucan"), "Ucan");
+        assert_eq!(to_pascal_case("my_field"), "MyField");
+        assert_eq!(to_pascal_case("a_b_c"), "ABC");
+        assert_eq!(to_pascal_case("hello_world"), "HelloWorld");
+    }
 }

--- a/rust/dialog-storage/src/storage/provider/network/route.rs
+++ b/rust/dialog-storage/src/storage/provider/network/route.rs
@@ -196,10 +196,10 @@ mod tests {
             type Output = String;
         }
 
-        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
         struct AlphaAddr(String);
 
-        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
         struct BetaAddr(String);
 
         struct AlphaBackend;
@@ -264,6 +264,50 @@ mod tests {
             let remote_b = RemoteInvocation::new(cap_b, BetaAddr("site-b".into()));
             let result_b = remote_b.perform(&router).await;
             assert_eq!(result_b, "beta:site-b:doc-2");
+        }
+
+        #[dialog_common::test]
+        async fn it_dispatches_via_unified_address() {
+            let router = CompositeRouter {
+                alpha: AlphaBackend,
+                beta: BetaBackend,
+            };
+
+            let cap_a = Subject::from("did:key:zAlpha".parse::<Did>().unwrap())
+                .attenuate(Storage)
+                .invoke(Fetch {
+                    key: "doc-1".into(),
+                });
+            let addr_a: CompositeRouterAddress = AlphaAddr("site-a".into()).into();
+            let result_a = RemoteInvocation::new(cap_a, addr_a).perform(&router).await;
+            assert_eq!(result_a, "alpha:site-a:doc-1");
+
+            let cap_b = Subject::from("did:key:zBeta".parse::<Did>().unwrap())
+                .attenuate(Storage)
+                .invoke(Fetch {
+                    key: "doc-2".into(),
+                });
+            let addr_b: CompositeRouterAddress = BetaAddr("site-b".into()).into();
+            let result_b = RemoteInvocation::new(cap_b, addr_b).perform(&router).await;
+            assert_eq!(result_b, "beta:site-b:doc-2");
+        }
+
+        #[test]
+        fn it_generates_from_impls_for_unified_address() {
+            let alpha: CompositeRouterAddress = AlphaAddr("a".into()).into();
+            let beta: CompositeRouterAddress = BetaAddr("b".into()).into();
+
+            assert_eq!(alpha, CompositeRouterAddress::Alpha(AlphaAddr("a".into())));
+            assert_eq!(beta, CompositeRouterAddress::Beta(BetaAddr("b".into())));
+        }
+
+        #[test]
+        fn it_implements_provider_route_via_router() {
+            use dialog_capability::ProviderRoute;
+
+            // CompositeRouter implements ProviderRoute via the Router blanket
+            fn _assert_provider_route<T: ProviderRoute>() {}
+            _assert_provider_route::<CompositeRouter>();
         }
     }
 }


### PR DESCRIPTION
## Goal

Eliminates need for hand-written boilerplate needed when working with multiple network addresses. Without this change it requires manually creating enum and then having bunch of Provider impls that delegate to the Router impl, more annoyingly it required propagating cfg gates which are needed on type bounds.

## Overview

Changes here accomplish goal by updates `#[derive(Router)]` macro so it generates:

1. `{StructName}Address` enum with variant per route with same cfg gates.
2. `From` impls for every address variant in the enum so they can easily be turned into enums.
3. Unified `Provider<RemoteInvocation<Fx, StructAddress>>` that dispatches to corresponding route.

The `Router` was also updated gaining associated `Address` type that gets set to generated enum address.

The `Router` now also has a blanket impl for `ProviderRoute` so it can be used as is.