### PR TITLE
14 🏗️ feat: add dialog-remote-s3 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,7 +401,11 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -531,6 +544,12 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -1103,6 +1122,46 @@ dependencies = [
  "tokio",
  "tokio-test",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "dialog-remote-s3"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base58",
+ "base64",
+ "bytes",
+ "chrono",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-effects",
+ "dialog-varsig",
+ "futures-util",
+ "getrandom 0.2.16",
+ "hmac 0.12.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "ipld-core",
+ "md5",
+ "quick-xml",
+ "rand 0.8.5",
+ "reqwest",
+ "s3s",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-test",
+ "tower",
+ "tower-http",
+ "url",
  "wasm-bindgen-test",
 ]
 
@@ -1823,6 +1882,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4309,6 +4392,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4319,6 +4437,24 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "rust/dialog-encoding",
     "rust/dialog-prolly-tree",
     "rust/dialog-query",
+    "rust/dialog-remote-s3",
     "rust/dialog-search-tree",
     "rust/dialog-storage",
     "rust/dialog-ucan",
@@ -183,6 +184,9 @@ path = "./rust/dialog-macros"
 
 [workspace.dependencies.dialog-query]
 path = "./rust/dialog-query"
+
+[workspace.dependencies.dialog-remote-s3]
+path = "./rust/dialog-remote-s3"
 
 [workspace.dependencies.dialog-blobs]
 path = "./rust/dialog-blobs"

--- a/rust/dialog-remote-s3/Cargo.toml
+++ b/rust/dialog-remote-s3/Cargo.toml
@@ -1,0 +1,87 @@
+[package]
+name = "dialog-remote-s3"
+description = "S3-compatible remote storage backend for dialog-db"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[features]
+default = []
+helpers = [
+  "dep:tempfile",
+  "dep:anyhow",
+  "dep:rand",
+  "dep:futures-util",
+  "dialog-common/helpers",
+  "dep:s3s",
+  "dep:hyper",
+  "dep:hyper-util",
+  "dep:http-body-util",
+  "dep:bytes",
+  "dep:tokio-test",
+  "dep:tower",
+  "dep:tower-http",
+  "dep:tokio",
+]
+list = ["dep:quick-xml"]
+s3-integration-tests = ["list", "helpers"]
+integration-tests = ["list", "helpers", "dialog-common/integration-tests"]
+web-integration-tests = ["dialog-common/web-integration-tests"]
+
+[dependencies]
+async-trait = { workspace = true }
+base58 = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true }
+dialog-effects = { workspace = true }
+dialog-varsig = { workspace = true }
+hmac = { workspace = true }
+md5 = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+futures-util = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
+quick-xml = { workspace = true, features = ["serde", "serialize"], optional = true }
+rand = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tempfile = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync", "fs", "macros", "rt", "net"], optional = true }
+s3s = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true }
+hyper-util = { workspace = true, features = ["server", "tokio", "service"], optional = true }
+http-body-util = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
+tokio-test = { workspace = true, optional = true }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["cors"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+dialog-common = { workspace = true, features = ["helpers"] }
+ipld-core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
+wasm-bindgen-test = { workspace = true }
+
+[[test]]
+name = "integration_tests"
+path = "tests/integration_tests/main.rs"
+required-features = ["s3-integration-tests"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(feature, values(\"s3-integration-tests\", \"web-integration-tests\", \"helpers\"))",
+  "cfg(dialog_test_wasm_integration)",
+] }

--- a/rust/dialog-remote-s3/src/address.rs
+++ b/rust/dialog-remote-s3/src/address.rs
@@ -1,0 +1,278 @@
+//! S3 storage address types.
+//!
+//! This module provides the [`Address`] type for specifying S3-compatible storage locations.
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::AccessError;
+use crate::capability::Access;
+use crate::permit::Permit;
+use crate::s3::S3Credentials;
+
+/// Address for S3-compatible storage.
+///
+/// Combines endpoint, region, bucket, and path-style configuration into a
+/// type that can build URLs and authorize S3 requests.
+///
+/// # Examples
+///
+/// ```
+/// use dialog_remote_s3::Address;
+///
+/// // AWS S3
+/// let addr = Address::new(
+///     "https://s3.us-east-1.amazonaws.com",
+///     "us-east-1",
+///     "my-bucket",
+/// );
+///
+/// // Cloudflare R2
+/// let addr = Address::new(
+///     "https://account-id.r2.cloudflarestorage.com",
+///     "auto",
+///     "my-bucket",
+/// );
+///
+/// // MinIO (local development) — auto-detects path-style
+/// let addr = Address::new(
+///     "http://localhost:9000",
+///     "us-east-1",
+///     "my-bucket",
+/// );
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Address {
+    /// The S3-compatible endpoint URL (e.g., "https://s3.us-east-1.amazonaws.com")
+    endpoint: String,
+    /// AWS region for signing (e.g., "us-east-1", "auto" for R2)
+    region: String,
+    /// Bucket name
+    bucket: String,
+    /// Whether to use path-style URLs (auto-detected from endpoint)
+    #[serde(default)]
+    path_style: bool,
+    /// Optional S3 credentials for authenticated access.
+    /// `None` means public/unsigned access.
+    #[serde(default)]
+    credentials: Option<S3Credentials>,
+}
+
+impl Address {
+    /// Create a new address with the given endpoint, region, and bucket.
+    ///
+    /// Path-style is auto-detected: `true` for localhost/IP addresses,
+    /// `false` for domain names (virtual-hosted style).
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - The S3-compatible endpoint URL
+    /// * `region` - AWS region for signing (use "auto" for R2, "us-east-1" as default)
+    /// * `bucket` - The bucket name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dialog_remote_s3::Address;
+    ///
+    /// // AWS S3 (virtual-hosted style)
+    /// let addr = Address::new(
+    ///     "https://s3.us-east-1.amazonaws.com",
+    ///     "us-east-1",
+    ///     "my-bucket",
+    /// );
+    /// assert!(!addr.path_style());
+    ///
+    /// // localhost (path-style auto-detected)
+    /// let addr = Address::new("http://localhost:9000", "us-east-1", "my-bucket");
+    /// assert!(addr.path_style());
+    /// ```
+    pub fn new(
+        endpoint: impl Into<String>,
+        region: impl Into<String>,
+        bucket: impl Into<String>,
+    ) -> Self {
+        let endpoint = endpoint.into();
+        let path_style = Url::parse(&endpoint)
+            .map(|url| crate::s3::is_path_style_default(&url))
+            .unwrap_or(false);
+
+        Self {
+            endpoint,
+            region: region.into(),
+            bucket: bucket.into(),
+            path_style,
+            credentials: None,
+        }
+    }
+
+    /// Enable path-style URL addressing (e.g. `endpoint/bucket/key`
+    /// instead of `bucket.endpoint/key`).
+    pub fn with_path_style(mut self) -> Self {
+        self.path_style = true;
+        self
+    }
+
+    /// Get the endpoint URL string.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Get the region.
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    /// Get the bucket name.
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// Whether path-style URLs are used.
+    pub fn path_style(&self) -> bool {
+        self.path_style
+    }
+
+    /// Attach S3 credentials for authenticated access.
+    pub fn with_credentials(mut self, credentials: S3Credentials) -> Self {
+        self.credentials = Some(credentials);
+        self
+    }
+
+    /// Get the optional credentials.
+    pub fn credentials(&self) -> Option<&S3Credentials> {
+        self.credentials.as_ref()
+    }
+
+    /// Build a URL for the given key path.
+    pub fn build_url(&self, path: &str) -> Result<Url, AccessError> {
+        let endpoint =
+            Url::parse(&self.endpoint).map_err(|e| AccessError::Configuration(e.to_string()))?;
+        crate::s3::build_url(&endpoint, &self.bucket, path, self.path_style)
+    }
+
+    /// Authorize a request using the address's credentials.
+    ///
+    /// - No credentials → public/unsigned access (no SigV4 signing)
+    /// - With credentials → private access with SigV4 signing
+    pub async fn authorize<R: Access>(&self, request: &R) -> Result<Permit, AccessError> {
+        match &self.credentials {
+            None => self.build_unsigned_request(request).await,
+            Some(creds) => creds.grant(request, self).await,
+        }
+    }
+
+    /// Build an unsigned request for public access.
+    async fn build_unsigned_request<R: Access>(&self, request: &R) -> Result<Permit, AccessError> {
+        use crate::capability::Precondition;
+
+        let path = request.path();
+        let mut url = self.build_url(&path)?;
+
+        // Add query parameters if specified
+        if let Some(params) = request.params() {
+            let mut query = url.query_pairs_mut();
+            for (key, value) in params {
+                query.append_pair(&key, &value);
+            }
+        }
+
+        let host = crate::s3::extract_host(&url)?;
+
+        let mut headers = vec![("host".to_string(), host)];
+        if let Some(checksum) = request.checksum() {
+            let header_name = format!("x-amz-checksum-{}", checksum.name());
+            headers.push((header_name, checksum.to_string()));
+        }
+        match request.precondition() {
+            Precondition::IfMatch(etag) => {
+                headers.push(("if-match".to_string(), format!("\"{}\"", etag)));
+            }
+            Precondition::IfNoneMatch => {
+                headers.push(("if-none-match".to_string(), "*".to_string()));
+            }
+            Precondition::None => {}
+        }
+
+        Ok(Permit {
+            url,
+            method: request.method().to_string(),
+            headers,
+        })
+    }
+}
+
+/// `Address` is the canonical address type for the `S3` site.
+impl dialog_capability::site::SiteAddress for Address {
+    type Site = crate::s3::S3;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_creates_s3_address() {
+        let addr = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "my-bucket",
+        );
+
+        assert_eq!(addr.endpoint(), "https://s3.us-east-1.amazonaws.com");
+        assert_eq!(addr.region(), "us-east-1");
+        assert_eq!(addr.bucket(), "my-bucket");
+        assert!(!addr.path_style());
+    }
+
+    #[dialog_common::test]
+    fn it_creates_r2_address() {
+        let addr = Address::new(
+            "https://account-id.r2.cloudflarestorage.com",
+            "auto",
+            "my-bucket",
+        );
+
+        assert_eq!(
+            addr.endpoint(),
+            "https://account-id.r2.cloudflarestorage.com"
+        );
+        assert_eq!(addr.region(), "auto");
+        assert_eq!(addr.bucket(), "my-bucket");
+    }
+
+    #[dialog_common::test]
+    fn it_creates_localhost_address() {
+        let addr = Address::new("http://localhost:9000", "us-east-1", "my-bucket");
+
+        assert_eq!(addr.endpoint(), "http://localhost:9000");
+        assert_eq!(addr.region(), "us-east-1");
+        assert_eq!(addr.bucket(), "my-bucket");
+        assert!(addr.path_style());
+    }
+
+    #[dialog_common::test]
+    fn it_roundtrips_through_serde() {
+        let addr = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "my-bucket",
+        );
+
+        let json = serde_json::to_string(&addr).unwrap();
+        let parsed: Address = serde_json::from_str(&json).unwrap();
+        assert_eq!(addr, parsed);
+    }
+
+    #[dialog_common::test]
+    fn it_supports_with_path_style() {
+        let addr = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "my-bucket",
+        )
+        .with_path_style();
+
+        assert!(addr.path_style());
+    }
+}

--- a/rust/dialog-remote-s3/src/authorized.rs
+++ b/rust/dialog-remote-s3/src/authorized.rs
@@ -1,0 +1,42 @@
+//! Authorized operation ready for HTTP execution.
+//!
+//! [`Authorized<Fx>`] pairs a [`Permit`] (presigned HTTP request) with a
+//! [`Capability<Fx>`] (the typed operation). `Provider<Authorized<Fx>>` impls
+//! on [`Http`](crate::s3::Http) execute the HTTP call and interpret the response.
+//!
+//! Both direct-S3 (`Provider<Fork<S3, Fx>>`) and UCAN (`Provider<Fork<UcanSite, Fx>>`)
+//! paths produce an `Authorized<Fx>` after their respective authorization step,
+//! then delegate to the shared `Http` execution layer.
+
+use crate::permit::Permit;
+use dialog_capability::command::Command;
+use dialog_capability::{Capability, Constraint, Effect};
+
+/// A pre-authorized operation ready for HTTP execution.
+///
+/// Combines a [`Permit`] (the presigned HTTP request) with the
+/// [`Capability<Fx>`] (carrying the typed effect parameters).
+pub struct Authorized<Fx: Effect> {
+    /// The presigned HTTP request (URL + method + headers).
+    pub permit: Permit,
+    /// The capability with effect-specific parameters.
+    pub capability: Capability<Fx>,
+}
+
+impl<Fx: Effect> Authorized<Fx>
+where
+    Fx::Of: Constraint,
+{
+    /// Create a new authorized operation.
+    pub fn new(permit: Permit, capability: Capability<Fx>) -> Self {
+        Self { permit, capability }
+    }
+}
+
+impl<Fx: Effect> Command for Authorized<Fx>
+where
+    Fx::Of: Constraint,
+{
+    type Input = Self;
+    type Output = Fx::Output;
+}

--- a/rust/dialog-remote-s3/src/capability.rs
+++ b/rust/dialog-remote-s3/src/capability.rs
@@ -1,0 +1,143 @@
+//! S3 request translation for capabilities.
+//!
+//! This module provides [`Access`] implementations for capability types
+//! defined in [`dialog_effects`], enabling them to be translated into
+//! presigned S3 URLs.
+//!
+//! Effect types and their claim types from `dialog_effects` are used directly —
+//! this module only provides the S3-specific request translation.
+//!
+//! # Example
+//!
+//! ```
+//! use dialog_capability::{Subject, did};
+//! use dialog_effects::storage::{Storage, Store, Get, Set};
+//!
+//! let subject = did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+//!
+//! // Build a capability to get a value from the "index" store
+//! let get_capability = Subject::from(subject.clone())
+//!     .attenuate(Storage)
+//!     .attenuate(Store::new("index"))
+//!     .invoke(Get::new(b"my-key"));
+//!
+//! // Build a capability to set a value in the "blob" store
+//! let set_capability = Subject::from(subject)
+//!     .attenuate(Storage)
+//!     .attenuate(Store::new("blob"))
+//!     .invoke(Set::new(b"my-key", b"my-value"));
+//! ```
+//!
+//! # Submodules
+//!
+//! - [`storage`]: `Access` impls for storage capabilities
+//! - [`memory`]: `Access` impls for memory capabilities
+//! - [`archive`]: `Access` impls for archive capabilities
+
+use super::checksum::Checksum;
+use chrono::{DateTime, Utc};
+use dialog_common::{ConditionalSend, ConditionalSync};
+
+/// Default URL expiration: 1 hour.
+pub const DEFAULT_EXPIRES: u64 = 3600;
+
+pub mod archive;
+pub mod memory;
+pub mod storage;
+
+/// Precondition for conditional S3 operations (CAS semantics).
+#[derive(Debug, Clone)]
+pub enum Precondition {
+    /// No precondition - unconditional operation.
+    None,
+    /// Update only if current ETag matches (If-Match: <etag>).
+    IfMatch(String),
+    /// Update only if key doesn't exist (If-None-Match: *).
+    IfNoneMatch,
+}
+
+/// This trait can be implemented by effects that that be translated into
+/// S3 requests. Providing convenient way for creating authorizations in
+/// form of presigned URLs + headers.
+///
+pub trait Access: ConditionalSend + ConditionalSync {
+    /// The HTTP method for this request.
+    fn method(&self) -> &'static str;
+
+    /// The URL path for this request.
+    fn path(&self) -> String;
+
+    /// The checksum of the body, if any.
+    fn checksum(&self) -> Option<Checksum> {
+        None
+    }
+
+    /// The service name for signing. Defaults to "s3".
+    fn service(&self) -> &str {
+        "s3"
+    }
+
+    /// URL signature expiration in seconds. Defaults to 24 hours.
+    fn expires(&self) -> u64 {
+        DEFAULT_EXPIRES
+    }
+
+    /// The timestamp for signing. Defaults to current time.
+    fn time(&self) -> DateTime<Utc> {
+        current_time()
+    }
+
+    /// Query parameters for the request.
+    fn params(&self) -> Option<Vec<(String, String)>> {
+        None
+    }
+
+    /// Precondition for conditional operations.
+    fn precondition(&self) -> Precondition {
+        Precondition::None
+    }
+
+    /// The ACL for this request, if any.
+    fn acl(&self) -> Option<Acl> {
+        None
+    }
+}
+
+/// S3 Access Control List (ACL) settings.
+///
+/// These are canned ACLs supported by S3 and S3-compatible services.
+/// See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Acl {
+    /// Owner gets FULL_CONTROL. No one else has access rights.
+    Private,
+    /// Owner gets FULL_CONTROL. The AllUsers group gets READ access.
+    PublicRead,
+    /// Owner gets FULL_CONTROL. The AllUsers group gets READ and WRITE access.
+    PublicReadWrite,
+    /// Owner gets FULL_CONTROL. The AuthenticatedUsers group gets READ access.
+    AuthenticatedRead,
+    /// Object owner gets FULL_CONTROL. Bucket owner gets READ access.
+    BucketOwnerRead,
+    /// Both the object owner and the bucket owner get FULL_CONTROL.
+    BucketOwnerFullControl,
+}
+
+impl Acl {
+    /// Get the S3 ACL header value.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Private => "private",
+            Self::PublicRead => "public-read",
+            Self::PublicReadWrite => "public-read-write",
+            Self::AuthenticatedRead => "authenticated-read",
+            Self::BucketOwnerRead => "bucket-owner-read",
+            Self::BucketOwnerFullControl => "bucket-owner-full-control",
+        }
+    }
+}
+
+/// Get the current time as a UTC datetime.
+pub fn current_time() -> DateTime<Utc> {
+    DateTime::<Utc>::from(dialog_common::time::now())
+}

--- a/rust/dialog-remote-s3/src/capability/archive.rs
+++ b/rust/dialog-remote-s3/src/capability/archive.rs
@@ -1,0 +1,59 @@
+//! Archive S3 request implementations.
+//!
+//! This module provides `Access` implementations for archive
+//! (content-addressed) capabilities, enabling them to be translated into
+//! presigned S3 URLs.
+
+use super::Access;
+use crate::Checksum;
+use base58::ToBase58;
+use dialog_capability::{Capability, Policy};
+use dialog_effects::archive::{Catalog, Get, Put, PutClaim};
+
+impl Access for Capability<Get> {
+    fn method(&self) -> &'static str {
+        "GET"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            Catalog::of(self).catalog,
+            Get::of(self).digest.as_bytes().to_base58()
+        )
+    }
+}
+
+impl Access for Capability<Put> {
+    fn method(&self) -> &'static str {
+        "PUT"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            Catalog::of(self).catalog,
+            Put::of(self).digest.as_bytes().to_base58()
+        )
+    }
+    fn checksum(&self) -> Option<Checksum> {
+        Some(crate::Hasher::Sha256.checksum(&Put::of(self).content))
+    }
+}
+
+impl Access for Capability<PutClaim> {
+    fn method(&self) -> &'static str {
+        "PUT"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            Catalog::of(self).catalog,
+            PutClaim::of(self).digest.as_bytes().to_base58()
+        )
+    }
+    fn checksum(&self) -> Option<Checksum> {
+        Some(PutClaim::of(self).checksum.clone())
+    }
+}

--- a/rust/dialog-remote-s3/src/capability/memory.rs
+++ b/rust/dialog-remote-s3/src/capability/memory.rs
@@ -1,0 +1,103 @@
+//! Memory S3 request implementations.
+//!
+//! This module provides `Access` implementations for memory (CAS cell)
+//! capabilities, enabling them to be translated into presigned S3 URLs.
+
+use super::{Access, Precondition};
+use crate::Checksum;
+use dialog_capability::{Capability, Policy};
+use dialog_effects::memory::{self, Cell, Space};
+
+impl Access for Capability<memory::Resolve> {
+    fn method(&self) -> &'static str {
+        "GET"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            &Space::of(self).space,
+            &Cell::of(self).cell
+        )
+    }
+}
+
+impl Access for Capability<memory::Publish> {
+    fn method(&self) -> &'static str {
+        "PUT"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            &Space::of(self).space,
+            &Cell::of(self).cell
+        )
+    }
+    fn checksum(&self) -> Option<Checksum> {
+        Some(crate::Hasher::Sha256.checksum(&memory::Publish::of(self).content))
+    }
+    fn precondition(&self) -> Precondition {
+        match &memory::Publish::of(self).when {
+            Some(edition) => Precondition::IfMatch(String::from_utf8_lossy(edition).to_string()),
+            None => Precondition::IfNoneMatch,
+        }
+    }
+}
+
+impl Access for Capability<memory::PublishClaim> {
+    fn method(&self) -> &'static str {
+        "PUT"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            &Space::of(self).space,
+            &Cell::of(self).cell
+        )
+    }
+    fn checksum(&self) -> Option<Checksum> {
+        Some(memory::PublishClaim::of(self).checksum.clone())
+    }
+    fn precondition(&self) -> Precondition {
+        match &memory::PublishClaim::of(self).when {
+            Some(edition) => Precondition::IfMatch(edition.0.clone()),
+            None => Precondition::IfNoneMatch,
+        }
+    }
+}
+
+impl Access for Capability<memory::Retract> {
+    fn method(&self) -> &'static str {
+        "DELETE"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            &Space::of(self).space,
+            &Cell::of(self).cell
+        )
+    }
+    fn precondition(&self) -> Precondition {
+        Precondition::IfMatch(String::from_utf8_lossy(&memory::Retract::of(self).when).to_string())
+    }
+}
+
+impl Access for Capability<memory::RetractClaim> {
+    fn method(&self) -> &'static str {
+        "DELETE"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            &Space::of(self).space,
+            &Cell::of(self).cell
+        )
+    }
+    fn precondition(&self) -> Precondition {
+        Precondition::IfMatch(memory::RetractClaim::of(self).when.0.clone())
+    }
+}

--- a/rust/dialog-remote-s3/src/capability/storage.rs
+++ b/rust/dialog-remote-s3/src/capability/storage.rs
@@ -1,0 +1,96 @@
+//! Storage S3 request implementations.
+//!
+//! This module provides `Access` implementations for storage capabilities,
+//! enabling them to be translated into presigned S3 URLs.
+
+use super::Access;
+use crate::Checksum;
+use base58::ToBase58;
+use dialog_capability::{Capability, Policy};
+use dialog_effects::storage::{self, Store};
+
+impl Access for Capability<storage::Get> {
+    fn method(&self) -> &'static str {
+        "GET"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            Store::of(self).store,
+            storage::Get::of(self).key.to_base58()
+        )
+    }
+}
+
+impl Access for Capability<storage::Set> {
+    fn method(&self) -> &'static str {
+        "PUT"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            Store::of(self).store,
+            storage::Set::of(self).key.to_base58()
+        )
+    }
+    fn checksum(&self) -> Option<Checksum> {
+        Some(crate::Hasher::Sha256.checksum(&storage::Set::of(self).value))
+    }
+}
+
+impl Access for Capability<storage::SetClaim> {
+    fn method(&self) -> &'static str {
+        "PUT"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            Store::of(self).store,
+            storage::SetClaim::of(self).key.to_base58()
+        )
+    }
+    fn checksum(&self) -> Option<Checksum> {
+        Some(storage::SetClaim::of(self).checksum.clone())
+    }
+}
+
+impl Access for Capability<storage::Delete> {
+    fn method(&self) -> &'static str {
+        "DELETE"
+    }
+    fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.subject(),
+            Store::of(self).store,
+            storage::Delete::of(self).key.to_base58()
+        )
+    }
+}
+
+impl Access for Capability<storage::List> {
+    fn method(&self) -> &'static str {
+        "GET"
+    }
+    fn path(&self) -> String {
+        String::new()
+    }
+    fn params(&self) -> Option<Vec<(String, String)>> {
+        let mut params = vec![
+            ("list-type".to_owned(), "2".to_owned()),
+            (
+                "prefix".to_owned(),
+                format!("{}/{}", self.subject(), &Store::of(self).store),
+            ),
+        ];
+
+        if let Some(token) = &storage::List::of(self).continuation_token {
+            params.push(("continuation-token".to_owned(), token.clone()));
+        }
+
+        Some(params)
+    }
+}

--- a/rust/dialog-remote-s3/src/checksum.rs
+++ b/rust/dialog-remote-s3/src/checksum.rs
@@ -1,0 +1,2 @@
+//! Re-exports checksum types from `dialog_common`.
+pub use dialog_common::{Checksum, Hasher};

--- a/rust/dialog-remote-s3/src/error.rs
+++ b/rust/dialog-remote-s3/src/error.rs
@@ -1,0 +1,23 @@
+//! Error types for S3 access operations.
+
+use thiserror::Error;
+
+/// Error type for authorization operations.
+#[derive(Debug, Error)]
+pub enum AccessError {
+    /// No delegation found for the subject.
+    #[error("No delegation for subject: {0}")]
+    NoDelegation(String),
+
+    /// Failed to build the invocation.
+    #[error("Invocation error: {0}")]
+    Invocation(String),
+
+    /// Access service returned an error.
+    #[error("Access service error: {0}")]
+    Service(String),
+
+    /// Invalid configuration.
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+}

--- a/rust/dialog-remote-s3/src/helpers.rs
+++ b/rust/dialog-remote-s3/src/helpers.rs
@@ -1,0 +1,174 @@
+//! S3-compatible test server for integration testing.
+//!
+//! This module provides address types and a simple in-memory S3-compatible server
+//! for testing S3 storage backend functionality.
+//!
+//! The module is split into:
+//! - Address types (available on all platforms for deserialization in WASM tests)
+//! - Server implementation (native-only, in the `server` submodule)
+//! - Test operator types for capability-based testing
+use dialog_capability::{Capability, Did, Principal, Provider, authority};
+
+use serde::{Deserialize, Serialize};
+
+/// S3 test server connection info with credentials, passed to inner tests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S3Address {
+    /// The endpoint URL of the running S3 server
+    pub endpoint: String,
+    /// The bucket name to use for testing
+    pub bucket: String,
+    /// AWS access key ID
+    pub access_key_id: String,
+    /// AWS secret access key
+    pub secret_access_key: String,
+}
+
+/// Public S3 test server connection info (no authentication).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublicS3Address {
+    /// The endpoint URL of the running S3 server
+    pub endpoint: String,
+    /// The bucket name to use for testing
+    pub bucket: String,
+}
+
+/// A simple test session that implements [`Principal`] and credential effects.
+///
+/// This is useful for testing capability-based operations where an operator
+/// is required but actual cryptographic signing is not needed (S3 uses its
+/// own SigV4 signing).
+///
+/// # Example
+///
+/// ```no_run
+/// use dialog_remote_s3::helpers::Session;
+///
+/// let session = Session::new("did:key:zTestIssuer".parse::<dialog_capability::Did>().unwrap());
+/// ```
+#[derive(Debug, Clone)]
+pub struct Session {
+    did: Did,
+}
+
+impl Session {
+    /// Create a new test session with the given DID.
+    pub fn new(did: impl Into<Did>) -> Self {
+        Self { did: did.into() }
+    }
+}
+
+impl Principal for Session {
+    fn did(&self) -> Did {
+        self.did.clone()
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<authority::Identify> for Session {
+    async fn execute(
+        &self,
+        _input: Capability<authority::Identify>,
+    ) -> Result<authority::Authority, authority::AuthorityError> {
+        Err(authority::AuthorityError::Identity(
+            "Session does not provide identity".into(),
+        ))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<authority::Sign> for Session {
+    async fn execute(
+        &self,
+        _input: Capability<authority::Sign>,
+    ) -> Result<Vec<u8>, authority::AuthorityError> {
+        Err(authority::AuthorityError::SigningFailed(
+            "Session does not provide signing".into(),
+        ))
+    }
+}
+
+use dialog_capability::storage;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<storage::Get> for Session {
+    async fn execute(
+        &self,
+        _input: Capability<storage::Get>,
+    ) -> Result<Option<Vec<u8>>, storage::StorageError> {
+        Err(storage::StorageError::Storage(
+            "Session does not provide storage".into(),
+        ))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<storage::List> for Session {
+    async fn execute(
+        &self,
+        _input: Capability<storage::List>,
+    ) -> Result<storage::ListResult, storage::StorageError> {
+        Err(storage::StorageError::Storage(
+            "Session does not provide storage".into(),
+        ))
+    }
+}
+
+/// Helper macro to implement Provider<Fork<S3, Fx>> for Session by delegating to S3.
+macro_rules! impl_fork_provider {
+    ($fx:ty, $output:ty) => {
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        impl Provider<dialog_capability::fork::Fork<crate::s3::S3, $fx>> for Session {
+            async fn execute(
+                &self,
+                invocation: dialog_capability::fork::ForkInvocation<crate::s3::S3, $fx>,
+            ) -> $output {
+                let s3 = crate::s3::S3;
+                <crate::s3::S3 as Provider<dialog_capability::fork::Fork<crate::s3::S3, $fx>>>::execute(&s3, invocation).await
+            }
+        }
+    };
+}
+
+impl_fork_provider!(
+    dialog_effects::storage::Get,
+    Result<Option<Vec<u8>>, dialog_effects::storage::StorageError>
+);
+impl_fork_provider!(
+    dialog_effects::storage::Set,
+    Result<(), dialog_effects::storage::StorageError>
+);
+impl_fork_provider!(
+    dialog_effects::storage::Delete,
+    Result<(), dialog_effects::storage::StorageError>
+);
+impl_fork_provider!(
+    dialog_effects::memory::Resolve,
+    Result<Option<dialog_effects::memory::Publication>, dialog_effects::memory::MemoryError>
+);
+impl_fork_provider!(
+    dialog_effects::memory::Publish,
+    Result<Vec<u8>, dialog_effects::memory::MemoryError>
+);
+impl_fork_provider!(
+    dialog_effects::memory::Retract,
+    Result<(), dialog_effects::memory::MemoryError>
+);
+impl_fork_provider!(
+    dialog_effects::archive::Get,
+    Result<Option<Vec<u8>>, dialog_effects::archive::ArchiveError>
+);
+impl_fork_provider!(
+    dialog_effects::archive::Put,
+    Result<(), dialog_effects::archive::ArchiveError>
+);
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod server;
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;

--- a/rust/dialog-remote-s3/src/helpers/server.rs
+++ b/rust/dialog-remote-s3/src/helpers/server.rs
@@ -1,0 +1,410 @@
+//! In-memory S3-compatible test server (native-only).
+//!
+//! This module provides a local S3-compatible server for integration testing.
+//! It includes CORS support for browser-based testing via web-integration-tests.
+use super::{PublicS3Address, S3Address};
+use async_trait::async_trait;
+use bytes::Bytes;
+use dialog_common::helpers::{Provider, Service};
+use hyper::Response;
+use hyper::server::conn::http1;
+use hyper_util::rt::TokioIo;
+use hyper_util::service::TowerToHyperService;
+use s3s::dto::{
+    DeleteObjectInput, DeleteObjectOutput, ETag, GetObjectInput, GetObjectOutput, HeadObjectInput,
+    HeadObjectOutput, ListObjectsV2Input, ListObjectsV2Output, Object, PutObjectInput,
+    PutObjectOutput, StreamingBlob, Timestamp,
+};
+use s3s::service::S3ServiceBuilder;
+use s3s::{S3, S3Request, S3Response, S3Result, s3_error};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+use tower::ServiceBuilder;
+use tower_http::cors::CorsLayer;
+
+/// Simple in-memory backend for testing.
+///
+/// Structure: bucket_name -> key -> StoredObject
+#[derive(Clone, Default)]
+pub struct InMemoryS3 {
+    buckets: Arc<RwLock<HashMap<String, HashMap<String, StoredObject>>>>,
+}
+
+/// A running S3 test server instance.
+pub struct LocalS3 {
+    /// The endpoint URL where the server is listening
+    pub endpoint: String,
+    shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+impl LocalS3 {
+    /// Start a local S3-compatible test server with pre-created buckets.
+    ///
+    /// Returns a handle that can be used to get the endpoint URL and stop the server.
+    pub async fn start(buckets: &[&str]) -> anyhow::Result<Self> {
+        Self::start_internal(None, buckets).await
+    }
+
+    /// Start a test server with authentication and pre-created buckets.
+    pub async fn start_with_auth(
+        access_key: &str,
+        secret_key: &str,
+        buckets: &[&str],
+    ) -> anyhow::Result<LocalS3> {
+        let auth = s3s::auth::SimpleAuth::from_single(access_key, secret_key);
+        Self::start_internal(Some(auth), buckets).await
+    }
+
+    async fn start_internal(
+        auth: Option<s3s::auth::SimpleAuth>,
+        buckets: &[&str],
+    ) -> anyhow::Result<LocalS3> {
+        let storage = InMemoryS3::default();
+
+        // Pre-create buckets
+        for bucket in buckets {
+            storage.create_bucket(bucket).await;
+        }
+
+        let mut builder = S3ServiceBuilder::new(storage.clone());
+        if let Some(auth) = auth {
+            builder.set_auth(auth);
+        }
+        let s3_service = builder.build();
+
+        let service = ServiceBuilder::new()
+            .layer(CorsLayer::very_permissive().expose_headers([
+                hyper::header::ETAG,
+                hyper::header::CONTENT_LENGTH,
+                hyper::header::CONTENT_TYPE,
+                hyper::header::HeaderName::from_static("x-amz-checksum-sha256"),
+                hyper::header::HeaderName::from_static("x-amz-request-id"),
+            ]))
+            .map_response(|mut response: Response<s3s::Body>| {
+                response
+                    .headers_mut()
+                    .insert(hyper::header::CACHE_CONTROL, "no-store".parse().unwrap());
+                response
+            })
+            .service(s3_service);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}", addr);
+
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    result = listener.accept() => {
+                        if let Ok((stream, _)) = result {
+                            let hyper_service = TowerToHyperService::new(service.clone());
+                            tokio::spawn(async move {
+                                let _ = http1::Builder::new()
+                                    .serve_connection(TokioIo::new(stream), hyper_service)
+                                    .await;
+                            });
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(LocalS3 {
+            endpoint,
+            shutdown_tx,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct StoredObject {
+    data: Vec<u8>,
+    content_type: Option<String>,
+    e_tag: String,
+    last_modified: Timestamp,
+}
+
+impl InMemoryS3 {
+    /// Create a bucket if it doesn't exist.
+    pub async fn create_bucket(&self, bucket: &str) {
+        let mut buckets = self.buckets.write().await;
+        if !buckets.contains_key(bucket) {
+            buckets.insert(bucket.to_string(), HashMap::new());
+        }
+    }
+
+    async fn get_or_create_bucket(
+        &self,
+        bucket: &str,
+    ) -> tokio::sync::RwLockWriteGuard<'_, HashMap<String, HashMap<String, StoredObject>>> {
+        let mut buckets = self.buckets.write().await;
+        if !buckets.contains_key(bucket) {
+            buckets.insert(bucket.to_string(), HashMap::new());
+        }
+        buckets
+    }
+}
+
+#[async_trait]
+impl S3 for InMemoryS3 {
+    async fn get_object(
+        &self,
+        req: S3Request<GetObjectInput>,
+    ) -> S3Result<S3Response<GetObjectOutput>> {
+        let bucket = &req.input.bucket;
+        let key = &req.input.key;
+
+        let buckets = self.buckets.read().await;
+        if let Some(bucket_contents) = buckets.get(bucket)
+            && let Some(obj) = bucket_contents.get(key)
+        {
+            let body = s3s::Body::from(Bytes::from(obj.data.clone()));
+            let output = GetObjectOutput {
+                body: Some(StreamingBlob::from(body)),
+                content_length: Some(obj.data.len() as i64),
+                content_type: obj.content_type.clone(),
+                e_tag: Some(ETag::Strong(obj.e_tag.clone())),
+                last_modified: Some(obj.last_modified.clone()),
+                ..Default::default()
+            };
+            return Ok(S3Response::new(output));
+        }
+        Err(s3_error!(NoSuchKey))
+    }
+
+    async fn put_object(
+        &self,
+        req: S3Request<PutObjectInput>,
+    ) -> S3Result<S3Response<PutObjectOutput>> {
+        let bucket = req.input.bucket.clone();
+        let key = req.input.key.clone();
+        let content_type = req.input.content_type.clone();
+        let if_match = req.input.if_match.clone();
+        let if_none_match = req.input.if_none_match.clone();
+
+        let data = if let Some(mut body) = req.input.body {
+            // Collect stream data chunk by chunk using Stream trait
+            use futures_util::StreamExt;
+            let mut chunks = Vec::new();
+            while let Some(result) = body.next().await {
+                if let Ok(bytes) = result {
+                    chunks.extend_from_slice(&bytes);
+                }
+            }
+            chunks
+        } else {
+            Vec::new()
+        };
+
+        // Calculate MD5 for ETag
+        let e_tag = format!("{:x}", md5::compute(&data));
+
+        let stored = StoredObject {
+            data,
+            content_type,
+            e_tag: e_tag.clone(),
+            last_modified: Timestamp::from(SystemTime::now()),
+        };
+
+        let mut buckets = self.get_or_create_bucket(&bucket).await;
+        if let Some(bucket_contents) = buckets.get_mut(&bucket) {
+            // Handle If-Match precondition (CAS: only update if ETag matches)
+            if let Some(ref expected_etag) = if_match {
+                // ETagCondition can be either an ETag value or the wildcard "*"
+                if expected_etag.is_any() {
+                    // Wildcard "*" means "any existing object matches"
+                    if !bucket_contents.contains_key(&key) {
+                        return Err(s3_error!(PreconditionFailed));
+                    }
+                } else if let Some(etag) = expected_etag.as_etag() {
+                    match bucket_contents.get(&key) {
+                        Some(existing) => {
+                            // Compare ETags (strip quotes if present)
+                            let existing_etag = existing.e_tag.trim_matches('"');
+                            let expected_clean = etag.value().trim_matches('"');
+                            if existing_etag != expected_clean {
+                                return Err(s3_error!(PreconditionFailed));
+                            }
+                        }
+                        None => {
+                            // Object doesn't exist but If-Match was specified
+                            return Err(s3_error!(PreconditionFailed));
+                        }
+                    }
+                }
+            }
+
+            // Handle If-None-Match precondition (only create if doesn't exist)
+            if if_none_match.is_some() && bucket_contents.contains_key(&key) {
+                return Err(s3_error!(PreconditionFailed));
+            }
+
+            bucket_contents.insert(key, stored);
+        }
+
+        let output = PutObjectOutput {
+            e_tag: Some(ETag::Strong(e_tag)),
+            ..Default::default()
+        };
+        Ok(S3Response::new(output))
+    }
+
+    async fn delete_object(
+        &self,
+        req: S3Request<DeleteObjectInput>,
+    ) -> S3Result<S3Response<DeleteObjectOutput>> {
+        let bucket = &req.input.bucket;
+        let key = &req.input.key;
+
+        let mut buckets = self.buckets.write().await;
+        if let Some(bucket_contents) = buckets.get_mut(bucket) {
+            bucket_contents.remove(key);
+        }
+
+        Ok(S3Response::new(DeleteObjectOutput::default()))
+    }
+
+    async fn head_object(
+        &self,
+        req: S3Request<HeadObjectInput>,
+    ) -> S3Result<S3Response<HeadObjectOutput>> {
+        let bucket = &req.input.bucket;
+        let key = &req.input.key;
+
+        let buckets = self.buckets.read().await;
+        if let Some(bucket_contents) = buckets.get(bucket)
+            && let Some(obj) = bucket_contents.get(key)
+        {
+            let output = HeadObjectOutput {
+                content_length: Some(obj.data.len() as i64),
+                content_type: obj.content_type.clone(),
+                e_tag: Some(ETag::Strong(obj.e_tag.clone())),
+                last_modified: Some(obj.last_modified.clone()),
+                ..Default::default()
+            };
+            return Ok(S3Response::new(output));
+        }
+        Err(s3_error!(NoSuchKey))
+    }
+
+    async fn list_objects_v2(
+        &self,
+        req: S3Request<ListObjectsV2Input>,
+    ) -> S3Result<S3Response<ListObjectsV2Output>> {
+        let bucket = &req.input.bucket;
+        let prefix = req.input.prefix.as_deref().unwrap_or("");
+
+        let buckets = self.buckets.read().await;
+
+        // Return NoSuchBucket error if bucket doesn't exist (matches real S3 behavior)
+        let bucket_contents = buckets.get(bucket).ok_or_else(|| s3_error!(NoSuchBucket))?;
+
+        let mut contents = Vec::new();
+        for (key, obj) in bucket_contents.iter() {
+            // Filter by prefix
+            if key.starts_with(prefix) {
+                contents.push(Object {
+                    key: Some(key.clone()),
+                    size: Some(obj.data.len() as i64),
+                    e_tag: Some(ETag::Strong(obj.e_tag.clone())),
+                    last_modified: Some(obj.last_modified.clone()),
+                    ..Default::default()
+                });
+            }
+        }
+
+        // Sort by key for consistent ordering
+        contents.sort_by(|a, b| a.key.cmp(&b.key));
+
+        let output = ListObjectsV2Output {
+            contents: Some(contents),
+            is_truncated: Some(false),
+            key_count: None,
+            ..Default::default()
+        };
+        Ok(S3Response::new(output))
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for LocalS3 {
+    async fn stop(self) -> anyhow::Result<()> {
+        let _ = self.shutdown_tx.send(());
+        Ok(())
+    }
+}
+
+/// Settings for configuring the authenticated S3 test server.
+#[derive(Debug, Clone)]
+pub struct S3Settings {
+    /// The bucket name to create. Defaults to "test-bucket".
+    pub bucket: String,
+    /// AWS access key ID. Defaults to "test-access-key".
+    pub access_key_id: String,
+    /// AWS secret access key. Defaults to "test-secret-key".
+    pub secret_access_key: String,
+}
+
+impl Default for S3Settings {
+    fn default() -> Self {
+        Self {
+            bucket: String::new(),
+            access_key_id: "test-access-key".to_string(),
+            secret_access_key: "test-secret-key".to_string(),
+        }
+    }
+}
+
+/// Settings for configuring the public S3 test server.
+#[derive(Debug, Clone, Default)]
+pub struct PublicS3Settings {
+    /// The bucket name to create. Defaults to "test-bucket".
+    pub bucket: String,
+}
+
+/// Provider function for S3Address (authenticated server)
+#[dialog_common::provider]
+pub async fn local_s3(settings: S3Settings) -> anyhow::Result<Service<S3Address, LocalS3>> {
+    let bucket = if settings.bucket.is_empty() {
+        "test-bucket"
+    } else {
+        &settings.bucket
+    };
+    let server = LocalS3::start_with_auth(
+        &settings.access_key_id,
+        &settings.secret_access_key,
+        &[bucket],
+    )
+    .await?;
+    let address = S3Address {
+        endpoint: server.endpoint.clone(),
+        bucket: bucket.to_string(),
+        access_key_id: settings.access_key_id,
+        secret_access_key: settings.secret_access_key,
+    };
+    Ok(Service::new(address, server))
+}
+
+/// Provider function for PublicS3Address (public server, no auth)
+#[dialog_common::provider]
+pub async fn public_local_s3(
+    settings: PublicS3Settings,
+) -> anyhow::Result<Service<PublicS3Address, LocalS3>> {
+    let bucket = if settings.bucket.is_empty() {
+        "test-bucket"
+    } else {
+        &settings.bucket
+    };
+    let server = LocalS3::start(&[bucket]).await?;
+    let address = PublicS3Address {
+        endpoint: server.endpoint.clone(),
+        bucket: bucket.to_string(),
+    };
+    Ok(Service::new(address, server))
+}

--- a/rust/dialog-remote-s3/src/key.rs
+++ b/rust/dialog-remote-s3/src/key.rs
@@ -1,0 +1,141 @@
+//! S3 key encoding and decoding.
+//!
+//! Keys are automatically encoded to be S3-safe. Keys are treated as `/`-delimited
+//! paths, and each segment is encoded independently:
+//! - Segments containing only safe characters (`a-z`, `A-Z`, `0-9`, `-`, `_`, `.`) are kept as-is
+//! - Segments containing unsafe characters or binary data are base58-encoded with a `!` prefix
+//! - Path separators (`/`) preserve the S3 key hierarchy
+
+use base58::{FromBase58, ToBase58};
+
+use crate::s3::S3StorageError;
+
+/// S3-safe key encoding that preserves path structure.
+///
+/// Keys are treated as `/`-delimited paths. Each path component is checked:
+/// - If it contains only safe characters (alphanumeric, `-`, `_`, `.`), it's kept as-is
+/// - Otherwise, it's base58-encoded and prefixed with `!`
+///
+/// The `!` character is used as a prefix marker because it's in AWS S3's
+/// "safe for use" list and unlikely to appear at the start of path components.
+///
+/// See [Object key naming guidelines] for more information about S3 key requirements.
+///
+/// # Examples
+///
+/// - `remote/main` -> `remote/main` (all components safe)
+/// - `remote/user@example` -> `remote/!<base58>` (@ is unsafe, encode component)
+/// - `foo/bar/baz` -> `foo/bar/baz` (all safe)
+///
+/// [Object key naming guidelines]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+pub fn encode(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes)
+        .split('/')
+        .map(|component| {
+            // Check if component contains only safe characters
+            let is_safe = component.bytes().all(|b| {
+                matches!(b,
+                    b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'.'
+                )
+            });
+
+            if is_safe && !component.is_empty() {
+                component.to_string()
+            } else {
+                // Base58 encode and prefix with !
+                format!("!{}", component.as_bytes().to_base58())
+            }
+        })
+        .collect::<Vec<String>>()
+        .join("/")
+}
+
+/// Decode an S3-encoded key back to bytes.
+///
+/// Path components starting with `!` are base58-decoded.
+/// Other components are used as-is.
+pub fn decode(encoded: &str) -> Result<Vec<u8>, S3StorageError> {
+    // Decode each path component: `!`-prefixed ones are base58, others are plain text
+    let components = encoded
+        .split('/')
+        .map(|component| {
+            if let Some(encoded_part) = component.strip_prefix('!') {
+                encoded_part.from_base58().map_err(|e| {
+                    S3StorageError::SerializationError(format!(
+                        "Invalid base58 encoding in component '{}': {:?}",
+                        component, e
+                    ))
+                })
+            } else {
+                Ok(component.as_bytes().to_vec())
+            }
+        })
+        .collect::<Result<Vec<Vec<u8>>, S3StorageError>>()?;
+
+    // Join decoded components with `/` separator
+    Ok(components.join(&b'/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_encodes_safe_chars() {
+        assert_eq!(encode(b"simple-key"), "simple-key");
+        assert_eq!(encode(b"with_underscore"), "with_underscore");
+        assert_eq!(encode(b"with.dot"), "with.dot");
+        assert_eq!(encode(b"CamelCase123"), "CamelCase123");
+    }
+
+    #[dialog_common::test]
+    fn it_encodes_path_structure() {
+        assert_eq!(encode(b"path/to/key"), "path/to/key");
+        assert_eq!(encode(b"a/b/c"), "a/b/c");
+    }
+
+    #[dialog_common::test]
+    fn it_encodes_unsafe_chars() {
+        let encoded = encode(b"user@example");
+        assert!(encoded.starts_with('!'));
+
+        let encoded = encode(b"has space");
+        assert!(encoded.starts_with('!'));
+    }
+
+    #[dialog_common::test]
+    fn it_encodes_binary() {
+        let encoded = encode(&[0x01, 0x02, 0x03]);
+        assert!(encoded.starts_with('!'));
+    }
+
+    #[dialog_common::test]
+    fn it_decodes_safe_chars() {
+        assert_eq!(decode("simple-key").unwrap(), b"simple-key");
+        assert_eq!(decode("path/to/key").unwrap(), b"path/to/key");
+    }
+
+    #[dialog_common::test]
+    fn it_roundtrips() {
+        let original = b"test-key";
+        let encoded = encode(original);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded, original);
+
+        let binary = vec![1, 2, 3, 4, 5];
+        let encoded = encode(&binary);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded, binary);
+
+        let path = b"safe/!encoded/also-safe";
+        let encoded = encode(path);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded, path);
+    }
+
+    #[dialog_common::test]
+    fn it_errors_on_invalid_base58() {
+        let result = decode("!invalid@@base58");
+        assert!(result.is_err());
+    }
+}

--- a/rust/dialog-remote-s3/src/lib.rs
+++ b/rust/dialog-remote-s3/src/lib.rs
@@ -1,0 +1,82 @@
+//! S3-compatible remote storage backend for dialog-db.
+//!
+//! This crate provides the [`S3`] site type, credential/address types,
+//! and capability-based access control for S3-compatible storage services.
+//!
+//! # Core Types
+//!
+//! - [`Address`] - S3 endpoint/bucket/region + URL building + request authorization
+//! - [`S3Credentials`] - Direct S3 authentication (SigV4 signed)
+//! - [`S3`] - Site marker implementing `Provider<Fork<S3, Fx>>` for HTTP execution
+//!
+//! # Example
+//!
+//! ```no_run
+//! use dialog_remote_s3::{Address, S3Credentials};
+//! use dialog_effects::storage::{Storage, Store, Get};
+//! use dialog_capability::{Subject, did};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create address for S3 bucket
+//! let address = Address::new(
+//!     "https://s3.us-east-1.amazonaws.com",
+//!     "us-east-1",
+//!     "my-bucket",
+//! );
+//!
+//! // Subject DID identifies whose data we're accessing (used as path prefix)
+//! let subject = did!("key:zSubject");
+//!
+//! // Attach credentials for authenticated access
+//! let address = address.with_credentials(S3Credentials::new(
+//!     "AKIAIOSFODNN7EXAMPLE",
+//!     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+//! ));
+//!
+//! // Build a capability and authorize it using the address.
+//! let capability = Subject::from(subject)
+//!     .attenuate(Storage)
+//!     .attenuate(Store::new("index"))
+//!     .invoke(Get::new(b"my-key"));
+//!
+//! let request = address.authorize(&capability).await?;
+//! println!("Presigned URL: {}", request.url);
+//! # Ok(())
+//! # }
+//! ```
+
+mod address;
+mod authorized;
+pub mod capability;
+mod checksum;
+mod error;
+mod key;
+mod permit;
+pub mod s3;
+
+#[cfg(feature = "list")]
+#[allow(dead_code)]
+mod list;
+
+#[cfg(feature = "helpers")]
+pub mod helpers;
+
+pub use address::*;
+pub use authorized::Authorized;
+pub use capability::{Access, Acl, Precondition};
+pub use capability::{archive, memory, storage};
+pub use checksum::*;
+pub use error::AccessError;
+pub use permit::Permit;
+
+// Re-export site types at crate root
+pub use s3::{Bucket, RequestDescriptorExt, S3, S3StorageError};
+
+// Re-export S3Credentials at crate root for convenience
+pub use s3::S3Credentials;
+
+// Re-export key encoding
+pub use key::{decode as decode_s3_key, encode as encode_s3_key};
+
+#[cfg(feature = "list")]
+pub use list::ListResult;

--- a/rust/dialog-remote-s3/src/list.rs
+++ b/rust/dialog-remote-s3/src/list.rs
@@ -1,0 +1,240 @@
+//! S3 ListObjectsV2 operations.
+//!
+//! This module provides the [`ListResult`] response type for listing objects
+//! in an S3 bucket using the [ListObjectsV2] API, as well as XML parsing utilities.
+//!
+//! [ListObjectsV2]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+
+use serde::Deserialize;
+
+use crate::s3::S3StorageError;
+
+/// Response from S3 ListObjectsV2 API.
+#[derive(Debug)]
+pub struct ListResult {
+    /// Object keys returned in this response.
+    pub keys: Vec<String>,
+    /// If true, there are more results to fetch.
+    pub is_truncated: bool,
+    /// Token to use for fetching the next page of results.
+    pub next_continuation_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "ListBucketResult")]
+struct ListBucketResult {
+    #[serde(rename = "IsTruncated", default)]
+    is_truncated: bool,
+    #[serde(rename = "Contents", default)]
+    contents: Vec<Contents>,
+    #[serde(rename = "NextContinuationToken")]
+    next_continuation_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Contents {
+    #[serde(rename = "Key")]
+    key: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "Error")]
+struct S3Error {
+    #[serde(rename = "Code")]
+    code: String,
+    #[serde(rename = "Message")]
+    message: Option<String>,
+}
+
+/// Parse the S3 ListObjectsV2 XML response.
+///
+/// Returns an error if the XML is an S3 error response (e.g., NoSuchBucket, AccessDenied)
+/// or if the XML doesn't have the expected root element.
+pub(crate) fn parse_list_response(xml: &str) -> Result<ListResult, S3StorageError> {
+    // First, try to parse as an S3 error response
+    if let Ok(error) = quick_xml::de::from_str::<S3Error>(xml) {
+        let message = error.message.unwrap_or_default();
+        return Err(S3StorageError::ServiceError(format!(
+            "{}: {}",
+            error.code, message
+        )));
+    }
+
+    // Check that we have the expected root element.
+    // quick-xml is lenient and will parse any XML as defaults, so we need to validate.
+    if !xml.contains("<ListBucketResult") {
+        return Err(S3StorageError::SerializationError(
+            "Unexpected XML response: missing ListBucketResult element".into(),
+        ));
+    }
+
+    // Parse as ListBucketResult
+    let result: ListBucketResult = quick_xml::de::from_str(xml)
+        .map_err(|e| S3StorageError::SerializationError(format!("Failed to parse XML: {}", e)))?;
+
+    Ok(ListResult {
+        keys: result.contents.into_iter().map(|c| c.key).collect(),
+        is_truncated: result.is_truncated,
+        next_continuation_token: result.next_continuation_token,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_parses_empty_list_response() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult>
+                <IsTruncated>false</IsTruncated>
+            </ListBucketResult>"#;
+
+        let result = parse_list_response(xml).unwrap();
+        assert!(result.keys.is_empty());
+        assert!(!result.is_truncated);
+        assert!(result.next_continuation_token.is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_parses_list_response_with_keys() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult>
+                <IsTruncated>false</IsTruncated>
+                <Contents>
+                    <Key>prefix/key1</Key>
+                    <Size>100</Size>
+                </Contents>
+                <Contents>
+                    <Key>prefix/key2</Key>
+                    <Size>200</Size>
+                </Contents>
+            </ListBucketResult>"#;
+
+        let result = parse_list_response(xml).unwrap();
+        assert_eq!(result.keys.len(), 2);
+        assert_eq!(result.keys[0], "prefix/key1");
+        assert_eq!(result.keys[1], "prefix/key2");
+        assert!(!result.is_truncated);
+    }
+
+    #[dialog_common::test]
+    fn it_parses_truncated_list_response() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult>
+                <IsTruncated>true</IsTruncated>
+                <NextContinuationToken>abc123</NextContinuationToken>
+                <Contents>
+                    <Key>key1</Key>
+                </Contents>
+            </ListBucketResult>"#;
+
+        let result = parse_list_response(xml).unwrap();
+        assert_eq!(result.keys.len(), 1);
+        assert!(result.is_truncated);
+        assert_eq!(result.next_continuation_token, Some("abc123".to_string()));
+    }
+
+    #[dialog_common::test]
+    fn it_errors_on_malformed_xml() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult>
+                <IsTruncated>true</IsTruncated>
+                <Contents>
+                    <Key>key1</Key>
+                <!-- missing closing tags -->"#;
+
+        let result = parse_list_response(xml);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, S3StorageError::SerializationError(_)));
+    }
+
+    #[dialog_common::test]
+    fn it_errors_on_unexpected_xml_structure() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <SomeUnknownElement>
+                <Foo>bar</Foo>
+            </SomeUnknownElement>"#;
+
+        let result = parse_list_response(xml);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, S3StorageError::SerializationError(ref msg) if msg.contains("ListBucketResult")),
+            "Expected error about missing ListBucketResult, got: {:?}",
+            err
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_errors_on_wrong_root_element() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <WrongRootElement>
+                <IsTruncated>false</IsTruncated>
+                <Contents>
+                    <Key>key1</Key>
+                </Contents>
+            </WrongRootElement>"#;
+
+        let result = parse_list_response(xml);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, S3StorageError::SerializationError(ref msg) if msg.contains("ListBucketResult")),
+            "Expected error about missing ListBucketResult, got: {:?}",
+            err
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_errors_on_non_xml_input() {
+        let xml = "this is not xml at all { json: maybe? }";
+
+        let result = parse_list_response(xml);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, S3StorageError::SerializationError(_)));
+    }
+
+    #[dialog_common::test]
+    fn it_parses_no_such_bucket_error() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <Error>
+                <Code>NoSuchBucket</Code>
+                <Message>The specified bucket does not exist</Message>
+                <BucketName>nonexistent-bucket</BucketName>
+                <RequestId>ABC123</RequestId>
+                <HostId>xyz</HostId>
+            </Error>"#;
+
+        let result = parse_list_response(xml);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, S3StorageError::ServiceError(ref msg) if msg.contains("NoSuchBucket")),
+            "Expected NoSuchBucket error, got: {:?}",
+            err
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_parses_access_denied_error() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <Error>
+                <Code>AccessDenied</Code>
+                <Message>Access Denied</Message>
+                <RequestId>ABC123</RequestId>
+                <HostId>xyz</HostId>
+            </Error>"#;
+
+        let result = parse_list_response(xml);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, S3StorageError::ServiceError(ref msg) if msg.contains("AccessDenied")),
+            "Expected AccessDenied error, got: {:?}",
+            err
+        );
+    }
+}

--- a/rust/dialog-remote-s3/src/permit.rs
+++ b/rust/dialog-remote-s3/src/permit.rs
@@ -1,0 +1,22 @@
+//! Pre-authorized HTTP request for S3 operations.
+//!
+//! A [`Permit`] is the result of authorization — either SigV4 signing (direct S3)
+//! or a UCAN access service response. It carries everything needed to make the
+//! actual HTTP request: presigned URL, method, and headers.
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// A pre-authorized HTTP request — presigned URL + method + headers.
+///
+/// Produced by SigV4 signing (direct S3) or by a UCAN access service.
+/// Fed into [`Authorized<Fx>`](crate::Authorized) for typed execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Permit {
+    /// The presigned URL to use.
+    pub url: Url,
+    /// HTTP method (GET, PUT, DELETE).
+    pub method: String,
+    /// Headers to include in the request.
+    pub headers: Vec<(String, String)>,
+}

--- a/rust/dialog-remote-s3/src/s3.rs
+++ b/rust/dialog-remote-s3/src/s3.rs
@@ -1,0 +1,278 @@
+//! S3 site type, credential types, and Provider implementations.
+//!
+//! This module provides [`S3`] and [`Bucket`], S3-compatible storage types
+//! that execute pre-authorized HTTP requests via presigned URLs.
+//!
+//! Submodules:
+//! - [`credentials`] — S3 credential types for direct AWS SigV4 signing
+//! - [`provider`] — `Provider<Fork<S3, Fx>>` implementations for archive, memory, storage
+
+pub(crate) mod credentials;
+pub mod provider;
+
+pub use crate::Address;
+pub use credentials::S3Credentials;
+
+use dialog_capability::Did;
+use dialog_capability::access::Allow;
+use dialog_capability::site::Site;
+use thiserror::Error;
+use url::Url;
+
+use crate::Permit;
+
+/// Extension trait for RequestDescriptor to convert to reqwest RequestBuilder.
+pub trait RequestDescriptorExt {
+    /// Convert into a reqwest RequestBuilder with the client.
+    fn into_request(self, client: &reqwest::Client) -> reqwest::RequestBuilder;
+}
+
+impl RequestDescriptorExt for Permit {
+    fn into_request(self, client: &reqwest::Client) -> reqwest::RequestBuilder {
+        let mut builder = match self.method.as_str() {
+            "GET" => client.get(self.url),
+            "PUT" => client.put(self.url),
+            "DELETE" => client.delete(self.url),
+            _ => client.request(
+                reqwest::Method::from_bytes(self.method.as_bytes()).unwrap(),
+                self.url,
+            ),
+        };
+
+        for (key, value) in self.headers {
+            builder = builder.header(key, value);
+        }
+
+        builder
+    }
+}
+
+/// Errors that can occur when using the S3 storage backend.
+#[derive(Error, Debug)]
+pub enum S3StorageError {
+    /// Failed to authorize the request (signing or credential issues).
+    #[error("Authorization error: {0}")]
+    AuthorizationError(String),
+
+    /// Transport-level error (connection failed, timeout, network issues).
+    #[error("Transport error: {0}")]
+    TransportError(String),
+
+    /// Service-level error (S3 returned an error response).
+    #[error("Service error: {0}")]
+    ServiceError(String),
+
+    /// Error during serialization or deserialization of data.
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+
+    /// CAS edition mismatch (concurrent modification detected).
+    #[error("Edition mismatch: expected {expected:?}, got {actual:?}")]
+    EditionMismatch {
+        /// The expected edition.
+        expected: Option<String>,
+        /// The actual edition found.
+        actual: Option<String>,
+    },
+}
+
+impl From<reqwest::Error> for S3StorageError {
+    fn from(error: reqwest::Error) -> Self {
+        S3StorageError::TransportError(error.to_string())
+    }
+}
+
+impl From<crate::AccessError> for S3StorageError {
+    fn from(error: crate::AccessError) -> Self {
+        S3StorageError::AuthorizationError(error.to_string())
+    }
+}
+
+/// S3 direct-access site.
+///
+/// Combines SigV4 credential signing with HTTP execution. Fork provider impls
+/// authorize via `Address::authorize` then delegate to [`Http`] for the
+/// actual HTTP round-trip.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct S3;
+
+impl Site for S3 {
+    type Protocol = Allow;
+    type Address = crate::Address;
+}
+
+/// A scoped S3 storage bucket with subject and namespace path.
+///
+/// This is a wrapper around [`S3`] that adds the subject DID and namespace path.
+///
+/// # Example
+///
+/// ```no_run
+/// use dialog_remote_s3::s3::{S3, Bucket};
+///
+/// let subject: dialog_capability::Did = "did:key:zMySubject".parse().unwrap();
+/// let bucket = Bucket::new(S3, subject, "my-store");
+/// ```
+#[derive(Debug, Clone)]
+pub struct Bucket {
+    bucket: S3,
+    /// The subject DID (whose data we're accessing)
+    subject: Did,
+    /// The namespace path (store for StorageBackend, space for TransactionalMemoryBackend)
+    path: String,
+}
+
+impl Bucket {
+    /// Create a new scoped S3 bucket.
+    ///
+    /// - `bucket`: The underlying S3
+    /// - `subject`: The subject DID (whose data we're accessing)
+    /// - `path`: The namespace path (store for storage, space for memory)
+    pub fn new(bucket: S3, subject: impl Into<Did>, path: impl Into<String>) -> Self {
+        Self {
+            bucket,
+            subject: subject.into(),
+            path: path.into(),
+        }
+    }
+
+    /// Get the subject DID.
+    pub fn subject(&self) -> &Did {
+        &self.subject
+    }
+
+    /// Get the namespace path.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Create a new scoped bucket with a different path (nested namespace).
+    pub fn at(&self, path: impl Into<String>) -> Self {
+        Self {
+            bucket: self.bucket,
+            subject: self.subject.clone(),
+            path: format!("{}/{}", self.path, path.into()),
+        }
+    }
+
+    /// Get a reference to the underlying S3.
+    pub fn s3(&self) -> &S3 {
+        &self.bucket
+    }
+}
+
+/// Determine if path-style URLs should be used by default for this endpoint.
+///
+/// Returns true for IP addresses and localhost, since virtual-hosted style
+/// URLs require DNS resolution of `{bucket}.{host}`.
+pub fn is_path_style_default(endpoint: &Url) -> bool {
+    use url::Host;
+    match endpoint.host() {
+        Some(Host::Ipv4(_)) | Some(Host::Ipv6(_)) => true,
+        Some(Host::Domain(domain)) => domain == "localhost",
+        None => false,
+    }
+}
+
+/// Build an S3 URL for the given path.
+///
+/// Handles both path-style and virtual-hosted style URLs.
+pub(crate) fn build_url(
+    endpoint: &Url,
+    bucket: &str,
+    path: &str,
+    path_style: bool,
+) -> Result<Url, crate::AccessError> {
+    if path_style {
+        // Path-style: https://endpoint/bucket/path
+        let mut url = endpoint.clone();
+        let new_path = if path.is_empty() {
+            format!("{}/", bucket)
+        } else {
+            format!("{}/{}", bucket, path)
+        };
+        url.set_path(&new_path);
+        Ok(url)
+    } else {
+        // Virtual-hosted style: https://bucket.endpoint/path
+        let host = endpoint
+            .host_str()
+            .ok_or_else(|| crate::AccessError::Configuration("Invalid endpoint: no host".into()))?;
+        let new_host = format!("{}.{}", bucket, host);
+
+        let mut url = endpoint.clone();
+        url.set_host(Some(&new_host))
+            .map_err(|e| crate::AccessError::Configuration(format!("Invalid host: {}", e)))?;
+
+        let new_path = if path.is_empty() { "/" } else { path };
+        url.set_path(new_path);
+        Ok(url)
+    }
+}
+
+/// Extract host string from URL, including port for non-standard ports.
+pub(crate) fn extract_host(url: &Url) -> Result<String, crate::AccessError> {
+    let hostname = url
+        .host_str()
+        .ok_or_else(|| crate::AccessError::Configuration("URL missing host".into()))?;
+
+    Ok(match url.port() {
+        Some(port) => format!("{}:{}", hostname, port),
+        None => hostname.to_string(),
+    })
+}
+
+/// Default URL expiration: 1 hour.
+pub const DEFAULT_EXPIRES: u64 = 3600;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(dead_code)]
+    fn test_address() -> Address {
+        Address::new("https://s3.amazonaws.com", "us-east-1", "bucket")
+    }
+
+    #[dialog_common::test]
+    fn it_creates_address() {
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "my-bucket",
+        );
+
+        assert_eq!(address.endpoint(), "https://s3.us-east-1.amazonaws.com");
+        assert_eq!(address.region(), "us-east-1");
+        assert_eq!(address.bucket(), "my-bucket");
+    }
+
+    mod url_building_tests {
+        use super::*;
+
+        #[dialog_common::test]
+        fn it_creates_address_for_virtual_hosted() {
+            let address = Address::new("https://s3.amazonaws.com", "us-east-1", "my-bucket");
+            assert!(!address.path_style());
+        }
+
+        #[dialog_common::test]
+        fn it_creates_path_style_for_localhost() {
+            let address = Address::new("http://localhost:9000", "us-east-1", "bucket");
+            assert!(address.path_style());
+        }
+
+        #[dialog_common::test]
+        fn it_allows_forcing_path_style() {
+            let address = Address::new("https://custom-s3.example.com", "us-east-1", "bucket")
+                .with_path_style();
+            assert!(address.path_style());
+        }
+
+        #[dialog_common::test]
+        fn it_creates_r2_address() {
+            let address = Address::new("https://abc123.r2.cloudflarestorage.com", "auto", "bucket");
+            assert!(!address.path_style());
+        }
+    }
+}

--- a/rust/dialog-remote-s3/src/s3/credentials.rs
+++ b/rust/dialog-remote-s3/src/s3/credentials.rs
@@ -1,0 +1,383 @@
+//! S3 credentials for direct access.
+//!
+//! [`S3Credentials`] carries only auth material (access key + secret).
+//! Address info (endpoint, bucket, path_style) lives in [`Address`](crate::Address).
+//!
+//! - `None` → public/unsigned access
+//! - `Some(S3Credentials)` → private access with SigV4 signing
+
+use crate::capability::{Access, Precondition};
+use crate::permit::Permit;
+use crate::{AccessError, Address};
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write;
+use std::hash::{Hash, Hasher};
+
+/// S3 credentials for authenticated (SigV4 signed) access.
+///
+/// Use `Option<S3Credentials>`:
+/// - `None` for public/unsigned access
+/// - `Some(creds)` for private SigV4 signing
+///
+/// # Example
+///
+/// ```no_run
+/// use dialog_remote_s3::s3::S3Credentials;
+///
+/// // Private credentials
+/// let creds = S3Credentials::new("AKIAEXAMPLE", "secret-key");
+///
+/// // Use with Address::authorize()
+/// // address.authorize(&request, Some(&creds)).await?;
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct S3Credentials {
+    /// AWS Access Key ID
+    access_key_id: String,
+    /// AWS Secret Access Key
+    secret_access_key: String,
+}
+
+impl Hash for S3Credentials {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.access_key_id.hash(state);
+        self.secret_access_key.hash(state);
+    }
+}
+
+impl S3Credentials {
+    /// Create new credentials with the given access key and secret.
+    pub fn new(access_key_id: impl Into<String>, secret_access_key: impl Into<String>) -> Self {
+        Self {
+            access_key_id: access_key_id.into(),
+            secret_access_key: secret_access_key.into(),
+        }
+    }
+
+    /// Get the access key ID.
+    pub fn access_key_id(&self) -> &str {
+        &self.access_key_id
+    }
+
+    /// Get the secret access key.
+    pub fn secret_access_key(&self) -> &str {
+        &self.secret_access_key
+    }
+
+    /// Generates a signed URL using the given address for endpoint/region/bucket info.
+    pub(crate) async fn grant<R: Access>(
+        &self,
+        request: &R,
+        address: &Address,
+    ) -> Result<Permit, AccessError> {
+        let time = current_time();
+        let timestamp = time.format("%Y%m%dT%H%M%SZ").to_string();
+        let date = &timestamp[0..8];
+
+        let region = address.region();
+        let service = request.service();
+        let expires = request.expires();
+
+        // Derive signing key on demand
+        let key = SigningKey::derive(&self.secret_access_key, date, region, service);
+        let scope = format!("{}/{}/{}/aws4_request", date, region, service);
+
+        let path = request.path();
+        let url = address.build_url(&path)?;
+
+        // hostname does not include port, so we check if there is port in the
+        // host and include it if present
+        let hostname = url
+            .host_str()
+            .ok_or_else(|| AccessError::Configuration("URL missing host".into()))?;
+        let host = if let Some(port) = url.port() {
+            format!("{}:{}", hostname, port)
+        } else {
+            hostname.to_string()
+        };
+
+        // Build signed headers
+        let mut headers = vec![("host".to_string(), host.clone())];
+        if let Some(checksum) = request.checksum() {
+            let header_name = format!("x-amz-checksum-{}", checksum.name());
+            headers.push((header_name, checksum.to_string()));
+        }
+        match request.precondition() {
+            Precondition::IfMatch(etag) => {
+                headers.push(("if-match".to_string(), format!("\"{}\"", etag)));
+            }
+            Precondition::IfNoneMatch => {
+                headers.push(("if-none-match".to_string(), "*".to_string()));
+            }
+            Precondition::None => {}
+        }
+        headers.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let signed_headers: String = headers
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect::<Vec<_>>()
+            .join(";");
+
+        // Build query parameters
+        let mut query_params: Vec<(String, String)> = vec![
+            ("X-Amz-Algorithm".into(), "AWS4-HMAC-SHA256".into()),
+            ("X-Amz-Content-Sha256".into(), "UNSIGNED-PAYLOAD".into()),
+            (
+                "X-Amz-Credential".into(),
+                format!("{}/{}", self.access_key_id, scope),
+            ),
+            ("X-Amz-Date".into(), timestamp.clone()),
+            ("X-Amz-Expires".into(), expires.to_string()),
+        ];
+
+        // Include ACL if specified by the request
+        if let Some(acl) = request.acl() {
+            query_params.push(("x-amz-acl".into(), acl.as_str().to_string()));
+        }
+
+        query_params.push(("X-Amz-SignedHeaders".into(), signed_headers.clone()));
+
+        if let Some(params) = request.params() {
+            for (key, value) in params {
+                query_params.push((key, value));
+            }
+        }
+
+        // Sort all query parameters alphabetically (required by SigV4)
+        query_params.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // Build canonical request
+        let canonical_uri = percent_encode_path(url.path());
+
+        let canonical_query: String = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", percent_encode(k), percent_encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let canonical_headers: String = headers
+            .iter()
+            .map(|(k, v)| format!("{}:{}", k, v.trim()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let canonical_request = format!(
+            "{}\n{}\n{}\n{}\n\n{}\nUNSIGNED-PAYLOAD",
+            request.method(),
+            canonical_uri,
+            canonical_query,
+            canonical_headers,
+            signed_headers
+        );
+
+        // Create string to sign
+        let digest = Sha256::digest(canonical_request.as_bytes());
+        let payload = format!(
+            "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+            timestamp,
+            scope,
+            hex_encode(&digest)
+        );
+
+        // Compute signature
+        let signature = key.sign(payload.as_bytes());
+
+        // Build final URL with all query parameters
+        let mut url = url.clone();
+        url.set_query(None);
+        {
+            let mut query = url.query_pairs_mut();
+            for (k, v) in &query_params {
+                query.append_pair(k, v);
+            }
+            query.append_pair("X-Amz-Signature", &signature.to_string());
+        }
+
+        Ok(Permit {
+            url,
+            method: request.method().to_string(),
+            headers,
+        })
+    }
+}
+
+/// AWS SigV4 signing key.
+struct SigningKey(Hmac<Sha256>);
+
+impl SigningKey {
+    /// Derive a signing key for the given date, region, and service.
+    fn derive(secret_key: &str, date: &str, region: &str, service: &str) -> Self {
+        let date_key = hmac_sha256(format!("AWS4{}", secret_key).as_bytes(), date.as_bytes());
+        let region_key = hmac_sha256(&date_key, region.as_bytes());
+        let service_key = hmac_sha256(&region_key, service.as_bytes());
+        let signing_key = hmac_sha256(&service_key, b"aws4_request");
+
+        Self(Hmac::new_from_slice(&signing_key).expect("HMAC can take key of any size"))
+    }
+
+    /// Sign a message with this key.
+    fn sign(&self, message: &[u8]) -> Signature {
+        let mut mac = self.0.clone();
+        mac.update(message);
+        Signature(mac.finalize().into_bytes().to_vec())
+    }
+}
+
+/// AWS SigV4 signature.
+struct Signature(Vec<u8>);
+
+impl std::fmt::Display for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in &self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+/// Compute HMAC-SHA256.
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC can take key of any size");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Hex-encode bytes.
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut result = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(result, "{:02x}", byte).unwrap();
+    }
+    result
+}
+
+/// Percent-encode a string for URL use.
+fn percent_encode(s: &str) -> String {
+    let mut result = String::new();
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(byte as char);
+            }
+            _ => {
+                write!(result, "%{:02X}", byte).unwrap();
+            }
+        }
+    }
+    result
+}
+
+/// Percent-encode a URL path (preserving slashes).
+fn percent_encode_path(path: &str) -> String {
+    path.split('/')
+        .map(percent_encode)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Get the current time as a UTC datetime.
+fn current_time() -> DateTime<Utc> {
+    DateTime::<Utc>::from(dialog_common::time::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Checksum;
+    use dialog_capability::{Capability, Subject, did};
+    use dialog_effects::storage::{self, Storage, Store};
+
+    fn test_subject() -> dialog_capability::Did {
+        did!("key:zTestSubject")
+    }
+
+    fn test_address() -> Address {
+        Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "my-bucket",
+        )
+    }
+
+    fn localhost_address() -> Address {
+        Address::new("http://localhost:9000", "us-east-1", "test-bucket")
+    }
+
+    /// Helper to build a storage Get capability.
+    fn get_capability(store: &str, key: &[u8]) -> Capability<storage::Get> {
+        Subject::from(test_subject())
+            .attenuate(Storage)
+            .attenuate(Store::new(store))
+            .invoke(storage::Get::new(key))
+    }
+
+    /// Helper to build a storage SetClaim capability (with checksum).
+    fn set_capability(
+        store: &str,
+        key: &[u8],
+        checksum: Checksum,
+    ) -> Capability<storage::SetClaim> {
+        Subject::from(test_subject())
+            .attenuate(Storage)
+            .attenuate(Store::new(store))
+            .attenuate(storage::SetClaim {
+                key: key.to_vec(),
+                checksum,
+            })
+    }
+
+    #[dialog_common::test]
+    async fn it_signs_with_public_access() {
+        let address = test_address();
+
+        let get = get_capability("index", b"test-key");
+        let descriptor = address.authorize(&get).await.unwrap();
+
+        assert_eq!(descriptor.method, "GET");
+        assert!(descriptor.url.as_str().contains("my-bucket"));
+        assert!(descriptor.url.as_str().contains("index/"));
+    }
+
+    #[dialog_common::test]
+    async fn it_signs_with_private_credentials() {
+        let address = test_address().with_credentials(S3Credentials::new("AKIATEST", "secret123"));
+
+        let get = get_capability("index", b"test-key");
+        let descriptor = address.authorize(&get).await.unwrap();
+
+        assert_eq!(descriptor.method, "GET");
+        assert!(descriptor.url.as_str().contains("X-Amz-Signature="));
+        assert!(descriptor.url.as_str().contains("X-Amz-Credential="));
+    }
+
+    #[dialog_common::test]
+    async fn it_includes_checksum_header() {
+        let address = test_address();
+
+        let checksum = Checksum::Sha256([0u8; 32]);
+        let set = set_capability("store", b"key", checksum);
+        let descriptor = address.authorize(&set).await.unwrap();
+
+        assert!(
+            descriptor
+                .headers
+                .iter()
+                .any(|(k, _)| k == "x-amz-checksum-sha256")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_uses_path_style_for_localhost() {
+        let address = localhost_address();
+
+        let get = get_capability("test", b"key");
+        let descriptor = address.authorize(&get).await.unwrap();
+
+        assert_eq!(descriptor.url.host_str().unwrap(), "localhost");
+        assert!(descriptor.url.path().starts_with("/test-bucket/"));
+    }
+}

--- a/rust/dialog-remote-s3/src/s3/provider.rs
+++ b/rust/dialog-remote-s3/src/s3/provider.rs
@@ -1,0 +1,496 @@
+//! Provider implementations for S3 sites.
+//!
+//! Each module provides two layers:
+//! - `Provider<Authorized<Fx>>` on `Http` — shared HTTP execution (used by S3 and UCAN)
+//! - `Provider<Fork<S3, Fx>>` on `S3` — SigV4 authorization, then delegates to `Http`
+
+pub mod archive;
+pub mod memory;
+pub mod storage;
+
+#[cfg(test)]
+mod tests {
+    use crate::Address;
+    use crate::capability::Access;
+    use crate::permit::Permit;
+    use crate::s3::S3Credentials;
+    use base58::ToBase58;
+    use dialog_capability::{Capability, Constraint, Did, Subject, did};
+    use dialog_effects::{archive, memory, storage};
+
+    fn test_subject() -> Did {
+        did!("key:zTestSubject")
+    }
+
+    const TEST_SUBJECT: &str = "did:key:zTestSubject";
+
+    fn test_address() -> Address {
+        Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "my-bucket",
+        )
+    }
+
+    fn localhost_address() -> Address {
+        Address::new("http://localhost:9000", "us-east-1", "test-bucket")
+    }
+
+    fn private_creds() -> S3Credentials {
+        S3Credentials::new(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        )
+    }
+
+    /// Helper to presign a capability using Address (credentials on address).
+    async fn presign<C>(address: &Address, capability: &Capability<C>) -> Permit
+    where
+        C: Constraint + 'static,
+        Capability<C>: Access,
+    {
+        address.authorize(capability).await.unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_url_for_storage_get() {
+        let address = test_address();
+        let key = b"test-key";
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("index"))
+            .invoke(storage::Get::new(key));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "GET");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/index/{}", TEST_SUBJECT, key.to_base58())
+        );
+        assert!(req.url.host_str().unwrap().contains("my-bucket"));
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_binary_key_for_storage_get() {
+        let address = test_address();
+        let binary_key: [u8; 32] = [
+            0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+            0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0a, 0x0b, 0x0c,
+        ];
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("blob"))
+            .invoke(storage::Get::new(binary_key));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "GET");
+        assert!(req.url.path().contains(&binary_key.to_base58()));
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_url_and_checksum_for_storage_set() {
+        let address = test_address();
+        let key = b"my-key";
+        let checksum_bytes = [0x12u8; 32];
+        let checksum = crate::Checksum::Sha256(checksum_bytes);
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("blob"))
+            .attenuate(storage::SetClaim {
+                key: key.to_vec(),
+                checksum,
+            });
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "PUT");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/blob/{}", TEST_SUBJECT, key.to_base58())
+        );
+
+        let checksum_header = req
+            .headers
+            .iter()
+            .find(|(k, _)| k == "x-amz-checksum-sha256");
+        assert!(checksum_header.is_some(), "Should have checksum header");
+
+        let (_, value) = checksum_header.unwrap();
+        assert!(!value.is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_url_for_storage_delete() {
+        let address = test_address();
+        let key = b"key-to-delete";
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("index"))
+            .invoke(storage::Delete::new(key));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "DELETE");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/index/{}", TEST_SUBJECT, key.to_base58())
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_query_params_for_storage_list() {
+        let address = test_address();
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("index"))
+            .invoke(storage::List::new(None));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "GET");
+
+        let query: Vec<(String, String)> = req
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        assert!(query.iter().any(|(k, v)| k == "list-type" && v == "2"));
+
+        let prefix = query.iter().find(|(k, _)| k == "prefix");
+        assert!(prefix.is_some());
+        let (_, prefix_value) = prefix.unwrap();
+        assert!(prefix_value.contains(TEST_SUBJECT));
+        assert!(prefix_value.contains("index"));
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_continuation_token_for_storage_list() {
+        let address = test_address();
+        let token = "next-page-token-abc123";
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("data"))
+            .invoke(storage::List::new(Some(token.to_string())));
+
+        let req = presign(&address, &capability).await;
+
+        let query: Vec<(String, String)> = req
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        let cont_token = query.iter().find(|(k, _)| k == "continuation-token");
+        assert!(cont_token.is_some());
+        assert_eq!(cont_token.unwrap().1, token);
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_url_for_memory_resolve() {
+        let address = test_address();
+
+        let capability = Subject::from(test_subject())
+            .attenuate(memory::Memory)
+            .attenuate(memory::Space::new("did:key:zUser123"))
+            .attenuate(memory::Cell::new("main"))
+            .invoke(memory::Resolve);
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "GET");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/did:key:zUser123/main", TEST_SUBJECT)
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_publishes_memory_without_prior_edition() {
+        let address = test_address();
+        let checksum = crate::Checksum::Sha256([0xab; 32]);
+
+        let capability = Subject::from(test_subject())
+            .attenuate(memory::Memory)
+            .attenuate(memory::Space::new("did:key:zSpace"))
+            .attenuate(memory::Cell::new("head"))
+            .attenuate(memory::PublishClaim {
+                checksum,
+                when: None,
+            });
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "PUT");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/did:key:zSpace/head", TEST_SUBJECT)
+        );
+
+        assert!(
+            req.headers
+                .iter()
+                .any(|(k, _)| k == "x-amz-checksum-sha256")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_publishes_memory_with_prior_edition() {
+        let address = test_address();
+        let checksum = crate::Checksum::Sha256([0xcd; 32]);
+        let _prior_etag = "abc123etag".to_string();
+
+        let capability = Subject::from(test_subject())
+            .attenuate(memory::Memory)
+            .attenuate(memory::Space::new("did:key:zSpace"))
+            .attenuate(memory::Cell::new("main"))
+            .attenuate(memory::PublishClaim {
+                checksum,
+                when: Some(memory::Edition(_prior_etag)),
+            });
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "PUT");
+        assert!(
+            req.headers
+                .iter()
+                .any(|(k, _)| k == "x-amz-checksum-sha256")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_url_for_memory_retract() {
+        let address = test_address();
+
+        let capability = Subject::from(test_subject())
+            .attenuate(memory::Memory)
+            .attenuate(memory::Space::new("did:key:zOwner"))
+            .attenuate(memory::Cell::new("temp"))
+            .attenuate(memory::RetractClaim {
+                when: memory::Edition("etag-to-match".to_string()),
+            });
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "DELETE");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/did:key:zOwner/temp", TEST_SUBJECT)
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_url_for_archive_get() {
+        let address = test_address();
+        let digest: [u8; 32] = [0x42; 32];
+
+        let capability = Subject::from(test_subject())
+            .attenuate(archive::Archive)
+            .attenuate(archive::Catalog::new("blobs"))
+            .invoke(archive::Get::new(digest));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "GET");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/blobs/{}", TEST_SUBJECT, digest.to_base58())
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_correct_url_and_checksum_for_archive_put() {
+        let address = test_address();
+        let digest: [u8; 32] = [0x99; 32];
+        let checksum = crate::Checksum::Sha256([0x11; 32]);
+
+        let capability = Subject::from(test_subject())
+            .attenuate(archive::Archive)
+            .attenuate(archive::Catalog::new("index"))
+            .attenuate(archive::PutClaim {
+                digest: digest.into(),
+                checksum,
+            });
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "PUT");
+        assert_eq!(
+            req.url.path(),
+            format!("/{}/index/{}", TEST_SUBJECT, digest.to_base58())
+        );
+        assert!(
+            req.headers
+                .iter()
+                .any(|(k, _)| k == "x-amz-checksum-sha256")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_signed_url_for_get_with_private_creds() {
+        let address = test_address().with_credentials(private_creds());
+        let key = b"signed-key";
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("data"))
+            .invoke(storage::Get::new(key));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "GET");
+
+        let query: Vec<(String, String)> = req
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-Algorithm"));
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-Credential"));
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-Date"));
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-Expires"));
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-SignedHeaders"));
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-Signature"));
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_signed_url_for_put_with_private_creds() {
+        let address = test_address().with_credentials(private_creds());
+        let key = b"upload-key";
+        let checksum = crate::Checksum::Sha256([0xff; 32]);
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("uploads"))
+            .attenuate(storage::SetClaim {
+                key: key.to_vec(),
+                checksum,
+            });
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "PUT");
+
+        let query: Vec<(String, String)> = req
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-Signature"));
+
+        assert!(
+            req.headers
+                .iter()
+                .any(|(k, _)| k == "x-amz-checksum-sha256")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_generates_signed_url_for_list_with_private_creds() {
+        let address = test_address().with_credentials(private_creds());
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("files"))
+            .invoke(storage::List::new(None));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.method, "GET");
+
+        let query: Vec<(String, String)> = req
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        assert!(query.iter().any(|(k, v)| k == "list-type" && v == "2"));
+        assert!(query.iter().any(|(k, _)| k == "prefix"));
+
+        assert!(query.iter().any(|(k, _)| k == "X-Amz-Signature"));
+    }
+
+    #[dialog_common::test]
+    async fn it_uses_virtual_hosted_style_for_aws() {
+        let address = test_address();
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("test"))
+            .invoke(storage::Get::new(b"key"));
+
+        let req = presign(&address, &capability).await;
+
+        assert!(req.url.host_str().unwrap().starts_with("my-bucket."));
+    }
+
+    #[dialog_common::test]
+    async fn it_uses_path_style_for_localhost() {
+        let address = localhost_address();
+
+        let capability = Subject::from(test_subject())
+            .attenuate(storage::Storage)
+            .attenuate(storage::Store::new("test"))
+            .invoke(storage::Get::new(b"key"));
+
+        let req = presign(&address, &capability).await;
+
+        assert_eq!(req.url.host_str().unwrap(), "localhost");
+        assert!(req.url.path().starts_with("/test-bucket/"));
+    }
+
+    #[dialog_common::test]
+    async fn it_supports_different_store_names() {
+        let address = test_address();
+        let stores = ["index", "blob", "metadata", "cache", ""];
+
+        for store_name in stores {
+            let capability = Subject::from(test_subject())
+                .attenuate(storage::Storage)
+                .attenuate(storage::Store::new(store_name))
+                .invoke(storage::Get::new(b"key"));
+
+            let req = presign(&address, &capability).await;
+
+            if store_name.is_empty() {
+                assert!(req.url.path().contains(&format!("/{}/", TEST_SUBJECT)));
+            } else {
+                assert!(
+                    req.url
+                        .path()
+                        .contains(&format!("/{}/{}/", TEST_SUBJECT, store_name))
+                );
+            }
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_supports_different_catalog_names() {
+        let address = test_address();
+        let catalogs = ["blobs", "index", "refs"];
+        let digest: [u8; 32] = [0x55; 32];
+
+        for catalog_name in catalogs {
+            let capability = Subject::from(test_subject())
+                .attenuate(archive::Archive)
+                .attenuate(archive::Catalog::new(catalog_name))
+                .invoke(archive::Get::new(digest));
+
+            let req = presign(&address, &capability).await;
+
+            assert!(
+                req.url
+                    .path()
+                    .contains(&format!("/{}/{}/", TEST_SUBJECT, catalog_name))
+            );
+        }
+    }
+}

--- a/rust/dialog-remote-s3/src/s3/provider/archive.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/archive.rs
@@ -1,0 +1,106 @@
+//! Archive capability providers for S3.
+//!
+//! Each effect is paired: `Provider<Fork<S3, Fx>>` authorizes via SigV4,
+//! then delegates to `Provider<Authorized<Fx>>` for HTTP execution.
+
+use async_trait::async_trait;
+use dialog_capability::fork::{Fork, ForkInvocation};
+use dialog_capability::{Policy, Provider};
+use dialog_effects::archive::*;
+
+use crate::Authorized;
+use crate::s3::{RequestDescriptorExt, S3};
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Get>> for S3 {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<S3, Get>,
+    ) -> Result<Option<Vec<u8>>, ArchiveError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Get>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Get>> for S3 {
+    async fn execute(&self, input: Authorized<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .send()
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        if response.status().is_success() {
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|e| ArchiveError::Io(e.to_string()))?;
+            Ok(Some(bytes.to_vec()))
+        } else if response.status() == reqwest::StatusCode::NOT_FOUND {
+            Ok(None)
+        } else {
+            Err(ArchiveError::Storage(format!(
+                "Failed to get value: {}",
+                response.status()
+            )))
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Put>> for S3 {
+    async fn execute(&self, invocation: ForkInvocation<S3, Put>) -> Result<(), ArchiveError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Put>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Put>> for S3 {
+    async fn execute(&self, input: Authorized<Put>) -> Result<(), ArchiveError> {
+        let content = Put::of(&input.capability).content.clone();
+
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .body(content)
+            .send()
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(ArchiveError::Storage(format!(
+                "Failed to put value: {}",
+                response.status()
+            )))
+        }
+    }
+}

--- a/rust/dialog-remote-s3/src/s3/provider/memory.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/memory.rs
@@ -1,0 +1,186 @@
+//! Memory capability providers for S3.
+//!
+//! Each effect is paired: `Provider<Fork<S3, Fx>>` authorizes via SigV4,
+//! then delegates to `Provider<Authorized<Fx>>` for HTTP execution.
+
+use async_trait::async_trait;
+use dialog_capability::fork::{Fork, ForkInvocation};
+use dialog_capability::{Policy, Provider};
+use dialog_effects::memory::*;
+
+use crate::Authorized;
+use crate::s3::{RequestDescriptorExt, S3};
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Resolve>> for S3 {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<S3, Resolve>,
+    ) -> Result<Option<Publication>, MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Resolve>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Resolve>> for S3 {
+    async fn execute(
+        &self,
+        input: Authorized<Resolve>,
+    ) -> Result<Option<Publication>, MemoryError> {
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .send()
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        if response.status().is_success() {
+            let edition = response
+                .headers()
+                .get("etag")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.trim_matches('"').to_string())
+                .ok_or_else(|| MemoryError::Storage("Response missing ETag header".to_string()))?;
+
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+            Ok(Some(Publication {
+                content: bytes.to_vec(),
+                edition: edition.into_bytes(),
+            }))
+        } else if response.status() == reqwest::StatusCode::NOT_FOUND {
+            Ok(None)
+        } else {
+            Err(MemoryError::Storage(format!(
+                "Failed to resolve value: {}",
+                response.status()
+            )))
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Publish>> for S3 {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<S3, Publish>,
+    ) -> Result<Vec<u8>, MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Publish>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Publish>> for S3 {
+    async fn execute(&self, input: Authorized<Publish>) -> Result<Vec<u8>, MemoryError> {
+        let content = Publish::of(&input.capability).content.clone();
+        let when = Publish::of(&input.capability)
+            .when
+            .as_ref()
+            .map(|b| String::from_utf8_lossy(b).to_string());
+
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .body(content)
+            .send()
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        match response.status() {
+            status if status.is_success() => {
+                let new_edition = response
+                    .headers()
+                    .get("etag")
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.trim_matches('"').to_string())
+                    .ok_or_else(|| {
+                        MemoryError::Storage("Response missing ETag header".to_string())
+                    })?;
+                Ok(new_edition.into_bytes())
+            }
+            reqwest::StatusCode::PRECONDITION_FAILED => Err(MemoryError::EditionMismatch {
+                expected: when,
+                actual: None,
+            }),
+            status => Err(MemoryError::Storage(format!(
+                "Failed to publish value: {}",
+                status
+            ))),
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Retract>> for S3 {
+    async fn execute(&self, invocation: ForkInvocation<S3, Retract>) -> Result<(), MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Retract>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Retract>> for S3 {
+    async fn execute(&self, input: Authorized<Retract>) -> Result<(), MemoryError> {
+        let when = String::from_utf8_lossy(&Retract::of(&input.capability).when).to_string();
+
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .send()
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        match response.status() {
+            status if status.is_success() => Ok(()),
+            reqwest::StatusCode::PRECONDITION_FAILED => Err(MemoryError::EditionMismatch {
+                expected: Some(when),
+                actual: None,
+            }),
+            status => Err(MemoryError::Storage(format!(
+                "Failed to retract value: {}",
+                status
+            ))),
+        }
+    }
+}

--- a/rust/dialog-remote-s3/src/s3/provider/storage.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/storage.rs
@@ -1,0 +1,147 @@
+//! Storage capability providers for S3.
+//!
+//! Each effect is paired: `Provider<Fork<S3, Fx>>` authorizes via SigV4,
+//! then delegates to `Provider<Authorized<Fx>>` for HTTP execution.
+
+use async_trait::async_trait;
+use dialog_capability::fork::{Fork, ForkInvocation};
+use dialog_capability::{Policy, Provider};
+use dialog_effects::storage::*;
+
+use crate::Authorized;
+use crate::s3::{RequestDescriptorExt, S3};
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Get>> for S3 {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<S3, Get>,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Get>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Get>> for S3 {
+    async fn execute(&self, input: Authorized<Get>) -> Result<Option<Vec<u8>>, StorageError> {
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .send()
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        if response.status().is_success() {
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?;
+            Ok(Some(bytes.to_vec()))
+        } else if response.status() == reqwest::StatusCode::NOT_FOUND {
+            Ok(None)
+        } else {
+            Err(StorageError::Storage(format!(
+                "Failed to get value: {}",
+                response.status()
+            )))
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Set>> for S3 {
+    async fn execute(&self, invocation: ForkInvocation<S3, Set>) -> Result<(), StorageError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Set>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Set>> for S3 {
+    async fn execute(&self, input: Authorized<Set>) -> Result<(), StorageError> {
+        let value = Set::of(&input.capability).value.clone();
+
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .body(value)
+            .send()
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(StorageError::Storage(format!(
+                "Failed to set value: {}",
+                response.status()
+            )))
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<S3, Delete>> for S3 {
+    async fn execute(&self, invocation: ForkInvocation<S3, Delete>) -> Result<(), StorageError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.capability)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Delete>>>::execute(
+            self,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Authorized<Delete>> for S3 {
+    async fn execute(&self, input: Authorized<Delete>) -> Result<(), StorageError> {
+        let client = reqwest::Client::new();
+        let response = input
+            .permit
+            .into_request(&client)
+            .send()
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(StorageError::Storage(format!(
+                "Failed to delete value: {}",
+                response.status()
+            )))
+        }
+    }
+}

--- a/rust/dialog-remote-s3/tests/integration_tests/bucket.rs
+++ b/rust/dialog-remote-s3/tests/integration_tests/bucket.rs
@@ -1,0 +1,195 @@
+//! Test helpers for S3 integration tests.
+
+#![cfg(feature = "s3-integration-tests")]
+
+use dialog_capability::Did;
+use dialog_capability::Subject;
+use dialog_effects::memory::prelude::{
+    CellExt, MemoryExt, SpaceExt, SubjectExt as MemorySubjectExt,
+};
+use dialog_effects::memory::{MemoryError, Publication};
+use dialog_effects::storage::StorageError;
+use dialog_effects::storage::prelude::{StorageExt, StoreExt, SubjectExt as StorageSubjectExt};
+use dialog_remote_s3::{Address, S3, S3Credentials, S3StorageError, helpers::Session};
+
+/// Adds timestamp to the given string to make it unique
+pub fn unique(base: &str) -> String {
+    let millis = dialog_common::time::now()
+        .duration_since(dialog_common::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    format!("{}-{}", base, millis)
+}
+
+/// Test context with S3 backend, credentials, subject, and session for integration tests.
+pub struct TestBucket {
+    pub s3: S3,
+    pub address: Address,
+    pub subject: Did,
+    pub session: Session,
+    pub store: String,
+}
+
+impl TestBucket {
+    pub fn at(&self, path: &str) -> Self {
+        TestBucket {
+            s3: self.s3,
+            address: self.address.clone(),
+            subject: self.subject.clone(),
+            session: self.session.clone(),
+            store: format!("{}/{}", self.store, path),
+        }
+    }
+
+    pub async fn set(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), S3StorageError> {
+        let authorized = Subject::from(self.subject.clone())
+            .storage()
+            .store(&self.store)
+            .set(key, value)
+            .fork(&self.address)
+            .acquire(&self.session)
+            .await
+            .map_err(|e: dialog_capability::access::AuthorizeError| {
+                S3StorageError::AuthorizationError(e.to_string())
+            })?;
+
+        let result: Result<(), StorageError> = authorized.perform(&self.s3).await;
+        result.map_err(|e| S3StorageError::ServiceError(e.to_string()))
+    }
+
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, S3StorageError> {
+        let authorized = Subject::from(self.subject.clone())
+            .storage()
+            .store(&self.store)
+            .get(key)
+            .fork(&self.address)
+            .acquire(&self.session)
+            .await
+            .map_err(|e: dialog_capability::access::AuthorizeError| {
+                S3StorageError::AuthorizationError(e.to_string())
+            })?;
+
+        let result: Result<Option<Vec<u8>>, StorageError> = authorized.perform(&self.s3).await;
+        result.map_err(|e| S3StorageError::ServiceError(e.to_string()))
+    }
+
+    pub async fn delete(&self, key: &[u8]) -> Result<(), S3StorageError> {
+        let authorized = Subject::from(self.subject.clone())
+            .storage()
+            .store(&self.store)
+            .delete(key)
+            .fork(&self.address)
+            .acquire(&self.session)
+            .await
+            .map_err(|e: dialog_capability::access::AuthorizeError| {
+                S3StorageError::AuthorizationError(e.to_string())
+            })?;
+
+        let result: Result<(), StorageError> = authorized.perform(&self.s3).await;
+        result.map_err(|e| S3StorageError::ServiceError(e.to_string()))
+    }
+
+    pub async fn resolve(
+        &self,
+        space: &str,
+        cell: &str,
+    ) -> Result<Option<Publication>, S3StorageError> {
+        let authorized = Subject::from(self.subject.clone())
+            .memory()
+            .space(space)
+            .cell(cell)
+            .resolve()
+            .fork(&self.address)
+            .acquire(&self.session)
+            .await
+            .map_err(|e: dialog_capability::access::AuthorizeError| {
+                S3StorageError::AuthorizationError(e.to_string())
+            })?;
+
+        let result: Result<Option<Publication>, MemoryError> = authorized.perform(&self.s3).await;
+        result.map_err(|e| S3StorageError::ServiceError(e.to_string()))
+    }
+
+    pub async fn publish(
+        &self,
+        space: &str,
+        cell: &str,
+        content: Vec<u8>,
+        when: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, S3StorageError> {
+        let authorized = Subject::from(self.subject.clone())
+            .memory()
+            .space(space)
+            .cell(cell)
+            .publish(content, when)
+            .fork(&self.address)
+            .acquire(&self.session)
+            .await
+            .map_err(|e: dialog_capability::access::AuthorizeError| {
+                S3StorageError::AuthorizationError(e.to_string())
+            })?;
+
+        let result: Result<Vec<u8>, MemoryError> = authorized.perform(&self.s3).await;
+        result.map_err(|e| S3StorageError::ServiceError(e.to_string()))
+    }
+
+    #[allow(dead_code)]
+    pub async fn retract(
+        &self,
+        space: &str,
+        cell: &str,
+        when: Vec<u8>,
+    ) -> Result<(), S3StorageError> {
+        let authorized = Subject::from(self.subject.clone())
+            .memory()
+            .space(space)
+            .cell(cell)
+            .retract(when)
+            .fork(&self.address)
+            .acquire(&self.session)
+            .await
+            .map_err(|e: dialog_capability::access::AuthorizeError| {
+                S3StorageError::AuthorizationError(e.to_string())
+            })?;
+
+        let result: Result<(), MemoryError> = authorized.perform(&self.s3).await;
+        result.map_err(|e| S3StorageError::ServiceError(e.to_string()))
+    }
+}
+
+/// Helper to create an S3 test context from environment variables.
+pub fn open() -> TestBucket {
+    #![allow(clippy::option_env_unwrap)]
+    let address = Address::new(
+        option_env!("R2S3_ENDPOINT").expect("R2S3_ENDPOINT not set"),
+        option_env!("R2S3_REGION").expect("R2S3_REGION not set"),
+        option_env!("R2S3_BUCKET").expect("R2S3_BUCKET not set"),
+    );
+
+    let subject: Did = option_env!("R2S3_SUBJECT")
+        .unwrap_or("did:key:zTestSubject")
+        .parse()
+        .expect("Invalid DID in R2S3_SUBJECT");
+
+    let credentials = S3Credentials::new(
+        option_env!("R2S3_ACCESS_KEY_ID").expect("R2S3_ACCESS_KEY_ID not set"),
+        option_env!("R2S3_SECRET_ACCESS_KEY").expect("R2S3_SECRET_ACCESS_KEY not set"),
+    );
+
+    let address = address.with_credentials(credentials);
+
+    let s3 = S3;
+    let session = Session::new(subject.clone());
+
+    TestBucket {
+        s3,
+        address,
+        subject,
+        session,
+        store: "integration-tests".to_string(),
+    }
+}
+
+pub fn open_unique_at(base: &str) -> TestBucket {
+    open().at(&unique(base))
+}

--- a/rust/dialog-remote-s3/tests/integration_tests/main.rs
+++ b/rust/dialog-remote-s3/tests/integration_tests/main.rs
@@ -1,0 +1,19 @@
+//! S3 Integration Tests
+//!
+//! These tests run against a real S3/R2/MinIO endpoint and require the following
+//! environment variables to be set:
+//!
+//! - R2S3_ENDPOINT: The S3-compatible endpoint
+//! - R2S3_REGION: AWS region (e.g., "us-east-1" or "auto" for R2)
+//! - R2S3_BUCKET: Bucket name
+//! - R2S3_ACCESS_KEY_ID: Access key ID
+//! - R2S3_SECRET_ACCESS_KEY: Secret access key
+//!
+//! Run with:
+//! ```bash
+//! cargo test -p dialog-remote-s3 --features s3-integration-tests --test integration_tests
+//! ```
+
+mod bucket;
+mod storage;
+mod transactional_memory;

--- a/rust/dialog-remote-s3/tests/integration_tests/storage.rs
+++ b/rust/dialog-remote-s3/tests/integration_tests/storage.rs
@@ -1,0 +1,292 @@
+//! Integration tests that run against a real S3/R2/MinIO endpoint.
+
+#![cfg(feature = "s3-integration-tests")]
+
+use super::bucket;
+use anyhow::Result;
+use dialog_remote_s3::encode_s3_key;
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+#[dialog_common::test]
+async fn it_sets_and_gets_values() -> Result<()> {
+    let backend = bucket::open_unique_at("it_sets_and_gets_values");
+
+    let key = b"test-key-1".to_vec();
+    let value = b"test-value-1".to_vec();
+
+    backend.set(key.clone(), value.clone()).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_returns_none_for_missing_key() -> Result<()> {
+    let backend = bucket::open_unique_at("it_returns_none_for_missing_key");
+
+    let key = b"nonexistent-key-12345".to_vec();
+    let retrieved = backend.get(&key).await?;
+
+    assert_eq!(retrieved, None);
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_overwrites_values() -> Result<()> {
+    let backend = bucket::open_unique_at("it_overwrites_values");
+
+    let key = b"test-key-overwrite".to_vec();
+    let value1 = b"original-value".to_vec();
+    let value2 = b"updated-value".to_vec();
+
+    backend.set(key.clone(), value1.clone()).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value1));
+
+    backend.set(key.clone(), value2.clone()).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value2));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_handles_large_values() -> Result<()> {
+    let backend = bucket::open_unique_at("it_handles_large_values");
+
+    let key = b"test-key-large".to_vec();
+    let value: Vec<u8> = (0..1_000_000).map(|i| (i % 256) as u8).collect();
+
+    backend.set(key.clone(), value.clone()).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_handles_multiple_keys() -> Result<()> {
+    let backend = bucket::open_unique_at("it_handles_multiple_keys");
+
+    let pairs = vec![
+        (b"key1".to_vec(), b"value1".to_vec()),
+        (b"key2".to_vec(), b"value2".to_vec()),
+        (b"key3".to_vec(), b"value3".to_vec()),
+    ];
+
+    for (key, value) in &pairs {
+        backend.set(key.clone(), value.clone()).await?;
+    }
+
+    for (key, expected_value) in &pairs {
+        let retrieved = backend.get(key).await?;
+        assert_eq!(retrieved.as_ref(), Some(expected_value));
+    }
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_handles_binary_data() -> Result<()> {
+    let backend = bucket::open_unique_at("it_handles_binary_data");
+
+    let key = b"test-key-binary".to_vec();
+    let value: Vec<u8> = (0..=255).collect();
+
+    backend.set(key.clone(), value.clone()).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_performs_bulk_operations() -> Result<()> {
+    let backend = bucket::open_unique_at("it_performs_bulk_operations");
+
+    let test_data = vec![
+        (b"bulk1".to_vec(), b"value1".to_vec()),
+        (b"bulk2".to_vec(), b"value2".to_vec()),
+        (b"bulk3".to_vec(), b"value3".to_vec()),
+    ];
+
+    for (key, value) in &test_data {
+        backend.set(key.clone(), value.clone()).await?;
+    }
+
+    for (key, expected_value) in test_data {
+        let retrieved = backend.get(&key).await?;
+        assert_eq!(retrieved, Some(expected_value));
+    }
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_works_without_prefix() -> Result<()> {
+    let backend = bucket::open();
+
+    let key = bucket::unique("no-prefix-test-key").into_bytes();
+    let value = bucket::unique("no-prefix-test-value").into_bytes();
+
+    backend.set(key.clone(), value.clone()).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_handles_encoded_key_segments() -> Result<()> {
+    let backend = bucket::open_unique_at("it_handles_encoded_key_segments");
+
+    let key_mixed = b"safe-segment/user@example.com".to_vec();
+    let value_mixed = b"value-for-mixed-key".to_vec();
+
+    let encoded = encode_s3_key(&key_mixed);
+    assert!(
+        encoded.starts_with("safe-segment/!"),
+        "First segment should be safe, second should be encoded with ! prefix: {}",
+        encoded
+    );
+
+    backend.set(key_mixed.clone(), value_mixed.clone()).await?;
+    let retrieved = backend.get(&key_mixed).await?;
+    assert_eq!(retrieved, Some(value_mixed));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_handles_fully_encoded_key() -> Result<()> {
+    let backend = bucket::open_unique_at("it_handles_fully_encoded_key");
+
+    let key_binary = vec![0x01, 0x02, 0xFF, 0xFE];
+    let value_binary = b"value-for-binary-key".to_vec();
+
+    let encoded = encode_s3_key(&key_binary);
+    assert!(
+        encoded.starts_with('!'),
+        "Binary key should be encoded with ! prefix: {}",
+        encoded
+    );
+
+    backend
+        .set(key_binary.clone(), value_binary.clone())
+        .await?;
+    let retrieved = backend.get(&key_binary).await?;
+    assert_eq!(retrieved, Some(value_binary));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_handles_multi_segment_mixed_encoding() -> Result<()> {
+    let backend = bucket::open_unique_at("it_handles_multi_segment_mixed_encoding");
+
+    let key = b"data/file name with spaces/v1/special!chars".to_vec();
+    let value = b"value-for-complex-path".to_vec();
+
+    let encoded = encode_s3_key(&key);
+    let segments: Vec<&str> = encoded.split('/').collect();
+    assert_eq!(segments.len(), 4, "Should have 4 segments");
+    assert_eq!(segments[0], "data", "First segment should be safe");
+    assert!(
+        segments[1].starts_with('!'),
+        "Second segment should be encoded (has spaces)"
+    );
+    assert_eq!(segments[2], "v1", "Third segment should be safe");
+    assert!(
+        segments[3].starts_with('!'),
+        "Fourth segment should be encoded (has !)"
+    );
+
+    backend.set(key.clone(), value.clone()).await?;
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_handles_encoded_key_without_prefix() -> Result<()> {
+    let backend = bucket::open();
+
+    let name = bucket::unique("data");
+    let key = format!("path/with spaces/{name}",).into_bytes();
+    let value = b"value-for-encoded-no-prefix".to_vec();
+
+    let encoded = encode_s3_key(&key);
+    let segments: Vec<&str> = encoded.split('/').collect();
+    assert_eq!(segments[0], "path", "First segment should be safe");
+    assert!(
+        segments[1].starts_with('!'),
+        "Second segment should be encoded"
+    );
+    assert_eq!(segments[2], name, "Third segment should be safe");
+
+    backend.set(key.clone(), value.clone()).await?;
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value));
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_deletes_values() -> Result<()> {
+    let backend = bucket::open_unique_at("it_deletes_values");
+
+    let key = b"delete-integration-test".to_vec();
+    let value = b"value-to-delete".to_vec();
+
+    backend.set(key.clone(), value.clone()).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, Some(value));
+
+    backend.delete(&key).await?;
+
+    let retrieved = backend.get(&key).await?;
+    assert_eq!(retrieved, None);
+
+    Ok(())
+}
+
+#[cfg(feature = "list")]
+#[dialog_common::test]
+async fn it_lists_objects() -> Result<()> {
+    let test_prefix = bucket::unique("it_lists_objects");
+
+    let backend = bucket::open().at(&test_prefix);
+
+    backend
+        .set(b"list-key1".to_vec(), b"value1".to_vec())
+        .await?;
+    backend
+        .set(b"list-key2".to_vec(), b"value2".to_vec())
+        .await?;
+
+    // TODO: list not yet implemented via capability pattern
+
+    Ok(())
+}
+
+#[cfg(feature = "list")]
+#[dialog_common::test]
+async fn it_lists_empty_for_nonexistent_prefix() -> Result<()> {
+    let _backend = bucket::open_unique_at("it_lists_empty_for_nonexistent_prefix");
+
+    // TODO: list not yet implemented via capability pattern
+
+    Ok(())
+}

--- a/rust/dialog-remote-s3/tests/integration_tests/transactional_memory.rs
+++ b/rust/dialog-remote-s3/tests/integration_tests/transactional_memory.rs
@@ -1,0 +1,146 @@
+//! Integration tests for memory CAS (Compare-And-Swap) operations with S3 backend.
+//!
+//! These tests verify that memory resolve/publish/retract work correctly with the S3 backend,
+//! including CAS semantics and conflict detection.
+
+#![cfg(feature = "s3-integration-tests")]
+
+use super::bucket;
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct TestData {
+    name: String,
+    value: u32,
+}
+
+fn encode(data: &TestData) -> Vec<u8> {
+    serde_json::to_vec(data).unwrap()
+}
+
+fn decode(bytes: &[u8]) -> TestData {
+    serde_json::from_slice(bytes).unwrap()
+}
+
+#[dialog_common::test]
+async fn it_resolves_non_existent_cell() -> anyhow::Result<()> {
+    let backend = bucket::open_unique_at("it_resolves_non_existent_cell");
+
+    let result = backend.resolve("did:key:zUser", "test-key").await?;
+    assert!(result.is_none());
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_publishes_and_resolves_value() -> anyhow::Result<()> {
+    let backend = bucket::open_unique_at("it_publishes_and_resolves_value");
+
+    let data = TestData {
+        name: "test".to_string(),
+        value: 42,
+    };
+
+    let space = "did:key:zSpace";
+    let cell = &bucket::unique("test-key-rw");
+
+    // Publish (first write, no prior edition)
+    let edition = backend.publish(space, cell, encode(&data), None).await?;
+
+    // Resolve and verify
+    let publication = backend.resolve(space, cell).await?;
+    assert!(publication.is_some());
+    let publication = publication.unwrap();
+    assert_eq!(decode(&publication.content), data);
+    assert_eq!(publication.edition, edition);
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_updates_existing_value() -> anyhow::Result<()> {
+    let backend = bucket::open_unique_at("it_updates_existing_value");
+
+    let space = "did:key:zSpace";
+    let cell = &bucket::unique("test-update-key");
+
+    let initial_data = TestData {
+        name: "initial".to_string(),
+        value: 1,
+    };
+
+    let edition1 = backend
+        .publish(space, cell, encode(&initial_data), None)
+        .await?;
+
+    let updated_data = TestData {
+        name: "updated".to_string(),
+        value: 2,
+    };
+
+    let edition2 = backend
+        .publish(space, cell, encode(&updated_data), Some(edition1))
+        .await?;
+
+    // Resolve and verify the update
+    let publication = backend.resolve(space, cell).await?;
+    assert!(publication.is_some());
+    let publication = publication.unwrap();
+    assert_eq!(decode(&publication.content), updated_data);
+    assert_eq!(publication.edition, edition2);
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_detects_cas_conflict() -> anyhow::Result<()> {
+    let backend = bucket::open_unique_at("it_detects_cas_conflict");
+
+    let space = "did:key:zSpace";
+    let cell = &bucket::unique("test-cas-key");
+
+    let initial_data = TestData {
+        name: "initial".to_string(),
+        value: 1,
+    };
+
+    // Publish initial value
+    let edition1 = backend
+        .publish(space, cell, encode(&initial_data), None)
+        .await?;
+
+    // Update with correct edition (simulating cell1)
+    let updated_by_cell1 = TestData {
+        name: "updated_by_cell1".to_string(),
+        value: 10,
+    };
+    let _edition2 = backend
+        .publish(
+            space,
+            cell,
+            encode(&updated_by_cell1),
+            Some(edition1.clone()),
+        )
+        .await?;
+
+    // Try to update with stale edition (simulating cell2 with old edition)
+    let updated_by_cell2 = TestData {
+        name: "updated_by_cell2".to_string(),
+        value: 20,
+    };
+    let result = backend
+        .publish(space, cell, encode(&updated_by_cell2), Some(edition1))
+        .await;
+
+    assert!(result.is_err(), "CAS should fail due to edition mismatch");
+
+    // Verify the value is still what cell1 set
+    let publication = backend.resolve(space, cell).await?;
+    assert!(publication.is_some());
+    assert_eq!(decode(&publication.unwrap().content), updated_by_cell1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- New `dialog-remote-s3` crate for raw S3 storage operations
- Presigned request generation for archive, memory, and storage capabilities
- S3 provider implementations with credential-based authentication
- Integration test helpers using s3s emulator
- Replaces the deleted `dialog-s3-credentials` crate