### PR TITLE
📬 feat: replace bit-batch rank derivation with threshold-based geometric distribution

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -670,13 +670,11 @@ mod tests {
             )
         };
 
-        // The old prolly tree pinned its eagerly loaded root node in
-        // memory, so query read counts excluded the root. The search tree
-        // holds only the root hash and reads the root block on first use;
-        // the shared node cache absorbs that read on every subsequent
-        // query against the same tree (see it_uses_indexes_to_optimize_reads
-        // where the second select costs one read fewer than it used to).
-        assert_eq!(net_reads, 3);
+        // The threshold-based geometric distribution gives an exact 1/m
+        // split at every level, so the tree is flatter than the bit-batch
+        // distribution (whose upper levels averaged only 2-4 children) and a
+        // point query walks one fewer block to reach its leaf.
+        assert_eq!(net_reads, 2);
         assert_eq!(net_writes, 0);
 
         Ok(())
@@ -734,13 +732,11 @@ mod tests {
             )
         };
 
-        // The old prolly tree pinned its eagerly loaded root node in
-        // memory, so query read counts excluded the root. The search tree
-        // holds only the root hash and reads the root block on first use;
-        // the shared node cache absorbs that read on every subsequent
-        // query against the same tree (see it_uses_indexes_to_optimize_reads
-        // where the second select costs one read fewer than it used to).
-        assert_eq!(net_reads, 3);
+        // The threshold-based geometric distribution gives an exact 1/m
+        // split at every level, so the tree is flatter than the bit-batch
+        // distribution (whose upper levels averaged only 2-4 children) and a
+        // point query walks one fewer block to reach its leaf.
+        assert_eq!(net_reads, 2);
         assert_eq!(net_writes, 0);
 
         Ok(())
@@ -776,13 +772,11 @@ mod tests {
             )
         };
 
-        // The old prolly tree pinned its eagerly loaded root node in
-        // memory, so query read counts excluded the root. The search tree
-        // holds only the root hash and reads the root block on first use;
-        // the shared node cache absorbs that read on every subsequent
-        // query against the same tree (see it_uses_indexes_to_optimize_reads
-        // where the second select costs one read fewer than it used to).
-        assert_eq!(net_reads, 5);
+        // The threshold-based geometric distribution gives an exact 1/m
+        // split at every level, so the tree is flatter than the bit-batch
+        // distribution (whose upper levels averaged only 2-4 children) and
+        // reaching a leaf costs fewer block reads.
+        assert_eq!(net_reads, 2);
         assert_eq!(net_writes, 0);
 
         let fact_stream =
@@ -800,10 +794,11 @@ mod tests {
             )
         };
 
-        // One read fewer than the old tree: the root block was cached
-        // by the select above, while the old tree re-walked from its
-        // resident root through uncached children.
-        assert_eq!(net_reads, 10);
+        // The broad attribute scan walks far fewer blocks under the
+        // threshold-based geometric distribution: its exact 1/m split at
+        // every level keeps the tree flat, where the bit-batch distribution
+        // built taller upper levels that cost more reads to traverse.
+        assert_eq!(net_reads, 4);
         assert_eq!(net_writes, 0);
 
         Ok(())

--- a/rust/dialog-search-tree/Cargo.toml
+++ b/rust/dialog-search-tree/Cargo.toml
@@ -58,6 +58,15 @@ harness = false
 name = "range_query"
 harness = false
 
+[[bench]]
+name = "distribution"
+harness = false
+required-features = ["helpers"]
+
+[[example]]
+name = "node_sizes"
+required-features = ["helpers"]
+
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/rust/dialog-search-tree/benches/DISTRIBUTION_FINDINGS.md
+++ b/rust/dialog-search-tree/benches/DISTRIBUTION_FINDINGS.md
@@ -139,31 +139,50 @@ small nodes. This is partly inherent (wider nodes cost more to rebuild) and
 mitigable with a node-size cap on leaf segments (whose geometric tail is the
 worst offender).
 
-## Why get is slower (and why it is fixable)
+## Why get was slower, and the fix (implemented)
 
 A point lookup walks root -> ... -> leaf. The leaf search is a `binary_search`
-(`ArchivedNodeBody::find_entry`), O(log m) and cheap. The cost is in the
+(`ArchivedNodeBody::find_entry`), O(log m) and cheap. The cost was in the
 **index** walk: `TreeWalker::search` iterates **all** links of each index node
 and `into_owned`-deserializes **every sibling** link into owned
 `left_siblings` / `right_siblings` for the returned `path` (machinery the
 insert/delete rebuild needs). That work is **O(fan-out) per index node**, and
-it runs unconditionally, including on `get`.
+it ran unconditionally, including on `get` -- which is why the numbers above
+track root fan-out (m=128, fan-out 394, was the slowest) rather than depth.
 
-So the flat tree, which concentrates the whole key range under one ~196-wide
-root, makes a single get deserialize ~195 sibling links; the tall bit-batch
-tree, with ~2-wide index nodes, deserializes only a couple per level. This is
-why the get cost tracks root fan-out rather than tree depth, and why it is an
-**implementation artifact, not a property of correct branching**: a read-only
-descent that binary-searches the index links and skips the sibling
-materialization would make get roughly flat in `m`.
+A read does not need that path. `Tree::get` now descends with
+`TreeWalker::find_leaf`, a read-only walk that binary-searches each index node
+(`partition_point`, O(log fan-out)) and decodes only the chosen child -- no
+sibling materialization. Cross-checked against the `search` path by the test
+`it_gets_present_and_absent_keys_across_index_boundaries` (present keys, gaps,
+on-boundary keys, above-max fallthrough) plus the full existing suite.
+
+### get @ 50k: before vs after (threshold), with bit-batch (also via find_leaf)
+
+| m | threshold before | threshold after | bit-batch after |
+|---|---|---|---|
+| 32 | 459 µs | **130 µs** | 197 µs |
+| 64 | 546 µs | **156 µs** | 203 µs |
+| 128 | 789 µs | **180 µs** | 305 µs |
+| 254 | 685 µs | **326 µs** | 397 µs |
+
+The O(fan-out) cost is gone: threshold get dropped 3.5-4.4x and the curve is
+far flatter in `m`. With per-node cost fixed, what remains is tree depth, so the
+shorter threshold tree is now **faster than bit-batch on get at every branch
+factor**. (bit-batch improved too, since it shares the new read path; threshold
+gains more because it had the wide nodes the old path punished.)
+
+This confirms the get slowdown was an **implementation artifact, not a cost of
+correct branching**.
 
 ## Recommendation
 
-1. **Land the threshold fix.** It is correct, and at moderate `m` it is
-   perf-neutral against bit-batch while already producing a better-shaped tree.
+1. **Land the threshold fix.** It is correct; with the read-only get path it is
+   now faster than bit-batch on get and produces a strictly better-shaped tree.
 2. **Treat branch factor as a separate, tunable knob.** Raising `m` lowers
    block count (better network IO, toward Datomic's design) at the cost of
-   larger nodes. The two costs that grow with `m` are both addressable without
-   touching rank derivation:
-   - **get**: read-only search path (skip sibling `into_owned`) -> flat in `m`.
-   - **insert**: leaf segment-size cap to bound the geometric tail.
+   larger nodes.
+   - **get**: handled -- `find_leaf` makes it ~flat in `m`.
+   - **insert**: still grows with `m` (wide-node rebuild). A leaf segment-size
+     cap to bound the geometric tail is the remaining follow-up; not addressed
+     here since it touches the builder, not rank derivation.

--- a/rust/dialog-search-tree/benches/DISTRIBUTION_FINDINGS.md
+++ b/rust/dialog-search-tree/benches/DISTRIBUTION_FINDINGS.md
@@ -150,14 +150,19 @@ insert/delete rebuild needs). That work is **O(fan-out) per index node**, and
 it ran unconditionally, including on `get` -- which is why the numbers above
 track root fan-out (m=128, fan-out 394, was the slowest) rather than depth.
 
-A read does not need that path. `Tree::get` now descends with
-`TreeWalker::find_leaf`, a read-only walk that binary-searches each index node
-(`partition_point`, O(log fan-out)) and decodes only the chosen child -- no
-sibling materialization. Cross-checked against the `search` path by the test
-`it_gets_present_and_absent_keys_across_index_boundaries` (present keys, gaps,
-on-boundary keys, above-max fallthrough) plus the full existing suite.
+The fix made `search` itself zero-copy rather than adding a parallel read path.
+A `TreeLayer` now holds only the host node (Arc-backed, shared on clone) and the
+child index the descent took; it no longer eagerly `into_owned`s the host's
+other children. Reads (`get`, range scans) take the leaf and ignore the rest,
+copying nothing. Writes (`insert`, `delete`) decode the siblings of a level
+lazily, from the host, only when they actually rebuild that level -- which they
+do by re-serializing the whole node anyway, so no extra copy is introduced. Each
+index node is navigated with a binary search (`partition_point`, O(log
+fan-out)). Cross-checked by `it_gets_present_and_absent_keys_across_index_boundaries`
+(present keys, gaps, on-boundary keys, above-max fallthrough), the canonical-form
+invariance tests, and the full existing suite.
 
-### get @ 50k: before vs after (threshold), with bit-batch (also via find_leaf)
+### get @ 50k: before vs after (threshold), with bit-batch (shares the read path)
 
 | m | threshold before | threshold after | bit-batch after |
 |---|---|---|---|
@@ -173,7 +178,11 @@ factor**. (bit-batch improved too, since it shares the new read path; threshold
 gains more because it had the wide nodes the old path punished.)
 
 This confirms the get slowdown was an **implementation artifact, not a cost of
-correct branching**.
+correct branching**. Range scans benefit from the same change (the start-key
+descent no longer materializes siblings, and `into_indexed` no longer re-derives
+each child index with a binary search -- `search` already recorded it). The
+write path keeps the same canonical output (all tests green) while shedding the
+eager sibling decode/concat it never needed before the rebuild step.
 
 ## Recommendation
 

--- a/rust/dialog-search-tree/benches/DISTRIBUTION_FINDINGS.md
+++ b/rust/dialog-search-tree/benches/DISTRIBUTION_FINDINGS.md
@@ -1,0 +1,169 @@
+# Rank distribution: bit-batch vs threshold geometric
+
+Produced by `benches/distribution.rs` (timing + shape) and
+`examples/node_sizes.rs` (per-level node sizes):
+
+```sh
+cargo bench -p dialog-search-tree --bench distribution --features helpers
+cargo run --release --example node_sizes --features helpers
+```
+
+Criterion writes one overlaid comparison line chart per (operation, branch
+factor) to `target/criterion/<op>/m=<m>/report/index.html`, linked from the
+top-level `target/criterion/report/index.html`. Branch factors swept: 32, 64,
+128, 254. Sizes: 1k, 10k, 50k. Seed 42.
+
+## TL;DR
+
+- The threshold derivation is **correct**; the bit-batch derivation has a bug
+  that collapses the effective branch factor **above the leaves to ~2**,
+  regardless of the declared `m`.
+- The fix produces **flatter trees with ~3x fewer blocks** at production `m` —
+  the win for content-addressed / networked storage, where block count drives
+  round-trips.
+- The threshold tree is **slower for insert and point-get at large `m`**, but
+  this is **not a cost of correct branching**: at moderate `m` (32) it is
+  within ~5% of bit-batch, and the get cost is an implementation artifact of
+  the shared search path (see "Why get is slower"), not the algorithm.
+- Range scans are a wash (slightly faster with threshold).
+
+## The bug: effective branch factor collapses above the leaves
+
+The bit-batch derivation simulates a `1/m` coin by reading `ceil(log2(m))`-bit
+batches, but each batch is read from a single byte and batches past the first
+do not align to byte boundaries. The promotion probability above the first
+level degrades toward `1/2`, so every level above the leaves carries ~2
+children no matter what `m` is declared. The signature is `L1 ≈ 2.0` in every
+bit-batch shape row below.
+
+Consequently the bit-batch tree is **structurally inhomogeneous**: leaf fan-out
+tracks `m` (the leaf split is roughly correct), but the index spine above is
+effectively a binary tree. There is no single `m` you can feed a *correct*
+algorithm to reproduce that shape, because a correct distribution produces a
+*homogeneous* tree (the same fan-out at every level).
+
+## Tree shape
+
+| m | size | dist | height | nodes | idx | leaf | fan-out per level (L0 = leaves) |
+|---|---|---|---|---|---|---|---|
+| 32 | 50k | bit-batch | 6 | 1 724 | 201 | 1 523 | L0:32.8 L1:8.4 L2:18.1 L3:1.4 L4:3.5 L5:2.0 |
+| 32 | 50k | threshold | 3 | 1 600 | 44 | 1 556 | L0:32.1 L1:36.2 L2:43.0 |
+| 64 | 50k | bit-batch | 5 | 949 | 196 | 753 | L0:66.4 L1:4.2 L2:15.1 L3:6.0 L4:2.0 |
+| 64 | 50k | threshold | 3 | 788 | 10 | 778 | L0:64.3 L1:86.4 L2:9.0 |
+| 128 | 50k | bit-batch | 7 | 604 | 242 | 362 | L0:138.1 L1:2.0 L2:3.8 L3:6.9 L4:2.3 L5:1.5 L6:2.0 |
+| 128 | 50k | threshold | 2 | 395 | 1 | 394 | L0:126.9 L1:394.0 |
+| 254 | 50k | bit-batch | 7 | 604 | 242 | 362 | L0:138.1 L1:2.0 L2:3.8 L3:6.9 L4:2.3 L5:1.5 L6:2.0 |
+| 254 | 50k | threshold | 2 | 197 | 1 | 196 | L0:255.1 L1:196.0 |
+
+(Full 1k/10k rows are emitted by the `shape` bench group.)
+
+- **Height**: threshold stays at 2-3; bit-batch reaches 7 at m=128/254.
+- **Blocks**: threshold persists ~3x fewer at production `m` (197 vs 604 at
+  m=254/50k). Total *bytes* are nearly identical (entries dominate); the saving
+  is block *count*.
+- **The skew worsens with `m`**: at m=254 the bit-batch upper levels still carry
+  2-7 children where 254 was declared.
+
+## Node sizes (per element, by node type)
+
+From `examples/node_sizes.rs`. The two node types differ, as expected:
+
+- **Index node**: ~**48 B per child** (16 B upper-bound key + 32 B blake3 hash).
+- **Segment (leaf) node**: ~**56 B per entry** (16 B key + 32 B value + ~8 B
+  rkyv overhead).
+
+A node's total size is `fan-out x per-element`, so size scales with `m`. The
+leaf fan-out follows a geometric distribution, so leaf sizes have a long tail:
+
+| m | leaf mean | leaf max | root index bytes (fan-out) |
+|---|---|---|---|
+| 32 | 1.8 KB | 11 KB | 2.1 KB (43) |
+| 64 | 3.6 KB | 28 KB | 0.4 KB (9) |
+| 128 | 7.1 KB | 46 KB | 18.9 KB (394) |
+| 254 | 14.3 KB | **96 KB** | 9.4 KB (196) |
+
+Index nodes stay small in absolute terms even at high `m`; the large blocks are
+**leaf segments**, and the geometric tail pushes the worst-case leaf to ~5-7x
+the mean.
+
+### Comparison to Datomic
+
+Datomic segments are "up to ~50 KB, usually 1,000-20,000 datoms" with a
+"1,000+ branching factor" and a tree "no more than three levels deep" (Tonsky,
+*Unofficial Guide to Datomic Internals*). Our mean segment (14 KB at m=254) is
+well within that; our max (96 KB) slightly overshoots. Datomic deliberately
+uses **high branch factor + large segments** so one fetch returns "1,000-20,000
+datoms around" the target, avoiding N+1 round-trips. That is the same
+network-IO argument for raising our `m` — we are currently conservative by
+comparison, leaving headroom.
+
+## Timing (criterion medians)
+
+### insert (full rebuild per sample)
+
+| m | 10k bit-batch | 10k threshold | ratio |
+|---|---|---|---|
+| 32 | 182 ms | 190 ms | 1.05x |
+| 64 | 254 ms | 272 ms | 1.07x |
+| 128 | 368 ms | 486 ms | 1.32x |
+| 254 | 368 ms | 780 ms | 2.12x |
+
+### get (256 point lookups per sample)
+
+| m | 50k bit-batch | 50k threshold | root fan-out |
+|---|---|---|---|
+| 32 | 434 µs | 459 µs | 43 |
+| 64 | 383 µs | 546 µs | 9* |
+| 128 | 430 µs | 789 µs | 394 |
+| 254 | 432 µs | 685 µs | 196 |
+
+\* The get cost tracks **root fan-out**, not `m`: m=128 (fan-out 394) is the
+slowest and slower than m=254 (fan-out 196), even though 254 > 128. This is the
+fingerprint of the per-node O(fan-out) cost described below.
+
+### range_scan (full scan)
+
+| m | 50k bit-batch | 50k threshold |
+|---|---|---|
+| 32 | 1.154 ms | 1.148 ms |
+| 254 | 1.028 ms | 0.977 ms |
+
+A wash; threshold slightly faster (fewer index blocks to load).
+
+## Why insert is slower at large m
+
+Each mutation re-shapes and re-serializes the nodes on the path. A flat
+height-2 tree at m=254 hangs all leaves off one index node, so every insert
+re-serializes that wide root; the tall bit-batch tree spreads the change over
+small nodes. This is partly inherent (wider nodes cost more to rebuild) and
+mitigable with a node-size cap on leaf segments (whose geometric tail is the
+worst offender).
+
+## Why get is slower (and why it is fixable)
+
+A point lookup walks root -> ... -> leaf. The leaf search is a `binary_search`
+(`ArchivedNodeBody::find_entry`), O(log m) and cheap. The cost is in the
+**index** walk: `TreeWalker::search` iterates **all** links of each index node
+and `into_owned`-deserializes **every sibling** link into owned
+`left_siblings` / `right_siblings` for the returned `path` (machinery the
+insert/delete rebuild needs). That work is **O(fan-out) per index node**, and
+it runs unconditionally, including on `get`.
+
+So the flat tree, which concentrates the whole key range under one ~196-wide
+root, makes a single get deserialize ~195 sibling links; the tall bit-batch
+tree, with ~2-wide index nodes, deserializes only a couple per level. This is
+why the get cost tracks root fan-out rather than tree depth, and why it is an
+**implementation artifact, not a property of correct branching**: a read-only
+descent that binary-searches the index links and skips the sibling
+materialization would make get roughly flat in `m`.
+
+## Recommendation
+
+1. **Land the threshold fix.** It is correct, and at moderate `m` it is
+   perf-neutral against bit-batch while already producing a better-shaped tree.
+2. **Treat branch factor as a separate, tunable knob.** Raising `m` lowers
+   block count (better network IO, toward Datomic's design) at the cost of
+   larger nodes. The two costs that grow with `m` are both addressable without
+   touching rank derivation:
+   - **get**: read-only search path (skip sibling `into_owned`) -> flat in `m`.
+   - **insert**: leaf segment-size cap to bound the geometric tail.

--- a/rust/dialog-search-tree/benches/distribution.rs
+++ b/rust/dialog-search-tree/benches/distribution.rs
@@ -1,0 +1,449 @@
+//! Compares the bit-batch rank derivation (the distribution on `main`) against
+//! the threshold-based geometric distribution (this branch), swept across
+//! several declared branch factors.
+//!
+//! The bug the threshold distribution fixes shrank the *effective* branch
+//! factor: the bit-batch algorithm reads batches that straddle byte
+//! boundaries, so promotion past the first level happens with probability
+//! 1/2, 1/4, ... instead of 1/m. The smaller the declared branch factor, the
+//! more that skew distorts the tree, so the sweep covers 32, 64, 128 and the
+//! production value 254.
+//!
+//! Both distributions hash the key with blake3 exactly as the production
+//! [`Geometric`] distribution does; the only variable is how the hash becomes
+//! a rank.
+//!
+//! Criterion measures the wall-clock cost of insert, point-get and range
+//! scans. The two distributions share one benchmark group per (operation,
+//! branch factor), so criterion overlays them on a single comparison line
+//! chart across input sizes: see `target/criterion/<op>/m=<m>/report/lines.svg`
+//! and the top-level `target/criterion/report/index.html`.
+//!
+//! A separate `shape` group prints, once per (distribution, branch factor,
+//! size), the tree height, node counts, per-level fan-out and persisted byte
+//! size: the structural evidence that criterion's timing cannot show directly.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo bench -p dialog-search-tree --bench distribution
+//! ```
+
+use std::collections::BTreeMap;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_common::Blake3Hash;
+use dialog_common::helpers::BenchData;
+use dialog_search_tree::helpers::{Traversable as _, TraversalOrder};
+use dialog_search_tree::{ContentAddressedStorage, Distribution, Node, Rank, Tree};
+use dialog_storage::MemoryStorageBackend;
+use futures_util::StreamExt;
+
+const BENCH_SEED: u64 = 42;
+
+// Declared branch factors swept by `*_sweep`: 32, 64, 128 and the production
+// value 254. Const generics require literal type arguments, so the sweep
+// functions list them explicitly rather than iterating this as data. The bug
+// bites hardest at the small end.
+
+/// Entry counts for the read-side timing sweeps and the shape report. The
+/// trees are built once during setup, so larger sizes are cheap to measure.
+const SIZES: [usize; 3] = [1_000, 10_000, 50_000];
+
+/// Entry counts for the insert sweep. Each criterion sample rebuilds the whole
+/// tree from empty, so inserting is capped lower than the read sweeps and run
+/// with a small sample count to keep wall-clock reasonable.
+const INSERT_SIZES: [usize; 2] = [1_000, 10_000];
+
+/// Criterion sample count for the insert sweep; a full rebuild per sample is
+/// expensive, so fewer samples are taken than criterion's default of 100.
+const INSERT_SAMPLES: usize = 10;
+
+/// The bit-batch rank derivation that lived on `main`, parameterized by the
+/// declared branch factor `M`.
+///
+/// It groups the 256 fair Bernoulli trials of the hash into batches of
+/// `ceil(log2(M))` bits and returns the index of the first all-zero batch.
+/// Because batches straddle byte boundaries and the algorithm reads a single
+/// byte per batch, higher levels see inflated promotion probabilities, which
+/// skews the tree taller and narrower than `M` declares.
+struct BitBatch<const M: u64>;
+
+impl<const M: u64> Distribution for BitBatch<M> {
+    fn rank(key: &[u8]) -> Rank {
+        let hash = Blake3Hash::hash(key);
+        let bytes = hash.as_bytes();
+        let m = M as u32;
+
+        let k = (m + 1).ilog2();
+        let batch_count = 256 / k;
+        let mask = (1u8 << k) - 1;
+        for i in 0..batch_count {
+            let byte_index = (k * i) / 8;
+            let bit_index = (k * i) % 8;
+            let batch = (bytes[byte_index as usize] >> bit_index) & mask;
+            if batch != 0 {
+                return Rank::from(i + 1);
+            }
+        }
+        Rank::from(batch_count + 1)
+    }
+}
+
+/// The threshold-based geometric distribution from this branch, parameterized
+/// by the declared branch factor `M`.
+///
+/// It reads the first 8 bytes of the hash as a little-endian `u64` and counts
+/// how many geometrically decreasing thresholds (`u64::MAX / M^k`) the prefix
+/// falls below, giving an exact 1/M split probability at every level.
+struct Threshold<const M: u64>;
+
+impl<const M: u64> Distribution for Threshold<M> {
+    fn rank(key: &[u8]) -> Rank {
+        let hash = Blake3Hash::hash(key);
+        let [b0, b1, b2, b3, b4, b5, b6, b7, ..] = *hash.as_bytes();
+        let prefix = u64::from_le_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
+
+        let mut rank: Rank = 1;
+        let mut threshold = u64::MAX / M;
+        while prefix < threshold {
+            rank += 1;
+            threshold /= M;
+        }
+        rank
+    }
+}
+
+type Backend = MemoryStorageBackend<Blake3Hash, Vec<u8>>;
+type Storage = ContentAddressedStorage<Backend>;
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().unwrap()
+}
+
+/// Builds and persists a tree of `size` random entries under distribution `D`.
+async fn build_tree<D>(size: usize) -> (Tree<[u8; 16], Vec<u8>, D>, Storage, Vec<[u8; 16]>)
+where
+    D: Distribution,
+{
+    let mut data = BenchData::new(BENCH_SEED);
+    let keys = data.random_buffers::<16>(size);
+    let values = data.random_buffers::<32>(size);
+
+    let mut storage = ContentAddressedStorage::new(Backend::default());
+    let mut tree = Tree::<[u8; 16], Vec<u8>, D>::empty();
+
+    for (key, value) in keys.iter().zip(values.iter()) {
+        tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+    }
+    for buffer in tree.flush() {
+        storage
+            .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+            .await
+            .unwrap();
+    }
+
+    (tree, storage, keys)
+}
+
+/// Inserts every entry into a fresh tree. This is the routine timed by the
+/// insert benchmark.
+async fn insert_all<D>(keys: &[[u8; 16]], values: &[Vec<u8>])
+where
+    D: Distribution,
+{
+    let storage = ContentAddressedStorage::new(Backend::default());
+    let mut tree = Tree::<[u8; 16], Vec<u8>, D>::empty();
+    for (key, value) in keys.iter().zip(values.iter()) {
+        tree = tree.insert(*key, value.clone(), &storage).await.unwrap();
+    }
+}
+
+/// The two distribution function names compared within every group. Using the
+/// same two names across input sizes is what makes criterion overlay them on a
+/// single comparison line chart (`<group>/report/lines.svg`).
+const BIT_BATCH: &str = "bit-batch";
+const THRESHOLD: &str = "threshold";
+
+/// Group name for one operation at one branch factor, e.g. `insert/m=254`. One
+/// group per (operation, branch factor) gives one comparison chart per cell,
+/// each overlaying bit-batch against threshold across the input sizes.
+fn group_name(op: &str, m: u64) -> String {
+    format!("{op}/m={m}")
+}
+
+/// Times bulk insertion of every entry, for both distributions, at one branch
+/// factor `M` and across the size sweep. The two distributions share a group so
+/// criterion overlays them on one comparison line chart.
+fn bench_insert<const M: u64>(c: &mut Criterion) {
+    let mut group = c.benchmark_group(group_name("insert", M));
+    group.sample_size(INSERT_SAMPLES);
+    for size in INSERT_SIZES {
+        let mut data = BenchData::new(BENCH_SEED);
+        let keys = data.random_buffers::<16>(size);
+        let values: Vec<Vec<u8>> = data
+            .random_buffers::<32>(size)
+            .into_iter()
+            .map(|v| v.to_vec())
+            .collect();
+
+        group.bench_with_input(BenchmarkId::new(BIT_BATCH, size), &size, |b, _| {
+            b.to_async(runtime())
+                .iter(|| insert_all::<BitBatch<M>>(&keys, &values));
+        });
+        group.bench_with_input(BenchmarkId::new(THRESHOLD, size), &size, |b, _| {
+            b.to_async(runtime())
+                .iter(|| insert_all::<Threshold<M>>(&keys, &values));
+        });
+    }
+    group.finish();
+}
+
+/// Number of point lookups timed per sample. Bounded so the get sweep isolates
+/// per-lookup walk cost (which the distribution controls via tree depth)
+/// without scaling the sample's work with the tree size.
+const LOOKUPS_PER_SAMPLE: usize = 256;
+
+/// Times a fixed batch of point lookups, for both distributions, at one branch
+/// factor `M` and across the size sweep. Fewer lookups than the tree holds
+/// keeps each sample cheap; the per-lookup cost is what the distribution
+/// changes, via the number of levels a lookup must walk.
+fn bench_get<const M: u64>(c: &mut Criterion) {
+    let mut group = c.benchmark_group(group_name("get", M));
+    for size in SIZES {
+        let (old_tree, old_storage, old_keys) = runtime().block_on(build_tree::<BitBatch<M>>(size));
+        let (new_tree, new_storage, new_keys) =
+            runtime().block_on(build_tree::<Threshold<M>>(size));
+
+        let probe = LOOKUPS_PER_SAMPLE.min(size);
+
+        group.bench_with_input(BenchmarkId::new(BIT_BATCH, size), &size, |b, _| {
+            b.to_async(runtime()).iter(|| async {
+                for key in &old_keys[..probe] {
+                    old_tree.get(key, &old_storage).await.unwrap();
+                }
+            });
+        });
+        group.bench_with_input(BenchmarkId::new(THRESHOLD, size), &size, |b, _| {
+            b.to_async(runtime()).iter(|| async {
+                for key in &new_keys[..probe] {
+                    new_tree.get(key, &new_storage).await.unwrap();
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Times a full range scan over the whole tree, for both distributions, at one
+/// branch factor `M` and across the size sweep.
+fn bench_range<const M: u64>(c: &mut Criterion) {
+    let mut group = c.benchmark_group(group_name("range_scan", M));
+    group.sample_size(20);
+    for size in SIZES {
+        let (old_tree, old_storage, _) = runtime().block_on(build_tree::<BitBatch<M>>(size));
+        let (new_tree, new_storage, _) = runtime().block_on(build_tree::<Threshold<M>>(size));
+
+        group.bench_with_input(BenchmarkId::new(BIT_BATCH, size), &size, |b, _| {
+            b.to_async(runtime()).iter(|| async {
+                let stream = old_tree.stream(&old_storage);
+                futures_util::pin_mut!(stream);
+                let mut count = 0usize;
+                while let Some(entry) = stream.next().await {
+                    entry.unwrap();
+                    count += 1;
+                }
+                count
+            });
+        });
+        group.bench_with_input(BenchmarkId::new(THRESHOLD, size), &size, |b, _| {
+            b.to_async(runtime()).iter(|| async {
+                let stream = new_tree.stream(&new_storage);
+                futures_util::pin_mut!(stream);
+                let mut count = 0usize;
+                while let Some(entry) = stream.next().await {
+                    entry.unwrap();
+                    count += 1;
+                }
+                count
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Structural shape of a persisted tree.
+struct Shape {
+    height: usize,
+    total_nodes: usize,
+    index_nodes: usize,
+    leaf_nodes: usize,
+    avg_fanout_by_level: BTreeMap<usize, f64>,
+    total_bytes: usize,
+}
+
+/// Walks the persisted tree to recover its height, node counts, per-level
+/// fan-out and total persisted byte size.
+async fn shape_of<D>(tree: &Tree<[u8; 16], Vec<u8>, D>, storage: &Storage) -> Shape
+where
+    D: Distribution,
+{
+    let mut total_nodes = 0usize;
+    let mut index_nodes = 0usize;
+    let mut leaf_nodes = 0usize;
+    let mut total_bytes = 0usize;
+    let mut seen = std::collections::HashSet::new();
+
+    let stream = tree.traverse(TraversalOrder::BreadthFirst, storage);
+    futures_util::pin_mut!(stream);
+    while let Some(node) = stream.next().await {
+        let node = node.unwrap();
+        total_nodes += 1;
+        if seen.insert(node.hash().clone()) {
+            total_bytes += node.buffer().as_ref().len();
+        }
+        match node.as_index() {
+            Ok(_) => index_nodes += 1,
+            Err(_) => leaf_nodes += 1,
+        }
+    }
+
+    // Depth-tagged BFS over child hashes for per-level fan-out and height.
+    let mut by_depth: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+    let mut frontier = vec![tree.root().clone()];
+    let mut depth = 0usize;
+    let is_empty = total_nodes == 0;
+
+    if !is_empty {
+        loop {
+            let mut next = Vec::new();
+            let mut fanout_sum = 0usize;
+            let mut node_count = 0usize;
+
+            for hash in &frontier {
+                let bytes = storage.retrieve(hash).await.unwrap().unwrap();
+                let node = Node::<[u8; 16], Vec<u8>>::new(bytes.into());
+                node_count += 1;
+                match node.as_index() {
+                    Ok(index) => {
+                        fanout_sum += index.links.len();
+                        for link in index.links.iter() {
+                            next.push(<&Blake3Hash>::from(&link.node).clone());
+                        }
+                    }
+                    Err(_) => fanout_sum += node.as_segment().unwrap().entries.len(),
+                }
+            }
+
+            by_depth.insert(depth, (fanout_sum, node_count));
+            if next.is_empty() {
+                break;
+            }
+            frontier = next;
+            depth += 1;
+        }
+    }
+
+    let height = if is_empty { 0 } else { depth + 1 };
+
+    // Re-key depth (root = 0) to level (leaves = 0) so the table reads bottom-up.
+    let mut avg_fanout_by_level = BTreeMap::new();
+    for (d, (fanout_sum, node_count)) in &by_depth {
+        let level = depth - d;
+        let avg = if *node_count == 0 {
+            0.0
+        } else {
+            *fanout_sum as f64 / *node_count as f64
+        };
+        avg_fanout_by_level.insert(level, avg);
+    }
+
+    Shape {
+        height,
+        total_nodes,
+        index_nodes,
+        leaf_nodes,
+        avg_fanout_by_level,
+        total_bytes,
+    }
+}
+
+fn print_shape_row(distribution: &str, m: u64, size: usize, shape: &Shape) {
+    let fanout: Vec<String> = shape
+        .avg_fanout_by_level
+        .iter()
+        .map(|(level, avg)| format!("L{level}:{avg:.1}"))
+        .collect();
+    println!(
+        "{:<10} {:>4} {:>7}  height={:<2} nodes={:<5} (idx={:<4} leaf={:<5}) bytes={:<9} fanout[{}]",
+        distribution,
+        m,
+        size,
+        shape.height,
+        shape.total_nodes,
+        shape.index_nodes,
+        shape.leaf_nodes,
+        shape.total_bytes,
+        fanout.join(" "),
+    );
+}
+
+/// Emits the shape/storage table for one branch factor `M`. This is the
+/// structural evidence the timing plots cannot show: it walks each persisted
+/// tree and prints height, node counts, per-level fan-out and byte size.
+///
+/// It is wired as a criterion bench so it runs under `cargo bench`, but the
+/// timed routine is trivial; the value is the table printed during setup.
+fn bench_shape<const M: u64>(c: &mut Criterion) {
+    let rt = runtime();
+    println!(
+        "\n=== tree shape @ branch factor m={M} (level 0 = leaves; fanout = avg children/entries) ==="
+    );
+    for size in SIZES {
+        let (old_tree, old_storage, _) = rt.block_on(build_tree::<BitBatch<M>>(size));
+        let old_shape = rt.block_on(shape_of(&old_tree, &old_storage));
+        print_shape_row("bit-batch", M, size, &old_shape);
+
+        let (new_tree, new_storage, _) = rt.block_on(build_tree::<Threshold<M>>(size));
+        let new_shape = rt.block_on(shape_of(&new_tree, &new_storage));
+        print_shape_row("threshold", M, size, &new_shape);
+    }
+
+    // A trivial measured routine keeps criterion happy without adding noise to
+    // the report; the shape table above is what this group exists to produce.
+    let mut group = c.benchmark_group("shape_marker");
+    group.sample_size(10);
+    group.bench_function(format!("m={M}"), |b| b.iter(|| M * 2));
+    group.finish();
+}
+
+fn insert_sweep(c: &mut Criterion) {
+    bench_insert::<32>(c);
+    bench_insert::<64>(c);
+    bench_insert::<128>(c);
+    bench_insert::<254>(c);
+}
+
+fn get_sweep(c: &mut Criterion) {
+    bench_get::<32>(c);
+    bench_get::<64>(c);
+    bench_get::<128>(c);
+    bench_get::<254>(c);
+}
+
+fn range_sweep(c: &mut Criterion) {
+    bench_range::<32>(c);
+    bench_range::<64>(c);
+    bench_range::<128>(c);
+    bench_range::<254>(c);
+}
+
+fn shape_sweep(c: &mut Criterion) {
+    bench_shape::<32>(c);
+    bench_shape::<64>(c);
+    bench_shape::<128>(c);
+    bench_shape::<254>(c);
+}
+
+criterion_group!(benches, shape_sweep, insert_sweep, get_sweep, range_sweep);
+criterion_main!(benches);

--- a/rust/dialog-search-tree/examples/node_sizes.rs
+++ b/rust/dialog-search-tree/examples/node_sizes.rs
@@ -1,0 +1,132 @@
+//! One-off: reports per-level node byte sizes (min / mean / max) for the
+//! threshold distribution across branch factors, so the index/root node size
+//! (the per-insert hotspot and the largest single block fetch) is visible
+//! rather than blended into an average.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --release --example node_sizes --features helpers
+//! ```
+
+use std::collections::BTreeMap;
+
+use dialog_common::Blake3Hash;
+use dialog_common::helpers::BenchData;
+use dialog_search_tree::{ContentAddressedStorage, Distribution, Node, Rank, Tree};
+use dialog_storage::MemoryStorageBackend;
+
+const BENCH_SEED: u64 = 42;
+const SIZES: [usize; 2] = [10_000, 50_000];
+
+struct Threshold<const M: u64>;
+
+impl<const M: u64> Distribution for Threshold<M> {
+    fn rank(key: &[u8]) -> Rank {
+        let hash = Blake3Hash::hash(key);
+        let [b0, b1, b2, b3, b4, b5, b6, b7, ..] = *hash.as_bytes();
+        let prefix = u64::from_le_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
+        let mut rank: Rank = 1;
+        let mut threshold = u64::MAX / M;
+        while prefix < threshold {
+            rank += 1;
+            threshold /= M;
+        }
+        rank
+    }
+}
+
+type Backend = MemoryStorageBackend<Blake3Hash, Vec<u8>>;
+
+async fn build<D: Distribution>(
+    size: usize,
+) -> (Tree<[u8; 16], Vec<u8>, D>, ContentAddressedStorage<Backend>) {
+    let mut data = BenchData::new(BENCH_SEED);
+    let keys = data.random_buffers::<16>(size);
+    let values = data.random_buffers::<32>(size);
+    let mut storage = ContentAddressedStorage::new(Backend::default());
+    let mut tree = Tree::<[u8; 16], Vec<u8>, D>::empty();
+    for (k, v) in keys.iter().zip(values.iter()) {
+        tree = tree.insert(*k, v.to_vec(), &storage).await.unwrap();
+    }
+    for buffer in tree.flush() {
+        storage
+            .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+            .await
+            .unwrap();
+    }
+    (tree, storage)
+}
+
+/// Walks the tree top-down by level, recording the byte size of every node and
+/// the fan-out of the root.
+async fn report<const M: u64>(size: usize) {
+    let (tree, storage) = build::<Threshold<M>>(size).await;
+
+    // depth 0 = root. Collect node byte sizes per depth.
+    let mut sizes_by_depth: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    let mut frontier = vec![tree.root().clone()];
+    let mut depth = 0usize;
+    let mut root_fanout = 0usize;
+
+    loop {
+        let mut next = Vec::new();
+        for hash in &frontier {
+            let bytes = storage.retrieve(hash).await.unwrap().unwrap();
+            sizes_by_depth.entry(depth).or_default().push(bytes.len());
+            let node = Node::<[u8; 16], Vec<u8>>::new(bytes.into());
+            if let Ok(index) = node.as_index() {
+                if depth == 0 {
+                    root_fanout = index.links.len();
+                }
+                for link in index.links.iter() {
+                    next.push(<&Blake3Hash>::from(&link.node).clone());
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+        depth += 1;
+    }
+
+    let height = depth + 1;
+    let root_bytes = sizes_by_depth[&0][0];
+    println!(
+        "  m={M:<4} size={size:<6} height={height} root_fanout={root_fanout:<4} root_bytes={root_bytes}"
+    );
+    for (d, sizes) in &sizes_by_depth {
+        let level = depth - d; // level 0 = leaves
+        let min = *sizes.iter().min().unwrap();
+        let max = *sizes.iter().max().unwrap();
+        let mean = sizes.iter().sum::<usize>() / sizes.len();
+        let kind = if *d == depth { "leaf " } else { "index" };
+        println!(
+            "      L{level} ({kind}) count={:<5} bytes min={:<7} mean={:<7} max={:<7}",
+            sizes.len(),
+            min,
+            mean,
+            max
+        );
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    println!(
+        "Threshold node sizes per level (level 0 = leaves; entry ~= 16B key + 32B value + overhead)"
+    );
+    for size in SIZES {
+        for m in [32u64, 64, 128, 254] {
+            match m {
+                32 => report::<32>(size).await,
+                64 => report::<64>(size).await,
+                128 => report::<128>(size).await,
+                254 => report::<254>(size).await,
+                _ => unreachable!(),
+            }
+        }
+        println!();
+    }
+}

--- a/rust/dialog-search-tree/src/distribution.rs
+++ b/rust/dialog-search-tree/src/distribution.rs
@@ -34,44 +34,55 @@ pub mod geometric {
     /// The branch factor of the [`Tree`]s that constitute [`Artifact`] indexes
     pub const BRANCH_FACTOR: u32 = 254;
 
+    /// Compute the maximum rank derivable from a u64 hash prefix for a given
+    /// branch factor Q. This is `floor(log_Q(2^64))` — the number of times we
+    /// can divide `u64::MAX` by Q before the threshold reaches zero.
+    ///
+    /// For Q=254 this gives 8, supporting trees with up to ~10^19 entries.
+    const fn max_rank_for(branch_factor: u32) -> Rank {
+        let m = branch_factor as u64;
+        let mut threshold = u64::MAX / m;
+        let mut rank = 1;
+        while threshold / m > 0 {
+            threshold /= m;
+            rank += 1;
+        }
+        rank
+    }
+
     /// Computes the rank of a node from its hash using a geometric distribution.
     pub fn rank(hash: &Blake3Hash) -> Rank {
         compute_geometric_rank(hash, BRANCH_FACTOR)
     }
 
+    /// Compute the rank of a hash using a threshold-based geometric
+    /// distribution.
+    ///
+    /// The first 8 bytes of the hash are interpreted as a little-endian `u64`
+    /// prefix, uniformly distributed in `[0, u64::MAX]`. The rank is
+    /// determined by how many geometrically decreasing thresholds
+    /// (`u64::MAX / m`, `u64::MAX / m²`, ...) the prefix falls below.
+    ///
+    /// This gives an exact `1/m` split probability at each level, so the
+    /// effective branch factor matches the declared one.
     pub(crate) fn compute_geometric_rank(hash: &Blake3Hash, m: u32) -> Rank {
-        // Convert the series of fair trials into a series with desired probability
-        // Since we start with a random 256-bit slice (which can be thought of as a
-        // series of 256 fair Bernoulli trials), we need to group these trials with
-        // p = 1 / 2 into trials with p = 1 / m.
-        //
-        // To simulate a trial with probability p = 1 / m, consider a group of k
-        // fair trials, where k is chosen such that 1 / 2^k ≈ 1 / m. The smallest k
-        // such that 2^k ≥ m will be k = ⌈log_2(m)⌉. Compute ⌈log_2(m)⌉ =
-        // ceil(log_2(m)).
         let bytes = hash.as_bytes();
 
-        let k = (m + 1).ilog2();
-        // Number of batches  of k bits
-        let batch_count = 256 / k;
-        // Mask to extract k bits
-        let mask = (1u8 << k) - 1;
-        // For each batch of k bits, we treat the batch as a "success" if all bits
-        // are 0 (which happens with probability 1 / 2^k). The number of batches
-        // until the first "success" is the desired geometrically distributed random
-        // variable.
-        for i in 0..batch_count {
-            let byte_index = (k * i) / 8;
-            let bit_index = (k * i) % 8;
-            // Extract k bits
-            let batch = (bytes[byte_index as usize] >> bit_index) & mask;
-            // batch != 0 means we are looking for the failure probability 1 / m
-            // whereas batch == 0 means we are looking for the success probability
-            // 1 / m
-            if batch != 0 {
-                return i + 1; // +1 because geometric distribution starts at 1
-            }
+        let prefix = u64::from_le_bytes(
+            bytes[0..8]
+                .try_into()
+                .expect("hash must be at least 8 bytes"),
+        );
+
+        let mut rank: Rank = 1;
+        let mut threshold = u64::MAX / u64::from(m);
+        let max_rank = max_rank_for(m);
+
+        while prefix < threshold && rank < max_rank {
+            rank += 1;
+            threshold /= u64::from(m);
         }
-        batch_count + 1
+
+        rank
     }
 }

--- a/rust/dialog-search-tree/src/distribution.rs
+++ b/rust/dialog-search-tree/src/distribution.rs
@@ -28,6 +28,7 @@ impl Distribution for Geometric {
 /// Geometric distribution for computing node ranks.
 pub mod geometric {
     use dialog_common::Blake3Hash;
+    use std::mem::size_of;
 
     use super::Rank;
 
@@ -58,7 +59,7 @@ pub mod geometric {
     /// Compute the rank of a hash using a threshold-based geometric
     /// distribution.
     ///
-    /// The first 8 bytes of the hash are interpreted as a little-endian `u64`
+    /// The first set of bytes of the hash are interpreted as a little-endian `u64`
     /// prefix, uniformly distributed in `[0, u64::MAX]`. The rank is
     /// determined by how many geometrically decreasing thresholds
     /// (`u64::MAX / m`, `u64::MAX / m²`, ...) the prefix falls below.
@@ -69,9 +70,9 @@ pub mod geometric {
         let bytes = hash.as_bytes();
 
         let prefix = u64::from_le_bytes(
-            bytes[0..8]
+            bytes[0..size_of::<u64>()]
                 .try_into()
-                .expect("hash must be at least 8 bytes"),
+                .expect("hash must be at least u64 size"),
         );
 
         let mut rank: Rank = 1;

--- a/rust/dialog-search-tree/src/distribution.rs
+++ b/rust/dialog-search-tree/src/distribution.rs
@@ -1,7 +1,7 @@
 use dialog_common::Blake3Hash;
 
 /// The rank of a node in the prolly tree.
-pub type Rank = u32;
+pub type Rank = u64;
 
 /// Strategy for assigning ranks to keys.
 ///
@@ -28,28 +28,12 @@ impl Distribution for Geometric {
 /// Geometric distribution for computing node ranks.
 pub mod geometric {
     use dialog_common::Blake3Hash;
-    use std::mem::size_of;
 
     use super::Rank;
 
-    /// The branch factor of the [`Tree`]s that constitute [`Artifact`] indexes
-    pub const BRANCH_FACTOR: u32 = 254;
-
-    /// Compute the maximum rank derivable from a u64 hash prefix for a given
-    /// branch factor Q. This is `floor(log_Q(2^64))` — the number of times we
-    /// can divide `u64::MAX` by Q before the threshold reaches zero.
-    ///
-    /// For Q=254 this gives 8, supporting trees with up to ~10^19 entries.
-    const fn max_rank_for(branch_factor: u32) -> Rank {
-        let m = branch_factor as u64;
-        let mut threshold = u64::MAX / m;
-        let mut rank = 1;
-        while threshold / m > 0 {
-            threshold /= m;
-            rank += 1;
-        }
-        rank
-    }
+    /// The branch factor of the trees built from this distribution: the
+    /// average number of children per node.
+    pub const BRANCH_FACTOR: u64 = 254;
 
     /// Computes the rank of a node from its hash using a geometric distribution.
     pub fn rank(hash: &Blake3Hash) -> Rank {
@@ -59,31 +43,197 @@ pub mod geometric {
     /// Compute the rank of a hash using a threshold-based geometric
     /// distribution.
     ///
-    /// The first set of bytes of the hash are interpreted as a little-endian `u64`
+    /// The first 8 bytes of the hash are interpreted as a little-endian `u64`
     /// prefix, uniformly distributed in `[0, u64::MAX]`. The rank is
     /// determined by how many geometrically decreasing thresholds
-    /// (`u64::MAX / m`, `u64::MAX / m²`, ...) the prefix falls below.
+    /// (`u64::MAX / m`, `u64::MAX / m²`, ...) the prefix falls below:
+    ///
+    /// ```text
+    ///   rank = 1  if  prefix >= threshold_1                (probability: 1 - 1/m)
+    ///   rank = 2  if  threshold_2 <= prefix < threshold_1  (probability: 1/m - 1/m²)
+    ///   rank = 3  if  threshold_3 <= prefix < threshold_2  (probability: 1/m² - 1/m³)
+    ///   ...
+    /// ```
     ///
     /// This gives an exact `1/m` split probability at each level, so the
     /// effective branch factor matches the declared one.
-    pub(crate) fn compute_geometric_rank(hash: &Blake3Hash, m: u32) -> Rank {
-        let bytes = hash.as_bytes();
+    ///
+    /// The loop terminates on its own: integer division drives the threshold
+    /// to zero after `floor(log_m(2^64))` steps, and no prefix is below zero,
+    /// so ranks naturally top out at `floor(log_m(2^64)) + 1` (9 for m=254,
+    /// enough for trees with ~10^19 entries).
+    pub(crate) fn compute_geometric_rank(hash: &Blake3Hash, m: u64) -> Rank {
+        debug_assert!(m >= 2, "branch factor must be at least 2, got {m}");
 
-        let prefix = u64::from_le_bytes(
-            bytes[0..size_of::<u64>()]
-                .try_into()
-                .expect("hash must be at least u64 size"),
-        );
+        // Destructuring the first 8 bytes of the (fixed-size) hash makes the
+        // prefix extraction infallible: there is no slice conversion to fail.
+        // Little-endian is an arbitrary but deterministic choice; uniformity
+        // is unaffected, but the same bytes must always produce the same rank
+        // for the tree structure to be consistent.
+        let [b0, b1, b2, b3, b4, b5, b6, b7, ..] = *hash.as_bytes();
+        let prefix = u64::from_le_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
 
         let mut rank: Rank = 1;
-        let mut threshold = u64::MAX / u64::from(m);
-        let max_rank = max_rank_for(m);
+        let mut threshold = u64::MAX / m;
 
-        while prefix < threshold && rank < max_rank {
+        while prefix < threshold {
             rank += 1;
-            threshold /= u64::from(m);
+            threshold /= m;
         }
 
         rank
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use anyhow::Result;
+    use dialog_common::Blake3Hash;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::geometric::compute_geometric_rank;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    /// Fixed seed so the statistical tests are deterministic; the assertions
+    /// then verify exact, reproducible outcomes rather than racing sigma
+    /// tolerances against an unseeded RNG.
+    fn test_rng() -> StdRng {
+        StdRng::seed_from_u64(0x_D1A1_06DB)
+    }
+
+    fn hash_for(prefix: u64) -> Blake3Hash {
+        let mut bytes = [0u8; 32];
+        bytes[0..8].copy_from_slice(&prefix.to_le_bytes());
+        // Bytes 8..32 must not affect the result; make them non-zero to
+        // prove it.
+        bytes[8..].fill(0xFF);
+        Blake3Hash::from(bytes)
+    }
+
+    /// The threshold comparisons are exact, deterministic golden values: a
+    /// prefix at a threshold stays at the lower rank (the comparison is
+    /// strict), a prefix one below it is promoted, a prefix of zero falls
+    /// through every nonzero threshold and a prefix of `u64::MAX` is never
+    /// promoted.
+    #[dialog_common::test]
+    async fn it_has_correct_rank_boundaries() -> Result<()> {
+        let factor = 254u64;
+
+        // For m=254 the thresholds are u64::MAX / 254^k for k = 1..=8
+        // (254^8 < 2^64), so the maximum rank is 9.
+        assert_eq!(compute_geometric_rank(&hash_for(0), factor), 9);
+        assert_eq!(compute_geometric_rank(&hash_for(u64::MAX), factor), 1);
+
+        let threshold_1 = u64::MAX / factor;
+        let threshold_2 = threshold_1 / factor;
+
+        assert_eq!(compute_geometric_rank(&hash_for(threshold_1), factor), 1);
+        assert_eq!(
+            compute_geometric_rank(&hash_for(threshold_1 - 1), factor),
+            2
+        );
+        assert_eq!(compute_geometric_rank(&hash_for(threshold_2), factor), 2);
+        assert_eq!(
+            compute_geometric_rank(&hash_for(threshold_2 - 1), factor),
+            3
+        );
+
+        Ok(())
+    }
+
+    /// `P(rank >= 2)` must be approximately `1/m` so that segments average
+    /// `m` entries.
+    #[dialog_common::test]
+    async fn it_splits_with_branch_factor_probability() -> Result<()> {
+        let factor = 254u64;
+        let rounds = 1_000_000u32;
+        let mut rng = test_rng();
+
+        let mut promoted = 0u32;
+        for _ in 0..rounds {
+            let mut bytes = [0u8; 32];
+            rng.fill(&mut bytes);
+            if compute_geometric_rank(&Blake3Hash::from(bytes), factor) >= 2 {
+                promoted += 1;
+            }
+        }
+
+        let p_promoted = f64::from(promoted) / f64::from(rounds);
+        let expected_p = 1.0 / factor as f64;
+
+        assert!(
+            (p_promoted - expected_p).abs() / expected_p < 0.2,
+            "P(rank >= 2) = {p_promoted:.6} should be close to 1/{factor} = {expected_p:.6}"
+        );
+
+        Ok(())
+    }
+
+    /// The promotion probability must also be `1/m` at every level above the
+    /// first, i.e. `P(rank >= k+1 | rank >= k) ≈ 1/m`.
+    ///
+    /// This is the regression test for the bit-batch implementation this
+    /// module replaced: there, batches straddling byte boundaries were
+    /// zero-filled, which inflated the conditional promotion probabilities to
+    /// 1/2, 1/4, 1/8 instead of 1/m, producing much taller trees whose upper
+    /// levels averaged only 2-4 children.
+    #[dialog_common::test]
+    async fn it_has_geometric_promotion_at_every_level() -> Result<()> {
+        let factor = 16u64;
+        let rounds = 2_000_000u32;
+        let mut rng = test_rng();
+
+        let mut at_least = [0u32; 4];
+        for _ in 0..rounds {
+            let mut bytes = [0u8; 32];
+            rng.fill(&mut bytes);
+            let rank = compute_geometric_rank(&Blake3Hash::from(bytes), factor);
+            for (level, count) in at_least.iter_mut().enumerate() {
+                if rank >= (level + 1) as u64 {
+                    *count += 1;
+                }
+            }
+        }
+
+        for level in 1..at_least.len() - 1 {
+            let conditional = f64::from(at_least[level + 1]) / f64::from(at_least[level]);
+            let expected = 1.0 / factor as f64;
+            assert!(
+                (conditional - expected).abs() / expected < 0.15,
+                "promotion from rank {} to {} should happen with probability ~1/{factor}, got {conditional:.6}",
+                level + 1,
+                level + 2,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// The same hash must always produce the same rank, and only the first
+    /// 8 bytes of the hash participate.
+    #[dialog_common::test]
+    async fn it_is_deterministic_and_uses_only_the_prefix() -> Result<()> {
+        let mut rng = test_rng();
+        for _ in 0..1000 {
+            let mut bytes = [0u8; 32];
+            rng.fill(&mut bytes);
+            let hash = Blake3Hash::from(bytes);
+
+            let rank = compute_geometric_rank(&hash, 254);
+            assert_eq!(rank, compute_geometric_rank(&hash, 254));
+
+            let mut tail_mutated = bytes;
+            tail_mutated[8..].fill(0xAB);
+            assert_eq!(
+                rank,
+                compute_geometric_rank(&Blake3Hash::from(tail_mutated), 254)
+            );
+        }
+
+        Ok(())
     }
 }

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -731,7 +731,7 @@ where
     where
         NodeBody<Key, Value>: TryFrom<Vec<Child>, Error = DialogSearchTreeError>,
     {
-        let mut output: Vec<(Node<Key, Value>, u32)> = vec![];
+        let mut output: Vec<(Node<Key, Value>, Rank)> = vec![];
         let mut pending = vec![];
 
         for (child, rank) in children {

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -368,12 +368,12 @@ where
     /// boundary rightward at every level, so the boundary's host is always
     /// the last child; the right-adjacent descent takes leftmost children)
     /// we can rely on:
-    /// - `main_layer.right_siblings == None` for every layer below the LCA, and
-    /// - `right_layer.left_siblings == None` for every layer below the LCA.
+    /// - `!main_layer.has_right_siblings()` for every layer below the LCA, and
+    /// - `!right_layer.has_left_siblings()` for every layer below the LCA.
     ///
     /// The fold that produces each fused node (`[w y]`, then `DE`) is
     /// therefore just
-    /// `[main_layer.left_siblings | unified | right_layer.right_siblings]`.
+    /// `[main_layer.left_siblings() | unified | right_layer.right_siblings()]`.
     ///
     /// The tree above the LCA is unaffected and handed off to the standard
     /// merge routine.
@@ -437,50 +437,55 @@ where
             context.delta().remove(right_layer.host.hash());
 
             debug_assert!(
-                main_layer.right_siblings.is_none(),
+                !main_layer.has_right_siblings(),
                 "main descent follows the rightmost path; no right siblings below LCA"
             );
             debug_assert!(
-                right_layer.left_siblings.is_none(),
+                !right_layer.has_left_siblings(),
                 "right-adjacent descent is leftmost; no left siblings below LCA"
             );
 
             let unified_links = promote_to_ranked_links(unified, &mut context)?;
 
-            let mut parts: Vec<NonEmpty<(Link<Key>, Rank)>> = Vec::new();
-            if let Some(left) = main_layer.left_siblings {
-                parts.push(into_ranked_links(left, &mut context));
-            }
-            parts.push(unified_links);
-            if let Some(right) = right_layer.right_siblings {
-                parts.push(into_ranked_links(right, &mut context));
-            }
-
-            let combined_links = concat_nonempty(parts)?;
+            // The unified subtree sits between the main descent's left siblings
+            // and the right descent's right siblings (the asserts above pin that
+            // those are the only siblings below the LCA).
+            let combined_links = Self::splice_siblings(
+                unified_links,
+                main_layer.left_siblings()?,
+                right_layer.right_siblings()?,
+                &mut context,
+            )?;
             unified = Self::collect::<Link<_>>(combined_links, level_minimum_rank)?;
             level_minimum_rank += 1;
         }
 
-        // At the LCA, the first right sibling was the right-descent target; it
-        // has been subsumed by the unified subtree. The remaining right
-        // siblings stay as peers of the unified subtree at this level.
-        let right_siblings_at_lca = lca_layer.right_siblings.ok_or_else(|| {
-            DialogSearchTreeError::Operation(
-                "LCA layer had no right siblings during overflow".into(),
-            )
-        })?;
-        let modified_right_siblings =
-            NonEmpty::from_vec(right_siblings_at_lca.into_iter().skip(1).collect());
+        // At the LCA, the main descent took child `lca_layer.index` and the
+        // right descent took the next child (`index + 1`); both have been
+        // subsumed by the unified subtree. The LCA's left siblings are the
+        // children before the main target, and its surviving right siblings are
+        // the children after the right target (i.e. skip the subsumed pair).
+        context.delta().remove(lca_layer.host.hash());
+        let lca_links = &lca_layer.host.as_index()?.links;
+        let lca_left = NonEmpty::from_vec(
+            lca_links[..lca_layer.index]
+                .iter()
+                .map(into_owned)
+                .collect::<Result<Vec<Link<Key>>, _>>()?,
+        );
+        let lca_right = NonEmpty::from_vec(
+            lca_links[(lca_layer.index + 2).min(lca_links.len())..]
+                .iter()
+                .map(into_owned)
+                .collect::<Result<Vec<Link<Key>>, _>>()?,
+        );
 
-        let lca_has_own_siblings =
-            lca_layer.left_siblings.is_some() || modified_right_siblings.is_some();
+        let lca_has_own_siblings = lca_left.is_some() || lca_right.is_some();
 
         if !lca_has_own_siblings {
             // The LCA's only children were the main- and right-descent targets;
             // both were subsumed by the unified subtree. The LCA node itself
             // disappears from the canonical tree.
-            context.delta().remove(lca_layer.host.hash());
-
             if above_lca.is_empty() {
                 // The LCA was the tree root; the unified subtree becomes the
                 // new root via the standard merge with nothing left to merge
@@ -498,17 +503,14 @@ where
             return Self::merge_with_path(promoted, above_lca, context, level_minimum_rank + 1);
         }
 
-        // LCA has genuine siblings: rebuild the LCA around the unified subtree
-        // and the preserved siblings, then hand off to the standard merge.
-        let modified_lca_layer = TreeLayer {
-            host: lca_layer.host,
-            left_siblings: lca_layer.left_siblings,
-            right_siblings: modified_right_siblings,
-        };
-        let mut final_path = above_lca;
-        final_path.push(modified_lca_layer);
+        // LCA has genuine siblings: rebuild the LCA level around the unified
+        // subtree and the preserved siblings, then hand off to the standard
+        // merge for everything above it.
+        let unified_links = promote_to_ranked_links(unified, &mut context)?;
+        let spliced = Self::splice_siblings(unified_links, lca_left, lca_right, &mut context)?;
+        let collected = Self::collect::<Link<_>>(spliced, level_minimum_rank)?;
 
-        Self::merge_with_path(unified, final_path, context, level_minimum_rank)
+        Self::merge_with_path(collected, above_lca, context, level_minimum_rank + 1)
     }
 
     /// Redistributes a non-empty list of entries into a new tree structure,
@@ -548,6 +550,29 @@ where
         // Nodes start at level 0 (segments); the first level-up collect uses
         // the level-1 threshold.
         Self::merge_with_path(nodes, search_path, context, FIRST_INDEX_RANK)
+    }
+
+    /// Splices the rebuilt children of a level between its unchanged left and
+    /// right siblings, ranking the siblings as it goes.
+    ///
+    /// The siblings are passed already decoded (via [`TreeLayer::left_siblings`]
+    /// / [`TreeLayer::right_siblings`], or assembled directly by the overflow
+    /// path), so this is the single place the three cases (left only, right only,
+    /// both, neither) are handled.
+    fn splice_siblings(
+        middle: NonEmpty<(Link<Key>, Rank)>,
+        left: Option<NonEmpty<Link<Key>>>,
+        right: Option<NonEmpty<Link<Key>>>,
+        context: &mut MutationContext<Key, D>,
+    ) -> Result<NonEmpty<(Link<Key>, Rank)>, DialogSearchTreeError> {
+        let left = left.map(|links| into_ranked_links(links, context));
+        let right = right.map(|links| into_ranked_links(links, context));
+        match (left, right) {
+            (None, None) => Ok(middle),
+            (Some(left), None) => concat_nonempty(vec![left, middle]),
+            (None, Some(right)) => concat_nonempty(vec![middle, right]),
+            (Some(left), Some(right)) => concat_nonempty(vec![left, middle, right]),
+        }
     }
 
     /// Merges a collection of nodes with a search path, rebuilding from leaves
@@ -600,29 +625,11 @@ where
                 match search_path.pop() {
                     Some(layer) => {
                         context.delta().remove(layer.host.hash());
-                        let ranked_left_siblings = layer
-                            .left_siblings
-                            .map(|links| into_ranked_links(links, &mut context));
-                        let ranked_right_siblings = layer
-                            .right_siblings
-                            .map(|links| into_ranked_links(links, &mut context));
-
-                        match (ranked_left_siblings, ranked_right_siblings) {
-                            (None, None) => ranked_links,
-                            (Some(ranked_left_siblings), None) => {
-                                concat_nonempty(vec![ranked_left_siblings, ranked_links])?
-                            }
-                            (None, Some(ranked_right_siblings)) => {
-                                concat_nonempty(vec![ranked_links, ranked_right_siblings])?
-                            }
-                            (Some(ranked_left_siblings), Some(ranked_right_siblings)) => {
-                                concat_nonempty(vec![
-                                    ranked_left_siblings,
-                                    ranked_links,
-                                    ranked_right_siblings,
-                                ])?
-                            }
-                        }
+                        // Rebuilding this level needs the host's other children,
+                        // so decode them from the host now.
+                        let left = layer.left_siblings()?;
+                        let right = layer.right_siblings()?;
+                        Self::splice_siblings(ranked_links, left, right, &mut context)?
                     }
                     None => ranked_links,
                 }
@@ -677,12 +684,12 @@ where
         while let Some(layer) = path.pop() {
             context.delta().remove(layer.host.hash());
 
-            // Collect left and right siblings, excluding the removed child
+            // Collect left and right siblings, excluding the removed child.
             let mut links = Vec::new();
-            if let Some(left_siblings) = layer.left_siblings {
+            if let Some(left_siblings) = layer.left_siblings()? {
                 links.extend(left_siblings);
             }
-            if let Some(right_siblings) = layer.right_siblings {
+            if let Some(right_siblings) = layer.right_siblings()? {
                 links.extend(right_siblings);
             }
 

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -171,8 +171,17 @@ where
         Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
             + ConditionalSync,
     {
-        if let Some(result) = self.search(key, storage, SearchOptions::default()).await? {
-            if let Some(entry) = result.leaf.body()?.find_entry(key)? {
+        // A read does not need the search path (sibling links, prefetch) that
+        // `search` builds for the insert/delete rebuild; that path is
+        // `O(fan-out)` per index node and dominates a point lookup on a flat,
+        // high-fan-out tree. `find_leaf` does the same descent with a binary
+        // search per index node and no sibling materialization.
+        let accessor = Accessor::new(self.delta.clone(), self.node_cache.clone(), storage.clone());
+        if let Some(leaf) = TreeWalker::<Key, Value>::new(self.root.clone())
+            .find_leaf(key, accessor)
+            .await?
+        {
+            if let Some(entry) = leaf.body()?.find_entry(key)? {
                 into_owned(&entry.value).map(|value| Some(value))
             } else {
                 Ok(None)
@@ -1401,6 +1410,56 @@ mod tests {
             let value = tree.get(&key, &storage).await?;
             assert_eq!(value, Some(expected_value));
         }
+
+        Ok(())
+    }
+
+    /// `get` descends with [`TreeWalker::find_leaf`], a read-only path that
+    /// binary-searches each index node instead of walking and materializing the
+    /// sibling links the way the insert/delete `search` does. This pins that the
+    /// two descents agree on every key, including the boundary cases the binary
+    /// search's `partition_point` must get right: a key below the minimum, keys
+    /// that sit exactly on an index `upper_bound`, keys between stored keys, and
+    /// a key above the maximum (which must fall through to the last child).
+    #[dialog_common::test]
+    async fn it_gets_present_and_absent_keys_across_index_boundaries() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Even keys only, so every odd key probes a gap; spread wide enough to
+        // force a multi-level index whose boundaries the descent must navigate.
+        let present: Vec<u32> = (0..4000u32).map(|i| i * 2).collect();
+        for &k in &present {
+            tree = tree
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
+        }
+
+        // Every present (even) key resolves to its value.
+        for &k in &present {
+            assert_eq!(
+                tree.get(&k.to_le_bytes(), &storage).await?,
+                Some(k.to_le_bytes().to_vec()),
+                "present key {k} should resolve"
+            );
+        }
+
+        // Every absent (odd) key in range, plus one above the maximum, returns
+        // None. The odd keys land between stored keys and on the far side of
+        // index boundaries; the above-max key exercises the last-child fallback.
+        for k in (1..8000u32).step_by(2) {
+            assert_eq!(
+                tree.get(&k.to_le_bytes(), &storage).await?,
+                None,
+                "absent key {k} should not resolve"
+            );
+        }
+        assert_eq!(tree.get(&100_000u32.to_le_bytes(), &storage).await?, None);
 
         Ok(())
     }

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -171,17 +171,12 @@ where
         Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
             + ConditionalSync,
     {
-        // A read does not need the search path (sibling links, prefetch) that
-        // `search` builds for the insert/delete rebuild; that path is
-        // `O(fan-out)` per index node and dominates a point lookup on a flat,
-        // high-fan-out tree. `find_leaf` does the same descent with a binary
-        // search per index node and no sibling materialization.
-        let accessor = Accessor::new(self.delta.clone(), self.node_cache.clone(), storage.clone());
-        if let Some(leaf) = TreeWalker::<Key, Value>::new(self.root.clone())
-            .find_leaf(key, accessor)
-            .await?
-        {
-            if let Some(entry) = leaf.body()?.find_entry(key)? {
+        // The search path is the copy-on-write frontier for an update; a read
+        // ignores it and takes only the leaf. Building it is allocation-free
+        // (each layer is an Arc-backed node plus a child index), so the read
+        // pays nothing for the siblings an update would later decode.
+        if let Some(result) = self.search(key, storage, SearchOptions::default()).await? {
+            if let Some(entry) = result.leaf.body()?.find_entry(key)? {
                 into_owned(&entry.value).map(|value| Some(value))
             } else {
                 Ok(None)

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -98,7 +98,7 @@ where
             else {
                 return;
             };
-            let mut search_path = search_result.into_indexed()?;
+            let mut search_path = search_result.into_indexed();
             let mut entered_range = false;
 
             while let Some((node, maybe_index)) = search_path.pop() {
@@ -172,48 +172,22 @@ where
 
             match node.body()? {
                 ArchivedNodeBody::Index(index) => {
-                    let mut left = vec![];
-                    let mut right = vec![];
-                    let mut next_descendant = None;
+                    // Descend into the first child whose `upper_bound >= key`,
+                    // falling back to the last child when the key is above every
+                    // bound. `partition_point` counts the children strictly below
+                    // `key`, so it lands on that first candidate without scanning
+                    // or decoding any sibling.
+                    let child_index = index
+                        .links
+                        .partition_point(|link| &link.upper_bound < key)
+                        .min(index.links.len() - 1);
 
-                    for link in index.links.iter() {
-                        if next_descendant.is_some() {
-                            right.push(link);
-                        } else if key <= &link.upper_bound {
-                            next_descendant = Some(&link.node);
-                        } else {
-                            left.push(link);
-                        }
-                    }
-
-                    if next_descendant.is_none() {
-                        let last_candidate = left.pop().ok_or(DialogSearchTreeError::Operation(
-                            "No upper bound found".into(),
-                        ))?;
-
-                        next_descendant = Some(&last_candidate.node);
-                    }
+                    next_node = into_owned(&index.links[child_index].node)?;
 
                     path.push(TreeLayer {
                         host: node.clone(),
-                        left_siblings: NonEmpty::from_vec(
-                            left.into_iter()
-                                .map(into_owned)
-                                .collect::<Result<_, DialogSearchTreeError>>()?,
-                        ),
-                        right_siblings: NonEmpty::from_vec(
-                            right
-                                .into_iter()
-                                .map(into_owned)
-                                .collect::<Result<_, DialogSearchTreeError>>()?,
-                        ),
+                        index: child_index,
                     });
-
-                    next_node = next_descendant
-                        .ok_or_else(|| {
-                            DialogSearchTreeError::Operation("Next node not found".into())
-                        })
-                        .and_then(into_owned)?;
                 }
                 ArchivedNodeBody::Segment(_) => {
                     let right_neighbor = if options.prefetch_right_neighbor {
@@ -228,71 +202,6 @@ where
                     }));
                 }
             }
-        }
-    }
-
-    /// Descends to the leaf segment that would contain `key`, returning just
-    /// that leaf node.
-    ///
-    /// This is the read-only counterpart to [`search`](Self::search): it does
-    /// the same root-to-leaf descent but performs no work a read does not need.
-    /// In particular it does **not** materialize the search path, which means it
-    /// never `into_owned`s the sibling links of the index nodes it passes
-    /// through. `search` builds that path for the insert/delete rebuild, and
-    /// doing so is `O(fan-out)` per index node — proportional to how many
-    /// children each index holds. For a flat, high-fan-out tree that dominates
-    /// a point lookup, even though the descent itself touches only a couple of
-    /// nodes.
-    ///
-    /// Here each index node is instead navigated with a binary search over its
-    /// links (`O(log fan-out)`), and only the chosen child hash is decoded, so
-    /// the cost is independent of fan-out. Callers that only read a value (e.g.
-    /// [`Tree::get`](crate::Tree::get)) should prefer this.
-    pub async fn find_leaf<Backend>(
-        &self,
-        key: &Key,
-        accessor: Accessor<Backend>,
-    ) -> Result<Option<Node<Key, Value>>, DialogSearchTreeError>
-    where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
-            + ConditionalSync,
-    {
-        if &self.root == NULL_BLAKE3_HASH {
-            return Ok(None);
-        }
-
-        const MAXIMUM_TREE_DEPTH: usize = 32;
-
-        let mut next_node = self.root.clone();
-        let mut depth = 0;
-
-        loop {
-            if depth > MAXIMUM_TREE_DEPTH {
-                return Err(DialogSearchTreeError::Operation(format!(
-                    "Tree depth exceded the soft maximum ({MAXIMUM_TREE_DEPTH})"
-                )));
-            }
-
-            let node = accessor.get_node(&next_node).await?;
-
-            match node.body()? {
-                ArchivedNodeBody::Index(index) => {
-                    // Links are sorted by `upper_bound`; descend into the first
-                    // whose `upper_bound >= key`, falling back to the last when
-                    // the key is above every bound. `partition_point` counts the
-                    // links strictly below `key`, so it lands on that first
-                    // candidate without scanning or owning any sibling.
-                    let child = index
-                        .links
-                        .partition_point(|link| &link.upper_bound < key)
-                        .min(index.links.len() - 1);
-
-                    next_node = into_owned(&index.links[child].node)?;
-                }
-                ArchivedNodeBody::Segment(_) => return Ok(Some(node)),
-            }
-
-            depth += 1;
         }
     }
 }
@@ -348,43 +257,34 @@ where
 
     // Find the deepest ancestor with a right sibling: that's the lowest common
     // ancestor of the main descent and the right-adjacent descent.
-    let Some(lca_depth) = path
-        .iter()
-        .rposition(|layer| layer.right_siblings.is_some())
-    else {
+    let Some(lca_depth) = path.iter().rposition(|layer| layer.has_right_siblings()) else {
         // The leaf is the rightmost segment in the tree; nothing to prefetch.
         return Ok(None);
     };
 
-    // Safe to unwrap: `rposition` only matches layers whose right_siblings are
-    // `Some(_)`.
-    let first_right_link = &path[lca_depth]
-        .right_siblings
-        .as_ref()
-        .expect("rposition guarantees right_siblings is Some")
-        .head;
-    let mut next_hash: Blake3Hash = first_right_link.node.clone();
+    // The right-descent starts at the LCA's first right sibling (the child just
+    // past the one the main descent took).
+    let lca = &path[lca_depth];
+    let lca_links = &lca.host.as_index()?.links;
+    let mut next_hash: Blake3Hash = into_owned(&lca_links[lca.index + 1].node)?;
     let mut diverged_path: Vec<TreeLayer<Key, Value>> = Vec::new();
 
     let right_leaf = loop {
         let node: Node<Key, Value> = accessor.get_node(&next_hash).await?;
         match node.body()? {
             ArchivedNodeBody::Index(index) => {
-                let mut links = index.links.iter();
-                let first = links.next().ok_or_else(|| {
+                let first = index.links.first().ok_or_else(|| {
                     DialogSearchTreeError::Node(
                         "Empty index node during right-neighbor descent".into(),
                     )
                 })?;
                 let child_hash: Blake3Hash = into_owned(&first.node)?;
-                let rest: Vec<Link<Key>> = links
-                    .map(into_owned)
-                    .collect::<Result<_, DialogSearchTreeError>>()?;
 
+                // The right-adjacent descent is leftmost, so it always takes
+                // child 0; the remaining children are its right siblings.
                 diverged_path.push(TreeLayer {
                     host: node.clone(),
-                    left_siblings: None,
-                    right_siblings: NonEmpty::from_vec(rest),
+                    index: 0,
                 });
                 next_hash = child_hash;
             }
@@ -414,19 +314,87 @@ pub struct SearchOptions {
     pub prefetch_right_neighbor: bool,
 }
 
-/// A layer in the tree traversal path, containing a node and its sibling links.
+/// A layer in the tree traversal path: the index node descended through and the
+/// position of the child the descent took.
+///
+/// [`TreeWalker::search`] assembles a path of these as the copy-on-write
+/// frontier for an update: each layer names a node an update rebuilds and the
+/// child slot within it that changes. A layer is cheap to hold: `host` is an
+/// [`Arc`]-backed [`Node`] that shares its buffer when cloned, and `index` is a
+/// `usize`. The host's other children stay encoded in its buffer; a read leaves
+/// them there, and a write decodes the ones it needs on demand through
+/// [`left_siblings`](Self::left_siblings) /
+/// [`right_siblings`](Self::right_siblings) when it rebuilds the level.
+///
+/// [`Arc`]: std::sync::Arc
 pub struct TreeLayer<Key, Value>
 where
     Key: self::Key,
     Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
 {
-    // pub host: Blake3Hash,
-    /// The node at this layer of the tree.
+    /// The index node at this layer of the tree.
     pub host: Node<Key, Value>,
-    /// Links to sibling nodes to the left of the current path.
-    pub left_siblings: Option<NonEmpty<Link<Key>>>,
-    /// Links to sibling nodes to the right of the current path.
-    pub right_siblings: Option<NonEmpty<Link<Key>>>,
+    /// Position within `host.links` of the child the descent followed.
+    pub index: usize,
+}
+
+impl<Key, Value> TreeLayer<Key, Value>
+where
+    Key: self::Key + PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key>
+        + PartialEq<Key>
+        + SymmetryWith<Key>
+        + Ord
+        + for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+{
+    /// Whether the descended child has any sibling to its left. Cheap: a length
+    /// comparison, no decoding.
+    pub fn has_left_siblings(&self) -> bool {
+        self.index > 0
+    }
+
+    /// Whether the descended child has any sibling to its right. Cheap: a length
+    /// comparison, no decoding.
+    pub fn has_right_siblings(&self) -> bool {
+        self.host
+            .as_index()
+            .map(|index| self.index + 1 < index.links.len())
+            .unwrap_or(false)
+    }
+
+    /// The host's children strictly to the left of the descended child, decoded
+    /// to owned links. Materialized on demand: only an update that rebuilds this
+    /// level calls it.
+    pub fn left_siblings(&self) -> Result<Option<NonEmpty<Link<Key>>>, DialogSearchTreeError> {
+        self.siblings(0, self.index)
+    }
+
+    /// The host's children strictly to the right of the descended child, decoded
+    /// to owned links. Materialized on demand: only an update that rebuilds this
+    /// level calls it.
+    pub fn right_siblings(&self) -> Result<Option<NonEmpty<Link<Key>>>, DialogSearchTreeError> {
+        let links = self.host.as_index()?.links.len();
+        self.siblings(self.index + 1, links)
+    }
+
+    fn siblings(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Result<Option<NonEmpty<Link<Key>>>, DialogSearchTreeError> {
+        let index = self.host.as_index()?;
+        let owned = index.links[start..end]
+            .iter()
+            .map(into_owned)
+            .collect::<Result<Vec<Link<Key>>, _>>()?;
+        Ok(NonEmpty::from_vec(owned))
+    }
 }
 
 /// The path taken from the root to a leaf during a tree search.
@@ -510,31 +478,18 @@ where
         Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
     >,
 {
-    /// Converts this search result into a path with child indices.
-    pub fn into_indexed(mut self) -> Result<IndexedPath<Key, Value>, DialogSearchTreeError> {
+    /// Converts this search result into a root-to-leaf path of
+    /// `(node, child index)` pairs, where the leaf carries `None` and each index
+    /// node carries the slot of the child the search descended into.
+    pub fn into_indexed(mut self) -> IndexedPath<Key, Value> {
         let mut path = Vec::new();
-        let mut leaf = self.leaf;
-
-        path.push((leaf.clone(), None));
+        path.push((self.leaf, None));
 
         while let Some(layer) = self.path.pop() {
-            let Some(leaf_upper_bound) = leaf.upper_bound()? else {
-                return Err(DialogSearchTreeError::Node(
-                    "Could not discover child's upper bound".to_string(),
-                ));
-            };
-            let Some(index) = layer.host.get_child_index(leaf_upper_bound)? else {
-                return Err(DialogSearchTreeError::Node(
-                    "Could not find node's index relative to parent".to_string(),
-                ));
-            };
-
-            leaf = layer.host;
-            path.push((leaf.clone(), Some(index)));
+            path.push((layer.host, Some(layer.index)));
         }
 
         path.reverse();
-
-        Ok(path)
+        path
     }
 }

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -230,6 +230,71 @@ where
             }
         }
     }
+
+    /// Descends to the leaf segment that would contain `key`, returning just
+    /// that leaf node.
+    ///
+    /// This is the read-only counterpart to [`search`](Self::search): it does
+    /// the same root-to-leaf descent but performs no work a read does not need.
+    /// In particular it does **not** materialize the search path, which means it
+    /// never `into_owned`s the sibling links of the index nodes it passes
+    /// through. `search` builds that path for the insert/delete rebuild, and
+    /// doing so is `O(fan-out)` per index node — proportional to how many
+    /// children each index holds. For a flat, high-fan-out tree that dominates
+    /// a point lookup, even though the descent itself touches only a couple of
+    /// nodes.
+    ///
+    /// Here each index node is instead navigated with a binary search over its
+    /// links (`O(log fan-out)`), and only the chosen child hash is decoded, so
+    /// the cost is independent of fan-out. Callers that only read a value (e.g.
+    /// [`Tree::get`](crate::Tree::get)) should prefer this.
+    pub async fn find_leaf<Backend>(
+        &self,
+        key: &Key,
+        accessor: Accessor<Backend>,
+    ) -> Result<Option<Node<Key, Value>>, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+    {
+        if &self.root == NULL_BLAKE3_HASH {
+            return Ok(None);
+        }
+
+        const MAXIMUM_TREE_DEPTH: usize = 32;
+
+        let mut next_node = self.root.clone();
+        let mut depth = 0;
+
+        loop {
+            if depth > MAXIMUM_TREE_DEPTH {
+                return Err(DialogSearchTreeError::Operation(format!(
+                    "Tree depth exceded the soft maximum ({MAXIMUM_TREE_DEPTH})"
+                )));
+            }
+
+            let node = accessor.get_node(&next_node).await?;
+
+            match node.body()? {
+                ArchivedNodeBody::Index(index) => {
+                    // Links are sorted by `upper_bound`; descend into the first
+                    // whose `upper_bound >= key`, falling back to the last when
+                    // the key is above every bound. `partition_point` counts the
+                    // links strictly below `key`, so it lands on that first
+                    // candidate without scanning or owning any sibling.
+                    let child = index
+                        .links
+                        .partition_point(|link| &link.upper_bound < key)
+                        .min(index.links.len() - 1);
+
+                    next_node = into_owned(&index.links[child].node)?;
+                }
+                ArchivedNodeBody::Segment(_) => return Ok(Some(node)),
+            }
+
+            depth += 1;
+        }
+    }
 }
 
 /// Walks the narrow "overflow" path for [`RightNeighbor`] prefetching.


### PR DESCRIPTION
 The previous implementation grouped hash bits into k-bit batches where `k = ceil(log₂(BRANCH_FACTOR))`. For BRANCH_FACTOR=254, this gave k=7, making each trial probability `1/2^7 = 1/128` instead of `1/254`.  This made effective branch factor ~128, not the declared 254.
 
 > This is also why number of read/writes in tests went down

Proposed threshold approach offers IMO much easier to reason about algorithm, which is described in detail in the code comments. 

This also addresses prior upper limit on the possible branching factor. 