### PR TITLE
10 📬 feat: add UCAN scope, parameters, and issuer bridge

### DIFF
--- a/rust/dialog-capability/src/lib.rs
+++ b/rust/dialog-capability/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust
 //! # mod example {
-//! use dialog_capability::{did, Subject, Did, Ability, Attenuation, Policy, Effect};
+//! use dialog_capability::{did, Subject, Did, Ability, Attenuation, Policy, Effect, Claim};
 //! use serde::{Serialize, Deserialize};
 //!
 //! // Attenuation: narrows ability (adds "/storage" to path) and adds parameters
@@ -28,7 +28,7 @@
 //! }
 //!
 //! // Effect: narrows ability (adds "/get"), and is invocable
-//! #[derive(Debug, Clone, Serialize, Deserialize)]
+//! #[derive(Debug, Clone, Serialize, Deserialize, Claim)]
 //! struct Get { key: Vec<u8> }
 //! impl Effect for Get {
 //!     type Of = Store;

--- a/rust/dialog-capability/src/ucan.rs
+++ b/rust/dialog-capability/src/ucan.rs
@@ -1,39 +1,17 @@
-//! UCAN bridge types.
+//! UCAN bridge types and authorization utilities.
 //!
-//! When the `ucan` feature is enabled this module provides IPLD parameter
-//! collection utilities for UCAN invocations.
+//! When the `ucan` feature is enabled this module provides:
 //!
-//! The core bridging is automatic: any type implementing [`Authority`](crate::Authority)
-//! automatically satisfies `dialog_ucan::Issuer<A::Signature>` because `Authority`
-//! extends `dialog_varsig::Principal + dialog_varsig::Signer<Self::Signature>`, and
-//! `dialog_ucan::Issuer<S>` has a blanket impl for `Signer<S> + Principal`.
+//! - [`Scope`] and [`Parameters`] for IPLD parameter collection
+//! - [`Issuer`] adapter bridging credential effects to UCAN signing
+//! - [`UcanInvocation`] wrapper for signed UCAN invocation chains
 
-use crate::{Ability, PolicyBuilder};
-use ipld_core::ipld::Ipld;
-use ipld_core::serde::to_ipld;
-use serde::Serialize;
-use std::collections::BTreeMap;
+mod invocation;
+pub mod issuer;
+mod parameters;
+mod scope;
 
-/// IPLD-based parameter map for UCAN invocations.
-pub type Parameters = BTreeMap<String, Ipld>;
-
-/// Builder that collects caveats as IPLD parameters.
-struct ParametersBuilder(Parameters);
-
-impl PolicyBuilder for ParametersBuilder {
-    fn push<T: Serialize>(&mut self, caveat: &T) {
-        if let Ok(Ipld::Map(map)) = to_ipld(caveat) {
-            self.0.extend(map);
-        }
-    }
-}
-
-/// Collect parameters from a capability into an IPLD map.
-///
-/// This function iterates over all caveats in the capability chain,
-/// serializes each to IPLD, and merges their fields into a single map.
-pub fn parameters<T: Ability>(capability: &T) -> Parameters {
-    let mut builder = ParametersBuilder(Parameters::new());
-    capability.constrain(&mut builder);
-    builder.0
-}
+pub use invocation::UcanInvocation;
+pub use issuer::Issuer;
+pub use parameters::{parameters, parameters_to_args, parameters_to_policy};
+pub use scope::{Args, Parameters, Scope};

--- a/rust/dialog-capability/src/ucan/invocation.rs
+++ b/rust/dialog-capability/src/ucan/invocation.rs
@@ -1,0 +1,46 @@
+//! Signed UCAN invocation.
+
+use crate::Did;
+use dialog_ucan::InvocationChain;
+use dialog_varsig::eddsa::Ed25519Signature;
+
+/// A signed UCAN invocation ready to be redeemed at an access service.
+///
+/// Contains the signed invocation chain and metadata. The chain proves
+/// the invoker's authority to perform the operation. To actually execute
+/// against a remote service, send the serialized chain to the access
+/// service endpoint (transport-specific, handled by `dialog-remote-ucan-s3`).
+#[derive(Debug, Clone)]
+pub struct UcanInvocation {
+    /// The signed invocation chain (invocation + delegation proofs).
+    pub chain: Box<InvocationChain<Ed25519Signature>>,
+    /// The subject DID this invocation acts on.
+    pub subject: Did,
+    /// The ability path (e.g., "/storage/get").
+    pub ability: String,
+}
+
+impl UcanInvocation {
+    /// Get the subject DID.
+    pub fn subject(&self) -> &Did {
+        &self.subject
+    }
+
+    /// Get the ability path.
+    pub fn ability(&self) -> &str {
+        &self.ability
+    }
+
+    /// Get the invocation chain.
+    pub fn chain(&self) -> &InvocationChain<Ed25519Signature> {
+        &self.chain
+    }
+
+    /// Serialize the invocation chain to bytes.
+    ///
+    /// Returns the CBOR-encoded container suitable for sending to an
+    /// access service endpoint.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        self.chain.to_bytes().map_err(|e| e.to_string())
+    }
+}

--- a/rust/dialog-capability/src/ucan/issuer.rs
+++ b/rust/dialog-capability/src/ucan/issuer.rs
@@ -1,0 +1,56 @@
+//! Credential bridge for UCAN signing.
+//!
+//! [`Issuer`] adapts an [`Authority`] chain and environment into
+//! UCAN's `Principal` + `Signer` interface, allowing the UCAN
+//! `InvocationBuilder` to work with the capability system.
+
+use crate::authority::{Authority, Operator, Sign};
+use crate::{Did, Policy, Provider};
+use dialog_common::ConditionalSync;
+use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::{Principal, Signer};
+
+/// Bridge adapter that wraps an authority chain into a UCAN-compatible issuer.
+///
+/// Implements `Principal` and `Signer<Ed25519Signature>` by delegating
+/// signing to the environment via the authority's `Sign` effect.
+pub struct Issuer<'a, Env> {
+    env: &'a Env,
+    /// The authority capability chain (`Subject → Profile → Operator`).
+    capability: Authority,
+}
+
+impl<'a, Env> Issuer<'a, Env> {
+    /// Create an issuer from an authority chain and environment.
+    pub fn new(env: &'a Env, capability: Authority) -> Self {
+        Self { env, capability }
+    }
+
+    /// Get the authority capability chain.
+    pub fn capability(&self) -> &Authority {
+        &self.capability
+    }
+}
+
+impl<Env> Principal for Issuer<'_, Env> {
+    fn did(&self) -> Did {
+        Operator::of(&self.capability).operator.clone()
+    }
+}
+
+impl<Env> Signer<Ed25519Signature> for Issuer<'_, Env>
+where
+    Env: Provider<Sign> + ConditionalSync,
+{
+    async fn sign(&self, payload: &[u8]) -> Result<Ed25519Signature, signature::Error> {
+        let sign_cap = self.capability.clone().invoke(Sign::new(payload));
+
+        let bytes = self
+            .env
+            .execute(sign_cap)
+            .await
+            .map_err(signature::Error::from_source)?;
+
+        Ed25519Signature::try_from(bytes.as_slice())
+    }
+}

--- a/rust/dialog-capability/src/ucan/parameters.rs
+++ b/rust/dialog-capability/src/ucan/parameters.rs
@@ -1,0 +1,179 @@
+//! IPLD parameter collection and UCAN argument conversion.
+
+use crate::{Ability, PolicyBuilder};
+use dialog_ucan::delegation::policy::predicate::Predicate;
+use dialog_ucan::delegation::policy::selector::filter::Filter;
+use dialog_ucan::delegation::policy::selector::select::Select;
+use dialog_ucan::promise::Promised;
+use ipld_core::ipld::Ipld;
+use ipld_core::serde::to_ipld;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// IPLD-based parameter map for UCAN invocations.
+pub type Parameters = BTreeMap<String, Ipld>;
+
+/// UCAN invocation arguments (Promised values for the invocation body).
+pub type Args = BTreeMap<String, Promised>;
+
+/// Builder that collects caveats as IPLD parameters.
+struct ParametersBuilder(Parameters);
+
+impl PolicyBuilder for ParametersBuilder {
+    fn push<T: Serialize>(&mut self, caveat: &T) {
+        if let Ok(Ipld::Map(map)) = to_ipld(caveat) {
+            self.0.extend(map);
+        }
+    }
+}
+
+/// Collect parameters from a capability into an IPLD map.
+///
+/// Iterates over all caveats in the capability chain, serializes each
+/// to IPLD, and merges their fields into a single map.
+pub fn parameters<T: Ability>(capability: &T) -> Parameters {
+    let mut builder = ParametersBuilder(Parameters::new());
+    capability.constrain(&mut builder);
+    builder.0
+}
+
+/// Convert an IPLD value to a Promised value (for UCAN invocation arguments).
+pub(super) fn ipld_to_promised(ipld: Ipld) -> Promised {
+    match ipld {
+        Ipld::Null => Promised::Null,
+        Ipld::Bool(b) => Promised::Bool(b),
+        Ipld::Integer(i) => Promised::Integer(i),
+        Ipld::Float(f) => Promised::Float(f),
+        Ipld::String(s) => Promised::String(s),
+        Ipld::Bytes(b) => Promised::Bytes(b),
+        Ipld::Link(c) => Promised::Link(c),
+        Ipld::List(l) => Promised::List(l.into_iter().map(ipld_to_promised).collect()),
+        Ipld::Map(m) => Promised::Map(
+            m.into_iter()
+                .map(|(k, v)| (k, ipld_to_promised(v)))
+                .collect(),
+        ),
+    }
+}
+
+/// Convert IPLD parameters to UCAN invocation arguments.
+pub fn parameters_to_args(parameters: Parameters) -> Args {
+    parameters
+        .into_iter()
+        .map(|(k, v)| (k, ipld_to_promised(v)))
+        .collect()
+}
+
+/// Convert capability parameters to UCAN delegation policy predicates.
+///
+/// Each parameter becomes an equality constraint: `.{key} == value`.
+pub fn parameters_to_policy(parameters: Parameters) -> Vec<Predicate> {
+    parameters
+        .into_iter()
+        .map(|(key, value)| Predicate::Equal(Select::new(vec![Filter::Field(key)]), value))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{Get, Set, Storage, Store};
+    use crate::{Subject, did};
+
+    #[test]
+    fn parameters_from_empty_subject() {
+        let cap = Subject::from(did!("key:z6MkTest"));
+        let params = parameters(&cap);
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn parameters_from_storage_store() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Storage)
+            .attenuate(Store::new("index"));
+        let params = parameters(&cap);
+        assert_eq!(params.get("store"), Some(&Ipld::String("index".into())));
+    }
+
+    #[test]
+    fn parameters_from_storage_get() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Storage)
+            .attenuate(Store::new("data"))
+            .invoke(Get::new(b"my-key"));
+        let params = parameters(&cap);
+        assert_eq!(params.get("store"), Some(&Ipld::String("data".into())));
+        assert_eq!(params.get("key"), Some(&Ipld::Bytes(b"my-key".to_vec())));
+    }
+
+    #[test]
+    fn parameters_to_policy_empty() {
+        let policy = parameters_to_policy(Parameters::new());
+        assert!(policy.is_empty());
+    }
+
+    #[test]
+    fn parameters_to_policy_produces_equality_constraints() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Storage)
+            .attenuate(Store::new("data"));
+        let policy = parameters_to_policy(parameters(&cap));
+
+        assert_eq!(policy.len(), 1);
+        assert_eq!(
+            policy[0],
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("store".into())]),
+                Ipld::String("data".into())
+            )
+        );
+    }
+
+    #[test]
+    fn parameters_to_policy_multiple_constraints() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Storage)
+            .attenuate(Store::new("index"))
+            .invoke(Set::new(b"key1", b"val1"));
+        let policy = parameters_to_policy(parameters(&cap));
+
+        // Should have constraints for store, key, and value (via checksum)
+        assert!(
+            policy.len() >= 2,
+            "expected at least 2 constraints, got {}",
+            policy.len()
+        );
+
+        let has_store = policy.iter().any(|p| {
+            matches!(
+                p,
+                Predicate::Equal(sel, Ipld::String(v))
+                    if sel == &Select::new(vec![Filter::Field("store".into())])
+                    && v == "index"
+            )
+        });
+        assert!(has_store, "should have store equality constraint");
+
+        let has_key = policy.iter().any(|p| {
+            matches!(
+                p,
+                Predicate::Equal(sel, Ipld::Bytes(v))
+                    if sel == &Select::new(vec![Filter::Field("key".into())])
+                    && v == b"key1"
+            )
+        });
+        assert!(has_key, "should have key equality constraint");
+    }
+
+    #[test]
+    fn parameters_to_args_roundtrip() {
+        let mut params = Parameters::new();
+        params.insert("name".into(), Ipld::String("test".into()));
+        params.insert("count".into(), Ipld::Integer(42));
+
+        let args = parameters_to_args(params);
+        assert_eq!(args.get("name"), Some(&Promised::String("test".into())));
+        assert_eq!(args.get("count"), Some(&Promised::Integer(42)));
+    }
+}

--- a/rust/dialog-capability/src/ucan/scope.rs
+++ b/rust/dialog-capability/src/ucan/scope.rs
@@ -1,0 +1,226 @@
+//! Capability-derived scope for UCAN delegation and invocation.
+
+use crate::{Ability, Capability, Constraint, Effect, Policy, Subject};
+use dialog_ucan::command::Command;
+use dialog_ucan::delegation::policy::predicate::Predicate;
+use dialog_ucan::subject::Subject as UcanSubject;
+use ipld_core::ipld::Ipld;
+use std::collections::BTreeMap;
+
+use super::parameters::{self, parameters_to_args, parameters_to_policy};
+
+pub use super::parameters::Args;
+
+/// Parameters extracted from a capability chain.
+#[derive(Debug, Clone, Default)]
+pub struct Parameters(pub BTreeMap<String, Ipld>);
+
+impl Parameters {
+    /// Get the inner map.
+    pub fn as_map(&self) -> &BTreeMap<String, Ipld> {
+        &self.0
+    }
+
+    /// Convert to delegation policy predicates (equality constraints).
+    pub fn policy(&self) -> Vec<Predicate> {
+        parameters_to_policy(self.0.clone())
+    }
+
+    /// Convert to invocation arguments.
+    pub fn args(&self) -> Args {
+        parameters_to_args(self.0.clone())
+    }
+}
+
+/// Scope extracted from a capability chain for UCAN operations.
+pub struct Scope {
+    /// The subject (specific DID or `Any` for powerline).
+    pub subject: UcanSubject,
+    /// The command.
+    pub command: Command,
+    /// Parameters from the capability's policy chain.
+    pub parameters: Parameters,
+}
+
+impl Scope {
+    /// Convert parameters to delegation policy predicates.
+    pub fn policy(&self) -> Vec<Predicate> {
+        self.parameters.policy()
+    }
+
+    /// Convert parameters to invocation arguments.
+    pub fn args(&self) -> Args {
+        self.parameters.args()
+    }
+}
+
+fn ucan_subject(did: &crate::Did) -> UcanSubject {
+    if Subject::from(did.clone()).is_any() {
+        UcanSubject::Any
+    } else {
+        UcanSubject::Specific(did.clone())
+    }
+}
+
+fn ability_to_command(ability: &str) -> Command {
+    if ability == "/" {
+        Command::new(vec![])
+    } else {
+        Command::new(
+            ability
+                .trim_start_matches('/')
+                .split('/')
+                .map(String::from)
+                .collect(),
+        )
+    }
+}
+
+impl<T: Ability> From<&T> for Scope {
+    fn from(capability: &T) -> Self {
+        Self {
+            subject: ucan_subject(capability.subject()),
+            command: ability_to_command(&capability.ability()),
+            parameters: Parameters(parameters::parameters(capability)),
+        }
+    }
+}
+
+impl Scope {
+    /// Build a scope from an effect capability, projecting through Claim.
+    #[allow(dead_code)]
+    pub(crate) fn invoke<Fx>(capability: &Capability<Fx>) -> Self
+    where
+        Fx: Effect + Clone,
+        Capability<Fx>: Ability,
+    {
+        // Collect parameters from the parent chain (excluding the leaf effect)
+        let chain: &<Fx as Constraint>::Capability = capability.as_ref();
+        let mut params = parameters::parameters(&chain.capability);
+
+        // Add claim-projected parameters for the effect
+        let claim = Policy::of(capability).clone().claim();
+        if let Ok(Ipld::Map(map)) = ipld_core::serde::to_ipld(&claim) {
+            params.extend(map);
+        }
+
+        Self {
+            subject: ucan_subject(capability.subject()),
+            command: ability_to_command(&capability.ability()),
+            parameters: Parameters(params),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{Get, Storage, Store};
+    use crate::{Subject, did};
+    use dialog_ucan::delegation::policy::predicate::Predicate;
+    use dialog_ucan::delegation::policy::selector::filter::Filter;
+    use dialog_ucan::delegation::policy::selector::select::Select;
+    use dialog_ucan::promise::Promised;
+
+    #[test]
+    fn scope_from_subject() {
+        let cap = Subject::from(did!("key:z6MkTest"));
+        let scope = Scope::from(&cap);
+
+        assert!(matches!(scope.subject, UcanSubject::Specific(_)));
+        assert!(scope.command.segments().is_empty());
+        assert!(scope.parameters.0.is_empty());
+        assert!(scope.policy().is_empty());
+        assert!(scope.args().is_empty());
+    }
+
+    #[test]
+    fn scope_from_any_subject() {
+        let cap = Subject::any();
+        let scope = Scope::from(&cap);
+        assert!(matches!(scope.subject, UcanSubject::Any));
+    }
+
+    #[test]
+    fn scope_from_storage_store() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Storage)
+            .attenuate(Store::new("data"));
+        let scope = Scope::from(&cap);
+
+        assert_eq!(scope.command, Command::parse("/storage").unwrap());
+
+        let policy = scope.policy();
+        assert_eq!(policy.len(), 1);
+        assert_eq!(
+            policy[0],
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("store".into())]),
+                Ipld::String("data".into())
+            )
+        );
+
+        let args = scope.args();
+        assert_eq!(args.get("store"), Some(&Promised::String("data".into())));
+    }
+
+    #[test]
+    fn scope_from_storage_get() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Storage)
+            .attenuate(Store::new("data"))
+            .invoke(Get::new(b"my-key"));
+        let scope = Scope::from(&cap);
+
+        assert_eq!(scope.command, Command::parse("/storage/get").unwrap());
+
+        let policy = scope.policy();
+        assert!(
+            policy.contains(&Predicate::Equal(
+                Select::new(vec![Filter::Field("store".into())]),
+                Ipld::String("data".into())
+            )),
+            "policy should contain store=data constraint"
+        );
+        assert!(
+            policy.contains(&Predicate::Equal(
+                Select::new(vec![Filter::Field("key".into())]),
+                Ipld::Bytes(b"my-key".to_vec())
+            )),
+            "policy should contain key=my-key constraint"
+        );
+
+        let args = scope.args();
+        assert_eq!(args.get("store"), Some(&Promised::String("data".into())));
+        assert_eq!(args.get("key"), Some(&Promised::Bytes(b"my-key".to_vec())));
+    }
+
+    #[test]
+    fn parameters_to_policy() {
+        let mut map = BTreeMap::new();
+        map.insert("store".into(), Ipld::String("data".into()));
+        let params = Parameters(map);
+        let policy = params.policy();
+
+        assert_eq!(policy.len(), 1);
+        assert_eq!(
+            policy[0],
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("store".into())]),
+                Ipld::String("data".into())
+            )
+        );
+    }
+
+    #[test]
+    fn parameters_to_args() {
+        let mut map = BTreeMap::new();
+        map.insert("name".into(), Ipld::String("test".into()));
+        map.insert("count".into(), Ipld::Integer(42));
+        let params = Parameters(map);
+        let args = params.args();
+
+        assert_eq!(args.get("name"), Some(&Promised::String("test".into())));
+        assert_eq!(args.get("count"), Some(&Promised::Integer(42)));
+    }
+}

--- a/rust/dialog-ucan/src/lib.rs
+++ b/rust/dialog-ucan/src/lib.rs
@@ -27,6 +27,8 @@ pub mod unset;
 mod ipld;
 mod sealed;
 
+pub use container::delegation::DelegationChain;
+pub use container::invocation::InvocationChain;
 pub use delegation::{
     Delegation,
     builder::{BuildError as DelegationBuildError, DelegationBuilder},


### PR DESCRIPTION
## Summary

- Add `Scope` type: ability path + IPLD parameter map for UCAN claims
- Add `parameters` module: IPLD parameter collection with policy-to-args/policy conversion
- Add `Issuer` adapter: bridges authority chain + environment to UCAN Principal+Signer
- Add `UcanInvocation` wrapper for signed invocation chains
- Re-export `DelegationChain` and `InvocationChain` from `dialog-ucan` root
- Fix lib.rs doc example to derive `Claim` on Effect types