### PR TITLE
25 📬 feat: add pluggable import/export for artifacts with CSV support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-csv"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base58",
+ "csv-async",
+ "dialog-artifacts",
+ "dialog-common",
+ "futures-util",
+ "getrandom 0.2.16",
+ "serde",
+ "tempfile",
+ "tokio",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "dialog-dbsp"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "rust/dialog-diagnose",
     "rust/dialog-dbsp",
     "rust/dialog-encoding",
+    "rust/dialog-csv",
     "rust/dialog-prolly-tree",
     "rust/dialog-query",
     "rust/dialog-search-tree",
@@ -176,6 +177,9 @@ path = "./rust/dialog-credentials"
 
 [workspace.dependencies.dialog-encoding]
 path = "./rust/dialog-encoding"
+
+[workspace.dependencies.dialog-csv]
+path = "./rust/dialog-csv"
 
 [workspace.dependencies.dialog-prolly-tree]
 path = "./rust/dialog-prolly-tree"

--- a/rust/dialog-artifacts/src/exporter.rs
+++ b/rust/dialog-artifacts/src/exporter.rs
@@ -1,0 +1,23 @@
+//! Format-agnostic export trait for artifacts.
+//!
+//! Implementations live in separate crates (e.g., `dialog-csv`).
+
+use async_trait::async_trait;
+
+use crate::{Artifact, DialogArtifactsError};
+
+/// Writes artifacts to some output format.
+///
+/// Implementors handle the format-specific serialization of each artifact.
+/// The caller is responsible for iterating over artifacts and calling
+/// [`Exporter::write`] for each one, followed by [`Exporter::close`] to
+/// finalize the output.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait Exporter {
+    /// Write a single artifact to the output.
+    async fn write(&mut self, artifact: &Artifact) -> Result<(), DialogArtifactsError>;
+
+    /// Finalize the output. Called after all artifacts have been written.
+    async fn close(&mut self) -> Result<(), DialogArtifactsError>;
+}

--- a/rust/dialog-artifacts/src/importer.rs
+++ b/rust/dialog-artifacts/src/importer.rs
@@ -1,0 +1,15 @@
+//! Format-agnostic import trait for artifacts.
+//!
+//! Implementations live in separate crates (e.g., `dialog-csv`).
+
+use futures_util::Stream;
+
+use crate::{Artifact, DialogArtifactsError};
+
+/// Reads artifacts from some input format.
+///
+/// An importer is simply a stream of artifacts. Implementations handle
+/// the format-specific deserialization internally.
+pub trait Importer: Stream<Item = Result<Artifact, DialogArtifactsError>> {}
+
+impl<T> Importer for T where T: Stream<Item = Result<Artifact, DialogArtifactsError>> {}

--- a/rust/dialog-artifacts/src/lib.rs
+++ b/rust/dialog-artifacts/src/lib.rs
@@ -59,6 +59,14 @@ pub use reference::*;
 mod error;
 pub use error::*;
 
+/// Format-agnostic export trait for artifacts.
+pub mod exporter;
+pub use exporter::Exporter;
+
+/// Format-agnostic import trait for artifacts.
+pub mod importer;
+pub use importer::Importer;
+
 mod state;
 pub use state::*;
 

--- a/rust/dialog-csv/Cargo.toml
+++ b/rust/dialog-csv/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "dialog-csv"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+dialog-artifacts = { workspace = true }
+async-trait = { workspace = true }
+base58 = { workspace = true }
+csv-async = { workspace = true, features = ["tokio"] }
+futures-util = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["io-util"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+dialog-common = { workspace = true, features = ["helpers"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "macros", "rt", "fs"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("web-integration-tests"))', "cfg(dialog_test_wasm_integration)"] }

--- a/rust/dialog-csv/README.md
+++ b/rust/dialog-csv/README.md
@@ -1,0 +1,60 @@
+# dialog-csv
+
+CSV import/export for Dialog artifacts.
+
+Implements the `Exporter` and `Importer` traits from `dialog-artifacts`,
+enabling artifacts to be serialized to and deserialized from CSV files.
+
+## CSV format
+
+Each row represents a single artifact with five columns:
+
+| Column  | Description | Example |
+|---------|-------------|---------|
+| `the`   | Attribute (predicate) | `user/name` |
+| `of`    | Entity (subject URI) | `user:alice` |
+| `as`    | Value type | `text` |
+| `is`    | Value | `Alice` |
+| `cause` | Causal reference (base58, optional) | |
+
+Supported value types: `text`, `natural`, `integer`, `boolean`,
+`float`, `bytes` (base58), `entity` (URI), `attribute` (namespace/name),
+`record` (base58).
+
+## Usage
+
+### Export a branch to a CSV file
+
+```rs
+let file = tokio::fs::File::create("artifacts.csv").await?;
+branch
+    .export(CsvExporter::from(file))
+    .perform(&operator)
+    .await?;
+```
+
+### Import a CSV file into a branch
+
+```rs
+let file = tokio::fs::File::open("artifacts.csv").await?;
+branch
+    .import(CsvImporter::from(file))
+    .perform(&operator)
+    .await?;
+```
+
+### Standalone usage without a repository
+
+```rs
+// Export
+let mut exporter = CsvExporter::from(writer);
+exporter.write(&artifact).await?;
+exporter.close().await?;
+
+// Import
+let importer = CsvImporter::from(reader);
+while let Some(result) = importer.next().await {
+    let artifact = result?;
+    println!("{artifact}");
+}
+```

--- a/rust/dialog-csv/src/exporter.rs
+++ b/rust/dialog-csv/src/exporter.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use dialog_artifacts::Exporter;
+use dialog_artifacts::{Artifact, DialogArtifactsError};
+use tokio::io::AsyncWrite;
+
+use crate::row::CsvRow;
+
+/// Exports artifacts as CSV rows.
+///
+/// Columns: `the`, `of`, `as` (value type), `is`, `cause`.
+pub struct CsvExporter<W: AsyncWrite + Unpin> {
+    writer: csv_async::AsyncSerializer<W>,
+}
+
+impl<W: AsyncWrite + Unpin> CsvExporter<W> {
+    /// Create a new CSV exporter writing to the given writer.
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer: csv_async::AsyncSerializer::from_writer(writer),
+        }
+    }
+}
+
+impl<W: AsyncWrite + Unpin> From<W> for CsvExporter<W> {
+    fn from(writer: W) -> Self {
+        Self::new(writer)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<W: AsyncWrite + Unpin + Send> Exporter for CsvExporter<W> {
+    async fn write(&mut self, artifact: &Artifact) -> Result<(), DialogArtifactsError> {
+        let row = CsvRow::from(artifact);
+        self.writer
+            .serialize(row)
+            .await
+            .map_err(|e| DialogArtifactsError::Export(e.to_string()))
+    }
+
+    async fn close(&mut self) -> Result<(), DialogArtifactsError> {
+        Ok(())
+    }
+}

--- a/rust/dialog-csv/src/importer.rs
+++ b/rust/dialog-csv/src/importer.rs
@@ -1,0 +1,46 @@
+use dialog_artifacts::{Artifact, DialogArtifactsError};
+use futures_util::{Stream, StreamExt};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncRead;
+
+use crate::row::CsvRow;
+
+/// Imports artifacts from CSV rows.
+///
+/// Expects columns: `the`, `of`, `as` (value type), `is`, `cause`.
+///
+/// Implements [`Stream`] yielding one [`Artifact`] per CSV row.
+pub struct CsvImporter {
+    inner: Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>,
+}
+
+impl CsvImporter {
+    /// Create a new CSV importer reading from the given reader.
+    pub fn new<R: AsyncRead + Unpin + Send + 'static>(reader: R) -> Self {
+        let deserializer = csv_async::AsyncReaderBuilder::new().create_deserializer(reader);
+        let stream = deserializer
+            .into_deserialize::<CsvRow>()
+            .map(|result| match result {
+                Ok(row) => Artifact::try_from(row),
+                Err(e) => Err(DialogArtifactsError::Export(e.to_string())),
+            });
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin + Send + 'static> From<R> for CsvImporter {
+    fn from(reader: R) -> Self {
+        Self::new(reader)
+    }
+}
+
+impl Stream for CsvImporter {
+    type Item = Result<Artifact, DialogArtifactsError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}

--- a/rust/dialog-csv/src/lib.rs
+++ b/rust/dialog-csv/src/lib.rs
@@ -1,0 +1,232 @@
+#![warn(missing_docs)]
+
+//! CSV format support for the Dialog artifact exchange system.
+//!
+//! Provides [`CsvExporter`] and [`CsvImporter`] that implement the
+//! [`Exporter`] and [`Importer`] traits from `dialog-artifacts`.
+//!
+//! Each CSV row represents a single artifact with columns:
+//! `the` (attribute), `of` (entity), `as` (value type), `is` (value),
+//! `cause` (optional causal reference).
+
+mod row;
+
+mod exporter;
+pub use exporter::CsvExporter;
+
+mod importer;
+pub use importer::CsvImporter;
+
+#[cfg(test)]
+mod tests {
+    use dialog_artifacts::Exporter;
+    use dialog_artifacts::{Artifact, Cause, Value};
+    use futures_util::StreamExt;
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_service_worker);
+
+    fn test_artifacts() -> Vec<Artifact> {
+        vec![
+            Artifact {
+                the: "user/name".parse().unwrap(),
+                of: "user:alice".parse().unwrap(),
+                is: Value::String("Alice".into()),
+                cause: None,
+            },
+            Artifact {
+                the: "user/email".parse().unwrap(),
+                of: "user:alice".parse().unwrap(),
+                is: Value::String("alice@example.com".into()),
+                cause: None,
+            },
+            Artifact {
+                the: "user/name".parse().unwrap(),
+                of: "user:bob".parse().unwrap(),
+                is: Value::String("Bob".into()),
+                cause: None,
+            },
+        ]
+    }
+
+    async fn export_artifacts(artifacts: &[Artifact]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut exporter = CsvExporter::from(&mut buf);
+            for artifact in artifacts {
+                exporter.write(artifact).await.unwrap();
+            }
+            exporter.close().await.unwrap();
+        }
+        buf
+    }
+
+    async fn import_artifacts(csv: Vec<u8>) -> Vec<Artifact> {
+        CsvImporter::from(Cursor::new(csv))
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_roundtrips_artifacts() {
+        let artifacts = test_artifacts();
+        let csv = export_artifacts(&artifacts).await;
+        let imported = import_artifacts(csv).await;
+
+        assert_eq!(artifacts.len(), imported.len());
+        for (original, imported) in artifacts.iter().zip(imported.iter()) {
+            assert_eq!(original.the, imported.the);
+            assert_eq!(original.of, imported.of);
+            assert_eq!(original.is, imported.is);
+            assert_eq!(original.cause, imported.cause);
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_valid_csv() {
+        let artifacts = test_artifacts();
+        let csv = export_artifacts(&artifacts).await;
+        let content = String::from_utf8(csv).unwrap();
+
+        // Header + 3 data rows
+        assert_eq!(content.lines().count(), 4);
+        assert!(content.starts_with("the,of,as,is,cause\n"));
+    }
+
+    #[dialog_common::test]
+    async fn it_exports_empty_input() {
+        let csv = export_artifacts(&[]).await;
+        let content = String::from_utf8(csv).unwrap();
+
+        // Header only
+        assert!(
+            content.is_empty() || content.lines().count() <= 1,
+            "empty export should have at most a header"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_roundtrips_all_value_types() {
+        let artifacts = vec![
+            Artifact {
+                the: "test/string".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::String("hello world".into()),
+                cause: None,
+            },
+            Artifact {
+                the: "test/uint".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::UnsignedInt(12345),
+                cause: None,
+            },
+            Artifact {
+                the: "test/sint".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::SignedInt(-42),
+                cause: None,
+            },
+            Artifact {
+                the: "test/bool".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::Boolean(false),
+                cause: None,
+            },
+            Artifact {
+                the: "test/float".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::Float(1.23),
+                cause: None,
+            },
+            Artifact {
+                the: "test/bytes".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+                cause: None,
+            },
+            Artifact {
+                the: "test/entity".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::Entity("ref:other".parse().unwrap()),
+                cause: None,
+            },
+            Artifact {
+                the: "test/symbol".parse().unwrap(),
+                of: "item:1".parse().unwrap(),
+                is: Value::Symbol("meta/attribute".parse().unwrap()),
+                cause: None,
+            },
+        ];
+
+        let csv = export_artifacts(&artifacts).await;
+        let imported = import_artifacts(csv).await;
+
+        assert_eq!(artifacts.len(), imported.len());
+        for (original, imported) in artifacts.iter().zip(imported.iter()) {
+            assert_eq!(original.is, imported.is, "mismatch for {:?}", original.the);
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_roundtrips_cause() {
+        let base = Artifact {
+            the: "test/name".parse().unwrap(),
+            of: "item:1".parse().unwrap(),
+            is: Value::String("v1".into()),
+            cause: None,
+        };
+        let cause = Cause::from(&base);
+        let updated = Artifact {
+            the: "test/name".parse().unwrap(),
+            of: "item:1".parse().unwrap(),
+            is: Value::String("v2".into()),
+            cause: Some(cause.clone()),
+        };
+
+        let csv = export_artifacts(std::slice::from_ref(&updated)).await;
+        let imported = import_artifacts(csv).await;
+
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].cause, Some(cause));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn it_roundtrips_via_file() {
+        let artifacts = test_artifacts();
+
+        // Export to a temp file
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.csv");
+
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut exporter = CsvExporter::from(file);
+        for artifact in &artifacts {
+            exporter.write(artifact).await.unwrap();
+        }
+        exporter.close().await.unwrap();
+
+        // Import from the file
+        let file = tokio::fs::File::open(&path).await.unwrap();
+        let importer = CsvImporter::from(file);
+        let imported: Vec<Artifact> = importer
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(artifacts.len(), imported.len());
+        for (original, imported) in artifacts.iter().zip(imported.iter()) {
+            assert_eq!(original.the, imported.the);
+            assert_eq!(original.of, imported.of);
+            assert_eq!(original.is, imported.is);
+        }
+    }
+}

--- a/rust/dialog-csv/src/row.rs
+++ b/rust/dialog-csv/src/row.rs
@@ -1,0 +1,110 @@
+use base58::{FromBase58, ToBase58};
+use dialog_artifacts::{Artifact, Attribute, Cause, Entity, Value};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+use dialog_artifacts::DialogArtifactsError;
+
+/// Intermediate CSV row representation.
+///
+/// Converts between `Artifact` and flat text fields suitable for CSV.
+/// The value is split into a type column (`as`) and the raw text
+/// payload (`is`), rather than using a tagged `type:value` encoding.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct CsvRow {
+    pub the: String,
+    pub of: String,
+    #[serde(rename = "as")]
+    pub value_type: String,
+    pub is: String,
+    pub cause: Option<String>,
+}
+
+fn value_to_parts(value: &Value) -> (&'static str, String) {
+    match value {
+        Value::Bytes(bytes) => ("bytes", bytes.to_base58()),
+        Value::Entity(entity) => ("entity", entity.to_string()),
+        Value::Boolean(v) => ("boolean", v.to_string()),
+        Value::String(s) => ("text", s.clone()),
+        Value::UnsignedInt(n) => ("natural", n.to_string()),
+        Value::SignedInt(n) => ("integer", n.to_string()),
+        Value::Float(n) => ("float", n.to_string()),
+        Value::Record(record) => ("record", record.to_base58()),
+        Value::Symbol(attr) => ("attribute", attr.to_string()),
+    }
+}
+
+fn parts_to_value(value_type: &str, is: &str) -> Result<Value, DialogArtifactsError> {
+    fn parse_err<E: std::fmt::Debug>(e: E) -> DialogArtifactsError {
+        DialogArtifactsError::InvalidValue(format!("{:?}", e))
+    }
+
+    match value_type {
+        "bytes" => Ok(Value::Bytes(is.from_base58().map_err(parse_err)?)),
+        "entity" => Ok(Value::Entity(Entity::from_str(is)?)),
+        "boolean" => {
+            Ok(Value::Boolean(bool::from_str(is).map_err(|e| {
+                DialogArtifactsError::InvalidValue(e.to_string())
+            })?))
+        }
+        "text" => Ok(Value::String(is.to_owned())),
+        "natural" => {
+            Ok(Value::UnsignedInt(is.parse().map_err(|e| {
+                DialogArtifactsError::InvalidValue(format!("{e}"))
+            })?))
+        }
+        "integer" => {
+            Ok(Value::SignedInt(is.parse().map_err(|e| {
+                DialogArtifactsError::InvalidValue(format!("{e}"))
+            })?))
+        }
+        "float" => {
+            Ok(Value::Float(is.parse().map_err(|e| {
+                DialogArtifactsError::InvalidValue(format!("{e}"))
+            })?))
+        }
+        "record" => Ok(Value::Record(is.from_base58().map_err(parse_err)?)),
+        "attribute" => Ok(Value::Symbol(Attribute::from_str(is)?)),
+        _ => Err(DialogArtifactsError::InvalidValue(format!(
+            "unknown value type: {value_type}"
+        ))),
+    }
+}
+
+impl From<&Artifact> for CsvRow {
+    fn from(artifact: &Artifact) -> Self {
+        let (value_type, is) = value_to_parts(&artifact.is);
+        Self {
+            the: artifact.the.to_string(),
+            of: artifact.of.to_string(),
+            value_type: value_type.to_string(),
+            is,
+            cause: artifact.cause.as_ref().map(|c| c.to_base58()),
+        }
+    }
+}
+
+impl TryFrom<CsvRow> for Artifact {
+    type Error = DialogArtifactsError;
+
+    fn try_from(row: CsvRow) -> Result<Self, Self::Error> {
+        let the = Attribute::from_str(&row.the)?;
+        let of = Entity::from_str(&row.of)?;
+        let is = parts_to_value(&row.value_type, &row.is)?;
+        let cause = row
+            .cause
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                let bytes = s.from_base58().map_err(|e| {
+                    DialogArtifactsError::InvalidReference(format!("invalid base58: {:?}", e))
+                })?;
+                let mut hash = [0u8; 32];
+                let len = bytes.len().min(32);
+                hash[..len].copy_from_slice(&bytes[..len]);
+                Ok::<Cause, DialogArtifactsError>(Cause::from(hash))
+            })
+            .transpose()?;
+
+        Ok(Artifact { the, of, is, cause })
+    }
+}

--- a/rust/dialog-repository/src/lib.rs
+++ b/rust/dialog-repository/src/lib.rs
@@ -35,6 +35,8 @@
 mod repository;
 pub use repository::*;
 
+pub use dialog_artifacts::{Exporter, Importer};
+
 /// Test helpers for setting up profiles, operators, repositories, and test data.
 #[cfg(any(test, feature = "helpers"))]
 pub mod helpers;

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -1,6 +1,6 @@
 use super::memory::Cell;
 use crate::Revision;
-use dialog_artifacts::{Datum, Key, State};
+use dialog_artifacts::{Datum, Exporter, Importer, Key, State};
 use dialog_capability::{Capability, Did, Subject};
 use dialog_effects::archive::Archive;
 use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
@@ -14,8 +14,14 @@ pub use claims::*;
 mod commit;
 pub use commit::*;
 
+mod export;
+pub use export::*;
+
 mod fetch;
 pub use fetch::*;
+
+mod import;
+pub use import::*;
 
 mod load;
 pub use load::*;
@@ -97,6 +103,18 @@ impl Branch {
     /// Archive capability for this branch's subject.
     pub fn archive(&self) -> Capability<Archive> {
         self.subject().archive()
+    }
+
+    /// Export all artifacts from this branch to the given exporter.
+    pub fn export<E: Exporter>(&self, exporter: E) -> Export<'_, E> {
+        Export::new(self, exporter)
+    }
+
+    /// Import artifacts into this branch from the given importer.
+    ///
+    /// Each artifact read from the importer is committed as an assertion.
+    pub fn import<I: Importer>(&self, importer: I) -> Import<'_, I> {
+        Import::new(self, importer)
     }
 
     /// Query with an application. Shortcut for `branch.query().select(query)`.

--- a/rust/dialog-repository/src/repository/branch/export.rs
+++ b/rust/dialog-repository/src/repository/branch/export.rs
@@ -1,0 +1,80 @@
+use dialog_artifacts::{
+    Artifact, DialogArtifactsError, EntityKey, Exporter, Key, KeyViewConstruct, State,
+};
+use dialog_capability::{Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::memory::Resolve;
+use dialog_prolly_tree::{EMPT_TREE_HASH, Entry, Tree};
+use futures_util::TryStreamExt;
+
+use crate::{
+    Branch, Index, NetworkedIndex, RemoteSite, RepositoryArchiveExt as _, RepositoryMemoryExt,
+    Upstream,
+};
+
+/// Command struct for exporting all artifacts from a branch.
+pub struct Export<'a, E> {
+    branch: &'a Branch,
+    exporter: E,
+}
+
+impl<'a, E> Export<'a, E> {
+    pub(super) fn new(branch: &'a Branch, exporter: E) -> Self {
+        Self { branch, exporter }
+    }
+}
+
+impl<E: Exporter> Export<'_, E> {
+    /// Execute the export, writing all artifacts to the exporter.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), DialogArtifactsError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let mut exporter = self.exporter;
+
+        let remote = match branch.upstream() {
+            Some(Upstream::Remote { remote: name, .. }) => {
+                branch.subject().remote(name).load().perform(env).await.ok()
+            }
+            _ => None,
+        };
+
+        let catalog = branch.subject().archive().index();
+        let store = NetworkedIndex::new(env, catalog, remote);
+
+        let tree_hash = branch
+            .revision()
+            .as_ref()
+            .map(|rev| *rev.tree.hash())
+            .unwrap_or(EMPT_TREE_HASH);
+
+        let tree: Index = Tree::from_hash(&tree_hash, &store).await?;
+
+        let range = <EntityKey<Key> as KeyViewConstruct>::min().into_key()
+            ..<EntityKey<Key> as KeyViewConstruct>::max().into_key();
+
+        let stream = tree.stream_range(range, &store);
+        tokio::pin!(stream);
+
+        while let Some(entry) = stream.try_next().await? {
+            let Entry { value, .. } = entry;
+            if let State::Added(datum) = value {
+                let artifact = Artifact::try_from(datum)?;
+                exporter.write(&artifact).await?;
+            }
+        }
+
+        exporter.close().await?;
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/import.rs
+++ b/rust/dialog-repository/src/repository/branch/import.rs
@@ -1,0 +1,49 @@
+use dialog_artifacts::{Importer, Instruction};
+use dialog_capability::{Fork, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::authority::Identify;
+use dialog_effects::memory::{Publish, Resolve};
+use futures_util::StreamExt;
+
+use crate::{Branch, CommitError, RemoteSite, Revision};
+
+/// Command struct for importing artifacts into a branch.
+pub struct Import<'a, I> {
+    branch: &'a Branch,
+    importer: I,
+}
+
+impl<'a, I> Import<'a, I> {
+    pub(super) fn new(branch: &'a Branch, importer: I) -> Self {
+        Self { branch, importer }
+    }
+}
+
+impl<I: Importer + Unpin + ConditionalSend> Import<'_, I> {
+    /// Execute the import, reading artifacts and committing them as assertions.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Revision, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let instructions = self.importer.filter_map(|result| async {
+            match result {
+                Ok(artifact) => Some(Instruction::Assert(artifact)),
+                Err(error) => {
+                    eprintln!("Skipping incompatible datum: {error}");
+                    None
+                }
+            }
+        });
+
+        self.branch.commit(instructions).perform(env).await
+    }
+}


### PR DESCRIPTION
Add Exporter/Importer traits to dialog-artifacts for format-agnostic artifact serialization. Exporter uses write/close, Importer is a Stream.

Add dialog-csv crate implementing CSV format with columns: the, of, as (value type), is (value), cause. Value types use human-readable names (text, natural, integer, boolean, float, bytes, entity, attribute, record).

Add Branch::export/import methods to dialog-repository that wire the traits into the capability-based commit pipeline.