### PR TITLE
🔁 feat: add UCAN container format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "base64",
+ "dialog-common",
  "dialog-credentials",
  "dialog-varsig",
  "futures",

--- a/rust/dialog-ucan-core/Cargo.toml
+++ b/rust/dialog-ucan-core/Cargo.toml
@@ -27,6 +27,7 @@ web-time = { workspace = true }
 
 # Optional deps
 arbitrary = { workspace = true, optional = true }
+dialog-credentials = { workspace = true, optional = true }
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 proptest = { workspace = true, optional = true }
@@ -40,6 +41,7 @@ wasm-bindgen = { workspace = true }
 [dev-dependencies]
 arbitrary = { workspace = true }
 base64 = { workspace = true }
+dialog-common = { workspace = true, features = ["helpers"] }
 dialog-credentials = { workspace = true }
 ipld-core = { workspace = true, features = ["arb"] }
 pretty_assertions = { workspace = true }
@@ -60,3 +62,11 @@ default = []
 test_utils = ["arb", "property_test"]
 arb = ["dep:arbitrary", "ipld-core/arb"]
 property_test = ["dep:proptest", "dep:proptest-arbitrary-interop"]
+# Test helpers exposed for use by other crates (signer/delegation builders)
+helpers = ["dep:dialog-credentials"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(feature, values(\"web-integration-tests\"))",
+  "cfg(dialog_test_wasm_integration)",
+] }

--- a/rust/dialog-ucan-core/src/container.rs
+++ b/rust/dialog-ucan-core/src/container.rs
@@ -1,0 +1,194 @@
+//! UCAN Container format utilities.
+//!
+//! This module provides [`Container`], a type that represents a UCAN container
+//! following the [UCAN Container spec](https://github.com/ucan-wg/container).
+//!
+//! The container format is:
+//! ```text
+//! { "ctn-v1": [token_bytes_0, token_bytes_1, ..., token_bytes_n] }
+//! ```
+//!
+//! Where tokens are DAG-CBOR serialized UCANs.
+//!
+//! # Usage
+//!
+//! `Container` can be converted to/from:
+//! - [`DelegationChain`] - A chain of delegations
+//! - [`InvocationChain`] - An invocation with its delegation chain
+
+pub mod delegation;
+pub mod invocation;
+
+mod check_failed;
+pub use check_failed::check_failed_to_container_error;
+
+use ipld_core::ipld::Ipld;
+use std::collections::BTreeMap;
+use thiserror::Error;
+
+/// Errors that can occur when working with UCAN containers, delegation chains,
+/// and invocation chains.
+#[derive(Debug, Error)]
+pub enum ContainerError {
+    /// Failed to parse or validate a UCAN token/invocation.
+    #[error("Invocation error: {0}")]
+    Invocation(String),
+
+    /// Invalid configuration.
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+}
+
+/// UCAN Container version key
+pub const CONTAINER_VERSION: &str = "ctn-v1";
+
+/// A UCAN container holding a sequence of DAG-CBOR encoded tokens.
+///
+/// This is the wire format for UCAN delegation chains and invocation chains.
+/// The container is serialized as `{ "ctn-v1": [token_bytes...] }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Container {
+    /// The DAG-CBOR encoded tokens in order.
+    tokens: Vec<Vec<u8>>,
+}
+
+impl Container {
+    /// Create a new container with the given token bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `tokens` - Vector of DAG-CBOR encoded token bytes
+    pub fn new(tokens: Vec<Vec<u8>>) -> Self {
+        Self { tokens }
+    }
+
+    /// Get the tokens in this container.
+    pub fn tokens(&self) -> &[Vec<u8>] {
+        &self.tokens
+    }
+
+    /// Consume the container and return the tokens.
+    pub fn into_tokens(self) -> Vec<Vec<u8>> {
+        self.tokens
+    }
+
+    /// Parse a container from DAG-CBOR bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The bytes are not valid DAG-CBOR
+    /// - The container is missing the "ctn-v1" key
+    /// - The tokens array is invalid
+    /// - The container is empty
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ContainerError> {
+        // Deserialize as a map with "ctn-v1" key
+        let container: BTreeMap<String, Ipld> =
+            serde_ipld_dagcbor::from_slice(bytes).map_err(|e| {
+                ContainerError::Invocation(format!("failed to decode container: {}", e))
+            })?;
+
+        // Extract the token array under "ctn-v1"
+        let tokens_ipld = container.get(CONTAINER_VERSION).ok_or_else(|| {
+            ContainerError::Invocation(format!("missing '{}' key", CONTAINER_VERSION))
+        })?;
+
+        let Ipld::List(tokens) = tokens_ipld else {
+            return Err(ContainerError::Invocation(
+                "tokens must be an array".to_string(),
+            ));
+        };
+
+        if tokens.is_empty() {
+            return Err(ContainerError::Invocation(
+                "container must contain at least one token".to_string(),
+            ));
+        }
+
+        // Extract token bytes
+        let mut token_bytes: Vec<Vec<u8>> = Vec::with_capacity(tokens.len());
+        for (i, token) in tokens.iter().enumerate() {
+            let Ipld::Bytes(bytes) = token else {
+                return Err(ContainerError::Invocation(format!(
+                    "token {} must be bytes",
+                    i
+                )));
+            };
+            token_bytes.push(bytes.clone());
+        }
+
+        Ok(Self {
+            tokens: token_bytes,
+        })
+    }
+
+    /// Serialize the container to DAG-CBOR bytes.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ContainerError> {
+        // Build container: { "ctn-v1": [token_bytes...] }
+        let tokens: Vec<Ipld> = self.tokens.iter().cloned().map(Ipld::Bytes).collect();
+        let mut container: BTreeMap<String, Ipld> = BTreeMap::new();
+        container.insert(CONTAINER_VERSION.to_string(), Ipld::List(tokens));
+
+        serde_ipld_dagcbor::to_vec(&container)
+            .map_err(|e| ContainerError::Invocation(format!("failed to encode container: {}", e)))
+    }
+
+    /// Check if the container is empty.
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+
+    /// Get the number of tokens in the container.
+    pub fn len(&self) -> usize {
+        self.tokens.len()
+    }
+}
+
+impl TryFrom<&[u8]> for Container {
+    type Error = ContainerError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Self::from_bytes(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_roundtrips_through_bytes() {
+        let original_bytes = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+
+        let container = Container::new(original_bytes.clone());
+        let serialized = container.to_bytes().unwrap();
+        let parsed = Container::from_bytes(&serialized).unwrap();
+
+        assert_eq!(parsed.tokens(), &original_bytes[..]);
+    }
+
+    #[test]
+    fn it_fails_on_empty_container() {
+        let container = Container::new(vec![]);
+        let serialized = container.to_bytes().unwrap();
+        let result = Container::from_bytes(&serialized);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at least one token")
+        );
+    }
+
+    #[test]
+    fn it_fails_on_missing_version_key() {
+        let mut container: BTreeMap<String, Ipld> = BTreeMap::new();
+        container.insert("wrong-key".to_string(), Ipld::List(vec![]));
+        let bytes = serde_ipld_dagcbor::to_vec(&container).unwrap();
+
+        let result = Container::from_bytes(&bytes);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ctn-v1"));
+    }
+}

--- a/rust/dialog-ucan-core/src/container/check_failed.rs
+++ b/rust/dialog-ucan-core/src/container/check_failed.rs
@@ -1,0 +1,52 @@
+//! Conversion from [`CheckFailed`] (defined in `crate::invocation`) to
+//! [`ContainerError`]. A free function rather than a `From` impl because
+//! both types live outside this module's defining crate (orphan rule).
+
+use super::ContainerError;
+use crate::invocation::CheckFailed;
+
+/// Convert a `CheckFailed` error to a `ContainerError`.
+pub fn check_failed_to_container_error(err: CheckFailed) -> ContainerError {
+    match err {
+        CheckFailed::DelegationAudienceMismatch {
+            claimed,
+            authorized,
+        } => ContainerError::Invocation(format!(
+            "invalid proof issuer chain: claimed {} authorized {}",
+            claimed, authorized
+        )),
+        CheckFailed::UnauthorizedSubject {
+            claimed,
+            authorized,
+        } => ContainerError::Invocation(format!(
+            "subject not allowed by proof: claimed {} authorized {}",
+            claimed, authorized
+        )),
+        CheckFailed::UnprovenSubject { subject, issuer } => ContainerError::Invocation(format!(
+            "root proof issuer is not the subject: subject {} issuer {}",
+            subject, issuer
+        )),
+        CheckFailed::CommandEscalation {
+            claimed,
+            authorized,
+        } => ContainerError::Invocation(format!(
+            "command mismatch: expected {:?}, found {:?}",
+            authorized, claimed
+        )),
+        CheckFailed::PolicyViolation(predicate) => {
+            ContainerError::Invocation(format!("predicate failed: {:?}", predicate))
+        }
+        CheckFailed::PolicyIncompatibility(run_err) => {
+            ContainerError::Invocation(format!("predicate run error: {}", run_err))
+        }
+        CheckFailed::WaitingOnPromise(waiting) => {
+            ContainerError::Invocation(format!("waiting on promise: {:?}", waiting))
+        }
+        CheckFailed::InvalidTimeWindow { range } => {
+            ContainerError::Invocation(format!("invalid time window: {:?}", range))
+        }
+        CheckFailed::TimeBound(err) => {
+            ContainerError::Invocation(format!("time bound error: {:?}", err))
+        }
+    }
+}

--- a/rust/dialog-ucan-core/src/container/delegation.rs
+++ b/rust/dialog-ucan-core/src/container/delegation.rs
@@ -1,0 +1,743 @@
+//! UCAN delegation chain management.
+//!
+//! This module provides [`DelegationChain`], which represents a chain of UCAN delegations
+//! proving authority from a subject to an operator.
+//!
+//! Delegations are stored in subject-first (root-to-leaf) order:
+//! - Index 0 is the root delegation (closest to subject, its `iss` is the subject)
+//! - Last index is closest to the invoker (its `aud` is the operator)
+//!
+//! This matches the proof order expected by UCAN invocation verification.
+
+use super::{Container, ContainerError};
+use crate::Delegation;
+use crate::subject::Subject;
+use crate::time::Timestamp;
+use dialog_varsig::Did;
+use dialog_varsig::eddsa::Ed25519Signature;
+use ipld_core::cid::Cid;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// A chain of UCAN delegations proving authority over a subject.
+///
+/// A delegation chain consists of one or more delegations that together prove
+/// that the operator has been granted authority over a subject. Each delegation
+/// in the chain grants authority from one party to another, forming a chain
+/// from the subject (root authority) to the operator.
+///
+/// A chain must have at least one delegation. For cases where no delegations
+/// are present, use `Option<DelegationChain>` instead.
+#[derive(Debug, Clone)]
+pub struct DelegationChain {
+    /// The delegation proofs keyed by CID.
+    delegations: HashMap<Cid, Arc<Delegation<Ed25519Signature>>>,
+    /// The CIDs of the delegation proofs in subject-first (root-to-leaf) order.
+    /// This is guaranteed to be non-empty.
+    proof_cids: Vec<Cid>,
+}
+
+impl PartialEq for DelegationChain {
+    fn eq(&self, other: &Self) -> bool {
+        // Delegation chains are equal if they have the same proof CIDs
+        // (CIDs are content-addressed, so same CIDs means same content)
+        self.proof_cids == other.proof_cids
+    }
+}
+
+impl Eq for DelegationChain {}
+
+impl DelegationChain {
+    /// Create a new delegation chain with a single delegation.
+    ///
+    /// This is the primary constructor for creating a delegation chain from a single
+    /// root delegation (typically subject -> operator).
+    pub fn new(delegation: Delegation<Ed25519Signature>) -> Self {
+        let cid = delegation.to_cid();
+        let mut delegations = HashMap::with_capacity(1);
+        delegations.insert(cid, Arc::new(delegation));
+
+        Self {
+            delegations,
+            proof_cids: vec![cid],
+        }
+    }
+
+    /// Create from raw delegation bytes (deserializes each as a Delegation).
+    ///
+    /// This is a lower-level method that takes a list of DAG-CBOR encoded delegation bytes.
+    /// For parsing from the container format, use the `TryFrom<&[u8]>` implementation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bytes list is empty or if any delegation fails to deserialize.
+    pub fn from_delegation_bytes(proof_bytes: Vec<Vec<u8>>) -> Result<Self, ContainerError> {
+        if proof_bytes.is_empty() {
+            return Err(ContainerError::Configuration(
+                "DelegationChain requires at least one delegation".to_string(),
+            ));
+        }
+
+        let mut delegations_vec = Vec::with_capacity(proof_bytes.len());
+        for (i, bytes) in proof_bytes.iter().enumerate() {
+            let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
+                .map_err(|e| {
+                    ContainerError::Invocation(format!("failed to decode delegation {}: {}", i, e))
+                })?;
+            delegations_vec.push(delegation);
+        }
+        Self::try_from(delegations_vec)
+    }
+
+    /// Serialize to DAG-CBOR bytes in the UCAN container format.
+    ///
+    /// The container format is: `{ "ctn-v1": [delegation_0_bytes, ...] }`
+    /// where delegations are in subject-first (root-to-leaf) order.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ContainerError> {
+        Container::from(self).to_bytes()
+    }
+
+    /// Get the CIDs for use in invocation proofs field.
+    pub fn proof_cids(&self) -> &[Cid] {
+        &self.proof_cids
+    }
+
+    /// Get the delegations map for building InvocationChain.
+    pub fn delegations(&self) -> &HashMap<Cid, Arc<Delegation<Ed25519Signature>>> {
+        &self.delegations
+    }
+
+    /// Get the audience of the last delegation in the chain (closest to invoker).
+    ///
+    /// This is the operator/invoker DID.
+    /// Since the chain is guaranteed non-empty, this always returns a value.
+    pub fn audience(&self) -> &Did {
+        let cid = &self.proof_cids[self.proof_cids.len() - 1];
+        self.delegations.get(cid).unwrap().audience()
+    }
+
+    /// Get the subject of the delegation chain.
+    ///
+    /// The root delegation's (index 0) subject should match the claimed subject.
+    ///
+    /// Returns `None` if the delegation has no specific subject (i.e., `Subject::Any`).
+    pub fn subject(&self) -> Option<&Did> {
+        let cid = &self.proof_cids[0];
+        let delegation = self.delegations.get(cid).unwrap();
+        match delegation.subject() {
+            Subject::Specific(did) => Some(did),
+            Subject::Any => None,
+        }
+    }
+
+    /// Get the issuer of the root delegation (index 0, closest to subject).
+    ///
+    /// The root delegation's issuer is the original authority that started the
+    /// delegation chain. For powerline delegations (`Subject::Any`), this issuer
+    /// is typically used as the effective subject.
+    pub fn issuer(&self) -> &Did {
+        let cid = &self.proof_cids[0];
+        self.delegations.get(cid).unwrap().issuer()
+    }
+
+    /// Get the ability path of the last delegation (closest to invoker).
+    ///
+    /// Returns the ability as a string path (e.g., "/storage/get").
+    /// The leaf delegation defines the most attenuated capability.
+    pub fn ability(&self) -> String {
+        let cid = &self.proof_cids[self.proof_cids.len() - 1];
+        let delegation = self.delegations.get(cid).unwrap();
+        let cmd = delegation.command();
+        if cmd.0.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", cmd.0.join("/"))
+        }
+    }
+
+    /// The effective earliest validity time across all delegations.
+    ///
+    /// Returns the latest `not_before` in the chain (most restrictive).
+    /// `None` means no lower bound is imposed by any delegation.
+    pub fn not_before(&self) -> Option<Timestamp> {
+        self.proof_cids
+            .iter()
+            .filter_map(|cid| self.delegations.get(cid)?.not_before())
+            .max()
+    }
+
+    /// The effective expiration time across all delegations.
+    ///
+    /// Returns the earliest `expiration` in the chain (most restrictive).
+    /// `None` means no delegation in the chain expires.
+    pub fn expiration(&self) -> Option<Timestamp> {
+        self.proof_cids
+            .iter()
+            .filter_map(|cid| self.delegations.get(cid)?.expiration())
+            .min()
+    }
+
+    /// Push a delegation onto the chain (closer to invoker).
+    ///
+    /// Its issuer must match the current chain's audience.
+    pub fn push(&self, delegation: Delegation<Ed25519Signature>) -> Result<Self, ContainerError> {
+        let current_audience = self.audience();
+        let new_issuer = delegation.issuer();
+        if new_issuer != current_audience {
+            return Err(ContainerError::Invocation(format!(
+                "Principal alignment error: delegation issuer '{}' does not match chain audience '{}'",
+                new_issuer, current_audience
+            )));
+        }
+
+        let cid = delegation.to_cid();
+
+        let mut delegations = self.delegations.clone();
+        delegations.insert(cid, Arc::new(delegation));
+
+        let mut proof_cids = self.proof_cids.clone();
+        proof_cids.push(cid);
+
+        Ok(Self {
+            delegations,
+            proof_cids,
+        })
+    }
+}
+
+impl TryFrom<Vec<Delegation<Ed25519Signature>>> for DelegationChain {
+    type Error = ContainerError;
+
+    /// Create a delegation chain from a vector of delegations.
+    ///
+    /// The delegations must be in subject-first (root-to-leaf) order:
+    /// - delegations[0] is closest to subject (its `iss` is the subject)
+    /// - delegations[n-1] is closest to invoker (its `aud` is the operator)
+    ///
+    /// # Principal Alignment
+    ///
+    /// For each consecutive pair (i, i+1), the audience of delegation[i] must match
+    /// the issuer of delegation[i+1]. This ensures a proper chain of authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vector is empty or if principal alignment fails.
+    fn try_from(delegations_vec: Vec<Delegation<Ed25519Signature>>) -> Result<Self, Self::Error> {
+        if delegations_vec.is_empty() {
+            return Err(ContainerError::Configuration(
+                "DelegationChain requires at least one delegation".to_string(),
+            ));
+        }
+
+        // Verify principal alignment between consecutive delegations
+        // In subject-first order: delegation[i].aud must == delegation[i+1].iss
+        for i in 0..delegations_vec.len().saturating_sub(1) {
+            let current = &delegations_vec[i];
+            let next = &delegations_vec[i + 1];
+
+            if current.audience() != next.issuer() {
+                return Err(ContainerError::Invocation(format!(
+                    "Principal alignment error at position {}: delegation audience '{}' does not match next delegation issuer '{}'",
+                    i,
+                    current.audience(),
+                    next.issuer()
+                )));
+            }
+        }
+
+        let mut map = HashMap::with_capacity(delegations_vec.len());
+        let mut cids = Vec::with_capacity(delegations_vec.len());
+
+        for delegation in delegations_vec {
+            let cid = delegation.to_cid();
+            cids.push(cid);
+            map.insert(cid, Arc::new(delegation));
+        }
+
+        Ok(Self {
+            delegations: map,
+            proof_cids: cids,
+        })
+    }
+}
+
+impl From<Delegation<Ed25519Signature>> for DelegationChain {
+    fn from(delegation: Delegation<Ed25519Signature>) -> Self {
+        Self::new(delegation)
+    }
+}
+
+impl TryFrom<&[u8]> for DelegationChain {
+    type Error = ContainerError;
+
+    /// Deserialize a delegation chain from DAG-CBOR container format.
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let container = Container::from_bytes(bytes)?;
+        DelegationChain::try_from(container)
+    }
+}
+
+impl TryFrom<Container> for DelegationChain {
+    type Error = ContainerError;
+
+    /// Convert a container to a delegation chain.
+    fn try_from(container: Container) -> Result<Self, Self::Error> {
+        let token_bytes = container.into_tokens();
+
+        // Deserialize delegations and verify principal alignment
+        let mut delegations_vec: Vec<Delegation<Ed25519Signature>> =
+            Vec::with_capacity(token_bytes.len());
+        for (i, bytes) in token_bytes.iter().enumerate() {
+            let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
+                .map_err(|e| {
+                    ContainerError::Invocation(format!("failed to decode delegation {}: {}", i, e))
+                })?;
+            delegations_vec.push(delegation);
+        }
+
+        // Use TryFrom<Vec<...>> to get principal alignment validation
+        DelegationChain::try_from(delegations_vec)
+    }
+}
+
+impl From<&DelegationChain> for Container {
+    fn from(chain: &DelegationChain) -> Self {
+        // Serialize delegations in proof_cids order
+        let mut tokens: Vec<Vec<u8>> = Vec::with_capacity(chain.proof_cids.len());
+
+        for cid in &chain.proof_cids {
+            if let Some(delegation) = chain.delegations.get(cid) {
+                // Note: This unwrap is safe because we're serializing from a valid delegation
+                if let Ok(bytes) = serde_ipld_dagcbor::to_vec(delegation.as_ref()) {
+                    tokens.push(bytes);
+                }
+            }
+        }
+
+        Container::new(tokens)
+    }
+}
+
+impl Serialize for DelegationChain {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = self.to_bytes().map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for DelegationChain {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Use serde_bytes::ByteBuf to properly deserialize CBOR byte strings
+        let bytes: serde_bytes::ByteBuf = serde_bytes::ByteBuf::deserialize(deserializer)?;
+        DelegationChain::try_from(bytes.as_slice()).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Tests for delegation chains.
+///
+/// These are only compiled when running tests (not when `helpers` feature is enabled),
+/// because they use `#[dialog_common::test]` which requires dev-dependencies like
+/// `wasm-bindgen-test` and `tokio` that are only available in test builds.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DelegationBuilder;
+    use crate::helpers::*;
+    use crate::time::Timestamp;
+    use crate::time::timestamp::{Duration, UNIX_EPOCH};
+    use dialog_varsig::Principal;
+
+    #[test]
+    fn it_requires_non_empty_chain() {
+        let result = DelegationChain::try_from(vec![]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("at least one"));
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_chain_from_single_delegation() {
+        let space_signer = generate_signer().await;
+        let space_did = space_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(delegation);
+        assert_eq!(chain.proof_cids().len(), 1);
+        assert_eq!(chain.delegations().len(), 1);
+        assert_eq!(chain.audience(), &operator_signer.did());
+        assert_eq!(chain.subject(), Some(&space_did));
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_chain_from_vec() {
+        let space_signer = generate_signer().await;
+        let space_did = space_signer.did();
+        let operator1_signer = generate_signer().await;
+        let operator2_signer = generate_signer().await;
+
+        // First delegation: space -> operator1
+        let delegation1 = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator1_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        // Second delegation: operator1 -> operator2
+        let delegation2 = DelegationBuilder::new()
+            .issuer(operator1_signer.clone())
+            .audience(&operator2_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        // Subject-first order: root delegation first, leaf delegation last
+        let chain = DelegationChain::try_from(vec![delegation1, delegation2]).unwrap();
+        assert_eq!(chain.proof_cids().len(), 2);
+        assert_eq!(chain.delegations().len(), 2);
+    }
+
+    #[dialog_common::test]
+    async fn it_extends_chain_with_new_delegation() {
+        // Create initial delegation: space -> operator1
+        let space_signer = generate_signer().await;
+        let space_did = space_signer.did();
+        let operator1_signer = generate_signer().await;
+
+        let initial_delegation = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator1_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(initial_delegation);
+        assert_eq!(chain.proof_cids().len(), 1);
+
+        // Extend: operator1 -> operator2
+        let operator2_signer = generate_signer().await;
+
+        let second_delegation = DelegationBuilder::new()
+            .issuer(operator1_signer.clone())
+            .audience(&operator2_signer)
+            .subject(Subject::Specific(space_did))
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let extended_chain = chain.push(second_delegation).unwrap();
+
+        // Extended chain should have 2 delegations
+        assert_eq!(extended_chain.proof_cids().len(), 2);
+        assert_eq!(extended_chain.delegations().len(), 2);
+
+        // Original chain should be unchanged
+        assert_eq!(chain.proof_cids().len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_extend_on_principal_misalignment() {
+        // Create initial delegation: space -> operator1
+        let space_signer = generate_signer().await;
+        let space_did = space_signer.did();
+        let operator1_signer = generate_signer().await;
+
+        let initial_delegation = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator1_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(initial_delegation);
+
+        // Try to extend with wrong issuer (operator2 instead of operator1)
+        let operator2_signer = generate_signer().await;
+        let operator3_signer = generate_signer().await;
+
+        let bad_delegation = DelegationBuilder::new()
+            .issuer(operator2_signer.clone()) // Wrong! Should be operator1
+            .audience(&operator3_signer)
+            .subject(Subject::Specific(space_did))
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let result = chain.push(bad_delegation);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Principal alignment error")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_try_from_on_principal_misalignment() {
+        // Create delegations that don't align
+        let space_signer = generate_signer().await;
+        let space_did = space_signer.did();
+        let operator1_signer = generate_signer().await;
+        let operator2_signer = generate_signer().await;
+        let operator3_signer = generate_signer().await;
+
+        // Root delegation: space -> operator1 (closest to subject)
+        let delegation1 = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator1_signer) // Wrong! Should be operator2 for alignment
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        // Leaf delegation: operator2 -> operator3 (closest to invoker)
+        let delegation2 = DelegationBuilder::new()
+            .issuer(operator2_signer.clone())
+            .audience(&operator3_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        // Subject-first order: delegation1.aud (operator1) != delegation2.iss (operator2)
+        let result = DelegationChain::try_from(vec![delegation1, delegation2]);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Principal alignment error")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_serializes_and_deserializes_roundtrip() {
+        let space_signer = generate_signer().await;
+        let space_did = space_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(delegation);
+
+        // Serialize to bytes
+        let bytes = chain.to_bytes().unwrap();
+
+        // Deserialize back
+        let restored = DelegationChain::try_from(bytes.as_slice()).unwrap();
+
+        // Verify the chains match
+        assert_eq!(chain.proof_cids().len(), restored.proof_cids().len());
+        assert_eq!(chain.audience(), restored.audience());
+        assert_eq!(chain.subject(), restored.subject());
+    }
+
+    #[dialog_common::test]
+    async fn it_serde_roundtrips_via_dagcbor() {
+        let space_signer = generate_signer().await;
+        let space_did = space_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(space_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(delegation);
+
+        // Serialize via serde to DAG-CBOR (this uses serialize_bytes internally)
+        let cbor_bytes = serde_ipld_dagcbor::to_vec(&chain).unwrap();
+
+        // Deserialize via serde from DAG-CBOR (this uses dialog_common::Bytes)
+        let restored: DelegationChain = serde_ipld_dagcbor::from_slice(&cbor_bytes).unwrap();
+
+        // Verify the chains match
+        assert_eq!(chain, restored);
+        assert_eq!(chain.proof_cids(), restored.proof_cids());
+        assert_eq!(chain.audience(), restored.audience());
+        assert_eq!(chain.subject(), restored.subject());
+    }
+
+    /// Test that a delegation for archive capability roundtrips correctly.
+    /// This tests creating a delegation that grants /archive access.
+    #[dialog_common::test]
+    async fn it_roundtrips_archive_delegation() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        // Create delegation granting /archive capability
+        let delegation = DelegationBuilder::new()
+            .issuer(subject_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(subject_did.clone()))
+            .command(vec!["archive".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(delegation);
+
+        // Verify ability path
+        assert_eq!(chain.ability(), "/archive");
+
+        // Serialize and deserialize
+        let bytes = chain.to_bytes().unwrap();
+        let restored = DelegationChain::try_from(bytes.as_slice()).unwrap();
+
+        assert_eq!(chain, restored);
+        assert_eq!(restored.ability(), "/archive");
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_unbounded_when_no_time_constraints() {
+        let space_signer = generate_signer().await;
+        let operator_signer = generate_signer().await;
+
+        let delegation = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(space_signer.did()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(delegation);
+        assert!(chain.not_before().is_none());
+        assert!(chain.expiration().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_time_bounds_from_single_delegation() {
+        let space_signer = generate_signer().await;
+        let operator_signer = generate_signer().await;
+
+        let nbf = Timestamp::new(UNIX_EPOCH + Duration::from_secs(1000)).unwrap();
+        let exp = Timestamp::new(UNIX_EPOCH + Duration::from_secs(5000)).unwrap();
+
+        let delegation = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(space_signer.did()))
+            .command(vec!["storage".to_string()])
+            .not_before(nbf)
+            .expiration(exp)
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(delegation);
+        assert_eq!(chain.not_before(), Some(nbf));
+        assert_eq!(chain.expiration(), Some(exp));
+    }
+
+    #[dialog_common::test]
+    async fn it_computes_tightest_bounds_from_chain() {
+        let space_signer = generate_signer().await;
+        let mid_signer = generate_signer().await;
+        let operator_signer = generate_signer().await;
+
+        // First delegation: valid from 100 to 10000
+        let d1 = DelegationBuilder::new()
+            .issuer(space_signer.clone())
+            .audience(&mid_signer)
+            .subject(Subject::Specific(space_signer.did()))
+            .command(vec!["storage".to_string()])
+            .not_before(Timestamp::new(UNIX_EPOCH + Duration::from_secs(100)).unwrap())
+            .expiration(Timestamp::new(UNIX_EPOCH + Duration::from_secs(10000)).unwrap())
+            .try_build()
+            .await
+            .unwrap();
+
+        // Second delegation: valid from 500 to 5000 (tighter)
+        let d2 = DelegationBuilder::new()
+            .issuer(mid_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(space_signer.did()))
+            .command(vec!["storage".to_string()])
+            .not_before(Timestamp::new(UNIX_EPOCH + Duration::from_secs(500)).unwrap())
+            .expiration(Timestamp::new(UNIX_EPOCH + Duration::from_secs(5000)).unwrap())
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::try_from(vec![d1, d2]).unwrap();
+
+        // Effective bounds should be the tightest: not_before=500, expiration=5000
+        let nbf = chain.not_before().unwrap();
+        let exp = chain.expiration().unwrap();
+        assert_eq!(nbf.to_unix(), 500);
+        assert_eq!(exp.to_unix(), 5000);
+    }
+
+    /// Test that a delegation for archive/put capability roundtrips correctly.
+    /// This tests the more specific command path.
+    #[dialog_common::test]
+    async fn it_roundtrips_archive_put_delegation() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        // Create delegation granting /archive/put capability
+        let delegation = DelegationBuilder::new()
+            .issuer(subject_signer.clone())
+            .audience(&operator_signer)
+            .subject(Subject::Specific(subject_did.clone()))
+            .command(vec!["archive".to_string(), "put".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let chain = DelegationChain::new(delegation);
+
+        // Verify ability path
+        assert_eq!(chain.ability(), "/archive/put");
+
+        // Serialize via serde to DAG-CBOR
+        let cbor_bytes = serde_ipld_dagcbor::to_vec(&chain).unwrap();
+        let restored: DelegationChain = serde_ipld_dagcbor::from_slice(&cbor_bytes).unwrap();
+
+        assert_eq!(chain, restored);
+        assert_eq!(restored.ability(), "/archive/put");
+    }
+}

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -1,0 +1,917 @@
+//! UCAN invocation chain management.
+//!
+//! This module provides [`InvocationChain`], which represents a complete UCAN
+//! authorization bundle containing an invocation and its delegation proofs.
+//!
+//! # Container Format
+//!
+//! The UCAN container follows the [UCAN Container spec](https://github.com/ucan-wg/container):
+//!
+//! ```text
+//! { "ctn-v1": [token_bytes_0, token_bytes_1, ..., token_bytes_n] }
+//! ```
+//!
+//! Where tokens are DAG-CBOR serialized UCANs, ordered bytewise for determinism.
+//! The first token is the invocation, followed by the delegation chain from
+//! closest to invoker to root.
+
+use super::check_failed_to_container_error;
+use super::{Container, ContainerError};
+use crate::{
+    Delegation, Invocation,
+    invocation::{InvocationCheckError, StoredCheckError},
+};
+use dialog_varsig::Did;
+use dialog_varsig::Resolver;
+use dialog_varsig::Signature;
+use dialog_varsig::eddsa::Ed25519Signature;
+use ipld_core::cid::Cid;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{Arc, Mutex},
+};
+
+// On WASM, Ed25519 keys contain JsValue (via WebCrypto) which is !Send,
+// so we use Local (LocalBoxFuture) instead of Sendable (BoxFuture).
+#[cfg(target_arch = "wasm32")]
+use crate::future::Local as Runtime;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::future::Sendable as Runtime;
+
+/// In-memory delegation store for verification.
+type ProofStore<S> = Arc<Mutex<HashMap<Cid, Arc<Delegation<S>>>>>;
+
+/// An invocation with its delegation chain, parsed from a UCAN container.
+///
+/// This represents a complete authorization bundle containing:
+/// - The invocation (the signed command to execute)
+/// - The delegation chain (proofs of authority from subject to invoker)
+///
+/// The invocation references its proofs by CID, and the delegation chain
+/// provides those proofs for verification.
+#[derive(Debug, Clone)]
+pub struct InvocationChain<S: Signature> {
+    /// The signed invocation containing the command and arguments.
+    pub invocation: Invocation<S>,
+    /// The delegation chain as a map keyed by CID for proof lookup.
+    delegations: HashMap<Cid, Arc<Delegation<S>>>,
+}
+
+impl<S: Signature> InvocationChain<S> {
+    /// Create a new invocation chain from an invocation and delegations.
+    pub fn new(invocation: Invocation<S>, delegations: HashMap<Cid, Arc<Delegation<S>>>) -> Self {
+        Self {
+            invocation,
+            delegations,
+        }
+    }
+
+    /// Verify the invocation chain using rs-ucan's verification.
+    ///
+    /// This performs complete verification:
+    /// 1. Signature verification (issuer signed the invocation)
+    /// 2. Proof chain validation (issuer->subject chain via proofs)
+    /// 3. Command attenuation checks
+    /// 4. Policy predicate evaluation
+    ///
+    /// The invocation's `proofs` field contains CIDs that reference
+    /// delegations in the container. This method builds a store from
+    /// those delegations and uses rs-ucan's `Invocation::check` to verify.
+    pub async fn verify<R: Resolver<S>>(&self, resolver: &R) -> Result<(), ContainerError>
+    where
+        R::Error: std::error::Error,
+    {
+        // Build delegation store from our map
+        let store: ProofStore<S> = Arc::new(Mutex::new(self.delegations.clone()));
+
+        // Use rs-ucan's full verification
+        self.invocation
+            .check::<Runtime, _, _, _>(&store, resolver)
+            .await
+            .map(|_| ())
+            .map_err(|err| match err {
+                InvocationCheckError::SignatureVerification(sig_err) => {
+                    ContainerError::Invocation(format!("invalid signature: {}", sig_err))
+                }
+                InvocationCheckError::StoredCheck(stored_err) => match stored_err {
+                    StoredCheckError::GetError(get_err) => {
+                        ContainerError::Invocation(format!("proof not found: {}", get_err))
+                    }
+                    StoredCheckError::CheckFailed(check_err) => {
+                        check_failed_to_container_error(check_err)
+                    }
+                },
+            })
+    }
+
+    /// Get the command from the invocation.
+    pub fn command(&self) -> &crate::command::Command {
+        self.invocation.command()
+    }
+
+    /// Get the arguments from the invocation.
+    pub fn arguments(&self) -> &BTreeMap<String, crate::promise::Promised> {
+        self.invocation.arguments()
+    }
+
+    /// Get the subject (root authority) of the invocation.
+    pub fn subject(&self) -> &Did {
+        self.invocation.subject()
+    }
+
+    /// Get the issuer of the invocation.
+    pub fn issuer(&self) -> &Did {
+        self.invocation.issuer()
+    }
+
+    /// Get the proof CIDs referenced by the invocation.
+    pub fn proofs(&self) -> &Vec<Cid> {
+        self.invocation.proofs()
+    }
+}
+
+impl<S: Signature + Serialize> InvocationChain<S>
+where
+    Delegation<S>: Serialize,
+{
+    /// Serialize to DAG-CBOR bytes (UCAN container format).
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ContainerError> {
+        Container::from(self).to_bytes()
+    }
+}
+
+impl TryFrom<&[u8]> for InvocationChain<Ed25519Signature> {
+    type Error = ContainerError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let container = Container::from_bytes(bytes)?;
+        InvocationChain::try_from(container)
+    }
+}
+
+impl TryFrom<Container> for InvocationChain<Ed25519Signature> {
+    type Error = ContainerError;
+
+    /// Convert a container to an invocation chain.
+    ///
+    /// The first token must be the invocation, followed by the delegation chain.
+    fn try_from(container: Container) -> Result<Self, Self::Error> {
+        let token_bytes = container.into_tokens();
+
+        if token_bytes.is_empty() {
+            return Err(ContainerError::Invocation(
+                "container must contain at least an invocation".to_string(),
+            ));
+        }
+
+        // First token is the invocation
+        let invocation: Invocation<Ed25519Signature> =
+            serde_ipld_dagcbor::from_slice(&token_bytes[0]).map_err(|e| {
+                ContainerError::Invocation(format!("failed to decode invocation: {}", e))
+            })?;
+
+        // Remaining tokens are delegations - build a map keyed by CID
+        let mut delegations: HashMap<Cid, Arc<Delegation<Ed25519Signature>>> =
+            HashMap::with_capacity(token_bytes.len() - 1);
+        for (i, bytes) in token_bytes.iter().skip(1).enumerate() {
+            let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
+                .map_err(|e| {
+                    ContainerError::Invocation(format!("failed to decode delegation {}: {}", i, e))
+                })?;
+            let cid = delegation.to_cid();
+            delegations.insert(cid, Arc::new(delegation));
+        }
+
+        Ok(InvocationChain {
+            invocation,
+            delegations,
+        })
+    }
+}
+
+impl<S: Signature + Serialize> From<&InvocationChain<S>> for Container
+where
+    Delegation<S>: Serialize,
+{
+    fn from(chain: &InvocationChain<S>) -> Self {
+        let mut tokens: Vec<Vec<u8>> = Vec::with_capacity(1 + chain.delegations.len());
+
+        // First token is the invocation
+        if let Ok(invocation_bytes) = serde_ipld_dagcbor::to_vec(&chain.invocation) {
+            tokens.push(invocation_bytes);
+        }
+
+        // Add delegations in the order they appear in the invocation's proofs
+        for cid in chain.invocation.proofs() {
+            if let Some(delegation) = chain.delegations.get(cid)
+                && let Ok(delegation_bytes) = serde_ipld_dagcbor::to_vec(delegation.as_ref())
+            {
+                tokens.push(delegation_bytes);
+            }
+        }
+
+        Container::new(tokens)
+    }
+}
+
+impl<Sig: Signature + Serialize> Serialize for InvocationChain<Sig>
+where
+    Delegation<Sig>: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = self.to_bytes().map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for InvocationChain<Ed25519Signature> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Use serde_bytes::ByteBuf to properly deserialize CBOR byte strings
+        let bytes: serde_bytes::ByteBuf = serde_bytes::ByteBuf::deserialize(deserializer)?;
+        InvocationChain::try_from(bytes.as_slice()).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::{create_delegation, generate_signer};
+    use crate::subject::Subject;
+    use crate::{DelegationBuilder, InvocationBuilder};
+    use dialog_credentials::Ed25519KeyResolver;
+    use dialog_varsig::Principal;
+
+    /// Create a test invocation chain with a valid delegation.
+    async fn create_test_invocation_chain() -> (InvocationChain<Ed25519Signature>, Did) {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        // Create delegation: subject -> operator
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["storage", "get"],
+        )
+        .await
+        .expect("Failed to create delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        // Create invocation from operator
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+
+        (InvocationChain::new(invocation, delegations), subject_did)
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_invocation_chain() {
+        let (chain, subject_did) = create_test_invocation_chain().await;
+
+        assert_eq!(chain.subject(), &subject_did);
+        assert_eq!(chain.proofs().len(), 1);
+        assert_eq!(chain.command().to_string(), "/storage/get");
+    }
+
+    #[dialog_common::test]
+    async fn it_serializes_and_deserializes_roundtrip() {
+        let (chain, subject_did) = create_test_invocation_chain().await;
+
+        // Serialize to bytes
+        let bytes = chain.to_bytes().expect("Failed to serialize");
+
+        // Deserialize back
+        let restored = InvocationChain::try_from(bytes.as_slice()).expect("Failed to deserialize");
+
+        // Verify the chains match
+        assert_eq!(restored.subject(), &subject_did);
+        assert_eq!(restored.proofs().len(), chain.proofs().len());
+        assert_eq!(restored.command().to_string(), chain.command().to_string());
+    }
+
+    #[dialog_common::test]
+    async fn it_serde_roundtrips_via_dagcbor() {
+        let (chain, subject_did) = create_test_invocation_chain().await;
+
+        // Serialize via serde to DAG-CBOR (this uses serialize_bytes internally)
+        let cbor_bytes = serde_ipld_dagcbor::to_vec(&chain).expect("Failed to serialize");
+
+        // Deserialize via serde from DAG-CBOR (this uses dialog_common::Bytes)
+        let restored: InvocationChain<Ed25519Signature> =
+            serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
+
+        // Verify the chains match
+        assert_eq!(restored.subject(), &subject_did);
+        assert_eq!(restored.proofs().len(), chain.proofs().len());
+        assert_eq!(restored.command().to_string(), chain.command().to_string());
+    }
+
+    #[dialog_common::test]
+    async fn it_verifies_valid_chain() {
+        let (chain, _) = create_test_invocation_chain().await;
+
+        // Should verify successfully
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Expected verification to succeed: {:?}",
+            result
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_verification_when_proof_is_missing() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        // Create delegation but don't include it in the chain
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["storage"],
+        )
+        .await
+        .expect("Failed to create delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        // Create invocation referencing the delegation
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        // Create chain WITHOUT the delegation
+        let chain = InvocationChain::new(invocation, HashMap::new());
+
+        // Should fail verification due to missing proof
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("proof not found"));
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_verification_when_issuer_is_wrong() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+        let wrong_operator_signer = generate_signer().await;
+
+        // Create delegation to operator
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["storage"],
+        )
+        .await
+        .expect("Failed to create delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        // Create invocation from WRONG operator (not the delegation audience)
+        let invocation = InvocationBuilder::new()
+            .issuer(wrong_operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        // Should fail verification due to issuer mismatch
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(result.is_err());
+    }
+
+    #[dialog_common::test]
+    fn it_fails_on_empty_container() {
+        let container = Container::new(vec![]);
+        let result = InvocationChain::try_from(container);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at least an invocation")
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_fails_on_invalid_bytes() {
+        let container = Container::new(vec![vec![1, 2, 3, 4]]); // Invalid CBOR
+        let result = InvocationChain::try_from(container);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("failed to decode invocation")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_verifies_chain_with_powerline_delegation_in_middle() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let device1_signer = generate_signer().await;
+        let device2_signer = generate_signer().await;
+
+        // Root delegation: subject -> device1 (with specific subject)
+        let root_delegation = DelegationBuilder::new()
+            .issuer(subject_signer.clone())
+            .audience(&device1_signer)
+            .subject(Subject::Specific(subject_did.clone()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build root delegation");
+
+        let root_cid = root_delegation.to_cid();
+
+        // Powerline delegation: device1 -> device2 (with sub: null)
+        let powerline_delegation = DelegationBuilder::new()
+            .issuer(device1_signer.clone())
+            .audience(&device2_signer)
+            .subject(Subject::Any)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build powerline delegation");
+
+        let powerline_cid = powerline_delegation.to_cid();
+
+        // Invocation from device2
+        let invocation = InvocationBuilder::new()
+            .issuer(device2_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![root_cid, powerline_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(root_cid, Arc::new(root_delegation));
+        delegations.insert(powerline_cid, Arc::new(powerline_delegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Expected verification to succeed with powerline in middle: {:?}",
+            result
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_verification_with_powerline_at_root_wrong_subject() {
+        let device1_signer = generate_signer().await;
+        let device2_signer = generate_signer().await;
+        let some_other_subject = generate_signer().await.did();
+
+        let powerline_root = DelegationBuilder::new()
+            .issuer(device1_signer.clone())
+            .audience(&device2_signer)
+            .subject(Subject::Any)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build powerline delegation");
+
+        let powerline_cid = powerline_root.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(device2_signer.clone())
+            .audience(&some_other_subject)
+            .subject(&some_other_subject)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![powerline_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(powerline_cid, Arc::new(powerline_root));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_err(),
+            "Expected verification to fail when invocation subject doesn't match powerline root issuer"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_verifies_chain_with_powerline_at_root_matching_issuer() {
+        let device1_signer = generate_signer().await;
+        let device1_did = device1_signer.did();
+        let device2_signer = generate_signer().await;
+
+        let powerline_root = DelegationBuilder::new()
+            .issuer(device1_signer.clone())
+            .audience(&device2_signer)
+            .subject(Subject::Any)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build powerline delegation");
+
+        let powerline_cid = powerline_root.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(device2_signer.clone())
+            .audience(&device1_did)
+            .subject(&device1_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![powerline_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(powerline_cid, Arc::new(powerline_root));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Expected verification to succeed when invocation subject matches powerline root issuer: {:?}",
+            result
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_when_redelegation_after_powerline_root_uses_wrong_subject() {
+        let device1_signer = generate_signer().await;
+        let device2_signer = generate_signer().await;
+        let device3_signer = generate_signer().await;
+        let some_other_resource = generate_signer().await.did();
+
+        let powerline_root = DelegationBuilder::new()
+            .issuer(device1_signer.clone())
+            .audience(&device2_signer)
+            .subject(Subject::Any)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build powerline delegation");
+
+        let powerline_cid = powerline_root.to_cid();
+
+        let bad_redelegation = DelegationBuilder::new()
+            .issuer(device2_signer.clone())
+            .audience(&device3_signer)
+            .subject(Subject::Specific(some_other_resource.clone()))
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build redelegation");
+
+        let bad_cid = bad_redelegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(device3_signer.clone())
+            .audience(&some_other_resource)
+            .subject(&some_other_resource)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![powerline_cid, bad_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(powerline_cid, Arc::new(powerline_root));
+        delegations.insert(bad_cid, Arc::new(bad_redelegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_err(),
+            "Expected verification to fail when redelegation after powerline root uses wrong subject"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_verifies_when_redelegation_after_powerline_root_uses_correct_subject() {
+        let device1_signer = generate_signer().await;
+        let device1_did = device1_signer.did();
+        let device2_signer = generate_signer().await;
+        let device3_signer = generate_signer().await;
+
+        let powerline_root = DelegationBuilder::new()
+            .issuer(device1_signer.clone())
+            .audience(&device2_signer)
+            .subject(Subject::Any)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build powerline delegation");
+
+        let powerline_cid = powerline_root.to_cid();
+
+        let valid_redelegation = DelegationBuilder::new()
+            .issuer(device2_signer.clone())
+            .audience(&device3_signer)
+            .subject(Subject::Specific(device1_did.clone()))
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build redelegation");
+
+        let valid_cid = valid_redelegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(device3_signer.clone())
+            .audience(&device1_did)
+            .subject(&device1_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![powerline_cid, valid_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(powerline_cid, Arc::new(powerline_root));
+        delegations.insert(valid_cid, Arc::new(valid_redelegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Expected verification to succeed when redelegation after powerline root uses correct subject: {:?}",
+            result
+        );
+    }
+
+    /// Test invocation chain with archive/put command roundtrips correctly.
+    #[dialog_common::test]
+    async fn it_roundtrips_archive_put_invocation() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["archive"],
+        )
+        .await
+        .expect("Failed to create delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["archive".to_string(), "put".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        assert_eq!(chain.command().to_string(), "/archive/put");
+
+        let bytes = chain.to_bytes().expect("Failed to serialize");
+        let restored = InvocationChain::try_from(bytes.as_slice()).expect("Failed to deserialize");
+
+        assert_eq!(restored.command().to_string(), "/archive/put");
+        assert_eq!(restored.subject(), &subject_did);
+    }
+
+    /// Test invocation chain with serde DAG-CBOR roundtrip for archive/put.
+    #[dialog_common::test]
+    async fn it_serde_roundtrips_archive_put_invocation() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["archive"],
+        )
+        .await
+        .expect("Failed to create delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["archive".to_string(), "put".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let cbor_bytes = serde_ipld_dagcbor::to_vec(&chain).expect("Failed to serialize");
+
+        let restored: InvocationChain<Ed25519Signature> =
+            serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
+
+        assert_eq!(restored.command().to_string(), "/archive/put");
+        assert_eq!(restored.subject(), &subject_did);
+    }
+
+    /// Test that a delegation granting /archive can authorize an /archive/put invocation.
+    #[dialog_common::test]
+    async fn it_verifies_archive_delegation_authorizes_archive_put_invocation() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["archive"],
+        )
+        .await
+        .expect("Failed to create delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["archive".to_string(), "put".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Expected /archive delegation to authorize /archive/put invocation: {:?}",
+            result
+        );
+    }
+
+    /// Test the full chain: delegation grants /archive, invocation uses /archive/put,
+    /// and we verify the chain can be serialized, deserialized, and still verify.
+    #[dialog_common::test]
+    async fn it_roundtrips_and_verifies_archive_to_put_chain() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["archive"],
+        )
+        .await
+        .expect("Failed to create delegation");
+
+        let delegation_cid = delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["archive".to_string(), "put".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+
+        let original_chain = InvocationChain::new(invocation, delegations);
+
+        assert!(
+            original_chain.verify(&Ed25519KeyResolver).await.is_ok(),
+            "Original chain should verify"
+        );
+
+        let cbor_bytes = serde_ipld_dagcbor::to_vec(&original_chain).expect("Failed to serialize");
+
+        let restored_chain: InvocationChain<Ed25519Signature> =
+            serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
+
+        let result = restored_chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Restored chain should still verify: {:?}",
+            result
+        );
+
+        assert_eq!(
+            restored_chain.command().to_string(),
+            original_chain.command().to_string()
+        );
+        assert_eq!(restored_chain.subject(), original_chain.subject());
+        assert_eq!(restored_chain.proofs().len(), original_chain.proofs().len());
+    }
+
+    #[dialog_common::test]
+    async fn it_verifies_self_invocation_with_empty_proofs() {
+        let signer = generate_signer().await;
+        let did = signer.did();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(signer.clone())
+            .audience(&did)
+            .subject(&did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let chain = InvocationChain::new(invocation, HashMap::new());
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Self-invocation (issuer == subject, empty proofs) should verify: {:?}",
+            result
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_self_invocation_with_wrong_subject() {
+        let signer = generate_signer().await;
+        let other_subject = generate_signer().await.did();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(signer.clone())
+            .audience(&other_subject)
+            .subject(&other_subject)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let chain = InvocationChain::new(invocation, HashMap::new());
+
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_err(),
+            "Invocation with issuer != subject and no proofs should fail verification"
+        );
+    }
+}

--- a/rust/dialog-ucan-core/src/helpers.rs
+++ b/rust/dialog-ucan-core/src/helpers.rs
@@ -1,0 +1,40 @@
+//! Test helpers for building delegation chains.
+//!
+//! These are gated behind the `helpers` feature so other crates' tests can
+//! reuse them without re-implementing the wire format or signer setup.
+
+use super::ContainerError;
+use crate::DelegationBuilder;
+use crate::delegation::Delegation;
+use crate::subject::Subject;
+use dialog_credentials::Ed25519Signer;
+use dialog_varsig::Principal;
+use dialog_varsig::eddsa::Ed25519Signature;
+
+/// Generate a new random Ed25519 signer.
+///
+/// This is useful for creating space signers in tests.
+pub async fn generate_signer() -> Ed25519Signer {
+    Ed25519Signer::generate()
+        .await
+        .expect("Failed to generate signer")
+}
+
+/// Create a delegation from issuer to audience for a subject with the given command.
+///
+/// This is a convenience function for building simple delegations in tests.
+pub async fn create_delegation(
+    issuer: &Ed25519Signer,
+    audience: &impl Principal,
+    subject: &impl Principal,
+    command: &[&str],
+) -> Result<Delegation<Ed25519Signature>, ContainerError> {
+    DelegationBuilder::new()
+        .issuer(issuer.clone())
+        .audience(audience)
+        .subject(Subject::Specific(subject.did()))
+        .command(command.iter().map(|&s| s.to_string()).collect())
+        .try_build()
+        .await
+        .map_err(|e| ContainerError::Invocation(format!("Failed to build delegation: {:?}", e)))
+}

--- a/rust/dialog-ucan-core/src/lib.rs
+++ b/rust/dialog-ucan-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cid;
 pub mod codec;
 pub mod collection;
 pub mod command;
+pub mod container;
 pub mod crypto;
 pub mod delegation;
 pub mod envelope;
@@ -22,10 +23,16 @@ pub mod task;
 pub mod time;
 pub mod unset;
 
+#[cfg(any(test, feature = "helpers"))]
+pub mod helpers;
+
 // Internal modules
 mod ipld;
 mod sealed;
 
+pub use container::delegation::DelegationChain;
+pub use container::invocation::InvocationChain;
+pub use container::{Container, ContainerError};
 pub use delegation::{
     Delegation,
     builder::{BuildError as DelegationBuildError, DelegationBuilder},


### PR DESCRIPTION
Parallel rebase of #269 onto the v2/v3 chain.

Adds DelegationChain and InvocationChain UCAN container format on top of the
`feat/ucan-core-rename-v2` (#308) base.

In addition to the original work in #269, this rebase:
- Lifts test helpers out of `container/delegation.rs` into a top-level
  `helpers` module (was buried inside delegation.rs and reached into via
  `super::super::delegation::helpers` from invocation tests)
- Splits `check_failed_to_container_error` into `container/check_failed.rs`
- Adds a `helpers` cargo feature so other crates' tests can reuse the
  signer/delegation builders without re-implementing them