### PR TITLE
8 ✅ feat: add credential newtypes and key export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
 name = "dialog-credentials"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base58",
  "dialog-capability",
  "dialog-common",

--- a/rust/dialog-credentials/Cargo.toml
+++ b/rust/dialog-credentials/Cargo.toml
@@ -18,6 +18,7 @@ ed25519 = [
 ucan = ["dep:dialog-ucan", "dialog-capability/ucan"]
 
 [dependencies]
+async-trait = { workspace = true }
 dialog-capability = { workspace = true }
 dialog-common = { workspace = true }
 dialog-varsig = { workspace = true }

--- a/rust/dialog-credentials/src/credential.rs
+++ b/rust/dialog-credentials/src/credential.rs
@@ -1,0 +1,105 @@
+//! Credential types for identity management.
+//!
+//! A [`Credential`] represents either a full signing keypair ([`SignerCredential`])
+//! or a public-key-only verifier ([`VerifierCredential`]).
+
+pub mod export;
+pub mod signer;
+pub mod verifier;
+
+pub use export::{
+    CredentialExport, CredentialExportError, SignerCredentialExport, VerifierCredentialExport,
+};
+pub use signer::SignerCredential;
+pub use verifier::VerifierCredential;
+
+use crate::{Ed25519Signer, Ed25519Verifier};
+use dialog_varsig::{Did, Principal};
+use serde::ser::Error as SerError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Either a signer or verifier credential.
+///
+/// # Serialization
+///
+/// Only the `Verifier` variant is serializable (as the DID string).
+/// Serializing a `Signer` will fail to prevent accidental key leakage.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone)]
+pub enum Credential {
+    /// Full keypair — can sign as this identity.
+    Signer(SignerCredential),
+    /// Public key only — can verify but not sign.
+    Verifier(VerifierCredential),
+}
+
+impl From<Ed25519Signer> for Credential {
+    fn from(signer: Ed25519Signer) -> Self {
+        Self::Signer(SignerCredential(signer))
+    }
+}
+
+impl From<Ed25519Verifier> for Credential {
+    fn from(verifier: Ed25519Verifier) -> Self {
+        Self::Verifier(VerifierCredential(verifier))
+    }
+}
+
+impl Principal for Credential {
+    fn did(&self) -> Did {
+        match self {
+            Self::Signer(s) => s.did(),
+            Self::Verifier(v) => v.did(),
+        }
+    }
+}
+
+impl From<Credential> for Did {
+    fn from(credential: Credential) -> Self {
+        credential.did()
+    }
+}
+
+impl Credential {
+    /// Get a reference to the signer, if this credential holds one.
+    pub fn signer(&self) -> Option<&Ed25519Signer> {
+        match self {
+            Self::Signer(s) => Some(&s.0),
+            Self::Verifier(_) => None,
+        }
+    }
+
+    /// Export to a platform-specific storage form.
+    pub async fn export(&self) -> Result<CredentialExport, CredentialExportError> {
+        match self {
+            Self::Signer(s) => Ok(CredentialExport::Signer(s.export().await?)),
+            Self::Verifier(v) => Ok(CredentialExport::Verifier(v.export())),
+        }
+    }
+
+    /// Import from a platform-specific storage form.
+    pub async fn import(export: CredentialExport) -> Result<Self, CredentialExportError> {
+        match export {
+            CredentialExport::Signer(s) => Ok(Self::Signer(SignerCredential::import(s).await?)),
+            CredentialExport::Verifier(v) => Ok(Self::Verifier(VerifierCredential::import(v)?)),
+        }
+    }
+}
+
+impl Serialize for Credential {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Signer(_) => Err(SerError::custom(
+                "Serialization of secret key material is not supported",
+            )),
+            Self::Verifier(v) => v.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Credential {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let verifier = Ed25519Verifier::deserialize(deserializer)?;
+        Ok(Self::Verifier(VerifierCredential(verifier)))
+    }
+}

--- a/rust/dialog-credentials/src/credential.rs
+++ b/rust/dialog-credentials/src/credential.rs
@@ -3,6 +3,7 @@
 //! A [`Credential`] represents either a full signing keypair ([`SignerCredential`])
 //! or a public-key-only verifier ([`VerifierCredential`]).
 
+pub(crate) mod constants;
 pub mod export;
 pub mod signer;
 pub mod verifier;

--- a/rust/dialog-credentials/src/credential/constants.rs
+++ b/rust/dialog-credentials/src/credential/constants.rs
@@ -1,0 +1,12 @@
+//! Shared multicodec constants and sizes for credential export formats.
+
+/// Multicodec varint for ed25519 private key (0x1300).
+pub const ED25519_PRIV_TAG: &[u8] = &[0x80, 0x26];
+/// Multicodec varint for ed25519 public key (0xed).
+pub const ED25519_PUB_TAG: &[u8] = &[0xed, 0x01];
+pub const KEY_SIZE: usize = 32;
+pub const PRIV_TAG_SIZE: usize = ED25519_PRIV_TAG.len();
+pub const PUB_TAG_SIZE: usize = ED25519_PUB_TAG.len();
+pub const SIGNER_EXPORT_SIZE: usize = PRIV_TAG_SIZE + KEY_SIZE + PUB_TAG_SIZE + KEY_SIZE;
+pub const VERIFIER_EXPORT_SIZE: usize = PUB_TAG_SIZE + KEY_SIZE;
+pub const PUB_KEY_OFFSET: usize = PRIV_TAG_SIZE + KEY_SIZE;

--- a/rust/dialog-credentials/src/credential/export.rs
+++ b/rust/dialog-credentials/src/credential/export.rs
@@ -3,14 +3,20 @@
 //! These are plain data containers for serialized credential material.
 //! Import/export logic lives on the credential types themselves.
 
+use thiserror::Error;
+
+#[cfg(not(target_arch = "wasm32"))]
+use super::constants::{
+    ED25519_PRIV_TAG, ED25519_PUB_TAG, PUB_KEY_OFFSET, SIGNER_EXPORT_SIZE, VERIFIER_EXPORT_SIZE,
+};
+
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use js_sys::Uint8Array;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen::{JsCast, JsValue};
 
-
 /// Error type for credential export/import operations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Error)]
 pub enum CredentialExportError {
     /// Key export/import operation failed.
     #[error("key operation failed: {0}")]
@@ -51,17 +57,6 @@ pub enum CredentialExport {
     Signer(SignerCredentialExport),
     Verifier(VerifierCredentialExport),
 }
-
-/// Multicodec varint for ed25519 private key (0x1300).
-pub(crate) const ED25519_PRIV_TAG: &[u8] = &[0x80, 0x26];
-/// Multicodec varint for ed25519 public key (0xed).
-pub(crate) const ED25519_PUB_TAG: &[u8] = &[0xed, 0x01];
-pub(crate) const KEY_SIZE: usize = 32;
-pub(crate) const PRIV_TAG_SIZE: usize = ED25519_PRIV_TAG.len();
-pub(crate) const PUB_TAG_SIZE: usize = ED25519_PUB_TAG.len();
-pub(crate) const SIGNER_EXPORT_SIZE: usize = PRIV_TAG_SIZE + KEY_SIZE + PUB_TAG_SIZE + KEY_SIZE;
-pub(crate) const VERIFIER_EXPORT_SIZE: usize = PUB_TAG_SIZE + KEY_SIZE;
-pub(crate) const PUB_KEY_OFFSET: usize = PRIV_TAG_SIZE + KEY_SIZE;
 
 /// Raw byte type for a serialized signer credential.
 #[cfg(not(target_arch = "wasm32"))]

--- a/rust/dialog-credentials/src/credential/export.rs
+++ b/rust/dialog-credentials/src/credential/export.rs
@@ -1,0 +1,197 @@
+//! Platform-specific credential export types.
+//!
+//! These are plain data containers for serialized credential material.
+//! Import/export logic lives on the credential types themselves.
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use js_sys::Uint8Array;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen::{JsCast, JsValue};
+
+
+/// Error type for credential export/import operations.
+#[derive(Debug, thiserror::Error)]
+pub enum CredentialExportError {
+    /// Key export/import operation failed.
+    #[error("key operation failed: {0}")]
+    Key(String),
+
+    /// The stored data has an invalid format.
+    #[error("invalid credential format: {0}")]
+    InvalidFormat(String),
+}
+
+/// Platform-specific serialized form of a signer credential.
+///
+/// On native: multicodec-tagged fixed-size bytes (68 bytes).
+/// On web: JsValue wrapping a CryptoKeyPair.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+pub struct SignerCredentialExport(pub [u8; SIGNER_EXPORT_SIZE]);
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[derive(Debug, Clone)]
+pub struct SignerCredentialExport(pub JsValue);
+
+/// Platform-specific serialized form of a verifier credential.
+///
+/// On native: multicodec-tagged fixed-size bytes (34 bytes).
+/// On web: JsValue wrapping a Uint8Array of public key bytes.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+pub struct VerifierCredentialExport(pub [u8; VERIFIER_EXPORT_SIZE]);
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[derive(Debug, Clone)]
+pub struct VerifierCredentialExport(pub JsValue);
+
+/// Platform-specific serialized form of a credential (signer or verifier).
+#[derive(Debug, Clone)]
+pub enum CredentialExport {
+    Signer(SignerCredentialExport),
+    Verifier(VerifierCredentialExport),
+}
+
+/// Multicodec varint for ed25519 private key (0x1300).
+pub(crate) const ED25519_PRIV_TAG: &[u8] = &[0x80, 0x26];
+/// Multicodec varint for ed25519 public key (0xed).
+pub(crate) const ED25519_PUB_TAG: &[u8] = &[0xed, 0x01];
+pub(crate) const KEY_SIZE: usize = 32;
+pub(crate) const PRIV_TAG_SIZE: usize = ED25519_PRIV_TAG.len();
+pub(crate) const PUB_TAG_SIZE: usize = ED25519_PUB_TAG.len();
+pub(crate) const SIGNER_EXPORT_SIZE: usize = PRIV_TAG_SIZE + KEY_SIZE + PUB_TAG_SIZE + KEY_SIZE;
+pub(crate) const VERIFIER_EXPORT_SIZE: usize = PUB_TAG_SIZE + KEY_SIZE;
+pub(crate) const PUB_KEY_OFFSET: usize = PRIV_TAG_SIZE + KEY_SIZE;
+
+/// Raw byte type for a serialized signer credential.
+#[cfg(not(target_arch = "wasm32"))]
+pub type SignerExport = [u8; SIGNER_EXPORT_SIZE];
+
+/// Raw byte type for a serialized verifier credential.
+#[cfg(not(target_arch = "wasm32"))]
+pub type VerifierExport = [u8; VERIFIER_EXPORT_SIZE];
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TryFrom<Vec<u8>> for SignerCredentialExport {
+    type Error = CredentialExportError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let arr: SignerExport = bytes.try_into().map_err(|_| {
+            CredentialExportError::InvalidFormat("invalid signer export length".into())
+        })?;
+        Ok(Self(arr))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TryFrom<Vec<u8>> for VerifierCredentialExport {
+    type Error = CredentialExportError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let arr: VerifierExport = bytes.try_into().map_err(|_| {
+            CredentialExportError::InvalidFormat("invalid verifier export length".into())
+        })?;
+        Ok(Self(arr))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<SignerExport> for SignerCredentialExport {
+    fn from(bytes: SignerExport) -> Self {
+        Self(bytes)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<SignerCredentialExport> for SignerExport {
+    fn from(export: SignerCredentialExport) -> Self {
+        export.0
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<VerifierExport> for VerifierCredentialExport {
+    fn from(bytes: VerifierExport) -> Self {
+        Self(bytes)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<VerifierCredentialExport> for VerifierExport {
+    fn from(export: VerifierCredentialExport) -> Self {
+        export.0
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AsRef<[u8]> for SignerCredentialExport {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AsRef<[u8]> for VerifierCredentialExport {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TryFrom<Vec<u8>> for CredentialExport {
+    type Error = CredentialExportError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        if bytes.len() == SIGNER_EXPORT_SIZE
+            && bytes.starts_with(ED25519_PRIV_TAG)
+            && bytes[PUB_KEY_OFFSET..].starts_with(ED25519_PUB_TAG)
+        {
+            let arr: SignerExport = bytes.try_into().map_err(|_| {
+                CredentialExportError::InvalidFormat("invalid signer length".into())
+            })?;
+            Ok(Self::Signer(arr.into()))
+        } else if bytes.len() == VERIFIER_EXPORT_SIZE && bytes.starts_with(ED25519_PUB_TAG) {
+            let arr: VerifierExport = bytes.try_into().map_err(|_| {
+                CredentialExportError::InvalidFormat("invalid verifier length".into())
+            })?;
+            Ok(Self::Verifier(arr.into()))
+        } else {
+            Err(CredentialExportError::InvalidFormat(format!(
+                "unrecognized credential format: length={}",
+                bytes.len()
+            )))
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl CredentialExport {
+    /// Get the underlying bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Signer(s) => s.as_ref(),
+            Self::Verifier(v) => v.as_ref(),
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<JsValue> for CredentialExport {
+    fn from(js: JsValue) -> Self {
+        if js.is_instance_of::<Uint8Array>() {
+            Self::Verifier(VerifierCredentialExport(js))
+        } else {
+            Self::Signer(SignerCredentialExport(js))
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<CredentialExport> for JsValue {
+    fn from(export: CredentialExport) -> Self {
+        match export {
+            CredentialExport::Signer(s) => s.0,
+            CredentialExport::Verifier(v) => v.0,
+        }
+    }
+}

--- a/rust/dialog-credentials/src/credential/signer.rs
+++ b/rust/dialog-credentials/src/credential/signer.rs
@@ -6,12 +6,12 @@ use dialog_capability::Issuer;
 use dialog_varsig::eddsa::Ed25519Signature;
 use dialog_varsig::{Did, Principal, Signer};
 
-use super::export::{CredentialExportError, SignerCredentialExport};
 #[cfg(not(target_arch = "wasm32"))]
-use super::export::{
+use super::constants::{
     ED25519_PRIV_TAG, ED25519_PUB_TAG, KEY_SIZE, PRIV_TAG_SIZE, PUB_KEY_OFFSET, PUB_TAG_SIZE,
     SIGNER_EXPORT_SIZE,
 };
+use super::export::{CredentialExportError, SignerCredentialExport};
 
 /// A signer credential — wraps an `Ed25519Signer` (full keypair).
 #[derive(Debug, Clone)]

--- a/rust/dialog-credentials/src/credential/signer.rs
+++ b/rust/dialog-credentials/src/credential/signer.rs
@@ -1,0 +1,127 @@
+//! Signer credential — wraps a full Ed25519 keypair.
+
+use crate::Ed25519Signer;
+use crate::key::KeyExport;
+use dialog_capability::Issuer;
+use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::{Did, Principal, Signer};
+
+use super::export::{CredentialExportError, SignerCredentialExport};
+#[cfg(not(target_arch = "wasm32"))]
+use super::export::{
+    ED25519_PRIV_TAG, ED25519_PUB_TAG, KEY_SIZE, PRIV_TAG_SIZE, PUB_KEY_OFFSET, PUB_TAG_SIZE,
+    SIGNER_EXPORT_SIZE,
+};
+
+/// A signer credential — wraps an `Ed25519Signer` (full keypair).
+#[derive(Debug, Clone)]
+pub struct SignerCredential(pub Ed25519Signer);
+
+impl From<Ed25519Signer> for SignerCredential {
+    fn from(signer: Ed25519Signer) -> Self {
+        Self(signer)
+    }
+}
+
+impl Principal for SignerCredential {
+    fn did(&self) -> Did {
+        Principal::did(&self.0)
+    }
+}
+
+impl From<SignerCredential> for Did {
+    fn from(credential: SignerCredential) -> Self {
+        credential.did()
+    }
+}
+
+impl SignerCredential {
+    /// Get a reference to the underlying signer.
+    pub fn signer(&self) -> &Ed25519Signer {
+        &self.0
+    }
+
+    /// Consume and return the underlying signer.
+    pub fn into_signer(self) -> Ed25519Signer {
+        self.0
+    }
+}
+
+impl From<SignerCredential> for Ed25519Signer {
+    fn from(credential: SignerCredential) -> Self {
+        credential.0
+    }
+}
+
+impl Signer<Ed25519Signature> for SignerCredential {
+    async fn sign(&self, msg: &[u8]) -> Result<Ed25519Signature, signature::Error> {
+        Signer::sign(&self.0, msg).await
+    }
+}
+
+impl Issuer for SignerCredential {
+    type Signature = Ed25519Signature;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SignerCredential {
+    /// Export to multicodec-tagged bytes for native storage.
+    pub async fn export(&self) -> Result<SignerCredentialExport, CredentialExportError> {
+        let KeyExport::Extractable(ref seed) = self
+            .0
+            .export()
+            .await
+            .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+
+        let public_key = self.0.ed25519_did().0.to_bytes();
+        let mut buf = [0u8; SIGNER_EXPORT_SIZE];
+        buf[..PRIV_TAG_SIZE].copy_from_slice(ED25519_PRIV_TAG);
+        buf[PRIV_TAG_SIZE..PUB_KEY_OFFSET].copy_from_slice(seed);
+        buf[PUB_KEY_OFFSET..PUB_KEY_OFFSET + PUB_TAG_SIZE].copy_from_slice(ED25519_PUB_TAG);
+        buf[PUB_KEY_OFFSET + PUB_TAG_SIZE..].copy_from_slice(&public_key);
+        Ok(SignerCredentialExport(buf))
+    }
+
+    /// Import from multicodec-tagged bytes.
+    pub async fn import(export: SignerCredentialExport) -> Result<Self, CredentialExportError> {
+        let data = &export.0;
+        if !data.starts_with(ED25519_PRIV_TAG)
+            || !data[PUB_KEY_OFFSET..].starts_with(ED25519_PUB_TAG)
+        {
+            return Err(CredentialExportError::InvalidFormat(
+                "invalid multicodec tags".into(),
+            ));
+        }
+
+        let seed: &[u8; KEY_SIZE] = data[PRIV_TAG_SIZE..PUB_KEY_OFFSET]
+            .try_into()
+            .map_err(|_| CredentialExportError::InvalidFormat("invalid seed".into()))?;
+        let signer = Ed25519Signer::import(seed)
+            .await
+            .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+        Ok(Self(signer))
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl SignerCredential {
+    /// Export to a JsValue (CryptoKeyPair) for web storage.
+    pub async fn export(&self) -> Result<SignerCredentialExport, CredentialExportError> {
+        let key_export = self
+            .0
+            .export()
+            .await
+            .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+        Ok(SignerCredentialExport(key_export.into()))
+    }
+
+    /// Import from a JsValue (CryptoKeyPair).
+    pub async fn import(export: SignerCredentialExport) -> Result<Self, CredentialExportError> {
+        let key_export = KeyExport::try_from(export.0)
+            .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+        let signer = Ed25519Signer::import(key_export)
+            .await
+            .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+        Ok(Self(signer))
+    }
+}

--- a/rust/dialog-credentials/src/credential/verifier.rs
+++ b/rust/dialog-credentials/src/credential/verifier.rs
@@ -4,9 +4,10 @@ use crate::Ed25519Verifier;
 use crate::ed25519::Ed25519VerifyingKey;
 use dialog_varsig::{Did, Principal};
 
-use super::export::{CredentialExportError, KEY_SIZE, VerifierCredentialExport};
+use super::constants::KEY_SIZE;
 #[cfg(not(target_arch = "wasm32"))]
-use super::export::{ED25519_PUB_TAG, PUB_TAG_SIZE, VERIFIER_EXPORT_SIZE};
+use super::constants::{ED25519_PUB_TAG, PUB_TAG_SIZE, VERIFIER_EXPORT_SIZE};
+use super::export::{CredentialExportError, VerifierCredentialExport};
 
 /// A verifier credential — wraps an `Ed25519Verifier` (public key only).
 #[derive(Debug, Clone)]

--- a/rust/dialog-credentials/src/credential/verifier.rs
+++ b/rust/dialog-credentials/src/credential/verifier.rs
@@ -1,0 +1,88 @@
+//! Verifier credential — wraps an Ed25519 public key.
+
+use crate::Ed25519Verifier;
+use crate::ed25519::Ed25519VerifyingKey;
+use dialog_varsig::{Did, Principal};
+
+use super::export::{CredentialExportError, KEY_SIZE, VerifierCredentialExport};
+#[cfg(not(target_arch = "wasm32"))]
+use super::export::{ED25519_PUB_TAG, PUB_TAG_SIZE, VERIFIER_EXPORT_SIZE};
+
+/// A verifier credential — wraps an `Ed25519Verifier` (public key only).
+#[derive(Debug, Clone)]
+pub struct VerifierCredential(pub Ed25519Verifier);
+
+impl From<Ed25519Verifier> for VerifierCredential {
+    fn from(verifier: Ed25519Verifier) -> Self {
+        Self(verifier)
+    }
+}
+
+impl Principal for VerifierCredential {
+    fn did(&self) -> Did {
+        Principal::did(&self.0)
+    }
+}
+
+impl From<VerifierCredential> for Did {
+    fn from(credential: VerifierCredential) -> Self {
+        credential.did()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl VerifierCredential {
+    /// Export to multicodec-tagged bytes for native storage.
+    pub fn export(&self) -> VerifierCredentialExport {
+        let mut buf = [0u8; VERIFIER_EXPORT_SIZE];
+        buf[..PUB_TAG_SIZE].copy_from_slice(ED25519_PUB_TAG);
+        buf[PUB_TAG_SIZE..].copy_from_slice(&self.0.0.to_bytes());
+        VerifierCredentialExport(buf)
+    }
+
+    /// Import from multicodec-tagged bytes.
+    pub fn import(export: VerifierCredentialExport) -> Result<Self, CredentialExportError> {
+        let data = &export.0;
+        if !data.starts_with(ED25519_PUB_TAG) {
+            return Err(CredentialExportError::InvalidFormat(
+                "invalid ed25519-pub multicodec tag".into(),
+            ));
+        }
+
+        let key_arr: &[u8; KEY_SIZE] = data[PUB_TAG_SIZE..]
+            .try_into()
+            .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
+        let vk = ed25519_dalek::VerifyingKey::from_bytes(key_arr)
+            .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+        Ok(Self(Ed25519Verifier(Ed25519VerifyingKey::Native(vk))))
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use js_sys::Uint8Array;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen::JsCast;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl VerifierCredential {
+    /// Export to a JsValue (Uint8Array) for web storage.
+    pub fn export(&self) -> VerifierCredentialExport {
+        let bytes = self.0.0.to_bytes();
+        VerifierCredentialExport(Uint8Array::from(bytes.as_slice()).into())
+    }
+
+    /// Import from a JsValue (Uint8Array).
+    pub fn import(export: VerifierCredentialExport) -> Result<Self, CredentialExportError> {
+        let array: &Uint8Array = export
+            .0
+            .dyn_ref()
+            .ok_or_else(|| CredentialExportError::InvalidFormat("expected Uint8Array".into()))?;
+        let bytes = array.to_vec();
+        let key_arr: [u8; KEY_SIZE] = bytes.as_slice().try_into().map_err(|_| {
+            CredentialExportError::InvalidFormat(format!("invalid verifier length={}", bytes.len()))
+        })?;
+        let vk = ed25519_dalek::VerifyingKey::from_bytes(&key_arr)
+            .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+        Ok(Self(Ed25519Verifier(Ed25519VerifyingKey::Native(vk))))
+    }
+}

--- a/rust/dialog-credentials/src/key.rs
+++ b/rust/dialog-credentials/src/key.rs
@@ -1,4 +1,4 @@
-//! Algorithm-agnostic key export types.
+//! Algorithm-agnostic key export types and credential storage formats.
 
 /// Key material for import/export.
 ///
@@ -33,6 +33,49 @@ impl From<web_sys::CryptoKeyPair> for KeyExport {
             private_key: pair.get_private_key(),
             public_key: pair.get_public_key(),
         }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<KeyExport> for wasm_bindgen::JsValue {
+    fn from(export: KeyExport) -> Self {
+        match export {
+            KeyExport::Extractable(bytes) => js_sys::Uint8Array::from(bytes.as_slice()).into(),
+            KeyExport::NonExtractable {
+                private_key,
+                public_key,
+            } => web_sys::CryptoKeyPair::new(&private_key, &public_key).into(),
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl TryFrom<wasm_bindgen::JsValue> for KeyExport {
+    type Error = WebCryptoError;
+
+    fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
+        use wasm_bindgen::JsCast;
+
+        // If it's a Uint8Array, treat as extractable bytes
+        if let Some(array) = value.dyn_ref::<js_sys::Uint8Array>() {
+            return Ok(KeyExport::Extractable(array.to_vec()));
+        }
+
+        // Otherwise treat as { privateKey, publicKey } object
+        let private_key: web_sys::CryptoKey = js_sys::Reflect::get(&value, &"privateKey".into())
+            .map_err(|_| WebCryptoError::KeyImport("missing privateKey".into()))?
+            .dyn_into()
+            .map_err(|_| WebCryptoError::KeyImport("invalid privateKey".into()))?;
+
+        let public_key: web_sys::CryptoKey = js_sys::Reflect::get(&value, &"publicKey".into())
+            .map_err(|_| WebCryptoError::KeyImport("missing publicKey".into()))?
+            .dyn_into()
+            .map_err(|_| WebCryptoError::KeyImport("invalid publicKey".into()))?;
+
+        Ok(KeyExport::NonExtractable {
+            private_key,
+            public_key,
+        })
     }
 }
 
@@ -88,4 +131,102 @@ pub trait ExtractableKey: Sized {
 
     /// Export the key material.
     fn export(&self) -> impl std::future::Future<Output = Result<KeyExport, WebCryptoError>>;
+}
+
+// Re-export credential types for backward compatibility.
+pub use crate::credential::{
+    Credential, CredentialExport, CredentialExportError, SignerCredential, SignerCredentialExport,
+    VerifierCredential, VerifierCredentialExport,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extractable_roundtrip_through_bytes() {
+        let original = KeyExport::Extractable(vec![1, 2, 3, 4, 5]);
+        let bytes = match &original {
+            KeyExport::Extractable(b) => b.clone(),
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            _ => panic!("expected extractable"),
+        };
+        let restored = KeyExport::Extractable(bytes);
+        match (&original, &restored) {
+            (KeyExport::Extractable(a), KeyExport::Extractable(b)) => assert_eq!(a, b),
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            _ => panic!("expected extractable"),
+        }
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod wasm_tests {
+    use super::*;
+    use crate::Ed25519Signer;
+    use wasm_bindgen::{JsCast, JsValue};
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[dialog_common::test]
+    fn extractable_to_jsvalue_produces_uint8array() {
+        let export = KeyExport::Extractable(vec![10, 20, 30]);
+        let js_val: JsValue = export.into();
+        assert!(js_val.is_instance_of::<js_sys::Uint8Array>());
+
+        let array = js_sys::Uint8Array::from(js_val);
+        assert_eq!(array.to_vec(), vec![10, 20, 30]);
+    }
+
+    #[dialog_common::test]
+    fn extractable_roundtrip_through_jsvalue() {
+        let original = KeyExport::Extractable(vec![42; 32]);
+        let js_val: JsValue = original.into();
+        let restored = KeyExport::try_from(js_val).unwrap();
+
+        match restored {
+            KeyExport::Extractable(bytes) => assert_eq!(bytes, vec![42; 32]),
+            _ => panic!("expected Extractable variant"),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn non_extractable_roundtrip_through_jsvalue() {
+        let signer = Ed25519Signer::generate().await.unwrap();
+        let export = signer.export().await.unwrap();
+
+        // Should be NonExtractable on web
+        assert!(
+            matches!(&export, KeyExport::NonExtractable { .. }),
+            "default generate should produce non-extractable key"
+        );
+
+        let js_val: JsValue = export.into();
+
+        // Should be a JS object with privateKey and publicKey
+        assert!(js_val.is_object());
+        let private = js_sys::Reflect::get(&js_val, &"privateKey".into()).unwrap();
+        let public = js_sys::Reflect::get(&js_val, &"publicKey".into()).unwrap();
+        assert!(private.is_instance_of::<web_sys::CryptoKey>());
+        assert!(public.is_instance_of::<web_sys::CryptoKey>());
+
+        // Roundtrip back to KeyExport
+        let restored = KeyExport::try_from(js_val).unwrap();
+        assert!(matches!(restored, KeyExport::NonExtractable { .. }));
+
+        // Should be importable back into a signer
+        let restored_signer = Ed25519Signer::import(restored).await.unwrap();
+        assert_eq!(
+            dialog_varsig::Principal::did(&signer),
+            dialog_varsig::Principal::did(&restored_signer),
+            "roundtripped signer should have same DID"
+        );
+    }
+
+    #[dialog_common::test]
+    fn try_from_invalid_jsvalue_fails() {
+        let result = KeyExport::try_from(JsValue::from_str("not a key"));
+        assert!(result.is_err());
+    }
 }

--- a/rust/dialog-credentials/src/key.rs
+++ b/rust/dialog-credentials/src/key.rs
@@ -1,5 +1,14 @@
 //! Algorithm-agnostic key export types and credential storage formats.
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use js_sys::{Reflect, Uint8Array};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use thiserror::Error;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen::{JsCast, JsValue};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use web_sys::{CryptoKey, CryptoKeyPair};
+
 /// Key material for import/export.
 ///
 /// On native platforms, only the `Extractable` variant is available.
@@ -14,9 +23,9 @@ pub enum KeyExport {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     NonExtractable {
         /// The WebCrypto private key.
-        private_key: web_sys::CryptoKey,
+        private_key: CryptoKey,
         /// The WebCrypto public key.
-        public_key: web_sys::CryptoKey,
+        public_key: CryptoKey,
     },
 }
 
@@ -27,8 +36,8 @@ impl From<&[u8; 32]> for KeyExport {
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-impl From<web_sys::CryptoKeyPair> for KeyExport {
-    fn from(pair: web_sys::CryptoKeyPair) -> Self {
+impl From<CryptoKeyPair> for KeyExport {
+    fn from(pair: CryptoKeyPair) -> Self {
         KeyExport::NonExtractable {
             private_key: pair.get_private_key(),
             public_key: pair.get_public_key(),
@@ -37,37 +46,35 @@ impl From<web_sys::CryptoKeyPair> for KeyExport {
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-impl From<KeyExport> for wasm_bindgen::JsValue {
+impl From<KeyExport> for JsValue {
     fn from(export: KeyExport) -> Self {
         match export {
-            KeyExport::Extractable(bytes) => js_sys::Uint8Array::from(bytes.as_slice()).into(),
+            KeyExport::Extractable(bytes) => Uint8Array::from(bytes.as_slice()).into(),
             KeyExport::NonExtractable {
                 private_key,
                 public_key,
-            } => web_sys::CryptoKeyPair::new(&private_key, &public_key).into(),
+            } => CryptoKeyPair::new(&private_key, &public_key).into(),
         }
     }
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-impl TryFrom<wasm_bindgen::JsValue> for KeyExport {
+impl TryFrom<JsValue> for KeyExport {
     type Error = WebCryptoError;
 
-    fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
-        use wasm_bindgen::JsCast;
-
+    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
         // If it's a Uint8Array, treat as extractable bytes
-        if let Some(array) = value.dyn_ref::<js_sys::Uint8Array>() {
+        if let Some(array) = value.dyn_ref::<Uint8Array>() {
             return Ok(KeyExport::Extractable(array.to_vec()));
         }
 
         // Otherwise treat as { privateKey, publicKey } object
-        let private_key: web_sys::CryptoKey = js_sys::Reflect::get(&value, &"privateKey".into())
+        let private_key: CryptoKey = Reflect::get(&value, &"privateKey".into())
             .map_err(|_| WebCryptoError::KeyImport("missing privateKey".into()))?
             .dyn_into()
             .map_err(|_| WebCryptoError::KeyImport("invalid privateKey".into()))?;
 
-        let public_key: web_sys::CryptoKey = js_sys::Reflect::get(&value, &"publicKey".into())
+        let public_key: CryptoKey = Reflect::get(&value, &"publicKey".into())
             .map_err(|_| WebCryptoError::KeyImport("missing publicKey".into()))?
             .dyn_into()
             .map_err(|_| WebCryptoError::KeyImport("invalid publicKey".into()))?;
@@ -81,7 +88,7 @@ impl TryFrom<wasm_bindgen::JsValue> for KeyExport {
 
 /// Errors that can occur when using WebCrypto operations.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, Error)]
 pub enum WebCryptoError {
     /// WebCrypto API is not available.
     #[error("WebCrypto not available: {0}")]
@@ -144,7 +151,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extractable_roundtrip_through_bytes() {
+    fn it_roundtrips_extractable_key_through_bytes() {
         let original = KeyExport::Extractable(vec![1, 2, 3, 4, 5]);
         let bytes = match &original {
             KeyExport::Extractable(b) => b.clone(),
@@ -160,27 +167,27 @@ mod tests {
     }
 }
 
+// Web-only: `JsValue` conversions and `NonExtractable` (WebCrypto) roundtrips
+// do not exist on native, so these tests cannot run outside `wasm32-unknown`.
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
-mod wasm_tests {
+mod web_tests {
     use super::*;
     use crate::Ed25519Signer;
-    use wasm_bindgen::{JsCast, JsValue};
 
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_service_worker);
 
     #[dialog_common::test]
-    fn extractable_to_jsvalue_produces_uint8array() {
+    fn it_converts_extractable_key_to_uint8array() {
         let export = KeyExport::Extractable(vec![10, 20, 30]);
         let js_val: JsValue = export.into();
-        assert!(js_val.is_instance_of::<js_sys::Uint8Array>());
+        assert!(js_val.is_instance_of::<Uint8Array>());
 
-        let array = js_sys::Uint8Array::from(js_val);
+        let array = Uint8Array::from(js_val);
         assert_eq!(array.to_vec(), vec![10, 20, 30]);
     }
 
     #[dialog_common::test]
-    fn extractable_roundtrip_through_jsvalue() {
+    fn it_roundtrips_extractable_key_through_jsvalue() {
         let original = KeyExport::Extractable(vec![42; 32]);
         let js_val: JsValue = original.into();
         let restored = KeyExport::try_from(js_val).unwrap();
@@ -206,10 +213,10 @@ mod wasm_tests {
 
         // Should be a JS object with privateKey and publicKey
         assert!(js_val.is_object());
-        let private = js_sys::Reflect::get(&js_val, &"privateKey".into()).unwrap();
-        let public = js_sys::Reflect::get(&js_val, &"publicKey".into()).unwrap();
-        assert!(private.is_instance_of::<web_sys::CryptoKey>());
-        assert!(public.is_instance_of::<web_sys::CryptoKey>());
+        let private = Reflect::get(&js_val, &"privateKey".into()).unwrap();
+        let public = Reflect::get(&js_val, &"publicKey".into()).unwrap();
+        assert!(private.is_instance_of::<CryptoKey>());
+        assert!(public.is_instance_of::<CryptoKey>());
 
         // Roundtrip back to KeyExport
         let restored = KeyExport::try_from(js_val).unwrap();
@@ -225,7 +232,7 @@ mod wasm_tests {
     }
 
     #[dialog_common::test]
-    fn try_from_invalid_jsvalue_fails() {
+    fn it_fails_to_convert_invalid_jsvalue() {
         let result = KeyExport::try_from(JsValue::from_str("not a key"));
         assert!(result.is_err());
     }

--- a/rust/dialog-credentials/src/lib.rs
+++ b/rust/dialog-credentials/src/lib.rs
@@ -1,17 +1,20 @@
 //! Concrete key and signing types for dialog-capability.
 //!
 //! This crate provides credential implementations that satisfy the
-//! [`Principal`] and [`Authority`] traits from `dialog-capability`.
+//! [`Principal`] and [`Issuer`] traits from `dialog-capability`.
 //!
 //! Currently the only implementation is Ed25519 (enabled by the `ed25519`
 //! feature, which is on by default).
 //!
 //! [`Principal`]: dialog_capability::Principal
-//! [`Authority`]: dialog_capability::Authority
+//! [`Issuer`]: dialog_capability::Issuer
 
+pub mod credential;
 pub mod key;
 
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
 #[cfg(feature = "ed25519")]
 pub use ed25519::*;
+
+pub use credential::*;


### PR DESCRIPTION
## Why

Downstream code (profiles, repositories, storage providers) needs to handle credentials at a higher level than raw Ed25519 signers. A profile always has a signer, but a repository might receive a credential from a delegation that only carries the public key. Without newtypes, every consumer has to match on key material directly and handle the signer/verifier distinction ad hoc.

SignerCredential wraps a signer with Issuer capability. VerifierCredential wraps a public key for verification only. Credential is the enum for contexts where either is valid. Key export is extended with platform-specific formats (multicodec bytes on native, CryptoKey on wasm) so credentials can be persisted and restored across sessions.