### PR TITLE
17 🏗️ feat: add storage dispatcher and remote dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,10 +1095,13 @@ dependencies = [
  "dialog-capability",
  "dialog-common",
  "dialog-credentials",
+ "dialog-effects",
  "dialog-remote-s3",
  "dialog-remote-ucan-s3",
+ "dialog-storage",
  "dialog-ucan",
  "dialog-varsig",
+ "parking_lot",
  "serde",
  "signature",
 ]

--- a/rust/dialog-operator/Cargo.toml
+++ b/rust/dialog-operator/Cargo.toml
@@ -21,6 +21,8 @@ dialog-artifacts = { workspace = true }
 dialog-capability = { workspace = true }
 dialog-common = { workspace = true }
 dialog-credentials = { workspace = true }
+dialog-effects = { workspace = true }
+dialog-storage = { workspace = true }
 dialog-varsig = { workspace = true }
 dialog-ucan = { workspace = true, optional = true }
 dialog-remote-s3 = { workspace = true, optional = true }
@@ -28,6 +30,7 @@ dialog-remote-ucan-s3 = { workspace = true, optional = true }
 
 anyhow = { workspace = true, optional = true }
 async-trait = { workspace = true }
+parking_lot = { workspace = true }
 serde = { workspace = true }
 signature = { workspace = true }
 

--- a/rust/dialog-operator/src/lib.rs
+++ b/rust/dialog-operator/src/lib.rs
@@ -25,3 +25,10 @@ pub use dialog_artifacts::{
 /// Authority — profile and operator signers for identity and signing.
 pub mod authority;
 pub use authority::Authority;
+
+/// DID-routed storage dispatcher.
+pub mod storage;
+
+/// Remote dispatch for fork invocations.
+pub mod remote;
+pub use remote::Remote;

--- a/rust/dialog-operator/src/remote.rs
+++ b/rust/dialog-operator/src/remote.rs
@@ -1,0 +1,59 @@
+//! Remote dispatch — routes `Fork<S, Fx>` to the appropriate site provider.
+//!
+//! [`Remote`] implements `Provider<Fork<S3, Fx>>` (and optionally
+//! `Provider<Fork<UcanSite, Fx>>` with the `ucan` feature) by delegating
+//! to the stateless site executors.
+
+/// Remote dispatch — routes fork invocations to the appropriate site.
+///
+/// Both `S3` and `UcanSite` are stateless, so `Remote::default()` is all
+/// you need. The Environment routes `Fork<S, Fx>` here, and this type
+/// delegates to the right site provider.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Remote;
+
+#[cfg(feature = "s3")]
+mod s3_dispatch {
+    use super::Remote;
+    use async_trait::async_trait;
+    use dialog_capability::fork::{Fork, ForkInvocation};
+    use dialog_capability::{Constraint, Effect, Provider};
+    use dialog_remote_s3::S3;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl<Fx> Provider<Fork<S3, Fx>> for Remote
+    where
+        Fx: Effect + 'static,
+        Fx::Of: Constraint,
+        ForkInvocation<S3, Fx>: dialog_common::ConditionalSend,
+        S3: Provider<Fork<S3, Fx>>,
+    {
+        async fn execute(&self, input: ForkInvocation<S3, Fx>) -> Fx::Output {
+            <S3 as Provider<Fork<S3, Fx>>>::execute(&S3, input).await
+        }
+    }
+}
+
+#[cfg(feature = "ucan")]
+mod ucan_dispatch {
+    use super::Remote;
+    use async_trait::async_trait;
+    use dialog_capability::fork::{Fork, ForkInvocation};
+    use dialog_capability::{Constraint, Effect, Provider};
+    use dialog_remote_ucan_s3::UcanSite;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl<Fx> Provider<Fork<UcanSite, Fx>> for Remote
+    where
+        Fx: Effect + 'static,
+        Fx::Of: Constraint,
+        ForkInvocation<UcanSite, Fx>: dialog_common::ConditionalSend,
+        UcanSite: Provider<Fork<UcanSite, Fx>>,
+    {
+        async fn execute(&self, input: ForkInvocation<UcanSite, Fx>) -> Fx::Output {
+            <UcanSite as Provider<Fork<UcanSite, Fx>>>::execute(&UcanSite, input).await
+        }
+    }
+}

--- a/rust/dialog-operator/src/storage.rs
+++ b/rust/dialog-operator/src/storage.rs
@@ -1,0 +1,334 @@
+//! Storage — Address-based Load/Save with DID-routed effect dispatch.
+//!
+//! [`Storage`] handles byte Load/Save by unwrapping the
+//! [`Address`] enum and forwarding to the matching [`Store`] variant.
+//!
+//! [`Stores`] handles runtime effects (archive, memory, storage) by
+//! routing on the subject DID.
+
+use dialog_capability::storage::{Location, StorageError};
+use dialog_capability::{Capability, Effect, Policy, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_storage::provider::{Address, Store};
+use dialog_varsig::Did;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+
+use dialog_capability::storage::{Load, Save};
+
+use std::sync::Arc;
+
+/// DID-routed store table.
+///
+/// Blanket `Provider<Fx>` impl routes any effect to the [`Store`]
+/// registered for the subject DID in the capability chain.
+///
+/// Cheaply cloneable — shares the underlying table via `Arc`.
+#[derive(Clone)]
+pub struct Stores(Arc<RwLock<HashMap<Did, Store>>>);
+
+impl Stores {
+    /// Create an empty store table.
+    pub fn new() -> Self {
+        Self(Arc::new(RwLock::new(HashMap::new())))
+    }
+
+    /// Register a DID → Store mapping.
+    pub fn mount(&self, did: Did, store: Store) {
+        self.0.write().insert(did, store);
+    }
+
+    /// Look up the store for a DID.
+    pub fn lookup(&self, did: &Did) -> Option<Store> {
+        self.0.read().get(did).cloned()
+    }
+
+    /// Whether a DID is mounted.
+    pub fn contains(&self, did: &Did) -> bool {
+        self.0.read().contains_key(did)
+    }
+}
+
+impl Default for Stores {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+trait FromUnmounted {
+    fn unmounted(did: &Did) -> Self;
+}
+
+impl<T, E: From<StorageError>> FromUnmounted for Result<T, E> {
+    fn unmounted(did: &Did) -> Self {
+        Err(StorageError::Storage(format!("no mount for {did}")).into())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<Fx> Provider<Fx> for Stores
+where
+    Fx: Effect + ConditionalSend + 'static,
+    Fx::Output: FromUnmounted,
+    Capability<Fx>: ConditionalSend,
+    Store: Provider<Fx> + ConditionalSync,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(&self, input: Capability<Fx>) -> Fx::Output {
+        let did = input.subject().clone();
+        match self.lookup(&did) {
+            Some(store) => store.execute(input).await,
+            None => Fx::Output::unmounted(&did),
+        }
+    }
+}
+
+use dialog_effects::{archive, memory, storage as fx_storage};
+
+/// Address-dispatched storage with DID-routed effect table.
+#[derive(Clone, Provider)]
+pub struct Storage {
+    #[provide(
+        archive::Get,
+        archive::Put,
+        memory::Resolve,
+        memory::Publish,
+        memory::Retract,
+        fx_storage::Get,
+        fx_storage::Set,
+        fx_storage::Delete,
+        fx_storage::List
+    )]
+    stores: Stores,
+}
+
+use dialog_capability::storage::Storage as CapStorage;
+
+/// Extension trait for resolving sub-paths on location capabilities.
+pub trait LocationExt {
+    /// Resolve a sub-path under this location capability.
+    ///
+    /// Returns a new capability with the resolved address.
+    /// Errors if the segment would escape the base address.
+    fn resolve(&self, segment: &str) -> Result<Capability<Location<Address>>, StorageError>;
+}
+
+impl LocationExt for Capability<Location<Address>> {
+    fn resolve(&self, segment: &str) -> Result<Capability<Location<Address>>, StorageError> {
+        let address = Location::of(self).address();
+        let resolved = address.resolve(segment)?;
+        Ok(CapStorage::locate(resolved))
+    }
+}
+
+impl Storage {
+    /// Create an empty storage.
+    pub fn new() -> Self {
+        Self {
+            stores: Stores::new(),
+        }
+    }
+
+    /// Location capability for the platform profile directory with the given name.
+    ///
+    /// On native: `profile:///name` (resolves to platform data dir).
+    /// On web: IndexedDb address.
+    pub fn profile(name: &str) -> Capability<Location<Address>> {
+        CapStorage::locate(Address::profile(name))
+    }
+
+    /// Location capability for a named storage space under the current directory.
+    ///
+    /// On native: `storage:///name` (resolves to cwd).
+    /// On web: IndexedDb address.
+    pub fn current(name: &str) -> Capability<Location<Address>> {
+        CapStorage::locate(Address::current(name))
+    }
+
+    /// Location capability for a named temporary directory.
+    pub fn temp(name: &str) -> Capability<Location<Address>> {
+        CapStorage::locate(Address::temp(name))
+    }
+
+    /// Register a DID → Store mapping.
+    pub fn mount(&self, did: Did, store: Store) {
+        self.stores.0.write().insert(did, store);
+    }
+
+    /// Mount a DID at the given location.
+    ///
+    /// Creates a Store from the address and registers `did → store`
+    /// so that future effects with this DID as subject are routed
+    /// to the correct storage backend.
+    pub fn mount_at(
+        &self,
+        did: Did,
+        location: &Capability<Location<Address>>,
+    ) -> Result<(), StorageError> {
+        let address = Location::of(location).address();
+        let store = Store::mount(address)?;
+        self.mount(did, store);
+        Ok(())
+    }
+
+    /// The DID-routed store table for runtime effects.
+    pub fn stores(&self) -> &Stores {
+        &self.stores
+    }
+
+    /// Create a Storage backed by a temporary filesystem directory.
+    ///
+    /// Mounts a FileStore for `did:local:storage` at a unique temp path.
+    /// Useful for tests.
+    /// Create a Storage backed by a temporary filesystem directory.
+    ///
+    /// Mounts a FileStore for `did:local:storage` at a unique temp path.
+    /// Useful for tests.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn temp_storage() -> Self {
+        let address = Address::temp(&unique_id());
+        let store = Store::mount(&address).expect("mount temp");
+        let storage = Self::new();
+        storage.mount(dialog_capability::did!("local:storage"), store);
+        storage
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub fn temp_storage() -> Self {
+        let address = Address::temp(&unique_id());
+        let store = Store::mount(&address).expect("mount temp");
+        let storage = Self::new();
+        storage.mount(dialog_capability::did!("local:storage"), store);
+        storage
+    }
+}
+
+fn unique_id() -> String {
+    use dialog_common::time;
+    format!(
+        "dialog-{}",
+        time::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    )
+}
+
+impl Default for Storage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+use dialog_capability::storage::Mount;
+
+/// Mount effect — registers a DID → Store mapping in the store table.
+///
+/// The subject DID from the capability chain is mounted at the address
+/// from the Location. Uses `Mount<(), Address>` (unit Resource) to
+/// distinguish from provider-specific mounts that return a Store.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<Mount<Address>> for Storage
+where
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(&self, input: Capability<Mount<Address>>) -> Result<(), StorageError> {
+        let did = input.subject().clone();
+        let address = Location::of(&input).address();
+        let store = Store::mount(address)?;
+        self.stores.mount(did, store);
+        Ok(())
+    }
+}
+
+macro_rules! impl_addressed {
+    ($content:ty) => {
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        impl Provider<Load<$content, Address>> for Storage
+        where
+            Self: ConditionalSend + ConditionalSync,
+        {
+            async fn execute(
+                &self,
+                input: Capability<Load<$content, Address>>,
+            ) -> Result<$content, StorageError> {
+                let did = input.subject();
+                let expected = dialog_capability::did!("local:storage");
+                if *did != expected {
+                    return Err(StorageError::Storage(format!(
+                        "addressed Load requires subject did:local:storage, got {did}"
+                    )));
+                }
+                let address = Location::of(&input).address().clone();
+                let store = Store::mount(&address)?;
+
+                match (store, address) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    (Store::FileSystem(fs), Address::FileSystem(addr)) => {
+                        CapStorage::locate(addr)
+                            .load::<$content>()
+                            .perform(&fs)
+                            .await
+                    }
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+                    (Store::IndexedDb(idb), Address::IndexedDb(addr)) => {
+                        CapStorage::locate(addr)
+                            .load::<$content>()
+                            .perform(&idb)
+                            .await
+                    }
+                    (Store::Volatile(v), Address::Volatile(addr)) => {
+                        CapStorage::locate(addr)
+                            .load::<$content>()
+                            .perform(&v)
+                            .await
+                    }
+                    _ => Err(StorageError::Storage("store/address mismatch".into())),
+                }
+            }
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        impl Provider<Save<$content, Address>> for Storage
+        where
+            Self: ConditionalSend + ConditionalSync,
+        {
+            async fn execute(
+                &self,
+                input: Capability<Save<$content, Address>>,
+            ) -> Result<(), StorageError> {
+                let did = input.subject();
+                let expected = dialog_capability::did!("local:storage");
+                if *did != expected {
+                    return Err(StorageError::Storage(format!(
+                        "addressed Save requires subject did:local:storage, got {did}"
+                    )));
+                }
+                let address = Location::of(&input).address().clone();
+                let content = Save::<$content, Address>::of(&input).content.clone();
+                let store = Store::mount(&address)?;
+
+                match (store, address) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    (Store::FileSystem(fs), Address::FileSystem(addr)) => {
+                        CapStorage::locate(addr).save(content).perform(&fs).await
+                    }
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+                    (Store::IndexedDb(idb), Address::IndexedDb(addr)) => {
+                        CapStorage::locate(addr).save(content).perform(&idb).await
+                    }
+                    (Store::Volatile(v), Address::Volatile(addr)) => {
+                        CapStorage::locate(addr).save(content).perform(&v).await
+                    }
+                    _ => Err(StorageError::Storage("store/address mismatch".into())),
+                }
+            }
+        }
+    };
+}
+
+impl_addressed!(Vec<u8>);


### PR DESCRIPTION
## Summary

- `Storage` type: address-dispatched Load/Save/Mount with DID-routed effect table
- `Stores` type: blanket `Provider<Fx>` routing by subject DID
- `Remote` type: fork dispatch wrapper for remote site operations
- `LocationExt` trait for resolving sub-paths on location capabilities