### PR TITLE
13 ✅ feat: add dialog-ucan capability protocol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-ucan"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base58",
+ "blake3",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-effects",
+ "dialog-ucan-core",
+ "dialog-varsig",
+ "ipld-core",
+ "serde",
+ "serde_bytes",
+ "serde_ipld_dagcbor",
+ "signature",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "rust/dialog-search-tree",
     "rust/dialog-storage",
     "rust/dialog-ucan-core",
+    "rust/dialog-ucan",
     "rust/dialog-varsig",
     "rust/dialog-blobs",
 ]
@@ -140,6 +141,7 @@ tower = "0.5"
 tower-http = "0.6"
 tracing = "0.1"
 dialog-ucan-core = { path = "./rust/dialog-ucan-core" }
+dialog-ucan = { path = "./rust/dialog-ucan" }
 dialog-varsig = { path = "./rust/dialog-varsig" }
 ucan = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "main", package = "ucan" }
 varsig = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "main", package = "varsig" }

--- a/rust/dialog-ucan/Cargo.toml
+++ b/rust/dialog-ucan/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dialog-ucan"
 description = "UCAN protocol implementation for dialog capability system"
-edition = "2024"
+edition.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/rust/dialog-ucan/Cargo.toml
+++ b/rust/dialog-ucan/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "dialog-ucan"
+description = "UCAN protocol implementation for dialog capability system"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-ucan-core = { workspace = true }
+dialog-varsig = { workspace = true }
+
+async-trait = { workspace = true }
+base58 = { workspace = true }
+blake3 = { workspace = true }
+ipld-core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+signature = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
+dialog-credentials = { workspace = true }
+dialog-effects = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+wasm-bindgen-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(feature, values(\"web-integration-tests\"))",
+  "cfg(dialog_test_wasm_integration)",
+] }

--- a/rust/dialog-ucan/README.md
+++ b/rust/dialog-ucan/README.md
@@ -1,0 +1,34 @@
+# dialog-ucan
+
+UCAN authorization protocol for Dialog-DB.
+
+Bridges `dialog-capability`'s generic access protocol with `dialog-ucan-core`'s UCAN spec implementation. Defines how UCAN delegation chains are used to prove and delegate access.
+
+## Usage
+
+```rust
+// Delegate repo access from Alice to Bob
+let delegation = alice_profile.access()
+    .claim(&repo)
+    .delegate(bob_profile.did())
+    .perform(&alice_operator)
+    .await?;
+
+// Bob retains the delegation
+bob_profile.access()
+    .save(delegation)
+    .perform(&bob_operator)
+    .await?;
+
+// Capability to access archive's "index" catalog
+let capability = repo
+    .subject()
+    .archive()
+    .catalog("index");
+
+let chain = alice_profile.access()
+    .claim(capability)
+    .delegate(bob_profile.did())
+    .perform(&alice_operator)
+    .await?;
+```

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -1,0 +1,348 @@
+//! UCAN Protocol implementation.
+//!
+//! Implements [`Protocol`](dialog_capability::access::Protocol) for [`Ucan`],
+//! defining the UCAN-specific proof, permit, and authorization types.
+
+use dialog_capability::Did;
+use dialog_capability::access::{self, AuthorizeError};
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::DelegationChain;
+use dialog_varsig::eddsa::Ed25519Signature;
+
+use super::Ucan;
+use super::scope::Scope;
+
+/// A single UCAN delegation — one proof link in a chain.
+///
+/// Implements [`Delegation`](access::Delegation) for generic chain verification.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct UcanCertificate(pub dialog_ucan_core::Delegation<Ed25519Signature>);
+
+impl access::Certificate for UcanCertificate {
+    type Access = Scope;
+
+    fn issuer(&self) -> &Did {
+        self.0.issuer()
+    }
+
+    fn audience(&self) -> &Did {
+        self.0.audience()
+    }
+
+    fn subject(&self) -> Option<&Did> {
+        use dialog_ucan_core::subject::Subject as UcanSubject;
+        match self.0.subject() {
+            UcanSubject::Specific(did) => Some(did),
+            UcanSubject::Any => None,
+        }
+    }
+
+    fn verify(&self, access: &Scope) -> Result<access::TimeRange, AuthorizeError> {
+        // Command attenuation: delegation command must be a prefix of requested command
+        if !access.command.starts_with(self.0.command()) {
+            return Err(AuthorizeError::Denied(format!(
+                "command '{}' not covered by delegation '{}'",
+                access.command,
+                self.0.command()
+            )));
+        }
+
+        // Policy predicates: all must pass against the access parameters
+        let args = ipld_core::ipld::Ipld::Map(access.parameters.as_map().clone());
+        let all_pass = self
+            .0
+            .policy()
+            .iter()
+            .all(|pred| pred.clone().run(&args).unwrap_or(false));
+
+        if !all_pass {
+            return Err(AuthorizeError::Denied(
+                "policy predicates not satisfied".into(),
+            ));
+        }
+
+        Ok(access::TimeRange {
+            not_before: self.0.not_before().map(|t| t.to_unix()),
+            expiration: self.0.expiration().map(|t| t.to_unix()),
+        })
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, AuthorizeError> {
+        serde_ipld_dagcbor::to_vec(&self.0)
+            .map_err(|e| AuthorizeError::Configuration(format!("Failed to encode proof: {e}")))
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, AuthorizeError> {
+        serde_ipld_dagcbor::from_slice(bytes)
+            .map_err(|e| AuthorizeError::Configuration(format!("Failed to decode proof: {e}")))
+    }
+}
+
+/// Verified UCAN permit — delegation chain without a signer.
+///
+/// Built incrementally: create with `new(scope)`, push proofs
+/// as the chain is walked, then `claim(signer)` to authorize.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct UcanProof {
+    /// The collected proofs (individual delegations).
+    pub proofs: Vec<UcanCertificate>,
+    /// The scope of access being authorized.
+    pub scope: Scope,
+    /// The time range this proof covers.
+    pub duration: access::TimeRange,
+}
+
+impl UcanProof {
+    /// Build a permit from a delegation chain and scope.
+    ///
+    /// Used when importing externally-built delegation chains.
+    pub fn from_chain(chain: &DelegationChain, scope: Scope) -> Self {
+        let proofs = chain
+            .delegations()
+            .values()
+            .map(|d| UcanCertificate(d.as_ref().clone()))
+            .collect();
+        let duration = access::TimeRange {
+            not_before: chain.not_before().map(|t| t.to_unix()),
+            expiration: chain.expiration().map(|t| t.to_unix()),
+        };
+        Self {
+            proofs,
+            scope,
+            duration,
+        }
+    }
+}
+
+impl access::Proof<Ucan> for UcanProof {
+    fn new(access: Scope) -> Self {
+        Self {
+            proofs: Vec::new(),
+            scope: access,
+            duration: access::TimeRange::unbounded(),
+        }
+    }
+
+    fn access(&self) -> &Scope {
+        &self.scope
+    }
+
+    fn push(&mut self, proof: UcanCertificate) {
+        self.proofs.push(proof);
+    }
+
+    fn proofs(&self) -> &[UcanCertificate] {
+        &self.proofs
+    }
+
+    fn duration(&self) -> &access::TimeRange {
+        &self.duration
+    }
+
+    fn set_duration(&mut self, duration: access::TimeRange) {
+        self.duration = duration;
+    }
+
+    fn claim(self, signer: Ed25519Signer) -> Result<UcanAuthorization, AuthorizeError> {
+        let chain = if self.proofs.is_empty() {
+            None
+        } else {
+            let mut iter = self.proofs.into_iter();
+            let first = iter.next().expect("non-empty proofs").0;
+            let mut chain = DelegationChain::new(first);
+            for proof in iter {
+                chain = chain
+                    .push(proof.0)
+                    .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+            }
+            Some(chain)
+        };
+
+        Ok(UcanAuthorization {
+            chain,
+            signer,
+            scope: self.scope,
+            duration: self.duration,
+        })
+    }
+}
+
+/// Full UCAN authorization — can delegate and invoke.
+///
+/// Created by [`UcanProof::claim`]. Holds the verified delegation
+/// chain, signer, and scope.
+pub struct UcanAuthorization {
+    /// The delegation chain proving authority (None if self-authorized).
+    pub chain: Option<DelegationChain>,
+    /// The signer (operator key).
+    pub signer: Ed25519Signer,
+    /// The scope of the capability being authorized.
+    pub scope: Scope,
+    /// The time range this authorization is valid for.
+    pub duration: access::TimeRange,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl access::Authorization<Ucan> for UcanAuthorization {
+    fn duration(&self) -> &access::TimeRange {
+        &self.duration
+    }
+
+    fn not_before(mut self, timestamp: u64) -> Result<Self, AuthorizeError> {
+        if let Some(nbf) = self.duration.not_before
+            && timestamp < nbf
+        {
+            return Err(AuthorizeError::Denied(format!(
+                "cannot set not_before to {timestamp}, proof is not valid before {nbf}"
+            )));
+        }
+        self.duration.not_before = Some(timestamp);
+        Ok(self)
+    }
+
+    fn expires(mut self, timestamp: u64) -> Result<Self, AuthorizeError> {
+        if let Some(exp) = self.duration.expiration
+            && timestamp > exp
+        {
+            return Err(AuthorizeError::Denied(format!(
+                "cannot set expiration to {timestamp}, proof expires at {exp}"
+            )));
+        }
+        self.duration.expiration = Some(timestamp);
+        Ok(self)
+    }
+
+    async fn delegate(&self, audience: Did) -> Result<UcanDelegation, AuthorizeError> {
+        use dialog_ucan_core::delegation::builder::DelegationBuilder;
+        use dialog_ucan_core::time::Timestamp;
+        use dialog_ucan_core::time::timestamp::{Duration, UNIX_EPOCH};
+
+        let mut builder = DelegationBuilder::new()
+            .issuer(self.signer.clone())
+            .audience(&audience)
+            .subject(self.scope.subject.clone())
+            .command(self.scope.command.segments().clone())
+            .policy(self.scope.policy());
+
+        if let Some(exp) = self.duration.expiration
+            && let Ok(ts) = Timestamp::new(UNIX_EPOCH + Duration::from_secs(exp))
+        {
+            builder = builder.expiration(ts);
+        }
+        if let Some(nbf) = self.duration.not_before
+            && let Ok(ts) = Timestamp::new(UNIX_EPOCH + Duration::from_secs(nbf))
+        {
+            builder = builder.not_before(ts);
+        }
+
+        let delegation = builder
+            .try_build()
+            .await
+            .map_err(|e| AuthorizeError::Configuration(format!("{e:?}")))?;
+
+        let chain = match &self.chain {
+            Some(chain) => chain
+                .push(delegation)
+                .map_err(|e| AuthorizeError::Configuration(format!("{e}")))?,
+            None => DelegationChain::new(delegation),
+        };
+
+        Ok(UcanDelegation::from(chain))
+    }
+
+    async fn invoke(&self) -> Result<super::UcanInvocation, AuthorizeError> {
+        use dialog_capability::ANY_SUBJECT;
+        use dialog_ucan_core::InvocationBuilder;
+        use dialog_ucan_core::subject::Subject as UcanSubject;
+
+        let subject_did = match &self.scope.subject {
+            UcanSubject::Specific(did) => did.clone(),
+            UcanSubject::Any => ANY_SUBJECT.parse().expect("valid DID"),
+        };
+
+        let command: Vec<String> = self.scope.command.segments().clone();
+        let args = self.scope.parameters.args();
+
+        let (proofs, delegations_map) = match &self.chain {
+            Some(chain) => (chain.proof_cids().into(), chain.delegations().clone()),
+            None => (vec![], Default::default()),
+        };
+
+        let ability = if command.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", command.join("/"))
+        };
+
+        let invocation = InvocationBuilder::new()
+            .issuer(self.signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(command)
+            .arguments(args)
+            .proofs(proofs)
+            .try_build()
+            .await
+            .map_err(|e| AuthorizeError::Denied(format!("{e:?}")))?;
+
+        let chain = dialog_ucan_core::InvocationChain::new(invocation, delegations_map);
+
+        Ok(super::UcanInvocation {
+            chain: Box::new(chain),
+            subject: subject_did,
+            ability,
+        })
+    }
+}
+
+/// A UCAN delegation bundle — wraps [`DelegationChain`] to implement [`Delegation`](access::Delegation).
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct UcanDelegation(pub DelegationChain);
+
+impl UcanDelegation {
+    /// Create a new delegation from a chain.
+    pub fn new(chain: DelegationChain) -> Self {
+        Self(chain)
+    }
+
+    /// The inner delegation chain.
+    pub fn chain(&self) -> &DelegationChain {
+        &self.0
+    }
+
+    /// Consume and return the inner delegation chain.
+    pub fn into_chain(self) -> DelegationChain {
+        self.0
+    }
+}
+
+impl From<DelegationChain> for UcanDelegation {
+    fn from(chain: DelegationChain) -> Self {
+        Self(chain)
+    }
+}
+
+impl access::Delegation for UcanDelegation {
+    type Certificate = UcanCertificate;
+
+    fn certificates(&self) -> Vec<UcanCertificate> {
+        self.0
+            .delegations()
+            .values()
+            .map(|d| UcanCertificate(d.as_ref().clone()))
+            .collect()
+    }
+}
+
+impl access::Protocol for Ucan {
+    type Access = Scope;
+    type Signer = Ed25519Signer;
+    type Certificate = UcanCertificate;
+    type Delegation = UcanDelegation;
+    type Invocation = super::UcanInvocation;
+    type Proof = UcanProof;
+    type Authorization = UcanAuthorization;
+}

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -4,22 +4,29 @@
 //! defining the UCAN-specific proof, permit, and authorization types.
 
 use dialog_capability::Did;
-use dialog_capability::access::{self, AuthorizeError};
+use dialog_capability::access::{
+    Authorization, AuthorizeError, Certificate, Delegation as AccessDelegation, Proof, Protocol,
+    TimeRange,
+};
 use dialog_credentials::Ed25519Signer;
-use dialog_ucan_core::DelegationChain;
+use dialog_ucan_core::delegation::builder::DelegationBuilder;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use dialog_ucan_core::time::Timestamp;
+use dialog_ucan_core::time::timestamp::{Duration, UNIX_EPOCH};
+use dialog_ucan_core::{Delegation, DelegationChain, InvocationBuilder, InvocationChain};
 use dialog_varsig::eddsa::Ed25519Signature;
 
-use super::Ucan;
 use super::scope::Scope;
+use super::{Ucan, UcanInvocation};
 
 /// A single UCAN delegation — one proof link in a chain.
 ///
-/// Implements [`Delegation`](access::Delegation) for generic chain verification.
+/// Implements [`Certificate`] for generic chain verification.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
-pub struct UcanCertificate(pub dialog_ucan_core::Delegation<Ed25519Signature>);
+pub struct UcanCertificate(pub Delegation<Ed25519Signature>);
 
-impl access::Certificate for UcanCertificate {
+impl Certificate for UcanCertificate {
     type Access = Scope;
 
     fn issuer(&self) -> &Did {
@@ -31,14 +38,13 @@ impl access::Certificate for UcanCertificate {
     }
 
     fn subject(&self) -> Option<&Did> {
-        use dialog_ucan_core::subject::Subject as UcanSubject;
         match self.0.subject() {
             UcanSubject::Specific(did) => Some(did),
             UcanSubject::Any => None,
         }
     }
 
-    fn verify(&self, access: &Scope) -> Result<access::TimeRange, AuthorizeError> {
+    fn verify(&self, access: &Scope) -> Result<TimeRange, AuthorizeError> {
         // Command attenuation: delegation command must be a prefix of requested command
         if !access.command.starts_with(self.0.command()) {
             return Err(AuthorizeError::Denied(format!(
@@ -62,7 +68,7 @@ impl access::Certificate for UcanCertificate {
             ));
         }
 
-        Ok(access::TimeRange {
+        Ok(TimeRange {
             not_before: self.0.not_before().map(|t| t.to_unix()),
             expiration: self.0.expiration().map(|t| t.to_unix()),
         })
@@ -90,7 +96,7 @@ pub struct UcanProof {
     /// The scope of access being authorized.
     pub scope: Scope,
     /// The time range this proof covers.
-    pub duration: access::TimeRange,
+    pub duration: TimeRange,
 }
 
 impl UcanProof {
@@ -103,7 +109,7 @@ impl UcanProof {
             .values()
             .map(|d| UcanCertificate(d.as_ref().clone()))
             .collect();
-        let duration = access::TimeRange {
+        let duration = TimeRange {
             not_before: chain.not_before().map(|t| t.to_unix()),
             expiration: chain.expiration().map(|t| t.to_unix()),
         };
@@ -115,12 +121,12 @@ impl UcanProof {
     }
 }
 
-impl access::Proof<Ucan> for UcanProof {
+impl Proof<Ucan> for UcanProof {
     fn new(access: Scope) -> Self {
         Self {
             proofs: Vec::new(),
             scope: access,
-            duration: access::TimeRange::unbounded(),
+            duration: TimeRange::unbounded(),
         }
     }
 
@@ -136,27 +142,27 @@ impl access::Proof<Ucan> for UcanProof {
         &self.proofs
     }
 
-    fn duration(&self) -> &access::TimeRange {
+    fn duration(&self) -> &TimeRange {
         &self.duration
     }
 
-    fn set_duration(&mut self, duration: access::TimeRange) {
+    fn set_duration(&mut self, duration: TimeRange) {
         self.duration = duration;
     }
 
     fn claim(self, signer: Ed25519Signer) -> Result<UcanAuthorization, AuthorizeError> {
-        let chain = if self.proofs.is_empty() {
-            None
-        } else {
-            let mut iter = self.proofs.into_iter();
-            let first = iter.next().expect("non-empty proofs").0;
-            let mut chain = DelegationChain::new(first);
-            for proof in iter {
-                chain = chain
-                    .push(proof.0)
-                    .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+        let mut iter = self.proofs.into_iter();
+        let chain = match iter.next() {
+            None => None,
+            Some(first) => {
+                let mut chain = DelegationChain::new(first.0);
+                for proof in iter {
+                    chain = chain
+                        .push(proof.0)
+                        .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+                }
+                Some(chain)
             }
-            Some(chain)
         };
 
         Ok(UcanAuthorization {
@@ -180,13 +186,13 @@ pub struct UcanAuthorization {
     /// The scope of the capability being authorized.
     pub scope: Scope,
     /// The time range this authorization is valid for.
-    pub duration: access::TimeRange,
+    pub duration: TimeRange,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl access::Authorization<Ucan> for UcanAuthorization {
-    fn duration(&self) -> &access::TimeRange {
+impl Authorization<Ucan> for UcanAuthorization {
+    fn duration(&self) -> &TimeRange {
         &self.duration
     }
 
@@ -215,10 +221,6 @@ impl access::Authorization<Ucan> for UcanAuthorization {
     }
 
     async fn delegate(&self, audience: Did) -> Result<UcanDelegation, AuthorizeError> {
-        use dialog_ucan_core::delegation::builder::DelegationBuilder;
-        use dialog_ucan_core::time::Timestamp;
-        use dialog_ucan_core::time::timestamp::{Duration, UNIX_EPOCH};
-
         let mut builder = DelegationBuilder::new()
             .issuer(self.signer.clone())
             .audience(&audience)
@@ -252,14 +254,15 @@ impl access::Authorization<Ucan> for UcanAuthorization {
         Ok(UcanDelegation::from(chain))
     }
 
-    async fn invoke(&self) -> Result<super::UcanInvocation, AuthorizeError> {
-        use dialog_capability::ANY_SUBJECT;
-        use dialog_ucan_core::InvocationBuilder;
-        use dialog_ucan_core::subject::Subject as UcanSubject;
-
+    async fn invoke(&self) -> Result<UcanInvocation, AuthorizeError> {
         let subject_did = match &self.scope.subject {
             UcanSubject::Specific(did) => did.clone(),
-            UcanSubject::Any => ANY_SUBJECT.parse().expect("valid DID"),
+            UcanSubject::Any => match dialog_capability::ANY_SUBJECT.parse() {
+                Ok(did) => did,
+                Err(_) => {
+                    unreachable!("ANY_SUBJECT is a fixed compile-time constant DID and must parse")
+                }
+            },
         };
 
         let command: Vec<String> = self.scope.command.segments().clone();
@@ -287,9 +290,9 @@ impl access::Authorization<Ucan> for UcanAuthorization {
             .await
             .map_err(|e| AuthorizeError::Denied(format!("{e:?}")))?;
 
-        let chain = dialog_ucan_core::InvocationChain::new(invocation, delegations_map);
+        let chain = InvocationChain::new(invocation, delegations_map);
 
-        Ok(super::UcanInvocation {
+        Ok(UcanInvocation {
             chain: Box::new(chain),
             subject: subject_did,
             ability,
@@ -297,7 +300,8 @@ impl access::Authorization<Ucan> for UcanAuthorization {
     }
 }
 
-/// A UCAN delegation bundle — wraps [`DelegationChain`] to implement [`Delegation`](access::Delegation).
+/// A UCAN delegation bundle — wraps [`DelegationChain`] to implement
+/// [`Delegation`](dialog_capability::access::Delegation).
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct UcanDelegation(pub DelegationChain);
@@ -325,7 +329,7 @@ impl From<DelegationChain> for UcanDelegation {
     }
 }
 
-impl access::Delegation for UcanDelegation {
+impl AccessDelegation for UcanDelegation {
     type Certificate = UcanCertificate;
 
     fn certificates(&self) -> Vec<UcanCertificate> {
@@ -337,12 +341,12 @@ impl access::Delegation for UcanDelegation {
     }
 }
 
-impl access::Protocol for Ucan {
+impl Protocol for Ucan {
     type Access = Scope;
     type Signer = Ed25519Signer;
     type Certificate = UcanCertificate;
     type Delegation = UcanDelegation;
-    type Invocation = super::UcanInvocation;
+    type Invocation = UcanInvocation;
     type Proof = UcanProof;
     type Authorization = UcanAuthorization;
 }

--- a/rust/dialog-ucan/src/invocation.rs
+++ b/rust/dialog-ucan/src/invocation.rs
@@ -1,0 +1,46 @@
+//! Signed UCAN invocation.
+
+use dialog_capability::Did;
+use dialog_ucan_core::InvocationChain;
+use dialog_varsig::eddsa::Ed25519Signature;
+
+/// A signed UCAN invocation ready to be redeemed at an access service.
+///
+/// Contains the signed invocation chain and metadata. The chain proves
+/// the invoker's authority to perform the operation. To actually execute
+/// against a remote service, send the serialized chain to the access
+/// service endpoint (transport-specific, handled by `dialog-remote-ucan-s3`).
+#[derive(Debug, Clone)]
+pub struct UcanInvocation {
+    /// The signed invocation chain (invocation + delegation proofs).
+    pub chain: Box<InvocationChain<Ed25519Signature>>,
+    /// The subject DID this invocation acts on.
+    pub subject: Did,
+    /// The ability path (e.g., "/storage/get").
+    pub ability: String,
+}
+
+impl UcanInvocation {
+    /// Get the subject DID.
+    pub fn subject(&self) -> &Did {
+        &self.subject
+    }
+
+    /// Get the ability path.
+    pub fn ability(&self) -> &str {
+        &self.ability
+    }
+
+    /// Get the invocation chain.
+    pub fn chain(&self) -> &InvocationChain<Ed25519Signature> {
+        &self.chain
+    }
+
+    /// Serialize the invocation chain to bytes.
+    ///
+    /// Returns the CBOR-encoded container suitable for sending to an
+    /// access service endpoint.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        self.chain.to_bytes().map_err(|e| e.to_string())
+    }
+}

--- a/rust/dialog-ucan/src/lib.rs
+++ b/rust/dialog-ucan/src/lib.rs
@@ -6,8 +6,8 @@
 
 mod access;
 mod invocation;
-pub mod parameters;
-pub mod scope;
+mod parameters;
+mod scope;
 
 pub use access::{
     UcanAuthorization, UcanCertificate, UcanDelegation, UcanProof, UcanProof as UcanProofChain,

--- a/rust/dialog-ucan/src/lib.rs
+++ b/rust/dialog-ucan/src/lib.rs
@@ -1,0 +1,23 @@
+//! UCAN authorization protocol implementation.
+//!
+//! Provides the [`Ucan`] protocol type and proof chain types.
+//! Delegation is handled via
+//! [`profile.access().claim().delegate()`](dialog_operator::profile::access).
+
+mod access;
+mod invocation;
+pub mod parameters;
+pub mod scope;
+
+pub use access::{
+    UcanAuthorization, UcanCertificate, UcanDelegation, UcanProof, UcanProof as UcanProofChain,
+};
+pub use invocation::UcanInvocation;
+pub use parameters::{parameters, parameters_to_args, parameters_to_policy};
+pub use scope::{Args, Parameters, Scope};
+
+/// UCAN authorization protocol marker.
+///
+/// Implements [`Protocol`](dialog_capability::access::Protocol) for UCAN-based
+/// authorization with Ed25519 signatures.
+pub struct Ucan;

--- a/rust/dialog-ucan/src/parameters.rs
+++ b/rust/dialog-ucan/src/parameters.rs
@@ -1,0 +1,189 @@
+//! IPLD parameter collection and UCAN argument conversion.
+
+use dialog_capability::{Ability, PolicyBuilder};
+use dialog_ucan_core::promise::Promised;
+use ipld_core::ipld::Ipld;
+use ipld_core::serde::to_ipld;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// IPLD-based parameter map for UCAN invocations.
+pub type Parameters = BTreeMap<String, Ipld>;
+
+/// UCAN invocation arguments (Promised values for the invocation body).
+pub type Args = BTreeMap<String, Promised>;
+
+/// Builder that collects caveats as IPLD parameters.
+struct ParametersBuilder(Parameters);
+
+impl PolicyBuilder for ParametersBuilder {
+    fn push<T: Serialize>(&mut self, caveat: &T) {
+        if let Ok(Ipld::Map(map)) = to_ipld(caveat) {
+            self.0.extend(map);
+        }
+    }
+}
+
+/// Collect parameters from a capability into an IPLD map.
+///
+/// Iterates over all caveats in the capability chain, serializes each
+/// to IPLD, and merges their fields into a single map.
+pub fn parameters<T: Ability>(capability: &T) -> Parameters {
+    let mut builder = ParametersBuilder(Parameters::new());
+    capability.constrain(&mut builder);
+    builder.0
+}
+
+/// Convert an IPLD value to a Promised value (for UCAN invocation arguments).
+fn ipld_to_promised(ipld: Ipld) -> Promised {
+    match ipld {
+        Ipld::Null => Promised::Null,
+        Ipld::Bool(b) => Promised::Bool(b),
+        Ipld::Integer(i) => Promised::Integer(i),
+        Ipld::Float(f) => Promised::Float(f),
+        Ipld::String(s) => Promised::String(s),
+        Ipld::Bytes(b) => Promised::Bytes(b),
+        Ipld::Link(c) => Promised::Link(c),
+        Ipld::List(l) => Promised::List(l.into_iter().map(ipld_to_promised).collect()),
+        Ipld::Map(m) => Promised::Map(
+            m.into_iter()
+                .map(|(k, v)| (k, ipld_to_promised(v)))
+                .collect(),
+        ),
+    }
+}
+
+/// Convert IPLD parameters to UCAN invocation arguments.
+pub fn parameters_to_args(parameters: Parameters) -> Args {
+    parameters
+        .into_iter()
+        .map(|(k, v)| (k, ipld_to_promised(v)))
+        .collect()
+}
+
+use dialog_ucan_core::delegation::policy::predicate::Predicate;
+use dialog_ucan_core::delegation::policy::selector::filter::Filter;
+use dialog_ucan_core::delegation::policy::selector::select::Select;
+
+/// Convert capability parameters to UCAN delegation policy predicates.
+///
+/// Each parameter becomes an equality constraint: `.{key} == value`.
+pub fn parameters_to_policy(parameters: Parameters) -> Vec<Predicate> {
+    parameters
+        .into_iter()
+        .map(|(key, value)| Predicate::Equal(Select::new(vec![Filter::Field(key)]), value))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_capability::{Subject, did};
+    use dialog_common::Blake3Hash;
+    use dialog_effects::archive::{Archive, Catalog, Get, Put};
+
+    #[test]
+    fn parameters_from_empty_subject() {
+        let cap = Subject::from(did!("key:z6MkTest"));
+        let params = parameters(&cap);
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn parameters_from_archive_catalog() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"));
+        let params = parameters(&cap);
+        assert_eq!(params.get("catalog"), Some(&Ipld::String("index".into())));
+    }
+
+    #[test]
+    fn parameters_from_archive_get() {
+        let digest = Blake3Hash::hash(b"my-content");
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Archive)
+            .attenuate(Catalog::new("data"))
+            .invoke(Get::new(digest));
+        let params = parameters(&cap);
+        assert_eq!(params.get("catalog"), Some(&Ipld::String("data".into())));
+        assert!(
+            params.contains_key("digest"),
+            "should contain digest parameter"
+        );
+    }
+
+    #[test]
+    fn parameters_to_policy_empty() {
+        let policy = parameters_to_policy(Parameters::new());
+        assert!(policy.is_empty());
+    }
+
+    #[test]
+    fn parameters_to_policy_produces_equality_constraints() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Archive)
+            .attenuate(Catalog::new("data"));
+        let policy = parameters_to_policy(parameters(&cap));
+
+        assert_eq!(policy.len(), 1);
+        assert_eq!(
+            policy[0],
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("catalog".into())]),
+                Ipld::String("data".into())
+            )
+        );
+    }
+
+    #[test]
+    fn parameters_to_policy_multiple_constraints() {
+        let content = b"hello world";
+        let digest = Blake3Hash::hash(content);
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Put::new(digest, content.to_vec()));
+        let policy = parameters_to_policy(parameters(&cap));
+
+        // Should have constraints for catalog, digest, and content (via checksum)
+        assert!(
+            policy.len() >= 2,
+            "expected at least 2 constraints, got {}",
+            policy.len()
+        );
+
+        let has_catalog = policy.iter().any(|p| {
+            matches!(
+                p,
+                Predicate::Equal(sel, Ipld::String(v))
+                    if sel == &Select::new(vec![Filter::Field("catalog".into())])
+                    && v == "index"
+            )
+        });
+        assert!(has_catalog, "should have catalog equality constraint");
+
+        let has_digest = policy.iter().any(|p| {
+            matches!(
+                p,
+                Predicate::Equal(sel, Ipld::Bytes(_))
+                    if sel == &Select::new(vec![Filter::Field("digest".into())])
+            )
+        });
+        assert!(has_digest, "should have digest equality constraint");
+    }
+
+    #[test]
+    fn parameters_to_args_roundtrip() {
+        let mut params = Parameters::new();
+        params.insert("name".into(), Ipld::String("test".into()));
+        params.insert("count".into(), Ipld::Integer(42));
+
+        let args = parameters_to_args(params);
+        assert_eq!(args.get("name"), Some(&Promised::String("test".into())));
+        assert_eq!(args.get("count"), Some(&Promised::Integer(42)));
+    }
+}

--- a/rust/dialog-ucan/src/parameters.rs
+++ b/rust/dialog-ucan/src/parameters.rs
@@ -85,15 +85,15 @@ mod tests {
     use dialog_common::Blake3Hash;
     use dialog_effects::archive::{Archive, Catalog, Get, Put};
 
-    #[test]
-    fn parameters_from_empty_subject() {
+    #[dialog_common::test]
+    fn it_returns_no_parameters_for_bare_subject() {
         let cap = Subject::from(did!("key:z6MkTest"));
         let params = parameters(&cap);
         assert!(params.is_empty());
     }
 
-    #[test]
-    fn parameters_from_archive_catalog() {
+    #[dialog_common::test]
+    fn it_collects_parameters_from_archive_catalog_chain() {
         let cap = Subject::from(did!("key:z6MkTest"))
             .attenuate(Archive)
             .attenuate(Catalog::new("index"));
@@ -101,8 +101,8 @@ mod tests {
         assert_eq!(params.get("catalog"), Some(&Ipld::String("index".into())));
     }
 
-    #[test]
-    fn parameters_from_archive_get() {
+    #[dialog_common::test]
+    fn it_collects_parameters_from_archive_get_invocation() {
         let digest = Blake3Hash::hash(b"my-content");
         let cap = Subject::from(did!("key:z6MkTest"))
             .attenuate(Archive)
@@ -116,14 +116,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parameters_to_policy_empty() {
+    #[dialog_common::test]
+    fn it_returns_empty_policy_for_empty_parameters() {
         let policy = parameters_to_policy(Parameters::new());
         assert!(policy.is_empty());
     }
 
-    #[test]
-    fn parameters_to_policy_produces_equality_constraints() {
+    #[dialog_common::test]
+    fn it_produces_equality_constraints_for_each_parameter() {
         let cap = Subject::from(did!("key:z6MkTest"))
             .attenuate(Archive)
             .attenuate(Catalog::new("data"));
@@ -139,8 +139,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parameters_to_policy_multiple_constraints() {
+    #[dialog_common::test]
+    fn it_produces_multiple_constraints_for_chain_with_payload() {
         let content = b"hello world";
         let digest = Blake3Hash::hash(content);
         let cap = Subject::from(did!("key:z6MkTest"))
@@ -176,8 +176,8 @@ mod tests {
         assert!(has_digest, "should have digest equality constraint");
     }
 
-    #[test]
-    fn parameters_to_args_roundtrip() {
+    #[dialog_common::test]
+    fn it_converts_parameters_to_args() {
         let mut params = Parameters::new();
         params.insert("name".into(), Ipld::String("test".into()));
         params.insert("count".into(), Ipld::Integer(42));

--- a/rust/dialog-ucan/src/scope.rs
+++ b/rust/dialog-ucan/src/scope.rs
@@ -1,0 +1,321 @@
+//! Capability-derived scope for UCAN delegation and invocation.
+
+use dialog_capability::{Ability, Capability, Constraint, Effect, Policy, Subject};
+use dialog_ucan_core::command::Command;
+use dialog_ucan_core::delegation::policy::predicate::Predicate;
+use dialog_ucan_core::delegation::policy::selector::filter::Filter;
+use dialog_ucan_core::delegation::policy::selector::select::Select;
+use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use ipld_core::ipld::Ipld;
+use std::collections::BTreeMap;
+
+use super::parameters::parameters;
+
+/// UCAN invocation arguments.
+pub type Args = BTreeMap<String, Promised>;
+
+/// Parameters extracted from a capability chain.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Parameters(pub BTreeMap<String, Ipld>);
+
+impl Parameters {
+    /// Get the inner map.
+    pub fn as_map(&self) -> &BTreeMap<String, Ipld> {
+        &self.0
+    }
+
+    /// Convert to delegation policy predicates (equality constraints).
+    pub fn policy(&self) -> Vec<Predicate> {
+        self.into()
+    }
+
+    /// Convert to invocation arguments.
+    pub fn args(&self) -> Args {
+        self.into()
+    }
+}
+
+impl From<&Parameters> for Vec<Predicate> {
+    fn from(parameters: &Parameters) -> Self {
+        parameters
+            .0
+            .iter()
+            .map(|(key, value)| {
+                Predicate::Equal(Select::new(vec![Filter::Field(key.clone())]), value.clone())
+            })
+            .collect()
+    }
+}
+
+impl From<&Parameters> for Args {
+    fn from(parameters: &Parameters) -> Self {
+        parameters
+            .0
+            .iter()
+            .map(|(k, v)| (k.clone(), ipld_to_promised(v.clone())))
+            .collect()
+    }
+}
+
+/// Scope extracted from a capability chain for UCAN operations.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Scope {
+    /// The subject (specific DID or `Any` for powerline).
+    pub subject: UcanSubject,
+    /// The command.
+    pub command: Command,
+    /// Parameters from the capability's policy chain.
+    pub parameters: Parameters,
+}
+
+impl dialog_capability::access::Scope for Scope {
+    fn subject(&self) -> &dialog_varsig::Did {
+        use dialog_ucan_core::subject::Subject as UcanSubject;
+        match &self.subject {
+            UcanSubject::Specific(did) => did,
+            UcanSubject::Any => {
+                static ANY: std::sync::LazyLock<dialog_varsig::Did> =
+                    std::sync::LazyLock::new(|| {
+                        dialog_capability::ANY_SUBJECT.parse().expect("valid DID")
+                    });
+                &ANY
+            }
+        }
+    }
+}
+
+impl Scope {
+    /// Convert parameters to delegation policy predicates.
+    pub fn policy(&self) -> Vec<Predicate> {
+        self.parameters.policy()
+    }
+
+    /// Convert parameters to invocation arguments.
+    pub fn args(&self) -> Args {
+        self.parameters.args()
+    }
+}
+
+fn ipld_to_promised(ipld: Ipld) -> Promised {
+    match ipld {
+        Ipld::Null => Promised::Null,
+        Ipld::Bool(b) => Promised::Bool(b),
+        Ipld::Integer(i) => Promised::Integer(i),
+        Ipld::Float(f) => Promised::Float(f),
+        Ipld::String(s) => Promised::String(s),
+        Ipld::Bytes(b) => Promised::Bytes(b),
+        Ipld::Link(c) => Promised::Link(c),
+        Ipld::List(l) => Promised::List(l.into_iter().map(ipld_to_promised).collect()),
+        Ipld::Map(m) => Promised::Map(
+            m.into_iter()
+                .map(|(k, v)| (k, ipld_to_promised(v)))
+                .collect(),
+        ),
+    }
+}
+
+fn ability_to_command(ability: &str) -> Command {
+    if ability == "/" {
+        Command::new(vec![])
+    } else {
+        Command::new(
+            ability
+                .trim_start_matches('/')
+                .split('/')
+                .map(String::from)
+                .collect(),
+        )
+    }
+}
+
+impl<T: Ability> From<&T> for Scope {
+    fn from(capability: &T) -> Self {
+        let ability = capability.ability();
+        let subject_did = capability.subject();
+
+        let subject = if Subject::from(subject_did.clone()).is_any() {
+            UcanSubject::Any
+        } else {
+            UcanSubject::Specific(subject_did.clone())
+        };
+
+        Self {
+            subject,
+            command: ability_to_command(&ability),
+            parameters: Parameters(parameters(capability)),
+        }
+    }
+}
+
+impl Scope {
+    /// Build a scope from a delegation chain.
+    ///
+    /// Extracts subject, command, and an empty parameter set from the chain.
+    pub fn from_chain(chain: &dialog_ucan_core::DelegationChain) -> Self {
+        let subject = chain
+            .subject()
+            .map(|did| UcanSubject::Specific(did.clone()))
+            .unwrap_or(UcanSubject::Any);
+
+        let ability = chain.ability();
+        let command = ability_to_command(&ability);
+
+        Self {
+            subject,
+            command,
+            parameters: Parameters::default(),
+        }
+    }
+
+    /// Build a scope from an effect capability, projecting through Claim.
+    ///
+    /// Unlike `Scope::from`, this projects effect fields through their
+    /// [`Claim`](dialog_capability::Claim) type, so payload fields like
+    /// `content` become `checksum` in the scope parameters.
+    pub fn invoke<Fx>(capability: &Capability<Fx>) -> Self
+    where
+        Fx: Effect + Clone,
+        Capability<Fx>: Ability,
+    {
+        let ability = capability.ability();
+        let subject_did = capability.subject();
+
+        let subject = if Subject::from(subject_did.clone()).is_any() {
+            UcanSubject::Any
+        } else {
+            UcanSubject::Specific(subject_did.clone())
+        };
+
+        // Collect parameters from the parent chain (excluding the leaf effect)
+        let chain: &<Fx as Constraint>::Capability = capability.as_ref();
+        let mut params = parameters(&chain.capability);
+
+        // Add claim-projected parameters for the effect
+        let claim = Policy::of(capability).clone().claim();
+        if let Ok(Ipld::Map(map)) = ipld_core::serde::to_ipld(&claim) {
+            params.extend(map);
+        }
+
+        Self {
+            subject,
+            command: ability_to_command(&ability),
+            parameters: Parameters(params),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_capability::{Subject, did};
+    use dialog_common::Blake3Hash;
+    use dialog_effects::archive::{Archive, Catalog, Get};
+
+    #[test]
+    fn scope_from_subject() {
+        let cap = Subject::from(did!("key:z6MkTest"));
+        let scope = Scope::from(&cap);
+
+        assert!(matches!(scope.subject, UcanSubject::Specific(_)));
+        assert!(scope.command.segments().is_empty());
+        assert!(scope.parameters.0.is_empty());
+        assert!(scope.policy().is_empty());
+        assert!(scope.args().is_empty());
+    }
+
+    #[test]
+    fn scope_from_any_subject() {
+        let cap = Subject::any();
+        let scope = Scope::from(&cap);
+        assert!(matches!(scope.subject, UcanSubject::Any));
+    }
+
+    #[test]
+    fn scope_from_archive_catalog() {
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"));
+        let scope = Scope::from(&cap);
+
+        assert_eq!(scope.command, Command::parse("/archive").unwrap());
+
+        let policy = scope.policy();
+        assert_eq!(policy.len(), 1);
+        assert_eq!(
+            policy[0],
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("catalog".into())]),
+                Ipld::String("index".into())
+            )
+        );
+
+        let args = scope.args();
+        assert_eq!(args.get("catalog"), Some(&Promised::String("index".into())));
+    }
+
+    #[test]
+    fn scope_from_archive_get() {
+        let digest = Blake3Hash::hash(b"hello");
+        let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Get::new(digest.clone()));
+        let scope = Scope::from(&cap);
+
+        assert_eq!(scope.command, Command::parse("/archive/get").unwrap());
+
+        let policy = scope.policy();
+        assert!(
+            policy.contains(&Predicate::Equal(
+                Select::new(vec![Filter::Field("catalog".into())]),
+                Ipld::String("index".into())
+            )),
+            "policy should contain catalog=index constraint"
+        );
+        assert!(
+            policy
+                .iter()
+                .any(|p| matches!(p, Predicate::Equal(sel, Ipld::Bytes(_))
+                    if sel == &Select::new(vec![Filter::Field("digest".into())])
+                )),
+            "policy should contain digest constraint"
+        );
+
+        let args = scope.args();
+        assert_eq!(args.get("catalog"), Some(&Promised::String("index".into())));
+        assert!(args.contains_key("digest"), "args should contain digest");
+    }
+
+    #[test]
+    fn parameters_to_policy() {
+        let mut map = BTreeMap::new();
+        map.insert("catalog".into(), Ipld::String("index".into()));
+        let params = Parameters(map);
+        let policy = params.policy();
+
+        assert_eq!(policy.len(), 1);
+        assert_eq!(
+            policy[0],
+            Predicate::Equal(
+                Select::new(vec![Filter::Field("catalog".into())]),
+                Ipld::String("index".into())
+            )
+        );
+    }
+
+    #[test]
+    fn parameters_to_args() {
+        let mut map = BTreeMap::new();
+        map.insert("name".into(), Ipld::String("test".into()));
+        map.insert("count".into(), Ipld::Integer(42));
+        let params = Parameters(map);
+        let args = params.args();
+
+        assert_eq!(args.get("name"), Some(&Promised::String("test".into())));
+        assert_eq!(args.get("count"), Some(&Promised::Integer(42)));
+    }
+}

--- a/rust/dialog-ucan/src/scope.rs
+++ b/rust/dialog-ucan/src/scope.rs
@@ -76,8 +76,11 @@ impl dialog_capability::access::Scope for Scope {
             UcanSubject::Specific(did) => did,
             UcanSubject::Any => {
                 static ANY: std::sync::LazyLock<dialog_varsig::Did> =
-                    std::sync::LazyLock::new(|| {
-                        dialog_capability::ANY_SUBJECT.parse().expect("valid DID")
+                    std::sync::LazyLock::new(|| match dialog_capability::ANY_SUBJECT.parse() {
+                        Ok(did) => did,
+                        Err(_) => unreachable!(
+                            "ANY_SUBJECT is a fixed compile-time constant DID and must parse"
+                        ),
                     });
                 &ANY
             }
@@ -168,10 +171,10 @@ impl Scope {
         }
     }
 
-    /// Build a scope from an effect capability, projecting through Claim.
+    /// Build a scope from an effect capability, projecting through Attenuate.
     ///
     /// Unlike `Scope::from`, this projects effect fields through their
-    /// [`Claim`](dialog_capability::Claim) type, so payload fields like
+    /// [`Attenuate`](dialog_capability::Attenuate) type, so payload fields like
     /// `content` become `checksum` in the scope parameters.
     pub fn invoke<Fx>(capability: &Capability<Fx>) -> Self
     where
@@ -191,9 +194,9 @@ impl Scope {
         let chain: &<Fx as Constraint>::Capability = capability.as_ref();
         let mut params = parameters(&chain.capability);
 
-        // Add claim-projected parameters for the effect
-        let claim = Policy::of(capability).clone().claim();
-        if let Ok(Ipld::Map(map)) = ipld_core::serde::to_ipld(&claim) {
+        // Add attenuation-projected parameters for the effect
+        let attenuation = Policy::of(capability).clone().into_attenuation();
+        if let Ok(Ipld::Map(map)) = ipld_core::serde::to_ipld(&attenuation) {
             params.extend(map);
         }
 
@@ -215,8 +218,8 @@ mod tests {
     use dialog_common::Blake3Hash;
     use dialog_effects::archive::{Archive, Catalog, Get};
 
-    #[test]
-    fn scope_from_subject() {
+    #[dialog_common::test]
+    fn it_builds_scope_from_subject() {
         let cap = Subject::from(did!("key:z6MkTest"));
         let scope = Scope::from(&cap);
 
@@ -227,15 +230,15 @@ mod tests {
         assert!(scope.args().is_empty());
     }
 
-    #[test]
-    fn scope_from_any_subject() {
+    #[dialog_common::test]
+    fn it_builds_scope_from_any_subject() {
         let cap = Subject::any();
         let scope = Scope::from(&cap);
         assert!(matches!(scope.subject, UcanSubject::Any));
     }
 
-    #[test]
-    fn scope_from_archive_catalog() {
+    #[dialog_common::test]
+    fn it_builds_scope_from_archive_catalog() {
         let cap = Subject::from(did!("key:z6MkTest"))
             .attenuate(Archive)
             .attenuate(Catalog::new("index"));
@@ -257,8 +260,8 @@ mod tests {
         assert_eq!(args.get("catalog"), Some(&Promised::String("index".into())));
     }
 
-    #[test]
-    fn scope_from_archive_get() {
+    #[dialog_common::test]
+    fn it_builds_scope_from_archive_get() {
         let digest = Blake3Hash::hash(b"hello");
         let cap = Subject::from(did!("key:z6MkTest"))
             .attenuate(Archive)
@@ -290,8 +293,8 @@ mod tests {
         assert!(args.contains_key("digest"), "args should contain digest");
     }
 
-    #[test]
-    fn parameters_to_policy() {
+    #[dialog_common::test]
+    fn it_converts_parameters_to_policy() {
         let mut map = BTreeMap::new();
         map.insert("catalog".into(), Ipld::String("index".into()));
         let params = Parameters(map);
@@ -307,8 +310,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parameters_to_args() {
+    #[dialog_common::test]
+    fn it_converts_parameters_to_args() {
         let mut map = BTreeMap::new();
         map.insert("name".into(), Ipld::String("test".into()));
         map.insert("count".into(), Ipld::Integer(42));


### PR DESCRIPTION
## Why

The access system #249 defines generic traits for authorization (Protocol, Certificate, Proof, Authorization, Delegation) but has no concrete implementation. UCAN tokens need a bridge that maps these traits to the UCAN delegation/invocation format from `dialog-ucan-core`.

Previously this lived inside `dialog-capability` behind a feature flag, tightly coupled to the old access design. As a standalone crate it can evolve independently and import cleanly from both `dialog-capability` (traits) and `dialog-ucan-core` (token format).

## Overview

`dialog-ucan` implements `access::Protocol` for the Ucan marker type:

- `UcanCertificate`: wraps a signed `Delegation`, implements `Certificate` for chain verification
- `UcanProof`: collects certificates during chain walking, tracks effective time bounds from the chain
- `UcanAuthorization`: binds a signer to a proof, can narrow time bounds (rejects widening), produces `UcanDelegation` or `UcanInvocation`
- `UcanDelegation`: newtype over `DelegationChain` implementing the `Delegation` trait
- `Scope/Parameters`: extract capability chain metadata for UCAN serialization