### PR TITLE
5 ✅ feat: add Checksum types and #[derive(Attenuate)] macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,27 +49,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -79,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
@@ -93,39 +78,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle-query"
-version = "1.1.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.11"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -138,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -233,16 +209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base256emoji"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
-dependencies = [
- "const-str",
- "match-lookup",
-]
-
-[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.8.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bit-set"
@@ -293,16 +259,15 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
 ]
 
 [[package]]
@@ -325,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -346,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecheck"
@@ -420,11 +385,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
- "find-msvc-tools",
  "shlex",
 ]
 
@@ -450,7 +414,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -499,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -509,11 +473,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -521,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -533,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmov"
@@ -571,21 +535,15 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const-str"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -773,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.13"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -818,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -828,10 +786,11 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -841,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -866,15 +825,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -882,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
  "syn",
@@ -903,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -937,7 +896,7 @@ dependencies = [
  "dialog-storage",
  "ed25519-dalek",
  "futures-util",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "leb128",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -967,8 +926,8 @@ dependencies = [
  "dirs",
  "futures-core",
  "futures-util",
- "getrandom 0.2.17",
- "getrandom 0.3.4",
+ "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "js-sys",
  "tempfile",
  "thiserror 2.0.18",
@@ -1006,15 +965,17 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base58",
+ "base64",
  "blake3",
  "dialog-macros",
  "futures-util",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "wasm-bindgen",
@@ -1036,7 +997,7 @@ dependencies = [
  "dialog-ucan",
  "dialog-varsig",
  "ed25519-dalek",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "js-sys",
  "serde",
  "signature",
@@ -1128,7 +1089,7 @@ dependencies = [
  "dialog-storage",
  "futures-core",
  "futures-util",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "nonempty",
  "rand 0.8.5",
  "serde",
@@ -1177,7 +1138,7 @@ dependencies = [
  "dialog-effects",
  "dialog-ucan",
  "dialog-varsig",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "hmac 0.12.1",
  "ipld-core",
  "reqwest",
@@ -1210,7 +1171,7 @@ dependencies = [
  "dialog-storage",
  "futures-core",
  "futures-util",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "hashbrown 0.16.1",
  "nonempty",
  "parking_lot",
@@ -1246,7 +1207,7 @@ dependencies = [
  "dialog-s3-credentials",
  "dialog-varsig",
  "futures-util",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1286,7 +1247,7 @@ dependencies = [
  "dialog-credentials",
  "dialog-varsig",
  "futures",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "ipld-core",
  "js-sys",
  "leb128",
@@ -1356,12 +1317,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285743a676ccb6b3e116bc14cc69319b957867930ae9c4822f8e0f54509d7243"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid 0.10.1",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -1489,7 +1450,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "log",
@@ -1503,12 +1464,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.14"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1532,12 +1493,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -1656,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1667,28 +1622,28 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasip2",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1807,7 +1762,7 @@ version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
- "digest 0.11.1",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1857,9 +1812,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -1906,13 +1861,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1921,7 +1877,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1929,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1953,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1966,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1979,10 +1935,11 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1993,38 +1950,42 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
+ "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2034,14 +1995,13 @@ dependencies = [
 
 [[package]]
 name = "idb"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6554f394e990a1af530a528a7fdcad6e01b29cb1b990f89df3ffd62cf15f7828"
+checksum = "3afe8830d5802f769dc0be20a87f9f116798c896650cb6266eb5c19a3c109eed"
 dependencies = [
- "indexmap",
  "js-sys",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tokio",
  "wasm-bindgen",
  "web-sys",
@@ -2086,18 +2046,15 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.7"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling",
  "indoc",
@@ -2108,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "ipld-core"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090f624976d72f0b0bb71b86d58dc16c15e069193067cb3a3a09d655246cbbda"
+checksum = "104718b1cc124d92a6d01ca9c9258a7df311405debb3408c445a36452f9bf8db"
 dependencies = [
  "cid",
  "quickcheck",
@@ -2120,15 +2077,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
@@ -2147,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.2"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2225,9 +2182,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -2237,9 +2194,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
@@ -2252,30 +2209,31 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
@@ -2293,17 +2251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "match-lookup"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e715bb6f273068fc89403d6c4f5eeb83708c62b74c8d43e3e8772ca73a6288"
 dependencies = [
  "cfg-if",
- "digest 0.11.1",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2358,24 +2305,23 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi",
- "windows-sys 0.61.2",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
 dependencies = [
  "base-x",
- "base256emoji",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -2478,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2520,15 +2466,15 @@ checksum = "a3c00a0c9600379bd32f8972de90676a7672cba3bf4886986bc05902afc1e093"
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.2"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -2597,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.5"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2607,15 +2553,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.12"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2713,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
 ]
@@ -2756,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2841,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2852,7 +2798,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2861,12 +2807,12 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -2882,23 +2828,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2936,7 +2882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2956,7 +2902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2965,16 +2911,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2983,7 +2929,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3029,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -3042,16 +2988,16 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3061,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3072,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rend"
@@ -3087,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
@@ -3152,7 +3098,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3238,22 +3184,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring",
@@ -3265,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3275,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3304,9 +3250,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3s"
@@ -3391,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -3456,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46182f4f08349a02b45c998ba3215d3f9de826246ba02bb9dddfe9a2a2100778"
+checksum = "99600723cf53fb000a66175555098db7e75217c415bdd9a16a65d52a19dcc4fc"
 dependencies = [
  "cbor4ii",
  "ipld-core",
@@ -3510,7 +3456,7 @@ checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.1",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3532,7 +3478,7 @@ checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.1",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3552,9 +3498,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sieve-cache"
-version = "1.1.6"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879e304c6ec8e95de2bc5425b546df072ee5812d0b2b8497b73f0b68b31ddbbb"
+checksum = "5cfaac82727ec6de7f6065963e1d4c6f539bc4d01c1df332c3e16aa2a9014f62"
 
 [[package]]
 name = "signal-hook"
@@ -3568,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio",
@@ -3579,11 +3525,10 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.8"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
- "errno",
  "libc",
 ]
 
@@ -3605,9 +3550,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -3617,12 +3562,22 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3649,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3705,9 +3660,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3736,15 +3691,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "rustix 1.0.8",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3867,9 +3822,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3887,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3910,16 +3865,16 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3928,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -3938,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3949,10 +3904,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
 dependencies = [
+ "async-stream",
+ "bytes",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -3988,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags",
  "bytes",
@@ -4093,9 +4050,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ulid"
@@ -4115,9 +4072,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4254,12 +4211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -4395,9 +4352,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4420,11 +4377,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.11"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4441,7 +4398,7 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result",
  "windows-strings",
 ]
@@ -4470,6 +4427,12 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -4480,7 +4443,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4489,7 +4452,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4534,7 +4497,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4543,7 +4506,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4594,19 +4557,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.5"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows-link 0.1.3",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4629,9 +4592,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4653,9 +4616,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4677,9 +4640,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -4689,9 +4652,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4713,9 +4676,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4737,9 +4700,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4761,9 +4724,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4785,21 +4748,24 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yansi"
@@ -4809,10 +4775,11 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
+ "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4820,9 +4787,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4832,18 +4799,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4879,9 +4846,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4890,9 +4857,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4901,9 +4868,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "serde",
  "signature",
  "thiserror 2.0.18",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/rust/dialog-capability/Cargo.toml
+++ b/rust/dialog-capability/Cargo.toml
@@ -6,6 +6,12 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("web-integration-tests"))',
+    'cfg(dialog_test_wasm_integration)',
+] }
+
 [features]
 default = []
 # UCAN support (IPLD serialization for capabilities)
@@ -22,3 +28,7 @@ signature = { workspace = true }
 dialog-varsig = { workspace = true }
 ipld-core = { workspace = true, optional = true }
 dialog-ucan = { workspace = true, optional = true }
+
+[dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
+wasm-bindgen-test = { workspace = true }

--- a/rust/dialog-capability/src/attenuate.rs
+++ b/rust/dialog-capability/src/attenuate.rs
@@ -84,7 +84,7 @@ mod tests {
     #[derive(Debug, Clone, Copy, Serialize, Deserialize, Attenuate)]
     struct Ping;
 
-    #[test]
+    #[dialog_common::test]
     fn it_derives_attenuation_for_unit_struct() {
         let ping = Ping;
         let attenuation = ping.into_attenuation();
@@ -98,7 +98,7 @@ mod tests {
         key: Vec<u8>,
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_derives_identity_attenuation_for_plain_struct() {
         let get = Get {
             key: b"hello".to_vec(),
@@ -120,7 +120,7 @@ mod tests {
         type Output = ();
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_projects_content_to_checksum() {
         let put = Put {
             digest: vec![1, 2, 3],
@@ -144,7 +144,7 @@ mod tests {
         type Output = ();
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_renames_projected_field() {
         let publish = Publish {
             when: Some(42),
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(attenuation.checksum, Checksum(3));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_generates_attenuation_struct_with_renamed_field() {
         let publish = Publish {
             when: None,
@@ -167,7 +167,7 @@ mod tests {
         assert_eq!(attenuation.when, None);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_preserves_ability_path_on_attenuation_struct() {
         // The generated *Attenuation struct must occupy the same position
         // in the capability chain as its source: same `Of` and same
@@ -205,7 +205,7 @@ mod tests {
         type Output = ();
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_uses_custom_with_function() {
         let upload = Upload {
             key: "test".to_string(),
@@ -221,7 +221,7 @@ mod tests {
     #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
     struct GenericEffect<T>(PhantomData<T>);
 
-    #[test]
+    #[dialog_common::test]
     fn it_derives_attenuation_for_generic_struct() {
         let effect = GenericEffect::<String>(PhantomData);
         let _attenuation = effect.into_attenuation();

--- a/rust/dialog-capability/src/attenuate.rs
+++ b/rust/dialog-capability/src/attenuate.rs
@@ -1,0 +1,229 @@
+pub use dialog_macros::Attenuate;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// Trait for effect types that can produce an attenuation shape suitable
+/// for embedding in delegations and invocations.
+///
+/// Delegated capabilities and invocations carry their effect parameters as
+/// constraints. Those constraints travel over the wire and live inside
+/// signed capability chains, so they need a wire-safe shape — e.g. a
+/// payload byte buffer is projected to its checksum. The `Attenuate`
+/// trait defines this projection: `into_attenuation()` returns the
+/// attenuation shape of the effect.
+///
+/// For effects without payload fields, `type Attenuation = Self` — the
+/// attenuation shape is identical to the execution shape.
+///
+/// For effects with payload fields (e.g., `archive::Put` with `content`),
+/// `type Attenuation` is a generated struct where payload fields are
+/// replaced with their checksums.
+///
+/// # Deriving
+///
+/// Use `#[derive(Attenuate)]` to generate the implementation automatically.
+/// Fields that need projection are annotated with
+/// `#[attenuate(into = TargetType)]` (uses `From` conversion) or
+/// `#[attenuate(into = Type, with = path)]` (calls a custom function).
+/// Use `rename` to change the field name in the attenuation struct:
+///
+/// ```no_run
+/// # use serde::{Serialize, Deserialize};
+/// # use dialog_macros::Attenuate;
+/// # use dialog_common::Checksum;
+/// #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+/// pub struct Put {
+///     pub digest: Vec<u8>,
+///     #[attenuate(into = Checksum, with = Checksum::sha256, rename = checksum)]
+///     pub content: Vec<u8>,
+/// }
+/// // Generates:
+/// // - `PutAttenuation { digest: Vec<u8>, checksum: Checksum }`
+/// // - `impl Attenuate for Put { type Attenuation = PutAttenuation; ... }`
+/// ```
+pub trait Attenuate {
+    /// The attenuation-safe representation of this effect.
+    ///
+    /// For effects without payload fields, this is `Self`.
+    /// For effects with payload fields, this is a generated struct
+    /// where payloads are replaced with checksums.
+    type Attenuation: Serialize + DeserializeOwned;
+
+    /// Project this effect into its attenuation form.
+    ///
+    /// Named `into_attenuation` (not `attenuate`) to avoid collision with
+    /// `Subject::attenuate` / `Capability::attenuate`, which build chains
+    /// rather than project payloads.
+    fn into_attenuation(self) -> Self::Attenuation;
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::{Attenuation, Effect, Subject};
+    use serde::{Deserialize, Serialize};
+    use std::marker::PhantomData;
+    use std::mem::size_of_val;
+
+    // A mock checksum type for testing projections.
+    // Uses byte length as a stand-in for hashing — just enough to verify
+    // that the derive macro calls `From` rather than copying raw bytes.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Checksum(usize);
+
+    impl From<Vec<u8>> for Checksum {
+        fn from(bytes: Vec<u8>) -> Self {
+            Checksum(bytes.len())
+        }
+    }
+
+    // Unit struct — Attenuation = Self
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, Attenuate)]
+    struct Ping;
+
+    #[test]
+    fn it_derives_attenuation_for_unit_struct() {
+        let ping = Ping;
+        let attenuation = ping.into_attenuation();
+        // Unit struct attenuation is identity.
+        assert_eq!(size_of_val(&attenuation), 0);
+    }
+
+    // Named struct without projections — Attenuation = Self
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Attenuate)]
+    struct Get {
+        key: Vec<u8>,
+    }
+
+    #[test]
+    fn it_derives_identity_attenuation_for_plain_struct() {
+        let get = Get {
+            key: b"hello".to_vec(),
+        };
+        let attenuation = get.into_attenuation();
+        assert_eq!(attenuation.key, b"hello");
+    }
+
+    // Named struct with projection — generates PutAttenuation
+    #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+    struct Put {
+        digest: Vec<u8>,
+        #[attenuate(into = Checksum)]
+        content: Vec<u8>,
+    }
+
+    impl Effect for Put {
+        type Of = Subject;
+        type Output = ();
+    }
+
+    #[test]
+    fn it_projects_content_to_checksum() {
+        let put = Put {
+            digest: vec![1, 2, 3],
+            content: vec![4, 5, 6],
+        };
+        let attenuation = put.into_attenuation();
+        assert_eq!(attenuation.digest, vec![1, 2, 3]);
+        assert_eq!(attenuation.content, Checksum(3));
+    }
+
+    // Named struct with projection + rename
+    #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+    struct Publish {
+        when: Option<u64>,
+        #[attenuate(into = Checksum, rename = checksum)]
+        content: Vec<u8>,
+    }
+
+    impl Effect for Publish {
+        type Of = Subject;
+        type Output = ();
+    }
+
+    #[test]
+    fn it_renames_projected_field() {
+        let publish = Publish {
+            when: Some(42),
+            content: vec![7, 8, 9],
+        };
+        let attenuation = publish.into_attenuation();
+        assert_eq!(attenuation.when, Some(42));
+        assert_eq!(attenuation.checksum, Checksum(3));
+    }
+
+    #[test]
+    fn it_generates_attenuation_struct_with_renamed_field() {
+        let publish = Publish {
+            when: None,
+            content: vec![1, 2],
+        };
+        let attenuation: PublishAttenuation = publish.into_attenuation();
+        // The generated struct has `checksum` (not `content`).
+        assert_eq!(attenuation.checksum, Checksum(2));
+        assert_eq!(attenuation.when, None);
+    }
+
+    #[test]
+    fn it_preserves_ability_path_on_attenuation_struct() {
+        // The generated *Attenuation struct must occupy the same position
+        // in the capability chain as its source: same `Of` and same
+        // ability-path segment. This is what makes it safe to substitute
+        // for the source in delegations/invocations.
+        assert_eq!(
+            <PublishAttenuation as Attenuation>::attenuation(),
+            <Publish as Attenuation>::attenuation()
+        );
+        assert_eq!(
+            <PutAttenuation as Attenuation>::attenuation(),
+            <Put as Attenuation>::attenuation()
+        );
+        assert_eq!(
+            <UploadAttenuation as Attenuation>::attenuation(),
+            <Upload as Attenuation>::attenuation()
+        );
+    }
+
+    // Custom conversion function for testing `with`.
+    fn hash_len(data: Vec<u8>) -> Checksum {
+        Checksum(data.len() * 10)
+    }
+
+    // Named struct with `with` — uses custom function instead of From
+    #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+    struct Upload {
+        key: String,
+        #[attenuate(into = Checksum, with = hash_len, rename = checksum)]
+        payload: Vec<u8>,
+    }
+
+    impl Effect for Upload {
+        type Of = Subject;
+        type Output = ();
+    }
+
+    #[test]
+    fn it_uses_custom_with_function() {
+        let upload = Upload {
+            key: "test".to_string(),
+            payload: vec![1, 2, 3],
+        };
+        let attenuation = upload.into_attenuation();
+        assert_eq!(attenuation.key, "test");
+        // hash_len multiplies length by 10
+        assert_eq!(attenuation.checksum, Checksum(30));
+    }
+
+    // Generic struct — Attenuation = Self
+    #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+    struct GenericEffect<T>(PhantomData<T>);
+
+    #[test]
+    fn it_derives_attenuation_for_generic_struct() {
+        let effect = GenericEffect::<String>(PhantomData);
+        let _attenuation = effect.into_attenuation();
+    }
+}

--- a/rust/dialog-capability/src/lib.rs
+++ b/rust/dialog-capability/src/lib.rs
@@ -154,6 +154,8 @@
 //! | [`Delegation<C, A>`] | Grants capability to another principal |
 //! | [`Access`] | Looks up authorization proofs |
 
+extern crate self as dialog_capability;
+
 mod error;
 pub use error::*;
 
@@ -180,6 +182,9 @@ pub use policy::*;
 
 mod attenuation;
 pub use attenuation::*;
+
+mod attenuate;
+pub use attenuate::*;
 
 mod effect;
 pub use effect::*;

--- a/rust/dialog-common/Cargo.toml
+++ b/rust/dialog-common/Cargo.toml
@@ -17,11 +17,13 @@ web-integration-tests = ["helpers"]
 
 [dependencies]
 base58 = { workspace = true }
+base64 = { workspace = true }
 blake3 = { workspace = true }
 futures-util = { workspace = true }
 rkyv = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 web-time = { workspace = true }
 zerocopy = { workspace = true }

--- a/rust/dialog-common/src/checksum.rs
+++ b/rust/dialog-common/src/checksum.rs
@@ -115,8 +115,8 @@ impl TryFrom<Vec<u8>> for Checksum {
 impl Checksum {
     /// Compute the SHA-256 checksum of the given data.
     ///
-    /// This is the primary constructor for use with `#[derive(Claim)]`:
-    /// `#[claim(with = Checksum::sha256, rename = checksum)]`
+    /// This is the primary constructor for use with `#[derive(Attenuate)]`:
+    /// `#[attenuate(with = Checksum::sha256, rename = checksum)]`
     pub fn sha256(data: impl AsRef<[u8]>) -> Self {
         Hasher::Sha256.checksum(data.as_ref())
     }

--- a/rust/dialog-common/src/checksum.rs
+++ b/rust/dialog-common/src/checksum.rs
@@ -1,0 +1,202 @@
+//! Checksum types for content integrity verification.
+//!
+//! Provides checksum types used for content-addressed storage and authorization.
+//! Checksums are serialized in [multihash] format: `<varint code><varint length><digest>`.
+//! For SHA-256, the code is `0x12` and length is `0x20` (32 bytes).
+//!
+//! [multihash]: https://multiformats.io/multihash/
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// [Multihash code for SHA-256]
+/// (https://github.com/multiformats/multicodec/blob/master/table.csv#L9)
+const SHA256_CODE: u8 = 0x12;
+/// SHA-256 digest length (32 bytes)
+const SHA256_LEN: u8 = 0x20;
+
+/// A checksum algorithm that can compute checksums from data.
+///
+/// Use a `Hasher` variant to compute a [`Checksum`] from data:
+///
+/// ```no_run
+/// # use dialog_common::Hasher;
+/// let checksum = Hasher::Sha256.checksum(b"hello world");
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub enum Hasher {
+    /// SHA-256 hashing algorithm.
+    Sha256,
+}
+
+impl Hasher {
+    /// Compute the checksum of the given data using this algorithm.
+    pub fn checksum(&self, data: &[u8]) -> Checksum {
+        match self {
+            Self::Sha256 => Checksum::Sha256(Sha256::digest(data).into()),
+        }
+    }
+}
+
+/// A checksum algorithm and its computed value.
+///
+/// Serializes as multihash bytes: `<varint code><varint length><digest>`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(into = "Multihash", try_from = "Multihash")]
+pub enum Checksum {
+    /// SHA-256 checksum.
+    Sha256([u8; 32]),
+}
+
+/// Wrapper for multihash byte serialization.
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+struct Multihash(#[serde(with = "serde_bytes")] Vec<u8>);
+
+impl From<Checksum> for Multihash {
+    fn from(checksum: Checksum) -> Self {
+        match checksum {
+            Checksum::Sha256(digest) => {
+                let mut bytes = Vec::with_capacity(2 + digest.len());
+                bytes.push(SHA256_CODE);
+                bytes.push(SHA256_LEN);
+                bytes.extend_from_slice(&digest);
+                Multihash(bytes)
+            }
+        }
+    }
+}
+
+impl TryFrom<Multihash> for Checksum {
+    type Error = String;
+
+    fn try_from(mh: Multihash) -> Result<Self, Self::Error> {
+        Checksum::try_from(mh.0)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Checksum {
+    type Error = String;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        if bytes.len() < 2 {
+            return Err(format!(
+                "multihash too short: expected at least 2 bytes, got {}",
+                bytes.len()
+            ));
+        }
+
+        let code = bytes[0];
+        let len = bytes[1] as usize;
+
+        if bytes.len() != 2 + len {
+            return Err(format!(
+                "multihash length mismatch: header says {} bytes, got {}",
+                len,
+                bytes.len() - 2
+            ));
+        }
+
+        match code {
+            SHA256_CODE => {
+                if len != 32 {
+                    return Err(format!("SHA-256 digest must be 32 bytes, got {}", len));
+                }
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&bytes[2..]);
+                Ok(Checksum::Sha256(arr))
+            }
+            other => Err(format!("unsupported multihash code: 0x{:02x}", other)),
+        }
+    }
+}
+
+impl Checksum {
+    /// Compute the SHA-256 checksum of the given data.
+    ///
+    /// This is the primary constructor for use with `#[derive(Claim)]`:
+    /// `#[claim(with = Checksum::sha256, rename = checksum)]`
+    pub fn sha256(data: impl AsRef<[u8]>) -> Self {
+        Hasher::Sha256.checksum(data.as_ref())
+    }
+
+    /// Returns the raw bytes of the checksum.
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Sha256(checksum) => checksum,
+        }
+    }
+
+    /// Returns the algorithm name used in S3 headers (e.g., "sha256").
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Sha256(_) => "sha256",
+        }
+    }
+}
+
+impl std::fmt::Display for Checksum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&String::from(self))
+    }
+}
+
+impl From<&Checksum> for String {
+    fn from(checksum: &Checksum) -> Self {
+        base64::engine::general_purpose::STANDARD.encode(checksum.as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_computes_sha256_checksum() {
+        let checksum = Hasher::Sha256.checksum(b"hello world");
+        assert_eq!(checksum.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn it_formats_checksum_as_base64() {
+        let checksum = Hasher::Sha256.checksum(b"hello world");
+        assert_eq!(
+            checksum.to_string(),
+            "uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek="
+        );
+    }
+
+    #[test]
+    fn it_returns_checksum_algorithm_name() {
+        let checksum = Hasher::Sha256.checksum(b"test");
+        assert_eq!(checksum.name(), "sha256");
+    }
+
+    #[test]
+    fn it_serializes_as_multihash_bytes() {
+        let checksum = Hasher::Sha256.checksum(b"hello world");
+        let multihash: Multihash = checksum.clone().into();
+
+        assert_eq!(multihash.0[0], SHA256_CODE);
+        assert_eq!(multihash.0[1], SHA256_LEN);
+        assert_eq!(&multihash.0[2..], checksum.as_bytes());
+        assert_eq!(multihash.0.len(), 34);
+    }
+
+    #[test]
+    fn it_roundtrips_through_multihash() {
+        let original = Hasher::Sha256.checksum(b"hello world");
+        let multihash: Multihash = original.clone().into();
+        let decoded = Checksum::try_from(multihash).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn it_computes_checksum_via_sha256() {
+        let data = b"hello world".to_vec();
+        let from_method = Checksum::sha256(data);
+        let from_hasher = Hasher::Sha256.checksum(b"hello world");
+        assert_eq!(from_method, from_hasher);
+    }
+}

--- a/rust/dialog-common/src/lib.rs
+++ b/rust/dialog-common/src/lib.rs
@@ -42,6 +42,9 @@ pub mod time;
 mod hash;
 pub use hash::*;
 
+mod checksum;
+pub use checksum::*;
+
 /// Async utilities for cross-platform task management.
 pub mod r#async;
 pub use r#async::*;

--- a/rust/dialog-macros/src/attenuate.rs
+++ b/rust/dialog-macros/src/attenuate.rs
@@ -1,13 +1,17 @@
-//! `#[derive(Claim)]` macro implementation.
+//! `#[derive(Attenuate)]` macro implementation.
 //!
-//! Generates a `Claim` trait impl for effect types. Fields annotated with
-//! `#[claim(into = TargetType)]` are projected via `From` conversion;
-//! fields with `#[claim(into = Type, with = path)]` use a custom function.
+//! Generates an `Attenuate` trait impl for effect types. Fields annotated
+//! with `#[attenuate(into = TargetType)]` are projected via `From`
+//! conversion; fields with `#[attenuate(into = Type, with = path)]` use
+//! a custom function.
 //!
 //! Fields can also be renamed with `rename = name`.
 //!
-//! For types with no `#[claim(...)]` annotations, `Claim::Claim = Self`.
-//! For types with annotations, a parallel `{Name}Claim` struct is generated.
+//! For types with no `#[attenuate(...)]` annotations,
+//! `Attenuate::Attenuation = Self`.
+//!
+//! For types with annotations, a parallel `{Name}Attenuation` struct is
+//! generated.
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
@@ -15,13 +19,13 @@ use syn::{DeriveInput, Ident, Type, parse_macro_input};
 
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    match generate_claim(&input) {
+    match generate(&input) {
         Ok(tokens) => tokens.into(),
         Err(e) => e.to_compile_error().into(),
     }
 }
 
-/// How a field is converted in the generated Claim struct.
+/// How a field is converted in the generated Attenuation struct.
 enum Conversion {
     /// `<Type>::from(self.field)` — uses the `From` trait.
     From(Type),
@@ -29,10 +33,10 @@ enum Conversion {
     With(syn::ExprPath),
 }
 
-struct ClaimField<'a> {
+struct AttenuateField<'a> {
     ident: &'a syn::Ident,
     ty: &'a Type,
-    /// The target type for this field in the Claim struct (if projected).
+    /// The target type for this field in the Attenuation struct (if projected).
     into_ty: Option<Type>,
     /// How to convert the source field to the target type.
     conversion: Option<Conversion>,
@@ -40,13 +44,13 @@ struct ClaimField<'a> {
     attrs: Vec<&'a syn::Attribute>,
 }
 
-struct ClaimAttr {
+struct AttenuateAttr {
     into_ty: Type,
     with_fn: Option<syn::ExprPath>,
     rename: Option<Ident>,
 }
 
-fn parse_claim_attr(attr: &syn::Attribute) -> syn::Result<ClaimAttr> {
+fn parse_attenuate_attr(attr: &syn::Attribute) -> syn::Result<AttenuateAttr> {
     attr.parse_args_with(|input: syn::parse::ParseStream| {
         let mut into_ty = None;
         let mut with_fn = None;
@@ -80,7 +84,7 @@ fn parse_claim_attr(attr: &syn::Attribute) -> syn::Result<ClaimAttr> {
             syn::Error::new(proc_macro2::Span::call_site(), "missing `into = Type`")
         })?;
 
-        Ok(ClaimAttr {
+        Ok(AttenuateAttr {
             into_ty,
             with_fn,
             rename,
@@ -88,14 +92,14 @@ fn parse_claim_attr(attr: &syn::Attribute) -> syn::Result<ClaimAttr> {
     })
 }
 
-fn generate_claim(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+fn generate(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let name = &input.ident;
     let vis = &input.vis;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     match &input.data {
         syn::Data::Struct(data) => match &data.fields {
-            syn::Fields::Named(named) => generate_claim_for_named_struct(
+            syn::Fields::Named(named) => generate_for_named_struct(
                 name,
                 vis,
                 &impl_generics,
@@ -104,21 +108,21 @@ fn generate_claim(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 named,
             ),
             syn::Fields::Unit => {
-                generate_claim_for_unit(name, &impl_generics, &ty_generics, where_clause)
+                generate_for_unit(name, &impl_generics, &ty_generics, where_clause)
             }
             syn::Fields::Unnamed(_) => {
-                generate_claim_for_unit(name, &impl_generics, &ty_generics, where_clause)
+                generate_for_unit(name, &impl_generics, &ty_generics, where_clause)
             }
         },
         _ => Err(syn::Error::new_spanned(
             name,
-            "#[derive(Claim)] can only be used on structs",
+            "#[derive(Attenuate)] can only be used on structs",
         )),
     }
 }
 
 /// Build a where clause that includes existing predicates plus
-/// `Self: Serialize + DeserializeOwned` (needed when `Claim = Self`).
+/// `Self: Serialize + DeserializeOwned` (needed when `Attenuation = Self`).
 fn identity_where_clause(
     name: &syn::Ident,
     ty_generics: &syn::TypeGenerics,
@@ -133,7 +137,7 @@ fn identity_where_clause(
     }
 }
 
-fn generate_claim_for_unit(
+fn generate_for_unit(
     name: &syn::Ident,
     impl_generics: &syn::ImplGenerics,
     ty_generics: &syn::TypeGenerics,
@@ -141,16 +145,16 @@ fn generate_claim_for_unit(
 ) -> syn::Result<proc_macro2::TokenStream> {
     let wc = identity_where_clause(name, ty_generics, where_clause);
     Ok(quote! {
-        impl #impl_generics ::dialog_capability::Claim for #name #ty_generics
+        impl #impl_generics ::dialog_capability::Attenuate for #name #ty_generics
         #wc
         {
-            type Claim = Self;
-            fn claim(self) -> Self { self }
+            type Attenuation = Self;
+            fn attenuate(self) -> Self { self }
         }
     })
 }
 
-fn generate_claim_for_named_struct(
+fn generate_for_named_struct(
     name: &syn::Ident,
     vis: &syn::Visibility,
     impl_generics: &syn::ImplGenerics,
@@ -165,79 +169,79 @@ fn generate_claim_for_named_struct(
         let ident = field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        let mut claim_attr = None;
+        let mut attenuate_attr = None;
         let mut other_attrs = Vec::new();
 
         for attr in &field.attrs {
-            if attr.path().is_ident("claim") {
-                claim_attr = Some(parse_claim_attr(attr)?);
+            if attr.path().is_ident("attenuate") {
+                attenuate_attr = Some(parse_attenuate_attr(attr)?);
                 has_projections = true;
             } else {
                 other_attrs.push(attr);
             }
         }
 
-        let (into_ty, conversion, rename, claim_attrs) = match claim_attr {
-            Some(ca) => {
-                let conv = match ca.with_fn {
+        let (into_ty, conversion, rename, field_attrs) = match attenuate_attr {
+            Some(a) => {
+                let conv = match a.with_fn {
                     Some(path) => Conversion::With(path),
-                    None => Conversion::From(ca.into_ty.clone()),
+                    None => Conversion::From(a.into_ty.clone()),
                 };
                 // Projected fields get a fresh type — don't carry original attrs
                 // (e.g. #[serde(with = "serde_bytes")] doesn't apply to Checksum)
-                (Some(ca.into_ty), Some(conv), ca.rename, Vec::new())
+                (Some(a.into_ty), Some(conv), a.rename, Vec::new())
             }
             None => (None, None, None, other_attrs),
         };
 
-        fields.push(ClaimField {
+        fields.push(AttenuateField {
             ident,
             ty,
             into_ty,
             conversion,
             rename,
-            attrs: claim_attrs,
+            attrs: field_attrs,
         });
     }
 
     if !has_projections {
         let wc = identity_where_clause(name, ty_generics, where_clause);
         return Ok(quote! {
-            impl #impl_generics ::dialog_capability::Claim for #name #ty_generics
+            impl #impl_generics ::dialog_capability::Attenuate for #name #ty_generics
             #wc
             {
-                type Claim = Self;
-                fn claim(self) -> Self { self }
+                type Attenuation = Self;
+                fn attenuate(self) -> Self { self }
             }
         });
     }
 
-    let claim_name = format_ident!("{}Claim", name);
+    let attenuation_name = format_ident!("{}Attenuation", name);
 
-    let claim_fields: Vec<_> = fields
+    let attenuation_fields: Vec<_> = fields
         .iter()
         .map(|f| {
-            let claim_ident = f.rename.as_ref().unwrap_or(f.ident);
+            let field_ident = f.rename.as_ref().unwrap_or(f.ident);
             let ty = f.into_ty.as_ref().unwrap_or(f.ty);
             let attrs = &f.attrs;
-            quote! { #(#attrs)* pub #claim_ident: #ty }
+            quote! { #(#attrs)* pub #field_ident: #ty }
         })
         .collect();
 
-    let claim_conversions: Vec<_> = fields
+    let attenuation_conversions: Vec<_> = fields
         .iter()
         .map(|f| {
             let source_ident = f.ident;
-            let claim_ident = f.rename.as_ref().unwrap_or(f.ident);
+            let field_ident = f.rename.as_ref().unwrap_or(f.ident);
             match &f.conversion {
                 Some(Conversion::With(path)) => {
-                    quote! { #claim_ident: #path(self.#source_ident) }
+                    quote! { #field_ident: #path(self.#source_ident) }
                 }
                 Some(Conversion::From(into_ty)) => {
-                    quote! { #claim_ident: <#into_ty>::from(self.#source_ident) }
+                    quote! { #field_ident: <#into_ty>::from(self.#source_ident) }
                 }
                 None => {
-                    quote! { #claim_ident: self.#source_ident }
+                    quote! { #field_ident: self.#source_ident }
                 }
             }
         })
@@ -246,22 +250,22 @@ fn generate_claim_for_named_struct(
     Ok(quote! {
         #[derive(Debug, Clone, ::serde::Serialize, ::serde::Deserialize)]
         #[allow(missing_docs)]
-        #vis struct #claim_name {
-            #(#claim_fields,)*
+        #vis struct #attenuation_name {
+            #(#attenuation_fields,)*
         }
 
-        impl ::dialog_capability::Claim for #claim_name {
-            type Claim = Self;
-            fn claim(self) -> Self { self }
+        impl ::dialog_capability::Attenuate for #attenuation_name {
+            type Attenuation = Self;
+            fn attenuate(self) -> Self { self }
         }
 
-        impl #impl_generics ::dialog_capability::Claim for #name #ty_generics
+        impl #impl_generics ::dialog_capability::Attenuate for #name #ty_generics
         #where_clause
         {
-            type Claim = #claim_name;
-            fn claim(self) -> #claim_name {
-                #claim_name {
-                    #(#claim_conversions,)*
+            type Attenuation = #attenuation_name;
+            fn attenuate(self) -> #attenuation_name {
+                #attenuation_name {
+                    #(#attenuation_conversions,)*
                 }
             }
         }

--- a/rust/dialog-macros/src/attenuate.rs
+++ b/rust/dialog-macros/src/attenuate.rs
@@ -149,7 +149,7 @@ fn generate_for_unit(
         #wc
         {
             type Attenuation = Self;
-            fn attenuate(self) -> Self { self }
+            fn into_attenuation(self) -> Self { self }
         }
     })
 }
@@ -211,7 +211,7 @@ fn generate_for_named_struct(
             #wc
             {
                 type Attenuation = Self;
-                fn attenuate(self) -> Self { self }
+                fn into_attenuation(self) -> Self { self }
             }
         });
     }
@@ -256,7 +256,7 @@ fn generate_for_named_struct(
 
         impl ::dialog_capability::Attenuate for #attenuation_name {
             type Attenuation = Self;
-            fn attenuate(self) -> Self { self }
+            fn into_attenuation(self) -> Self { self }
         }
 
         // The generated projection struct mirrors the source's position in
@@ -274,7 +274,7 @@ fn generate_for_named_struct(
         #where_clause
         {
             type Attenuation = #attenuation_name;
-            fn attenuate(self) -> #attenuation_name {
+            fn into_attenuation(self) -> #attenuation_name {
                 #attenuation_name {
                     #(#attenuation_conversions,)*
                 }

--- a/rust/dialog-macros/src/attenuate.rs
+++ b/rust/dialog-macros/src/attenuate.rs
@@ -259,6 +259,17 @@ fn generate_for_named_struct(
             fn attenuate(self) -> Self { self }
         }
 
+        // The generated projection struct mirrors the source's position in
+        // the capability chain: same `Of` and same ability-path segment.
+        // The source must be an `Attenuation` — which `Effect` implies via
+        // blanket impl.
+        impl ::dialog_capability::Attenuation for #attenuation_name {
+            type Of = <#name as ::dialog_capability::Attenuation>::Of;
+            fn attenuation() -> &'static str {
+                <#name as ::dialog_capability::Attenuation>::attenuation()
+            }
+        }
+
         impl #impl_generics ::dialog_capability::Attenuate for #name #ty_generics
         #where_clause
         {

--- a/rust/dialog-macros/src/claim.rs
+++ b/rust/dialog-macros/src/claim.rs
@@ -1,0 +1,269 @@
+//! `#[derive(Claim)]` macro implementation.
+//!
+//! Generates a `Claim` trait impl for effect types. Fields annotated with
+//! `#[claim(into = TargetType)]` are projected via `From` conversion;
+//! fields with `#[claim(into = Type, with = path)]` use a custom function.
+//!
+//! Fields can also be renamed with `rename = name`.
+//!
+//! For types with no `#[claim(...)]` annotations, `Claim::Claim = Self`.
+//! For types with annotations, a parallel `{Name}Claim` struct is generated.
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Ident, Type, parse_macro_input};
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match generate_claim(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// How a field is converted in the generated Claim struct.
+enum Conversion {
+    /// `<Type>::from(self.field)` — uses the `From` trait.
+    From(Type),
+    /// `path(self.field)` — calls a custom function.
+    With(syn::ExprPath),
+}
+
+struct ClaimField<'a> {
+    ident: &'a syn::Ident,
+    ty: &'a Type,
+    /// The target type for this field in the Claim struct (if projected).
+    into_ty: Option<Type>,
+    /// How to convert the source field to the target type.
+    conversion: Option<Conversion>,
+    rename: Option<Ident>,
+    attrs: Vec<&'a syn::Attribute>,
+}
+
+struct ClaimAttr {
+    into_ty: Type,
+    with_fn: Option<syn::ExprPath>,
+    rename: Option<Ident>,
+}
+
+fn parse_claim_attr(attr: &syn::Attribute) -> syn::Result<ClaimAttr> {
+    attr.parse_args_with(|input: syn::parse::ParseStream| {
+        let mut into_ty = None;
+        let mut with_fn = None;
+        let mut rename = None;
+
+        loop {
+            let key: syn::Ident = input.parse()?;
+            let _: syn::Token![=] = input.parse()?;
+
+            if key == "into" {
+                into_ty = Some(input.parse::<Type>()?);
+            } else if key == "with" {
+                with_fn = Some(input.parse::<syn::ExprPath>()?);
+            } else if key == "rename" {
+                rename = Some(input.parse::<Ident>()?);
+            } else {
+                return Err(syn::Error::new_spanned(
+                    &key,
+                    "expected `into`, `with`, or `rename`",
+                ));
+            }
+
+            if input.peek(syn::Token![,]) {
+                let _: syn::Token![,] = input.parse()?;
+            } else {
+                break;
+            }
+        }
+
+        let into_ty = into_ty.ok_or_else(|| {
+            syn::Error::new(proc_macro2::Span::call_site(), "missing `into = Type`")
+        })?;
+
+        Ok(ClaimAttr {
+            into_ty,
+            with_fn,
+            rename,
+        })
+    })
+}
+
+fn generate_claim(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let name = &input.ident;
+    let vis = &input.vis;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    match &input.data {
+        syn::Data::Struct(data) => match &data.fields {
+            syn::Fields::Named(named) => generate_claim_for_named_struct(
+                name,
+                vis,
+                &impl_generics,
+                &ty_generics,
+                where_clause,
+                named,
+            ),
+            syn::Fields::Unit => {
+                generate_claim_for_unit(name, &impl_generics, &ty_generics, where_clause)
+            }
+            syn::Fields::Unnamed(_) => {
+                generate_claim_for_unit(name, &impl_generics, &ty_generics, where_clause)
+            }
+        },
+        _ => Err(syn::Error::new_spanned(
+            name,
+            "#[derive(Claim)] can only be used on structs",
+        )),
+    }
+}
+
+/// Build a where clause that includes existing predicates plus
+/// `Self: Serialize + DeserializeOwned` (needed when `Claim = Self`).
+fn identity_where_clause(
+    name: &syn::Ident,
+    ty_generics: &syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+) -> proc_macro2::TokenStream {
+    let existing = where_clause.map(|wc| {
+        let predicates = &wc.predicates;
+        quote! { #predicates, }
+    });
+    quote! {
+        where #existing #name #ty_generics: ::serde::Serialize + ::serde::de::DeserializeOwned
+    }
+}
+
+fn generate_claim_for_unit(
+    name: &syn::Ident,
+    impl_generics: &syn::ImplGenerics,
+    ty_generics: &syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let wc = identity_where_clause(name, ty_generics, where_clause);
+    Ok(quote! {
+        impl #impl_generics ::dialog_capability::Claim for #name #ty_generics
+        #wc
+        {
+            type Claim = Self;
+            fn claim(self) -> Self { self }
+        }
+    })
+}
+
+fn generate_claim_for_named_struct(
+    name: &syn::Ident,
+    vis: &syn::Visibility,
+    impl_generics: &syn::ImplGenerics,
+    ty_generics: &syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+    named: &syn::FieldsNamed,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let mut fields = Vec::new();
+    let mut has_projections = false;
+
+    for field in &named.named {
+        let ident = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+
+        let mut claim_attr = None;
+        let mut other_attrs = Vec::new();
+
+        for attr in &field.attrs {
+            if attr.path().is_ident("claim") {
+                claim_attr = Some(parse_claim_attr(attr)?);
+                has_projections = true;
+            } else {
+                other_attrs.push(attr);
+            }
+        }
+
+        let (into_ty, conversion, rename, claim_attrs) = match claim_attr {
+            Some(ca) => {
+                let conv = match ca.with_fn {
+                    Some(path) => Conversion::With(path),
+                    None => Conversion::From(ca.into_ty.clone()),
+                };
+                // Projected fields get a fresh type — don't carry original attrs
+                // (e.g. #[serde(with = "serde_bytes")] doesn't apply to Checksum)
+                (Some(ca.into_ty), Some(conv), ca.rename, Vec::new())
+            }
+            None => (None, None, None, other_attrs),
+        };
+
+        fields.push(ClaimField {
+            ident,
+            ty,
+            into_ty,
+            conversion,
+            rename,
+            attrs: claim_attrs,
+        });
+    }
+
+    if !has_projections {
+        let wc = identity_where_clause(name, ty_generics, where_clause);
+        return Ok(quote! {
+            impl #impl_generics ::dialog_capability::Claim for #name #ty_generics
+            #wc
+            {
+                type Claim = Self;
+                fn claim(self) -> Self { self }
+            }
+        });
+    }
+
+    let claim_name = format_ident!("{}Claim", name);
+
+    let claim_fields: Vec<_> = fields
+        .iter()
+        .map(|f| {
+            let claim_ident = f.rename.as_ref().unwrap_or(f.ident);
+            let ty = f.into_ty.as_ref().unwrap_or(f.ty);
+            let attrs = &f.attrs;
+            quote! { #(#attrs)* pub #claim_ident: #ty }
+        })
+        .collect();
+
+    let claim_conversions: Vec<_> = fields
+        .iter()
+        .map(|f| {
+            let source_ident = f.ident;
+            let claim_ident = f.rename.as_ref().unwrap_or(f.ident);
+            match &f.conversion {
+                Some(Conversion::With(path)) => {
+                    quote! { #claim_ident: #path(self.#source_ident) }
+                }
+                Some(Conversion::From(into_ty)) => {
+                    quote! { #claim_ident: <#into_ty>::from(self.#source_ident) }
+                }
+                None => {
+                    quote! { #claim_ident: self.#source_ident }
+                }
+            }
+        })
+        .collect();
+
+    Ok(quote! {
+        #[derive(Debug, Clone, ::serde::Serialize, ::serde::Deserialize)]
+        #[allow(missing_docs)]
+        #vis struct #claim_name {
+            #(#claim_fields,)*
+        }
+
+        impl ::dialog_capability::Claim for #claim_name {
+            type Claim = Self;
+            fn claim(self) -> Self { self }
+        }
+
+        impl #impl_generics ::dialog_capability::Claim for #name #ty_generics
+        #where_clause
+        {
+            type Claim = #claim_name;
+            fn claim(self) -> #claim_name {
+                #claim_name {
+                    #(#claim_conversions,)*
+                }
+            }
+        }
+    })
+}

--- a/rust/dialog-macros/src/lib.rs
+++ b/rust/dialog-macros/src/lib.rs
@@ -11,7 +11,7 @@
 //! here rather than in the crates that use them.
 
 use proc_macro::TokenStream;
-mod claim;
+mod attenuate;
 mod provider;
 mod query;
 mod router;
@@ -396,27 +396,31 @@ pub fn router(input: TokenStream) -> TokenStream {
     router::generate(input)
 }
 
-/// Derive macro that generates a `Claim` trait impl for effect types.
+/// Derive macro that generates an `Attenuate` trait impl for effect types.
 ///
-/// For types with no `#[claim(into = ...)]` annotations, `Claim::Claim = Self`
-/// (the authorization shape is identical to the execution shape).
+/// For types with no `#[attenuate(into = ...)]` annotations,
+/// `Attenuate::Attenuation = Self` (the attenuation shape is identical to
+/// the execution shape).
 ///
-/// For types with annotated fields, a parallel `{Name}Claim` struct is
-/// generated where annotated fields use the target type via `From` conversion.
+/// For types with annotated fields, a parallel `{Name}Attenuation` struct
+/// is generated where annotated fields use the target type via `From`
+/// conversion, and the generated struct implements the existing
+/// `Attenuation` trait so it can serve as an attenuation layer in
+/// capability chains.
 ///
 /// # Example
 ///
 /// ```rust,ignore
-/// #[derive(Debug, Clone, Serialize, Deserialize, Claim)]
+/// #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
 /// pub struct Put {
 ///     pub digest: Blake3Hash,
-///     #[claim(into = Checksum)]
+///     #[attenuate(into = Checksum)]
 ///     pub content: Vec<u8>,
 /// }
-/// // Generates PutClaim { digest: Blake3Hash, content: Checksum }
-/// // and impl Claim for Put { type Claim = PutClaim; ... }
+/// // Generates PutAttenuation { digest: Blake3Hash, content: Checksum }
+/// // and impl Attenuate for Put { type Attenuation = PutAttenuation; ... }
 /// ```
-#[proc_macro_derive(Claim, attributes(claim))]
-pub fn derive_claim(input: TokenStream) -> TokenStream {
-    claim::derive(input)
+#[proc_macro_derive(Attenuate, attributes(attenuate))]
+pub fn derive_attenuate(input: TokenStream) -> TokenStream {
+    attenuate::derive(input)
 }

--- a/rust/dialog-macros/src/lib.rs
+++ b/rust/dialog-macros/src/lib.rs
@@ -11,6 +11,7 @@
 //! here rather than in the crates that use them.
 
 use proc_macro::TokenStream;
+mod claim;
 mod provider;
 mod query;
 mod router;
@@ -393,4 +394,29 @@ pub fn derive_attribute(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Router, attributes(route))]
 pub fn router(input: TokenStream) -> TokenStream {
     router::generate(input)
+}
+
+/// Derive macro that generates a `Claim` trait impl for effect types.
+///
+/// For types with no `#[claim(into = ...)]` annotations, `Claim::Claim = Self`
+/// (the authorization shape is identical to the execution shape).
+///
+/// For types with annotated fields, a parallel `{Name}Claim` struct is
+/// generated where annotated fields use the target type via `From` conversion.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[derive(Debug, Clone, Serialize, Deserialize, Claim)]
+/// pub struct Put {
+///     pub digest: Blake3Hash,
+///     #[claim(into = Checksum)]
+///     pub content: Vec<u8>,
+/// }
+/// // Generates PutClaim { digest: Blake3Hash, content: Checksum }
+/// // and impl Claim for Put { type Claim = PutClaim; ... }
+/// ```
+#[proc_macro_derive(Claim, attributes(claim))]
+pub fn derive_claim(input: TokenStream) -> TokenStream {
+    claim::derive(input)
 }


### PR DESCRIPTION
## Summary

- Add Checksum and Hasher types to dialog-common for content integrity verification using multihash-encoded SHA-256 digests
- Add #[derive(Attenuate)] proc macro to dialog-macros that generates projections for authorizations

The Claim trait allows effect types to declare how they should be represented during authorization. Fields annotated with `#[attenuate(into = Type)]` are projected via `From` conversion (e.g., replacing raw content bytes with their checksum). Fields can also use custom conversion functions via `#[attenuate(into = Type, with = path)]` and be renamed with `rename = name`.

For types with no annotated fields, `Attenuate::Attenuation = Self` (identity projection). For types with annotations, a parallel `{Name}Attenuation` struct is generated automatically.