### PR TITLE
15 🏗️ feat: add dialog-remote-ucan-s3 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-signature"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "646dcc11163091f40c1618702bcde3d2e152c52b05fc4527fc67cfe077e47c22"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1171,41 @@ dependencies = [
  "tower",
  "tower-http",
  "url",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "dialog-remote-ucan-s3"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-signature",
+ "async-trait",
+ "base58",
+ "bytes",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-effects",
+ "dialog-remote-s3",
+ "dialog-storage",
+ "dialog-ucan",
+ "dialog-varsig",
+ "getrandom 0.2.16",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "ipld-core",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "signature",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-http",
  "wasm-bindgen-test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "rust/dialog-prolly-tree",
     "rust/dialog-query",
     "rust/dialog-remote-s3",
+    "rust/dialog-remote-ucan-s3",
     "rust/dialog-search-tree",
     "rust/dialog-storage",
     "rust/dialog-ucan",
@@ -187,6 +188,9 @@ path = "./rust/dialog-query"
 
 [workspace.dependencies.dialog-remote-s3]
 path = "./rust/dialog-remote-s3"
+
+[workspace.dependencies.dialog-remote-ucan-s3]
+path = "./rust/dialog-remote-ucan-s3"
 
 [workspace.dependencies.dialog-blobs]
 path = "./rust/dialog-blobs"

--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -1,0 +1,74 @@
+[package]
+name = "dialog-remote-ucan-s3"
+description = "UCAN-based remote authorization for S3-compatible storage"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[features]
+default = []
+helpers = [
+    "dep:anyhow",
+    "dep:bytes",
+    "dep:http-body-util",
+    "dep:hyper",
+    "dep:hyper-util",
+    "dep:tokio",
+    "dep:tower",
+    "dep:tower-http",
+    "dialog-common/helpers",
+    "dialog-remote-s3/helpers",
+]
+integration-tests = ["dialog-common/integration-tests"]
+web-integration-tests = ["dialog-common/web-integration-tests"]
+
+[dependencies]
+async-trait = { workspace = true }
+base58 = { workspace = true }
+dialog-capability = { workspace = true, features = ["ucan"] }
+dialog-common = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-effects = { workspace = true }
+dialog-remote-s3 = { workspace = true }
+dialog-ucan = { workspace = true }
+dialog-varsig = { workspace = true }
+ipld-core = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+serde_json = { workspace = true }
+signature = { workspace = true }
+thiserror = { workspace = true }
+
+# Optional dependencies (helpers feature, cross-platform)
+anyhow = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Optional dependencies (helpers feature, native-only server infrastructure)
+bytes = { workspace = true, optional = true }
+http-body-util = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true }
+hyper-util = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["net", "rt"], optional = true }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["cors"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+async-signature = { workspace = true }
+dialog-common = { workspace = true, features = ["helpers"] }
+dialog-storage = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
+wasm-bindgen-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(feature, values(\"web-integration-tests\", \"helpers\"))",
+  "cfg(dialog_test_wasm_integration)"
+] }

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -1,0 +1,767 @@
+//! UCAN provider for server-side authorization.
+//!
+//! This module provides [`UcanAuthorizer`], which wraps credentials and handles
+//! incoming UCAN invocations to authorize S3 operations.
+//!
+//! # Overview
+//!
+//! The UCAN provider sits on the server side and:
+//!
+//! 1. Receives a UCAN container (invocation + delegation chain)
+//! 2. Verifies the invocation and delegation chain
+//! 3. Extracts the command and arguments from the invocation
+//! 4. Delegates to wrapped credentials to get a presigned URL
+//!
+//! # Container Format
+//!
+//! The UCAN container follows the [UCAN Container spec](https://github.com/ucan-wg/container):
+//!
+//! ```text
+//! { "ctn-v1": [token_bytes_0, token_bytes_1, ..., token_bytes_n] }
+//! ```
+//!
+//! Where tokens are DAG-CBOR serialized UCANs, ordered bytewise for determinism.
+//! The first token is the invocation, followed by the delegation chain from
+//! closest to invoker to root.
+//!
+//! The delegation chain forms an authority path:
+//! ```text
+//! Subject (root) -> Delegation[n-1] -> ... -> Delegation[0] -> Invocation.issuer
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use dialog_remote_ucan_s3::UcanAuthorizer;
+//! use dialog_remote_s3::s3::S3Credentials;
+//! use dialog_remote_s3::Address;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create address for S3 bucket
+//! let address = Address::new(
+//!     "https://s3.us-east-1.amazonaws.com",
+//!     "us-east-1",
+//!     "my-bucket",
+//! );
+//!
+//! // Create underlying credentials for S3 access
+//! let s3_credentials = S3Credentials::new(
+//!     "access-key-id",
+//!     "secret-access-key",
+//! );
+//!
+//! // Wrap with UCAN authorizer
+//! let authorizer = UcanAuthorizer::new(address.with_credentials(s3_credentials));
+//!
+//! // Handle incoming UCAN container
+//! let container_bytes: Vec<u8> = vec![]; // UCAN container from request
+//! let result = authorizer.authorize(&container_bytes).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use std::collections::BTreeMap;
+
+use dialog_capability::{Capability, Constraint, Did, Policy};
+use dialog_credentials::Ed25519KeyResolver;
+use dialog_effects::{archive, memory, storage};
+use dialog_remote_s3::Address;
+use dialog_remote_s3::{AccessError, Permit};
+use dialog_ucan::InvocationChain;
+use dialog_ucan::promise::Promised;
+use ipld_core::ipld::Ipld;
+use serde::de::DeserializeOwned;
+
+// Generic deserialization from UCAN args
+
+type Args = BTreeMap<String, Promised>;
+
+/// Deserialize a typed struct from UCAN args via IPLD round-trip.
+///
+/// Converts `Promised` values to IPLD, then uses `ipld_core::serde::from_ipld`
+/// to deserialize the target type. Unknown fields are ignored, so this works
+/// on the flat args map containing fields from all capability chain layers.
+fn deserialize_from_args<T: DeserializeOwned>(args: &Args) -> Result<T, AccessError> {
+    let ipld_map: BTreeMap<String, Ipld> = args
+        .iter()
+        .map(|(k, v)| {
+            Ipld::try_from(v)
+                .map(|ipld| (k.clone(), ipld))
+                .map_err(|e| {
+                    AccessError::Invocation(format!("Unresolved promise for '{}': {}", k, e))
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    ipld_core::serde::from_ipld(Ipld::Map(ipld_map))
+        .map_err(|e| AccessError::Invocation(format!("Failed to deserialize: {}", e)))
+}
+
+/// Build a storage capability from UCAN args: `Subject -> Storage -> Store -> Claim`.
+fn storage_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, AccessError>
+where
+    C: Policy<Of = storage::Store> + DeserializeOwned,
+    <C as Constraint>::Capability: dialog_capability::Ability,
+{
+    let store: storage::Store = deserialize_from_args(args)?;
+    let claim: C = deserialize_from_args(args)?;
+    Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(storage::Storage)
+        .attenuate(store)
+        .attenuate(claim))
+}
+
+/// Build a memory capability from UCAN args: `Subject -> Memory -> Space -> Cell -> Claim`.
+fn memory_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, AccessError>
+where
+    C: Policy<Of = memory::Cell> + DeserializeOwned,
+    <C as Constraint>::Capability: dialog_capability::Ability,
+{
+    let space: memory::Space = deserialize_from_args(args)?;
+    let cell: memory::Cell = deserialize_from_args(args)?;
+    let claim: C = deserialize_from_args(args)?;
+    Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(memory::Memory)
+        .attenuate(space)
+        .attenuate(cell)
+        .attenuate(claim))
+}
+
+/// Build an archive capability from UCAN args: `Subject -> Archive -> Catalog -> Claim`.
+fn archive_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, AccessError>
+where
+    C: Policy<Of = archive::Catalog> + DeserializeOwned,
+    <C as Constraint>::Capability: dialog_capability::Ability,
+{
+    let catalog: archive::Catalog = deserialize_from_args(args)?;
+    let claim: C = deserialize_from_args(args)?;
+    Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(archive::Archive)
+        .attenuate(catalog)
+        .attenuate(claim))
+}
+
+/// Maps an execution effect type to its claim type that can be
+/// reconstructed from UCAN args.
+///
+/// The `Claim` associated type is the authorization-safe representation
+/// whose `Capability<Claim>` implements `Access`.
+trait FromUcanArgs {
+    /// The claim type for this effect (either Self or a generated {Name}Claim).
+    type Claim: Constraint;
+
+    /// Reconstruct a capability from UCAN args.
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError>;
+}
+
+impl FromUcanArgs for storage::Get {
+    type Claim = storage::Get;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        storage_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for storage::Set {
+    type Claim = storage::SetClaim;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        storage_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for storage::Delete {
+    type Claim = storage::Delete;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        storage_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for storage::List {
+    type Claim = storage::List;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        storage_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for memory::Resolve {
+    type Claim = memory::Resolve;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        let space: memory::Space = deserialize_from_args(args)?;
+        let cell: memory::Cell = deserialize_from_args(args)?;
+        Ok(dialog_capability::Subject::from(subject.clone())
+            .attenuate(memory::Memory)
+            .attenuate(space)
+            .attenuate(cell)
+            .attenuate(memory::Resolve))
+    }
+}
+impl FromUcanArgs for memory::Publish {
+    type Claim = memory::PublishClaim;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        memory_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for memory::Retract {
+    type Claim = memory::RetractClaim;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        memory_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for archive::Get {
+    type Claim = archive::Get;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        archive_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for archive::Put {
+    type Claim = archive::PutClaim;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        archive_claim_from_args(subject, args)
+    }
+}
+
+/// Dispatch UCAN command to the appropriate `FromUcanArgs` handler and authorize
+/// the resulting capability directly against the S3 address.
+macro_rules! dispatch {
+    ($self:expr, $subject:expr, $args:expr, $segments:expr, {
+        $( [$seg1:literal, $seg2:literal] => $fx:ty ),+ $(,)?
+    }) => {
+        match $segments {
+            $(
+                [$seg1, $seg2] => {
+                    let capability = <$fx as FromUcanArgs>::capability_from_args($subject, $args)?;
+                    $self.address.authorize(&capability).await
+                }
+            )+
+            _ => Err(AccessError::Invocation(format!("Unknown command: {:?}", $segments)))
+        }
+    };
+}
+
+/// UCAN authorizer that wraps credentials and handles UCAN invocations.
+///
+/// This is the server-side component that:
+/// 1. Receives UCAN containers (invocation + delegations)
+/// 2. Verifies the delegation chain
+/// 3. Extracts commands and constructs effects
+/// 4. Delegates to wrapped credentials for presigned URLs
+#[derive(Debug, Clone)]
+pub struct UcanAuthorizer {
+    address: Address,
+}
+
+impl UcanAuthorizer {
+    /// Create a new UCAN authorizer wrapping the given address.
+    ///
+    /// Credentials (if any) should be set on the address via `Address::with_credentials`.
+    pub fn new(address: Address) -> Self {
+        Self { address }
+    }
+
+    /// Authorize a UCAN container.
+    ///
+    /// # Arguments
+    ///
+    /// * `container` - CBOR-encoded UCAN container following the
+    ///   [UCAN Container spec](https://github.com/ucan-wg/container):
+    ///   `{ "ctn-v1": [invocation_bytes, delegation_0_bytes, ..., delegation_n_bytes] }`
+    ///
+    /// # Returns
+    ///
+    /// Returns a `RequestDescriptor` with a presigned URL and headers on success.
+    ///
+    /// # Verification
+    ///
+    /// The container is verified using rs-ucan's `syntactic_checks` which:
+    /// 1. Verifies the delegation chain from subject to invocation issuer
+    /// 2. Checks command prefix authorization at each delegation
+    /// 3. Validates policy predicates on each delegation
+    pub async fn authorize(&self, container: &[u8]) -> Result<Permit, AccessError> {
+        // Parse and verify the invocation chain
+        let chain = InvocationChain::try_from(container)
+            .map_err(|e| AccessError::Invocation(e.to_string()))?;
+        chain
+            .verify(&Ed25519KeyResolver)
+            .await
+            .map_err(|e| AccessError::Invocation(e.to_string()))?;
+
+        // Extract command path and arguments
+        let command = chain.command();
+        let args = chain.arguments();
+
+        // Get subject DID from the invocation
+        let subject_did = chain.subject();
+
+        let command_segments: Vec<&str> = command.0.iter().map(|s| s.as_str()).collect();
+
+        dispatch!(self, subject_did, args, command_segments.as_slice(), {
+            ["storage", "get"]     => dialog_effects::storage::Get,
+            ["storage", "set"]     => dialog_effects::storage::Set,
+            ["storage", "delete"]  => dialog_effects::storage::Delete,
+            ["storage", "list"]    => dialog_effects::storage::List,
+            ["memory", "resolve"]  => dialog_effects::memory::Resolve,
+            ["memory", "publish"]  => dialog_effects::memory::Publish,
+            ["memory", "retract"]  => dialog_effects::memory::Retract,
+            ["archive", "get"]     => dialog_effects::archive::Get,
+            ["archive", "put"]     => dialog_effects::archive::Put,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base58::ToBase58;
+    use dialog_capability::Principal;
+    use dialog_common::Blake3Hash;
+    use dialog_credentials::Ed25519Signer;
+    use dialog_remote_s3::Address;
+    use dialog_remote_s3::s3;
+    use dialog_remote_s3::s3::S3Credentials;
+    use dialog_ucan::DelegationBuilder;
+    use dialog_ucan::InvocationBuilder;
+    use dialog_ucan::InvocationChain;
+    use dialog_ucan::subject::Subject as DelegatedSubject;
+    use std::collections::BTreeMap;
+
+    /// Helper to create a test signer
+    async fn test_signer() -> Ed25519Signer {
+        Ed25519Signer::import(&[42u8; 32]).await.unwrap()
+    }
+
+    /// Build a valid UCAN container with invocation and delegation for testing
+    async fn build_test_container(
+        subject_signer: &Ed25519Signer,
+        operator_signer: &Ed25519Signer,
+        command: Vec<String>,
+        args: BTreeMap<String, Promised>,
+    ) -> Vec<u8> {
+        let subject_did = subject_signer.did();
+
+        // Create delegation: subject -> operator
+        let delegation = DelegationBuilder::new()
+            .issuer(subject_signer.clone())
+            .audience(operator_signer)
+            .subject(DelegatedSubject::Specific(subject_did.clone()))
+            .command(command.clone())
+            .try_build()
+            .await
+            .expect("Failed to build delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        // Create invocation: operator invokes on subject
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(command)
+            .arguments(args)
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        // Build InvocationChain
+        let mut delegations = std::collections::HashMap::new();
+        delegations.insert(delegation_cid, std::sync::Arc::new(delegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+        chain.to_bytes().expect("Failed to serialize container")
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_storage_get() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        let mut args = BTreeMap::new();
+        args.insert("store".to_string(), Promised::String("index".to_string()));
+        args.insert("key".to_string(), Promised::Bytes(b"test-key".to_vec()));
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["storage".to_string(), "get".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok());
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+        assert!(descriptor.url.as_str().contains("test-bucket"));
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_storage_set() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        // Multihash format: [code, length, ...digest]
+        // SHA-256 code is 0x12, length is 0x20 (32 bytes)
+        let mut checksum_bytes = vec![0x12, 0x20];
+        checksum_bytes.extend_from_slice(&[0u8; 32]);
+
+        let mut args = BTreeMap::new();
+        args.insert("store".to_string(), Promised::String("index".to_string()));
+        args.insert("key".to_string(), Promised::Bytes(b"test-key".to_vec()));
+        args.insert("checksum".to_string(), Promised::Bytes(checksum_bytes));
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["storage".to_string(), "set".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok());
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "PUT");
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_memory_resolve() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        let mut args = BTreeMap::new();
+        args.insert(
+            "space".to_string(),
+            Promised::String("test-space".to_string()),
+        );
+        args.insert(
+            "cell".to_string(),
+            Promised::String("test-cell".to_string()),
+        );
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["memory".to_string(), "resolve".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok(), "memory/resolve failed: {:?}", result);
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_archive_get() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert("digest".to_string(), Promised::Bytes([0u8; 32].to_vec()));
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["archive".to_string(), "get".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok());
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_archive_put() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        // Multihash format: [code, length, ...digest]
+        // SHA-256 code is 0x12, length is 0x20 (32 bytes)
+        let mut checksum_bytes = vec![0x12, 0x20];
+        checksum_bytes.extend_from_slice(&[0u8; 32]);
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert("digest".to_string(), Promised::Bytes([0u8; 32].to_vec()));
+        args.insert("checksum".to_string(), Promised::Bytes(checksum_bytes));
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["archive".to_string(), "put".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok());
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "PUT");
+    }
+
+    #[dialog_common::test]
+    async fn it_provides_authorized_requests() -> anyhow::Result<()> {
+        let operator = Ed25519Signer::import(&[0u8; 32]).await.unwrap();
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = s3::S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let digest = Blake3Hash::hash(b"hello");
+        let args = BTreeMap::from([
+            ("catalog".to_string(), Promised::String("blobs".into())),
+            (
+                "digest".to_string(),
+                Promised::Bytes(digest.as_bytes().into()),
+            ),
+        ]);
+
+        let payload = build_test_container(
+            &operator,
+            &operator,
+            vec!["archive".into(), "get".into()],
+            args,
+        )
+        .await;
+
+        let authorization = authorizer.authorize(&payload).await?;
+        assert_eq!(
+            authorization.url.path(),
+            format!(
+                "/{}/blobs/{}",
+                operator.did(),
+                digest.as_bytes().to_base58()
+            )
+        );
+
+        Ok(())
+    }
+
+    /// Build a self-invocation container (issuer == subject, no delegation).
+    /// This is used when a subject acts on itself, which is inherently authorized.
+    async fn build_self_invocation_container(
+        signer: &Ed25519Signer,
+        command: Vec<String>,
+        args: BTreeMap<String, Promised>,
+    ) -> Vec<u8> {
+        let did = signer.did();
+
+        // Self-invocation: issuer == subject, no proofs needed
+        let invocation = InvocationBuilder::new()
+            .issuer(signer.clone())
+            .audience(&did)
+            .subject(&did)
+            .command(command)
+            .arguments(args)
+            .proofs(vec![]) // Empty proofs for self-auth
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let chain = InvocationChain::new(invocation, std::collections::HashMap::new());
+        chain.to_bytes().expect("Failed to serialize container")
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_self_invocation_for_storage_get() {
+        let signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let mut args = BTreeMap::new();
+        args.insert("store".to_string(), Promised::String("index".to_string()));
+        args.insert("key".to_string(), Promised::Bytes(b"test-key".to_vec()));
+
+        // Build self-invocation (issuer == subject, no delegation)
+        let container = build_self_invocation_container(
+            &signer,
+            vec!["storage".to_string(), "get".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(
+            result.is_ok(),
+            "Self-invocation should be authorized: {:?}",
+            result
+        );
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+        assert!(descriptor.url.as_str().contains("test-bucket"));
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_self_invocation_for_storage_set() {
+        let signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        // Multihash format: [code, length, ...digest]
+        // SHA-256 code is 0x12, length is 0x20 (32 bytes)
+        let mut checksum_bytes = vec![0x12, 0x20];
+        checksum_bytes.extend_from_slice(&[0u8; 32]);
+
+        let mut args = BTreeMap::new();
+        args.insert("store".to_string(), Promised::String("index".to_string()));
+        args.insert("key".to_string(), Promised::Bytes(b"test-key".to_vec()));
+        args.insert("checksum".to_string(), Promised::Bytes(checksum_bytes));
+
+        // Build self-invocation (issuer == subject, no delegation)
+        let container = build_self_invocation_container(
+            &signer,
+            vec!["storage".to_string(), "set".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(
+            result.is_ok(),
+            "Self-invocation for storage/set should be authorized: {:?}",
+            result
+        );
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "PUT");
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_self_invocation_for_archive_get() {
+        let signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert(
+            "digest".to_string(),
+            Promised::Bytes(Blake3Hash::hash(b"test").as_bytes().to_vec()),
+        );
+
+        // Build self-invocation (issuer == subject, no delegation)
+        let container = build_self_invocation_container(
+            &signer,
+            vec!["archive".to_string(), "get".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(
+            result.is_ok(),
+            "Self-invocation for archive/get should be authorized: {:?}",
+            result
+        );
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/helpers.rs
+++ b/rust/dialog-remote-ucan-s3/src/helpers.rs
@@ -1,0 +1,29 @@
+//! UCAN access service test infrastructure.
+//!
+//! Provides [`UcanS3Address`] and a local UCAN access server backed by
+//! an in-memory S3 server for integration testing.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(not(target_arch = "wasm32"))]
+mod server;
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;
+
+/// UCAN+S3 test server connection info.
+///
+/// Combines a UCAN access service endpoint with the backing S3 server details.
+/// Passed to integration tests via `#[dialog_common::test]`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UcanS3Address {
+    /// URL of the UCAN access service.
+    pub access_service_url: String,
+    /// URL of the backing S3 server (for test verification).
+    pub s3_endpoint: String,
+    /// The bucket name.
+    pub bucket: String,
+    /// AWS access key ID (used by the access service).
+    pub access_key_id: String,
+    /// AWS secret access key (used by the access service).
+    pub secret_access_key: String,
+}

--- a/rust/dialog-remote-ucan-s3/src/helpers/server.rs
+++ b/rust/dialog-remote-ucan-s3/src/helpers/server.rs
@@ -1,0 +1,219 @@
+//! UCAN access service test server.
+//!
+//! Provides a local UCAN access service for integration testing.
+//! Receives UCAN invocation containers, verifies them using [`UcanAuthorizer`],
+//! and returns presigned S3 request descriptors.
+
+use super::UcanS3Address;
+use crate::UcanAuthorizer;
+use dialog_common::helpers::{Provider, Service};
+use dialog_remote_s3::helpers::LocalS3;
+use dialog_remote_s3::{Address, S3Credentials};
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use std::convert::Infallible;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+
+/// A running UCAN access service test server instance.
+pub struct UcanAccessServer {
+    /// The endpoint URL where the access service is listening.
+    pub endpoint: String,
+    /// The backing S3 server.
+    pub s3_server: LocalS3,
+    shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+impl UcanAccessServer {
+    /// Start a UCAN access service backed by a local S3 server.
+    pub async fn start(
+        s3_server: LocalS3,
+        bucket: &str,
+        access_key: &str,
+        secret_key: &str,
+    ) -> anyhow::Result<Self> {
+        let address = Address::new(&s3_server.endpoint, "us-east-1", bucket)
+            .with_credentials(S3Credentials::new(access_key, secret_key))
+            .with_path_style();
+
+        let authorizer = Arc::new(RwLock::new(UcanAuthorizer::new(address)));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}", addr);
+
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let authorizer_clone = authorizer.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    result = listener.accept() => {
+                        if let Ok((stream, _)) = result {
+                            let authorizer = authorizer_clone.clone();
+                            tokio::spawn(async move {
+                                let service = hyper::service::service_fn(move |req| {
+                                    let authorizer = authorizer.clone();
+                                    async move {
+                                        handle_request(req, authorizer).await
+                                    }
+                                });
+                                let _ = http1::Builder::new()
+                                    .serve_connection(TokioIo::new(stream), service)
+                                    .await;
+                            });
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(UcanAccessServer {
+            endpoint,
+            s3_server,
+            shutdown_tx,
+        })
+    }
+}
+
+fn add_cors_headers(builder: hyper::http::response::Builder) -> hyper::http::response::Builder {
+    builder
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        .header("Access-Control-Allow-Headers", "Content-Type")
+        .header("Access-Control-Max-Age", "86400")
+        .header("Cache-Control", "no-store")
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    authorizer: Arc<RwLock<UcanAuthorizer>>,
+) -> Result<Response<http_body_util::Full<bytes::Bytes>>, Infallible> {
+    use bytes::Bytes;
+    use http_body_util::Full;
+
+    if req.method() == Method::OPTIONS {
+        return Ok(add_cors_headers(Response::builder())
+            .status(StatusCode::NO_CONTENT)
+            .body(Full::new(Bytes::new()))
+            .unwrap());
+    }
+
+    if req.method() != Method::POST {
+        return Ok(add_cors_headers(Response::builder())
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .body(Full::new(Bytes::from("Method not allowed")))
+            .unwrap());
+    }
+
+    use http_body_util::BodyExt;
+    let body_bytes = match req.into_body().collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            return Ok(add_cors_headers(Response::builder())
+                .status(StatusCode::BAD_REQUEST)
+                .body(Full::new(Bytes::from(format!(
+                    "Failed to read body: {}",
+                    e
+                ))))
+                .unwrap());
+        }
+    };
+
+    let authorizer = authorizer.read().await;
+    match authorizer.authorize(&body_bytes).await {
+        Ok(descriptor) => match serde_ipld_dagcbor::to_vec(&descriptor) {
+            Ok(cbor_bytes) => Ok(add_cors_headers(Response::builder())
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/cbor")
+                .body(Full::new(Bytes::from(cbor_bytes)))
+                .unwrap()),
+            Err(e) => Ok(add_cors_headers(Response::builder())
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Full::new(Bytes::from(format!(
+                    "Failed to encode response: {}",
+                    e
+                ))))
+                .unwrap()),
+        },
+        Err(e) => Ok(add_cors_headers(Response::builder())
+            .status(StatusCode::FORBIDDEN)
+            .body(Full::new(Bytes::from(format!(
+                "Authorization failed: {}",
+                e
+            ))))
+            .unwrap()),
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for UcanAccessServer {
+    async fn stop(self) -> anyhow::Result<()> {
+        let _ = self.shutdown_tx.send(());
+        self.s3_server.stop().await
+    }
+}
+
+/// Settings for configuring the UCAN access service test server.
+#[derive(Debug, Clone)]
+pub struct UcanS3Settings {
+    /// The bucket name to create. Defaults to "test-bucket".
+    pub bucket: String,
+    /// AWS access key ID. Defaults to "test-access-key".
+    pub access_key_id: String,
+    /// AWS secret access key. Defaults to "test-secret-key".
+    pub secret_access_key: String,
+}
+
+impl Default for UcanS3Settings {
+    fn default() -> Self {
+        Self {
+            bucket: String::new(),
+            access_key_id: "test-access-key".to_string(),
+            secret_access_key: "test-secret-key".to_string(),
+        }
+    }
+}
+
+/// Starts both an S3 server and a UCAN access service.
+#[dialog_common::provider]
+pub async fn ucan_s3(
+    settings: UcanS3Settings,
+) -> anyhow::Result<Service<UcanS3Address, UcanAccessServer>> {
+    let bucket = if settings.bucket.is_empty() {
+        "test-bucket"
+    } else {
+        &settings.bucket
+    };
+
+    let s3_server = LocalS3::start_with_auth(
+        &settings.access_key_id,
+        &settings.secret_access_key,
+        &[bucket],
+    )
+    .await?;
+
+    let s3_endpoint = s3_server.endpoint.clone();
+
+    let ucan_server = UcanAccessServer::start(
+        s3_server,
+        bucket,
+        &settings.access_key_id,
+        &settings.secret_access_key,
+    )
+    .await?;
+
+    let address = UcanS3Address {
+        access_service_url: ucan_server.endpoint.clone(),
+        s3_endpoint,
+        bucket: bucket.to_string(),
+        access_key_id: settings.access_key_id,
+        secret_access_key: settings.secret_access_key,
+    };
+
+    Ok(Service::new(address, ucan_server))
+}

--- a/rust/dialog-remote-ucan-s3/src/lib.rs
+++ b/rust/dialog-remote-ucan-s3/src/lib.rs
@@ -1,0 +1,64 @@
+//! UCAN-based authorization for S3-compatible storage.
+//!
+//! This crate provides UCAN (User Controlled Authorization Networks) support:
+//!
+//! ## Client-side (making requests)
+//!
+//! - [`Credentials`] - Credentials that delegate to an external access service
+//! - [`DelegationChain`] - Chain of delegations proving authority
+//!
+//! ## Server-side (handling requests)
+//!
+//! - [`UcanAuthorizer`] - Wraps credentials to handle UCAN invocations and authorize requests
+//! - [`InvocationChain`] - Parsed UCAN container with invocation and delegation chain
+
+mod authorizer;
+mod provider;
+pub mod site;
+
+pub use authorizer::UcanAuthorizer;
+pub use dialog_capability::ucan::import_delegation_chain;
+pub use site::{Ucan, UcanAddress, UcanInvocation, UcanSite};
+
+// Re-export container types from dialog-ucan
+pub use dialog_ucan::{Container, ContainerError, DelegationChain, InvocationChain};
+
+#[cfg(feature = "helpers")]
+pub mod helpers;
+
+/// Test helpers for creating UCAN delegations.
+/// Only available with the `helpers` feature.
+#[cfg(any(test, feature = "helpers"))]
+pub mod test_helpers {
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan::ContainerError;
+    use dialog_ucan::Delegation;
+    use dialog_ucan::DelegationBuilder;
+    use dialog_ucan::subject::Subject;
+    use dialog_varsig::Principal;
+    use dialog_varsig::eddsa::Ed25519Signature;
+
+    /// Generate a new random Ed25519 signer.
+    pub async fn generate_signer() -> Ed25519Signer {
+        Ed25519Signer::generate()
+            .await
+            .expect("Failed to generate signer")
+    }
+
+    /// Create a delegation from issuer to audience for a subject with the given command.
+    pub async fn create_delegation(
+        issuer: &Ed25519Signer,
+        audience: &impl Principal,
+        subject: &impl Principal,
+        command: &[&str],
+    ) -> Result<Delegation<Ed25519Signature>, ContainerError> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Specific(subject.did()))
+            .command(command.iter().map(|&s| s.to_string()).collect())
+            .try_build()
+            .await
+            .map_err(|e| ContainerError::Invocation(format!("Failed to build delegation: {:?}", e)))
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/provider.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider.rs
@@ -1,0 +1,8 @@
+//! `Provider<Fork<UcanSite, Fx>>` implementations.
+//!
+//! Each impl authorizes via the UCAN access service (`UcanAddress::authorize`),
+//! then delegates to `Provider<Authorized<Fx>>` on `S3` for shared HTTP execution.
+
+pub mod archive;
+pub mod memory;
+pub mod storage;

--- a/rust/dialog-remote-ucan-s3/src/provider/archive.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/archive.rs
@@ -1,0 +1,48 @@
+//! Archive capability `Provider<Fork<UcanSite, Fx>>` implementations.
+
+use async_trait::async_trait;
+use dialog_capability::Provider;
+use dialog_capability::fork::{Fork, ForkInvocation};
+use dialog_effects::archive::*;
+use dialog_remote_s3::{Authorized, S3};
+
+use crate::site::UcanSite;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Get>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Get>,
+    ) -> Result<Option<Vec<u8>>, ArchiveError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Get>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Put>> for UcanSite {
+    async fn execute(&self, invocation: ForkInvocation<UcanSite, Put>) -> Result<(), ArchiveError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Put>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/provider/memory.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/memory.rs
@@ -1,0 +1,72 @@
+//! Memory capability `Provider<Fork<UcanSite, Fx>>` implementations.
+
+use async_trait::async_trait;
+use dialog_capability::Provider;
+use dialog_capability::fork::{Fork, ForkInvocation};
+use dialog_effects::memory::*;
+use dialog_remote_s3::{Authorized, S3};
+
+use crate::site::UcanSite;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Resolve>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Resolve>,
+    ) -> Result<Option<Publication>, MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Resolve>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Publish>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Publish>,
+    ) -> Result<Vec<u8>, MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Publish>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Retract>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Retract>,
+    ) -> Result<(), MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Retract>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/provider/storage.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/storage.rs
@@ -1,0 +1,69 @@
+//! Storage capability `Provider<Fork<UcanSite, Fx>>` implementations.
+
+use async_trait::async_trait;
+use dialog_capability::Provider;
+use dialog_capability::fork::{Fork, ForkInvocation};
+use dialog_effects::storage::*;
+use dialog_remote_s3::{Authorized, S3};
+
+use crate::site::UcanSite;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Get>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Get>,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Get>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Set>> for UcanSite {
+    async fn execute(&self, invocation: ForkInvocation<UcanSite, Set>) -> Result<(), StorageError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Set>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Fork<UcanSite, Delete>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Delete>,
+    ) -> Result<(), StorageError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.authorization.authorization)
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Delete>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.authorization.capability),
+        )
+        .await
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -1,0 +1,79 @@
+//! UCAN site configuration -- marker trait + address type.
+
+use dialog_capability::site::{Site, SiteAddress};
+
+// Re-export UCAN types from dialog-capability for convenience.
+pub use dialog_capability::ucan::{Ucan, UcanInvocation};
+
+/// UCAN site address -- wraps the access service endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct UcanAddress {
+    /// The access service endpoint URL.
+    pub endpoint: String,
+}
+
+impl UcanAddress {
+    /// Create a new UCAN address with the given endpoint.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+        }
+    }
+
+    /// Get the access service endpoint URL.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// POST the signed invocation to the access service endpoint and get back
+    /// a presigned URL for the S3 operation.
+    pub async fn authorize(
+        &self,
+        invocation: &UcanInvocation,
+    ) -> Result<dialog_remote_s3::Permit, dialog_remote_s3::AccessError> {
+        let ucan = invocation
+            .to_bytes()
+            .map_err(|e| dialog_remote_s3::AccessError::Invocation(e.to_string()))?;
+
+        let response = reqwest::Client::new()
+            .post(&self.endpoint)
+            .header("Content-Type", "application/cbor")
+            .body(ucan)
+            .send()
+            .await
+            .map_err(|e| dialog_remote_s3::AccessError::Service(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(dialog_remote_s3::AccessError::Service(format!(
+                "Access service returned {}: {}",
+                status, body
+            )));
+        }
+
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| dialog_remote_s3::AccessError::Service(e.to_string()))?;
+
+        serde_ipld_dagcbor::from_slice(&body).map_err(|e| {
+            dialog_remote_s3::AccessError::Service(format!("Failed to decode response: {}", e))
+        })
+    }
+}
+
+impl SiteAddress for UcanAddress {
+    type Site = UcanSite;
+}
+
+/// UCAN site configuration for delegated authorization.
+///
+/// A marker type -- no fields. Address info lives in `UcanAddress`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UcanSite;
+
+impl Site for UcanSite {
+    type Protocol = Ucan;
+    type Address = UcanAddress;
+}

--- a/rust/dialog-ucan/src/lib.rs
+++ b/rust/dialog-ucan/src/lib.rs
@@ -29,6 +29,7 @@ mod sealed;
 
 pub use container::delegation::DelegationChain;
 pub use container::invocation::InvocationChain;
+pub use container::{Container, ContainerError};
 pub use delegation::{
     Delegation,
     builder::{BuildError as DelegationBuildError, DelegationBuilder},


### PR DESCRIPTION
## Summary

- New `dialog-remote-ucan-s3` crate for UCAN-authorized S3 access
- Site type with UCAN Protocol implementation
- Authorizer producing signed invocation chains for S3 operations
- Provider implementations dispatching authorized requests
- Re-export `Container`/`ContainerError` from `dialog-ucan`