### PR TITLE
10 ✅ feat: add effects hierarchy modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ name = "dialog-effects"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base58",
  "dialog-capability",
  "dialog-common",
  "dialog-credentials",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "async-trait",
  "dialog-capability",
  "dialog-common",
+ "dialog-credentials",
  "serde",
  "serde_bytes",
  "thiserror 2.0.18",

--- a/rust/dialog-effects/Cargo.toml
+++ b/rust/dialog-effects/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 thiserror = { workspace = true }
+base58.workspace = true
 
 [lints.rust]
 missing_docs = "warn"

--- a/rust/dialog-effects/Cargo.toml
+++ b/rust/dialog-effects/Cargo.toml
@@ -5,17 +5,14 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 
-
 [dependencies]
 dialog-capability = { workspace = true }
+dialog-credentials = { workspace = true }
 dialog-common = { workspace = true }
-
 async-trait = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 thiserror = { workspace = true }
-
-
 
 [lints.rust]
 missing_docs = "warn"

--- a/rust/dialog-effects/README.md
+++ b/rust/dialog-effects/README.md
@@ -1,0 +1,79 @@
+# dialog-effects
+
+Capability hierarchy types for Dialog-DB.
+
+Defines the domain-specific attenuations, policies, and effects that form capability chains. Each module corresponds to a capability domain.
+
+## access
+
+Authorization and delegation.
+
+```text
+Subject (profile DID)
+└── Access
+    ├── Prove { principal, access, duration } → Proof
+    └── Retain { delegation } → ()
+```
+
+## storage
+
+Bootstrap space operations. Used during setup before the operator is built.
+
+```text
+Subject (did:local:storage)
+└── Storage
+    └── Location { directory, name }
+        ├── Load → Credential
+        └── Create { credential } → Credential
+```
+
+## space
+
+Operator-level space operations. Used after bootstrap to open repositories.
+
+```text
+Subject (profile DID)
+└── Space { name }
+    ├── Load → Credential
+    └── Create { credential } → Credential
+```
+
+## archive
+
+Content-addressed block storage.
+
+```text
+Subject (repository DID)
+└── Archive
+    └── Catalog { name }
+        ├── Get { digest } → Option<Vec<u8>>
+        └── Put { digest, content } → ()
+```
+
+## memory
+
+Transactional memory cells for branch state.
+
+```text
+Subject (repository DID)
+└── Memory
+    └── Space { name }
+        └── Cell { name }
+            ├── Resolve → Option<Vec<u8>>
+            ├── Publish { content } → ()
+            └── Retract → ()
+```
+
+## credential
+
+Credential read/write for identity persistence.
+
+```text
+Subject (did:local:storage)
+└── Credential
+    └── Address { address }
+        ├── Load → Credential
+        └── Save { credential } → ()
+```
+
+Effects are structural types only. Storage providers in `dialog-storage` implement `Provider<Fx>` for each effect.

--- a/rust/dialog-effects/src/access.rs
+++ b/rust/dialog-effects/src/access.rs
@@ -1,0 +1,6 @@
+//! Access capability hierarchy for authorization.
+//!
+//! Re-exports from [`dialog_capability::access`].
+
+pub use dialog_capability::StorageError;
+pub use dialog_capability::access::*;

--- a/rust/dialog-effects/src/archive.rs
+++ b/rust/dialog-effects/src/archive.rs
@@ -16,9 +16,10 @@ use std::error::Error;
 
 pub use dialog_capability::{
     Attenuate, Attenuation, Capability, DialogCapabilityAuthorizationError,
-    DialogCapabilityPerformError, Effect, Policy, Subject,
+    DialogCapabilityPerformError, Effect, Policy, StorageError, Subject,
 };
 pub use dialog_common::Blake3Hash;
+use dialog_common::Checksum;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -106,6 +107,7 @@ pub struct Put {
     pub digest: Blake3Hash,
     /// The content to store.
     #[serde(with = "serde_bytes")]
+    #[attenuate(into = Checksum, with = Checksum::sha256, rename = checksum)]
     pub content: Vec<u8>,
 }
 
@@ -148,6 +150,8 @@ impl PutCapability for Capability<Put> {
     }
 }
 
+pub mod prelude;
+
 /// Errors that can occur during archive operations.
 #[derive(Debug, Error)]
 pub enum ArchiveError {
@@ -175,6 +179,12 @@ pub enum ArchiveError {
     /// IO error.
     #[error("IO error: {0}")]
     Io(String),
+}
+
+impl From<StorageError> for ArchiveError {
+    fn from(e: StorageError) -> Self {
+        Self::Storage(e.to_string())
+    }
 }
 
 impl From<DialogCapabilityAuthorizationError> for ArchiveError {

--- a/rust/dialog-effects/src/archive/prelude.rs
+++ b/rust/dialog-effects/src/archive/prelude.rs
@@ -1,0 +1,73 @@
+//! Extension traits for fluent archive capability chains.
+//!
+//! Import all traits with:
+//! ```
+//! use dialog_effects::archive::prelude::*;
+//! ```
+
+use dialog_capability::{Capability, Did, Subject};
+use dialog_common::Blake3Hash;
+
+use super::{Archive, Catalog, Get, Put};
+
+/// Extension trait to start an archive capability chain.
+pub trait SubjectExt {
+    /// The resulting archive chain type.
+    type Archive;
+    /// Begin an archive capability chain.
+    fn archive(self) -> Self::Archive;
+}
+
+impl SubjectExt for Subject {
+    type Archive = Capability<Archive>;
+    fn archive(self) -> Capability<Archive> {
+        self.attenuate(Archive)
+    }
+}
+
+impl SubjectExt for Did {
+    type Archive = Capability<Archive>;
+    fn archive(self) -> Capability<Archive> {
+        Subject::from(self).attenuate(Archive)
+    }
+}
+
+/// Extension methods for scoping archive to a named catalog.
+pub trait ArchiveExt {
+    /// The resulting catalog chain type.
+    type Catalog;
+    /// Scope to a named catalog.
+    fn catalog(self, name: impl Into<String>) -> Self::Catalog;
+}
+
+impl ArchiveExt for Capability<Archive> {
+    type Catalog = Capability<Catalog>;
+    fn catalog(self, name: impl Into<String>) -> Capability<Catalog> {
+        self.attenuate(Catalog::new(name))
+    }
+}
+
+/// Extension methods for invoking effects on a catalog.
+pub trait CatalogExt {
+    /// The resulting get chain type.
+    type Get;
+    /// The resulting put chain type.
+    type Put;
+    /// Get content by digest.
+    fn get(self, digest: impl Into<Blake3Hash>) -> Self::Get;
+    /// Put content by digest.
+    fn put(self, digest: impl Into<Blake3Hash>, content: impl Into<Vec<u8>>) -> Self::Put;
+}
+
+impl CatalogExt for Capability<Catalog> {
+    type Get = Capability<Get>;
+    type Put = Capability<Put>;
+
+    fn get(self, digest: impl Into<Blake3Hash>) -> Capability<Get> {
+        self.invoke(Get::new(digest))
+    }
+
+    fn put(self, digest: impl Into<Blake3Hash>, content: impl Into<Vec<u8>>) -> Capability<Put> {
+        self.invoke(Put::new(digest, content))
+    }
+}

--- a/rust/dialog-effects/src/archive/prelude.rs
+++ b/rust/dialog-effects/src/archive/prelude.rs
@@ -11,21 +11,21 @@ use dialog_common::Blake3Hash;
 use super::{Archive, Catalog, Get, Put};
 
 /// Extension trait to start an archive capability chain.
-pub trait SubjectExt {
+pub trait ArchiveSubjectExt {
     /// The resulting archive chain type.
     type Archive;
     /// Begin an archive capability chain.
     fn archive(self) -> Self::Archive;
 }
 
-impl SubjectExt for Subject {
+impl ArchiveSubjectExt for Subject {
     type Archive = Capability<Archive>;
     fn archive(self) -> Capability<Archive> {
         self.attenuate(Archive)
     }
 }
 
-impl SubjectExt for Did {
+impl ArchiveSubjectExt for Did {
     type Archive = Capability<Archive>;
     fn archive(self) -> Capability<Archive> {
         Subject::from(self).attenuate(Archive)

--- a/rust/dialog-effects/src/authority.rs
+++ b/rust/dialog-effects/src/authority.rs
@@ -8,10 +8,13 @@
 //!     └── Operator { operator: Did }
 //! ```
 //!
-//! [`Identify`] is an effect on `Subject` that returns the current
-//! `Capability<Operator>` chain.
+//! [`Identify`] is a direct env command that returns the current
+//! `Capability<Operator>` chain. It is not a capability itself — session
+//! identity is ambient state, so we query it from the env rather than
+//! pretending it scopes to a subject.
 
-use dialog_capability::{Attenuation, Capability, Attenuate, Did, Effect, Subject};
+use dialog_capability::{Attenuation, Capability, Command, Did, Policy, Provider, Subject};
+use dialog_common::ConditionalSync;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -79,15 +82,55 @@ impl Attenuation for Operator {
     type Of = Profile;
 }
 
-/// Identify operation — returns the current authority chain.
+/// Identify command — returns the current session's authority chain.
 ///
-/// This is an effect directly on `Subject` — no intermediate attenuation.
-/// The returned `Capability<Operator>` encodes the full identity hierarchy:
+/// Session identity is ambient: regardless of which repository we're
+/// operating on, there is one current operator. `Identify` is a direct
+/// env query for that ambient state rather than a capability invocation.
+///
+/// The returned `Capability<Operator>` encodes the identity hierarchy:
 /// subject, profile, and operator.
-#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Identify;
 
-impl Effect for Identify {
-    type Of = Subject;
+impl Command for Identify {
+    type Input = Self;
     type Output = Result<Capability<Operator>, AuthorityError>;
+}
+
+impl Identify {
+    /// Perform this command against an env that can provide it.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Capability<Operator>, AuthorityError>
+    where
+        Env: Provider<Identify> + ConditionalSync,
+    {
+        env.execute(self).await
+    }
+}
+
+/// Extension trait for `Capability<Operator>` providing convenient
+/// access to the authority chain fields.
+pub trait OperatorExt {
+    /// The operator DID (ephemeral session key).
+    fn did(&self) -> Did;
+
+    /// The profile DID from the authority chain.
+    fn profile(&self) -> &Did;
+
+    /// The optional account DID from the authority chain.
+    fn account(&self) -> &Option<Did>;
+}
+
+impl OperatorExt for Capability<Operator> {
+    fn did(&self) -> Did {
+        Operator::of(self).operator.clone()
+    }
+
+    fn profile(&self) -> &Did {
+        &Profile::of(self).profile
+    }
+
+    fn account(&self) -> &Option<Did> {
+        &Profile::of(self).account
+    }
 }

--- a/rust/dialog-effects/src/authority.rs
+++ b/rust/dialog-effects/src/authority.rs
@@ -1,0 +1,93 @@
+//! Authority capability hierarchy — identity chain.
+//!
+//! The authority chain encodes the identity hierarchy as a capability chain:
+//!
+//! ```text
+//! Subject (repository DID)
+//! └── Profile { profile: Did, account: Option<Did> }
+//!     └── Operator { operator: Did }
+//! ```
+//!
+//! [`Identify`] is an effect on `Subject` that returns the current
+//! `Capability<Operator>` chain.
+
+use dialog_capability::{Attenuation, Capability, Attenuate, Did, Effect, Subject};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Error type for authority operations.
+#[derive(Debug, Error)]
+pub enum AuthorityError {
+    /// Identity resolution failed.
+    #[error("Identity error: {0}")]
+    Identity(String),
+}
+
+/// Device identity — attenuates from Subject.
+///
+/// A profile is a named user identity on a specific device, with its own
+/// ed25519 keypair. The optional `account` links to a persistent identity
+/// that survives device loss (None = local only, Some = linked/recovered).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Profile {
+    /// The profile's DID (ed25519 public key).
+    pub profile: Did,
+    /// Optional account DID for cross-device recovery.
+    pub account: Option<Did>,
+}
+
+impl Profile {
+    /// Create a local profile (no account).
+    pub fn local(profile: Did) -> Self {
+        Self {
+            profile,
+            account: None,
+        }
+    }
+
+    /// Create a linked profile with an account.
+    pub fn linked(profile: Did, account: Did) -> Self {
+        Self {
+            profile,
+            account: Some(account),
+        }
+    }
+}
+
+impl Attenuation for Profile {
+    type Of = Subject;
+}
+
+/// Session key — attenuates from Profile.
+///
+/// An ephemeral key representing the immediate invoker of a capability
+/// in a specific session or process context.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Operator {
+    /// The operator's DID (ephemeral session key).
+    pub operator: Did,
+}
+
+impl Operator {
+    /// Create a new operator.
+    pub fn new(operator: Did) -> Self {
+        Self { operator }
+    }
+}
+
+impl Attenuation for Operator {
+    type Of = Profile;
+}
+
+/// Identify operation — returns the current authority chain.
+///
+/// This is an effect directly on `Subject` — no intermediate attenuation.
+/// The returned `Capability<Operator>` encodes the full identity hierarchy:
+/// subject, profile, and operator.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Identify;
+
+impl Effect for Identify {
+    type Of = Subject;
+    type Output = Result<Capability<Operator>, AuthorityError>;
+}

--- a/rust/dialog-effects/src/credential.rs
+++ b/rust/dialog-effects/src/credential.rs
@@ -21,6 +21,8 @@ pub use dialog_capability::{
 };
 pub use dialog_credentials;
 use serde::{Deserialize, Serialize};
+use std::convert::Infallible;
+use std::marker::PhantomData;
 use thiserror::Error;
 
 /// Opaque secret bytes for site credentials.
@@ -121,14 +123,14 @@ impl Effect for Save<Secret> {
 #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
 pub struct Load<T> {
     #[serde(skip)]
-    _marker: std::marker::PhantomData<T>,
+    _marker: PhantomData<T>,
 }
 
 impl<T> Load<T> {
     /// Create a new load effect.
     pub fn new() -> Self {
         Self {
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 }
@@ -177,8 +179,8 @@ impl From<CredentialError> for AuthorizeError {
     }
 }
 
-impl From<std::convert::Infallible> for CredentialError {
-    fn from(never: std::convert::Infallible) -> Self {
+impl From<Infallible> for CredentialError {
+    fn from(never: Infallible) -> Self {
         match never {}
     }
 }

--- a/rust/dialog-effects/src/credential.rs
+++ b/rust/dialog-effects/src/credential.rs
@@ -13,8 +13,11 @@
 //!             └── Load<Secret> → Result<Secret, CredentialError>
 //! ```
 
+pub mod prelude;
+
 pub use dialog_capability::{
-    Attenuation, Capability, Attenuate, Effect, Policy, StorageError, Subject,
+    Attenuate, Attenuation, AuthorizeError, Capability, Effect, Policy, SiteId, StorageError,
+    Subject,
 };
 pub use dialog_credentials;
 use serde::{Deserialize, Serialize};
@@ -69,22 +72,20 @@ impl Attenuation for Key {
     type Of = Credential;
 }
 
-/// Site credential address (e.g., S3 access keys).
+/// Site credential address.
 ///
-/// Keyed by URL so that the address naturally identifies the remote
-/// service the credentials are for.
+/// Keyed by [`SiteId`](dialog_capability::SiteId) which uniquely identifies
+/// the remote site the credentials are for.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Site {
-    /// The credential address (e.g., "https://s3.us-east-1.amazonaws.com/my-bucket").
-    pub address: String,
+    /// The site identifier.
+    pub address: SiteId,
 }
 
 impl Site {
     /// Create a new site credential address.
-    pub fn new(address: impl Into<String>) -> Self {
-        Self {
-            address: address.into(),
-        }
+    pub fn new(id: impl Into<SiteId>) -> Self {
+        Self { address: id.into() }
     }
 }
 
@@ -167,5 +168,17 @@ pub enum CredentialError {
 impl From<StorageError> for CredentialError {
     fn from(e: StorageError) -> Self {
         Self::Storage(e.to_string())
+    }
+}
+
+impl From<CredentialError> for AuthorizeError {
+    fn from(e: CredentialError) -> Self {
+        Self::Denied(e.to_string())
+    }
+}
+
+impl From<std::convert::Infallible> for CredentialError {
+    fn from(never: std::convert::Infallible) -> Self {
+        match never {}
     }
 }

--- a/rust/dialog-effects/src/credential.rs
+++ b/rust/dialog-effects/src/credential.rs
@@ -1,0 +1,91 @@
+//! Credential capability hierarchy.
+//!
+//! # Capability Hierarchy
+//!
+//! ```text
+//! Subject (profile or repository DID)
+//!   └── Credential (ability: /credential)
+//!         └── Address { address: String }
+//!             ├── Save { credential } → Effect → Result<(), CredentialError>
+//!             └── Load → Effect → Result<Credential, CredentialError>
+//! ```
+
+pub use dialog_capability::{
+    Attenuation, Capability, Attenuate, Effect, Policy, StorageError, Subject,
+};
+pub use dialog_credentials;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Root attenuation for credential operations.
+///
+/// Attaches to Subject and provides the `/credential` ability path segment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Credential;
+
+impl Attenuation for Credential {
+    type Of = Subject;
+}
+
+/// Address for a credential store.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Address {
+    /// The storage address path.
+    pub address: String,
+}
+
+impl Address {
+    /// Create a new credential address.
+    pub fn new(address: impl Into<String>) -> Self {
+        Self {
+            address: address.into(),
+        }
+    }
+}
+
+impl Policy for Address {
+    type Of = Credential;
+}
+
+/// Save a credential to storage.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Save {
+    /// The credential to save.
+    pub credential: dialog_credentials::Credential,
+}
+
+impl Effect for Save {
+    type Of = Address;
+    type Output = Result<(), CredentialError>;
+}
+
+/// Load a credential from storage.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Load;
+
+impl Effect for Load {
+    type Of = Address;
+    type Output = Result<dialog_credentials::Credential, CredentialError>;
+}
+
+/// Errors that can occur during credential operations.
+#[derive(Debug, Error)]
+pub enum CredentialError {
+    /// Credential not found at the given address.
+    #[error("Credential not found: {0}")]
+    NotFound(String),
+
+    /// Storage error while reading or writing a credential.
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    /// Credential data is corrupted or unreadable.
+    #[error("Corrupted credential: {0}")]
+    Corrupted(String),
+}
+
+impl From<StorageError> for CredentialError {
+    fn from(e: StorageError) -> Self {
+        Self::Storage(e.to_string())
+    }
+}

--- a/rust/dialog-effects/src/credential.rs
+++ b/rust/dialog-effects/src/credential.rs
@@ -5,9 +5,12 @@
 //! ```text
 //! Subject (profile or repository DID)
 //!   └── Credential (ability: /credential)
-//!         └── Address { address: String }
-//!             ├── Save { credential } → Effect → Result<(), CredentialError>
-//!             └── Load → Effect → Result<Credential, CredentialError>
+//!         ├── Key { address: String }
+//!         │   ├── Save<Credential> → Result<(), CredentialError>
+//!         │   └── Load<Credential> → Result<Credential, CredentialError>
+//!         └── Site { address: String }
+//!             ├── Save<Secret> → Result<(), CredentialError>
+//!             └── Load<Secret> → Result<Secret, CredentialError>
 //! ```
 
 pub use dialog_capability::{
@@ -16,6 +19,22 @@ pub use dialog_capability::{
 pub use dialog_credentials;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// Opaque secret bytes for site credentials.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Secret(pub Vec<u8>);
+
+impl From<Vec<u8>> for Secret {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Secret> for Vec<u8> {
+    fn from(secret: Secret) -> Self {
+        secret.0
+    }
+}
 
 /// Root attenuation for credential operations.
 ///
@@ -27,15 +46,18 @@ impl Attenuation for Credential {
     type Of = Subject;
 }
 
-/// Address for a credential store.
+/// Key credential address (e.g., signing keypair).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Address {
-    /// The storage address path.
+pub struct Key {
+    /// The credential address (e.g., "self").
     pub address: String,
 }
 
-impl Address {
-    /// Create a new credential address.
+/// The default key address for a space's own identity.
+pub const SELF: &str = "self";
+
+impl Key {
+    /// Create a new key credential address.
     pub fn new(address: impl Into<String>) -> Self {
         Self {
             address: address.into(),
@@ -43,29 +65,87 @@ impl Address {
     }
 }
 
-impl Policy for Address {
+impl Attenuation for Key {
     type Of = Credential;
 }
 
-/// Save a credential to storage.
-#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
-pub struct Save {
-    /// The credential to save.
-    pub credential: dialog_credentials::Credential,
+/// Site credential address (e.g., S3 access keys).
+///
+/// Keyed by URL so that the address naturally identifies the remote
+/// service the credentials are for.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Site {
+    /// The credential address (e.g., "https://s3.us-east-1.amazonaws.com/my-bucket").
+    pub address: String,
 }
 
-impl Effect for Save {
-    type Of = Address;
+impl Site {
+    /// Create a new site credential address.
+    pub fn new(address: impl Into<String>) -> Self {
+        Self {
+            address: address.into(),
+        }
+    }
+}
+
+impl Attenuation for Site {
+    type Of = Credential;
+}
+
+/// Save a credential or secret to storage.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Save<T> {
+    /// The value to save.
+    pub credential: T,
+}
+
+impl<T> Save<T> {
+    /// Create a new save effect.
+    pub fn new(value: T) -> Self {
+        Self { credential: value }
+    }
+}
+
+impl Effect for Save<dialog_credentials::Credential> {
+    type Of = Key;
     type Output = Result<(), CredentialError>;
 }
 
-/// Load a credential from storage.
-#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
-pub struct Load;
+impl Effect for Save<Secret> {
+    type Of = Site;
+    type Output = Result<(), CredentialError>;
+}
 
-impl Effect for Load {
-    type Of = Address;
+/// Load a credential or secret from storage.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Load<T> {
+    #[serde(skip)]
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Load<T> {
+    /// Create a new load effect.
+    pub fn new() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> Default for Load<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Effect for Load<dialog_credentials::Credential> {
+    type Of = Key;
     type Output = Result<dialog_credentials::Credential, CredentialError>;
+}
+
+impl Effect for Load<Secret> {
+    type Of = Site;
+    type Output = Result<Secret, CredentialError>;
 }
 
 /// Errors that can occur during credential operations.

--- a/rust/dialog-effects/src/credential/prelude.rs
+++ b/rust/dialog-effects/src/credential/prelude.rs
@@ -1,0 +1,110 @@
+//! Extension traits for fluent credential capability chains.
+//!
+//! Import all traits with:
+//! ```
+//! use dialog_effects::credential::prelude::*;
+//! ```
+
+use dialog_capability::{Capability, Did, SiteId, Subject};
+
+use super::{Credential, Key, Load, Save, Secret, Site};
+
+/// Extension trait to start a credential capability chain.
+pub trait CredentialSubjectExt {
+    /// The resulting credential chain type.
+    type Credential;
+    /// Begin a credential capability chain.
+    fn credential(self) -> Self::Credential;
+}
+
+impl CredentialSubjectExt for Subject {
+    type Credential = Capability<Credential>;
+    fn credential(self) -> Capability<Credential> {
+        self.attenuate(Credential)
+    }
+}
+
+impl CredentialSubjectExt for Did {
+    type Credential = Capability<Credential>;
+    fn credential(self) -> Capability<Credential> {
+        Subject::from(self).attenuate(Credential)
+    }
+}
+
+/// Extension methods on the credential capability to select key or site.
+pub trait CredentialCapabilityExt {
+    /// The resulting key chain type.
+    type Key;
+    /// The resulting site chain type.
+    type Site;
+    /// Select a key credential by name.
+    fn key(self, address: impl Into<String>) -> Self::Key;
+    /// Select a site credential by address.
+    fn site(self, address: impl Into<SiteId>) -> Self::Site;
+}
+
+impl CredentialCapabilityExt for Capability<Credential> {
+    type Key = Capability<Key>;
+    type Site = Capability<Site>;
+
+    fn key(self, address: impl Into<String>) -> Capability<Key> {
+        self.attenuate(Key::new(address))
+    }
+
+    fn site(self, address: impl Into<SiteId>) -> Capability<Site> {
+        self.attenuate(Site::new(address))
+    }
+}
+
+/// Extension methods for invoking effects on a key credential.
+pub trait CredentialKeyExt {
+    /// The resulting load chain type.
+    type Load;
+    /// The resulting save chain type.
+    type Save;
+    /// Load a key credential from this address.
+    fn load(self) -> Self::Load;
+    /// Save a key credential to this address.
+    fn save(self, credential: dialog_credentials::Credential) -> Self::Save;
+}
+
+impl CredentialKeyExt for Capability<Key> {
+    type Load = Capability<Load<dialog_credentials::Credential>>;
+    type Save = Capability<Save<dialog_credentials::Credential>>;
+
+    fn load(self) -> Capability<Load<dialog_credentials::Credential>> {
+        self.invoke(Load::new())
+    }
+
+    fn save(
+        self,
+        credential: dialog_credentials::Credential,
+    ) -> Capability<Save<dialog_credentials::Credential>> {
+        self.invoke(Save::new(credential))
+    }
+}
+
+/// Extension methods for invoking effects on a site credential.
+pub trait CredentialSiteExt {
+    /// The resulting load chain type.
+    type Load;
+    /// The resulting save chain type.
+    type Save;
+    /// Load a site secret from this address.
+    fn load(self) -> Self::Load;
+    /// Save a site secret to this address.
+    fn save(self, secret: Secret) -> Self::Save;
+}
+
+impl CredentialSiteExt for Capability<Site> {
+    type Load = Capability<Load<Secret>>;
+    type Save = Capability<Save<Secret>>;
+
+    fn load(self) -> Capability<Load<Secret>> {
+        self.invoke(Load::new())
+    }
+
+    fn save(self, secret: Secret) -> Capability<Save<Secret>> {
+        self.invoke(Save::new(secret))
+    }
+}

--- a/rust/dialog-effects/src/lib.rs
+++ b/rust/dialog-effects/src/lib.rs
@@ -26,6 +26,15 @@
 //! ```
 
 #![warn(missing_docs)]
+#![warn(clippy::absolute_paths)]
+#![warn(clippy::default_trait_access)]
+#![warn(clippy::fallible_impl_from)]
+#![warn(clippy::panicking_unwrap)]
+#![warn(clippy::unused_async)]
+#![deny(clippy::partial_pub_fields)]
+#![deny(clippy::unnecessary_self_imports)]
+#![cfg_attr(not(test), warn(clippy::large_futures))]
+#![cfg_attr(not(test), deny(clippy::panic))]
 
 pub mod access;
 pub mod archive;

--- a/rust/dialog-effects/src/lib.rs
+++ b/rust/dialog-effects/src/lib.rs
@@ -6,27 +6,33 @@
 //!
 //! # Capability Domains
 //!
-//! - [`storage`]: Key-value storage operations (`Storage`, `Store`, `Get`, `Set`, `Delete`, `List`)
+//! - [`storage`]: Location-based storage operations (`Storage`, `Location`, `Mount`, `Load`, `Save`)
 //! - [`memory`]: CAS memory cells (`Memory`, `Space`, `Cell`, `Resolve`, `Publish`, `Retract`)
 //! - [`archive`]: Content-addressed archive (`Archive`, `Catalog`, `Get`, `Put`)
 //!
 //! # Example
 //!
 //! ```
-//! use dialog_effects::storage::{Storage, Store, Get};
+//! use dialog_effects::archive::{Archive, Catalog, Get};
 //! use dialog_capability::{did, Subject};
+//! use dialog_common::Blake3Hash;
 //!
-//! // Build a capability to get a value from the "index" store
+//! // Build a capability to get content from the "index" catalog
+//! let digest = Blake3Hash::hash(b"hello");
 //! let get_capability = Subject::from(did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"))
-//!     .attenuate(Storage)              // Domain: storage operations
-//!     .attenuate(Store::new("index"))  // Policy: only the "index" store
-//!     .invoke(Get::new(b"my-key"));    // Effect: get this specific key
+//!     .attenuate(Archive)              // Domain: archive operations
+//!     .attenuate(Catalog::new("index"))  // Policy: only the "index" catalog
+//!     .invoke(Get::new(digest));         // Effect: get this specific digest
 //! ```
 
 #![warn(missing_docs)]
 
+pub mod access;
 pub mod archive;
+pub mod authority;
+pub mod credential;
 pub mod memory;
+pub mod space;
 pub mod storage;
 
 // Re-export capability primitives for convenience

--- a/rust/dialog-effects/src/memory.rs
+++ b/rust/dialog-effects/src/memory.rs
@@ -19,6 +19,7 @@ pub use dialog_capability::{
 };
 use dialog_common::Checksum;
 use serde::{Deserialize, Serialize};
+use std::io;
 use thiserror::Error;
 
 /// Root attenuation for memory operations.
@@ -253,7 +254,7 @@ pub enum MemoryError {
 
     /// IO error.
     #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
+    Io(#[from] io::Error),
 }
 
 impl From<StorageError> for MemoryError {

--- a/rust/dialog-effects/src/memory.rs
+++ b/rust/dialog-effects/src/memory.rs
@@ -14,7 +14,10 @@
 //!                     └── Retract { when } → Effect → Result<(), MemoryError>
 //! ```
 
-pub use dialog_capability::{Attenuate, Attenuation, Capability, Effect, Policy, Subject};
+pub use dialog_capability::{
+    Attenuate, Attenuation, Capability, Effect, Policy, StorageError, Subject,
+};
+use dialog_common::Checksum;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -66,6 +69,16 @@ impl Policy for Cell {
 
 /// Edition identifier for CAS operations.
 pub type Edition = String;
+
+/// Convert raw bytes to an edition string (used by `#[derive(Claim)]`).
+fn edition(bytes: Vec<u8>) -> Edition {
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Convert optional raw bytes to an optional edition string (used by `#[derive(Claim)]`).
+fn optional_edition(bytes: Option<serde_bytes::ByteBuf>) -> Option<Edition> {
+    bytes.map(|b| String::from_utf8_lossy(&b).into_owned())
+}
 
 /// A cell's current state: content and its edition.
 ///
@@ -119,9 +132,11 @@ impl ResolveCapability for Capability<Resolve> {
 pub struct Publish {
     /// The content to publish.
     #[serde(with = "serde_bytes")]
+    #[attenuate(into = Checksum, with = Checksum::sha256, rename = checksum)]
     pub content: Vec<u8>,
     /// The expected current edition, or None if expecting empty cell.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[attenuate(into = Option<Edition>, with = optional_edition)]
     pub when: Option<serde_bytes::ByteBuf>,
 }
 
@@ -178,6 +193,7 @@ impl PublishCapability for Capability<Publish> {
 pub struct Retract {
     /// The expected current edition.
     #[serde(with = "serde_bytes")]
+    #[attenuate(into = Edition, with = edition)]
     pub when: Vec<u8>,
 }
 
@@ -217,6 +233,8 @@ impl RetractCapability for Capability<Retract> {
     }
 }
 
+pub mod prelude;
+
 /// Errors that can occur during memory operations.
 #[derive(Debug, Error)]
 pub enum MemoryError {
@@ -236,6 +254,12 @@ pub enum MemoryError {
     /// IO error.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+impl From<StorageError> for MemoryError {
+    fn from(e: StorageError) -> Self {
+        Self::Storage(e.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/rust/dialog-effects/src/memory/prelude.rs
+++ b/rust/dialog-effects/src/memory/prelude.rs
@@ -1,0 +1,96 @@
+//! Extension traits for fluent memory capability chains.
+//!
+//! Import all traits with:
+//! ```
+//! use dialog_effects::memory::prelude::*;
+//! ```
+
+use dialog_capability::{Capability, Did, Subject};
+
+use super::{Cell, Memory, Publish, Resolve, Retract, Space};
+
+/// Extension trait to start a memory capability chain.
+pub trait SubjectExt {
+    /// The resulting memory chain type.
+    type Memory;
+    /// Begin a memory capability chain.
+    fn memory(self) -> Self::Memory;
+}
+
+impl SubjectExt for Subject {
+    type Memory = Capability<Memory>;
+    fn memory(self) -> Capability<Memory> {
+        self.attenuate(Memory)
+    }
+}
+
+impl SubjectExt for Did {
+    type Memory = Capability<Memory>;
+    fn memory(self) -> Capability<Memory> {
+        Subject::from(self).attenuate(Memory)
+    }
+}
+
+/// Extension methods for scoping memory to a named space.
+pub trait MemoryExt {
+    /// The resulting space chain type.
+    type Space;
+    /// Scope to a named space.
+    fn space(self, name: impl Into<String>) -> Self::Space;
+}
+
+impl MemoryExt for Capability<Memory> {
+    type Space = Capability<Space>;
+    fn space(self, name: impl Into<String>) -> Capability<Space> {
+        self.attenuate(Space::new(name))
+    }
+}
+
+/// Extension methods for scoping a space to a named cell.
+pub trait SpaceExt {
+    /// The resulting cell chain type.
+    type Cell;
+    /// Scope to a named cell within the space.
+    fn cell(self, name: impl Into<String>) -> Self::Cell;
+}
+
+impl SpaceExt for Capability<Space> {
+    type Cell = Capability<Cell>;
+    fn cell(self, name: impl Into<String>) -> Capability<Cell> {
+        self.attenuate(Cell::new(name))
+    }
+}
+
+/// Extension methods for invoking effects on a cell.
+pub trait CellExt {
+    /// The resulting resolve chain type.
+    type Resolve;
+    /// The resulting publish chain type.
+    type Publish;
+    /// The resulting retract chain type.
+    type Retract;
+    /// Resolve the current cell content and edition.
+    fn resolve(self) -> Self::Resolve;
+    /// Publish content to the cell with CAS semantics.
+    fn publish(self, content: impl Into<Vec<u8>>, when: Option<Vec<u8>>) -> Self::Publish;
+    /// Retract (delete) cell content with CAS semantics.
+    fn retract(self, when: impl Into<Vec<u8>>) -> Self::Retract;
+}
+
+impl CellExt for Capability<Cell> {
+    type Resolve = Capability<Resolve>;
+    type Publish = Capability<Publish>;
+    type Retract = Capability<Retract>;
+
+    fn resolve(self) -> Capability<Resolve> {
+        self.invoke(Resolve)
+    }
+
+    fn publish(self, content: impl Into<Vec<u8>>, when: Option<Vec<u8>>) -> Capability<Publish> {
+        self.invoke(Publish::new(content, when))
+    }
+
+    fn retract(self, when: impl Into<Vec<u8>>) -> Capability<Retract> {
+        self.invoke(Retract::new(when))
+    }
+}

--- a/rust/dialog-effects/src/space.rs
+++ b/rust/dialog-effects/src/space.rs
@@ -1,0 +1,95 @@
+//! Space capability hierarchy for operator-level space operations.
+//!
+//! Resolves space names relative to the operator's mounted base
+//! directory. Used after bootstrap to load and create repositories.
+//!
+//! # Capability Hierarchy
+//!
+//! ```text
+//! Subject (profile DID) -> Space { name } -> Load / Create
+//! ```
+//!
+//! `Load` resolves the name against the operator's base directory
+//! and delegates to `storage::Load` internally.
+//!
+//! `Create` resolves the name and delegates to `storage::Create`.
+
+use dialog_capability::{Attenuate, Attenuation, Capability, Effect, Subject};
+use dialog_credentials::Credential;
+use serde::{Deserialize, Serialize};
+
+use super::storage::StorageError;
+
+/// Attenuation for space operations scoped by name.
+///
+/// Attaches to Subject (profile DID) and carries the space name.
+/// The operator resolves this name against its base directory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Space {
+    /// Space name, resolved relative to the operator's base directory.
+    pub name: String,
+}
+
+impl Space {
+    /// Create a new space attenuation.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl Attenuation for Space {
+    type Of = Subject;
+}
+
+/// Extension trait adding `.load()` and `.create()` sugar on Space capabilities.
+pub trait SpaceExt {
+    /// Load an existing space by name.
+    fn load(self) -> Capability<Load>;
+
+    /// Create a new space with the given credential.
+    fn create(self, credential: Credential) -> Capability<Create>;
+}
+
+impl SpaceExt for Capability<Space> {
+    fn load(self) -> Capability<Load> {
+        self.invoke(Load)
+    }
+
+    fn create(self, credential: Credential) -> Capability<Create> {
+        self.invoke(Create::new(credential))
+    }
+}
+
+/// Load an existing space by name.
+///
+/// The operator resolves the name against its base directory,
+/// loads the credential, mounts the space, and returns the credential.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Load;
+
+impl Effect for Load {
+    type Of = Space;
+    type Output = Result<Credential, StorageError>;
+}
+
+/// Create a new space by name with the given credential.
+///
+/// The operator resolves the name against its base directory,
+/// stores the credential, mounts the space, and returns the credential.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Create {
+    /// The credential to store at the new space.
+    pub credential: Credential,
+}
+
+impl Create {
+    /// Create a new space creation effect.
+    pub fn new(credential: Credential) -> Self {
+        Self { credential }
+    }
+}
+
+impl Effect for Create {
+    type Of = Space;
+    type Output = Result<Credential, StorageError>;
+}

--- a/rust/dialog-effects/src/storage.rs
+++ b/rust/dialog-effects/src/storage.rs
@@ -1,20 +1,18 @@
-//! Storage capability hierarchy.
+//! Storage capability hierarchy for bootstrap space operations.
 //!
-//! Storage provides key-value store operations.
+//! System-level capabilities for loading and creating spaces at
+//! explicit locations. Used during bootstrap before the operator
+//! is built. After bootstrap, use [`space`](super::space) capabilities
+//! which resolve names relative to the operator's base directory.
 //!
 //! # Capability Hierarchy
 //!
 //! ```text
-//! Subject (repository DID)
-//!   └── Storage (ability: /storage)
-//!         └── Store { store: String }
-//!               ├── Get { key } → Effect → Result<Option<Bytes>, StorageError>
-//!               ├── Set { key, value } → Effect → Result<(), StorageError>
-//!               ├── Delete { key } → Effect → Result<(), StorageError>
-//!               └── List { continuation_token } → Effect → Result<ListResult, StorageError>
+//! Subject -> Storage -> Location { directory, name } -> Load / Create
 //! ```
 
-pub use dialog_capability::{Attenuate, Attenuation, Capability, Effect, Policy, Subject};
+use dialog_capability::{Attenuate, Attenuation, Capability, Effect, Subject, did};
+use dialog_credentials::Credential;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -28,258 +26,184 @@ impl Attenuation for Storage {
     type Of = Subject;
 }
 
-/// Store policy that scopes operations to a named store.
+/// Directory category for platform-specific address resolution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum Directory {
+    /// User profile storage.
+    ///
+    /// Resolves to:
+    /// - FS: `~/Library/Application Support/dialog/` (macOS),
+    ///   `~/.local/share/dialog/` (Linux)
+    /// - IDB: database suffix `.profile`
+    Profile,
+
+    /// Working directory storage.
+    ///
+    /// Resolves to:
+    /// - FS: `$PWD/`
+    /// - IDB: no suffix
+    Current,
+
+    /// Temporary storage.
+    ///
+    /// Resolves to:
+    /// - FS: platform temp dir
+    /// - IDB: database prefix `temp.`
+    Temp,
+
+    /// Custom path.
+    At(String),
+}
+
+/// A resolved location: directory + name.
 ///
-/// This is a policy (not attenuation) so it doesn't contribute to the ability path.
-/// It restricts operations to a specific store (e.g., "index", "blob").
+/// Used as a policy in the storage capability chain. The provider
+/// resolves this to a platform-specific address.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Store {
-    /// The store name (e.g., "index", "blob").
-    pub store: String,
+pub struct Location {
+    /// The directory category.
+    pub directory: Directory,
+    /// The name within the directory.
+    pub name: String,
 }
 
-impl Store {
-    /// Create a new Store policy.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self { store: name.into() }
-    }
-}
-
-impl Policy for Store {
-    type Of = Storage;
-}
-
-/// Get operation - retrieves a value by key.
-#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
-pub struct Get {
-    /// The key to look up.
-    #[serde(with = "serde_bytes")]
-    pub key: Vec<u8>,
-}
-
-impl Get {
-    /// Create a new Get effect.
-    pub fn new(key: impl Into<Vec<u8>>) -> Self {
-        Self { key: key.into() }
-    }
-}
-
-impl Effect for Get {
-    type Of = Store;
-    type Output = Result<Option<Vec<u8>>, StorageError>;
-}
-
-/// Extension trait for `Capability<Get>` to access its fields.
-pub trait GetCapability {
-    /// Get the store name from the capability chain.
-    fn store(&self) -> &str;
-    /// Get the key from the capability chain.
-    fn key(&self) -> &[u8];
-}
-
-impl GetCapability for Capability<Get> {
-    fn store(&self) -> &str {
-        &Store::of(self).store
-    }
-
-    fn key(&self) -> &[u8] {
-        &Get::of(self).key
-    }
-}
-
-/// Set operation - sets a value for a key.
-#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
-pub struct Set {
-    /// The key to update.
-    #[serde(with = "serde_bytes")]
-    pub key: Vec<u8>,
-    /// The value to set.
-    #[serde(with = "serde_bytes")]
-    pub value: Vec<u8>,
-}
-
-impl Set {
-    /// Create a new Set effect.
-    pub fn new(key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Self {
+impl Location {
+    /// Create a location.
+    pub fn new(directory: Directory, name: impl Into<String>) -> Self {
         Self {
-            key: key.into(),
-            value: value.into(),
+            directory,
+            name: name.into(),
+        }
+    }
+
+    /// Profile location.
+    pub fn profile(name: impl Into<String>) -> Self {
+        Self::new(Directory::Profile, name)
+    }
+
+    /// Current directory location.
+    pub fn current(name: impl Into<String>) -> Self {
+        Self::new(Directory::Current, name)
+    }
+
+    /// Temp location.
+    pub fn temp(name: impl Into<String>) -> Self {
+        Self::new(Directory::Temp, name)
+    }
+
+    /// Explicit path location.
+    pub fn at(path: impl Into<String>) -> Self {
+        Self {
+            directory: Directory::At(path.into()),
+            name: String::new(),
         }
     }
 }
 
-impl Effect for Set {
-    type Of = Store;
-    type Output = Result<(), StorageError>;
+impl Attenuation for Location {
+    type Of = Storage;
 }
 
-/// Extension trait for `Capability<Set>` to access its fields.
-pub trait SetCapability {
-    /// Get the store name from the capability chain.
-    fn store(&self) -> &str;
-    /// Get the key from the capability chain.
-    fn key(&self) -> &[u8];
-    /// Get the value from the capability chain.
-    fn value(&self) -> &[u8];
+/// Extension trait adding `.load()` and `.create()` sugar on Location capabilities.
+pub trait LocationExt {
+    /// Load an existing space from this location.
+    fn load(self) -> Capability<Load>;
+
+    /// Create a new space at this location with the given credential.
+    fn create(self, credential: Credential) -> Capability<Create>;
 }
 
-impl SetCapability for Capability<Set> {
-    fn store(&self) -> &str {
-        &Store::of(self).store
+impl LocationExt for Capability<Location> {
+    fn load(self) -> Capability<Load> {
+        self.invoke(Load)
     }
 
-    fn key(&self) -> &[u8] {
-        &Set::of(self).key
-    }
-
-    fn value(&self) -> &[u8] {
-        &Set::of(self).value
+    fn create(self, credential: Credential) -> Capability<Create> {
+        self.invoke(Create::new(credential))
     }
 }
 
-/// Delete operation - removes a key.
+/// Load an existing space from a location.
+///
+/// Reads the credential from the resolved location, mounts the space,
+/// and returns the credential.
 #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
-pub struct Delete {
-    /// The key to delete.
-    #[serde(with = "serde_bytes")]
-    pub key: Vec<u8>,
+pub struct Load;
+
+impl Effect for Load {
+    type Of = Location;
+    type Output = Result<Credential, StorageError>;
 }
 
-impl Delete {
-    /// Create a new Delete effect.
-    pub fn new(key: impl Into<Vec<u8>>) -> Self {
-        Self { key: key.into() }
-    }
-}
-
-impl Effect for Delete {
-    type Of = Store;
-    type Output = Result<(), StorageError>;
-}
-
-/// Extension trait for `Capability<Delete>` to access its fields.
-pub trait DeleteCapability {
-    /// Get the store name from the capability chain.
-    fn store(&self) -> &str;
-    /// Get the key from the capability chain.
-    fn key(&self) -> &[u8];
-}
-
-impl DeleteCapability for Capability<Delete> {
-    fn store(&self) -> &str {
-        &Store::of(self).store
-    }
-
-    fn key(&self) -> &[u8] {
-        &Delete::of(self).key
-    }
-}
-
-/// List operation - lists keys in a store.
+/// Create a new space at a location with the given credential.
+///
+/// Writes the credential to the resolved location, mounts the space,
+/// and returns the credential.
 #[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
-pub struct List {
-    /// Continuation token for pagination.
-    pub continuation_token: Option<String>,
+pub struct Create {
+    /// The credential establishing the space's identity.
+    pub credential: Credential,
 }
 
-impl List {
-    /// Create a new List effect.
-    pub fn new(continuation_token: Option<String>) -> Self {
-        Self { continuation_token }
+impl Create {
+    /// Create a new space creation effect.
+    pub fn new(credential: Credential) -> Self {
+        Self { credential }
     }
 }
 
-impl Effect for List {
-    type Of = Store;
-    type Output = Result<ListResult, StorageError>;
+impl Effect for Create {
+    type Of = Location;
+    type Output = Result<Credential, StorageError>;
 }
 
-/// Result of a list operation.
-#[derive(Debug, Clone)]
-pub struct ListResult {
-    /// Object keys returned in this response.
-    pub keys: Vec<String>,
-    /// If true, there are more results to fetch.
-    pub is_truncated: bool,
-    /// Token to use for fetching the next page of results.
-    pub next_continuation_token: Option<String>,
-}
-
-/// Extension trait for `Capability<List>` to access its fields.
-pub trait ListCapability {
-    /// Get the store name from the capability chain.
-    fn store(&self) -> &str;
-    /// Get the continuation token from the capability chain.
-    fn continuation_token(&self) -> Option<&str>;
-}
-
-impl ListCapability for Capability<List> {
-    fn store(&self) -> &str {
-        &Store::of(self).store
-    }
-
-    fn continuation_token(&self) -> Option<&str> {
-        List::of(self).continuation_token.as_deref()
-    }
-}
-
-/// Errors that can occur during storage operations.
+/// Errors during storage operations.
 #[derive(Debug, Error)]
 pub enum StorageError {
-    /// Storage backend error.
+    /// No space found at the resolved location.
+    #[error("Space not found: {0}")]
+    NotFound(String),
+
+    /// A space already exists at the resolved location.
+    #[error("Space already exists: {0}")]
+    AlreadyExists(String),
+
+    /// Backend storage error.
     #[error("Storage error: {0}")]
     Storage(String),
 
-    /// IO error.
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
+    /// The credential at the location is invalid.
+    #[error("Invalid credential: {0}")]
+    InvalidCredential(String),
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use dialog_capability::did;
-
-    #[test]
-    fn it_builds_storage_claim_path() {
-        let claim = Subject::from(did!("key:zSpace")).attenuate(Storage);
-
-        assert_eq!(claim.subject(), &did!("key:zSpace"));
-        assert_eq!(claim.ability(), "/storage");
+/// Sugar: build a storage capability chain for a profile.
+impl Storage {
+    /// Build a capability chain for loading/creating a profile space.
+    pub fn profile(name: impl Into<String>) -> Capability<Location> {
+        Subject::from(did!("local:storage"))
+            .attenuate(Storage)
+            .attenuate(Location::profile(name))
     }
 
-    #[test]
-    fn it_builds_store_claim_path() {
-        let claim = Subject::from(did!("key:zSpace"))
+    /// Build a capability chain for loading/creating a current-dir space.
+    pub fn current(name: impl Into<String>) -> Capability<Location> {
+        Subject::from(did!("local:storage"))
             .attenuate(Storage)
-            .attenuate(Store::new("index"));
-
-        assert_eq!(claim.subject(), &did!("key:zSpace"));
-        // Store is Policy, not Ability, so it doesn't add to path
-        assert_eq!(claim.ability(), "/storage");
+            .attenuate(Location::current(name))
     }
 
-    #[test]
-    fn it_builds_get_claim_path() {
-        let claim = Subject::from(did!("key:zSpace"))
+    /// Build a capability chain for loading/creating a temp space.
+    pub fn temp(name: impl Into<String>) -> Capability<Location> {
+        Subject::from(did!("local:storage"))
             .attenuate(Storage)
-            .attenuate(Store::new("index"))
-            .invoke(Get::new(vec![1, 2, 3]));
-
-        assert_eq!(claim.ability(), "/storage/get");
+            .attenuate(Location::temp(name))
     }
 
-    #[test]
-    fn it_builds_set_claim_path() {
-        let claim = Subject::from(did!("key:zSpace"))
+    /// Build a capability chain for loading/creating at an explicit path.
+    pub fn at(path: impl Into<String>) -> Capability<Location> {
+        Subject::from(did!("local:storage"))
             .attenuate(Storage)
-            .attenuate(Store::new("index"))
-            .invoke(Set::new(vec![1, 2, 3], vec![4, 5, 6]));
-
-        assert_eq!(claim.ability(), "/storage/set");
-
-        // Use policy() method to extract nested constraints
-        assert_eq!(claim.policy::<Store, _>().store, "index");
-        assert_eq!(&claim.policy::<Set, _>().key[..], &[1, 2, 3]);
+            .attenuate(Location::at(path))
     }
 }


### PR DESCRIPTION
## Why

Effects previously re-exported storage KV types (Get/Set/Delete/List) from a flat module. The new storage design uses location-based bootstrap operations (load/create a space at a directory + name), and the operator layer needs space-level name resolution, credential persistence, and identity effects. These capabilities had no home.

## Overview

Replaces the old storage KV re-exports with location-based operations and adds the missing capability domains:

- storage: Directory/Location/Load/Create for bootstrap. LocationExt sugar for the capability chain. Storage::profile()/current()/temp() convenience builders.
- space: Space Load/Create for operator-level name resolution (resolves names against a base directory)
- authority: identity chain (Profile with DID + optional account, Operator with session DID, Identify effect)
- credential: Load/Save effects for credential persistence with CredentialError
- access: re-exports from dialog-capability::access for convenience
- archive/memory preludes: fluent builder extension traits (SubjectExt, ArchiveExt, CatalogExt, etc.)