### PR TITLE
15 ✅ feat: add CertificateStore implementations for all backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "dialog-common",
  "dialog-credentials",
  "dialog-effects",
+ "dialog-storage",
  "dialog-ucan-core",
  "dialog-varsig",
  "ipld-core",

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -15,6 +15,7 @@
 //! enforcing ensuring invariantns.
 
 mod archive;
+mod certificate;
 mod credential;
 mod error;
 mod memory;

--- a/rust/dialog-storage/src/storage/provider/fs/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/certificate.rs
@@ -1,0 +1,124 @@
+//! CertificateStore for filesystem storage.
+//!
+//! Layout: `{space_root}/certificate/{audience}/{subject}/{issuer}.{hash}`
+
+use base58::ToBase58;
+use dialog_capability::access::{
+    AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
+};
+use dialog_capability::{Capability, Policy, Provider};
+use dialog_varsig::Did;
+
+use super::{FileSystem, FileSystemError, FileSystemHandle};
+
+const CERTIFICATE: &str = "certificate";
+
+impl FileSystem {
+    /// Returns the handle for this space's certificate directory.
+    pub fn certificate(&self) -> Result<FileSystemHandle, FileSystemError> {
+        self.resolve(CERTIFICATE)
+    }
+}
+
+#[async_trait::async_trait]
+impl<P: Protocol> CertificateStore<P> for FileSystem
+where
+    P::Certificate: Send + Sync,
+{
+    /// List certificates where `audience` is the recipient and `subject`
+    /// is either the specific subject DID or, when `None`, a
+    /// [powerline](https://github.com/ucan-wg/delegation?tab=readme-ov-file#powerline)
+    /// delegation that applies to any subject.
+    async fn list(
+        &self,
+        audience: &Did,
+        subject: Option<&Did>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        let subject_segment = match subject {
+            Some(did) => did.to_string(),
+            None => "_".to_string(),
+        };
+
+        // Resolve certificate/{audience}/{subject} directory
+        let dir = match self
+            .certificate()
+            .and_then(|c| c.resolve(audience.as_ref()))
+            .and_then(|c| c.resolve(&subject_segment))
+        {
+            Ok(dir) => dir,
+            Err(_) => return Ok(Vec::new()),
+        };
+
+        let entries = match dir.list().await {
+            Ok(entries) => entries,
+            Err(_) => return Ok(Vec::new()),
+        };
+
+        let mut certificates = Vec::new();
+        for entry in entries {
+            let handle = dir.resolve(&entry)?;
+            if let Ok(bytes) = handle.read().await
+                && let Ok(cert) = <P::Certificate as Certificate>::decode(&bytes)
+            {
+                certificates.push(cert);
+            }
+        }
+
+        Ok(certificates)
+    }
+
+    /// Store a delegation's certificates as files for future lookups.
+    async fn save(&self, delegation: &P::Delegation) -> Result<(), AuthorizeError> {
+        for cert in delegation.certificates() {
+            let bytes = cert.encode()?;
+            let id = blake3::hash(&bytes).as_bytes().to_base58();
+
+            let audience = cert.audience();
+            let subject_segment = match cert.subject() {
+                Some(did) => did.to_string(),
+                None => "_".to_string(),
+            };
+            let issuer = cert.issuer();
+
+            // Write to certificate/{audience}/{subject}/{issuer}.{hash}
+            // write() creates parent directories automatically
+            let filename = format!("{issuer}.{id}");
+            let file_handle = self
+                .certificate()?
+                .resolve(audience.as_ref())?
+                .resolve(&subject_segment)?
+                .resolve(&filename)?;
+            file_handle.write(&bytes).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl<P> Provider<Prove<P>> for FileSystem
+where
+    P: Protocol,
+    P::Access: Clone + Send + Sync,
+    P::Certificate: Clone + Send + Sync,
+    P::Proof: Send,
+{
+    async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
+        let auth = Prove::<P>::of(&input);
+        let mut prove = Prove::new(auth.principal.clone(), auth.access.clone());
+        prove.duration = auth.duration;
+        CertificateStore::<P>::prove(self, prove).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<P> Provider<Retain<P>> for FileSystem
+where
+    P: Protocol,
+    P::Delegation: Send + Sync,
+{
+    async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
+        let delegation = &Retain::<P>::of(&input).delegation;
+        CertificateStore::<P>::save(self, delegation).await
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -51,6 +51,7 @@
 //! ```
 
 mod archive;
+mod certificate;
 mod credential;
 mod memory;
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
@@ -1,0 +1,122 @@
+//! CertificateStore for IndexedDB storage.
+//!
+//! Certificates are stored in a `certificate` object store with keys
+//! `{audience}/{subject}/{issuer}.{hash}` (or `{audience}/_/{issuer}.{hash}`
+//! for powerlines). Uses IDBKeyRange for efficient prefix queries.
+
+use async_trait::async_trait;
+use dialog_capability::access::{
+    AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
+};
+use dialog_capability::{Capability, Policy, Provider};
+use dialog_varsig::Did;
+use rexie::KeyRange;
+use wasm_bindgen::JsValue;
+
+use super::{IndexedDb, to_uint8array};
+
+const CERTIFICATE: &str = "certificate";
+
+#[async_trait(?Send)]
+impl<P: Protocol> CertificateStore<P> for IndexedDb {
+    async fn list(
+        &self,
+        audience: &Did,
+        subject: Option<&Did>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        let prefix = match subject {
+            Some(did) => format!("{}/{}/", audience, did),
+            None => format!("{}/_/", audience),
+        };
+
+        let has_store = self.connection.borrow().stores.contains(CERTIFICATE);
+        if !has_store {
+            return Ok(Vec::new());
+        }
+
+        let store = self.store(CERTIFICATE).await?;
+        let lower = JsValue::from_str(&prefix);
+        let upper = JsValue::from_str(&format!("{prefix}\u{ffff}"));
+        let range = KeyRange::bound(&lower, &upper, None, None)
+            .map_err(|e| AuthorizeError::Configuration(format!("key range error: {e:?}")))?;
+
+        store
+            .query(|object_store| async move {
+                let values = object_store
+                    .get_all(Some(range), None)
+                    .await
+                    .map_err(|e| AuthorizeError::Configuration(format!("query: {e:?}")))?;
+
+                let mut certs = Vec::new();
+                for value in values {
+                    let array = js_sys::Uint8Array::new(&value);
+                    let bytes = array.to_vec();
+                    if let Ok(cert) = <P::Certificate as Certificate>::decode(&bytes) {
+                        certs.push(cert);
+                    }
+                }
+                Ok(certs)
+            })
+            .await
+    }
+
+    async fn save(&self, delegation: &P::Delegation) -> Result<(), AuthorizeError> {
+        let certs = delegation.certificates();
+        if certs.is_empty() {
+            return Ok(());
+        }
+
+        let store = self.store(CERTIFICATE).await?;
+
+        for cert in &certs {
+            let bytes = cert.encode()?;
+            let id = base58::ToBase58::to_base58(blake3::hash(&bytes).as_bytes().as_slice());
+
+            let audience = cert.audience().to_string();
+            let subject_segment = match cert.subject() {
+                Some(did) => did.to_string(),
+                None => "_".to_string(),
+            };
+            let issuer = cert.issuer().to_string();
+            let key = format!("{audience}/{subject_segment}/{issuer}.{id}");
+
+            let js_key = JsValue::from_str(&key);
+            let js_val = JsValue::from(to_uint8array(&bytes));
+
+            store
+                .transact(|object_store| async move {
+                    object_store
+                        .put(&js_val, Some(&js_key))
+                        .await
+                        .map_err(|e| AuthorizeError::Configuration(format!("write: {e:?}")))?;
+                    Ok::<(), AuthorizeError>(())
+                })
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl<P> Provider<Prove<P>> for IndexedDb
+where
+    P: Protocol,
+    P::Access: Clone,
+    P::Certificate: Clone,
+{
+    async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
+        let auth = Prove::<P>::of(&input);
+        let mut prove = Prove::new(auth.principal.clone(), auth.access.clone());
+        prove.duration = auth.duration;
+        CertificateStore::<P>::prove(self, prove).await
+    }
+}
+
+#[async_trait(?Send)]
+impl<P: Protocol> Provider<Retain<P>> for IndexedDb {
+    async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
+        let delegation = &Retain::<P>::of(&input).delegation;
+        CertificateStore::<P>::save(self, delegation).await
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
@@ -5,6 +5,7 @@
 //! for powerlines). Uses IDBKeyRange for efficient prefix queries.
 
 use async_trait::async_trait;
+use base58::ToBase58;
 use dialog_capability::access::{
     AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
 };
@@ -70,7 +71,7 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
 
         for cert in &certs {
             let bytes = cert.encode()?;
-            let id = base58::ToBase58::to_base58(blake3::hash(&bytes).as_bytes().as_slice());
+            let id = blake3::hash(&bytes).as_bytes().to_base58();
 
             let audience = cert.audience().to_string();
             let subject_segment = match cert.subject() {

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -34,6 +34,7 @@
 //! ```
 
 mod archive;
+mod certificate;
 mod credential;
 mod memory;
 
@@ -49,6 +50,9 @@ type ArchiveKey = (String, String);
 /// Memory key: (space, cell)
 type MemoryKey = (String, String);
 
+/// Certificate key: "{audience}/{subject_or_wildcard}/{issuer}.{hash}"
+type CertificateKey = String;
+
 /// A session holds the in-memory storage for a single subject.
 #[derive(Default, Debug)]
 struct Session {
@@ -60,6 +64,8 @@ struct Session {
     credentials: HashMap<String, CredentialExport>,
     /// Secret storage keyed by site address.
     secrets: HashMap<String, Vec<u8>>,
+    /// Certificate storage keyed by "{audience}/{subject}/{issuer}.{hash}".
+    certificates: HashMap<CertificateKey, Vec<u8>>,
 }
 
 /// Volatile in-memory storage provider.

--- a/rust/dialog-storage/src/storage/provider/volatile/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/certificate.rs
@@ -1,0 +1,110 @@
+//! CertificateStore for volatile (in-memory) storage.
+//!
+//! Certificates are stored in-memory keyed by
+//! `{audience}/{subject}/{issuer}.{hash}` (or `{audience}/_/{issuer}.{hash}`
+//! for [powerlines](https://github.com/ucan-wg/delegation?tab=readme-ov-file#powerline)).
+
+use dialog_capability::access::{
+    AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
+};
+use dialog_capability::{Capability, Policy, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_varsig::Did;
+
+use super::Volatile;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<P: Protocol> CertificateStore<P> for Volatile
+where
+    P::Certificate: dialog_common::ConditionalSend,
+{
+    /// List certificates where `audience` is the recipient and `subject`
+    /// is either the specific subject DID or, when `None`, a
+    /// [powerline](https://github.com/ucan-wg/delegation?tab=readme-ov-file#powerline)
+    /// delegation that applies to any subject.
+    async fn list(
+        &self,
+        audience: &Did,
+        subject: Option<&Did>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        let prefix = match subject {
+            Some(did) => format!("{}/{}/", audience, did),
+            None => format!("{}/_/", audience),
+        };
+
+        let sessions = self.sessions.read();
+        let mut certificates = Vec::new();
+
+        for session in sessions.values() {
+            for (key, bytes) in &session.certificates {
+                if key.starts_with(&prefix)
+                    && let Ok(cert) = <P::Certificate as Certificate>::decode(bytes)
+                {
+                    certificates.push(cert);
+                }
+            }
+        }
+
+        Ok(certificates)
+    }
+
+    /// Store a delegation's certificates for future lookups.
+    ///
+    /// Each certificate is stored keyed by
+    /// `{audience}/{subject}/{issuer}.{hash}` where the hash is the
+    /// base58-encoded BLAKE3 hash of the encoded certificate bytes.
+    async fn save(&self, delegation: &P::Delegation) -> Result<(), AuthorizeError> {
+        let mut sessions = self.sessions.write();
+
+        for cert in delegation.certificates() {
+            let bytes = cert.encode()?;
+            let id = base58::ToBase58::to_base58(blake3::hash(&bytes).as_bytes().as_slice());
+
+            let audience = cert.audience().to_string();
+            let subject_segment = match cert.subject() {
+                Some(did) => did.to_string(),
+                None => "_".to_string(),
+            };
+            let issuer = cert.issuer().to_string();
+
+            let key = format!("{audience}/{subject_segment}/{issuer}.{id}");
+            let session = sessions.entry(cert.audience().clone()).or_default();
+            session.certificates.insert(key, bytes);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<P> Provider<Prove<P>> for Volatile
+where
+    P: Protocol,
+    P::Access: Clone + ConditionalSend + ConditionalSync,
+    P::Certificate: Clone + ConditionalSend + ConditionalSync,
+    P::Proof: ConditionalSend,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
+        let auth = Prove::<P>::of(&input);
+        let mut prove = Prove::new(auth.principal.clone(), auth.access.clone());
+        prove.duration = auth.duration;
+        CertificateStore::<P>::prove(self, prove).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<P> Provider<Retain<P>> for Volatile
+where
+    P: Protocol,
+    P::Delegation: ConditionalSend + ConditionalSync,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
+        let delegation = &Retain::<P>::of(&input).delegation;
+        CertificateStore::<P>::save(self, delegation).await
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/volatile/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/certificate.rs
@@ -4,6 +4,7 @@
 //! `{audience}/{subject}/{issuer}.{hash}` (or `{audience}/_/{issuer}.{hash}`
 //! for [powerlines](https://github.com/ucan-wg/delegation?tab=readme-ov-file#powerline)).
 
+use base58::ToBase58;
 use dialog_capability::access::{
     AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
 };
@@ -59,7 +60,7 @@ where
 
         for cert in delegation.certificates() {
             let bytes = cert.encode()?;
-            let id = base58::ToBase58::to_base58(blake3::hash(&bytes).as_bytes().as_slice());
+            let id = blake3::hash(&bytes).as_bytes().to_base58();
 
             let audience = cert.audience().to_string();
             let subject_segment = match cert.subject() {

--- a/rust/dialog-ucan/Cargo.toml
+++ b/rust/dialog-ucan/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = { workspace = true }
 dialog-common = { workspace = true, features = ["helpers"] }
 dialog-credentials = { workspace = true }
 dialog-effects = { workspace = true }
+dialog-storage = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 wasm-bindgen-test = { workspace = true }
 

--- a/rust/dialog-ucan/src/certificate_store.rs
+++ b/rust/dialog-ucan/src/certificate_store.rs
@@ -1,0 +1,556 @@
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use dialog_capability::access::{Certificate, CertificateStore};
+    use dialog_credentials::Ed25519Signer;
+    use dialog_effects::storage::{Directory, Location};
+    use dialog_storage::resource::Resource;
+    use dialog_ucan_core::subject::Subject;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal;
+
+    use crate::{Ucan, UcanDelegation};
+
+    async fn generate_signer() -> Ed25519Signer {
+        Ed25519Signer::generate().await.unwrap()
+    }
+
+    async fn delegate(
+        issuer: &Ed25519Signer,
+        audience: &Ed25519Signer,
+        subject: Subject,
+    ) -> UcanDelegation {
+        let delegation = DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(subject)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        UcanDelegation::new(DelegationChain::new(delegation))
+    }
+
+    fn unique_name(prefix: &str) -> String {
+        use dialog_common::time;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let ts = time::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("{prefix}-{ts}-{seq}")
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    type Store = dialog_storage::provider::FileSystem;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    type Store = dialog_storage::provider::IndexedDb;
+
+    async fn open_store(name: &str) -> Store {
+        let location = Location::new(Directory::Temp, name);
+        Store::open(&location).await.unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_saves_and_lists_certificates() {
+        let store = open_store(&unique_name("cert-save")).await;
+        let space = generate_signer().await;
+        let operator = generate_signer().await;
+
+        let delegation = delegate(&space, &operator, Subject::Specific(space.did())).await;
+
+        CertificateStore::<Ucan>::save(&store, &delegation)
+            .await
+            .unwrap();
+
+        let certs = CertificateStore::<Ucan>::list(&store, &operator.did(), Some(&space.did()))
+            .await
+            .unwrap();
+
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0].issuer(), &space.did());
+        assert_eq!(certs[0].audience(), &operator.did());
+        assert_eq!(certs[0].subject(), Some(&space.did()));
+    }
+
+    #[dialog_common::test]
+    async fn it_stores_powerline_certificates() {
+        let store = open_store(&unique_name("cert-powerline")).await;
+        let space = generate_signer().await;
+        let operator = generate_signer().await;
+
+        // Powerline: subject=None means it applies to any subject
+        let delegation = delegate(&space, &operator, Subject::Any).await;
+        CertificateStore::<Ucan>::save(&store, &delegation)
+            .await
+            .unwrap();
+
+        // Listed under subject=None
+        let certs = CertificateStore::<Ucan>::list(&store, &operator.did(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(certs.len(), 1);
+        assert!(certs[0].subject().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_separates_powerline_from_specific() {
+        let store = open_store(&unique_name("cert-separate")).await;
+        let space = generate_signer().await;
+        let operator = generate_signer().await;
+
+        // Store both a specific and a powerline delegation
+        let specific = delegate(&space, &operator, Subject::Specific(space.did())).await;
+        let powerline = delegate(&space, &operator, Subject::Any).await;
+
+        CertificateStore::<Ucan>::save(&store, &specific)
+            .await
+            .unwrap();
+        CertificateStore::<Ucan>::save(&store, &powerline)
+            .await
+            .unwrap();
+
+        // Specific query returns only the specific cert
+        let specific_certs =
+            CertificateStore::<Ucan>::list(&store, &operator.did(), Some(&space.did()))
+                .await
+                .unwrap();
+        assert_eq!(specific_certs.len(), 1);
+        assert_eq!(specific_certs[0].subject(), Some(&space.did()));
+
+        // Powerline query returns only the powerline cert
+        let powerline_certs = CertificateStore::<Ucan>::list(&store, &operator.did(), None)
+            .await
+            .unwrap();
+        assert_eq!(powerline_certs.len(), 1);
+        assert!(powerline_certs[0].subject().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_empty_for_unknown_audience() {
+        let store = open_store(&unique_name("cert-unknown")).await;
+        let unknown = generate_signer().await.did();
+
+        let certs = CertificateStore::<Ucan>::list(&store, &unknown, None)
+            .await
+            .unwrap();
+
+        assert!(certs.is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_isolates_by_audience() {
+        let store = open_store(&unique_name("cert-isolate")).await;
+        let space = generate_signer().await;
+        let operator1 = generate_signer().await;
+        let operator2 = generate_signer().await;
+
+        let delegation = delegate(&space, &operator1, Subject::Specific(space.did())).await;
+        CertificateStore::<Ucan>::save(&store, &delegation)
+            .await
+            .unwrap();
+
+        // operator2 should not see operator1's certificates
+        let certs = CertificateStore::<Ucan>::list(&store, &operator2.did(), Some(&space.did()))
+            .await
+            .unwrap();
+
+        assert!(certs.is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_stores_multiple_delegations_for_same_audience() {
+        let store = open_store(&unique_name("cert-multi")).await;
+        let space1 = generate_signer().await;
+        let space2 = generate_signer().await;
+        let operator = generate_signer().await;
+
+        let d1 = delegate(&space1, &operator, Subject::Specific(space1.did())).await;
+        let d2 = delegate(&space2, &operator, Subject::Specific(space2.did())).await;
+
+        CertificateStore::<Ucan>::save(&store, &d1).await.unwrap();
+        CertificateStore::<Ucan>::save(&store, &d2).await.unwrap();
+
+        let certs1 = CertificateStore::<Ucan>::list(&store, &operator.did(), Some(&space1.did()))
+            .await
+            .unwrap();
+        assert_eq!(certs1.len(), 1);
+
+        let certs2 = CertificateStore::<Ucan>::list(&store, &operator.did(), Some(&space2.did()))
+            .await
+            .unwrap();
+        assert_eq!(certs2.len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn it_persists_certificates_across_opens() {
+        let name = unique_name("cert-persist");
+        let space = generate_signer().await;
+        let operator = generate_signer().await;
+
+        {
+            let store = open_store(&name).await;
+            let delegation = delegate(&space, &operator, Subject::Specific(space.did())).await;
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+        }
+
+        let store = open_store(&name).await;
+        let certs = CertificateStore::<Ucan>::list(&store, &operator.did(), Some(&space.did()))
+            .await
+            .unwrap();
+
+        assert_eq!(certs.len(), 1);
+    }
+
+    mod volatile {
+        use super::*;
+        use dialog_storage::provider::Volatile;
+
+        #[dialog_common::test]
+        async fn it_saves_and_lists_certificates() {
+            let store = Volatile::new();
+            let space = generate_signer().await;
+            let operator = generate_signer().await;
+
+            let delegation = delegate(&space, &operator, Subject::Specific(space.did())).await;
+
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            let certs = CertificateStore::<Ucan>::list(&store, &operator.did(), Some(&space.did()))
+                .await
+                .unwrap();
+
+            assert_eq!(certs.len(), 1);
+        }
+
+        #[dialog_common::test]
+        async fn it_finds_powerline_certificates() {
+            let store = Volatile::new();
+            let space = generate_signer().await;
+            let operator = generate_signer().await;
+
+            let delegation = delegate(&space, &operator, Subject::Any).await;
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            let certs = CertificateStore::<Ucan>::list(&store, &operator.did(), None)
+                .await
+                .unwrap();
+
+            assert_eq!(certs.len(), 1);
+            assert!(certs[0].subject().is_none());
+        }
+    }
+
+    mod prove {
+        use super::*;
+        use crate::scope::{Parameters, Scope};
+        use dialog_capability::access::{Proof, Prove};
+        use dialog_ucan_core::command::Command;
+        use dialog_ucan_core::subject::Subject as UcanSubject;
+
+        fn scope(subject: &Ed25519Signer, command: &[&str]) -> Scope {
+            Scope {
+                subject: UcanSubject::Specific(subject.did()),
+                command: Command(command.iter().map(|s| s.to_string()).collect()),
+                parameters: Parameters::default(),
+            }
+        }
+
+        #[dialog_common::test]
+        async fn it_proves_with_direct_delegation() {
+            let store = open_store(&unique_name("prove-direct")).await;
+            let space = generate_signer().await;
+            let operator = generate_signer().await;
+
+            let delegation = delegate(&space, &operator, Subject::Specific(space.did())).await;
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let proof = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(
+                proof.is_ok(),
+                "direct delegation should prove: {:?}",
+                proof.err()
+            );
+            assert!(!proof.unwrap().proofs().is_empty());
+        }
+
+        #[dialog_common::test]
+        async fn it_proves_with_powerline_delegation() {
+            let store = open_store(&unique_name("prove-powerline")).await;
+            let space = generate_signer().await;
+            let operator = generate_signer().await;
+
+            let delegation = delegate(&space, &operator, Subject::Any).await;
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let proof = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(proof.is_ok(), "powerline should prove: {:?}", proof.err());
+        }
+
+        #[dialog_common::test]
+        async fn it_fails_prove_without_delegation() {
+            let store = open_store(&unique_name("prove-none")).await;
+            let space = generate_signer().await;
+            let operator = generate_signer().await;
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let result = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(result.is_err());
+        }
+
+        #[dialog_common::test]
+        async fn it_fails_prove_for_wrong_audience() {
+            let store = open_store(&unique_name("prove-wrong-aud")).await;
+            let space = generate_signer().await;
+            let operator1 = generate_signer().await;
+            let operator2 = generate_signer().await;
+
+            let delegation = delegate(&space, &operator1, Subject::Specific(space.did())).await;
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            // operator2 has no delegation
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator2.did(), access);
+            let result = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(result.is_err());
+        }
+
+        #[dialog_common::test]
+        async fn it_proves_self_authorization() {
+            // When principal == subject, prove succeeds without any stored certs
+            let store = open_store(&unique_name("prove-self")).await;
+            let space = generate_signer().await;
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(space.did(), access);
+            let proof = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(proof.is_ok(), "self-authorization should succeed");
+            // Self-auth proof has no delegation chain
+            assert!(proof.unwrap().proofs().is_empty());
+        }
+
+        async fn delegate_with_expiration(
+            issuer: &Ed25519Signer,
+            audience: &Ed25519Signer,
+            subject: Subject,
+            expiration: dialog_ucan_core::time::timestamp::Timestamp,
+        ) -> UcanDelegation {
+            let delegation = DelegationBuilder::new()
+                .issuer(issuer.clone())
+                .audience(audience)
+                .subject(subject)
+                .command(vec!["storage".to_string()])
+                .expiration(expiration)
+                .try_build()
+                .await
+                .unwrap();
+
+            UcanDelegation::new(DelegationChain::new(delegation))
+        }
+
+        #[dialog_common::test]
+        async fn it_rejects_expired_delegation() {
+            use dialog_capability::access::TimeRange;
+            use dialog_ucan_core::time::timestamp::Timestamp;
+
+            let store = open_store(&unique_name("prove-expired")).await;
+            let space = generate_signer().await;
+            let operator = generate_signer().await;
+
+            // Create a delegation that expired 1 hour ago
+            let now_secs = dialog_common::time::now()
+                .duration_since(dialog_common::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            let past = Timestamp::try_from((now_secs - 3600) as i128).unwrap();
+
+            let delegation =
+                delegate_with_expiration(&space, &operator, Subject::Specific(space.did()), past)
+                    .await;
+
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            // Request validity at "now", which is after the expiration
+            let now = dialog_common::time::now()
+                .duration_since(dialog_common::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            let access = scope(&space, &["storage"]);
+            let mut prove = Prove::<Ucan>::new(operator.did(), access);
+            prove.duration = TimeRange {
+                not_before: Some(now),
+                expiration: Some(now + 60),
+            };
+            let result = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(result.is_err(), "expired delegation should not prove");
+        }
+
+        #[dialog_common::test]
+        async fn it_proves_via_powerline_chain() {
+            // space delegates to intermediary via powerline (any subject),
+            // intermediary re-delegates to operator for a specific subject.
+            // prove should walk the chain: operator -> intermediary -> space.
+            let store = open_store(&unique_name("prove-powerline-chain")).await;
+            let space = generate_signer().await;
+            let intermediary = generate_signer().await;
+            let operator = generate_signer().await;
+
+            // space -> intermediary (powerline)
+            let d1 = delegate(&space, &intermediary, Subject::Any).await;
+            CertificateStore::<Ucan>::save(&store, &d1).await.unwrap();
+
+            // intermediary -> operator (specific subject = space)
+            let d2 = delegate(&intermediary, &operator, Subject::Specific(space.did())).await;
+            CertificateStore::<Ucan>::save(&store, &d2).await.unwrap();
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let proof = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(
+                proof.is_ok(),
+                "powerline chain should prove: {:?}",
+                proof.err()
+            );
+            assert_eq!(proof.unwrap().proofs().len(), 2);
+        }
+
+        #[dialog_common::test]
+        async fn it_fails_prove_for_wrong_subject() {
+            let store = open_store(&unique_name("prove-wrong-subj")).await;
+            let space1 = generate_signer().await;
+            let space2 = generate_signer().await;
+            let operator = generate_signer().await;
+
+            // Delegated for space1 only
+            let delegation = delegate(&space1, &operator, Subject::Specific(space1.did())).await;
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            // Try to prove for space2
+            let access = scope(&space2, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let result = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(result.is_err(), "wrong subject should not prove");
+        }
+
+        #[dialog_common::test]
+        async fn it_proves_through_powerline_middle_link() {
+            // space -> intermediary (specific) -> operator (powerline)
+            // The intermediary has a powerline delegation to operator,
+            // meaning operator can act on any subject the intermediary
+            // has access to.
+            let store = open_store(&unique_name("prove-mid-powerline")).await;
+            let space = generate_signer().await;
+            let intermediary = generate_signer().await;
+            let operator = generate_signer().await;
+
+            // space -> intermediary (specific for space)
+            let d1 = delegate(&space, &intermediary, Subject::Specific(space.did())).await;
+            CertificateStore::<Ucan>::save(&store, &d1).await.unwrap();
+
+            // intermediary -> operator (powerline)
+            let d2 = delegate(&intermediary, &operator, Subject::Any).await;
+            CertificateStore::<Ucan>::save(&store, &d2).await.unwrap();
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let proof = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(
+                proof.is_ok(),
+                "chain through powerline middle should prove: {:?}",
+                proof.err()
+            );
+            assert_eq!(proof.unwrap().proofs().len(), 2);
+        }
+
+        #[dialog_common::test]
+        async fn it_proves_through_powerline_chain() {
+            // space -> intermediary (powerline) -> operator (powerline)
+            let store = open_store(&unique_name("prove-powerline-powerline")).await;
+            let space = generate_signer().await;
+            let intermediary = generate_signer().await;
+            let operator = generate_signer().await;
+
+            let d1 = delegate(&space, &intermediary, Subject::Any).await;
+            CertificateStore::<Ucan>::save(&store, &d1).await.unwrap();
+
+            let d2 = delegate(&intermediary, &operator, Subject::Any).await;
+            CertificateStore::<Ucan>::save(&store, &d2).await.unwrap();
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let proof = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(
+                proof.is_ok(),
+                "powerline -> powerline chain should prove: {:?}",
+                proof.err()
+            );
+            assert_eq!(proof.unwrap().proofs().len(), 2);
+        }
+
+        #[dialog_common::test]
+        async fn it_proves_when_audience_is_subject() {
+            // Space delegates to itself (audience == subject). This happens
+            // when a space grants itself capabilities for internal operations.
+            let store = open_store(&unique_name("prove-audience-is-subject")).await;
+            let space = generate_signer().await;
+
+            let delegation = delegate(&space, &space, Subject::Specific(space.did())).await;
+            CertificateStore::<Ucan>::save(&store, &delegation)
+                .await
+                .unwrap();
+
+            // A different operator tries to prove via the self-delegation
+            let operator = generate_signer().await;
+            let d2 = delegate(&space, &operator, Subject::Specific(space.did())).await;
+            CertificateStore::<Ucan>::save(&store, &d2).await.unwrap();
+
+            let access = scope(&space, &["storage"]);
+            let prove = Prove::<Ucan>::new(operator.did(), access);
+            let proof = CertificateStore::<Ucan>::prove(&store, prove).await;
+
+            assert!(
+                proof.is_ok(),
+                "should prove via direct delegation: {:?}",
+                proof.err()
+            );
+        }
+    }
+}

--- a/rust/dialog-ucan/src/lib.rs
+++ b/rust/dialog-ucan/src/lib.rs
@@ -5,6 +5,7 @@
 //! [`profile.access().claim().delegate()`](dialog_operator::profile::access).
 
 mod access;
+mod certificate_store;
 mod invocation;
 mod parameters;
 mod scope;


### PR DESCRIPTION
## Summary

The access layer needs to persist delegation certificates so authorization
chains can be verified across sessions. Each backend stores encoded
certificate bytes keyed by audience/subject/issuer: FileSystem as files,
Volatile in a HashMap, IndexedDb using IDBKeyRange prefix queries.

Tests live in dialog-ucan which provides the concrete Ucan protocol type.
open_store() returns the platform backend (FileSystem on native, IndexedDb
on wasm) so the same assertions run everywhere. 20 tests cover the full
prove flow including powerline chains, time bounds, and edge cases.