### PR TITLE
11 📬 feat: add UCAN builder, delegation, and claim authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,15 +921,20 @@ dependencies = [
  "async-trait",
  "convert_case",
  "dialog-common",
+ "dialog-credentials",
  "dialog-macros",
  "dialog-ucan",
  "dialog-varsig",
  "ipld-core",
  "serde",
  "serde_bytes",
+ "serde_ipld_dagcbor",
+ "serde_json",
  "signature",
  "thiserror 2.0.18",
+ "tokio",
  "url",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/rust/dialog-capability/Cargo.toml
+++ b/rust/dialog-capability/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [features]
 default = []
 # UCAN support (IPLD serialization for capabilities)
-ucan = ["dep:ipld-core", "dep:dialog-ucan"]
+ucan = ["dep:ipld-core", "dep:dialog-ucan", "dep:serde_ipld_dagcbor"]
 
 [dependencies]
 convert_case = { workspace = true }
@@ -24,3 +24,19 @@ dialog-varsig = { workspace = true }
 url = { workspace = true }
 ipld-core = { workspace = true, optional = true }
 dialog-ucan = { workspace = true, optional = true }
+serde_ipld_dagcbor = { workspace = true, optional = true }
+
+[dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
+dialog-credentials = { workspace = true }
+dialog-ucan = { workspace = true }
+ipld-core = { workspace = true }
+serde_json = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+wasm-bindgen-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(feature, values(\"web-integration-tests\"))",
+] }

--- a/rust/dialog-capability/src/capability.rs
+++ b/rust/dialog-capability/src/capability.rs
@@ -330,4 +330,96 @@ mod tests {
         let archive: &Archive = cap.policy();
         assert_eq!(archive, &Archive);
     }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, crate::Claim)]
+    struct Upload {
+        digest: Vec<u8>,
+        #[claim(into = u64, with = byte_len, rename = size)]
+        content: Vec<u8>,
+    }
+
+    fn byte_len(v: Vec<u8>) -> u64 {
+        v.len() as u64
+    }
+
+    impl Effect for Upload {
+        type Of = Catalog;
+        type Output = Result<(), String>;
+    }
+
+    #[cfg(feature = "ucan")]
+    mod parameters_tests {
+        use super::*;
+        use crate::ucan::parameters;
+        use ipld_core::ipld::Ipld;
+
+        #[test]
+        fn it_collects_parameters_from_chain() {
+            let cap: Capability<Get> = Subject::from(did!("key:zSpace"))
+                .attenuate(Archive)
+                .attenuate(Catalog {
+                    name: "blobs".into(),
+                })
+                .invoke(Get {
+                    digest: vec![1, 2, 3],
+                });
+
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("name"), Some(&Ipld::String("blobs".into())));
+            assert_eq!(
+                params.get("digest"),
+                Some(&Ipld::List(vec![
+                    Ipld::Integer(1),
+                    Ipld::Integer(2),
+                    Ipld::Integer(3)
+                ]))
+            );
+        }
+
+        #[test]
+        fn it_collects_parameters_from_attenuations() {
+            let cap: Capability<Lookup> = Subject::from(did!("key:zSpace"))
+                .attenuate(Storage)
+                .attenuate(Store {
+                    name: "index".into(),
+                })
+                .invoke(Lookup {
+                    key: b"hello".to_vec(),
+                });
+
+            let params = parameters(&cap);
+
+            assert_eq!(params.get("name"), Some(&Ipld::String("index".into())));
+            let hello_bytes: Vec<Ipld> =
+                b"hello".iter().map(|&b| Ipld::Integer(b as i128)).collect();
+            assert_eq!(params.get("key"), Some(&Ipld::List(hello_bytes)));
+        }
+
+        #[test]
+        fn it_uses_claim_projection_for_invocation_parameters() {
+            let cap: Capability<Upload> = Subject::from(did!("key:zSpace"))
+                .attenuate(Archive)
+                .attenuate(Catalog {
+                    name: "blobs".into(),
+                })
+                .invoke(Upload {
+                    digest: vec![1, 2, 3],
+                    content: b"hello world".to_vec(),
+                });
+
+            let invoke = crate::ucan::Ucan::invoke(&cap);
+            let params = invoke.scope.parameters.as_map();
+
+            assert!(
+                !params.contains_key("content"),
+                "parameters should not contain raw 'content' field"
+            );
+            assert_eq!(
+                params.get("size"),
+                Some(&Ipld::Integer(11)),
+                "parameters should contain claim-projected 'size' field"
+            );
+        }
+    }
 }

--- a/rust/dialog-capability/src/subject.rs
+++ b/rust/dialog-capability/src/subject.rs
@@ -39,12 +39,17 @@ impl From<Subject> for Capability<Subject> {
 /// DID used to represent "any subject" in delegation scope.
 pub const ANY_SUBJECT: &str = "did:_:_";
 
+/// Parse the wildcard DID for "any subject".
+pub fn any_did() -> Did {
+    ANY_SUBJECT.parse::<Did>().expect("valid wildcard DID")
+}
+
 impl Subject {
     /// Create a wildcard subject representing "any resource".
     ///
     /// Used in delegation to grant unrestricted access across all subjects.
     pub fn any() -> Self {
-        Self::from(ANY_SUBJECT.parse::<Did>().expect("valid wildcard DID"))
+        Self::from(any_did())
     }
 
     /// Whether this is the wildcard "any" subject.

--- a/rust/dialog-capability/src/ucan.rs
+++ b/rust/dialog-capability/src/ucan.rs
@@ -2,16 +2,56 @@
 //!
 //! When the `ucan` feature is enabled this module provides:
 //!
-//! - [`Scope`] and [`Parameters`] for IPLD parameter collection
+//! - IPLD parameter collection from capability chains
+//! - [`Ucan`] authorization format producing signed UCAN invocations
+//! - [`UcanInvocation`] signed UCAN invocation (the authorization proof)
 //! - [`Issuer`] adapter bridging credential effects to UCAN signing
-//! - [`UcanInvocation`] wrapper for signed UCAN invocation chains
+//! - [`authorize`](claim::claim) builds a UCAN invocation from a capability and delegation chain
 
+mod access;
+mod builder;
+pub mod claim;
+pub mod delegation;
 mod invocation;
 pub mod issuer;
 mod parameters;
 mod scope;
 
+pub use builder::{DelegateRequest, InvokeRequest, IssuerUnset};
+pub use claim::find_chain;
+pub use delegation::import_delegation_chain;
 pub use invocation::UcanInvocation;
 pub use issuer::Issuer;
 pub use parameters::{parameters, parameters_to_args, parameters_to_policy};
 pub use scope::{Args, Parameters, Scope};
+
+use crate::{Ability, Capability, Effect};
+
+/// UCAN authorization format producing signed invocation chains.
+///
+/// Implements [`Protocol`](crate::access::Protocol) for environments
+/// that provide identity, signing, and storage effects.
+///
+/// Also provides builder APIs for delegations and invocations:
+/// - [`Ucan::delegate()`] to build and sign a delegation chain
+/// - [`Ucan::invoke()`] to build and sign an invocation chain
+pub struct Ucan;
+
+impl Ucan {
+    /// Start building a delegation for the given capability.
+    pub fn delegate(capability: &impl Ability) -> DelegateRequest<IssuerUnset> {
+        DelegateRequest::new(capability)
+    }
+
+    /// Start building a signed invocation for an effect capability.
+    ///
+    /// Projects the effect through [`Claim`](crate::Claim) so that
+    /// payload fields are replaced with checksums in the invocation arguments.
+    pub fn invoke<Fx>(capability: &Capability<Fx>) -> InvokeRequest<IssuerUnset>
+    where
+        Fx: Effect + Clone,
+        Capability<Fx>: Ability,
+    {
+        InvokeRequest::new(capability)
+    }
+}

--- a/rust/dialog-capability/src/ucan/access.rs
+++ b/rust/dialog-capability/src/ucan/access.rs
@@ -1,0 +1,31 @@
+//! UCAN access authorization -- Protocol implementation for Ucan.
+//!
+//! Implements [`Protocol`] for [`Ucan`], using the invoke builder to
+//! produce signed UCAN invocations.
+
+use crate::access::{Authorization, AuthorizeError, Protocol};
+use crate::authority::{Identify, Sign};
+use crate::storage::{Get, List};
+use crate::{Ability, Capability, Constraint, Effect, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
+
+use super::Ucan;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Protocol for Ucan {
+    type Authorization<Fx: Constraint> = super::UcanInvocation;
+
+    async fn authorize<Fx, Env>(
+        env: &Env,
+        capability: Capability<Fx>,
+    ) -> Result<Authorization<Fx, Self>, AuthorizeError>
+    where
+        Fx: Effect + Clone + ConditionalSend + 'static,
+        Capability<Fx>: Ability + ConditionalSend + ConditionalSync,
+        Env: Provider<Identify> + Provider<Sign> + Provider<List> + Provider<Get> + ConditionalSync,
+    {
+        let invocation = Ucan::invoke(&capability).perform(env).await?;
+        Ok(Authorization::new(capability, invocation))
+    }
+}

--- a/rust/dialog-capability/src/ucan/builder.rs
+++ b/rust/dialog-capability/src/ucan/builder.rs
@@ -1,0 +1,465 @@
+//! Builder API for UCAN delegations and invocations.
+//!
+//! Provides [`DelegateRequest`] and [`InvokeRequest`] with typestate tracking
+//! of whether an explicit issuer has been provided. When issuer is set,
+//! `perform` only needs storage bounds; when unset, it also needs
+//! `Provider<Identify>` and `Provider<Sign>`.
+
+use crate::access::AuthorizeError;
+use crate::authority::{Identify, Operator, Profile, Sign};
+use crate::storage::{Get, List};
+use crate::subject::any_did;
+use crate::{Ability, Capability, Did, Effect, Policy, Provider, Subject};
+use dialog_common::ConditionalSync;
+use dialog_ucan::time::Timestamp;
+use dialog_ucan::{DelegationChain, InvocationChain};
+use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::{Principal, Signer};
+
+use super::UcanInvocation;
+use super::claim::find_chain;
+use super::issuer::Issuer;
+use super::scope::Scope;
+
+/// Marker type indicating no explicit issuer was provided.
+///
+/// When used with `DelegateRequest` or `InvokeRequest`, the `perform` method
+/// will resolve the issuer via `Identify` and `Sign` effects.
+pub struct IssuerUnset;
+
+/// Builder for a UCAN delegation.
+///
+/// Created via [`Ucan::delegate()`](super::Ucan::delegate). Use `.issuer()` to
+/// provide an explicit signer, or leave it unset to resolve via `Identify`/`Sign`.
+pub struct DelegateRequest<I = IssuerUnset> {
+    scope: Scope,
+    audience: Option<Did>,
+    issuer: I,
+    expiration: Option<Timestamp>,
+    not_before: Option<Timestamp>,
+}
+
+impl DelegateRequest<IssuerUnset> {
+    pub(crate) fn new(capability: &impl Ability) -> Self {
+        Self {
+            scope: Scope::from(capability),
+            audience: None,
+            issuer: IssuerUnset,
+            expiration: None,
+            not_before: None,
+        }
+    }
+
+    /// Set an explicit issuer (signer) for the delegation.
+    ///
+    /// The signer must implement `Signer<Ed25519Signature> + Principal`.
+    pub fn issuer<S>(self, signer: S) -> DelegateRequest<S>
+    where
+        S: Signer<Ed25519Signature> + Principal,
+    {
+        DelegateRequest {
+            scope: self.scope,
+            audience: self.audience,
+            issuer: signer,
+            expiration: self.expiration,
+            not_before: self.not_before,
+        }
+    }
+}
+
+impl<I> DelegateRequest<I> {
+    /// Set the audience (recipient) of the delegation.
+    pub fn audience(mut self, audience: impl Into<Did>) -> Self {
+        self.audience = Some(audience.into());
+        self
+    }
+
+    /// Set when the delegation expires.
+    pub fn expires(mut self, expiration: Timestamp) -> Self {
+        self.expiration = Some(expiration);
+        self
+    }
+
+    /// Set the earliest time the delegation becomes valid.
+    pub fn not_before(mut self, not_before: Timestamp) -> Self {
+        self.not_before = Some(not_before);
+        self
+    }
+}
+
+impl<S> DelegateRequest<S>
+where
+    S: Signer<Ed25519Signature> + Principal,
+{
+    /// Sign the delegation and return the chain.
+    ///
+    /// When issuer is set explicitly, only `Identify` (for profile discovery)
+    /// and storage read bounds are needed — no `Sign` required.
+    pub async fn perform<Env>(self, env: &Env) -> Result<DelegationChain, AuthorizeError>
+    where
+        Env: Provider<Identify> + Provider<List> + Provider<Get> + ConditionalSync,
+    {
+        let audience = self.audience.ok_or_else(|| {
+            AuthorizeError::Configuration("delegation requires an audience".into())
+        })?;
+
+        // Discover profile/operator DIDs via Identify
+        let auth = Subject::from(self.issuer.did())
+            .invoke(Identify)
+            .perform(env)
+            .await
+            .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+
+        let profile_did = Profile::of(&auth).profile.clone();
+
+        // Find proof chain from subject to the issuer (not operator),
+        // since the issuer is the one signing the new delegation.
+        let issuer_did = self.issuer.did();
+        let proof = find_proof(
+            env,
+            &self.scope,
+            &profile_did,
+            &issuer_did,
+            &issuer_did,
+            true,
+        )
+        .await?;
+
+        // Build the outermost delegation
+        let delegation = build_delegation(
+            self.issuer,
+            &audience,
+            &self.scope,
+            self.expiration,
+            self.not_before,
+        )
+        .await?;
+
+        extend_chain(proof, delegation)
+    }
+}
+
+impl DelegateRequest<IssuerUnset> {
+    /// Sign the delegation, resolving issuer via environment.
+    ///
+    /// Requires `Identify` and `Sign` to discover and use the profile signer.
+    pub async fn perform<Env>(self, env: &Env) -> Result<DelegationChain, AuthorizeError>
+    where
+        Env: Provider<Identify> + Provider<Sign> + Provider<List> + Provider<Get> + ConditionalSync,
+    {
+        let audience = self.audience.ok_or_else(|| {
+            AuthorizeError::Configuration("delegation requires an audience".into())
+        })?;
+
+        // Use a dummy DID for Identify when subject is Any
+        let lookup_did = resolve_lookup_did(&self.scope);
+
+        let auth = Subject::from(lookup_did)
+            .invoke(Identify)
+            .perform(env)
+            .await
+            .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+
+        let profile_did = Profile::of(&auth).profile.clone();
+        let operator_did = Operator::of(&auth).operator.clone();
+
+        // Find proof chain (no explicit issuer → no self-grant shortcuts)
+        let proof = find_proof(
+            env,
+            &self.scope,
+            &profile_did,
+            &operator_did,
+            &profile_did,
+            false,
+        )
+        .await?;
+
+        // Build outermost delegation using Issuer bridge
+        let issuer = Issuer::new(env, auth);
+        let delegation = build_delegation(
+            issuer,
+            &audience,
+            &self.scope,
+            self.expiration,
+            self.not_before,
+        )
+        .await?;
+
+        extend_chain(proof, delegation)
+    }
+}
+
+/// Builder for a UCAN invocation.
+///
+/// Created via [`Ucan::invoke()`](super::Ucan::invoke). Use `.issuer()` to
+/// provide an explicit signer, or leave it unset to resolve via `Identify`/`Sign`.
+pub struct InvokeRequest<I = IssuerUnset> {
+    pub(crate) scope: Scope,
+    issuer: I,
+}
+
+impl InvokeRequest<IssuerUnset> {
+    pub(crate) fn new<Fx>(capability: &Capability<Fx>) -> Self
+    where
+        Fx: Effect + Clone,
+        Capability<Fx>: Ability,
+    {
+        Self {
+            scope: Scope::invoke(capability),
+            issuer: IssuerUnset,
+        }
+    }
+
+    /// Set an explicit issuer (signer) for the invocation.
+    pub fn issuer<S>(self, signer: S) -> InvokeRequest<S>
+    where
+        S: Signer<Ed25519Signature> + Principal,
+    {
+        InvokeRequest {
+            scope: self.scope,
+            issuer: signer,
+        }
+    }
+}
+
+impl<S> InvokeRequest<S>
+where
+    S: Signer<Ed25519Signature> + Principal,
+{
+    /// Build and sign the invocation.
+    ///
+    /// When issuer is set explicitly, only `Identify` and storage bounds needed.
+    pub async fn perform<Env>(self, env: &Env) -> Result<UcanInvocation, AuthorizeError>
+    where
+        Env: Provider<Identify> + Provider<List> + Provider<Get> + ConditionalSync,
+    {
+        let auth = Subject::from(self.issuer.did())
+            .invoke(Identify)
+            .perform(env)
+            .await
+            .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+
+        let profile_did = Profile::of(&auth).profile.clone();
+        let operator_did = Operator::of(&auth).operator.clone();
+
+        build_invocation(env, self.issuer, &self.scope, &profile_did, &operator_did).await
+    }
+}
+
+impl InvokeRequest<IssuerUnset> {
+    /// Build and sign the invocation, resolving issuer via environment.
+    ///
+    /// Requires `Identify` and `Sign` to discover and use the operator signer.
+    pub async fn perform<Env>(self, env: &Env) -> Result<UcanInvocation, AuthorizeError>
+    where
+        Env: Provider<Identify> + Provider<Sign> + Provider<List> + Provider<Get> + ConditionalSync,
+    {
+        let lookup_did = resolve_lookup_did(&self.scope);
+
+        let auth = Subject::from(lookup_did)
+            .invoke(Identify)
+            .perform(env)
+            .await
+            .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+
+        let profile_did = Profile::of(&auth).profile.clone();
+        let operator_did = Operator::of(&auth).operator.clone();
+
+        let issuer = Issuer::new(env, auth);
+        build_invocation(env, issuer, &self.scope, &profile_did, &operator_did).await
+    }
+}
+
+fn resolve_lookup_did(scope: &Scope) -> Did {
+    use dialog_ucan::subject::Subject as UcanSubject;
+    match &scope.subject {
+        UcanSubject::Any => any_did(),
+        UcanSubject::Specific(did) => did.clone(),
+    }
+}
+
+/// Find proof chain, with self-grant shortcutting when `explicit_issuer` is true.
+///
+/// Self-grant shortcuts (issuer == subject, or subject is Any) only apply when
+/// the issuer was explicitly provided. When resolving via the environment,
+/// the full chain search is always performed.
+async fn find_proof<Env>(
+    env: &Env,
+    scope: &Scope,
+    profile_did: &Did,
+    operator_did: &Did,
+    issuer_did: &Did,
+    explicit_issuer: bool,
+) -> Result<Option<DelegationChain>, AuthorizeError>
+where
+    Env: Provider<List> + Provider<Get> + ConditionalSync,
+{
+    use dialog_ucan::subject::Subject as UcanSubject;
+
+    let subject_did = match &scope.subject {
+        UcanSubject::Any => any_did(),
+        UcanSubject::Specific(did) => did.clone(),
+    };
+
+    // Self-grant shortcut only applies with an explicit issuer
+    if explicit_issuer {
+        let is_self_grant = issuer_did == &subject_did;
+        let is_powerline = matches!(&scope.subject, UcanSubject::Any);
+        if is_self_grant || is_powerline {
+            return Ok(None);
+        }
+    }
+
+    find_chain(
+        env,
+        profile_did,
+        operator_did,
+        &subject_did,
+        &scope.command,
+        scope.parameters.as_map(),
+        &Timestamp::now(),
+    )
+    .await
+    .and_then(|chain| match chain {
+        Some(c) => Ok(Some(c)),
+        None => Err(AuthorizeError::Denied(format!(
+            "no delegation chain found for operator '{}' on subject '{}'",
+            operator_did, subject_did
+        ))),
+    })
+}
+
+/// Build a delegation using any type that implements Signer + Principal.
+async fn build_delegation<S>(
+    signer: S,
+    audience: &Did,
+    scope: &Scope,
+    expiration: Option<Timestamp>,
+    not_before: Option<Timestamp>,
+) -> Result<dialog_ucan::Delegation<Ed25519Signature>, AuthorizeError>
+where
+    S: Signer<Ed25519Signature> + Principal,
+{
+    use dialog_ucan::delegation::builder::DelegationBuilder;
+
+    let mut builder = DelegationBuilder::new()
+        .issuer(signer)
+        .audience(audience)
+        .subject(scope.subject.clone())
+        .command(scope.command.segments().clone())
+        .policy(scope.policy());
+
+    if let Some(exp) = expiration {
+        builder = builder.expiration(exp);
+    }
+    if let Some(nbf) = not_before {
+        builder = builder.not_before(nbf);
+    }
+
+    builder
+        .try_build()
+        .await
+        .map_err(|e| AuthorizeError::Configuration(format!("failed to build delegation: {e:?}")))
+}
+
+/// Append a delegation to the proof chain (closer to invoker).
+fn extend_chain(
+    proof: Option<DelegationChain>,
+    delegation: dialog_ucan::Delegation<Ed25519Signature>,
+) -> Result<DelegationChain, AuthorizeError> {
+    match proof {
+        Some(proof_chain) => proof_chain
+            .push(delegation)
+            .map_err(|e| AuthorizeError::Configuration(format!("chain extension failed: {e}"))),
+        None => Ok(DelegationChain::new(delegation)),
+    }
+}
+
+/// Build a signed invocation with any Signer + Principal.
+async fn build_invocation<S, Env>(
+    env: &Env,
+    signer: S,
+    scope: &Scope,
+    profile_did: &Did,
+    operator_did: &Did,
+) -> Result<UcanInvocation, AuthorizeError>
+where
+    S: Signer<Ed25519Signature> + Principal,
+    Env: Provider<List> + Provider<Get> + ConditionalSync,
+{
+    use dialog_ucan::InvocationBuilder;
+    use dialog_ucan::subject::Subject as UcanSubject;
+
+    let subject_did = match &scope.subject {
+        UcanSubject::Specific(did) => did.clone(),
+        UcanSubject::Any => any_did(),
+    };
+
+    let ability = if scope.command.segments().is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", scope.command.segments().join("/"))
+    };
+
+    // Find delegation chain
+    let delegation_chain = if &subject_did == operator_did {
+        None
+    } else {
+        let chain = find_chain(
+            env,
+            profile_did,
+            operator_did,
+            &subject_did,
+            &scope.command,
+            scope.parameters.as_map(),
+            &Timestamp::now(),
+        )
+        .await?;
+
+        match chain {
+            Some(c) => Some(c),
+            None => {
+                return Err(AuthorizeError::Denied(format!(
+                    "no delegation chain found for operator '{}' to act on subject '{}'",
+                    operator_did, subject_did
+                )));
+            }
+        }
+    };
+
+    let (proofs, delegations_map) = match &delegation_chain {
+        Some(chain) => {
+            let chain_audience = chain.audience();
+            if operator_did != chain_audience {
+                return Err(AuthorizeError::Configuration(format!(
+                    "authority '{}' does not match delegation chain audience '{}'",
+                    operator_did, chain_audience
+                )));
+            }
+            (chain.proof_cids().into(), chain.delegations().clone())
+        }
+        None => (vec![], Default::default()),
+    };
+
+    let command: Vec<String> = scope.command.segments().clone();
+    let args = scope.parameters.args();
+
+    let invocation = InvocationBuilder::new()
+        .issuer(signer)
+        .audience(&subject_did)
+        .subject(&subject_did)
+        .command(command)
+        .arguments(args)
+        .proofs(proofs)
+        .try_build()
+        .await
+        .map_err(|e| AuthorizeError::Denied(format!("{e:?}")))?;
+
+    let chain = InvocationChain::new(invocation, delegations_map);
+
+    Ok(UcanInvocation {
+        chain: Box::new(chain),
+        subject: subject_did,
+        ability,
+    })
+}

--- a/rust/dialog-capability/src/ucan/claim.rs
+++ b/rust/dialog-capability/src/ucan/claim.rs
@@ -1,0 +1,1346 @@
+//! UCAN delegation chain discovery and invocation building.
+//!
+//! Searches stored delegations to find a valid chain from an operator
+//! back to a subject for a given capability, then builds a signed
+//! UCAN invocation proving the operator's authority.
+
+use crate::access::AuthorizeError;
+use crate::authority;
+use crate::storage;
+use crate::{Ability, Capability, Constraint, Did, Policy, Provider};
+use dialog_common::ConditionalSync;
+use dialog_ucan::command::Command;
+use dialog_ucan::{Delegation, DelegationChain, InvocationBuilder, InvocationChain};
+use dialog_varsig::eddsa::Ed25519Signature;
+use ipld_core::ipld::Ipld;
+use std::collections::BTreeMap;
+
+use super::UcanInvocation;
+use super::delegation::{delegation_prefix, parse_key_suffix, powerline_prefix};
+use super::issuer::Issuer;
+use super::parameters::{parameters, parameters_to_args};
+
+const MAX_CHAIN_DEPTH: usize = 10;
+
+struct Candidate {
+    issuer: Did,
+    delegation: Delegation<Ed25519Signature>,
+}
+
+/// Build a storage capability scoped to the "ucan" store for the given subject.
+fn ucan_store(subject: &Did) -> Capability<storage::Store> {
+    crate::Subject::from(subject.clone())
+        .attenuate(storage::Storage)
+        .attenuate(storage::Store::new("ucan"))
+}
+
+/// Discover a delegation chain for the given capability and build a signed
+/// UCAN invocation proving the operator's authority.
+///
+/// Takes a pre-constructed [`Issuer`] that provides the operator identity
+/// and signing capability.
+///
+/// 1. If operator == subject, builds a self-authorized invocation (no proofs)
+/// 2. Otherwise, searches stored delegations for a valid chain
+/// 3. Signs the invocation via the provided [`Issuer`]
+/// 4. Returns `Err(Denied)` if no chain is found
+pub async fn claim<C, Env>(
+    env: &Env,
+    issuer: Issuer<'_, Env>,
+    capability: &Capability<C>,
+) -> Result<UcanInvocation, AuthorizeError>
+where
+    C: Constraint,
+    Capability<C>: Ability,
+    Env: Provider<authority::Sign>
+        + Provider<storage::List>
+        + Provider<storage::Get>
+        + ConditionalSync,
+{
+    let subject_did = capability.subject().clone();
+    let ability = capability.ability();
+    let params = parameters(capability);
+
+    let profile_did = authority::Profile::of(issuer.capability()).profile.clone();
+    let operator_did = authority::Operator::of(issuer.capability())
+        .operator
+        .clone();
+
+    // Find delegation chain (or None if self-authorized)
+    let delegation_chain = if subject_did == operator_did {
+        None
+    } else {
+        let command = Command::parse(&ability)
+            .map_err(|e| AuthorizeError::Configuration(format!("Invalid command: {}", e)))?;
+
+        let now = dialog_ucan::time::Timestamp::now();
+
+        let chain = find_chain(
+            env,
+            &profile_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &params,
+            &now,
+        )
+        .await?;
+
+        match chain {
+            Some(c) => Some(c),
+            None => {
+                return Err(AuthorizeError::Denied(format!(
+                    "No delegation chain found for operator '{}' to act on subject '{}'",
+                    operator_did, subject_did
+                )));
+            }
+        }
+    };
+
+    // Build signed UCAN invocation
+    let (proofs, delegation) = match &delegation_chain {
+        Some(chain) => {
+            let chain_audience = chain.audience();
+            if &operator_did != chain_audience {
+                return Err(AuthorizeError::Configuration(format!(
+                    "Authority '{}' does not match delegation chain audience '{}'",
+                    operator_did, chain_audience
+                )));
+            }
+            (chain.proof_cids().into(), Some(chain))
+        }
+        None => (vec![], None),
+    };
+
+    let command: Vec<String> = ability
+        .trim_start_matches('/')
+        .split('/')
+        .map(|s| s.to_string())
+        .collect();
+
+    let args = parameters_to_args(params);
+
+    let invocation = InvocationBuilder::new()
+        .issuer(issuer)
+        .audience(&subject_did)
+        .subject(&subject_did)
+        .command(command)
+        .arguments(args)
+        .proofs(proofs)
+        .try_build()
+        .await
+        .map_err(|e| AuthorizeError::Denied(format!("{:?}", e)))?;
+
+    let delegations = delegation
+        .map(|c| c.delegations().clone())
+        .unwrap_or_default();
+
+    let chain = InvocationChain::new(invocation, delegations);
+
+    Ok(UcanInvocation {
+        chain: Box::new(chain),
+        subject: subject_did,
+        ability,
+    })
+}
+
+/// Find a delegation chain from `operator` back to `subject` for the given command.
+///
+/// Uses iterative BFS with `MAX_CHAIN_DEPTH` limit. Prioritizes direct grants
+/// (where issuer == subject) before following intermediate delegations.
+pub async fn find_chain<Env>(
+    env: &Env,
+    subject: &Did,
+    operator_did: &Did,
+    subject_did: &Did,
+    command: &Command,
+    args: &BTreeMap<String, Ipld>,
+    now: &dialog_ucan::time::Timestamp,
+) -> Result<Option<DelegationChain>, AuthorizeError>
+where
+    Env: Provider<storage::List> + Provider<storage::Get> + ConditionalSync,
+{
+    let mut queue: Vec<(Did, Vec<Delegation<Ed25519Signature>>, usize)> =
+        vec![(operator_did.clone(), vec![], 0)];
+
+    while let Some((current_audience, chain_so_far, depth)) = queue.pop() {
+        if depth >= MAX_CHAIN_DEPTH {
+            continue;
+        }
+
+        // Subject-specific delegations
+        let candidates = fetch_and_validate(
+            env,
+            subject,
+            &delegation_prefix(&current_audience, subject_did),
+            command,
+            args,
+            now,
+        )
+        .await?;
+
+        let (direct, indirect): (Vec<_>, Vec<_>) = candidates
+            .into_iter()
+            .partition(|c| &c.issuer == subject_did);
+
+        for candidate in direct.into_iter().chain(indirect) {
+            let mut new_chain = chain_so_far.clone();
+            // Prepend: each discovered delegation is closer to the subject
+            // than what we already have, building subject-first order.
+            new_chain.insert(0, candidate.delegation);
+
+            if &candidate.issuer == subject_did {
+                return build_chain(new_chain).map(Some);
+            }
+
+            queue.push((candidate.issuer, new_chain, depth + 1));
+        }
+
+        // Powerline delegations
+        let powerline = fetch_and_validate(
+            env,
+            subject,
+            &powerline_prefix(&current_audience),
+            command,
+            args,
+            now,
+        )
+        .await?;
+
+        for candidate in powerline {
+            let mut new_chain = chain_so_far.clone();
+            new_chain.insert(0, candidate.delegation);
+
+            if &candidate.issuer == subject_did {
+                return build_chain(new_chain).map(Some);
+            }
+
+            queue.push((candidate.issuer, new_chain, depth + 1));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Fetch delegations by key prefix and validate each against command/policy/time.
+async fn fetch_and_validate<Env>(
+    env: &Env,
+    subject: &Did,
+    prefix: &str,
+    command: &Command,
+    args: &BTreeMap<String, Ipld>,
+    now: &dialog_ucan::time::Timestamp,
+) -> Result<Vec<Candidate>, AuthorizeError>
+where
+    Env: Provider<storage::List> + Provider<storage::Get> + ConditionalSync,
+{
+    // List all keys in the ucan store
+    let list_cap = ucan_store(subject).invoke(storage::List::new(None));
+
+    let list_result: storage::ListResult = <Env as Provider<storage::List>>::execute(env, list_cap)
+        .await
+        .map_err(|e| AuthorizeError::Configuration(format!("List failed: {:?}", e)))?;
+
+    // Filter keys by prefix
+    let matching_keys: Vec<String> = list_result
+        .keys
+        .into_iter()
+        .filter(|key| key.starts_with(prefix))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for key in matching_keys {
+        let (issuer_str, _) = match parse_key_suffix(&key) {
+            Some(pair) => pair,
+            None => continue,
+        };
+
+        let get_cap = ucan_store(subject).invoke(storage::Get::new(key.as_bytes()));
+
+        let bytes: Vec<u8> = match <Env as Provider<storage::Get>>::execute(env, get_cap).await {
+            Ok(Some(b)) => b,
+            Ok(None) => continue,
+            Err(_) => continue,
+        };
+
+        let delegation: Delegation<Ed25519Signature> = match serde_ipld_dagcbor::from_slice(&bytes)
+        {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        // Validate command attenuation
+        if !command.starts_with(delegation.command()) {
+            continue;
+        }
+
+        // Validate policy predicates
+        let args_ipld = Ipld::Map(args.clone());
+        let policies_pass = delegation
+            .policy()
+            .iter()
+            .all(|pred| pred.clone().run(&args_ipld).unwrap_or(false));
+        if !policies_pass {
+            continue;
+        }
+
+        // Validate time bounds
+        if let Some(exp) = delegation.expiration()
+            && *now > exp
+        {
+            continue;
+        }
+        if let Some(nbf) = delegation.not_before()
+            && *now < nbf
+        {
+            continue;
+        }
+
+        // Verify issuer matches key
+        let issuer = delegation.issuer().clone();
+        if issuer.to_string() != issuer_str {
+            continue;
+        }
+
+        candidates.push(Candidate { issuer, delegation });
+    }
+
+    Ok(candidates)
+}
+
+fn build_chain(
+    delegations: Vec<Delegation<Ed25519Signature>>,
+) -> Result<DelegationChain, AuthorizeError> {
+    DelegationChain::try_from(delegations).map_err(|e| AuthorizeError::Configuration(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority;
+    use dialog_ucan::DelegationChain;
+    use dialog_ucan::command::Command;
+    use dialog_ucan::delegation::builder::DelegationBuilder;
+    use dialog_ucan::delegation::policy::predicate::Predicate;
+    use dialog_ucan::delegation::policy::selector::filter::Filter;
+    use dialog_ucan::delegation::policy::selector::select::Select;
+    use dialog_ucan::subject::Subject;
+    use dialog_ucan::time::Timestamp;
+    use dialog_varsig::Principal;
+    use dialog_varsig::eddsa::Ed25519Signature;
+    use ipld_core::ipld::Ipld;
+    use std::collections::BTreeMap;
+
+    use dialog_ucan::time::{Duration, SystemTime};
+
+    mod test_provider {
+        use crate::authority;
+        use crate::storage::{self, StorageError};
+        use crate::{Capability, Policy, Provider, Subject};
+        use async_trait::async_trait;
+        use std::collections::HashMap;
+        use std::sync::RwLock;
+
+        pub struct TestStore {
+            data: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
+            signer: dialog_credentials::Ed25519Signer,
+        }
+
+        impl TestStore {
+            pub fn new(signer: dialog_credentials::Ed25519Signer) -> Self {
+                Self {
+                    data: RwLock::new(HashMap::new()),
+                    signer,
+                }
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<storage::Set> for TestStore {
+            async fn execute(&self, input: Capability<storage::Set>) -> Result<(), StorageError> {
+                let subject = input.subject().to_string();
+                let key = String::from_utf8_lossy(input.key()).to_string();
+                let value = input.value().to_vec();
+
+                let mut data = self.data.write().unwrap();
+                let entry = data.entry(subject).or_default();
+                entry.insert(key, value);
+                Ok(())
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<storage::Get> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<storage::Get>,
+            ) -> Result<Option<Vec<u8>>, StorageError> {
+                let subject = input.subject().to_string();
+                let key = String::from_utf8_lossy(input.key()).to_string();
+
+                let data = self.data.read().unwrap();
+                let value = data
+                    .get(&subject)
+                    .and_then(|session| session.get(&key))
+                    .cloned();
+
+                Ok(value)
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<storage::List> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<storage::List>,
+            ) -> Result<storage::ListResult, StorageError> {
+                let subject = input.subject().to_string();
+                let _ = input.store();
+
+                let data = self.data.read().unwrap();
+                let keys = data
+                    .get(&subject)
+                    .map(|session| session.keys().cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+
+                Ok(storage::ListResult {
+                    keys,
+                    is_truncated: false,
+                    next_continuation_token: None,
+                })
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<authority::Identify> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<authority::Identify>,
+            ) -> Result<authority::Authority, authority::AuthorityError> {
+                let did = dialog_varsig::Principal::did(&self.signer);
+                let subject_did = input.subject().clone();
+                Ok(Subject::from(subject_did)
+                    .attenuate(authority::Profile::local(did.clone()))
+                    .attenuate(authority::Operator::new(did)))
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<authority::Sign> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<authority::Sign>,
+            ) -> Result<Vec<u8>, authority::AuthorityError> {
+                use dialog_varsig::Signer;
+                let payload = authority::Sign::of(&input).payload.clone();
+                let sig = self
+                    .signer
+                    .sign(&payload)
+                    .await
+                    .map_err(|e| authority::AuthorityError::SigningFailed(e.to_string()))?;
+                Ok(sig.to_bytes().to_vec())
+            }
+        }
+    }
+
+    use test_provider::TestStore;
+
+    async fn signer_async(seed: u8) -> dialog_credentials::Ed25519Signer {
+        dialog_credentials::Ed25519Signer::import(&[seed; 32])
+            .await
+            .expect("Failed to import signer")
+    }
+
+    fn test_env(signer: dialog_credentials::Ed25519Signer) -> TestStore {
+        TestStore::new(signer)
+    }
+
+    fn now() -> Timestamp {
+        Timestamp::now()
+    }
+
+    async fn build_delegation(
+        issuer: &dialog_credentials::Ed25519Signer,
+        audience: &impl Principal,
+        subject: &impl Principal,
+        cmd_segments: Vec<String>,
+    ) -> dialog_ucan::Delegation<Ed25519Signature> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Specific(subject.did()))
+            .command(cmd_segments)
+            .try_build()
+            .await
+            .expect("Failed to build delegation")
+    }
+
+    async fn build_powerline_delegation(
+        issuer: &dialog_credentials::Ed25519Signer,
+        audience: &impl Principal,
+        cmd_segments: Vec<String>,
+    ) -> dialog_ucan::Delegation<Ed25519Signature> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Any)
+            .command(cmd_segments)
+            .try_build()
+            .await
+            .expect("Failed to build powerline delegation")
+    }
+
+    async fn build_delegation_with_expiration(
+        issuer: &dialog_credentials::Ed25519Signer,
+        audience: &impl Principal,
+        subject: &impl Principal,
+        cmd_segments: Vec<String>,
+        expiration: Timestamp,
+    ) -> dialog_ucan::Delegation<Ed25519Signature> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Specific(subject.did()))
+            .command(cmd_segments)
+            .expiration(expiration)
+            .try_build()
+            .await
+            .expect("Failed to build delegation with expiration")
+    }
+
+    async fn build_delegation_with_not_before(
+        issuer: &dialog_credentials::Ed25519Signer,
+        audience: &impl Principal,
+        subject: &impl Principal,
+        cmd_segments: Vec<String>,
+        not_before: Timestamp,
+    ) -> dialog_ucan::Delegation<Ed25519Signature> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Specific(subject.did()))
+            .command(cmd_segments)
+            .not_before(not_before)
+            .try_build()
+            .await
+            .expect("Failed to build delegation with not_before")
+    }
+
+    async fn build_delegation_with_policy(
+        issuer: &dialog_credentials::Ed25519Signer,
+        audience: &impl Principal,
+        subject: &impl Principal,
+        cmd_segments: Vec<String>,
+        policy: Vec<Predicate>,
+    ) -> dialog_ucan::Delegation<Ed25519Signature> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Specific(subject.did()))
+            .command(cmd_segments)
+            .policy(policy)
+            .try_build()
+            .await
+            .expect("Failed to build delegation with policy")
+    }
+
+    fn cmd(s: &str) -> Vec<String> {
+        if s == "/" {
+            vec![]
+        } else {
+            s.trim_start_matches('/')
+                .split('/')
+                .map(|seg| seg.to_string())
+                .collect()
+        }
+    }
+
+    async fn import_single(
+        env: &TestStore,
+        subject: &Did,
+        delegation: dialog_ucan::Delegation<Ed25519Signature>,
+    ) {
+        let chain = DelegationChain::new(delegation);
+        super::super::delegation::import_delegation_chain(env, subject, &chain)
+            .await
+            .expect("Failed to import delegation");
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_direct_grant() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let delegation =
+            build_delegation(&subject_signer, &operator_signer, &subject_signer, cmd("/")).await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        let command = Command::parse("/storage/get").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+
+        assert!(chain.is_some(), "Should find direct grant chain");
+        assert_eq!(chain.unwrap().delegations().len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_two_hop() {
+        let subject_signer = signer_async(1).await;
+        let account_signer = signer_async(2).await;
+        let operator_signer = signer_async(3).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let d1 =
+            build_delegation(&subject_signer, &account_signer, &subject_signer, cmd("/")).await;
+        let d2 =
+            build_delegation(&account_signer, &operator_signer, &subject_signer, cmd("/")).await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, d1).await;
+        import_single(&env, &operator_did, d2).await;
+
+        let command = Command::parse("/storage/get").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+
+        assert!(chain.is_some(), "Should find 2-hop chain");
+        assert_eq!(chain.unwrap().delegations().len(), 2);
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_no_grant() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let env = test_env(operator_signer.clone());
+
+        let command = Command::parse("/storage/get").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+
+        assert!(chain.is_none(), "Should not find chain when none exists");
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_command_attenuation() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let delegation = build_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/storage/get"),
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        // Should find for /storage/get
+        let command_get = Command::parse("/storage/get").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command_get,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(chain.is_some(), "Should find chain for /storage/get");
+
+        // Should not find for /storage/set
+        let command_set = Command::parse("/storage/set").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command_set,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(chain.is_none(), "Should not find chain for /storage/set");
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_expired_delegation() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let past = Timestamp::try_from(SystemTime::now() - Duration::from_secs(3600)).unwrap();
+        let delegation = build_delegation_with_expiration(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/"),
+            past,
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        let command = Command::parse("/storage/get").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+
+        assert!(
+            chain.is_none(),
+            "Should not find chain for expired delegation"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_not_before_future() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let future = Timestamp::try_from(SystemTime::now() + Duration::from_secs(3600)).unwrap();
+        let delegation = build_delegation_with_not_before(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/"),
+            future,
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        let command = Command::parse("/storage/get").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+
+        assert!(
+            chain.is_none(),
+            "Should not find chain for not-yet-valid delegation"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_powerline_delegation() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let delegation =
+            build_powerline_delegation(&subject_signer, &operator_signer, cmd("/")).await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        let command = Command::parse("/storage/get").unwrap();
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+
+        assert!(
+            chain.is_some(),
+            "Should find chain via powerline delegation"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_with_policy() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let policy = vec![Predicate::Equal(
+            Select::new(vec![Filter::Field("bucket".to_string())]),
+            Ipld::String("my-bucket".to_string()),
+        )];
+
+        let delegation = build_delegation_with_policy(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/storage"),
+            policy,
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        // Matching policy
+        let command = Command::parse("/storage/get").unwrap();
+        let mut args = BTreeMap::new();
+        args.insert("bucket".to_string(), Ipld::String("my-bucket".to_string()));
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &args,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(chain.is_some(), "Should find chain with matching policy");
+
+        // Non-matching policy
+        let mut bad_args = BTreeMap::new();
+        bad_args.insert(
+            "bucket".to_string(),
+            Ipld::String("wrong-bucket".to_string()),
+        );
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &command,
+            &bad_args,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_none(),
+            "Should not find chain with non-matching policy"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn claim_self_authorized() {
+        let signer = signer_async(1).await;
+        let subject_did = signer.did();
+
+        let env = test_env(signer);
+        let authority = crate::Subject::from(subject_did.clone())
+            .invoke(authority::Identify)
+            .perform(&env)
+            .await
+            .unwrap();
+        let issuer = Issuer::new(&env, authority);
+
+        let cap = crate::Subject::from(subject_did).invoke(authority::Identify);
+
+        let result = claim(&env, issuer, &cap).await;
+        assert!(
+            result.is_ok(),
+            "Self-authorized claim should succeed: {:?}",
+            result.err()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn claim_with_delegation() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let delegation =
+            build_delegation(&subject_signer, &operator_signer, &subject_signer, cmd("/")).await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        let authority = crate::Subject::from(subject_did.clone())
+            .invoke(authority::Identify)
+            .perform(&env)
+            .await
+            .unwrap();
+        let issuer = Issuer::new(&env, authority);
+
+        let cap = crate::Subject::from(subject_did).invoke(authority::Identify);
+
+        let result = claim(&env, issuer, &cap).await;
+        assert!(
+            result.is_ok(),
+            "Delegated claim should succeed: {:?}",
+            result.err()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn claim_denied_without_delegation() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+
+        let env = test_env(operator_signer.clone());
+        let authority = crate::Subject::from(subject_did.clone())
+            .invoke(authority::Identify)
+            .perform(&env)
+            .await
+            .unwrap();
+        let issuer = Issuer::new(&env, authority);
+
+        let cap = crate::Subject::from(subject_did).invoke(authority::Identify);
+
+        let result = claim(&env, issuer, &cap).await;
+        assert!(result.is_err(), "Should be denied without delegation");
+        assert!(
+            matches!(result, Err(AuthorizeError::Denied(_))),
+            "Error should be Denied variant"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_with_parameters_to_policy() {
+        use crate::storage::{self, Storage, Store};
+        use crate::ucan::parameters::{parameters, parameters_to_policy};
+
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        // Build a capability with policy constraints
+        let cap = crate::Subject::from(subject_did.clone())
+            .attenuate(Storage)
+            .attenuate(Store::new("index"));
+
+        // Convert capability parameters to delegation policy
+        let policy = parameters_to_policy(parameters(&cap));
+        assert!(!policy.is_empty(), "should produce policy from capability");
+
+        // Create delegation with the generated policy
+        let delegation = build_delegation_with_policy(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/storage"),
+            policy,
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        // Claim with matching store should succeed
+        let matching_cap = crate::Subject::from(subject_did.clone())
+            .attenuate(Storage)
+            .attenuate(Store::new("index"))
+            .invoke(storage::Get::new(b"some-key"));
+
+        let matching_args = crate::ucan::parameters::parameters(&matching_cap);
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &matching_args,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_some(),
+            "should find chain when store matches delegated policy"
+        );
+
+        // Claim with different store should fail
+        let wrong_cap = crate::Subject::from(subject_did.clone())
+            .attenuate(Storage)
+            .attenuate(Store::new("secret"))
+            .invoke(storage::Get::new(b"some-key"));
+
+        let wrong_args = crate::ucan::parameters::parameters(&wrong_cap);
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &wrong_args,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_none(),
+            "should not find chain when store differs from delegated policy"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_rejects_command_escalation() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        // Delegate only /storage
+        let delegation = build_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/storage"),
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        // Requesting / (root, broader than /storage) should fail
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/").unwrap(),
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_none(),
+            "should not allow escalation from /storage to /"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_allows_narrower_command_under_delegation() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        // Delegate /storage (broad)
+        let delegation = build_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/storage"),
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        // Requesting /storage/get (narrower) should succeed
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_some(),
+            "/storage delegation should cover /storage/get"
+        );
+
+        // Requesting /storage/set should also succeed
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/set").unwrap(),
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_some(),
+            "/storage delegation should cover /storage/set"
+        );
+
+        // But /memory/resolve should fail (different branch)
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/memory/resolve").unwrap(),
+            &BTreeMap::new(),
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_none(),
+            "/storage delegation should not cover /memory"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_policy_multi_field_partial_match_fails() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        // Delegate with store=data AND key=foo
+        let policy = vec![
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("store".to_string())]),
+                Ipld::String("data".to_string()),
+            ),
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("key".to_string())]),
+                Ipld::Bytes(b"foo".to_vec()),
+            ),
+        ];
+
+        let delegation = build_delegation_with_policy(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/storage"),
+            policy,
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        // Matching both fields should succeed
+        let mut matching = BTreeMap::new();
+        matching.insert("store".to_string(), Ipld::String("data".to_string()));
+        matching.insert("key".to_string(), Ipld::Bytes(b"foo".to_vec()));
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &matching,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(chain.is_some(), "both fields matching should succeed");
+
+        // Matching store but wrong key should fail
+        let mut wrong_key = BTreeMap::new();
+        wrong_key.insert("store".to_string(), Ipld::String("data".to_string()));
+        wrong_key.insert("key".to_string(), Ipld::Bytes(b"bar".to_vec()));
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &wrong_key,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_none(),
+            "mismatched key should reject even if store matches"
+        );
+
+        // Matching store but missing key should fail (policy requires key)
+        let mut store_only = BTreeMap::new();
+        store_only.insert("store".to_string(), Ipld::String("data".to_string()));
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &store_only,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(chain.is_none(), "missing required key field should reject");
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_powerline_covers_any_command() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        // Powerline delegation (Subject::Any, command /)
+        let delegation = DelegationBuilder::new()
+            .issuer(subject_signer.clone())
+            .audience(&operator_signer)
+            .subject(dialog_ucan::subject::Subject::Any)
+            .command(vec![])
+            .try_build()
+            .await
+            .expect("build powerline");
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, delegation).await;
+
+        // Should match any command
+        for path in ["/", "/storage", "/storage/get", "/memory/resolve"] {
+            let chain = find_chain(
+                &env,
+                &operator_did,
+                &operator_did,
+                &subject_did,
+                &Command::parse(path).unwrap(),
+                &BTreeMap::new(),
+                &now(),
+            )
+            .await
+            .expect("find_chain should not error");
+            assert!(chain.is_some(), "powerline should cover command '{}'", path);
+        }
+    }
+
+    #[dialog_common::test]
+    async fn find_chain_two_hop_with_policy_narrowing() {
+        let subject_signer = signer_async(1).await;
+        let intermediate_signer = signer_async(2).await;
+        let operator_signer = signer_async(3).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        // subject -> intermediate: grant /storage with store=data
+        let d1 = build_delegation_with_policy(
+            &subject_signer,
+            &intermediate_signer,
+            &subject_signer,
+            cmd("/storage"),
+            vec![Predicate::Equal(
+                Select::new(vec![Filter::Field("store".to_string())]),
+                Ipld::String("data".to_string()),
+            )],
+        )
+        .await;
+
+        // intermediate -> operator: grant /storage/get (narrower command, no extra policy)
+        let d2 = build_delegation(
+            &intermediate_signer,
+            &operator_signer,
+            &subject_signer,
+            cmd("/storage/get"),
+        )
+        .await;
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &operator_did, d1).await;
+        import_single(&env, &operator_did, d2).await;
+
+        // Should find chain for /storage/get with store=data
+        let mut args = BTreeMap::new();
+        args.insert("store".to_string(), Ipld::String("data".to_string()));
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &args,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_some(),
+            "should find two-hop chain matching narrowed command and policy"
+        );
+
+        // Should NOT find chain for /storage/get with store=secret
+        // (first hop's policy requires store=data)
+        let mut wrong_args = BTreeMap::new();
+        wrong_args.insert("store".to_string(), Ipld::String("secret".to_string()));
+        let chain = find_chain(
+            &env,
+            &operator_did,
+            &operator_did,
+            &subject_did,
+            &Command::parse("/storage/get").unwrap(),
+            &wrong_args,
+            &now(),
+        )
+        .await
+        .expect("find_chain should not error");
+        assert!(
+            chain.is_none(),
+            "two-hop chain should reject when first hop's policy doesn't match"
+        );
+    }
+}

--- a/rust/dialog-capability/src/ucan/delegation.rs
+++ b/rust/dialog-capability/src/ucan/delegation.rs
@@ -1,0 +1,418 @@
+//! UCAN delegation storage and authorization extensions.
+//!
+//! Stores individual UCAN delegations in the credential store using storage
+//! effects, and provides blanket extension traits for UCAN authorization.
+//!
+//! # Storage Layout
+//!
+//! Delegations are stored in the `"ucan"` store with keys:
+//!
+//! - Subject-specific: `{audience}/{subject}/{issuer}.{cid}`
+//! - Powerline (`sub: *`): `{audience}/_/{issuer}.{cid}`
+//!
+//! This layout enables efficient lookup: list by `{audience}/{subject}/`
+//! to find all delegations granted to an operator for a given subject.
+//! Entries where `issuer == subject` are direct grants (no further chain needed).
+
+use crate::storage::{self, Storage, StorageError, Store};
+use crate::{Capability, Did, Provider};
+use dialog_common::ConditionalSync;
+use dialog_ucan::DelegationChain;
+use dialog_ucan::subject::Subject;
+
+const UCAN_STORE: &str = "ucan";
+
+/// Build the storage key prefix for subject-specific delegations.
+///
+/// Returns `"{audience}/{subject}/"` which can be used to list all
+/// delegations granted to `audience` for a specific `subject`.
+pub fn delegation_prefix(audience: &Did, subject: &Did) -> String {
+    format!("{}/{}/", audience, subject)
+}
+
+/// Build the storage key prefix for powerline (wildcard subject) delegations.
+///
+/// Returns `"{audience}/_/"` which can be used to list all
+/// delegations granted to `audience` with `sub: *`.
+pub fn powerline_prefix(audience: &Did) -> String {
+    format!("{}/_/", audience)
+}
+
+fn delegation_key(
+    audience: &Did,
+    subject: &Did,
+    issuer: &Did,
+    cid: &ipld_core::cid::Cid,
+) -> String {
+    format!("{}/{}/{}.{}", audience, subject, issuer, cid)
+}
+
+fn powerline_key(audience: &Did, issuer: &Did, cid: &ipld_core::cid::Cid) -> String {
+    format!("{}/_/{}.{}", audience, issuer, cid)
+}
+
+/// Parse an issuer DID and CID string from a key's filename portion.
+///
+/// Given `{aud}/{sub}/{issuer}.{cid}`, extracts `(issuer, cid)` from the last segment.
+pub fn parse_key_suffix(key: &str) -> Option<(String, String)> {
+    let filename = key.rsplit('/').next()?;
+    // DIDs contain colons (did:key:z...), so split on the last dot only
+    let dot_pos = filename.rfind('.')?;
+    let issuer = &filename[..dot_pos];
+    let cid_str = &filename[dot_pos + 1..];
+    if issuer.is_empty() || cid_str.is_empty() {
+        return None;
+    }
+    Some((issuer.to_string(), cid_str.to_string()))
+}
+
+/// Build a storage capability scoped to the "ucan" store for the given subject.
+fn ucan_store(subject: &Did) -> Capability<Store> {
+    crate::Subject::from(subject.clone())
+        .attenuate(Storage)
+        .attenuate(Store::new(UCAN_STORE))
+}
+
+/// Store a delegation chain's individual delegations into the storage backend.
+///
+/// Each delegation is stored separately at its computed key path so that
+/// chain discovery can find them by listing prefixes.
+pub async fn import_delegation_chain<Env>(
+    env: &Env,
+    subject: &Did,
+    chain: &DelegationChain,
+) -> Result<(), StorageError>
+where
+    Env: Provider<storage::Set> + ConditionalSync,
+{
+    for (cid, delegation) in chain.delegations() {
+        let audience = delegation.audience();
+        let key = match delegation.subject() {
+            Subject::Specific(did) => delegation_key(audience, did, delegation.issuer(), cid),
+            Subject::Any => powerline_key(audience, delegation.issuer(), cid),
+        };
+
+        let bytes = serde_ipld_dagcbor::to_vec(delegation.as_ref())
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        ucan_store(subject)
+            .invoke(storage::Set::new(key.as_bytes(), bytes))
+            .perform(env)
+            .await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_ucan::DelegationChain;
+    use dialog_ucan::delegation::builder::DelegationBuilder;
+    use dialog_ucan::subject::Subject;
+    use dialog_varsig::Principal;
+    use dialog_varsig::eddsa::Ed25519Signature;
+
+    // Minimal test provider that stores credentials in-memory using HashMaps
+    mod test_provider {
+        use crate::authority;
+        use crate::storage::{self, StorageError};
+        use crate::{Capability, Policy, Provider, Subject};
+        use async_trait::async_trait;
+        use dialog_varsig::Principal;
+        use std::collections::HashMap;
+        use std::sync::RwLock;
+
+        pub struct TestStore {
+            data: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
+            signer: dialog_credentials::Ed25519Signer,
+        }
+
+        impl TestStore {
+            pub fn new(signer: dialog_credentials::Ed25519Signer) -> Self {
+                Self {
+                    data: RwLock::new(HashMap::new()),
+                    signer,
+                }
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<storage::Set> for TestStore {
+            async fn execute(&self, input: Capability<storage::Set>) -> Result<(), StorageError> {
+                let subject = input.subject().to_string();
+                let key = String::from_utf8_lossy(input.key()).to_string();
+                let value = input.value().to_vec();
+
+                let mut data = self.data.write().unwrap();
+                let entry = data.entry(subject).or_default();
+                entry.insert(key, value);
+                Ok(())
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<storage::Get> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<storage::Get>,
+            ) -> Result<Option<Vec<u8>>, StorageError> {
+                let subject = input.subject().to_string();
+                let key = String::from_utf8_lossy(input.key()).to_string();
+
+                let data = self.data.read().unwrap();
+                let value = data
+                    .get(&subject)
+                    .and_then(|session| session.get(&key))
+                    .cloned();
+
+                Ok(value)
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<storage::List> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<storage::List>,
+            ) -> Result<storage::ListResult, StorageError> {
+                let subject = input.subject().to_string();
+                let store_name = input.store();
+
+                // The continuation_token is used as a prefix filter in tests
+                // We use the store name to scope, but the prefix is passed via
+                // continuation_token in the real API. For tests, we extract the
+                // prefix from the store's keys.
+                let _ = store_name;
+
+                let data = self.data.read().unwrap();
+                let keys = data
+                    .get(&subject)
+                    .map(|session| session.keys().cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+
+                Ok(storage::ListResult {
+                    keys,
+                    is_truncated: false,
+                    next_continuation_token: None,
+                })
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<authority::Identify> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<authority::Identify>,
+            ) -> Result<authority::Authority, authority::AuthorityError> {
+                let did = Principal::did(&self.signer);
+                let subject_did = input.subject().clone();
+                Ok(Subject::from(subject_did)
+                    .attenuate(authority::Profile::local(did.clone()))
+                    .attenuate(authority::Operator::new(did)))
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        impl Provider<authority::Sign> for TestStore {
+            async fn execute(
+                &self,
+                input: Capability<authority::Sign>,
+            ) -> Result<Vec<u8>, authority::AuthorityError> {
+                use dialog_varsig::Signer;
+                let payload = authority::Sign::of(&input).payload.clone();
+                let sig = self
+                    .signer
+                    .sign(&payload)
+                    .await
+                    .map_err(|e| authority::AuthorityError::SigningFailed(e.to_string()))?;
+                Ok(sig.to_bytes().to_vec())
+            }
+        }
+    }
+
+    use test_provider::TestStore;
+
+    async fn signer_async(seed: u8) -> dialog_credentials::Ed25519Signer {
+        dialog_credentials::Ed25519Signer::import(&[seed; 32])
+            .await
+            .expect("Failed to import signer")
+    }
+
+    fn test_env(signer: dialog_credentials::Ed25519Signer) -> TestStore {
+        TestStore::new(signer)
+    }
+
+    async fn build_delegation(
+        issuer: &dialog_credentials::Ed25519Signer,
+        audience: &impl Principal,
+        subject: &impl Principal,
+        cmd_segments: Vec<String>,
+    ) -> dialog_ucan::Delegation<Ed25519Signature> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Specific(subject.did()))
+            .command(cmd_segments)
+            .try_build()
+            .await
+            .expect("Failed to build delegation")
+    }
+
+    fn cmd(s: &str) -> Vec<String> {
+        if s == "/" {
+            vec![]
+        } else {
+            s.trim_start_matches('/')
+                .split('/')
+                .map(|seg| seg.to_string())
+                .collect()
+        }
+    }
+
+    async fn import_single(
+        env: &TestStore,
+        subject: &Did,
+        delegation: dialog_ucan::Delegation<Ed25519Signature>,
+    ) {
+        let chain = DelegationChain::new(delegation);
+        import_delegation_chain(env, subject, &chain)
+            .await
+            .expect("Failed to import delegation");
+    }
+
+    #[dialog_common::test]
+    fn parse_key_suffix_valid() {
+        let key = "did:key:zOperator/did:key:zSubject/did:key:zIssuer.bafy123";
+        let (issuer, cid) = parse_key_suffix(key).expect("Should parse valid key");
+        assert_eq!(issuer, "did:key:zIssuer");
+        assert_eq!(cid, "bafy123");
+    }
+
+    #[dialog_common::test]
+    fn parse_key_suffix_did_with_colons() {
+        let key = "did:key:z6MkOperator/did:key:z6MkSubject/did:key:z6MkfFJBxSBFgoAqTQLS7bTfP8MgyDypva5i6CL5PJN8RJZr.bafyreihxyz";
+        let (issuer, cid) = parse_key_suffix(key).expect("Should parse DID with colons");
+        assert_eq!(
+            issuer,
+            "did:key:z6MkfFJBxSBFgoAqTQLS7bTfP8MgyDypva5i6CL5PJN8RJZr"
+        );
+        assert_eq!(cid, "bafyreihxyz");
+    }
+
+    #[dialog_common::test]
+    fn parse_key_suffix_invalid_no_dot() {
+        assert!(parse_key_suffix("aud/sub/issuernodot").is_none());
+    }
+
+    #[dialog_common::test]
+    fn parse_key_suffix_empty_issuer() {
+        assert!(parse_key_suffix("aud/sub/.cid").is_none());
+    }
+
+    #[dialog_common::test]
+    fn parse_key_suffix_empty_cid() {
+        assert!(parse_key_suffix("aud/sub/issuer.").is_none());
+    }
+
+    #[dialog_common::test]
+    fn parse_key_suffix_empty_string() {
+        assert!(parse_key_suffix("").is_none());
+    }
+
+    #[dialog_common::test]
+    async fn import_single_delegation_stores_at_correct_key() {
+        let subject_signer = signer_async(1).await;
+        let operator_signer = signer_async(2).await;
+        let subject_did = subject_signer.did();
+        let operator_did = operator_signer.did();
+
+        let delegation =
+            build_delegation(&subject_signer, &operator_signer, &subject_signer, cmd("/")).await;
+        let cid = delegation.to_cid();
+
+        let env = test_env(operator_signer.clone());
+        import_single(&env, &subject_did, delegation).await;
+
+        let expected_key = format!("{}/{}/{}.{}", operator_did, subject_did, subject_did, cid);
+
+        // Retrieve via storage Get effect
+        let get_cap = ucan_store(&subject_did).invoke(storage::Get::new(expected_key.as_bytes()));
+        let result = <TestStore as Provider<storage::Get>>::execute(&env, get_cap).await;
+        assert!(
+            result.is_ok(),
+            "Expected key '{}' not found in store",
+            expected_key
+        );
+        assert!(
+            result.unwrap().is_some(),
+            "Expected key '{}' to have a value",
+            expected_key
+        );
+    }
+
+    #[dialog_common::test]
+    async fn import_multi_hop_chain_stores_each_delegation() {
+        let subject_signer = signer_async(1).await;
+        let account_signer = signer_async(2).await;
+        let operator_signer = signer_async(3).await;
+        let subject_did = subject_signer.did();
+
+        // subject -> account
+        let d1 =
+            build_delegation(&subject_signer, &account_signer, &subject_signer, cmd("/")).await;
+        let d1_cid = d1.to_cid();
+
+        // account -> operator
+        let d2 =
+            build_delegation(&account_signer, &operator_signer, &subject_signer, cmd("/")).await;
+        let d2_cid = d2.to_cid();
+
+        // Build chain: [d1, d2] (subject-first, root-to-leaf)
+        let chain = DelegationChain::try_from(vec![d1.clone(), d2.clone()]).expect("valid chain");
+
+        let env = test_env(operator_signer.clone());
+        import_delegation_chain(&env, &subject_did, &chain)
+            .await
+            .expect("import should succeed");
+
+        // Verify both delegations are stored
+        let key1 = delegation_key(
+            &account_signer.did(),
+            &subject_did,
+            &subject_signer.did(),
+            &d1_cid,
+        );
+        let key2 = delegation_key(
+            &operator_signer.did(),
+            &subject_did,
+            &account_signer.did(),
+            &d2_cid,
+        );
+
+        let r1 = <TestStore as Provider<storage::Get>>::execute(
+            &env,
+            ucan_store(&subject_did).invoke(storage::Get::new(key1.as_bytes())),
+        )
+        .await;
+        let r2 = <TestStore as Provider<storage::Get>>::execute(
+            &env,
+            ucan_store(&subject_did).invoke(storage::Get::new(key2.as_bytes())),
+        )
+        .await;
+        assert!(
+            r1.is_ok() && r1.unwrap().is_some(),
+            "d1 should be stored at {}",
+            key1
+        );
+        assert!(
+            r2.is_ok() && r2.unwrap().is_some(),
+            "d2 should be stored at {}",
+            key2
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add fluent builder API for UCAN delegations and invocations (typestate pattern)
- Add delegation chain import/verification against subject DID and capability scope
- Add claim authorization: find delegation paths through stored proofs
- Add Protocol implementation for Ucan authorization format
- Add Ucan struct as top-level entry point with delegate()/invoke()
- Restore UCAN parameter tests in capability.rs