### PR TITLE
19 ✅ feat: add dialog-remote-ucan-s3 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "async-signature",
  "async-trait",
  "base58",
+ "blake3",
  "bytes",
  "dialog-capability",
  "dialog-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-signature"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "646dcc11163091f40c1618702bcde3d2e152c52b05fc4527fc67cfe077e47c22"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1168,42 @@ dependencies = [
  "tower",
  "tower-http",
  "url",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "dialog-remote-ucan-s3"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-signature",
+ "async-trait",
+ "base58",
+ "bytes",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-effects",
+ "dialog-remote-s3",
+ "dialog-storage",
+ "dialog-ucan",
+ "dialog-ucan-core",
+ "dialog-varsig",
+ "getrandom 0.2.16",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "ipld-core",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "signature",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-http",
  "wasm-bindgen-test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "rust/dialog-ucan-core",
     "rust/dialog-ucan",
     "rust/dialog-remote-s3",
+    "rust/dialog-remote-ucan-s3",
     "rust/dialog-varsig",
     "rust/dialog-blobs",
 ]

--- a/rust/dialog-capability/src/access.rs
+++ b/rust/dialog-capability/src/access.rs
@@ -16,7 +16,7 @@
 //! 2. `proof.claim(signer)` binds a signer to produce an
 //!    [`Authorization`] that can `delegate()` and `invoke()`.
 
-use crate::{Attenuate, Attenuation, Did, Effect, Principal, StorageError, Subject};
+use crate::{Ability, Attenuate, Capability, Constraint, Did, Effect};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -28,6 +28,20 @@ use thiserror::Error;
 pub trait Scope {
     /// The subject (resource) this scope applies to.
     fn subject(&self) -> &Did;
+}
+
+/// Derive an access scope from an invocable capability.
+///
+/// Protocol-specific scope types implement this to extract the subject,
+/// command path, and parameters from a capability chain. The Operator
+/// uses this to build the [`Prove`] request generically across protocols.
+pub trait FromCapability: Scope {
+    /// Derive a scope from an effect capability.
+    fn from_capability<Fx>(capability: &Capability<Fx>) -> Self
+    where
+        Fx: Effect + Clone,
+        Fx::Of: Constraint,
+        Capability<Fx>: Ability;
 }
 
 /// The time range during which a delegation is valid.
@@ -220,8 +234,8 @@ pub trait Proof<P: Protocol>:
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Access;
 
-impl Attenuation for Access {
-    type Of = Subject;
+impl crate::Attenuation for Access {
+    type Of = crate::Subject;
 }
 
 /// Access protocol — defines how capability-based authorization is produced.
@@ -230,13 +244,21 @@ impl Attenuation for Access {
 /// formats, and authorization/invocation materials.
 pub trait Protocol: Sized + ConditionalSend + 'static {
     /// The type-erased form of a capability for this protocol.
-    type Access: Scope + Serialize + for<'de> Deserialize<'de>;
+    ///
+    /// Must implement [`FromCapability`] so the Operator can derive
+    /// a scope from any capability for the Prove request.
+    type Access: FromCapability
+        + Clone
+        + Serialize
+        + for<'de> Deserialize<'de>
+        + ConditionalSend
+        + ConditionalSync;
 
     /// The signer type for this protocol.
-    type Signer: Principal + ConditionalSend;
+    type Signer: crate::Principal + ConditionalSend;
 
     /// An individual delegation (signed certificate) in this protocol's format.
-    type Certificate: Certificate<Access = Self::Access>;
+    type Certificate: Certificate<Access = Self::Access> + Clone + ConditionalSend + ConditionalSync;
 
     /// A delegation bundle — what [`Authorization::delegate`] produces.
     type Delegation: Delegation<Certificate = Self::Certificate>;
@@ -315,12 +337,67 @@ impl<P: Protocol> Prove<P> {
     }
 }
 
-impl<P: Protocol> Effect for Prove<P>
+impl<P: Protocol> crate::Effect for Prove<P>
 where
     P::Access: ConditionalSend + 'static,
 {
     type Of = Access;
     type Output = Result<P::Proof, AuthorizeError>;
+}
+
+/// Authorize effect — proves access and binds a signer in one step.
+///
+/// Like [`Prove`], but also binds a signer to produce a full
+/// [`Protocol::Authorization`] rather than an unsigned proof.
+/// The provider (typically the Operator) handles both the proof
+/// lookup and the signing internally.
+#[derive(Serialize, Deserialize, Attenuate)]
+#[serde(bound(
+    serialize = "P::Access: Serialize",
+    deserialize = "P::Access: for<'a> Deserialize<'a>"
+))]
+pub struct Authorize<P: Protocol> {
+    /// The DID of the principal claiming access.
+    pub principal: Did,
+    /// The access being claimed.
+    pub access: P::Access,
+    /// Time range the authorization must cover.
+    pub duration: TimeRange,
+}
+
+impl<P: Protocol> Authorize<P> {
+    /// Create a new authorization request with unbounded duration.
+    pub fn new(by: Did, access: P::Access) -> Self {
+        Self {
+            principal: by,
+            access,
+            duration: TimeRange::unbounded(),
+        }
+    }
+
+    /// Constrain the authorization to a specific time range.
+    pub fn during(mut self, duration: TimeRange) -> Self {
+        self.duration = duration;
+        self
+    }
+}
+
+impl<P: Protocol> From<Authorize<P>> for Prove<P> {
+    fn from(authorize: Authorize<P>) -> Self {
+        Prove {
+            principal: authorize.principal,
+            access: authorize.access,
+            duration: authorize.duration,
+        }
+    }
+}
+
+impl<P: Protocol> Effect for Authorize<P>
+where
+    P::Access: ConditionalSend + 'static,
+{
+    type Of = Access;
+    type Output = Result<P::Authorization, AuthorizeError>;
 }
 
 /// Retain effect — retains a delegation for future proof lookups.
@@ -344,7 +421,7 @@ impl<P: Protocol> Retain<P> {
     }
 }
 
-impl<P: Protocol> Effect for Retain<P>
+impl<P: Protocol> crate::Effect for Retain<P>
 where
     P::Delegation: ConditionalSend + 'static,
 {
@@ -391,7 +468,7 @@ pub trait CertificateStore<P: Protocol> {
         let duration = &input.duration;
         let subject = access.subject().clone();
 
-        if *authority == subject || Subject::from(subject.clone()).is_any() {
+        if *authority == subject || crate::Subject::from(subject.clone()).is_any() {
             return Ok(P::Proof::new(access.clone()));
         }
 
@@ -461,8 +538,8 @@ pub enum AuthorizeError {
     Configuration(String),
 }
 
-impl From<StorageError> for AuthorizeError {
-    fn from(e: StorageError) -> Self {
+impl From<crate::StorageError> for AuthorizeError {
+    fn from(e: crate::StorageError) -> Self {
         AuthorizeError::Configuration(e.to_string())
     }
 }

--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -1,0 +1,75 @@
+[package]
+name = "dialog-remote-ucan-s3"
+description = "UCAN-based remote authorization for S3-compatible storage"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[features]
+default = []
+helpers = [
+    "dep:anyhow",
+    "dep:bytes",
+    "dep:http-body-util",
+    "dep:hyper",
+    "dep:hyper-util",
+    "dep:tokio",
+    "dep:tower",
+    "dep:tower-http",
+    "dialog-common/helpers",
+    "dialog-remote-s3/helpers",
+]
+integration-tests = ["dialog-common/integration-tests"]
+web-integration-tests = ["dialog-common/web-integration-tests"]
+
+[dependencies]
+async-trait = { workspace = true }
+base58 = { workspace = true }
+dialog-capability = { workspace = true }
+dialog-ucan = { workspace = true }
+dialog-common = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-effects = { workspace = true }
+dialog-remote-s3 = { workspace = true }
+dialog-ucan-core = { workspace = true }
+dialog-varsig = { workspace = true }
+ipld-core = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+serde_json = { workspace = true }
+signature = { workspace = true }
+thiserror = { workspace = true }
+
+# Optional dependencies (helpers feature, cross-platform)
+anyhow = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Optional dependencies (helpers feature, native-only server infrastructure)
+bytes = { workspace = true, optional = true }
+http-body-util = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true }
+hyper-util = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["net", "rt"], optional = true }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["cors"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+async-signature = { workspace = true }
+dialog-common = { workspace = true, features = ["helpers"] }
+dialog-storage = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
+wasm-bindgen-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(feature, values(\"web-integration-tests\", \"helpers\"))",
+  "cfg(dialog_test_wasm_integration)"
+] }

--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -26,6 +26,7 @@ web-integration-tests = ["dialog-common/web-integration-tests"]
 [dependencies]
 async-trait = { workspace = true }
 base58 = { workspace = true }
+blake3 = { workspace = true }
 dialog-capability = { workspace = true }
 dialog-ucan = { workspace = true }
 dialog-common = { workspace = true }

--- a/rust/dialog-remote-ucan-s3/README.md
+++ b/rust/dialog-remote-ucan-s3/README.md
@@ -1,0 +1,51 @@
+# dialog-remote-ucan-s3
+
+UCAN-authorized remote for Dialog-DB.
+
+Wraps S3 storage with UCAN (User Controlled Authorization Networks) for delegated access control. Instead of direct S3 credentials, requests are authorized through a UCAN access service that verifies delegation chains.
+
+## Usage
+
+```rust
+use dialog_remote_ucan_s3::UcanAddress;
+
+// Add a UCAN remote to a repository
+let origin = repo.remote("origin")
+    .create(UcanAddress::new("https://access.example.com"))
+    .perform(&operator)
+    .await?;
+
+// Set upstream and sync
+let main = repo.branch("main").open().perform(&operator).await?;
+let remote_main = origin.branch("main").open().perform(&operator).await?;
+main.set_upstream(remote_main).perform(&operator).await?;
+
+main.push().perform(&operator).await?;
+main.pull().perform(&operator).await?;
+```
+
+## Collaboration
+
+Access is shared through UCAN delegation chains:
+
+```rust
+// Alice delegates repo access to Bob
+let chain = alice_profile.access()
+    .claim(&repo)
+    .delegate(bob_profile.did())
+    .perform(&alice_operator)
+    .await?;
+
+// Bob retains the delegation
+bob_profile.access()
+    .save(chain)
+    .perform(&bob_operator)
+    .await?;
+
+// Bob can now push/pull through the same UCAN remote
+let origin = bob_repo.remote("origin")
+    .create(UcanAddress::new("https://access.example.com"))
+    .subject(alice_repo.did())
+    .perform(&bob_operator)
+    .await?;
+```

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -33,25 +33,20 @@
 //!
 //! ```rust,no_run
 //! use dialog_remote_ucan_s3::UcanAuthorizer;
-//! use dialog_remote_s3::s3::S3Credentials;
-//! use dialog_remote_s3::Address;
+//! use dialog_remote_s3::{Address, S3Authorization, S3Credential};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! // Create address for S3 bucket
-//! let address = Address::new(
-//!     "https://s3.us-east-1.amazonaws.com",
-//!     "us-east-1",
-//!     "my-bucket",
-//! );
+//! let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+//!     .region("us-east-1")
+//!     .bucket("my-bucket")
+//!     .build()?;
 //!
-//! // Create underlying credentials for S3 access
-//! let s3_credentials = S3Credentials::new(
+//! let auth = S3Authorization::from(S3Credential::new(
 //!     "access-key-id",
 //!     "secret-access-key",
-//! );
+//! ));
 //!
-//! // Wrap with UCAN authorizer
-//! let authorizer = UcanAuthorizer::new(address.with_credentials(s3_credentials));
+//! let authorizer = UcanAuthorizer::new(address, auth);
 //!
 //! // Handle incoming UCAN container
 //! let container_bytes: Vec<u8> = vec![]; // UCAN container from request
@@ -65,8 +60,7 @@ use std::collections::BTreeMap;
 use dialog_capability::{Capability, Constraint, Did, Policy};
 use dialog_credentials::Ed25519KeyResolver;
 use dialog_effects::{archive, memory};
-use dialog_remote_s3::Address;
-use dialog_remote_s3::{AccessError, Permit};
+use dialog_remote_s3::{Address, Permit, S3Authorization, S3Error};
 use dialog_ucan_core::InvocationChain;
 use dialog_ucan_core::promise::Promised;
 use ipld_core::ipld::Ipld;
@@ -81,24 +75,24 @@ type Args = BTreeMap<String, Promised>;
 /// Converts `Promised` values to IPLD, then uses `ipld_core::serde::from_ipld`
 /// to deserialize the target type. Unknown fields are ignored, so this works
 /// on the flat args map containing fields from all capability chain layers.
-fn deserialize_from_args<T: DeserializeOwned>(args: &Args) -> Result<T, AccessError> {
+fn deserialize_from_args<T: DeserializeOwned>(args: &Args) -> Result<T, S3Error> {
     let ipld_map: BTreeMap<String, Ipld> = args
         .iter()
         .map(|(k, v)| {
             Ipld::try_from(v)
                 .map(|ipld| (k.clone(), ipld))
                 .map_err(|e| {
-                    AccessError::Invocation(format!("Unresolved promise for '{}': {}", k, e))
+                    S3Error::Authorization(format!("Unresolved promise for '{}': {}", k, e))
                 })
         })
         .collect::<Result<_, _>>()?;
 
     ipld_core::serde::from_ipld(Ipld::Map(ipld_map))
-        .map_err(|e| AccessError::Invocation(format!("Failed to deserialize: {}", e)))
+        .map_err(|e| S3Error::Authorization(format!("Failed to deserialize: {}", e)))
 }
 
 /// Build a memory capability from UCAN args: `Subject -> Memory -> Space -> Cell -> Claim`.
-fn memory_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, AccessError>
+fn memory_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, S3Error>
 where
     C: Policy<Of = memory::Cell> + DeserializeOwned,
     <C as Constraint>::Capability: dialog_capability::Ability,
@@ -114,7 +108,7 @@ where
 }
 
 /// Build an archive capability from UCAN args: `Subject -> Archive -> Catalog -> Claim`.
-fn archive_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, AccessError>
+fn archive_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, S3Error>
 where
     C: Policy<Of = archive::Catalog> + DeserializeOwned,
     <C as Constraint>::Capability: dialog_capability::Ability,
@@ -137,10 +131,8 @@ trait FromUcanArgs {
     type Claim: Constraint;
 
     /// Reconstruct a capability from UCAN args.
-    fn capability_from_args(
-        subject: &Did,
-        args: &Args,
-    ) -> Result<Capability<Self::Claim>, AccessError>;
+    fn capability_from_args(subject: &Did, args: &Args)
+    -> Result<Capability<Self::Claim>, S3Error>;
 }
 
 impl FromUcanArgs for memory::Resolve {
@@ -148,7 +140,7 @@ impl FromUcanArgs for memory::Resolve {
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, AccessError> {
+    ) -> Result<Capability<Self::Claim>, S3Error> {
         let space: memory::Space = deserialize_from_args(args)?;
         let cell: memory::Cell = deserialize_from_args(args)?;
         Ok(dialog_capability::Subject::from(subject.clone())
@@ -163,7 +155,7 @@ impl FromUcanArgs for memory::Publish {
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, AccessError> {
+    ) -> Result<Capability<Self::Claim>, S3Error> {
         memory_claim_from_args(subject, args)
     }
 }
@@ -172,7 +164,7 @@ impl FromUcanArgs for memory::Retract {
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, AccessError> {
+    ) -> Result<Capability<Self::Claim>, S3Error> {
         memory_claim_from_args(subject, args)
     }
 }
@@ -181,7 +173,7 @@ impl FromUcanArgs for archive::Get {
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, AccessError> {
+    ) -> Result<Capability<Self::Claim>, S3Error> {
         archive_claim_from_args(subject, args)
     }
 }
@@ -190,7 +182,7 @@ impl FromUcanArgs for archive::Put {
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, AccessError> {
+    ) -> Result<Capability<Self::Claim>, S3Error> {
         archive_claim_from_args(subject, args)
     }
 }
@@ -205,10 +197,10 @@ macro_rules! dispatch {
             $(
                 [$seg1, $seg2] => {
                     let capability = <$fx as FromUcanArgs>::capability_from_args($subject, $args)?;
-                    $self.address.authorize(&capability).await
+                    $self.authorization.permit(&capability, &$self.address).await
                 }
             )+
-            _ => Err(AccessError::Invocation(format!("Unknown command: {:?}", $segments)))
+            _ => Err(S3Error::Authorization(format!("Unknown command: {:?}", $segments)))
         }
     };
 }
@@ -219,18 +211,20 @@ macro_rules! dispatch {
 /// 1. Receives UCAN containers (invocation + delegations)
 /// 2. Verifies the delegation chain
 /// 3. Extracts commands and constructs effects
-/// 4. Delegates to wrapped credentials for presigned URLs
+/// 4. Delegates to S3 authorization for presigned URLs
 #[derive(Debug, Clone)]
 pub struct UcanAuthorizer {
     address: Address,
+    authorization: S3Authorization,
 }
 
 impl UcanAuthorizer {
-    /// Create a new UCAN authorizer wrapping the given address.
-    ///
-    /// Credentials (if any) should be set on the address via `Address::with_credentials`.
-    pub fn new(address: Address) -> Self {
-        Self { address }
+    /// Create a new UCAN authorizer with the given address and authorization.
+    pub fn new(address: Address, authorization: S3Authorization) -> Self {
+        Self {
+            address,
+            authorization,
+        }
     }
 
     /// Authorize a UCAN container.
@@ -251,14 +245,14 @@ impl UcanAuthorizer {
     /// 1. Verifies the delegation chain from subject to invocation issuer
     /// 2. Checks command prefix authorization at each delegation
     /// 3. Validates policy predicates on each delegation
-    pub async fn authorize(&self, container: &[u8]) -> Result<Permit, AccessError> {
+    pub async fn authorize(&self, container: &[u8]) -> Result<Permit, S3Error> {
         // Parse and verify the invocation chain
         let chain = InvocationChain::try_from(container)
-            .map_err(|e| AccessError::Invocation(e.to_string()))?;
+            .map_err(|e| S3Error::Authorization(e.to_string()))?;
         chain
             .verify(&Ed25519KeyResolver)
             .await
-            .map_err(|e| AccessError::Invocation(e.to_string()))?;
+            .map_err(|e| S3Error::Authorization(e.to_string()))?;
 
         // Extract command path and arguments
         let command = chain.command();
@@ -288,7 +282,7 @@ mod tests {
     use dialog_credentials::Ed25519Signer;
     use dialog_remote_s3::Address;
     use dialog_remote_s3::s3;
-    use dialog_remote_s3::s3::S3Credentials;
+    use dialog_remote_s3::s3::S3Credential;
     use dialog_ucan_core::DelegationBuilder;
     use dialog_ucan_core::InvocationBuilder;
     use dialog_ucan_core::InvocationChain;
@@ -345,14 +339,14 @@ mod tests {
     async fn it_acquires_and_performs_memory_resolve() {
         let subject_signer = test_signer().await;
 
-        let address = Address::new(
-            "https://s3.us-east-1.amazonaws.com",
-            "us-east-1",
-            "test-bucket",
-        );
-        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
 
         let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
 
@@ -384,14 +378,14 @@ mod tests {
     async fn it_acquires_and_performs_archive_get() {
         let subject_signer = test_signer().await;
 
-        let address = Address::new(
-            "https://s3.us-east-1.amazonaws.com",
-            "us-east-1",
-            "test-bucket",
-        );
-        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
 
         let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
 
@@ -417,14 +411,14 @@ mod tests {
     async fn it_acquires_and_performs_archive_put() {
         let subject_signer = test_signer().await;
 
-        let address = Address::new(
-            "https://s3.us-east-1.amazonaws.com",
-            "us-east-1",
-            "test-bucket",
-        );
-        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
 
         let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
 
@@ -456,14 +450,14 @@ mod tests {
     async fn it_provides_authorized_requests() -> anyhow::Result<()> {
         let operator = Ed25519Signer::import(&[0u8; 32]).await.unwrap();
 
-        let address = Address::new(
-            "https://s3.us-east-1.amazonaws.com",
-            "us-east-1",
-            "test-bucket",
-        );
-        let credentials = s3::S3Credentials::new("access-key-id", "secret-access-key");
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = s3::S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
 
         let digest = Blake3Hash::hash(b"hello");
         let args = BTreeMap::from([
@@ -524,14 +518,14 @@ mod tests {
     async fn it_authorizes_self_invocation_for_archive_get() {
         let signer = test_signer().await;
 
-        let address = Address::new(
-            "https://s3.us-east-1.amazonaws.com",
-            "us-east-1",
-            "test-bucket",
-        );
-        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
 
         let mut args = BTreeMap::new();
         args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
@@ -563,14 +557,14 @@ mod tests {
     async fn it_authorizes_self_invocation_for_archive_put() {
         let signer = test_signer().await;
 
-        let address = Address::new(
-            "https://s3.us-east-1.amazonaws.com",
-            "us-east-1",
-            "test-bucket",
-        );
-        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
 
         // Multihash format: [code, length, ...digest]
         // SHA-256 code is 0x12, length is 0x20 (32 bytes)
@@ -604,14 +598,14 @@ mod tests {
     async fn it_authorizes_self_invocation_for_memory_resolve() {
         let signer = test_signer().await;
 
-        let address = Address::new(
-            "https://s3.us-east-1.amazonaws.com",
-            "us-east-1",
-            "test-bucket",
-        );
-        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
 
         let mut args = BTreeMap::new();
         args.insert(

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -197,7 +197,7 @@ macro_rules! dispatch {
             $(
                 [$seg1, $seg2] => {
                     let capability = <$fx as FromUcanArgs>::capability_from_args($subject, $args)?;
-                    $self.authorization.permit(&capability, &$self.address).await
+                    $self.authorization.redeem(&capability, &$self.address).await
                 }
             )+
             _ => Err(S3Error::Authorization(format!("Unknown command: {:?}", $segments)))

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -1,0 +1,640 @@
+//! UCAN provider for server-side authorization.
+//!
+//! This module provides [`UcanAuthorizer`], which wraps credentials and handles
+//! incoming UCAN invocations to authorize S3 operations.
+//!
+//! # Overview
+//!
+//! The UCAN provider sits on the server side and:
+//!
+//! 1. Receives a UCAN container (invocation + delegation chain)
+//! 2. Verifies the invocation and delegation chain
+//! 3. Extracts the command and arguments from the invocation
+//! 4. Delegates to wrapped credentials to get a presigned URL
+//!
+//! # Container Format
+//!
+//! The UCAN container follows the [UCAN Container spec](https://github.com/ucan-wg/container):
+//!
+//! ```text
+//! { "ctn-v1": [token_bytes_0, token_bytes_1, ..., token_bytes_n] }
+//! ```
+//!
+//! Where tokens are DAG-CBOR serialized UCANs, ordered bytewise for determinism.
+//! The first token is the invocation, followed by the delegation chain from
+//! closest to invoker to root.
+//!
+//! The delegation chain forms an authority path:
+//! ```text
+//! Subject (root) -> Delegation[n-1] -> ... -> Delegation[0] -> Invocation.issuer
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use dialog_remote_ucan_s3::UcanAuthorizer;
+//! use dialog_remote_s3::s3::S3Credentials;
+//! use dialog_remote_s3::Address;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create address for S3 bucket
+//! let address = Address::new(
+//!     "https://s3.us-east-1.amazonaws.com",
+//!     "us-east-1",
+//!     "my-bucket",
+//! );
+//!
+//! // Create underlying credentials for S3 access
+//! let s3_credentials = S3Credentials::new(
+//!     "access-key-id",
+//!     "secret-access-key",
+//! );
+//!
+//! // Wrap with UCAN authorizer
+//! let authorizer = UcanAuthorizer::new(address.with_credentials(s3_credentials));
+//!
+//! // Handle incoming UCAN container
+//! let container_bytes: Vec<u8> = vec![]; // UCAN container from request
+//! let result = authorizer.authorize(&container_bytes).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use std::collections::BTreeMap;
+
+use dialog_capability::{Capability, Constraint, Did, Policy};
+use dialog_credentials::Ed25519KeyResolver;
+use dialog_effects::{archive, memory};
+use dialog_remote_s3::Address;
+use dialog_remote_s3::{AccessError, Permit};
+use dialog_ucan_core::InvocationChain;
+use dialog_ucan_core::promise::Promised;
+use ipld_core::ipld::Ipld;
+use serde::de::DeserializeOwned;
+
+// Generic deserialization from UCAN args
+
+type Args = BTreeMap<String, Promised>;
+
+/// Deserialize a typed struct from UCAN args via IPLD round-trip.
+///
+/// Converts `Promised` values to IPLD, then uses `ipld_core::serde::from_ipld`
+/// to deserialize the target type. Unknown fields are ignored, so this works
+/// on the flat args map containing fields from all capability chain layers.
+fn deserialize_from_args<T: DeserializeOwned>(args: &Args) -> Result<T, AccessError> {
+    let ipld_map: BTreeMap<String, Ipld> = args
+        .iter()
+        .map(|(k, v)| {
+            Ipld::try_from(v)
+                .map(|ipld| (k.clone(), ipld))
+                .map_err(|e| {
+                    AccessError::Invocation(format!("Unresolved promise for '{}': {}", k, e))
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    ipld_core::serde::from_ipld(Ipld::Map(ipld_map))
+        .map_err(|e| AccessError::Invocation(format!("Failed to deserialize: {}", e)))
+}
+
+/// Build a memory capability from UCAN args: `Subject -> Memory -> Space -> Cell -> Claim`.
+fn memory_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, AccessError>
+where
+    C: Policy<Of = memory::Cell> + DeserializeOwned,
+    <C as Constraint>::Capability: dialog_capability::Ability,
+{
+    let space: memory::Space = deserialize_from_args(args)?;
+    let cell: memory::Cell = deserialize_from_args(args)?;
+    let claim: C = deserialize_from_args(args)?;
+    Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(memory::Memory)
+        .attenuate(space)
+        .attenuate(cell)
+        .attenuate(claim))
+}
+
+/// Build an archive capability from UCAN args: `Subject -> Archive -> Catalog -> Claim`.
+fn archive_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, AccessError>
+where
+    C: Policy<Of = archive::Catalog> + DeserializeOwned,
+    <C as Constraint>::Capability: dialog_capability::Ability,
+{
+    let catalog: archive::Catalog = deserialize_from_args(args)?;
+    let claim: C = deserialize_from_args(args)?;
+    Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(archive::Archive)
+        .attenuate(catalog)
+        .attenuate(claim))
+}
+
+/// Maps an execution effect type to its claim type that can be
+/// reconstructed from UCAN args.
+///
+/// The `Claim` associated type is the authorization-safe representation
+/// whose `Capability<Claim>` implements `Access`.
+trait FromUcanArgs {
+    /// The claim type for this effect (either Self or a generated {Name}Claim).
+    type Claim: Constraint;
+
+    /// Reconstruct a capability from UCAN args.
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError>;
+}
+
+impl FromUcanArgs for memory::Resolve {
+    type Claim = memory::Resolve;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        let space: memory::Space = deserialize_from_args(args)?;
+        let cell: memory::Cell = deserialize_from_args(args)?;
+        Ok(dialog_capability::Subject::from(subject.clone())
+            .attenuate(memory::Memory)
+            .attenuate(space)
+            .attenuate(cell)
+            .attenuate(memory::Resolve))
+    }
+}
+impl FromUcanArgs for memory::Publish {
+    type Claim = memory::PublishClaim;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        memory_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for memory::Retract {
+    type Claim = memory::RetractClaim;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        memory_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for archive::Get {
+    type Claim = archive::Get;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        archive_claim_from_args(subject, args)
+    }
+}
+impl FromUcanArgs for archive::Put {
+    type Claim = archive::PutClaim;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Claim>, AccessError> {
+        archive_claim_from_args(subject, args)
+    }
+}
+
+/// Dispatch UCAN command to the appropriate `FromUcanArgs` handler and authorize
+/// the resulting capability directly against the S3 address.
+macro_rules! dispatch {
+    ($self:expr, $subject:expr, $args:expr, $segments:expr, {
+        $( [$seg1:literal, $seg2:literal] => $fx:ty ),+ $(,)?
+    }) => {
+        match $segments {
+            $(
+                [$seg1, $seg2] => {
+                    let capability = <$fx as FromUcanArgs>::capability_from_args($subject, $args)?;
+                    $self.address.authorize(&capability).await
+                }
+            )+
+            _ => Err(AccessError::Invocation(format!("Unknown command: {:?}", $segments)))
+        }
+    };
+}
+
+/// UCAN authorizer that wraps credentials and handles UCAN invocations.
+///
+/// This is the server-side component that:
+/// 1. Receives UCAN containers (invocation + delegations)
+/// 2. Verifies the delegation chain
+/// 3. Extracts commands and constructs effects
+/// 4. Delegates to wrapped credentials for presigned URLs
+#[derive(Debug, Clone)]
+pub struct UcanAuthorizer {
+    address: Address,
+}
+
+impl UcanAuthorizer {
+    /// Create a new UCAN authorizer wrapping the given address.
+    ///
+    /// Credentials (if any) should be set on the address via `Address::with_credentials`.
+    pub fn new(address: Address) -> Self {
+        Self { address }
+    }
+
+    /// Authorize a UCAN container.
+    ///
+    /// # Arguments
+    ///
+    /// * `container` - CBOR-encoded UCAN container following the
+    ///   [UCAN Container spec](https://github.com/ucan-wg/container):
+    ///   `{ "ctn-v1": [invocation_bytes, delegation_0_bytes, ..., delegation_n_bytes] }`
+    ///
+    /// # Returns
+    ///
+    /// Returns a `RequestDescriptor` with a presigned URL and headers on success.
+    ///
+    /// # Verification
+    ///
+    /// The container is verified using rs-ucan's `syntactic_checks` which:
+    /// 1. Verifies the delegation chain from subject to invocation issuer
+    /// 2. Checks command prefix authorization at each delegation
+    /// 3. Validates policy predicates on each delegation
+    pub async fn authorize(&self, container: &[u8]) -> Result<Permit, AccessError> {
+        // Parse and verify the invocation chain
+        let chain = InvocationChain::try_from(container)
+            .map_err(|e| AccessError::Invocation(e.to_string()))?;
+        chain
+            .verify(&Ed25519KeyResolver)
+            .await
+            .map_err(|e| AccessError::Invocation(e.to_string()))?;
+
+        // Extract command path and arguments
+        let command = chain.command();
+        let args = chain.arguments();
+
+        // Get subject DID from the invocation
+        let subject_did = chain.subject();
+
+        let command_segments: Vec<&str> = command.0.iter().map(|s| s.as_str()).collect();
+
+        dispatch!(self, subject_did, args, command_segments.as_slice(), {
+            ["memory", "resolve"]  => dialog_effects::memory::Resolve,
+            ["memory", "publish"]  => dialog_effects::memory::Publish,
+            ["memory", "retract"]  => dialog_effects::memory::Retract,
+            ["archive", "get"]     => dialog_effects::archive::Get,
+            ["archive", "put"]     => dialog_effects::archive::Put,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base58::ToBase58;
+    use dialog_capability::Principal;
+    use dialog_common::Blake3Hash;
+    use dialog_credentials::Ed25519Signer;
+    use dialog_remote_s3::Address;
+    use dialog_remote_s3::s3;
+    use dialog_remote_s3::s3::S3Credentials;
+    use dialog_ucan_core::DelegationBuilder;
+    use dialog_ucan_core::InvocationBuilder;
+    use dialog_ucan_core::InvocationChain;
+    use dialog_ucan_core::subject::Subject as DelegatedSubject;
+    use std::collections::BTreeMap;
+
+    /// Helper to create a test signer
+    async fn test_signer() -> Ed25519Signer {
+        Ed25519Signer::import(&[42u8; 32]).await.unwrap()
+    }
+
+    /// Build a valid UCAN container with invocation and delegation for testing
+    async fn build_test_container(
+        subject_signer: &Ed25519Signer,
+        operator_signer: &Ed25519Signer,
+        command: Vec<String>,
+        args: BTreeMap<String, Promised>,
+    ) -> Vec<u8> {
+        let subject_did = subject_signer.did();
+
+        // Create delegation: subject -> operator
+        let delegation = DelegationBuilder::new()
+            .issuer(subject_signer.clone())
+            .audience(operator_signer)
+            .subject(DelegatedSubject::Specific(subject_did.clone()))
+            .command(command.clone())
+            .try_build()
+            .await
+            .expect("Failed to build delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        // Create invocation: operator invokes on subject
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(command)
+            .arguments(args)
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        // Build InvocationChain
+        let mut delegations = std::collections::HashMap::new();
+        delegations.insert(delegation_cid, std::sync::Arc::new(delegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+        chain.to_bytes().expect("Failed to serialize container")
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_memory_resolve() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        let mut args = BTreeMap::new();
+        args.insert(
+            "space".to_string(),
+            Promised::String("test-space".to_string()),
+        );
+        args.insert(
+            "cell".to_string(),
+            Promised::String("test-cell".to_string()),
+        );
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["memory".to_string(), "resolve".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok(), "memory/resolve failed: {:?}", result);
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_archive_get() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert("digest".to_string(), Promised::Bytes([0u8; 32].to_vec()));
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["archive".to_string(), "get".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok());
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+    }
+
+    #[dialog_common::test]
+    async fn it_acquires_and_performs_archive_put() {
+        let subject_signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
+
+        // Multihash format: [code, length, ...digest]
+        // SHA-256 code is 0x12, length is 0x20 (32 bytes)
+        let mut checksum_bytes = vec![0x12, 0x20];
+        checksum_bytes.extend_from_slice(&[0u8; 32]);
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert("digest".to_string(), Promised::Bytes([0u8; 32].to_vec()));
+        args.insert("checksum".to_string(), Promised::Bytes(checksum_bytes));
+
+        let container = build_test_container(
+            &subject_signer,
+            &operator_signer,
+            vec!["archive".to_string(), "put".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(result.is_ok());
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "PUT");
+    }
+
+    #[dialog_common::test]
+    async fn it_provides_authorized_requests() -> anyhow::Result<()> {
+        let operator = Ed25519Signer::import(&[0u8; 32]).await.unwrap();
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = s3::S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let digest = Blake3Hash::hash(b"hello");
+        let args = BTreeMap::from([
+            ("catalog".to_string(), Promised::String("blobs".into())),
+            (
+                "digest".to_string(),
+                Promised::Bytes(digest.as_bytes().into()),
+            ),
+        ]);
+
+        let payload = build_test_container(
+            &operator,
+            &operator,
+            vec!["archive".into(), "get".into()],
+            args,
+        )
+        .await;
+
+        let authorization = authorizer.authorize(&payload).await?;
+        assert_eq!(
+            authorization.url.path(),
+            format!(
+                "/{}/blobs/{}",
+                operator.did(),
+                digest.as_bytes().to_base58()
+            )
+        );
+
+        Ok(())
+    }
+
+    /// Build a self-invocation container (issuer == subject, no delegation).
+    /// This is used when a subject acts on itself, which is inherently authorized.
+    async fn build_self_invocation_container(
+        signer: &Ed25519Signer,
+        command: Vec<String>,
+        args: BTreeMap<String, Promised>,
+    ) -> Vec<u8> {
+        let did = signer.did();
+
+        // Self-invocation: issuer == subject, no proofs needed
+        let invocation = InvocationBuilder::new()
+            .issuer(signer.clone())
+            .audience(&did)
+            .subject(&did)
+            .command(command)
+            .arguments(args)
+            .proofs(vec![]) // Empty proofs for self-auth
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let chain = InvocationChain::new(invocation, std::collections::HashMap::new());
+        chain.to_bytes().expect("Failed to serialize container")
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_self_invocation_for_archive_get() {
+        let signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert(
+            "digest".to_string(),
+            Promised::Bytes(Blake3Hash::hash(b"test").as_bytes().to_vec()),
+        );
+
+        // Build self-invocation (issuer == subject, no delegation)
+        let container = build_self_invocation_container(
+            &signer,
+            vec!["archive".to_string(), "get".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(
+            result.is_ok(),
+            "Self-invocation for archive/get should be authorized: {:?}",
+            result
+        );
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_self_invocation_for_archive_put() {
+        let signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        // Multihash format: [code, length, ...digest]
+        // SHA-256 code is 0x12, length is 0x20 (32 bytes)
+        let mut checksum_bytes = vec![0x12, 0x20];
+        checksum_bytes.extend_from_slice(&[0xab; 32]);
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert("digest".to_string(), Promised::Bytes([0x99; 32].to_vec()));
+        args.insert("checksum".to_string(), Promised::Bytes(checksum_bytes));
+
+        let container = build_self_invocation_container(
+            &signer,
+            vec!["archive".to_string(), "put".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(
+            result.is_ok(),
+            "Self-invocation for archive/put should be authorized: {:?}",
+            result
+        );
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "PUT");
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_self_invocation_for_memory_resolve() {
+        let signer = test_signer().await;
+
+        let address = Address::new(
+            "https://s3.us-east-1.amazonaws.com",
+            "us-east-1",
+            "test-bucket",
+        );
+        let credentials = S3Credentials::new("access-key-id", "secret-access-key");
+
+        let authorizer = UcanAuthorizer::new(address.with_credentials(credentials));
+
+        let mut args = BTreeMap::new();
+        args.insert(
+            "space".to_string(),
+            Promised::String("did:key:zSpace".to_string()),
+        );
+        args.insert("cell".to_string(), Promised::String("main".to_string()));
+
+        let container = build_self_invocation_container(
+            &signer,
+            vec!["memory".to_string(), "resolve".to_string()],
+            args,
+        )
+        .await;
+
+        let result = authorizer.authorize(&container).await;
+        assert!(
+            result.is_ok(),
+            "Self-invocation for memory/resolve should be authorized: {:?}",
+            result
+        );
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.method, "GET");
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -33,7 +33,7 @@
 //!
 //! ```rust,no_run
 //! use dialog_remote_ucan_s3::UcanAuthorizer;
-//! use dialog_remote_s3::{Address, S3Authorization, S3Credential};
+//! use dialog_remote_s3::{Address, S3Credential};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let address = Address::builder("https://s3.us-east-1.amazonaws.com")
@@ -41,12 +41,9 @@
 //!     .bucket("my-bucket")
 //!     .build()?;
 //!
-//! let auth = S3Authorization::from(S3Credential::new(
-//!     "access-key-id",
-//!     "secret-access-key",
-//! ));
+//! let credential = S3Credential::new("access-key-id", "secret-access-key");
 //!
-//! let authorizer = UcanAuthorizer::new(address, auth);
+//! let authorizer = UcanAuthorizer::new(address, Some(credential));
 //!
 //! // Handle incoming UCAN container
 //! let container_bytes: Vec<u8> = vec![]; // UCAN container from request
@@ -60,7 +57,7 @@ use std::collections::BTreeMap;
 use dialog_capability::{Capability, Constraint, Did, Policy};
 use dialog_credentials::Ed25519KeyResolver;
 use dialog_effects::{archive, memory};
-use dialog_remote_s3::{Address, Permit, S3Authorization, S3Error};
+use dialog_remote_s3::{Address, Permit, S3Credential, S3Error};
 use dialog_ucan_core::InvocationChain;
 use dialog_ucan_core::promise::Promised;
 use ipld_core::ipld::Ipld;
@@ -91,7 +88,7 @@ fn deserialize_from_args<T: DeserializeOwned>(args: &Args) -> Result<T, S3Error>
         .map_err(|e| S3Error::Authorization(format!("Failed to deserialize: {}", e)))
 }
 
-/// Build a memory capability from UCAN args: `Subject -> Memory -> Space -> Cell -> Claim`.
+/// Build a memory capability from UCAN args: `Subject -> Memory -> Space -> Cell -> Attenuation`.
 fn memory_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, S3Error>
 where
     C: Policy<Of = memory::Cell> + DeserializeOwned,
@@ -107,7 +104,7 @@ where
         .attenuate(claim))
 }
 
-/// Build an archive capability from UCAN args: `Subject -> Archive -> Catalog -> Claim`.
+/// Build an archive capability from UCAN args: `Subject -> Archive -> Catalog -> Attenuation`.
 fn archive_claim_from_args<C>(subject: &Did, args: &Args) -> Result<Capability<C>, S3Error>
 where
     C: Policy<Of = archive::Catalog> + DeserializeOwned,
@@ -121,26 +118,29 @@ where
         .attenuate(claim))
 }
 
-/// Maps an execution effect type to its claim type that can be
+/// Maps an execution effect type to its attenuation type that can be
 /// reconstructed from UCAN args.
 ///
-/// The `Claim` associated type is the authorization-safe representation
-/// whose `Capability<Claim>` implements `Access`.
+/// The `Attenuation` associated type is the delegation-safe representation
+/// whose `Capability<Attenuation>` produces an `S3Request`.
 trait FromUcanArgs {
-    /// The claim type for this effect (either Self or a generated {Name}Claim).
-    type Claim: Constraint;
+    /// The attenuation type for this effect (either Self or a generated
+    /// `{Name}Attenuation`).
+    type Attenuation: Constraint;
 
     /// Reconstruct a capability from UCAN args.
-    fn capability_from_args(subject: &Did, args: &Args)
-    -> Result<Capability<Self::Claim>, S3Error>;
-}
-
-impl FromUcanArgs for memory::Resolve {
-    type Claim = memory::Resolve;
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, S3Error> {
+    ) -> Result<Capability<Self::Attenuation>, S3Error>;
+}
+
+impl FromUcanArgs for memory::Resolve {
+    type Attenuation = memory::Resolve;
+    fn capability_from_args(
+        subject: &Did,
+        args: &Args,
+    ) -> Result<Capability<Self::Attenuation>, S3Error> {
         let space: memory::Space = deserialize_from_args(args)?;
         let cell: memory::Cell = deserialize_from_args(args)?;
         Ok(dialog_capability::Subject::from(subject.clone())
@@ -151,38 +151,38 @@ impl FromUcanArgs for memory::Resolve {
     }
 }
 impl FromUcanArgs for memory::Publish {
-    type Claim = memory::PublishClaim;
+    type Attenuation = memory::PublishAttenuation;
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, S3Error> {
+    ) -> Result<Capability<Self::Attenuation>, S3Error> {
         memory_claim_from_args(subject, args)
     }
 }
 impl FromUcanArgs for memory::Retract {
-    type Claim = memory::RetractClaim;
+    type Attenuation = memory::Retract;
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, S3Error> {
+    ) -> Result<Capability<Self::Attenuation>, S3Error> {
         memory_claim_from_args(subject, args)
     }
 }
 impl FromUcanArgs for archive::Get {
-    type Claim = archive::Get;
+    type Attenuation = archive::Get;
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, S3Error> {
+    ) -> Result<Capability<Self::Attenuation>, S3Error> {
         archive_claim_from_args(subject, args)
     }
 }
 impl FromUcanArgs for archive::Put {
-    type Claim = archive::PutClaim;
+    type Attenuation = archive::PutAttenuation;
     fn capability_from_args(
         subject: &Did,
         args: &Args,
-    ) -> Result<Capability<Self::Claim>, S3Error> {
+    ) -> Result<Capability<Self::Attenuation>, S3Error> {
         archive_claim_from_args(subject, args)
     }
 }
@@ -197,7 +197,12 @@ macro_rules! dispatch {
             $(
                 [$seg1, $seg2] => {
                     let capability = <$fx as FromUcanArgs>::capability_from_args($subject, $args)?;
-                    $self.authorization.redeem(&capability, &$self.address).await
+                    let request = ::dialog_remote_s3::request::S3Request::from(&capability);
+                    let authorization = match $self.credential.clone() {
+                        Some(credential) => request.attest(credential),
+                        None => ::dialog_remote_s3::S3Authorization::public(request),
+                    };
+                    authorization.redeem(&$self.address).await
                 }
             )+
             _ => Err(S3Error::Authorization(format!("Unknown command: {:?}", $segments)))
@@ -215,15 +220,17 @@ macro_rules! dispatch {
 #[derive(Debug, Clone)]
 pub struct UcanAuthorizer {
     address: Address,
-    authorization: S3Authorization,
+    credential: Option<S3Credential>,
 }
 
 impl UcanAuthorizer {
-    /// Create a new UCAN authorizer with the given address and authorization.
-    pub fn new(address: Address, authorization: S3Authorization) -> Self {
+    /// Create a new UCAN authorizer with the given address and credential.
+    ///
+    /// `credential` is `None` for public/unsigned S3 endpoints.
+    pub fn new(address: Address, credential: Option<S3Credential>) -> Self {
         Self {
             address,
-            authorization,
+            credential,
         }
     }
 
@@ -346,7 +353,7 @@ mod tests {
             .unwrap();
         let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
 
         let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
 
@@ -385,7 +392,7 @@ mod tests {
             .unwrap();
         let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
 
         let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
 
@@ -418,7 +425,7 @@ mod tests {
             .unwrap();
         let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
 
         let operator_signer = Ed25519Signer::import(&[1u8; 32]).await.unwrap();
 
@@ -457,7 +464,7 @@ mod tests {
             .unwrap();
         let credentials = s3::S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
 
         let digest = Blake3Hash::hash(b"hello");
         let args = BTreeMap::from([
@@ -525,7 +532,7 @@ mod tests {
             .unwrap();
         let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
 
         let mut args = BTreeMap::new();
         args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
@@ -564,7 +571,7 @@ mod tests {
             .unwrap();
         let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
 
         // Multihash format: [code, length, ...digest]
         // SHA-256 code is 0x12, length is 0x20 (32 bytes)
@@ -605,7 +612,7 @@ mod tests {
             .unwrap();
         let credentials = S3Credential::new("access-key-id", "secret-access-key");
 
-        let authorizer = UcanAuthorizer::new(address, S3Authorization::from(credentials));
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
 
         let mut args = BTreeMap::new();
         args.insert(

--- a/rust/dialog-remote-ucan-s3/src/helpers.rs
+++ b/rust/dialog-remote-ucan-s3/src/helpers.rs
@@ -1,0 +1,29 @@
+//! UCAN access service test infrastructure.
+//!
+//! Provides [`UcanS3Address`] and a local UCAN access server backed by
+//! an in-memory S3 server for integration testing.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(not(target_arch = "wasm32"))]
+mod server;
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;
+
+/// UCAN+S3 test server connection info.
+///
+/// Combines a UCAN access service endpoint with the backing S3 server details.
+/// Passed to integration tests via `#[dialog_common::test]`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UcanS3Address {
+    /// URL of the UCAN access service.
+    pub access_service_url: String,
+    /// URL of the backing S3 server (for test verification).
+    pub s3_endpoint: String,
+    /// The bucket name.
+    pub bucket: String,
+    /// AWS access key ID (used by the access service).
+    pub access_key_id: String,
+    /// AWS secret access key (used by the access service).
+    pub secret_access_key: String,
+}

--- a/rust/dialog-remote-ucan-s3/src/helpers.rs
+++ b/rust/dialog-remote-ucan-s3/src/helpers.rs
@@ -1,19 +1,25 @@
-//! UCAN access service test infrastructure.
+//! UCAN test helpers.
 //!
-//! Provides [`UcanS3Address`] and a local UCAN access server backed by
-//! an in-memory S3 server for integration testing.
+//! Provides test infrastructure including delegation helpers,
+//! address types, and a local UCAN access server.
 
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::ContainerError;
+use dialog_ucan_core::Delegation;
+use dialog_ucan_core::DelegationBuilder;
+use dialog_ucan_core::subject::Subject;
+use dialog_varsig::Principal;
+use dialog_varsig::eddsa::Ed25519Signature;
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "helpers"))]
 mod server;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "helpers"))]
 pub use server::*;
 
 /// UCAN+S3 test server connection info.
 ///
 /// Combines a UCAN access service endpoint with the backing S3 server details.
-/// Passed to integration tests via `#[dialog_common::test]`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UcanS3Address {
     /// URL of the UCAN access service.
@@ -26,4 +32,28 @@ pub struct UcanS3Address {
     pub access_key_id: String,
     /// AWS secret access key (used by the access service).
     pub secret_access_key: String,
+}
+
+/// Generate a new random Ed25519 signer.
+pub async fn generate_signer() -> Ed25519Signer {
+    Ed25519Signer::generate()
+        .await
+        .expect("Failed to generate signer")
+}
+
+/// Create a delegation from issuer to audience for a subject with the given command.
+pub async fn create_delegation(
+    issuer: &Ed25519Signer,
+    audience: &impl Principal,
+    subject: &impl Principal,
+    command: &[&str],
+) -> Result<Delegation<Ed25519Signature>, ContainerError> {
+    DelegationBuilder::new()
+        .issuer(issuer.clone())
+        .audience(audience)
+        .subject(Subject::Specific(subject.did()))
+        .command(command.iter().map(|&s| s.to_string()).collect())
+        .try_build()
+        .await
+        .map_err(|e| ContainerError::Invocation(format!("Failed to build delegation: {:?}", e)))
 }

--- a/rust/dialog-remote-ucan-s3/src/helpers/server.rs
+++ b/rust/dialog-remote-ucan-s3/src/helpers/server.rs
@@ -8,7 +8,7 @@ use super::UcanS3Address;
 use crate::UcanAuthorizer;
 use dialog_common::helpers::{Provider, Service};
 use dialog_remote_s3::helpers::LocalS3;
-use dialog_remote_s3::{Address, S3Authorization, S3Credential};
+use dialog_remote_s3::{Address, S3Credential};
 use hyper::body::Incoming;
 use hyper::server::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
@@ -41,9 +41,9 @@ impl UcanAccessServer {
             .path_style(true)
             .build()?;
 
-        let authorization = S3Authorization::from(S3Credential::new(access_key, secret_key));
+        let credential = S3Credential::new(access_key, secret_key);
 
-        let authorizer = Arc::new(RwLock::new(UcanAuthorizer::new(address, authorization)));
+        let authorizer = Arc::new(RwLock::new(UcanAuthorizer::new(address, Some(credential))));
 
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;

--- a/rust/dialog-remote-ucan-s3/src/helpers/server.rs
+++ b/rust/dialog-remote-ucan-s3/src/helpers/server.rs
@@ -8,7 +8,7 @@ use super::UcanS3Address;
 use crate::UcanAuthorizer;
 use dialog_common::helpers::{Provider, Service};
 use dialog_remote_s3::helpers::LocalS3;
-use dialog_remote_s3::{Address, S3Credentials};
+use dialog_remote_s3::{Address, S3Authorization, S3Credential};
 use hyper::body::Incoming;
 use hyper::server::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
@@ -35,11 +35,15 @@ impl UcanAccessServer {
         access_key: &str,
         secret_key: &str,
     ) -> anyhow::Result<Self> {
-        let address = Address::new(&s3_server.endpoint, "us-east-1", bucket)
-            .with_credentials(S3Credentials::new(access_key, secret_key))
-            .with_path_style();
+        let address = Address::builder(&s3_server.endpoint)
+            .region("us-east-1")
+            .bucket(bucket)
+            .path_style(true)
+            .build()?;
 
-        let authorizer = Arc::new(RwLock::new(UcanAuthorizer::new(address)));
+        let authorization = S3Authorization::from(S3Credential::new(access_key, secret_key));
+
+        let authorizer = Arc::new(RwLock::new(UcanAuthorizer::new(address, authorization)));
 
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;

--- a/rust/dialog-remote-ucan-s3/src/helpers/server.rs
+++ b/rust/dialog-remote-ucan-s3/src/helpers/server.rs
@@ -1,0 +1,219 @@
+//! UCAN access service test server.
+//!
+//! Provides a local UCAN access service for integration testing.
+//! Receives UCAN invocation containers, verifies them using [`UcanAuthorizer`],
+//! and returns presigned S3 request descriptors.
+
+use super::UcanS3Address;
+use crate::UcanAuthorizer;
+use dialog_common::helpers::{Provider, Service};
+use dialog_remote_s3::helpers::LocalS3;
+use dialog_remote_s3::{Address, S3Credentials};
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use std::convert::Infallible;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+
+/// A running UCAN access service test server instance.
+pub struct UcanAccessServer {
+    /// The endpoint URL where the access service is listening.
+    pub endpoint: String,
+    /// The backing S3 server.
+    pub s3_server: LocalS3,
+    shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+impl UcanAccessServer {
+    /// Start a UCAN access service backed by a local S3 server.
+    pub async fn start(
+        s3_server: LocalS3,
+        bucket: &str,
+        access_key: &str,
+        secret_key: &str,
+    ) -> anyhow::Result<Self> {
+        let address = Address::new(&s3_server.endpoint, "us-east-1", bucket)
+            .with_credentials(S3Credentials::new(access_key, secret_key))
+            .with_path_style();
+
+        let authorizer = Arc::new(RwLock::new(UcanAuthorizer::new(address)));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}", addr);
+
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let authorizer_clone = authorizer.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    result = listener.accept() => {
+                        if let Ok((stream, _)) = result {
+                            let authorizer = authorizer_clone.clone();
+                            tokio::spawn(async move {
+                                let service = hyper::service::service_fn(move |req| {
+                                    let authorizer = authorizer.clone();
+                                    async move {
+                                        handle_request(req, authorizer).await
+                                    }
+                                });
+                                let _ = http1::Builder::new()
+                                    .serve_connection(TokioIo::new(stream), service)
+                                    .await;
+                            });
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(UcanAccessServer {
+            endpoint,
+            s3_server,
+            shutdown_tx,
+        })
+    }
+}
+
+fn add_cors_headers(builder: hyper::http::response::Builder) -> hyper::http::response::Builder {
+    builder
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        .header("Access-Control-Allow-Headers", "Content-Type")
+        .header("Access-Control-Max-Age", "86400")
+        .header("Cache-Control", "no-store")
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    authorizer: Arc<RwLock<UcanAuthorizer>>,
+) -> Result<Response<http_body_util::Full<bytes::Bytes>>, Infallible> {
+    use bytes::Bytes;
+    use http_body_util::Full;
+
+    if req.method() == Method::OPTIONS {
+        return Ok(add_cors_headers(Response::builder())
+            .status(StatusCode::NO_CONTENT)
+            .body(Full::new(Bytes::new()))
+            .unwrap());
+    }
+
+    if req.method() != Method::POST {
+        return Ok(add_cors_headers(Response::builder())
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .body(Full::new(Bytes::from("Method not allowed")))
+            .unwrap());
+    }
+
+    use http_body_util::BodyExt;
+    let body_bytes = match req.into_body().collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            return Ok(add_cors_headers(Response::builder())
+                .status(StatusCode::BAD_REQUEST)
+                .body(Full::new(Bytes::from(format!(
+                    "Failed to read body: {}",
+                    e
+                ))))
+                .unwrap());
+        }
+    };
+
+    let authorizer = authorizer.read().await;
+    match authorizer.authorize(&body_bytes).await {
+        Ok(descriptor) => match serde_ipld_dagcbor::to_vec(&descriptor) {
+            Ok(cbor_bytes) => Ok(add_cors_headers(Response::builder())
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/cbor")
+                .body(Full::new(Bytes::from(cbor_bytes)))
+                .unwrap()),
+            Err(e) => Ok(add_cors_headers(Response::builder())
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Full::new(Bytes::from(format!(
+                    "Failed to encode response: {}",
+                    e
+                ))))
+                .unwrap()),
+        },
+        Err(e) => Ok(add_cors_headers(Response::builder())
+            .status(StatusCode::FORBIDDEN)
+            .body(Full::new(Bytes::from(format!(
+                "Authorization failed: {}",
+                e
+            ))))
+            .unwrap()),
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for UcanAccessServer {
+    async fn stop(self) -> anyhow::Result<()> {
+        let _ = self.shutdown_tx.send(());
+        self.s3_server.stop().await
+    }
+}
+
+/// Settings for configuring the UCAN access service test server.
+#[derive(Debug, Clone)]
+pub struct UcanS3Settings {
+    /// The bucket name to create. Defaults to "test-bucket".
+    pub bucket: String,
+    /// AWS access key ID. Defaults to "test-access-key".
+    pub access_key_id: String,
+    /// AWS secret access key. Defaults to "test-secret-key".
+    pub secret_access_key: String,
+}
+
+impl Default for UcanS3Settings {
+    fn default() -> Self {
+        Self {
+            bucket: String::new(),
+            access_key_id: "test-access-key".to_string(),
+            secret_access_key: "test-secret-key".to_string(),
+        }
+    }
+}
+
+/// Starts both an S3 server and a UCAN access service.
+#[dialog_common::provider]
+pub async fn ucan_s3(
+    settings: UcanS3Settings,
+) -> anyhow::Result<Service<UcanS3Address, UcanAccessServer>> {
+    let bucket = if settings.bucket.is_empty() {
+        "test-bucket"
+    } else {
+        &settings.bucket
+    };
+
+    let s3_server = LocalS3::start_with_auth(
+        &settings.access_key_id,
+        &settings.secret_access_key,
+        &[bucket],
+    )
+    .await?;
+
+    let s3_endpoint = s3_server.endpoint.clone();
+
+    let ucan_server = UcanAccessServer::start(
+        s3_server,
+        bucket,
+        &settings.access_key_id,
+        &settings.secret_access_key,
+    )
+    .await?;
+
+    let address = UcanS3Address {
+        access_service_url: ucan_server.endpoint.clone(),
+        s3_endpoint,
+        bucket: bucket.to_string(),
+        access_key_id: settings.access_key_id,
+        secret_access_key: settings.secret_access_key,
+    };
+
+    Ok(Service::new(address, ucan_server))
+}

--- a/rust/dialog-remote-ucan-s3/src/lib.rs
+++ b/rust/dialog-remote-ucan-s3/src/lib.rs
@@ -1,0 +1,63 @@
+//! UCAN-based authorization for S3-compatible storage.
+//!
+//! This crate provides UCAN (User Controlled Authorization Networks) support:
+//!
+//! ## Client-side (making requests)
+//!
+//! - [`Credentials`] - Credentials that delegate to an external access service
+//! - [`DelegationChain`] - Chain of delegations proving authority
+//!
+//! ## Server-side (handling requests)
+//!
+//! - [`UcanAuthorizer`] - Wraps credentials to handle UCAN invocations and authorize requests
+//! - [`InvocationChain`] - Parsed UCAN container with invocation and delegation chain
+
+mod authorizer;
+mod provider;
+pub mod site;
+
+pub use authorizer::UcanAuthorizer;
+pub use site::{Ucan, UcanAddress, UcanInvocation, UcanSite};
+
+// Re-export container types from dialog-ucan
+pub use dialog_ucan_core::{Container, ContainerError, DelegationChain, InvocationChain};
+
+#[cfg(feature = "helpers")]
+pub mod helpers;
+
+/// Test helpers for creating UCAN delegations.
+/// Only available with the `helpers` feature.
+#[cfg(any(test, feature = "helpers"))]
+pub mod test_helpers {
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::ContainerError;
+    use dialog_ucan_core::Delegation;
+    use dialog_ucan_core::DelegationBuilder;
+    use dialog_ucan_core::subject::Subject;
+    use dialog_varsig::Principal;
+    use dialog_varsig::eddsa::Ed25519Signature;
+
+    /// Generate a new random Ed25519 signer.
+    pub async fn generate_signer() -> Ed25519Signer {
+        Ed25519Signer::generate()
+            .await
+            .expect("Failed to generate signer")
+    }
+
+    /// Create a delegation from issuer to audience for a subject with the given command.
+    pub async fn create_delegation(
+        issuer: &Ed25519Signer,
+        audience: &impl Principal,
+        subject: &impl Principal,
+        command: &[&str],
+    ) -> Result<Delegation<Ed25519Signature>, ContainerError> {
+        DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(Subject::Specific(subject.did()))
+            .command(command.iter().map(|&s| s.to_string()).collect())
+            .try_build()
+            .await
+            .map_err(|e| ContainerError::Invocation(format!("Failed to build delegation: {:?}", e)))
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/lib.rs
+++ b/rust/dialog-remote-ucan-s3/src/lib.rs
@@ -17,7 +17,7 @@ mod provider;
 pub mod site;
 
 pub use authorizer::UcanAuthorizer;
-pub use site::{Ucan, UcanAddress, UcanAuthorization, UcanInvocation, UcanSite};
+pub use site::{Ucan, UcanAddress, UcanAuthorization, UcanFork, UcanInvocation, UcanSite};
 
 // Re-export container types from dialog-ucan
 pub use dialog_ucan_core::{Container, ContainerError, DelegationChain, InvocationChain};

--- a/rust/dialog-remote-ucan-s3/src/lib.rs
+++ b/rust/dialog-remote-ucan-s3/src/lib.rs
@@ -4,12 +4,12 @@
 //!
 //! ## Client-side (making requests)
 //!
-//! - [`Credentials`] - Credentials that delegate to an external access service
-//! - [`DelegationChain`] - Chain of delegations proving authority
+//! - [`UcanAuthorization`] - Authorization material wrapping a signed UCAN chain
+//! - [`UcanAddress`] - Access service endpoint
 //!
 //! ## Server-side (handling requests)
 //!
-//! - [`UcanAuthorizer`] - Wraps credentials to handle UCAN invocations and authorize requests
+//! - [`UcanAuthorizer`] - Verifies UCAN invocations and produces presigned URLs
 //! - [`InvocationChain`] - Parsed UCAN container with invocation and delegation chain
 
 mod authorizer;
@@ -22,42 +22,5 @@ pub use site::{Ucan, UcanAddress, UcanAuthorization, UcanInvocation, UcanSite};
 // Re-export container types from dialog-ucan
 pub use dialog_ucan_core::{Container, ContainerError, DelegationChain, InvocationChain};
 
-#[cfg(feature = "helpers")]
-pub mod helpers;
-
-/// Test helpers for creating UCAN delegations.
-/// Only available with the `helpers` feature.
 #[cfg(any(test, feature = "helpers"))]
-pub mod test_helpers {
-    use dialog_credentials::Ed25519Signer;
-    use dialog_ucan_core::ContainerError;
-    use dialog_ucan_core::Delegation;
-    use dialog_ucan_core::DelegationBuilder;
-    use dialog_ucan_core::subject::Subject;
-    use dialog_varsig::Principal;
-    use dialog_varsig::eddsa::Ed25519Signature;
-
-    /// Generate a new random Ed25519 signer.
-    pub async fn generate_signer() -> Ed25519Signer {
-        Ed25519Signer::generate()
-            .await
-            .expect("Failed to generate signer")
-    }
-
-    /// Create a delegation from issuer to audience for a subject with the given command.
-    pub async fn create_delegation(
-        issuer: &Ed25519Signer,
-        audience: &impl Principal,
-        subject: &impl Principal,
-        command: &[&str],
-    ) -> Result<Delegation<Ed25519Signature>, ContainerError> {
-        DelegationBuilder::new()
-            .issuer(issuer.clone())
-            .audience(audience)
-            .subject(Subject::Specific(subject.did()))
-            .command(command.iter().map(|&s| s.to_string()).collect())
-            .try_build()
-            .await
-            .map_err(|e| ContainerError::Invocation(format!("Failed to build delegation: {:?}", e)))
-    }
-}
+pub mod helpers;

--- a/rust/dialog-remote-ucan-s3/src/lib.rs
+++ b/rust/dialog-remote-ucan-s3/src/lib.rs
@@ -17,7 +17,7 @@ mod provider;
 pub mod site;
 
 pub use authorizer::UcanAuthorizer;
-pub use site::{Ucan, UcanAddress, UcanInvocation, UcanSite};
+pub use site::{Ucan, UcanAddress, UcanAuthorization, UcanInvocation, UcanSite};
 
 // Re-export container types from dialog-ucan
 pub use dialog_ucan_core::{Container, ContainerError, DelegationChain, InvocationChain};

--- a/rust/dialog-remote-ucan-s3/src/provider.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider.rs
@@ -1,0 +1,7 @@
+//! `Provider<Fork<UcanSite, Fx>>` implementations.
+//!
+//! Each impl authorizes via the UCAN access service (`UcanAddress::authorize`),
+//! then delegates to `Provider<Authorized<Fx>>` on `S3` for shared HTTP execution.
+
+pub mod archive;
+pub mod memory;

--- a/rust/dialog-remote-ucan-s3/src/provider/archive.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/archive.rs
@@ -1,10 +1,10 @@
-//! Archive capability `Provider<ForkInvocation<UcanSite, Fx>>` implementations.
+//! Archive providers for UCAN-authorized S3.
 
 use async_trait::async_trait;
 use dialog_capability::Provider;
 use dialog_capability::fork::ForkInvocation;
 use dialog_effects::archive::*;
-use dialog_remote_s3::{Authorized, S3};
+use dialog_remote_s3::S3;
 
 use crate::site::UcanSite;
 
@@ -15,17 +15,13 @@ impl Provider<ForkInvocation<UcanSite, Get>> for UcanSite {
         &self,
         invocation: ForkInvocation<UcanSite, Get>,
     ) -> Result<Option<Vec<u8>>, ArchiveError> {
-        let permit = invocation
+        invocation
             .address
-            .authorize(&invocation.invocation)
+            .authorize(&invocation.authorization)
+            .await?
+            .invoke(invocation.capability)
+            .perform(&S3)
             .await
-            .map_err(|e| ArchiveError::Io(e.to_string()))?;
-
-        <S3 as Provider<Authorized<Get>>>::execute(
-            &S3,
-            Authorized::new(permit, invocation.capability),
-        )
-        .await
     }
 }
 
@@ -33,16 +29,12 @@ impl Provider<ForkInvocation<UcanSite, Get>> for UcanSite {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider<ForkInvocation<UcanSite, Put>> for UcanSite {
     async fn execute(&self, invocation: ForkInvocation<UcanSite, Put>) -> Result<(), ArchiveError> {
-        let permit = invocation
+        invocation
             .address
-            .authorize(&invocation.invocation)
+            .authorize(&invocation.authorization)
+            .await?
+            .invoke(invocation.capability)
+            .perform(&S3)
             .await
-            .map_err(|e| ArchiveError::Io(e.to_string()))?;
-
-        <S3 as Provider<Authorized<Put>>>::execute(
-            &S3,
-            Authorized::new(permit, invocation.capability),
-        )
-        .await
     }
 }

--- a/rust/dialog-remote-ucan-s3/src/provider/archive.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/archive.rs
@@ -1,8 +1,8 @@
 //! Archive providers for UCAN-authorized S3.
 
 use async_trait::async_trait;
+use dialog_capability::ForkInvocation;
 use dialog_capability::Provider;
-use dialog_capability::fork::ForkInvocation;
 use dialog_effects::archive::*;
 use dialog_remote_s3::S3;
 

--- a/rust/dialog-remote-ucan-s3/src/provider/archive.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/archive.rs
@@ -16,8 +16,8 @@ impl Provider<ForkInvocation<UcanSite, Get>> for UcanSite {
         invocation: ForkInvocation<UcanSite, Get>,
     ) -> Result<Option<Vec<u8>>, ArchiveError> {
         invocation
-            .address
-            .authorize(&invocation.authorization)
+            .authorization
+            .redeem(&invocation.address)
             .await?
             .invoke(invocation.capability)
             .perform(&S3)
@@ -30,8 +30,8 @@ impl Provider<ForkInvocation<UcanSite, Get>> for UcanSite {
 impl Provider<ForkInvocation<UcanSite, Put>> for UcanSite {
     async fn execute(&self, invocation: ForkInvocation<UcanSite, Put>) -> Result<(), ArchiveError> {
         invocation
-            .address
-            .authorize(&invocation.authorization)
+            .authorization
+            .redeem(&invocation.address)
             .await?
             .invoke(invocation.capability)
             .perform(&S3)

--- a/rust/dialog-remote-ucan-s3/src/provider/archive.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/archive.rs
@@ -1,0 +1,48 @@
+//! Archive capability `Provider<ForkInvocation<UcanSite, Fx>>` implementations.
+
+use async_trait::async_trait;
+use dialog_capability::Provider;
+use dialog_capability::fork::ForkInvocation;
+use dialog_effects::archive::*;
+use dialog_remote_s3::{Authorized, S3};
+
+use crate::site::UcanSite;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<ForkInvocation<UcanSite, Get>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Get>,
+    ) -> Result<Option<Vec<u8>>, ArchiveError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.invocation)
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Get>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<ForkInvocation<UcanSite, Put>> for UcanSite {
+    async fn execute(&self, invocation: ForkInvocation<UcanSite, Put>) -> Result<(), ArchiveError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.invocation)
+            .await
+            .map_err(|e| ArchiveError::Io(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Put>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.capability),
+        )
+        .await
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/provider/memory.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/memory.rs
@@ -1,0 +1,72 @@
+//! Memory capability `Provider<ForkInvocation<UcanSite, Fx>>` implementations.
+
+use async_trait::async_trait;
+use dialog_capability::Provider;
+use dialog_capability::fork::ForkInvocation;
+use dialog_effects::memory::*;
+use dialog_remote_s3::{Authorized, S3};
+
+use crate::site::UcanSite;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<ForkInvocation<UcanSite, Resolve>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Resolve>,
+    ) -> Result<Option<Publication>, MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.invocation)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Resolve>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<ForkInvocation<UcanSite, Publish>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Publish>,
+    ) -> Result<Vec<u8>, MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.invocation)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Publish>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.capability),
+        )
+        .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<ForkInvocation<UcanSite, Retract>> for UcanSite {
+    async fn execute(
+        &self,
+        invocation: ForkInvocation<UcanSite, Retract>,
+    ) -> Result<(), MemoryError> {
+        let permit = invocation
+            .address
+            .authorize(&invocation.invocation)
+            .await
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        <S3 as Provider<Authorized<Retract>>>::execute(
+            &S3,
+            Authorized::new(permit, invocation.capability),
+        )
+        .await
+    }
+}

--- a/rust/dialog-remote-ucan-s3/src/provider/memory.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/memory.rs
@@ -1,8 +1,8 @@
 //! Memory providers for UCAN-authorized S3.
 
 use async_trait::async_trait;
+use dialog_capability::ForkInvocation;
 use dialog_capability::Provider;
-use dialog_capability::fork::ForkInvocation;
 use dialog_effects::memory::*;
 use dialog_remote_s3::S3;
 
@@ -14,7 +14,7 @@ impl Provider<ForkInvocation<UcanSite, Resolve>> for UcanSite {
     async fn execute(
         &self,
         invocation: ForkInvocation<UcanSite, Resolve>,
-    ) -> Result<Option<Publication>, MemoryError> {
+    ) -> Result<Option<Edition<Vec<u8>>>, MemoryError> {
         invocation
             .authorization
             .redeem(&invocation.address)
@@ -31,7 +31,7 @@ impl Provider<ForkInvocation<UcanSite, Publish>> for UcanSite {
     async fn execute(
         &self,
         invocation: ForkInvocation<UcanSite, Publish>,
-    ) -> Result<Vec<u8>, MemoryError> {
+    ) -> Result<Version, MemoryError> {
         invocation
             .authorization
             .redeem(&invocation.address)

--- a/rust/dialog-remote-ucan-s3/src/provider/memory.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/memory.rs
@@ -16,8 +16,8 @@ impl Provider<ForkInvocation<UcanSite, Resolve>> for UcanSite {
         invocation: ForkInvocation<UcanSite, Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
         invocation
-            .address
-            .authorize(&invocation.authorization)
+            .authorization
+            .redeem(&invocation.address)
             .await?
             .invoke(invocation.capability)
             .perform(&S3)
@@ -33,8 +33,8 @@ impl Provider<ForkInvocation<UcanSite, Publish>> for UcanSite {
         invocation: ForkInvocation<UcanSite, Publish>,
     ) -> Result<Vec<u8>, MemoryError> {
         invocation
-            .address
-            .authorize(&invocation.authorization)
+            .authorization
+            .redeem(&invocation.address)
             .await?
             .invoke(invocation.capability)
             .perform(&S3)
@@ -50,8 +50,8 @@ impl Provider<ForkInvocation<UcanSite, Retract>> for UcanSite {
         invocation: ForkInvocation<UcanSite, Retract>,
     ) -> Result<(), MemoryError> {
         invocation
-            .address
-            .authorize(&invocation.authorization)
+            .authorization
+            .redeem(&invocation.address)
             .await?
             .invoke(invocation.capability)
             .perform(&S3)

--- a/rust/dialog-remote-ucan-s3/src/provider/memory.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider/memory.rs
@@ -1,10 +1,10 @@
-//! Memory capability `Provider<ForkInvocation<UcanSite, Fx>>` implementations.
+//! Memory providers for UCAN-authorized S3.
 
 use async_trait::async_trait;
 use dialog_capability::Provider;
 use dialog_capability::fork::ForkInvocation;
 use dialog_effects::memory::*;
-use dialog_remote_s3::{Authorized, S3};
+use dialog_remote_s3::S3;
 
 use crate::site::UcanSite;
 
@@ -15,17 +15,13 @@ impl Provider<ForkInvocation<UcanSite, Resolve>> for UcanSite {
         &self,
         invocation: ForkInvocation<UcanSite, Resolve>,
     ) -> Result<Option<Publication>, MemoryError> {
-        let permit = invocation
+        invocation
             .address
-            .authorize(&invocation.invocation)
+            .authorize(&invocation.authorization)
+            .await?
+            .invoke(invocation.capability)
+            .perform(&S3)
             .await
-            .map_err(|e| MemoryError::Storage(e.to_string()))?;
-
-        <S3 as Provider<Authorized<Resolve>>>::execute(
-            &S3,
-            Authorized::new(permit, invocation.capability),
-        )
-        .await
     }
 }
 
@@ -36,17 +32,13 @@ impl Provider<ForkInvocation<UcanSite, Publish>> for UcanSite {
         &self,
         invocation: ForkInvocation<UcanSite, Publish>,
     ) -> Result<Vec<u8>, MemoryError> {
-        let permit = invocation
+        invocation
             .address
-            .authorize(&invocation.invocation)
+            .authorize(&invocation.authorization)
+            .await?
+            .invoke(invocation.capability)
+            .perform(&S3)
             .await
-            .map_err(|e| MemoryError::Storage(e.to_string()))?;
-
-        <S3 as Provider<Authorized<Publish>>>::execute(
-            &S3,
-            Authorized::new(permit, invocation.capability),
-        )
-        .await
     }
 }
 
@@ -57,16 +49,12 @@ impl Provider<ForkInvocation<UcanSite, Retract>> for UcanSite {
         &self,
         invocation: ForkInvocation<UcanSite, Retract>,
     ) -> Result<(), MemoryError> {
-        let permit = invocation
+        invocation
             .address
-            .authorize(&invocation.invocation)
+            .authorize(&invocation.authorization)
+            .await?
+            .invoke(invocation.capability)
+            .perform(&S3)
             .await
-            .map_err(|e| MemoryError::Storage(e.to_string()))?;
-
-        <S3 as Provider<Authorized<Retract>>>::execute(
-            &S3,
-            Authorized::new(permit, invocation.capability),
-        )
-        .await
     }
 }

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -1,6 +1,15 @@
 //! UCAN site configuration -- marker trait + address type.
 
-use dialog_capability::site::{Site, SiteAddress, SiteAuthorization};
+use dialog_capability::access::{
+    Access, Authorization as _, Authorize as AuthorizeEffect, AuthorizeError, FromCapability,
+    Protocol,
+};
+use dialog_capability::{
+    Ability, Capability, Constraint, Effect, Fork, ForkInvocation, Provider, Site, SiteAddress,
+    SiteFork, SiteId, Subject,
+};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_effects::authority::{self, OperatorExt};
 use dialog_remote_s3::{Permit, S3Error};
 
 // Re-export UCAN types for convenience.
@@ -11,7 +20,7 @@ pub use dialog_ucan::{Ucan, UcanInvocation};
 /// Wraps a [`UcanInvocation`] (signed UCAN chain) that gets sent to the
 /// access service to obtain a presigned URL.
 #[derive(Debug, Clone)]
-pub struct UcanAuthorization(pub UcanInvocation);
+pub struct UcanAuthorization(UcanInvocation);
 
 impl UcanAuthorization {
     /// Redeem this authorization at the access service for a presigned URL permit.
@@ -42,10 +51,6 @@ impl UcanAuthorization {
         serde_ipld_dagcbor::from_slice(&body)
             .map_err(|e| S3Error::Service(format!("Failed to decode response: {}", e)))
     }
-}
-
-impl SiteAuthorization for UcanAuthorization {
-    type Protocol = Ucan;
 }
 
 impl From<UcanInvocation> for UcanAuthorization {
@@ -79,6 +84,60 @@ impl SiteAddress for UcanAddress {
     type Site = UcanSite;
 }
 
+impl From<UcanAddress> for SiteId {
+    fn from(address: UcanAddress) -> Self {
+        address.endpoint.into()
+    }
+}
+
+/// Site-owned fork wrapper for UCAN.
+///
+/// Thin newtype around [`Fork<UcanSite, Fx>`] that carries the
+/// site-specific [`Authorize`](dialog_capability::SiteFork)
+/// impl: fetches session identity from the env, invokes UCAN's
+/// `Authorize` on that identity, and bundles the resulting signed
+/// delegation into a [`ForkInvocation`].
+pub struct UcanFork<Fx: Effect>(Fork<UcanSite, Fx>);
+
+impl<Fx: Effect> From<Fork<UcanSite, Fx>> for UcanFork<Fx> {
+    fn from(fork: Fork<UcanSite, Fx>) -> Self {
+        Self(fork)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<Fx, Env> SiteFork<Env> for UcanFork<Fx>
+where
+    Fx: Effect + Clone + ConditionalSend + ConditionalSync + 'static,
+    Fx::Of: Constraint<Capability: ConditionalSend + ConditionalSync>,
+    Capability<Fx>: Ability + ConditionalSend + ConditionalSync,
+    Env: Provider<AuthorizeEffect<Ucan>> + Provider<authority::Identify> + ConditionalSync,
+{
+    type Site = UcanSite;
+    type Effect = Fx;
+
+    async fn authorize(self, env: &Env) -> Result<ForkInvocation<UcanSite, Fx>, AuthorizeError> {
+        let identity = authority::Identify
+            .perform(env)
+            .await
+            .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+        let profile = identity.profile().clone();
+        let operator = identity.did();
+
+        let scope = <Ucan as Protocol>::Access::from_capability(self.0.capability());
+
+        let authorization = Subject::from(profile)
+            .attenuate(Access)
+            .invoke(AuthorizeEffect::<Ucan>::new(operator, scope))
+            .perform(env)
+            .await?;
+
+        let invocation = authorization.invoke().await?;
+        Ok(self.0.attest(UcanAuthorization::from(invocation)))
+    }
+}
+
 /// UCAN site configuration for delegated authorization.
 ///
 /// A marker type -- no fields. Address info lives in `UcanAddress`.
@@ -88,4 +147,5 @@ pub struct UcanSite;
 impl Site for UcanSite {
     type Authorization = UcanAuthorization;
     type Address = UcanAddress;
+    type Fork<Fx: Effect> = UcanFork<Fx>;
 }

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -1,9 +1,27 @@
 //! UCAN site configuration -- marker trait + address type.
 
-use dialog_capability::site::{Site, SiteAddress};
+use dialog_capability::site::{Site, SiteAddress, SiteAuthorization};
+use dialog_remote_s3::{Permit, S3Error};
 
 // Re-export UCAN types for convenience.
 pub use dialog_ucan::{Ucan, UcanInvocation};
+
+/// UCAN authorization material for site providers.
+///
+/// Wraps a [`UcanInvocation`] (signed UCAN chain) that the site
+/// provider sends to the access service to obtain a presigned URL.
+#[derive(Debug, Clone)]
+pub struct UcanAuthorization(pub UcanInvocation);
+
+impl SiteAuthorization for UcanAuthorization {
+    type Protocol = Ucan;
+}
+
+impl From<UcanInvocation> for UcanAuthorization {
+    fn from(invocation: UcanInvocation) -> Self {
+        Self(invocation)
+    }
+}
 
 /// UCAN site address -- wraps the access service endpoint.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -27,39 +45,32 @@ impl UcanAddress {
 
     /// POST a signed UCAN invocation to the access service and get back
     /// a presigned URL for the S3 operation.
-    pub async fn authorize(
-        &self,
-        invocation: &UcanInvocation,
-    ) -> Result<dialog_remote_s3::Permit, dialog_remote_s3::AccessError> {
-        let body = invocation
+    pub async fn authorize(&self, authorization: &UcanAuthorization) -> Result<Permit, S3Error> {
+        let body = authorization
+            .0
             .to_bytes()
-            .map_err(|e| dialog_remote_s3::AccessError::Invocation(e.to_string()))?;
+            .map_err(|e| S3Error::Authorization(e.to_string()))?;
 
         let response = reqwest::Client::new()
             .post(&self.endpoint)
             .header("Content-Type", "application/cbor")
             .body(body)
             .send()
-            .await
-            .map_err(|e| dialog_remote_s3::AccessError::Service(e.to_string()))?;
+            .await?;
 
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(dialog_remote_s3::AccessError::Service(format!(
+            return Err(S3Error::Service(format!(
                 "Access service returned {}: {}",
                 status, body
             )));
         }
 
-        let body = response
-            .bytes()
-            .await
-            .map_err(|e| dialog_remote_s3::AccessError::Service(e.to_string()))?;
+        let body = response.bytes().await?;
 
-        serde_ipld_dagcbor::from_slice(&body).map_err(|e| {
-            dialog_remote_s3::AccessError::Service(format!("Failed to decode response: {}", e))
-        })
+        serde_ipld_dagcbor::from_slice(&body)
+            .map_err(|e| S3Error::Service(format!("Failed to decode response: {}", e)))
     }
 }
 
@@ -74,6 +85,6 @@ impl SiteAddress for UcanAddress {
 pub struct UcanSite;
 
 impl Site for UcanSite {
-    type Protocol = Ucan;
+    type Authorization = UcanAuthorization;
     type Address = UcanAddress;
 }

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -8,10 +8,41 @@ pub use dialog_ucan::{Ucan, UcanInvocation};
 
 /// UCAN authorization material for site providers.
 ///
-/// Wraps a [`UcanInvocation`] (signed UCAN chain) that the site
-/// provider sends to the access service to obtain a presigned URL.
+/// Wraps a [`UcanInvocation`] (signed UCAN chain) that gets sent to the
+/// access service to obtain a presigned URL.
 #[derive(Debug, Clone)]
 pub struct UcanAuthorization(pub UcanInvocation);
+
+impl UcanAuthorization {
+    /// Redeem this authorization at the access service for a presigned URL permit.
+    pub async fn redeem(&self, address: &UcanAddress) -> Result<Permit, S3Error> {
+        let body = self
+            .0
+            .to_bytes()
+            .map_err(|e| S3Error::Authorization(e.to_string()))?;
+
+        let response = reqwest::Client::new()
+            .post(&address.endpoint)
+            .header("Content-Type", "application/cbor")
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(S3Error::Service(format!(
+                "Access service returned {}: {}",
+                status, body
+            )));
+        }
+
+        let body = response.bytes().await?;
+
+        serde_ipld_dagcbor::from_slice(&body)
+            .map_err(|e| S3Error::Service(format!("Failed to decode response: {}", e)))
+    }
+}
 
 impl SiteAuthorization for UcanAuthorization {
     type Protocol = Ucan;
@@ -41,36 +72,6 @@ impl UcanAddress {
     /// Get the access service endpoint URL.
     pub fn endpoint(&self) -> &str {
         &self.endpoint
-    }
-
-    /// POST a signed UCAN invocation to the access service and get back
-    /// a presigned URL for the S3 operation.
-    pub async fn authorize(&self, authorization: &UcanAuthorization) -> Result<Permit, S3Error> {
-        let body = authorization
-            .0
-            .to_bytes()
-            .map_err(|e| S3Error::Authorization(e.to_string()))?;
-
-        let response = reqwest::Client::new()
-            .post(&self.endpoint)
-            .header("Content-Type", "application/cbor")
-            .body(body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(S3Error::Service(format!(
-                "Access service returned {}: {}",
-                status, body
-            )));
-        }
-
-        let body = response.bytes().await?;
-
-        serde_ipld_dagcbor::from_slice(&body)
-            .map_err(|e| S3Error::Service(format!("Failed to decode response: {}", e)))
     }
 }
 

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -1,0 +1,79 @@
+//! UCAN site configuration -- marker trait + address type.
+
+use dialog_capability::site::{Site, SiteAddress};
+
+// Re-export UCAN types for convenience.
+pub use dialog_ucan::{Ucan, UcanInvocation};
+
+/// UCAN site address -- wraps the access service endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct UcanAddress {
+    /// The access service endpoint URL.
+    pub endpoint: String,
+}
+
+impl UcanAddress {
+    /// Create a new UCAN address with the given endpoint.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+        }
+    }
+
+    /// Get the access service endpoint URL.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// POST a signed UCAN invocation to the access service and get back
+    /// a presigned URL for the S3 operation.
+    pub async fn authorize(
+        &self,
+        invocation: &UcanInvocation,
+    ) -> Result<dialog_remote_s3::Permit, dialog_remote_s3::AccessError> {
+        let body = invocation
+            .to_bytes()
+            .map_err(|e| dialog_remote_s3::AccessError::Invocation(e.to_string()))?;
+
+        let response = reqwest::Client::new()
+            .post(&self.endpoint)
+            .header("Content-Type", "application/cbor")
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| dialog_remote_s3::AccessError::Service(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(dialog_remote_s3::AccessError::Service(format!(
+                "Access service returned {}: {}",
+                status, body
+            )));
+        }
+
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| dialog_remote_s3::AccessError::Service(e.to_string()))?;
+
+        serde_ipld_dagcbor::from_slice(&body).map_err(|e| {
+            dialog_remote_s3::AccessError::Service(format!("Failed to decode response: {}", e))
+        })
+    }
+}
+
+impl SiteAddress for UcanAddress {
+    type Site = UcanSite;
+}
+
+/// UCAN site configuration for delegated authorization.
+///
+/// A marker type -- no fields. Address info lives in `UcanAddress`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UcanSite;
+
+impl Site for UcanSite {
+    type Protocol = Ucan;
+    type Address = UcanAddress;
+}

--- a/rust/dialog-ucan/src/scope.rs
+++ b/rust/dialog-ucan/src/scope.rs
@@ -1,6 +1,8 @@
 //! Capability-derived scope for UCAN delegation and invocation.
 
-use dialog_capability::{Ability, Capability, Constraint, Effect, Policy, Subject};
+use dialog_capability::{
+    Ability, Capability, Constraint, Effect, Policy, Subject, access::FromCapability,
+};
 use dialog_ucan_core::command::Command;
 use dialog_ucan_core::delegation::policy::predicate::Predicate;
 use dialog_ucan_core::delegation::policy::selector::filter::Filter;
@@ -205,6 +207,17 @@ impl Scope {
             command: ability_to_command(&ability),
             parameters: Parameters(params),
         }
+    }
+}
+
+impl FromCapability for Scope {
+    fn from_capability<Fx>(capability: &Capability<Fx>) -> Self
+    where
+        Fx: Effect + Clone,
+        Fx::Of: Constraint,
+        Capability<Fx>: Ability,
+    {
+        Self::invoke(capability)
     }
 }
 


### PR DESCRIPTION
## Summary

Extracts UCAN-authorized S3 storage from the feature-gated code removed
in #246 into a standalone dialog-remote-ucan-s3 crate. This wraps
dialog-remote-s3 with UCAN delegation verification so that remote
storage operations require valid authorization chains before accessing
S3 buckets.