### PR TITLE
12 📬 feat: add mount/storage capabilities to storage providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,21 +1141,21 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base58",
+ "base64",
  "blake3",
  "brotli",
- "bytes",
- "clap",
  "dialog-capability",
  "dialog-common",
+ "dialog-credentials",
  "dialog-effects",
- "dialog-varsig",
+ "dirs",
  "futures-util",
  "getrandom 0.2.16",
- "http-body-util",
  "hyper",
  "hyper-util",
  "ipld-core",
  "js-sys",
+ "md5",
  "parking_lot",
  "pidlock",
  "rand 0.8.5",
@@ -1165,13 +1165,9 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_json",
  "sieve-cache",
- "signature",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-test",
- "tower",
- "tower-http",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -2185,6 +2181,12 @@ dependencies = [
  "cfg-if",
  "digest 0.11.2",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"

--- a/rust/dialog-storage/Cargo.toml
+++ b/rust/dialog-storage/Cargo.toml
@@ -11,14 +11,6 @@ helpers = [
   "anyhow",
   "rand",
   "dialog-common/helpers",
-  "dep:s3s",
-  "dep:hyper",
-  "dep:hyper-util",
-  "dep:http-body-util",
-  "dep:bytes",
-  "dep:tokio-test",
-  "dep:tower",
-  "dep:tower-http",
 ]
 # Enable integration tests (tests with service provisioning)
 integration-tests = ["dialog-common/integration-tests"]
@@ -29,37 +21,34 @@ web-integration-tests = ["dialog-common/web-integration-tests"]
 dialog-capability = { workspace = true }
 dialog-common = { workspace = true }
 dialog-effects = { workspace = true }
-dialog-varsig = { workspace = true }
-signature = { workspace = true }
 
 anyhow = { workspace = true, optional = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 base58 = { workspace = true }
+base64 = { workspace = true }
 blake3 = { workspace = true }
 brotli = { workspace = true }
 futures-util = { workspace = true }
 hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, features = ["server", "tokio", "service"], optional = true }
+md5 = { workspace = true }
 parking_lot = { workspace = true }
 s3s = { workspace = true, optional = true }
 sieve-cache = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_ipld_dagcbor = { workspace = true }
+serde_json = { workspace = true }
 rand = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dirs = { workspace = true }
 url = { workspace = true }
 pidlock = { workspace = true }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync", "fs", "macros", "rt", "net"] }
-http-body-util = { workspace = true, optional = true }
-bytes = { workspace = true, optional = true }
-tokio-test = { workspace = true, optional = true }
-tower = { workspace = true, optional = true }
-tower-http = { workspace = true, features = ["cors"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = { workspace = true }
@@ -71,19 +60,13 @@ web-time = { workspace = true }
 anyhow = { workspace = true }
 blake3 = { workspace = true }
 dialog-common = { workspace = true, features = ["helpers"] }
+dialog-credentials = { workspace = true }
 ipld-core = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 rand = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bytes = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
-s3s = { workspace = true }
-hyper = { workspace = true }
-hyper-util = { workspace = true, features = ["server", "tokio", "service"] }
-http-body-util = { workspace = true }
-serde_ipld_dagcbor = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [
   "sync",
@@ -92,11 +75,8 @@ tokio = { workspace = true, features = [
   "fs",
   "rt-multi-thread",
 ] }
-tower = { workspace = true }
-tower-http = { workspace = true, features = ["cors"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
-# getrandom = { workspace = true, features = ["wasm_js"] }
 getrandom = { workspace = true, features = ["js"] }
 wasm-bindgen-test = { workspace = true }
 

--- a/rust/dialog-storage/src/storage/provider.rs
+++ b/rust/dialog-storage/src/storage/provider.rs
@@ -26,13 +26,16 @@
 pub mod fs;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use fs::*;
+pub use fs::{FileStore, FileSystem, FileSystemError};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod indexeddb;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub use indexeddb::*;
+pub use indexeddb::IndexedDb;
 
 pub mod volatile;
-pub use volatile::*;
+pub use volatile::Volatile;
+
+mod store;
+pub use store::{Address, Store};

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -22,14 +22,13 @@
 //! # Example
 //!
 //! ```no_run
-//! use dialog_storage::provider::FileSystem;
+//! use dialog_storage::provider::{FileSystem, FileStore, fs};
 //! use dialog_capability::{did, Did, Subject};
 //! use dialog_effects::archive::{Archive, Catalog, Get};
 //! use dialog_common::Blake3Hash;
-//! use std::path::PathBuf;
 //!
 //! # async fn example() -> anyhow::Result<()> {
-//! let provider = FileSystem::mount("file:///tmp/storage")?;
+//! let provider = FileSystem::mount(&fs::Address::temp())?;
 //! let digest = Blake3Hash::hash(b"hello");
 //!
 //! let effect = Subject::from(did!("key:z6Mk..."))
@@ -45,16 +44,126 @@
 mod archive;
 mod error;
 mod memory;
+mod resource;
+mod storage;
 
 pub use error::FileSystemError;
 
 use dialog_capability::Did;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
 const ARCHIVE: &str = "archive";
 const MEMORY: &str = "memory";
+const STORAGE: &str = "storage";
 
+/// Address for filesystem-based storage.
+///
+/// Wraps a URL with scheme-based resolution:
+/// - `profile://` → platform data directory
+/// - `temp://` → system temp directory
+/// - `storage://` → current working directory
+///
+/// Use `resolve()` to narrow the address to a sub-path.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct Address(url::Url);
+
+impl Address {
+    /// Profile storage root.
+    pub fn profile() -> Self {
+        Self(url::Url::parse("profile:///").expect("valid URL"))
+    }
+
+    /// Temporary storage root.
+    pub fn temp() -> Self {
+        Self(url::Url::parse("temp:///").expect("valid URL"))
+    }
+
+    /// Current/working directory storage root.
+    pub fn current() -> Self {
+        Self(url::Url::parse("storage:///").expect("valid URL"))
+    }
+
+    /// The URL scheme (e.g. `"profile"`, `"temp"`, `"storage"`).
+    pub fn scheme(&self) -> &str {
+        self.0.scheme()
+    }
+
+    /// The path portion of the URL.
+    pub fn path(&self) -> &str {
+        self.0.path()
+    }
+
+    /// Resolve a sub-path under this address.
+    ///
+    /// Uses URL resolution to ensure the result is always nested
+    /// under this address.
+    pub fn resolve(&self, segment: &str) -> Result<Self, FileSystemError> {
+        let mut base = self.0.clone();
+        if !base.path().ends_with('/') {
+            base.set_path(&format!("{}/", base.path()));
+        }
+
+        let resolved = base
+            .join(&format!("./{segment}"))
+            .map_err(|e| FileSystemError::Io(format!("URL join failed: {e}")))?;
+
+        if !resolved.path().starts_with(base.path()) {
+            return Err(FileSystemError::Io(format!(
+                "path '{segment}' escapes base '{}'",
+                base.path()
+            )));
+        }
+
+        Ok(Self(resolved))
+    }
+}
+
+/// Stateless filesystem provider.
+///
+/// Provides `Mount`, `Load`, and `Save` capabilities by resolving
+/// paths from the capability chain against the native filesystem.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FileSystem;
+
+impl FileSystem {
+    /// Mount a FileStore from an address.
+    pub fn mount(address: &Address) -> Result<FileStore, FileSystemError> {
+        let path = Self::resolve(address)?;
+        FileStore::mount(path)
+    }
+
+    /// Resolve an address to a concrete filesystem path.
+    fn resolve(address: &Address) -> Result<PathBuf, FileSystemError> {
+        let base_path = match address.scheme() {
+            "profile" => {
+                let data_dir = dirs::data_dir().ok_or_else(|| {
+                    FileSystemError::Io("could not determine platform data directory".into())
+                })?;
+                data_dir.join("dialog")
+            }
+            "temp" => std::env::temp_dir(),
+            "storage" => std::env::current_dir().map_err(|e| FileSystemError::Io(e.to_string()))?,
+            scheme => {
+                return Err(FileSystemError::Io(format!(
+                    "unsupported location scheme: {scheme}"
+                )));
+            }
+        };
+
+        let relative = address.path().trim_start_matches('/');
+        if relative.is_empty() {
+            Ok(base_path)
+        } else {
+            Ok(base_path.join(relative))
+        }
+    }
+}
+
+/// Mounted filesystem store at a specific root location.
+///
 /// Filesystem-based storage provider.
 ///
 /// A transparent wrapper over a [`Location`] that manages storage directories
@@ -67,9 +176,15 @@ const MEMORY: &str = "memory";
 /// Directories are created lazily on first access.
 #[derive(Clone, Debug)]
 #[repr(transparent)]
-pub struct FileSystem(Location);
+pub struct FileStore(Location);
 
-impl TryFrom<Url> for FileSystem {
+impl From<Location> for FileStore {
+    fn from(location: Location) -> Self {
+        Self(location)
+    }
+}
+
+impl TryFrom<Url> for FileStore {
     type Error = FileSystemError;
 
     fn try_from(url: Url) -> Result<Self, Self::Error> {
@@ -77,7 +192,7 @@ impl TryFrom<Url> for FileSystem {
     }
 }
 
-impl TryFrom<String> for FileSystem {
+impl TryFrom<String> for FileStore {
     type Error = FileSystemError;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
@@ -85,7 +200,7 @@ impl TryFrom<String> for FileSystem {
     }
 }
 
-impl TryFrom<&str> for FileSystem {
+impl TryFrom<&str> for FileStore {
     type Error = FileSystemError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
@@ -93,7 +208,7 @@ impl TryFrom<&str> for FileSystem {
     }
 }
 
-impl TryFrom<PathBuf> for FileSystem {
+impl TryFrom<PathBuf> for FileStore {
     type Error = FileSystemError;
 
     fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
@@ -101,7 +216,7 @@ impl TryFrom<PathBuf> for FileSystem {
     }
 }
 
-impl FileSystem {
+impl FileStore {
     /// Mounts a filesystem provider at the given root.
     ///
     /// Accepts a `PathBuf`, `file:` URL string, or `Url`.
@@ -109,6 +224,20 @@ impl FileSystem {
         root: impl TryInto<Location, Error = FileSystemError>,
     ) -> Result<Self, FileSystemError> {
         Ok(Self(root.try_into()?))
+    }
+
+    /// Returns the location for profile key storage (old API, kept for compat).
+    pub fn profile_location() -> Result<Location, FileSystemError> {
+        let data_dir = dirs::data_dir().ok_or_else(|| {
+            FileSystemError::Io("could not determine platform data directory".into())
+        })?;
+        let root: Location = data_dir.join("dialog").try_into()?;
+        root.resolve("profile")
+    }
+
+    /// Resolves a path segment relative to this filesystem's root.
+    pub fn resolve(&self, segment: &str) -> Result<Location, FileSystemError> {
+        self.0.resolve(segment)
     }
 
     /// Returns the location for a subject's archive storage.
@@ -120,13 +249,22 @@ impl FileSystem {
     fn memory(&self, subject: &Did) -> Result<Location, FileSystemError> {
         self.0.resolve(subject.as_ref())?.resolve(MEMORY)
     }
+
+    /// Returns the location for a subject's key-value storage.
+    fn storage(&self, subject: &Did, store: &str) -> Result<Location, FileSystemError> {
+        self.0
+            .resolve(subject.as_ref())?
+            .resolve(STORAGE)?
+            .resolve(store)
+    }
 }
 
 /// A location in the filesystem, represented as a `file:` URL.
 ///
 /// Provides methods for resolving child paths with containment validation,
 /// and converting to native filesystem paths.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(transparent)]
 #[repr(transparent)]
 pub struct Location(Url);
 
@@ -251,12 +389,119 @@ impl Location {
         Ok(Self(joined))
     }
 
+    /// Ensures the parent directory of this location exists.
+    pub async fn ensure_parent(&self) -> Result<(), FileSystemError> {
+        let path: PathBuf = self.clone().try_into()?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| FileSystemError::Io(e.to_string()))?;
+        }
+        Ok(())
+    }
+
     /// Ensures this location exists as a directory.
     pub async fn ensure_dir(&self) -> Result<(), FileSystemError> {
         let path: PathBuf = self.clone().try_into()?;
         tokio::fs::create_dir_all(&path)
             .await
             .map_err(|e| FileSystemError::Io(e.to_string()))
+    }
+
+    /// Read the contents of this location as bytes.
+    pub async fn read(&self) -> Result<Vec<u8>, FileSystemError> {
+        let path: PathBuf = self.clone().try_into()?;
+        tokio::fs::read(&path)
+            .await
+            .map_err(|e| FileSystemError::Io(e.to_string()))
+    }
+
+    /// Write bytes to this location, creating parent directories as needed.
+    pub async fn write(&self, content: &[u8]) -> Result<(), FileSystemError> {
+        let path: PathBuf = self.clone().try_into()?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| FileSystemError::Io(e.to_string()))?;
+        }
+        tokio::fs::write(&path, content)
+            .await
+            .map_err(|e| FileSystemError::Io(e.to_string()))
+    }
+
+    /// Check whether this location exists on the filesystem.
+    pub async fn exists(&self) -> bool {
+        let Ok(path) = PathBuf::try_from(self.clone()) else {
+            return false;
+        };
+        tokio::fs::try_exists(&path).await.unwrap_or(false)
+    }
+
+    /// Remove the file at this location.
+    pub async fn remove(&self) -> Result<(), FileSystemError> {
+        let path: PathBuf = self.clone().try_into()?;
+        tokio::fs::remove_file(&path)
+            .await
+            .map_err(|e| FileSystemError::Io(e.to_string()))
+    }
+
+    /// Acquire a PID-based file lock at `{self}.lock`.
+    ///
+    /// Returns an RAII guard that releases the lock when dropped.
+    /// Handles stale lock detection and recovery automatically.
+    /// Fails immediately if the lock is held by an active process.
+    pub fn lock(&self) -> Result<Lock, FileSystemError> {
+        let mut path: PathBuf = self.clone().try_into()?;
+        let mut name = path.file_name().unwrap_or_default().to_os_string();
+        name.push(".lock");
+        path.set_file_name(name);
+        let lock_path = path;
+        let path_str = lock_path
+            .to_str()
+            .ok_or_else(|| FileSystemError::Lock("Lock path is not valid UTF-8".into()))?;
+
+        let mut pidlock = pidlock::Pidlock::new(path_str);
+
+        loop {
+            match pidlock.acquire() {
+                Ok(()) => return Ok(Lock(pidlock)),
+                Err(pidlock::PidlockError::LockExists) => {
+                    match pidlock.get_owner() {
+                        Some(pid) => {
+                            return Err(FileSystemError::Lock(format!(
+                                "Concurrent write in progress (lock held by pid {pid})"
+                            )));
+                        }
+                        None => {
+                            // Stale lock cleared, retry
+                        }
+                    }
+                }
+                Err(e) => {
+                    return Err(FileSystemError::Lock(format!(
+                        "Failed to acquire lock: {e:?}"
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Atomically rename this location to the target location.
+    pub async fn rename(&self, target: &Location) -> Result<(), FileSystemError> {
+        let from: PathBuf = self.clone().try_into()?;
+        let to: PathBuf = target.clone().try_into()?;
+        tokio::fs::rename(&from, &to)
+            .await
+            .map_err(|e| FileSystemError::Io(e.to_string()))
+    }
+}
+
+/// RAII guard that holds a PID lock and releases it when dropped.
+pub struct Lock(pidlock::Pidlock);
+
+impl Drop for Lock {
+    fn drop(&mut self) {
+        let _ = self.0.release();
     }
 }
 
@@ -267,7 +512,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_generates_correct_paths() {
-        let provider: FileSystem = "file:///root/".try_into().unwrap();
+        let provider: FileStore = "file:///root/".try_into().unwrap();
         let subject = did!("key:z6MkTest");
 
         // Archive path
@@ -289,7 +534,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_allows_nested_paths() {
-        let provider: FileSystem = "file:///root/".try_into().unwrap();
+        let provider: FileStore = "file:///root/".try_into().unwrap();
         let subject = did!("key:z6MkTest");
 
         // Nested space path should work
@@ -308,7 +553,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_prevents_containment_escape_via_dotdot() {
-        let provider: FileSystem = "file:///root/".try_into().unwrap();
+        let provider: FileStore = "file:///root/".try_into().unwrap();
         let subject = did!("key:z6MkTest");
 
         // Attempt to escape via ..
@@ -320,7 +565,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_handles_absolute_looking_path() {
-        let provider: FileSystem = "file:///root/".try_into().unwrap();
+        let provider: FileStore = "file:///root/".try_into().unwrap();
         let subject = did!("key:z6MkTest");
 
         // With "./" prefix, "/etc/passwd" becomes ".//etc/passwd" which URL normalizes
@@ -348,7 +593,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_prevents_escape_via_encoded_dotdot() {
-        let provider: FileSystem = "file:///root/".try_into().unwrap();
+        let provider: FileStore = "file:///root/".try_into().unwrap();
         let subject = did!("key:z6MkTest");
 
         // URL decodes %2e%2e to .. during join, so this should be caught
@@ -359,7 +604,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_prevents_deep_escape() {
-        let provider: FileSystem = "file:///root/".try_into().unwrap();
+        let provider: FileStore = "file:///root/".try_into().unwrap();
         let subject = did!("key:z6MkTest");
 
         // Try to escape multiple levels

--- a/rust/dialog-storage/src/storage/provider/fs/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/archive.rs
@@ -1,14 +1,11 @@
 //! Archive capability provider for filesystem.
 
-use super::{FileSystem, FileSystemError};
+use super::{FileStore, FileSystemError};
 use async_trait::async_trait;
 use base58::ToBase58;
 use dialog_capability::{Capability, Provider};
 use dialog_common::Blake3Hash;
 use dialog_effects::archive::{ArchiveError, Get, GetCapability, Put, PutCapability};
-use std::io::ErrorKind;
-use std::path::PathBuf;
-use tokio::fs::{read, rename, write};
 
 impl From<FileSystemError> for ArchiveError {
     fn from(e: FileSystemError) -> Self {
@@ -17,30 +14,28 @@ impl From<FileSystemError> for ArchiveError {
 }
 
 #[async_trait]
-impl Provider<Get> for FileSystem {
+impl Provider<Get> for FileStore {
     async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let catalog = effect.catalog();
         let digest = effect.digest();
 
-        let path: PathBuf = self
+        let location = self
             .archive(&subject)?
             .resolve(catalog)?
-            .resolve(&digest.as_bytes().to_base58())?
-            .try_into()?;
+            .resolve(&digest.as_bytes().to_base58())?;
 
-        match read(&path).await {
+        match location.read().await {
             Ok(bytes) => Ok(Some(bytes)),
-            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(ArchiveError::Storage(e.to_string())),
+            Err(_) => Ok(None),
         }
     }
 }
 
 #[async_trait]
-impl Provider<Put> for FileSystem {
+impl Provider<Put> for FileStore {
     async fn execute(&self, effect: Capability<Put>) -> Result<(), ArchiveError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let catalog = effect.catalog();
         let digest = effect.digest();
         let content = effect.content();
@@ -60,24 +55,18 @@ impl Provider<Put> for FileSystem {
         destination.ensure_dir().await?;
 
         let key = digest.as_bytes().to_base58();
-        let path: PathBuf = destination.resolve(&key)?.try_into()?;
+        let target = destination.resolve(&key)?;
 
-        // Content-addressed storage is idempotent - if file exists with same
+        // Content-addressed storage is idempotent — if file exists with same
         // content hash, no need to rewrite
-        if path.exists() {
+        if target.read().await.is_ok() {
             return Ok(());
         }
 
         // Write atomically via temp file + rename
-        let temp_path: PathBuf = destination.resolve(&format!("{}.tmp", key))?.try_into()?;
-
-        write(&temp_path, content)
-            .await
-            .map_err(|e| ArchiveError::Storage(e.to_string()))?;
-
-        rename(&temp_path, &path)
-            .await
-            .map_err(|e| ArchiveError::Storage(e.to_string()))?;
+        let temp = destination.resolve(&format!("{key}.tmp"))?;
+        temp.write(content).await?;
+        temp.rename(&target).await?;
 
         Ok(())
     }
@@ -106,7 +95,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_returns_none_for_missing_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-get-none");
         let digest = Blake3Hash::hash(b"nonexistent");
 
@@ -124,7 +113,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_stores_and_retrieves_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-put-get");
         let content = b"hello world".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -153,7 +142,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_rejects_digest_mismatch() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-mismatch");
         let content = b"hello world".to_vec();
         let wrong_digest = Blake3Hash::hash(b"different content");
@@ -172,7 +161,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_different_catalogs() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-catalogs");
         let content1 = b"content for catalog 1".to_vec();
         let content2 = b"content for catalog 2".to_vec();
@@ -231,7 +220,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_is_idempotent_for_same_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-idempotent");
         let content = b"idempotent content".to_vec();
         let digest = Blake3Hash::hash(&content);
@@ -268,7 +257,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_empty_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-empty");
         let content = vec![];
         let digest = Blake3Hash::hash(&content);
@@ -295,7 +284,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_large_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("archive-large");
         // 1MB content
         let content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();

--- a/rust/dialog-storage/src/storage/provider/fs/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/memory.rs
@@ -4,7 +4,7 @@
 //! Uses PID-based file locking for cross-process coordination and BLAKE3
 //! content hashing for edition tracking.
 
-use super::{FileSystem, FileSystemError, Location};
+use super::{FileStore, FileSystemError, Location};
 use async_trait::async_trait;
 use base58::ToBase58;
 use dialog_capability::{Capability, Provider};
@@ -13,8 +13,6 @@ use dialog_effects::memory::{
     MemoryError, Publication, Publish, PublishCapability, Resolve, ResolveCapability, Retract,
     RetractCapability,
 };
-use pidlock::Pidlock;
-use std::path::PathBuf;
 
 /// A 32-byte content hash used as the edition for CAS operations.
 type ContentHash = [u8; 32];
@@ -30,65 +28,6 @@ impl From<FileSystemError> for MemoryError {
     }
 }
 
-/// RAII guard that acquires a PID lock and releases it when dropped.
-///
-/// Handles stale lock detection and recovery automatically.
-struct PidlockGuard(Pidlock);
-
-impl PidlockGuard {
-    /// Acquire a PID lock at the given path.
-    ///
-    /// If a stale lock exists (from a dead process), it will be automatically
-    /// cleaned up and the lock acquired.
-    ///
-    /// If the lock is held by an active process, returns an error immediately
-    /// rather than waiting. This is intentional - the STM layer will retry
-    /// the entire transaction, which is the correct behavior since the locked
-    /// value will likely change anyway.
-    fn new(path: PathBuf) -> Result<Self, FileSystemError> {
-        let path_str = path
-            .to_str()
-            .ok_or_else(|| FileSystemError::Lock("Lock path is not valid UTF-8".to_string()))?;
-
-        let mut lock = Pidlock::new(path_str);
-
-        // Acquire lock, handling stale locks
-        loop {
-            match lock.acquire() {
-                Ok(()) => return Ok(Self(lock)),
-                Err(pidlock::PidlockError::LockExists) => {
-                    // get_owner() checks if the PID is valid and clears stale locks
-                    match lock.get_owner() {
-                        Some(pid) => {
-                            // Fail immediately rather than wait - the value is being
-                            // modified so the edition will change anyway. Let STM
-                            // retry the transaction with the new edition.
-                            return Err(FileSystemError::Lock(format!(
-                                "Concurrent write in progress (lock held by pid {})",
-                                pid
-                            )));
-                        }
-                        None => {
-                            // Lock was stale and cleared by get_owner(), retry
-                        }
-                    }
-                }
-                Err(e) => {
-                    return Err(FileSystemError::Lock(format!(
-                        "Failed to acquire lock: {e:?}"
-                    )));
-                }
-            }
-        }
-    }
-}
-
-impl Drop for PidlockGuard {
-    fn drop(&mut self) {
-        let _ = self.0.release();
-    }
-}
-
 /// Format edition bytes for error messages.
 fn format_edition(edition: Option<&[u8]>) -> Option<String> {
     edition.map(base58::ToBase58::to_base58)
@@ -100,32 +39,24 @@ impl Location {
         self.resolve(name)
     }
 
-    fn lock(&self, cell: &str) -> Result<Self, FileSystemError> {
-        self.resolve(&format!("{}.lock", cell))
-    }
-
     fn temp(&self, cell: &str, hash: &[u8; 32]) -> Result<Self, FileSystemError> {
-        self.resolve(&format!("{}.{}.tmp", cell, hash.to_base58()))
+        self.resolve(&format!("{cell}.{}.tmp", hash.to_base58()))
     }
 }
 
 #[async_trait]
-impl Provider<Resolve> for FileSystem {
+impl Provider<Resolve> for FileStore {
     async fn execute(
         &self,
         effect: Capability<Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let space = effect.space();
         let cell = effect.cell();
 
-        let path: PathBuf = self
-            .memory(&subject)?
-            .resolve(space)?
-            .cell(cell)?
-            .try_into()?;
+        let location = self.memory(&subject)?.resolve(space)?.cell(cell)?;
 
-        match tokio::fs::read(&path).await {
+        match location.read().await {
             Ok(bytes) => {
                 let edition = Blake3Hash::hash(&bytes);
                 Ok(Some(Publication {
@@ -133,16 +64,15 @@ impl Provider<Resolve> for FileSystem {
                     edition: edition.as_bytes().to_vec(),
                 }))
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(MemoryError::Storage(e.to_string())),
+            Err(_) => Ok(None),
         }
     }
 }
 
 #[async_trait]
-impl Provider<Publish> for FileSystem {
+impl Provider<Publish> for FileStore {
     async fn execute(&self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let space = effect.space();
         let cell = effect.cell();
         let content = effect.content().to_vec();
@@ -153,26 +83,18 @@ impl Provider<Publish> for FileSystem {
         // Ensure space directory exists
         space_location.ensure_dir().await?;
 
-        let path: PathBuf = space_location.cell(cell)?.try_into()?;
-        let lock_path: PathBuf = space_location.lock(cell)?.try_into()?;
+        let cell_location = space_location.cell(cell)?;
 
         // Ensure parent directory exists for nested cell paths (e.g. "subdir/cell").
-        // space_location.ensure_dir() only creates the space directory, not
-        // subdirectories within it that the cell path may require.
-        if let Some(parent) = path.parent() {
-            tokio::fs::create_dir_all(parent)
-                .await
-                .map_err(|e| MemoryError::Storage(e.to_string()))?;
-        }
+        cell_location.ensure_parent().await?;
 
         // Acquire lock for exclusive access
-        let _guard = PidlockGuard::new(lock_path)?;
+        let _guard = cell_location.lock()?;
 
         // Read current value to check CAS condition
-        let current_edition: Option<[u8; 32]> = match tokio::fs::read(&path).await {
+        let current_edition: Option<[u8; 32]> = match cell_location.read().await {
             Ok(bytes) => Some(content_hash(&bytes)),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
-            Err(e) => return Err(MemoryError::Storage(e.to_string())),
+            Err(_) => None,
         };
 
         // Compute new edition
@@ -213,50 +135,40 @@ impl Provider<Publish> for FileSystem {
         }
 
         // Write to temp file (hash in name prevents conflicts if cleanup fails)
-        let tmp_path: PathBuf = space_location.temp(cell, &new_edition)?.try_into()?;
-        tokio::fs::write(&tmp_path, &content)
-            .await
-            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+        let temp = space_location.temp(cell, &new_edition)?;
+        temp.write(&content).await?;
 
         // Atomic rename
-        tokio::fs::rename(&tmp_path, &path)
-            .await
-            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+        temp.rename(&cell_location).await?;
 
         Ok(new_edition.to_vec())
     }
 }
 
 #[async_trait]
-impl Provider<Retract> for FileSystem {
+impl Provider<Retract> for FileStore {
     async fn execute(&self, effect: Capability<Retract>) -> Result<(), MemoryError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let space = effect.space();
         let cell = effect.cell();
         let expected_edition = effect.when().to_vec();
 
         let space_location = self.memory(&subject)?.resolve(space)?;
-        let space_path: PathBuf = space_location.clone().try_into()?;
 
         // If space directory doesn't exist, the cell doesn't exist either
-        if !space_path.exists() {
+        if !space_location.exists().await {
             return Ok(());
         }
 
-        let path: PathBuf = space_location.cell(cell)?.try_into()?;
-        let lock_path: PathBuf = space_location.lock(cell)?.try_into()?;
+        let cell_location = space_location.cell(cell)?;
 
         // Acquire lock for exclusive access
-        let _guard = PidlockGuard::new(lock_path)?;
+        let _guard = cell_location.lock()?;
 
         // Read current value to check CAS condition
-        let current_bytes = match tokio::fs::read(&path).await {
+        let current_bytes = match cell_location.read().await {
             Ok(bytes) => bytes,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // Already deleted, succeed
-                return Ok(());
-            }
-            Err(e) => return Err(MemoryError::Storage(e.to_string())),
+            Err(_) => return Ok(()), // Already deleted, succeed
         };
 
         let current_edition = content_hash(&current_bytes);
@@ -270,10 +182,9 @@ impl Provider<Retract> for FileSystem {
         }
 
         // Delete the file
-        match tokio::fs::remove_file(&path).await {
+        match cell_location.remove().await {
             Ok(()) => Ok(()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(MemoryError::Storage(e.to_string())),
+            Err(_) => Ok(()), // Already deleted
         }
     }
 }
@@ -301,7 +212,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_resolves_non_existent_cell() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-resolve-none");
 
         let effect = subject
@@ -319,7 +230,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_publishes_new_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-publish-new");
         let content = b"hello world".to_vec();
 
@@ -354,7 +265,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_updates_existing_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-publish-update");
 
         // Create initial content
@@ -397,7 +308,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_fails_on_edition_mismatch() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-mismatch");
 
         // Create initial content
@@ -428,7 +339,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_fails_creating_when_exists() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-create-exists");
 
         // Create initial content
@@ -458,7 +369,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_retracts_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-retract");
 
         // Create content
@@ -498,7 +409,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_fails_retract_on_edition_mismatch() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-retract-mismatch");
 
         // Create content
@@ -529,7 +440,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_different_spaces() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-spaces");
 
         // Publish to different spaces
@@ -578,7 +489,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_succeeds_with_stale_edition_when_value_matches() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-stale-ok");
         let content = b"desired value".to_vec();
 
@@ -614,7 +525,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_produces_deterministic_content_hash() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-deterministic-hash");
         let content = b"same content".to_vec();
 
@@ -646,7 +557,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_succeeds_retracting_already_retracted() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-retract-already-retracted");
 
         // Try to retract non-existent cell - should succeed
@@ -667,7 +578,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_nested_spaces() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-nested-spaces");
         let content = b"nested content".to_vec();
 
@@ -701,7 +612,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_publishes_to_nested_cell() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-nested-cell");
         let content = b"nested cell content".to_vec();
 
@@ -735,7 +646,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_empty_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-empty");
         let content = vec![];
 
@@ -767,7 +678,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_handles_large_content() -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let provider = FileSystem::mount(tempdir.path().to_path_buf())?;
+        let provider = FileStore::mount(tempdir.path().to_path_buf())?;
         let subject = unique_subject("memory-large");
         // 1MB content
         let content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();

--- a/rust/dialog-storage/src/storage/provider/fs/resource.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/resource.rs
@@ -1,0 +1,38 @@
+//! Load and Save providers for FileStore.
+
+use super::{Address, FileStore};
+use async_trait::async_trait;
+use dialog_capability::storage::{Load, Location, Save, StorageError};
+use dialog_capability::{Capability, Policy, Provider};
+
+#[async_trait]
+impl Provider<Load<Vec<u8>, Address>> for FileStore {
+    async fn execute(
+        &self,
+        input: Capability<Load<Vec<u8>, Address>>,
+    ) -> Result<Vec<u8>, StorageError> {
+        let address = Location::of(&input).address();
+        let location = self
+            .resolve(address.path())
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+        location
+            .read()
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl Provider<Save<Vec<u8>, Address>> for FileStore {
+    async fn execute(&self, input: Capability<Save<Vec<u8>, Address>>) -> Result<(), StorageError> {
+        let address = Location::of(&input).address();
+        let bytes = &Save::<Vec<u8>, Address>::of(&input).content;
+        let location = self
+            .resolve(address.path())
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+        location
+            .write(bytes)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/fs/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/storage.rs
@@ -1,0 +1,254 @@
+//! Storage capability provider for filesystem.
+//!
+//! Implements key-value storage effects by storing data in files under
+//! `{root}/{subject}/storage/{store}/{key}`.
+//!
+//! Keys are used as file paths directly — slashes create subdirectories.
+//! List recursively walks the directory tree and returns full relative paths.
+
+use std::path::PathBuf;
+
+use super::FileStore;
+use async_trait::async_trait;
+use dialog_capability::{Capability, Did, Provider};
+use dialog_effects::storage::{Delete, Get, List, ListResult, Set, StorageError};
+
+fn store_dir(fs: &FileStore, subject: &Did, store: &str) -> Result<PathBuf, StorageError> {
+    let location = fs.storage(subject, store).map_err(to_err)?;
+    PathBuf::try_from(location).map_err(to_err)
+}
+
+fn key_path(
+    fs: &FileStore,
+    subject: &Did,
+    store: &str,
+    key: &[u8],
+) -> Result<PathBuf, StorageError> {
+    let key_str = std::str::from_utf8(key).map_err(|e| StorageError::Storage(e.to_string()))?;
+    let mut path = store_dir(fs, subject, store)?;
+    path.push(key_str);
+    Ok(path)
+}
+
+fn to_err(e: impl std::fmt::Display) -> StorageError {
+    StorageError::Storage(e.to_string())
+}
+
+async fn list_recursive(
+    dir: &std::path::Path,
+    base: &std::path::Path,
+    keys: &mut Vec<String>,
+) -> Result<(), StorageError> {
+    let mut entries = tokio::fs::read_dir(dir).await.map_err(StorageError::Io)?;
+    while let Some(entry) = entries.next_entry().await.map_err(StorageError::Io)? {
+        let ft = entry.file_type().await.map_err(StorageError::Io)?;
+        if ft.is_file()
+            && let Ok(rel) = entry.path().strip_prefix(base)
+            && let Some(s) = rel.to_str()
+        {
+            keys.push(s.to_string());
+        } else if ft.is_dir() {
+            Box::pin(list_recursive(&entry.path(), base, keys)).await?;
+        }
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl Provider<Get> for FileStore {
+    async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, StorageError> {
+        let path = key_path(self, effect.subject(), effect.store(), effect.key())?;
+        match tokio::fs::read(&path).await {
+            Ok(data) => Ok(Some(data)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(StorageError::Io(e)),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider<Set> for FileStore {
+    async fn execute(&self, effect: Capability<Set>) -> Result<(), StorageError> {
+        let path = key_path(self, effect.subject(), effect.store(), effect.key())?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(StorageError::Io)?;
+        }
+        tokio::fs::write(&path, effect.value())
+            .await
+            .map_err(StorageError::Io)
+    }
+}
+
+#[async_trait]
+impl Provider<Delete> for FileStore {
+    async fn execute(&self, effect: Capability<Delete>) -> Result<(), StorageError> {
+        let path = key_path(self, effect.subject(), effect.store(), effect.key())?;
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(StorageError::Io(e)),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider<List> for FileStore {
+    async fn execute(&self, effect: Capability<List>) -> Result<ListResult, StorageError> {
+        let base = store_dir(self, effect.subject(), effect.store())?;
+        let prefix = std::str::from_utf8(effect.prefix())
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        let search_dir = if prefix.is_empty() {
+            base.clone()
+        } else {
+            base.join(prefix)
+        };
+
+        let mut keys = Vec::new();
+        if search_dir.is_dir() {
+            list_recursive(&search_dir, &base, &mut keys).await?;
+        } else if search_dir.is_file()
+            && let Ok(rel) = search_dir.strip_prefix(&base)
+            && let Some(s) = rel.to_str()
+        {
+            keys.push(s.to_string());
+        }
+
+        Ok(ListResult {
+            keys,
+            is_truncated: false,
+            next_continuation_token: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FileStore;
+    use dialog_capability::{Subject, did};
+    use dialog_effects::storage::{Get, List, Set, Storage, Store};
+
+    fn store_cap(subject: Subject, store_name: &str) -> dialog_capability::Capability<Store> {
+        subject.attenuate(Storage).attenuate(Store::new(store_name))
+    }
+
+    #[dialog_common::test]
+    async fn set_and_get_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = FileStore::mount(dir.path().to_path_buf()).unwrap();
+        let subject = Subject::from(did!("key:z6MkTest"));
+
+        store_cap(subject.clone(), "data")
+            .invoke(Set::new(b"hello".to_vec(), b"world".to_vec()))
+            .perform(&fs)
+            .await
+            .unwrap();
+
+        let result = store_cap(subject, "data")
+            .invoke(Get::new(b"hello"))
+            .perform(&fs)
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(b"world".to_vec()));
+    }
+
+    #[dialog_common::test]
+    async fn get_missing_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = FileStore::mount(dir.path().to_path_buf()).unwrap();
+        let subject = Subject::from(did!("key:z6MkTest"));
+
+        let result = store_cap(subject, "data")
+            .invoke(Get::new(b"missing"))
+            .perform(&fs)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[dialog_common::test]
+    async fn keys_with_slashes_create_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = FileStore::mount(dir.path().to_path_buf()).unwrap();
+        let subject = Subject::from(did!("key:z6MkTest"));
+
+        let key = b"a/b/c";
+
+        store_cap(subject.clone(), "data")
+            .invoke(Set::new(key.to_vec(), b"nested".to_vec()))
+            .perform(&fs)
+            .await
+            .unwrap();
+
+        let result = store_cap(subject, "data")
+            .invoke(Get::new(key.to_vec()))
+            .perform(&fs)
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(b"nested".to_vec()));
+    }
+
+    #[dialog_common::test]
+    async fn list_returns_all_keys_recursively() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = FileStore::mount(dir.path().to_path_buf()).unwrap();
+        let subject = Subject::from(did!("key:z6MkTest"));
+
+        let key1 = "aud1/sub1/iss1.cid1";
+        let key2 = "aud1/_/iss2.cid2";
+        let key3 = "aud2/sub2/iss3.cid3";
+
+        for (k, v) in [(key1, "d1"), (key2, "d2"), (key3, "d3")] {
+            store_cap(subject.clone(), "ucan")
+                .invoke(Set::new(k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                .perform(&fs)
+                .await
+                .unwrap();
+        }
+
+        let result = store_cap(subject, "ucan")
+            .invoke(List::new(None))
+            .perform(&fs)
+            .await
+            .unwrap();
+
+        assert_eq!(result.keys.len(), 3);
+        assert!(result.keys.contains(&key1.to_string()));
+        assert!(result.keys.contains(&key2.to_string()));
+        assert!(result.keys.contains(&key3.to_string()));
+    }
+
+    #[dialog_common::test]
+    async fn list_with_prefix_filters() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = FileStore::mount(dir.path().to_path_buf()).unwrap();
+        let subject = Subject::from(did!("key:z6MkTest"));
+
+        let key1 = "aud1/sub1/iss1.cid1";
+        let key2 = "aud1/_/iss2.cid2";
+        let key3 = "aud2/sub2/iss3.cid3";
+
+        for (k, v) in [(key1, "d1"), (key2, "d2"), (key3, "d3")] {
+            store_cap(subject.clone(), "ucan")
+                .invoke(Set::new(k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                .perform(&fs)
+                .await
+                .unwrap();
+        }
+
+        let result = store_cap(subject, "ucan")
+            .invoke(List::with_prefix("aud1/"))
+            .perform(&fs)
+            .await
+            .unwrap();
+
+        assert_eq!(result.keys.len(), 2);
+        assert!(result.keys.contains(&key1.to_string()));
+        assert!(result.keys.contains(&key2.to_string()));
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -41,12 +41,66 @@
 
 mod archive;
 mod memory;
+mod resource;
+mod storage;
 
 use dialog_capability::Did;
 use js_sys::Uint8Array;
 use rexie::{ObjectStore, Rexie, RexieBuilder, TransactionMode};
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+
+/// Address for IndexedDB-based storage.
+///
+/// A string prefix that scopes database names.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct Address(String);
+
+impl Address {
+    /// Create an address with the given prefix.
+    pub fn new(prefix: impl Into<String>) -> Self {
+        Self(prefix.into())
+    }
+
+    /// Profile storage address with the given name.
+    pub fn profile(name: &str) -> Self {
+        Self(format!("profile/{name}"))
+    }
+
+    /// Current/working storage address with the given name.
+    pub fn current(name: &str) -> Self {
+        Self(format!("storage/{name}"))
+    }
+
+    /// Unique temporary storage address.
+    pub fn temp() -> Self {
+        use dialog_common::time;
+        let id = format!(
+            "dialog-{}",
+            time::now()
+                .duration_since(time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        Self(format!("temp/{id}"))
+    }
+
+    /// The prefix string.
+    pub fn prefix(&self) -> &str {
+        &self.0
+    }
+
+    /// Resolve a sub-path under this address.
+    pub fn resolve(&self, segment: &str) -> Self {
+        if self.0.is_empty() {
+            Self(segment.to_string())
+        } else {
+            Self(format!("{}/{}", self.0, segment))
+        }
+    }
+}
 
 /// Convert bytes to a JS Uint8Array.
 fn to_uint8array(bytes: &[u8]) -> Uint8Array {
@@ -59,7 +113,7 @@ fn to_uint8array(bytes: &[u8]) -> Uint8Array {
 ///
 /// Stores are populated from whatever exists in the database on open,
 /// and new stores are created via upgrade when needed.
-struct Session {
+pub struct Session {
     /// Database name (subject DID).
     name: String,
     /// Current database version.
@@ -128,7 +182,7 @@ impl Session {
     }
 
     /// Gets a store handle, upgrading the database if needed.
-    async fn store(&mut self, store_path: &str) -> Result<Store<'_>, IndexedDbError> {
+    pub async fn store(&mut self, store_path: &str) -> Result<Store<'_>, IndexedDbError> {
         if !self.stores.contains(store_path) {
             let mut stores = self.stores.clone();
             stores.insert(store_path.to_string());
@@ -143,14 +197,14 @@ impl Session {
 }
 
 /// A temporary handle to a specific object store for performing operations.
-struct Store<'a> {
+pub struct Store<'a> {
     db: &'a Rexie,
     name: &'a String,
 }
 
 impl<'a> Store<'a> {
     /// Executes a read-only query on this store.
-    async fn query<F, Fut, Output, E>(&self, select: F) -> Result<Output, E>
+    pub async fn query<F, Fut, Output, E>(&self, select: F) -> Result<Output, E>
     where
         F: FnOnce(rexie::Store) -> Fut,
         Fut: std::future::Future<Output = Result<Output, E>>,
@@ -175,7 +229,7 @@ impl<'a> Store<'a> {
     }
 
     /// Executes a read-write transaction on this store.
-    async fn transact<F, Fut, Output, E>(&self, mutate: F) -> Result<Output, E>
+    pub async fn transact<F, Fut, Output, E>(&self, mutate: F) -> Result<Output, E>
     where
         F: FnOnce(rexie::Store) -> Fut,
         Fut: std::future::Future<Output = Result<Output, E>>,
@@ -212,27 +266,66 @@ impl<'a> Store<'a> {
 /// wasm32 (single-threaded). This avoids the overhead and poisoning concerns
 /// of `RwLock`.
 pub struct IndexedDb {
-    /// Cached database sessions keyed by subject DID.
-    sessions: RefCell<HashMap<Did, Session>>,
+    /// Mount prefix prepended to database names.
+    mount: String,
+    /// Cached database sessions keyed by name (shared across mounts).
+    sessions: std::rc::Rc<RefCell<HashMap<String, Session>>>,
+}
+
+impl Clone for IndexedDb {
+    fn clone(&self) -> Self {
+        Self {
+            mount: self.mount.clone(),
+            sessions: self.sessions.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for IndexedDb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndexedDb")
+            .field("mount", &self.mount)
+            .finish_non_exhaustive()
+    }
 }
 
 impl IndexedDb {
-    /// Creates a new IndexedDB provider.
+    /// Creates a new IndexedDB provider with no prefix.
     pub fn new() -> Self {
         Self {
-            sessions: RefCell::new(HashMap::new()),
+            mount: String::new(),
+            sessions: std::rc::Rc::new(RefCell::new(HashMap::new())),
         }
     }
 
-    /// Opens or returns an existing session for the given subject.
+    /// Create an IndexedDB provider mounted at the given address.
+    pub fn mount(address: &Address) -> Self {
+        Self {
+            mount: address.prefix().to_string(),
+            sessions: std::rc::Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+
+    /// Returns the prefixed database name for a given name.
+    fn prefixed(&self, name: &str) -> String {
+        if self.mount.is_empty() {
+            name.to_string()
+        } else {
+            format!("{}/{}", self.mount, name)
+        }
+    }
+
+    /// Opens or returns an existing session for the given name.
     ///
+    /// Accepts any string-like type (`Did`, `&str`, `String`).
     /// Checks for an existing session via a short borrow, drops it before
     /// any async work, then borrows mutably to insert a new session if needed.
-    async fn open(&self, subject: &Did) -> Result<(), IndexedDbError> {
-        let exists = self.sessions.borrow().contains_key(subject);
+    pub async fn open(&self, name: &str) -> Result<(), IndexedDbError> {
+        let db_name = self.prefixed(name);
+        let exists = self.sessions.borrow().contains_key(&db_name);
         if !exists {
-            let session = Session::open(subject.as_ref()).await?;
-            self.sessions.borrow_mut().insert(subject.clone(), session);
+            let session = Session::open(&db_name).await?;
+            self.sessions.borrow_mut().insert(db_name, session);
         }
         Ok(())
     }
@@ -243,16 +336,18 @@ impl IndexedDb {
     /// cannot hold a `RefCell` borrow across `.await` points. Instead we
     /// remove the session, perform the work, then re-insert it via
     /// [`IndexedDb::return_session`].
-    fn take_session(&self, subject: &Did) -> Result<Session, IndexedDbError> {
+    pub fn take_session(&self, name: &str) -> Result<Session, IndexedDbError> {
+        let db_name = self.prefixed(name);
         self.sessions
             .borrow_mut()
-            .remove(subject)
-            .ok_or_else(|| IndexedDbError::Database(format!("No session for {}", subject)))
+            .remove(&db_name)
+            .ok_or_else(|| IndexedDbError::Database(format!("No session for {db_name}")))
     }
 
     /// Returns a session to the cache after async operations complete.
-    fn return_session(&self, subject: Did, session: Session) {
-        self.sessions.borrow_mut().insert(subject, session);
+    pub fn return_session(&self, name: &str, session: Session) {
+        let db_name = self.prefixed(name);
+        self.sessions.borrow_mut().insert(db_name, session);
     }
 }
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
@@ -22,15 +22,15 @@ impl From<super::IndexedDbError> for ArchiveError {
 #[async_trait(?Send)]
 impl Provider<Get> for IndexedDb {
     async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let catalog = effect.catalog();
         let digest = effect.digest();
 
         let store_path = format!("archive/{}", catalog);
         let key = JsValue::from_str(&digest.as_bytes().to_base58());
 
-        self.open(&subject).await?;
-        let mut session = self.take_session(&subject)?;
+        self.open(subject.as_ref()).await?;
+        let mut session = self.take_session(subject.as_ref())?;
 
         let result = async {
             let store = session.store(&store_path).await?;
@@ -53,7 +53,7 @@ impl Provider<Get> for IndexedDb {
         }
         .await;
 
-        self.return_session(subject, session);
+        self.return_session(subject.as_ref(), session);
         result
     }
 }
@@ -61,7 +61,7 @@ impl Provider<Get> for IndexedDb {
 #[async_trait(?Send)]
 impl Provider<Put> for IndexedDb {
     async fn execute(&self, effect: Capability<Put>) -> Result<(), ArchiveError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let catalog = effect.catalog();
         let digest = effect.digest();
         let content = effect.content();
@@ -79,8 +79,8 @@ impl Provider<Put> for IndexedDb {
         let key = JsValue::from_str(&digest.as_bytes().to_base58());
         let value: JsValue = to_uint8array(content).into();
 
-        self.open(&subject).await?;
-        let mut session = self.take_session(&subject)?;
+        self.open(subject.as_ref()).await?;
+        let mut session = self.take_session(subject.as_ref())?;
 
         let result = async {
             let store = session.store(&store_path).await?;
@@ -96,7 +96,7 @@ impl Provider<Put> for IndexedDb {
         }
         .await;
 
-        self.return_session(subject, session);
+        self.return_session(subject.as_ref(), session);
         result
     }
 }

--- a/rust/dialog-storage/src/storage/provider/indexeddb/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/memory.rs
@@ -43,11 +43,11 @@ impl Provider<Resolve> for IndexedDb {
         &self,
         effect: Capability<Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let key = make_key(effect.space(), effect.cell());
 
-        self.open(&subject).await?;
-        let mut session = self.take_session(&subject)?;
+        self.open(subject.as_ref()).await?;
+        let mut session = self.take_session(subject.as_ref())?;
 
         let result = async {
             let store = session.store(MEMORY_STORE).await?;
@@ -75,7 +75,7 @@ impl Provider<Resolve> for IndexedDb {
         }
         .await;
 
-        self.return_session(subject, session);
+        self.return_session(subject.as_ref(), session);
         result
     }
 }
@@ -83,13 +83,13 @@ impl Provider<Resolve> for IndexedDb {
 #[async_trait(?Send)]
 impl Provider<Publish> for IndexedDb {
     async fn execute(&self, effect: Capability<Publish>) -> Result<Vec<u8>, MemoryError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let key = make_key(effect.space(), effect.cell());
         let content = effect.content().to_vec();
         let expected_edition = effect.when().map(|e| e.to_vec());
 
-        self.open(&subject).await?;
-        let mut session = self.take_session(&subject)?;
+        self.open(subject.as_ref()).await?;
+        let mut session = self.take_session(subject.as_ref())?;
 
         let result = async {
             let store = session.store(MEMORY_STORE).await?;
@@ -165,7 +165,7 @@ impl Provider<Publish> for IndexedDb {
         }
         .await;
 
-        self.return_session(subject, session);
+        self.return_session(subject.as_ref(), session);
         result
     }
 }
@@ -173,12 +173,12 @@ impl Provider<Publish> for IndexedDb {
 #[async_trait(?Send)]
 impl Provider<Retract> for IndexedDb {
     async fn execute(&self, effect: Capability<Retract>) -> Result<(), MemoryError> {
-        let subject = effect.subject().into();
+        let subject = effect.subject().clone();
         let key = make_key(effect.space(), effect.cell());
         let expected_edition = effect.when().to_vec();
 
-        self.open(&subject).await?;
-        let mut session = self.take_session(&subject)?;
+        self.open(subject.as_ref()).await?;
+        let mut session = self.take_session(subject.as_ref())?;
 
         let result = async {
             let store = session.store(MEMORY_STORE).await?;
@@ -215,7 +215,7 @@ impl Provider<Retract> for IndexedDb {
         }
         .await;
 
-        self.return_session(subject, session);
+        self.return_session(subject.as_ref(), session);
         result
     }
 }

--- a/rust/dialog-storage/src/storage/provider/indexeddb/resource.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/resource.rs
@@ -1,0 +1,109 @@
+//! Load and Save providers for IndexedDb.
+
+use super::{Address, IndexedDb, IndexedDbError};
+use async_trait::async_trait;
+use dialog_capability::storage::{self, Location, StorageError};
+use dialog_capability::{Capability, Policy, Provider};
+use js_sys::Uint8Array;
+use wasm_bindgen::JsValue;
+
+const DATA_STORE: &str = "data";
+
+struct Err(StorageError);
+
+impl From<IndexedDbError> for Err {
+    fn from(e: IndexedDbError) -> Self {
+        Self(StorageError::Storage(e.to_string()))
+    }
+}
+
+impl From<StorageError> for Err {
+    fn from(e: StorageError) -> Self {
+        Self(e)
+    }
+}
+
+#[async_trait(?Send)]
+impl Provider<storage::Load<Vec<u8>, Address>> for IndexedDb {
+    async fn execute(
+        &self,
+        input: Capability<storage::Load<Vec<u8>, Address>>,
+    ) -> Result<Vec<u8>, StorageError> {
+        let prefix = Location::of(&input).address().prefix().to_owned();
+        let subject = input.subject().to_string();
+
+        self.open(&subject)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+        let mut session = self
+            .take_session(&subject)
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        let result: Result<_, Err> = async {
+            let store = session.store(DATA_STORE).await?;
+            let js_key = JsValue::from_str(&prefix);
+
+            let value = store
+                .query(|object_store| async move {
+                    object_store
+                        .get(js_key)
+                        .await
+                        .map_err(|e| Err(StorageError::Storage(e.to_string())))
+                })
+                .await?;
+
+            match value {
+                Some(js_val) => {
+                    let array = Uint8Array::new(&js_val);
+                    Ok(array.to_vec())
+                }
+                None => Result::Err(StorageError::Storage(format!("not found: {}", prefix)).into()),
+            }
+        }
+        .await;
+
+        self.return_session(&subject, session);
+        result.map_err(|e| e.0)
+    }
+}
+
+#[async_trait(?Send)]
+impl Provider<storage::Save<Vec<u8>, Address>> for IndexedDb {
+    async fn execute(
+        &self,
+        input: Capability<storage::Save<Vec<u8>, Address>>,
+    ) -> Result<(), StorageError> {
+        let prefix = Location::of(&input).address().prefix().to_owned();
+        let bytes = &storage::Save::<Vec<u8>, Address>::of(&input).content;
+        let subject = input.subject().to_string();
+
+        let js_val: JsValue = super::to_uint8array(bytes).into();
+
+        self.open(&subject)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+        let mut session = self
+            .take_session(&subject)
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        let result: Result<_, Err> = async {
+            let store = session.store(DATA_STORE).await?;
+            let js_key = JsValue::from_str(&prefix);
+
+            store
+                .transact(|object_store| async move {
+                    object_store
+                        .put(&js_val, Some(&js_key))
+                        .await
+                        .map_err(|e| Err(StorageError::Storage(e.to_string())))?;
+                    Ok::<(), Err>(())
+                })
+                .await?;
+            Ok(())
+        }
+        .await;
+
+        self.return_session(&subject, session);
+        result.map_err(|e| e.0)
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/indexeddb/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/storage.rs
@@ -1,0 +1,329 @@
+//! Storage capability provider for IndexedDB.
+//!
+//! Implements key-value storage effects using IndexedDB object stores.
+//! Each `Store` maps to an IndexedDB object store named `storage/{store_name}`.
+//! Keys are stored as strings.
+
+use super::{IndexedDb, IndexedDbError, to_uint8array};
+use async_trait::async_trait;
+use dialog_capability::{Capability, Provider};
+use dialog_effects::storage::{Delete, Get, List, ListResult, Set, StorageError};
+use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
+
+const STORAGE_PREFIX: &str = "storage/";
+
+fn store_name(store: &str) -> String {
+    format!("{STORAGE_PREFIX}{store}")
+}
+
+fn to_err(e: impl std::fmt::Display) -> StorageError {
+    StorageError::Storage(e.to_string())
+}
+
+struct Err(StorageError);
+
+impl From<IndexedDbError> for Err {
+    fn from(e: IndexedDbError) -> Self {
+        Self(StorageError::Storage(e.to_string()))
+    }
+}
+
+impl From<StorageError> for Err {
+    fn from(e: StorageError) -> Self {
+        Self(e)
+    }
+}
+
+#[async_trait(?Send)]
+impl Provider<Get> for IndexedDb {
+    async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, StorageError> {
+        let subject = effect.subject().to_string();
+        let store = store_name(effect.store());
+        let key = String::from_utf8_lossy(effect.key()).into_owned();
+
+        self.open(&subject).await.map_err(to_err)?;
+        let mut session = self.take_session(&subject).map_err(to_err)?;
+
+        let result: Result<_, Err> = async {
+            let idb_store = session.store(&store).await?;
+            let js_key = JsValue::from_str(&key);
+
+            let value = idb_store
+                .query(|object_store| async move {
+                    object_store
+                        .get(js_key)
+                        .await
+                        .map_err(|e| Err(StorageError::Storage(e.to_string())))
+                })
+                .await?;
+
+            match value {
+                Some(js_val) => {
+                    let array: js_sys::Uint8Array = js_val
+                        .dyn_into()
+                        .map_err(|_| StorageError::Storage("expected Uint8Array".into()))?;
+                    Ok(Some(array.to_vec()))
+                }
+                None => Ok(None),
+            }
+        }
+        .await;
+
+        self.return_session(&subject, session);
+        result.map_err(|e| e.0)
+    }
+}
+
+#[async_trait(?Send)]
+impl Provider<Set> for IndexedDb {
+    async fn execute(&self, effect: Capability<Set>) -> Result<(), StorageError> {
+        let subject = effect.subject().to_string();
+        let store = store_name(effect.store());
+        let key = String::from_utf8_lossy(effect.key()).into_owned();
+        let value = effect.value().to_vec();
+
+        self.open(&subject).await.map_err(to_err)?;
+        let mut session = self.take_session(&subject).map_err(to_err)?;
+
+        let result: Result<_, Err> = async {
+            let idb_store = session.store(&store).await?;
+            let js_key = JsValue::from_str(&key);
+            let js_val = to_uint8array(&value);
+
+            idb_store
+                .transact(|object_store| async move {
+                    object_store
+                        .put(&js_val, Some(&js_key))
+                        .await
+                        .map_err(|e| Err(StorageError::Storage(e.to_string())))?;
+                    Ok::<(), Err>(())
+                })
+                .await?;
+            Ok(())
+        }
+        .await;
+
+        self.return_session(&subject, session);
+        result.map_err(|e| e.0)
+    }
+}
+
+#[async_trait(?Send)]
+impl Provider<Delete> for IndexedDb {
+    async fn execute(&self, effect: Capability<Delete>) -> Result<(), StorageError> {
+        let subject = effect.subject().to_string();
+        let store = store_name(effect.store());
+        let key = String::from_utf8_lossy(effect.key()).into_owned();
+
+        self.open(&subject).await.map_err(to_err)?;
+        let mut session = self.take_session(&subject).map_err(to_err)?;
+
+        let result: Result<_, Err> = async {
+            let idb_store = session.store(&store).await?;
+            let js_key = JsValue::from_str(&key);
+
+            idb_store
+                .transact(|object_store| async move {
+                    object_store
+                        .delete(js_key)
+                        .await
+                        .map_err(|e| Err(StorageError::Storage(e.to_string())))?;
+                    Ok::<(), Err>(())
+                })
+                .await?;
+            Ok(())
+        }
+        .await;
+
+        self.return_session(&subject, session);
+        result.map_err(|e| e.0)
+    }
+}
+
+#[async_trait(?Send)]
+impl Provider<List> for IndexedDb {
+    async fn execute(&self, effect: Capability<List>) -> Result<ListResult, StorageError> {
+        let subject = effect.subject().to_string();
+        let store = store_name(effect.store());
+        let prefix = String::from_utf8_lossy(effect.prefix()).into_owned();
+
+        self.open(&subject).await.map_err(to_err)?;
+        let mut session = self.take_session(&subject).map_err(to_err)?;
+
+        let result: Result<_, Err> = async {
+            let idb_store = session.store(&store).await?;
+
+            let all_keys: Vec<String> = idb_store
+                .query(|object_store| async move {
+                    let js_keys = object_store
+                        .get_all_keys(None, None)
+                        .await
+                        .map_err(|e| Err(StorageError::Storage(e.to_string())))?;
+
+                    let mut keys = Vec::new();
+                    for js_key in js_keys {
+                        if let Some(s) = js_key.as_string() {
+                            keys.push(s);
+                        }
+                    }
+                    Ok::<_, Err>(keys)
+                })
+                .await?;
+
+            let filtered: Vec<String> = if prefix.is_empty() {
+                all_keys
+            } else {
+                all_keys
+                    .into_iter()
+                    .filter(|k| k.starts_with(&prefix))
+                    .collect()
+            };
+
+            Ok(ListResult {
+                keys: filtered,
+                is_truncated: false,
+                next_continuation_token: None,
+            })
+        }
+        .await;
+
+        self.return_session(&subject, session);
+        result.map_err(|e| e.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IndexedDb;
+    use dialog_capability::Subject;
+    use dialog_effects::storage::{Get, List, Set, Storage, Store};
+
+    use dialog_capability::{Capability, Did};
+
+    fn unique_subject(prefix: &str) -> Subject {
+        let did_str = format!(
+            "did:test:idb-storage-{}-{}",
+            prefix,
+            js_sys::Date::now() as u64
+        );
+        let did: Did = did_str.parse().unwrap();
+        Subject::from(did)
+    }
+
+    fn store_cap(subject: Subject, store_name: &str) -> Capability<Store> {
+        subject.attenuate(Storage).attenuate(Store::new(store_name))
+    }
+
+    #[dialog_common::test]
+    async fn set_and_get_roundtrip() {
+        let provider = IndexedDb::new();
+        let subject = unique_subject("set-get");
+
+        store_cap(subject.clone(), "data")
+            .invoke(Set::new(b"hello".to_vec(), b"world".to_vec()))
+            .perform(&provider)
+            .await
+            .unwrap();
+
+        let result = store_cap(subject, "data")
+            .invoke(Get::new(b"hello"))
+            .perform(&provider)
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(b"world".to_vec()));
+    }
+
+    #[dialog_common::test]
+    async fn get_missing_returns_none() {
+        let provider = IndexedDb::new();
+        let subject = unique_subject("get-none");
+
+        let result = store_cap(subject, "data")
+            .invoke(Get::new(b"missing"))
+            .perform(&provider)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[dialog_common::test]
+    async fn keys_with_slashes_roundtrip() {
+        let provider = IndexedDb::new();
+        let subject = unique_subject("slash-keys");
+
+        let key = b"a/b/c";
+        store_cap(subject.clone(), "data")
+            .invoke(Set::new(key.to_vec(), b"nested".to_vec()))
+            .perform(&provider)
+            .await
+            .unwrap();
+
+        let result = store_cap(subject, "data")
+            .invoke(Get::new(key.to_vec()))
+            .perform(&provider)
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(b"nested".to_vec()));
+    }
+
+    #[dialog_common::test]
+    async fn list_returns_all_keys() {
+        let provider = IndexedDb::new();
+        let subject = unique_subject("list-all");
+
+        let key1 = "aud1/sub1/iss1.cid1";
+        let key2 = "aud1/_/iss2.cid2";
+        let key3 = "aud2/sub2/iss3.cid3";
+
+        for (k, v) in [(key1, "d1"), (key2, "d2"), (key3, "d3")] {
+            store_cap(subject.clone(), "ucan")
+                .invoke(Set::new(k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                .perform(&provider)
+                .await
+                .unwrap();
+        }
+
+        let result = store_cap(subject, "ucan")
+            .invoke(List::new(None))
+            .perform(&provider)
+            .await
+            .unwrap();
+
+        assert_eq!(result.keys.len(), 3);
+        assert!(result.keys.contains(&key1.to_string()));
+        assert!(result.keys.contains(&key2.to_string()));
+        assert!(result.keys.contains(&key3.to_string()));
+    }
+
+    #[dialog_common::test]
+    async fn list_with_prefix_filters() {
+        let provider = IndexedDb::new();
+        let subject = unique_subject("list-prefix");
+
+        let key1 = "aud1/sub1/iss1.cid1";
+        let key2 = "aud1/_/iss2.cid2";
+        let key3 = "aud2/sub2/iss3.cid3";
+
+        for (k, v) in [(key1, "d1"), (key2, "d2"), (key3, "d3")] {
+            store_cap(subject.clone(), "ucan")
+                .invoke(Set::new(k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                .perform(&provider)
+                .await
+                .unwrap();
+        }
+
+        let result = store_cap(subject, "ucan")
+            .invoke(List::with_prefix("aud1/"))
+            .perform(&provider)
+            .await
+            .unwrap();
+
+        assert_eq!(result.keys.len(), 2);
+        assert!(result.keys.contains(&key1.to_string()));
+        assert!(result.keys.contains(&key2.to_string()));
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/store.rs
+++ b/rust/dialog-storage/src/storage/provider/store.rs
@@ -1,0 +1,158 @@
+//! Unified storage types — platform-agnostic `Store` and `Address` enums.
+
+use serde::{Deserialize, Serialize};
+
+use crate::provider::{Volatile, volatile};
+use dialog_effects::{archive, memory, storage};
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::provider::{FileStore, fs};
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use crate::provider::{IndexedDb, indexeddb};
+
+/// Address for a storage location.
+///
+/// Tags provider-specific addresses under a single enum so that
+/// capabilities can carry routing info without knowing the concrete provider.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Address {
+    /// Filesystem address (native only).
+    #[cfg(not(target_arch = "wasm32"))]
+    FileSystem(fs::Address),
+
+    /// IndexedDB address (web only).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    IndexedDb(indexeddb::Address),
+
+    /// Volatile (in-memory) address.
+    Volatile(volatile::Address),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<fs::Address> for Address {
+    fn from(addr: fs::Address) -> Self {
+        Self::FileSystem(addr)
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<indexeddb::Address> for Address {
+    fn from(addr: indexeddb::Address) -> Self {
+        Self::IndexedDb(addr)
+    }
+}
+
+impl From<volatile::Address> for Address {
+    fn from(addr: volatile::Address) -> Self {
+        Self::Volatile(addr)
+    }
+}
+
+impl Address {
+    /// Resolve a sub-path under this address.
+    ///
+    /// Returns an error if the segment would escape the base address.
+    pub fn resolve(&self, segment: &str) -> Result<Self, StorageError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::FileSystem(addr) => addr
+                .resolve(segment)
+                .map(Self::FileSystem)
+                .map_err(|e| StorageError::Storage(e.to_string())),
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Self::IndexedDb(addr) => Ok(Self::IndexedDb(addr.resolve(segment))),
+            Self::Volatile(addr) => Ok(Self::Volatile(addr.resolve(segment))),
+        }
+    }
+
+    /// Profile storage address with the given name.
+    ///
+    /// Uses the platform default: FileSystem on native, IndexedDb on web.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn profile(name: &str) -> Self {
+        Self::FileSystem(fs::Address::profile().resolve(name).expect("valid name"))
+    }
+
+    /// Profile storage address with the given name (web).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub fn profile(name: &str) -> Self {
+        Self::IndexedDb(indexeddb::Address::new(format!("profile/{name}")))
+    }
+
+    /// Current/working directory storage address with the given name.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn current(name: &str) -> Self {
+        Self::FileSystem(fs::Address::current().resolve(name).expect("valid name"))
+    }
+
+    /// Current storage address with the given name (web).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub fn current(name: &str) -> Self {
+        Self::IndexedDb(indexeddb::Address::new(format!("storage/{name}")))
+    }
+
+    /// Temporary storage address with the given name.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn temp(name: &str) -> Self {
+        Self::FileSystem(fs::Address::temp().resolve(name).expect("valid name"))
+    }
+
+    /// Temporary storage address with the given name (web).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub fn temp(name: &str) -> Self {
+        Self::IndexedDb(indexeddb::Address::new(format!("temp/{name}")))
+    }
+}
+
+/// A concrete storage backend.
+///
+/// Platform-gated enum that dispatches `Provider` impls to the active variant.
+/// Use `#[derive(Provider)]` with `#[provide(...)]` to generate the dispatch.
+#[derive(Clone, Debug, dialog_capability::Provider)]
+#[provide(
+    archive::Get,
+    archive::Put,
+    memory::Resolve,
+    memory::Publish,
+    memory::Retract,
+    storage::Get,
+    storage::Set,
+    storage::Delete,
+    storage::List
+)]
+pub enum Store {
+    /// Filesystem-backed store (native only).
+    #[cfg(not(target_arch = "wasm32"))]
+    FileSystem(FileStore),
+
+    /// IndexedDB-backed store (web only).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    IndexedDb(IndexedDb),
+
+    /// In-memory volatile store.
+    Volatile(Volatile),
+}
+
+use dialog_capability::storage::StorageError;
+
+impl Store {
+    /// Create a Store from an Address.
+    ///
+    /// Matches the address variant and creates the corresponding store.
+    pub fn mount(address: &Address) -> Result<Self, StorageError> {
+        match address {
+            #[cfg(not(target_arch = "wasm32"))]
+            Address::FileSystem(addr) => {
+                let store = crate::provider::FileSystem::mount(addr)
+                    .map_err(|e| StorageError::Storage(e.to_string()))?;
+                Ok(Self::FileSystem(store))
+            }
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Address::IndexedDb(addr) => {
+                Ok(Self::IndexedDb(crate::provider::IndexedDb::mount(addr)))
+            }
+            Address::Volatile(addr) => Ok(Self::Volatile(Volatile::mount(addr))),
+        }
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -35,6 +35,8 @@
 
 mod archive;
 mod memory;
+mod resource;
+mod storage;
 
 use dialog_capability::Did;
 use parking_lot::RwLock;
@@ -46,6 +48,9 @@ type ArchiveKey = (String, String);
 /// Memory key: (space, cell)
 type MemoryKey = (String, String);
 
+/// Storage key: (store, key_bytes)
+type StorageKey = (String, Vec<u8>);
+
 /// A session holds the in-memory storage for a single subject.
 #[derive(Default, Debug)]
 struct Session {
@@ -53,6 +58,10 @@ struct Session {
     archive: HashMap<ArchiveKey, Vec<u8>>,
     /// Transactional memory storage keyed by (space, cell).
     memory: HashMap<MemoryKey, Vec<u8>>,
+    /// Mounted byte storage keyed by address prefix.
+    mounted: HashMap<String, Vec<u8>>,
+    /// Key-value storage keyed by (store, key).
+    storage: HashMap<StorageKey, Vec<u8>>,
 }
 
 /// Volatile in-memory storage provider.
@@ -60,19 +69,84 @@ struct Session {
 /// A simple provider that stores all data in memory. Each subject DID gets its
 /// own session with separate archive and memory storage. Data is not persisted.
 ///
+use serde::{Deserialize, Serialize};
+
+/// Address for volatile (in-memory) storage.
+///
+/// A string prefix that scopes storage operations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct Address(String);
+
+impl Address {
+    /// Create an address with the given prefix.
+    pub fn new(prefix: impl Into<String>) -> Self {
+        Self(prefix.into())
+    }
+
+    /// Profile storage address with the given name.
+    pub fn profile(name: &str) -> Self {
+        Self(format!("profile/{name}"))
+    }
+
+    /// Current/working storage address with the given name.
+    pub fn current(name: &str) -> Self {
+        Self(format!("storage/{name}"))
+    }
+
+    /// Temporary storage address with the given name.
+    pub fn temp(name: &str) -> Self {
+        Self(format!("temp/{name}"))
+    }
+
+    /// The prefix string.
+    pub fn prefix(&self) -> &str {
+        &self.0
+    }
+
+    /// Resolve a sub-path under this address.
+    pub fn resolve(&self, segment: &str) -> Self {
+        if self.0.is_empty() {
+            Self(segment.to_string())
+        } else {
+            Self(format!("{}/{}", self.0, segment))
+        }
+    }
+}
+
 /// Uses `parking_lot::RwLock` for interior mutability so that
 /// `Provider::execute` can take `&self`. All lock guards are dropped before
 /// any `.await` points. Unlike `std::sync::RwLock`, `parking_lot` locks are
 /// infallible (no poisoning).
-#[derive(Default, Debug)]
+#[derive(Debug, Clone)]
 pub struct Volatile {
-    sessions: RwLock<HashMap<Did, Session>>,
+    /// Mount prefix prepended to session keys.
+    mount: String,
+    /// Shared session storage.
+    sessions: std::sync::Arc<RwLock<HashMap<Did, Session>>>,
+}
+
+impl Default for Volatile {
+    fn default() -> Self {
+        Self {
+            mount: String::new(),
+            sessions: std::sync::Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
 }
 
 impl Volatile {
     /// Creates a new volatile provider.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a volatile store mounted at the given address.
+    pub fn mount(address: &Address) -> Self {
+        Self {
+            mount: address.prefix().to_string(),
+            sessions: std::sync::Arc::new(RwLock::new(HashMap::new())),
+        }
     }
 }
 

--- a/rust/dialog-storage/src/storage/provider/volatile/resource.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/resource.rs
@@ -1,0 +1,55 @@
+//! Load and Save providers for Volatile.
+
+use super::{Address, Volatile};
+use async_trait::async_trait;
+use dialog_capability::storage::{self, Location, StorageError};
+use dialog_capability::{Capability, Policy, Provider};
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<storage::Load<Vec<u8>, Address>> for Volatile {
+    async fn execute(
+        &self,
+        input: Capability<storage::Load<Vec<u8>, Address>>,
+    ) -> Result<Vec<u8>, StorageError> {
+        let subject = input.subject().clone();
+        let prefix = Location::of(&input).address().prefix().to_owned();
+        let key = if self.mount.is_empty() {
+            prefix
+        } else {
+            format!("{}/{}", self.mount, prefix)
+        };
+
+        let sessions = self.sessions.read();
+        sessions
+            .get(&subject)
+            .and_then(|session| session.mounted.get(&key))
+            .cloned()
+            .ok_or_else(|| StorageError::Storage(format!("not found: {}", key)))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<storage::Save<Vec<u8>, Address>> for Volatile {
+    async fn execute(
+        &self,
+        input: Capability<storage::Save<Vec<u8>, Address>>,
+    ) -> Result<(), StorageError> {
+        let subject = input.subject().clone();
+        let prefix = Location::of(&input).address().prefix().to_owned();
+        let bytes = storage::Save::<Vec<u8>, Address>::of(&input)
+            .content
+            .clone();
+        let key = if self.mount.is_empty() {
+            prefix
+        } else {
+            format!("{}/{}", self.mount, prefix)
+        };
+
+        let mut sessions = self.sessions.write();
+        let session = sessions.entry(subject).or_default();
+        session.mounted.insert(key, bytes);
+        Ok(())
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/volatile/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/storage.rs
@@ -1,0 +1,237 @@
+//! Storage capability provider for volatile storage.
+//!
+//! Implements key-value storage effects by storing data in the session's
+//! storage HashMap, keyed by (store_name, key_bytes).
+
+use super::{StorageKey, Volatile};
+use async_trait::async_trait;
+use dialog_capability::{Capability, Provider};
+use dialog_effects::storage::{Delete, Get, List, ListResult, Set, StorageError};
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Get> for Volatile {
+    async fn execute(&self, effect: Capability<Get>) -> Result<Option<Vec<u8>>, StorageError> {
+        let subject = effect.subject().clone();
+        let store = effect.store().to_string();
+        let key = effect.key().to_vec();
+
+        let storage_key: StorageKey = (store, key);
+
+        let sessions = self.sessions.read();
+        Ok(sessions
+            .get(&subject)
+            .and_then(|session| session.storage.get(&storage_key).cloned()))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Set> for Volatile {
+    async fn execute(&self, effect: Capability<Set>) -> Result<(), StorageError> {
+        let subject = effect.subject().clone();
+        let store = effect.store().to_string();
+        let key = effect.key().to_vec();
+        let value = effect.value().to_vec();
+
+        let storage_key: StorageKey = (store, key);
+
+        let mut sessions = self.sessions.write();
+        let session = sessions.entry(subject).or_default();
+        session.storage.insert(storage_key, value);
+
+        Ok(())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Delete> for Volatile {
+    async fn execute(&self, effect: Capability<Delete>) -> Result<(), StorageError> {
+        let subject = effect.subject().clone();
+        let store = effect.store().to_string();
+        let key = effect.key().to_vec();
+
+        let storage_key: StorageKey = (store, key);
+
+        let mut sessions = self.sessions.write();
+        if let Some(session) = sessions.get_mut(&subject) {
+            session.storage.remove(&storage_key);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<List> for Volatile {
+    async fn execute(&self, effect: Capability<List>) -> Result<ListResult, StorageError> {
+        let subject = effect.subject().clone();
+        let store = effect.store().to_string();
+        let prefix = String::from_utf8_lossy(effect.prefix()).into_owned();
+
+        let sessions = self.sessions.read();
+        let keys: Vec<String> = sessions
+            .get(&subject)
+            .map(|session| {
+                session
+                    .storage
+                    .keys()
+                    .filter(|(s, _)| s == &store)
+                    .filter_map(|(_, k)| String::from_utf8(k.clone()).ok())
+                    .filter(|k| k.starts_with(&prefix))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(ListResult {
+            keys,
+            is_truncated: false,
+            next_continuation_token: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_capability::{Did, Subject};
+    use dialog_effects::storage::{Storage, Store};
+
+    fn unique_subject(prefix: &str) -> Subject {
+        let did: Did = format!(
+            "did:test:{}-{}",
+            prefix,
+            dialog_common::time::now()
+                .duration_since(dialog_common::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+        .parse()
+        .unwrap();
+        Subject::from(did)
+    }
+
+    fn store_cap(subject: Subject, store_name: &str) -> Capability<Store> {
+        subject.attenuate(Storage).attenuate(Store::new(store_name))
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_none_for_missing_key() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let subject = unique_subject("storage-get-none");
+
+        let effect = store_cap(subject, "index").invoke(Get::new(b"missing"));
+        let result = effect.perform(&provider).await?;
+        assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_stores_and_retrieves_value() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let subject = unique_subject("storage-set-get");
+
+        store_cap(subject.clone(), "index")
+            .invoke(Set::new(b"key1".to_vec(), b"value1".to_vec()))
+            .perform(&provider)
+            .await?;
+
+        let result = store_cap(subject, "index")
+            .invoke(Get::new(b"key1"))
+            .perform(&provider)
+            .await?;
+        assert_eq!(result, Some(b"value1".to_vec()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_isolates_by_store_name() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let subject = unique_subject("storage-isolation");
+
+        store_cap(subject.clone(), "store-a")
+            .invoke(Set::new(b"key".to_vec(), b"value-a".to_vec()))
+            .perform(&provider)
+            .await?;
+
+        store_cap(subject.clone(), "store-b")
+            .invoke(Set::new(b"key".to_vec(), b"value-b".to_vec()))
+            .perform(&provider)
+            .await?;
+
+        let result_a = store_cap(subject.clone(), "store-a")
+            .invoke(Get::new(b"key"))
+            .perform(&provider)
+            .await?;
+        assert_eq!(result_a, Some(b"value-a".to_vec()));
+
+        let result_b = store_cap(subject, "store-b")
+            .invoke(Get::new(b"key"))
+            .perform(&provider)
+            .await?;
+        assert_eq!(result_b, Some(b"value-b".to_vec()));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_deletes_key() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let subject = unique_subject("storage-delete");
+
+        store_cap(subject.clone(), "index")
+            .invoke(Set::new(b"key".to_vec(), b"value".to_vec()))
+            .perform(&provider)
+            .await?;
+
+        store_cap(subject.clone(), "index")
+            .invoke(Delete::new(b"key"))
+            .perform(&provider)
+            .await?;
+
+        let result = store_cap(subject, "index")
+            .invoke(Get::new(b"key"))
+            .perform(&provider)
+            .await?;
+        assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_lists_keys_in_store() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let subject = unique_subject("storage-list");
+
+        store_cap(subject.clone(), "index")
+            .invoke(Set::new(b"alpha".to_vec(), b"1".to_vec()))
+            .perform(&provider)
+            .await?;
+
+        store_cap(subject.clone(), "index")
+            .invoke(Set::new(b"beta".to_vec(), b"2".to_vec()))
+            .perform(&provider)
+            .await?;
+
+        store_cap(subject.clone(), "other")
+            .invoke(Set::new(b"gamma".to_vec(), b"3".to_vec()))
+            .perform(&provider)
+            .await?;
+
+        let result = store_cap(subject, "index")
+            .invoke(List::new(None))
+            .perform(&provider)
+            .await?;
+
+        assert_eq!(result.keys.len(), 2);
+        assert!(result.keys.contains(&"alpha".to_string()));
+        assert!(result.keys.contains(&"beta".to_string()));
+        assert!(!result.is_truncated);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Location`-based `Load`/`Save`/`Mount` provider impls for fs, indexeddb, volatile
- Add key-value `Get`/`Set`/`Delete`/`List` provider impls for all backends
- Add `FileStore` wrapper and `Location` type with filesystem helpers
- Add `Address` enum and `Store` enum for platform-agnostic routing
- Add `volatile::Address` and `indexeddb::Address` types