### PR TITLE
16 🏗️ feat: add dialog-repository crate with credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-operator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dialog-artifacts",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-remote-s3",
+ "dialog-remote-ucan-s3",
+ "dialog-ucan",
+ "dialog-varsig",
+ "serde",
+ "signature",
+]
+
+[[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "rust/dialog-encoding",
     "rust/dialog-prolly-tree",
     "rust/dialog-query",
+    "rust/dialog-operator",
     "rust/dialog-remote-s3",
     "rust/dialog-remote-ucan-s3",
     "rust/dialog-search-tree",
@@ -185,6 +186,9 @@ path = "./rust/dialog-macros"
 
 [workspace.dependencies.dialog-query]
 path = "./rust/dialog-query"
+
+[workspace.dependencies.dialog-operator]
+path = "./rust/dialog-operator"
 
 [workspace.dependencies.dialog-remote-s3]
 path = "./rust/dialog-remote-s3"

--- a/rust/dialog-capability/src/authority.rs
+++ b/rust/dialog-capability/src/authority.rs
@@ -9,9 +9,8 @@
 //!         └── Sign { payload } -> Effect -> Result<Vec<u8>, CredentialError>
 //! ```
 //!
-//! [`Authority`] is a type alias for `Capability<Operator>` — the chain itself
-//! is the identity. [`Identify`] is an effect on `Subject` that returns the
-//! current `Authority`.
+//! The authority chain `Capability<Operator>` is the identity itself.
+//! [`Identify`] is an effect on `Subject` that returns the current chain.
 
 use crate::{Attenuation, Capability, Did, Effect, Policy, Subject};
 use serde::{Deserialize, Serialize};
@@ -85,21 +84,6 @@ impl Attenuation for Operator {
     type Of = Profile;
 }
 
-/// The authority chain — `Subject → Profile → Operator`.
-///
-/// This is the identity itself, encoded as a capability chain.
-/// Extract DIDs by reading the chain:
-///
-/// ```no_run
-/// # use dialog_capability::{Subject, Policy, did};
-/// # use dialog_capability::authority::{Profile, Operator, Authority};
-/// # let authority: Authority = todo!();
-/// let repo_subject = authority.subject();
-/// let profile = Profile::of(&authority);
-/// let operator = Operator::of(&authority);
-/// ```
-pub type Authority = Capability<Operator>;
-
 /// Sign operation — signs a payload using the operator's key.
 #[derive(Debug, Clone, Serialize, Deserialize, crate::Claim)]
 pub struct Sign {
@@ -134,15 +118,15 @@ impl SignCapability for Capability<Sign> {
     }
 }
 
-/// Identify operation — returns the current [`Authority`] chain.
+/// Identify operation — returns the current authority chain.
 ///
 /// This is an effect directly on `Subject` — no intermediate attenuation.
-/// The returned `Authority` (`Capability<Operator>`) encodes the full
-/// identity hierarchy: subject, profile, and operator.
+/// The returned `Capability<Operator>` encodes the full identity hierarchy:
+/// subject, profile, and operator.
 #[derive(Debug, Clone, Serialize, Deserialize, crate::Claim)]
 pub struct Identify;
 
 impl Effect for Identify {
     type Of = Subject;
-    type Output = Result<Authority, AuthorityError>;
+    type Output = Result<Capability<Operator>, AuthorityError>;
 }

--- a/rust/dialog-capability/src/ucan/claim.rs
+++ b/rust/dialog-capability/src/ucan/claim.rs
@@ -421,7 +421,7 @@ mod tests {
             async fn execute(
                 &self,
                 input: Capability<authority::Identify>,
-            ) -> Result<authority::Authority, authority::AuthorityError> {
+            ) -> Result<Capability<authority::Operator>, authority::AuthorityError> {
                 let did = dialog_varsig::Principal::did(&self.signer);
                 let subject_did = input.subject().clone();
                 Ok(Subject::from(subject_did)

--- a/rust/dialog-capability/src/ucan/delegation.rs
+++ b/rust/dialog-capability/src/ucan/delegation.rs
@@ -207,7 +207,7 @@ mod tests {
             async fn execute(
                 &self,
                 input: Capability<authority::Identify>,
-            ) -> Result<authority::Authority, authority::AuthorityError> {
+            ) -> Result<Capability<authority::Operator>, authority::AuthorityError> {
                 let did = Principal::did(&self.signer);
                 let subject_did = input.subject().clone();
                 Ok(Subject::from(subject_did)

--- a/rust/dialog-capability/src/ucan/issuer.rs
+++ b/rust/dialog-capability/src/ucan/issuer.rs
@@ -4,8 +4,8 @@
 //! UCAN's `Principal` + `Signer` interface, allowing the UCAN
 //! `InvocationBuilder` to work with the capability system.
 
-use crate::authority::{Authority, Operator, Sign};
-use crate::{Did, Policy, Provider};
+use crate::authority::{Operator, Sign};
+use crate::{Capability, Did, Policy, Provider};
 use dialog_common::ConditionalSync;
 use dialog_varsig::eddsa::Ed25519Signature;
 use dialog_varsig::{Principal, Signer};
@@ -17,17 +17,17 @@ use dialog_varsig::{Principal, Signer};
 pub struct Issuer<'a, Env> {
     env: &'a Env,
     /// The authority capability chain (`Subject → Profile → Operator`).
-    capability: Authority,
+    capability: Capability<Operator>,
 }
 
 impl<'a, Env> Issuer<'a, Env> {
     /// Create an issuer from an authority chain and environment.
-    pub fn new(env: &'a Env, capability: Authority) -> Self {
+    pub fn new(env: &'a Env, capability: Capability<Operator>) -> Self {
         Self { env, capability }
     }
 
     /// Get the authority capability chain.
-    pub fn capability(&self) -> &Authority {
+    pub fn capability(&self) -> &Capability<Operator> {
         &self.capability
     }
 }

--- a/rust/dialog-operator/Cargo.toml
+++ b/rust/dialog-operator/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "dialog-operator"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["s3", "ucan"]
+helpers = ["dep:anyhow"]
+integration-tests = ["dialog-common/integration-tests"]
+web-integration-tests = ["dialog-common/web-integration-tests"]
+s3 = ["dep:dialog-remote-s3"]
+ucan = ["s3", "dep:dialog-remote-ucan-s3", "dep:dialog-ucan", "dialog-capability/ucan"]
+
+[dependencies]
+dialog-artifacts = { workspace = true }
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-varsig = { workspace = true }
+dialog-ucan = { workspace = true, optional = true }
+dialog-remote-s3 = { workspace = true, optional = true }
+dialog-remote-ucan-s3 = { workspace = true, optional = true }
+
+anyhow = { workspace = true, optional = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+signature = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(dialog_test_wasm_integration)"] }

--- a/rust/dialog-operator/README.md
+++ b/rust/dialog-operator/README.md
@@ -1,0 +1,92 @@
+# dialog-operator
+
+Identity and operating environment for Dialog-DB.
+
+This crate provides the identity layer (authority, profiles, operators) and
+the operating environment (storage dispatch, remote dispatch) that sits
+between raw capabilities and the repository abstraction.
+
+## Identity Model
+
+Three Ed25519 keypairs form a delegation chain, each identified by a `did:key`:
+
+- **Profile**: a named identity on a device. Created on first use, persists
+  for the device lifetime. Lives at a storage location.
+- **Operator**: a session key derived deterministically from the profile.
+  Same profile + context always yields the same key. Ephemeral, revocable.
+- **Account** *(optional)*: a passkey or hardware key for cross-device
+  recovery. Can be deferred.
+
+Every capability invocation carries a delegation chain:
+`subject -> profile -> operator`.
+
+## Setup
+
+```rust,ignore
+use dialog_operator::{Authority, Profile, Operator, Remote};
+use dialog_operator::storage::Storage;
+use dialog_capability::Subject;
+
+// 1. Create a storage dispatcher
+let storage = Storage::temp_storage();
+
+// 2. Open (or create) a profile at a storage location
+let profile = Profile::open(Storage::profile("alice"))
+    .perform(&storage)
+    .await?;
+
+// 3. Derive an operator with capability grants
+let operator = profile
+    .derive(b"my-app")
+    .allow(Subject::any())       // powerline: full access
+    .build(storage)
+    .await?;
+```
+
+## Storage Locations
+
+Storage locations are capabilities. Point them wherever you want:
+
+```rust,ignore
+Storage::profile("my-app");       // platform data dir (~/.local/share on Linux)
+Storage::current("my-project");   // working directory (native only)
+Storage::temp("test");            // temporary / in-memory
+```
+
+On native, these resolve to filesystem paths. On web, they resolve to
+IndexedDB databases. `Storage::temp_storage()` creates a volatile
+(in-memory) dispatcher for testing.
+
+## Components
+
+### Authority
+
+Holds profile and operator signers. Implements `Provider<Identify>` and
+`Provider<Sign>` so the capability system can resolve identity and produce
+signatures.
+
+### Profile
+
+A named identity backed by a signing credential at a storage location.
+`Profile::open(location)` loads an existing profile or creates a new one.
+Profiles are the long-lived identity; operators are derived from them.
+
+### Operator
+
+The top-level operating environment. Composes:
+- `Authority` for identity and signing
+- `Storage` for DID-routed storage dispatch
+- `Remote` for fork-based remote operations
+
+Built via `profile.derive(context).allow(...).build(storage)`.
+
+### Storage
+
+DID-routed effect dispatcher. Each subject DID maps to a storage backend
+(filesystem, IndexedDB, or volatile). Handles Load/Save/Mount for
+location-addressed content and Get/Set/Delete/List for key-value stores.
+
+### Remote
+
+Dispatch wrapper for fork invocations targeting remote sites (e.g., S3
+with UCAN authorization).

--- a/rust/dialog-operator/src/authority.rs
+++ b/rust/dialog-operator/src/authority.rs
@@ -1,0 +1,132 @@
+//! Authority — profile and operator signers for identity and signing.
+//!
+//! [`Authority`] holds the profile and operator signers and implements
+//! the provider traits needed by `Operator` for identity and signing effects.
+
+use dialog_capability::authority::{self, AuthorityError, Operator};
+use dialog_capability::{Capability, Policy, Provider, Subject};
+use dialog_credentials::Ed25519Signer;
+use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::{Did, Principal};
+
+/// An opened profile with profile and operator signers.
+///
+/// Implements `Provider<Identify>`, `Provider<Sign>`, `Principal`, and
+/// `Issuer` so the capability system can resolve identity and produce
+/// signatures.
+#[derive(Debug, Clone)]
+pub struct Authority {
+    name: String,
+    profile: Ed25519Signer,
+    operator: Ed25519Signer,
+    account: Option<Did>,
+}
+
+impl Authority {
+    /// Create an opened profile from existing signers.
+    pub fn new(name: impl Into<String>, profile: Ed25519Signer, operator: Ed25519Signer) -> Self {
+        Self {
+            name: name.into(),
+            profile,
+            operator,
+            account: None,
+        }
+    }
+
+    /// Set the account DID.
+    pub fn with_account(mut self, account: Did) -> Self {
+        self.account = Some(account);
+        self
+    }
+
+    /// Get the profile name.
+    pub fn profile_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the profile DID.
+    pub fn profile_did(&self) -> Did {
+        Principal::did(&self.profile)
+    }
+
+    /// Get the operator DID.
+    pub fn operator_did(&self) -> Did {
+        Principal::did(&self.operator)
+    }
+
+    /// Get the account DID, if configured.
+    pub fn account_did(&self) -> Option<&Did> {
+        self.account.as_ref()
+    }
+
+    /// Get a reference to the profile signer.
+    pub fn profile_signer(&self) -> &Ed25519Signer {
+        &self.profile
+    }
+
+    /// Get a reference to the operator signer.
+    pub fn operator_signer(&self) -> &Ed25519Signer {
+        &self.operator
+    }
+
+    /// Build the authority chain for the given subject DID.
+    pub fn build_authority(&self, subject: Did) -> Capability<Operator> {
+        Subject::from(subject)
+            .attenuate(authority::Profile {
+                profile: self.profile_did(),
+                account: self.account.clone(),
+            })
+            .attenuate(authority::Operator {
+                operator: self.operator_did(),
+            })
+    }
+}
+
+impl Principal for Authority {
+    fn did(&self) -> Did {
+        self.operator_did()
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<authority::Identify> for Authority {
+    async fn execute(
+        &self,
+        input: Capability<authority::Identify>,
+    ) -> Result<Capability<Operator>, AuthorityError> {
+        let subject_did = input.subject().clone();
+        Ok(self.build_authority(subject_did))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<authority::Sign> for Authority {
+    async fn execute(&self, input: Capability<authority::Sign>) -> Result<Vec<u8>, AuthorityError> {
+        let payload = authority::Sign::of(&input).payload.as_slice();
+        let sig: Ed25519Signature = dialog_varsig::Signer::sign(&self.operator, payload)
+            .await
+            .map_err(|e| AuthorityError::SigningFailed(e.to_string()))?;
+        Ok(sig.to_bytes().to_vec())
+    }
+}
+
+impl dialog_capability::Issuer for Authority {
+    type Signature = Ed25519Signature;
+}
+
+impl dialog_varsig::Signer<Ed25519Signature> for Authority {
+    async fn sign(&self, msg: &[u8]) -> Result<Ed25519Signature, signature::Error> {
+        dialog_varsig::Signer::sign(&self.operator, msg).await
+    }
+}
+
+impl serde::Serialize for Authority {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.operator.serialize(serializer)
+    }
+}

--- a/rust/dialog-operator/src/lib.rs
+++ b/rust/dialog-operator/src/lib.rs
@@ -1,0 +1,27 @@
+#![warn(missing_docs)]
+#![warn(clippy::absolute_paths)]
+#![warn(clippy::default_trait_access)]
+#![warn(clippy::fallible_impl_from)]
+#![warn(clippy::panicking_unwrap)]
+#![warn(clippy::unused_async)]
+#![deny(clippy::partial_pub_fields)]
+#![deny(clippy::unnecessary_self_imports)]
+#![cfg_attr(not(test), warn(clippy::large_futures))]
+#![cfg_attr(not(test), deny(clippy::panic))]
+
+//! Operator layer for Dialog-DB.
+//!
+//! This crate provides the identity and operating environment layer:
+//! authority (identity + signing), profiles, operators, storage dispatch,
+//! and remote fork dispatch.
+
+// Re-export core artifact types for convenience.
+pub use dialog_artifacts::{
+    Artifact, ArtifactSelector, ArtifactStore, ArtifactStoreMut, Artifacts, Attribute,
+    AttributeKey, Cause, Datum, DialogArtifactsError, Entity, EntityKey, FromKey, Instruction, Key,
+    KeyView, KeyViewConstruct, KeyViewMut, State, Value, ValueKey,
+};
+
+/// Authority — profile and operator signers for identity and signing.
+pub mod authority;
+pub use authority::Authority;

--- a/rust/dialog-remote-s3/src/helpers.rs
+++ b/rust/dialog-remote-s3/src/helpers.rs
@@ -70,7 +70,7 @@ impl Provider<authority::Identify> for Session {
     async fn execute(
         &self,
         _input: Capability<authority::Identify>,
-    ) -> Result<authority::Authority, authority::AuthorityError> {
+    ) -> Result<Capability<authority::Operator>, authority::AuthorityError> {
         Err(authority::AuthorityError::Identity(
             "Session does not provide identity".into(),
         ))


### PR DESCRIPTION
## Summary

- New `dialog-repository` crate
- `Credentials` type with `Provider<Identify>` and `Provider<Sign>` impls
- `Open` command for load-or-create profile keypairs
- Platform-specific providers: native (fs), web (IndexedDB), volatile