### PR TITLE
🔁 feat: add dialog-operator crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-operator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base58",
+ "blake3",
+ "dialog-artifacts",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-effects",
+ "dialog-remote-s3",
+ "dialog-remote-ucan-s3",
+ "dialog-storage",
+ "dialog-ucan",
+ "dialog-ucan-core",
+ "dialog-varsig",
+ "dirs",
+ "ed25519-dalek",
+ "getrandom 0.2.16",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "reqwest",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "signature",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "dialog-common",
  "dialog-credentials",
  "dialog-effects",
+ "dialog-network",
  "dialog-remote-s3",
  "dialog-remote-ucan-s3",
  "dialog-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "rust/dialog-remote-s3",
     "rust/dialog-remote-ucan-s3",
     "rust/dialog-network",
+    "rust/dialog-operator",
     "rust/dialog-varsig",
     "rust/dialog-blobs",
 ]
@@ -202,3 +203,6 @@ path = "./rust/dialog-remote-s3"
 
 [workspace.dependencies.dialog-remote-ucan-s3]
 path = "./rust/dialog-remote-ucan-s3"
+
+[workspace.dependencies.dialog-operator]
+path = "./rust/dialog-operator"

--- a/rust/dialog-operator/Cargo.toml
+++ b/rust/dialog-operator/Cargo.toml
@@ -1,0 +1,79 @@
+[package]
+name = "dialog-operator"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["s3"]
+helpers = ["dep:anyhow"]
+# Enable integration tests (tests with service provisioning)
+integration-tests = ["dialog-common/integration-tests"]
+# Enable web integration tests
+web-integration-tests = ["dialog-common/web-integration-tests"]
+s3 = ["dep:dialog-remote-s3"]
+
+[dependencies]
+dialog-artifacts = { workspace = true }
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-effects = { workspace = true }
+dialog-ucan-core = { workspace = true }
+dialog-remote-s3 = { workspace = true, optional = true }
+dialog-remote-ucan-s3 = { workspace = true }
+dialog-ucan = { workspace = true }
+dialog-storage = { workspace = true }
+dialog-varsig = { workspace = true }
+anyhow = { workspace = true, optional = true }
+async-trait = { workspace = true }
+base58 = { workspace = true }
+blake3 = { workspace = true }
+ed25519-dalek = { workspace = true }
+rand = { workspace = true }
+rand_core = { workspace = true }
+rand_chacha = { workspace = true }
+serde = { workspace = true }
+signature = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "io-util"] }
+[dev-dependencies]
+dialog-storage = { workspace = true, features = ["helpers"] }
+dialog-remote-s3 = { workspace = true, features = ["helpers"] }
+dialog-remote-ucan-s3 = { workspace = true, features = ["helpers"] }
+dialog-common = { workspace = true, features = ["helpers"] }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dirs = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "io-util", "fs"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+reqwest = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = [
+    "io-util",
+    "io-std",
+    "sync",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }
+
+[lints.rust]
+# This cfg is used by the dialog_common::test proc macro for wasm inner tests
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(dialog_test_wasm_integration)"] }

--- a/rust/dialog-operator/Cargo.toml
+++ b/rust/dialog-operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dialog-operator"
-edition = "2024"
+edition.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -9,13 +9,12 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["s3"]
+default = []
 helpers = ["dep:anyhow"]
 # Enable integration tests (tests with service provisioning)
 integration-tests = ["dialog-common/integration-tests"]
 # Enable web integration tests
 web-integration-tests = ["dialog-common/web-integration-tests"]
-s3 = ["dep:dialog-remote-s3"]
 
 [dependencies]
 dialog-artifacts = { workspace = true }
@@ -23,9 +22,8 @@ dialog-capability = { workspace = true }
 dialog-common = { workspace = true }
 dialog-credentials = { workspace = true }
 dialog-effects = { workspace = true }
+dialog-network = { workspace = true }
 dialog-ucan-core = { workspace = true }
-dialog-remote-s3 = { workspace = true, optional = true }
-dialog-remote-ucan-s3 = { workspace = true }
 dialog-ucan = { workspace = true }
 dialog-storage = { workspace = true }
 dialog-varsig = { workspace = true }

--- a/rust/dialog-operator/README.md
+++ b/rust/dialog-operator/README.md
@@ -1,0 +1,34 @@
+# dialog-operator
+
+Profiles, operators, and the runtime capability environment for Dialog.
+
+A **Profile** is a named identity on a device, backed by a signing credential. An **Operator** is a session-scoped environment derived from a profile that routes all capability effects (storage, archive, memory, access control) through DID-based dispatch with privilege narrowing.
+
+## Usage
+
+```rust
+use dialog_operator::profile::Profile;
+use dialog_capability::Subject;
+use dialog_storage::provider::environment::Storage;
+
+// Create the environment (platform-specific storage)
+let storage = Storage::default();
+
+// Open or create a profile
+let profile = Profile::open("alice")
+    .perform(&storage)
+    .await?;
+
+// Derive an operator (narrows access, scoped to profile)
+let operator = profile
+    .derive(b"my-app")
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+
+// Open a repository through the profile
+let contacts = profile.repository("contacts")
+    .open()
+    .perform(&operator)
+    .await?;
+```

--- a/rust/dialog-operator/src/authority.rs
+++ b/rust/dialog-operator/src/authority.rs
@@ -1,0 +1,109 @@
+//! Authority — opened profile with signers and authority chain.
+//!
+//! [`Authority`] holds the profile and operator signers and implements
+//! the provider traits needed by `Operator` for identity effects.
+
+use dialog_capability::{Capability, Provider, Subject};
+use dialog_credentials::Ed25519Signer;
+use dialog_effects::authority::{self, AuthorityError, Operator as AuthOperator};
+use dialog_varsig::{Did, Principal};
+
+/// An opened profile with profile and operator signers.
+///
+/// Implements `Provider<Identify>` and `Principal` so the capability
+/// system can resolve identity.
+/// Built by [`OperatorBuilder`](crate::operator::OperatorBuilder).
+#[derive(Debug, Clone)]
+pub struct Authority {
+    name: String,
+    profile: Ed25519Signer,
+    operator: Ed25519Signer,
+    account: Option<Did>,
+}
+
+impl Authority {
+    /// Create an opened profile from existing signers.
+    pub fn new(name: impl Into<String>, profile: Ed25519Signer, operator: Ed25519Signer) -> Self {
+        Self {
+            name: name.into(),
+            profile,
+            operator,
+            account: None,
+        }
+    }
+
+    /// Set the account DID.
+    pub fn with_account(mut self, account: Did) -> Self {
+        self.account = Some(account);
+        self
+    }
+
+    /// Get the profile name.
+    pub fn profile_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the profile DID.
+    pub fn profile_did(&self) -> Did {
+        Principal::did(&self.profile)
+    }
+
+    /// Get the operator DID.
+    pub fn operator_did(&self) -> Did {
+        Principal::did(&self.operator)
+    }
+
+    /// Get the account DID, if configured.
+    pub fn account_did(&self) -> Option<&Did> {
+        self.account.as_ref()
+    }
+
+    /// Get a reference to the profile signer.
+    pub fn profile_signer(&self) -> &Ed25519Signer {
+        &self.profile
+    }
+
+    /// Get a reference to the operator signer.
+    pub fn operator_signer(&self) -> &Ed25519Signer {
+        &self.operator
+    }
+
+    /// Build the authority chain for the given subject DID.
+    pub fn build_authority(&self, subject: Did) -> Capability<AuthOperator> {
+        Subject::from(subject)
+            .attenuate(authority::Profile {
+                profile: self.profile_did(),
+                account: self.account.clone(),
+            })
+            .attenuate(authority::Operator {
+                operator: self.operator_did(),
+            })
+    }
+}
+
+impl Principal for Authority {
+    fn did(&self) -> Did {
+        self.operator_did()
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<authority::Identify> for Authority {
+    async fn execute(
+        &self,
+        input: Capability<authority::Identify>,
+    ) -> Result<Capability<AuthOperator>, AuthorityError> {
+        let subject_did = input.subject().clone();
+        Ok(self.build_authority(subject_did))
+    }
+}
+
+impl serde::Serialize for Authority {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.operator.serialize(serializer)
+    }
+}

--- a/rust/dialog-operator/src/authority.rs
+++ b/rust/dialog-operator/src/authority.rs
@@ -8,6 +8,10 @@ use dialog_credentials::Ed25519Signer;
 use dialog_effects::authority::{self, AuthorityError, Operator as AuthOperator};
 use dialog_varsig::{Did, Principal};
 
+// Authority always answers for the current session, regardless of which
+// repository we're operating on. We use the profile DID as the subject
+// of the returned chain since that's the identity the chain describes.
+
 /// An opened profile with profile and operator signers.
 ///
 /// Implements `Provider<Identify>` and `Principal` so the capability
@@ -92,10 +96,9 @@ impl Principal for Authority {
 impl Provider<authority::Identify> for Authority {
     async fn execute(
         &self,
-        input: Capability<authority::Identify>,
+        _input: authority::Identify,
     ) -> Result<Capability<AuthOperator>, AuthorityError> {
-        let subject_did = input.subject().clone();
-        Ok(self.build_authority(subject_did))
+        Ok(self.build_authority(self.profile_did()))
     }
 }
 

--- a/rust/dialog-operator/src/helpers.rs
+++ b/rust/dialog-operator/src/helpers.rs
@@ -1,0 +1,121 @@
+use std::str::FromStr;
+
+use crate::network::Network;
+use crate::operator::Operator;
+use crate::profile::Profile;
+use crate::{Artifact, Attribute, Entity, Value};
+use anyhow::Result;
+use base58::ToBase58;
+use dialog_capability::Subject;
+use dialog_storage::provider::storage::{Storage, VolatileSpace};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Generate a unique name with a prefix for test isolation.
+pub fn unique_name(prefix: &str) -> String {
+    use dialog_common::time;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let ts = time::now()
+        .duration_since(time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{ts}-{seq}")
+}
+
+/// Build a test operator with a fresh profile and powerline delegation.
+pub async fn test_operator() -> Operator<VolatileSpace> {
+    let storage = Storage::volatile();
+    let profile = Profile::open(unique_name("test"))
+        .perform(&storage)
+        .await
+        .unwrap();
+    profile
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network)
+        .build(storage)
+        .await
+        .unwrap()
+}
+
+/// Build a test operator and return both the operator and the profile.
+pub async fn test_operator_with_profile() -> (Operator<VolatileSpace>, Profile) {
+    let storage = Storage::volatile();
+    let profile = Profile::open(unique_name("test"))
+        .perform(&storage)
+        .await
+        .unwrap();
+    let operator = profile
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network)
+        .build(storage)
+        .await
+        .unwrap();
+    (operator, profile)
+}
+
+/// Generate deterministic test data consisting of facts that reference a
+/// specified number of [`Entity`]s.
+pub fn generate_data(entity_count: usize) -> Result<Vec<Artifact>> {
+    let item_id_attribute = Attribute::from_str("item/id")?;
+    let item_name_attribute = Attribute::from_str("item/name")?;
+    let item_pointer_attribute = Attribute::from_str("attribute/pointer")?;
+    let back_reference_attribute = Attribute::from_str("back/reference")?;
+    let parent_attribute = Attribute::from_str("relationship/parentOf")?;
+
+    let mut rng = ChaCha8Rng::from_seed([0u8; 32]);
+    let mut data = vec![];
+    let mut make_entity = || {
+        Entity::try_from(format!("entity:{}", rng.r#gen::<[u8; 32]>().to_base58()))
+            .expect("Failed to generate random entity")
+    };
+    let mut last_entity: Option<Entity> = None;
+
+    for i in 0..entity_count {
+        let entity = make_entity();
+
+        data.push(Artifact {
+            the: item_pointer_attribute.clone(),
+            of: entity.clone(),
+            is: Value::Symbol(parent_attribute.clone()),
+            cause: None,
+        });
+
+        data.push(Artifact {
+            the: item_id_attribute.clone(),
+            of: entity.clone(),
+            is: Value::UnsignedInt(i as u128),
+            cause: None,
+        });
+
+        data.push(Artifact {
+            the: item_name_attribute.clone(),
+            of: entity.clone(),
+            is: Value::String(format!("name{i}")),
+            cause: None,
+        });
+
+        if let Some(parent_entity) = last_entity {
+            data.push(Artifact {
+                the: parent_attribute.clone(),
+                of: entity.clone(),
+                is: Value::Entity(parent_entity.clone()),
+                cause: None,
+            });
+        }
+
+        data.push(Artifact {
+            the: back_reference_attribute.clone(),
+            of: make_entity(),
+            is: Value::Entity(entity.clone()),
+            cause: None,
+        });
+
+        last_entity = Some(entity);
+    }
+
+    Ok(data)
+}

--- a/rust/dialog-operator/src/helpers.rs
+++ b/rust/dialog-operator/src/helpers.rs
@@ -34,7 +34,7 @@ pub async fn test_operator() -> Operator<VolatileSpace> {
     profile
         .derive(b"test")
         .allow(Subject::any())
-        .network(Network)
+        .network(Network::default())
         .build(storage)
         .await
         .unwrap()
@@ -50,7 +50,7 @@ pub async fn test_operator_with_profile() -> (Operator<VolatileSpace>, Profile) 
     let operator = profile
         .derive(b"test")
         .allow(Subject::any())
-        .network(Network)
+        .network(Network::default())
         .build(storage)
         .await
         .unwrap();

--- a/rust/dialog-operator/src/lib.rs
+++ b/rust/dialog-operator/src/lib.rs
@@ -1,0 +1,42 @@
+#![warn(missing_docs)]
+#![warn(clippy::absolute_paths)]
+#![warn(clippy::default_trait_access)]
+#![warn(clippy::fallible_impl_from)]
+#![warn(clippy::panicking_unwrap)]
+#![warn(clippy::unused_async)]
+#![deny(clippy::partial_pub_fields)]
+#![deny(clippy::unnecessary_self_imports)]
+#![cfg_attr(not(test), warn(clippy::large_futures))]
+#![cfg_attr(not(test), deny(clippy::panic))]
+
+//! Operator layer for Dialog-DB.
+//!
+//! This crate provides the capability-based operator system: authority
+//! credentials, profiles, operator builders, and network dispatch that
+//! together form the operational layer above the core artifact store.
+
+// Re-export core artifact types for convenience.
+pub use dialog_artifacts::{
+    Artifact, ArtifactSelector, ArtifactStore, ArtifactStoreMut, Artifacts, Attribute,
+    AttributeKey, Cause, Datum, DialogArtifactsError, Entity, EntityKey, FromKey, Instruction, Key,
+    KeyView, KeyViewConstruct, KeyViewMut, State, Value, ValueKey,
+};
+
+/// Authority — opened profile with signers and authority chain.
+pub mod authority;
+pub use authority::Authority;
+
+/// Profile — named identity with signing credential.
+pub mod profile;
+
+/// Operator — operating environment built from a profile.
+pub mod operator;
+pub use operator::Operator;
+
+/// Network dispatch for fork invocations.
+pub mod network;
+pub use network::Network;
+
+/// Test helpers for setting up profiles, operators, and test data.
+#[cfg(any(test, feature = "helpers"))]
+pub mod helpers;

--- a/rust/dialog-operator/src/network.rs
+++ b/rust/dialog-operator/src/network.rs
@@ -1,0 +1,61 @@
+//! Network dispatch — routes `ForkInvocation<S, Fx>` to the appropriate site provider.
+//!
+//! [`Network`] implements `Provider<ForkInvocation<S3, Fx>>` (and optionally
+//! `Provider<ForkInvocation<UcanSite, Fx>>` with the `ucan` feature) by delegating
+//! to the stateless site executors.
+//!
+//! The Operator builds the authorization (converting `Fork` to `ForkInvocation`)
+//! before delegating here.
+
+/// Network dispatch — routes fork invocations to the appropriate site.
+///
+/// Both `S3` and `UcanSite` are stateless, so `Network::default()` is all
+/// you need. The Operator routes `ForkInvocation<S, Fx>` here after building
+/// the protocol-specific authorization.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Network;
+
+#[cfg(feature = "s3")]
+mod s3_dispatch {
+    use super::Network;
+    use async_trait::async_trait;
+    use dialog_capability::fork::ForkInvocation;
+    use dialog_capability::{Constraint, Effect, Provider};
+    use dialog_remote_s3::S3;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl<Fx> Provider<ForkInvocation<S3, Fx>> for Network
+    where
+        Fx: Effect + 'static,
+        Fx::Of: Constraint,
+        ForkInvocation<S3, Fx>: dialog_common::ConditionalSend,
+        S3: Provider<ForkInvocation<S3, Fx>>,
+    {
+        async fn execute(&self, input: ForkInvocation<S3, Fx>) -> Fx::Output {
+            input.perform(&S3).await
+        }
+    }
+}
+
+mod ucan_dispatch {
+    use super::Network;
+    use async_trait::async_trait;
+    use dialog_capability::fork::ForkInvocation;
+    use dialog_capability::{Constraint, Effect, Provider};
+    use dialog_remote_ucan_s3::UcanSite;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl<Fx> Provider<ForkInvocation<UcanSite, Fx>> for Network
+    where
+        Fx: Effect + 'static,
+        Fx::Of: Constraint,
+        ForkInvocation<UcanSite, Fx>: dialog_common::ConditionalSend,
+        UcanSite: Provider<ForkInvocation<UcanSite, Fx>>,
+    {
+        async fn execute(&self, input: ForkInvocation<UcanSite, Fx>) -> Fx::Output {
+            input.perform(&UcanSite).await
+        }
+    }
+}

--- a/rust/dialog-operator/src/network.rs
+++ b/rust/dialog-operator/src/network.rs
@@ -1,61 +1,7 @@
-//! Network dispatch — routes `ForkInvocation<S, Fx>` to the appropriate site provider.
+//! Re-export of [`dialog_network::Network`] for backwards compatibility.
 //!
-//! [`Network`] implements `Provider<ForkInvocation<S3, Fx>>` (and optionally
-//! `Provider<ForkInvocation<UcanSite, Fx>>` with the `ucan` feature) by delegating
-//! to the stateless site executors.
-//!
-//! The Operator builds the authorization (converting `Fork` to `ForkInvocation`)
-//! before delegating here.
+//! The composite `Network` site (and its `NetworkAddress`,
+//! `NetworkAuthorization`, `NetworkFork` companions) lives in the
+//! `dialog-network` crate.
 
-/// Network dispatch — routes fork invocations to the appropriate site.
-///
-/// Both `S3` and `UcanSite` are stateless, so `Network::default()` is all
-/// you need. The Operator routes `ForkInvocation<S, Fx>` here after building
-/// the protocol-specific authorization.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Network;
-
-#[cfg(feature = "s3")]
-mod s3_dispatch {
-    use super::Network;
-    use async_trait::async_trait;
-    use dialog_capability::fork::ForkInvocation;
-    use dialog_capability::{Constraint, Effect, Provider};
-    use dialog_remote_s3::S3;
-
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-    impl<Fx> Provider<ForkInvocation<S3, Fx>> for Network
-    where
-        Fx: Effect + 'static,
-        Fx::Of: Constraint,
-        ForkInvocation<S3, Fx>: dialog_common::ConditionalSend,
-        S3: Provider<ForkInvocation<S3, Fx>>,
-    {
-        async fn execute(&self, input: ForkInvocation<S3, Fx>) -> Fx::Output {
-            input.perform(&S3).await
-        }
-    }
-}
-
-mod ucan_dispatch {
-    use super::Network;
-    use async_trait::async_trait;
-    use dialog_capability::fork::ForkInvocation;
-    use dialog_capability::{Constraint, Effect, Provider};
-    use dialog_remote_ucan_s3::UcanSite;
-
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-    impl<Fx> Provider<ForkInvocation<UcanSite, Fx>> for Network
-    where
-        Fx: Effect + 'static,
-        Fx::Of: Constraint,
-        ForkInvocation<UcanSite, Fx>: dialog_common::ConditionalSend,
-        UcanSite: Provider<ForkInvocation<UcanSite, Fx>>,
-    {
-        async fn execute(&self, input: ForkInvocation<UcanSite, Fx>) -> Fx::Output {
-            input.perform(&UcanSite).await
-        }
-    }
-}
+pub use dialog_network::{Network, NetworkAddress, NetworkAuthorization, NetworkFork};

--- a/rust/dialog-operator/src/operator.rs
+++ b/rust/dialog-operator/src/operator.rs
@@ -13,8 +13,10 @@ pub use builder::{OperatorBuilder, OperatorError};
 
 use crate::Authority;
 use crate::network::Network;
-use dialog_capability::Capability;
+use dialog_capability::{Capability, Provider};
+use dialog_credentials::Credential;
 use dialog_effects::authority::{Identify, Operator as AuthOperator};
+use dialog_effects::credential::Secret;
 use dialog_effects::storage as storage_fx;
 use dialog_effects::{archive, credential, memory};
 use dialog_storage::provider::storage::Storage;
@@ -27,7 +29,7 @@ use dialog_varsig::{Did, Principal};
 /// - [`Storage`] for DID-routed effects
 /// - Base directory for resolving space names to storage locations
 /// - Remote for fork invocations
-#[derive(dialog_capability::Provider)]
+#[derive(Provider)]
 pub struct Operator<S: Clone> {
     #[provide(Identify)]
     /// Provider for authority effects (identity).
@@ -36,8 +38,10 @@ pub struct Operator<S: Clone> {
     #[provide(
         archive::Get,
         archive::Put,
-        credential::Load,
-        credential::Save,
+        credential::Load<Credential>,
+        credential::Save<Credential>,
+        credential::Load<Secret>,
+        credential::Save<Secret>,
         memory::Resolve,
         memory::Publish,
         memory::Retract

--- a/rust/dialog-operator/src/operator.rs
+++ b/rust/dialog-operator/src/operator.rs
@@ -1,0 +1,76 @@
+//! Operator — an operating environment built from a Profile.
+//!
+//! Build one via `Profile::derive()`.
+
+mod access;
+mod builder;
+mod fork;
+mod space;
+#[cfg(test)]
+mod test;
+
+pub use builder::{OperatorBuilder, OperatorError};
+
+use crate::Authority;
+use crate::network::Network;
+use dialog_capability::Capability;
+use dialog_effects::authority::{Identify, Operator as AuthOperator};
+use dialog_effects::storage as storage_fx;
+use dialog_effects::{archive, credential, memory};
+use dialog_storage::provider::storage::Storage;
+use dialog_varsig::{Did, Principal};
+
+/// An operating environment built from a [`Profile`](crate::profile::Profile).
+///
+/// Composes:
+/// - Authority credentials (identity)
+/// - [`Storage`] for DID-routed effects
+/// - Base directory for resolving space names to storage locations
+/// - Remote for fork invocations
+#[derive(dialog_capability::Provider)]
+pub struct Operator<S: Clone> {
+    #[provide(Identify)]
+    /// Provider for authority effects (identity).
+    authority: Authority,
+
+    #[provide(
+        archive::Get,
+        archive::Put,
+        credential::Load,
+        credential::Save,
+        memory::Resolve,
+        memory::Publish,
+        memory::Retract
+    )]
+    /// Storage — routes DID-based effects.
+    storage: Storage<S>,
+
+    /// Base directory for resolving space names.
+    directory: storage_fx::Directory,
+
+    /// Network dispatch for fork invocations.
+    network: Network,
+}
+
+impl<S: Clone> Operator<S> {
+    /// The operator's DID (the ephemeral/derived session key).
+    pub fn did(&self) -> Did {
+        self.authority.operator_did()
+    }
+
+    /// The profile's DID (the long-lived identity).
+    pub fn profile_did(&self) -> Did {
+        self.authority.profile_did()
+    }
+
+    /// Build the authority chain for a given subject DID.
+    pub fn build_authority(&self, subject: Did) -> Capability<AuthOperator> {
+        self.authority.build_authority(subject)
+    }
+}
+
+impl<S: Clone> Principal for Operator<S> {
+    fn did(&self) -> Did {
+        self.authority.operator_did()
+    }
+}

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -1,10 +1,13 @@
 //! Access capability providers for Operator.
 
 use super::Operator;
-use dialog_capability::Capability;
 use dialog_capability::Provider;
-use dialog_capability::access::{AuthorizeError, Protocol, Prove, Retain};
+use dialog_capability::access::{
+    Access, Authorize, AuthorizeError, Proof as _, Protocol, Prove, Retain,
+};
+use dialog_capability::{Capability, Subject};
 use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_credentials::Ed25519Signer;
 use dialog_storage::provider::storage::Storage;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -36,5 +39,36 @@ where
 {
     async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
         input.perform(&self.storage).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S, P> Provider<Authorize<P>> for Operator<S>
+where
+    S: Clone + ConditionalSend + ConditionalSync + 'static,
+    P: Protocol,
+    P::Access: Clone + ConditionalSend + ConditionalSync,
+    P::Certificate: Clone + ConditionalSend + ConditionalSync,
+    P::Proof: ConditionalSend,
+    P::Signer: From<Ed25519Signer>,
+    P::Authorization: ConditionalSend,
+    Storage<S>: Provider<Prove<P>>,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        input: Capability<Authorize<P>>,
+    ) -> Result<P::Authorization, AuthorizeError> {
+        let subject = input.subject().clone();
+        let prove: Prove<P> = input.into_effect().into();
+
+        let proof = Subject::from(subject)
+            .attenuate(Access)
+            .invoke(prove)
+            .perform(&self.storage)
+            .await?;
+
+        proof.claim(self.authority.operator_signer().clone().into())
     }
 }

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -1,0 +1,40 @@
+//! Access capability providers for Operator.
+
+use super::Operator;
+use dialog_capability::Capability;
+use dialog_capability::Provider;
+use dialog_capability::access::{AuthorizeError, Protocol, Prove, Retain};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_storage::provider::storage::Storage;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S, P> Provider<Prove<P>> for Operator<S>
+where
+    S: Clone + ConditionalSend + ConditionalSync + 'static,
+    P: Protocol,
+    P::Access: Clone + ConditionalSend + ConditionalSync,
+    P::Certificate: Clone + ConditionalSend + ConditionalSync,
+    P::Proof: ConditionalSend,
+    Storage<S>: Provider<Prove<P>>,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
+        input.perform(&self.storage).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S, P> Provider<Retain<P>> for Operator<S>
+where
+    S: Clone + ConditionalSend + ConditionalSync + 'static,
+    P: Protocol,
+    P::Delegation: ConditionalSend + ConditionalSync,
+    Storage<S>: Provider<Retain<P>>,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
+        input.perform(&self.storage).await
+    }
+}

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -1,0 +1,178 @@
+//! Builder for constructing an Operator from a Profile.
+
+use crate::Authority;
+use crate::network::Network;
+use crate::profile::Profile;
+use crate::profile::access::Access as ProfileAccess;
+use dialog_capability::access::{Access, Authorization as _, Proof as _, Prove, Retain};
+use dialog_capability::{Ability, Provider, Subject};
+use dialog_credentials::key::KeyExport;
+use dialog_credentials::{Ed25519Signer, SignerCredential};
+use dialog_effects::storage::Directory;
+use dialog_storage::provider::space::SpaceProvider;
+use dialog_storage::provider::storage::Storage;
+use dialog_ucan::{Scope, Ucan};
+use dialog_varsig::Principal;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use dialog_varsig::Signer;
+
+use super::Operator;
+
+const OPERATOR_DERIVATION_CONTEXT: &str = "dialog-db operator derivation";
+
+/// Builder for constructing an Operator from a Profile.
+pub struct OperatorBuilder {
+    credential: SignerCredential,
+    context: Vec<u8>,
+    allowed: Vec<Scope>,
+    directory: Directory,
+    network: Network,
+}
+
+impl OperatorBuilder {
+    pub(crate) fn new(profile: &Profile, context: Vec<u8>) -> Self {
+        Self {
+            credential: profile.credential().clone(),
+            context,
+            allowed: Vec::new(),
+            directory: Directory::Current,
+            network: Network,
+        }
+    }
+
+    /// Set the base directory for resolving space names.
+    ///
+    /// Defaults to `Directory::Current`.
+    pub fn base(mut self, directory: Directory) -> Self {
+        self.directory = directory;
+        self
+    }
+
+    /// Allow a capability: creates a delegation from profile to operator.
+    pub fn allow<T, C>(mut self, capability: C) -> Self
+    where
+        T: dialog_capability::Constraint,
+        C: Into<dialog_capability::Capability<T>>,
+        dialog_capability::Capability<T>: Ability,
+    {
+        let cap = capability.into();
+        self.allowed.push(Scope::from(&cap));
+        self
+    }
+
+    /// Set the network dispatch provider.
+    pub fn network(mut self, network: Network) -> Self {
+        self.network = network;
+        self
+    }
+
+    /// Build the operator, deriving the operator key.
+    pub async fn build<S>(self, storage: Storage<S>) -> Result<Operator<S>, OperatorError>
+    where
+        S: SpaceProvider + Clone + 'static,
+        S: Provider<Prove<Ucan>>,
+        S: Provider<Retain<Ucan>>,
+    {
+        let operator_signer = derive_operator(&self.credential, &self.context).await?;
+        let credentials = Authority::new(
+            "operator",
+            Ed25519Signer::from(self.credential.clone()),
+            operator_signer,
+        );
+
+        let operator = Operator {
+            authority: credentials.clone(),
+            storage,
+            directory: self.directory,
+            network: self.network,
+        };
+
+        // Create delegations for allowed capabilities
+        if !self.allowed.is_empty() {
+            let profile_did = self.credential.did();
+            let signer = Ed25519Signer::from(self.credential.clone());
+            let access = ProfileAccess::new(&self.credential);
+            let operator_did = credentials.operator_did();
+
+            for scope in &self.allowed {
+                // Prove authority (self-grant for profile)
+                let proof = Subject::from(profile_did.clone())
+                    .attenuate(Access)
+                    .invoke(Prove::<Ucan>::new(profile_did.clone(), scope.clone()))
+                    .perform(&operator)
+                    .await
+                    .map_err(|e| OperatorError::Delegation(e.to_string()))?;
+
+                // Sign and delegate to operator
+                let authorization = proof
+                    .claim(signer.clone())
+                    .map_err(|e| OperatorError::Delegation(e.to_string()))?;
+
+                let delegation = authorization
+                    .delegate(operator_did.clone())
+                    .await
+                    .map_err(|e| OperatorError::Delegation(e.to_string()))?;
+
+                // Retain the delegation under the profile
+                access
+                    .save(delegation)
+                    .perform(&operator)
+                    .await
+                    .map_err(|e| OperatorError::Delegation(e.to_string()))?;
+            }
+        }
+
+        Ok(operator)
+    }
+}
+
+async fn derive_operator(
+    credential: &SignerCredential,
+    context: &[u8],
+) -> Result<Ed25519Signer, OperatorError> {
+    let signer = Ed25519Signer::from(credential.clone());
+    let export = signer
+        .export()
+        .await
+        .map_err(|e| OperatorError::Key(e.to_string()))?;
+
+    match export {
+        KeyExport::Extractable(ref seed) => {
+            let mut key_material = seed.clone();
+            key_material.extend_from_slice(context);
+
+            let derived = blake3::derive_key(OPERATOR_DERIVATION_CONTEXT, &key_material);
+            Ed25519Signer::import(&derived)
+                .await
+                .map_err(|e| OperatorError::Key(e.to_string()))
+        }
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        KeyExport::NonExtractable { .. } => {
+            let mut derivation_input = OPERATOR_DERIVATION_CONTEXT.as_bytes().to_vec();
+            derivation_input.extend_from_slice(context);
+
+            let signature = signer
+                .sign(&derivation_input)
+                .await
+                .map_err(|e| OperatorError::Key(e.to_string()))?;
+
+            let sig_bytes: [u8; 64] = signature.into();
+            let derived = blake3::derive_key(OPERATOR_DERIVATION_CONTEXT, &sig_bytes);
+            Ed25519Signer::import(&derived)
+                .await
+                .map_err(|e| OperatorError::Key(e.to_string()))
+        }
+    }
+}
+
+/// Errors that can occur when building an Operator.
+#[derive(Debug, thiserror::Error)]
+pub enum OperatorError {
+    /// Key derivation or generation failed.
+    #[error("Key error: {0}")]
+    Key(String),
+
+    /// Delegation creation failed.
+    #[error("Delegation error: {0}")]
+    Delegation(String),
+}

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -32,11 +32,11 @@ pub struct OperatorBuilder {
 impl OperatorBuilder {
     pub(crate) fn new(profile: &Profile, context: Vec<u8>) -> Self {
         Self {
-            credential: profile.credential().clone(),
+            credential: profile.signer().clone(),
             context,
             allowed: Vec::new(),
             directory: Directory::Current,
-            network: Network,
+            network: Network::default(),
         }
     }
 

--- a/rust/dialog-operator/src/operator/fork.rs
+++ b/rust/dialog-operator/src/operator/fork.rs
@@ -1,79 +1,57 @@
-//! Fork dispatch providers for Operator.
+//! Fork dispatch provider for Operator.
+//!
+//! Calls [`Fork::authorize`] to produce a [`ForkInvocation`], then
+//! delegates execution to the network layer. The site's own fork
+//! wrapper fetches identity from the env via `authority::Identify`.
 
-use super::Operator;
-use dialog_capability::Capability;
-use dialog_capability::Provider;
-use dialog_capability::access::{AuthorizeError, Prove, Retain};
-use dialog_capability::fork::{Fork, ForkInvocation};
-use dialog_capability::{Constraint, Effect};
-use dialog_common::{ConditionalSend, ConditionalSync};
-
+use crate::Operator;
 use crate::network::Network;
 
-#[cfg(feature = "s3")]
-mod s3 {
-    use super::*;
-    use dialog_remote_s3::S3;
+use dialog_capability::SiteFork;
+use dialog_capability::access::AuthorizeError;
+use dialog_capability::{Effect, Provider};
+use dialog_capability::{Fork, ForkInvocation, Site};
+use dialog_common::{ConditionalSend, ConditionalSync};
 
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-    impl<S, Fx> Provider<Fork<S3, Fx>> for Operator<S>
-    where
-        S: Clone + ConditionalSend + ConditionalSync + 'static,
-        Fx: Effect + 'static,
-        Fx::Of: Constraint,
-        Fx::Output: ConditionalSend,
-        Fork<S3, Fx>: ConditionalSend,
-        ForkInvocation<S3, Fx>: ConditionalSend,
-        Network: Provider<ForkInvocation<S3, Fx>> + ConditionalSync,
-        Self: ConditionalSend + ConditionalSync,
-    {
-        async fn execute(&self, input: Fork<S3, Fx>) -> Result<Fx::Output, AuthorizeError> {
-            let (capability, address) = input.into_parts();
-            let invocation = ForkInvocation::new(capability, address, ());
-            Ok(invocation.perform(&self.network).await)
-        }
+/// Helper trait for effect outputs that can absorb authorization errors.
+///
+/// All our effects return `Result<T, E>` where `E: From<AuthorizeError>`.
+/// Enables converting authorization failures into effect-specific errors
+/// (e.g., `AuthorizeError` -> `ArchiveError::Authorization`).
+trait FromAuthError {
+    fn from_auth_error(e: AuthorizeError) -> Self;
+}
+
+impl<T, E: From<AuthorizeError>> FromAuthError for Result<T, E> {
+    fn from_auth_error(e: AuthorizeError) -> Self {
+        Err(E::from(e))
     }
 }
 
-mod ucan {
-    use super::*;
-    use dialog_capability::Ability;
-    use dialog_capability::access::{self, Authorization as _, Proof as _};
-    use dialog_remote_ucan_s3::UcanSite;
-    use dialog_storage::provider::space::SpaceProvider;
-    use dialog_ucan::scope::Scope as UcanScope;
-    use dialog_ucan::{Ucan, UcanProofChain};
-
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-    impl<S, Fx> Provider<Fork<UcanSite, Fx>> for Operator<S>
-    where
-        S: SpaceProvider + Clone + 'static + Provider<Prove<Ucan>> + Provider<Retain<Ucan>>,
-        Fx: Effect + Clone + ConditionalSend + 'static,
-        Fx::Of: Constraint,
-        Capability<Fx>: Ability + ConditionalSend + ConditionalSync,
-        Fork<UcanSite, Fx>: ConditionalSend,
-        ForkInvocation<UcanSite, Fx>: ConditionalSend,
-        Network: Provider<ForkInvocation<UcanSite, Fx>> + ConditionalSync,
-        Self: ConditionalSend + ConditionalSync,
-    {
-        async fn execute(&self, input: Fork<UcanSite, Fx>) -> Result<Fx::Output, AuthorizeError> {
-            let (capability, address) = input.into_parts();
-
-            let scope = UcanScope::invoke(&capability);
-
-            let proof_chain: UcanProofChain = dialog_capability::Subject::from(self.profile_did())
-                .attenuate(access::Access)
-                .invoke(access::Prove::<Ucan>::new(self.did(), scope))
-                .perform(self)
-                .await?;
-
-            let authorization = proof_chain.claim(self.authority.operator_signer().clone())?;
-            let ucan_invocation = authorization.invoke().await?;
-
-            let invocation = ForkInvocation::new(capability, address, ucan_invocation);
-            Ok(invocation.perform(&self.network).await)
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<A, At, Fx> Provider<Fork<At, Fx>> for Operator<A>
+where
+    // Operator's storage provider type
+    A: Clone + ConditionalSend + ConditionalSync + 'static,
+    At: Site,
+    // Site's own fork wrapper carries the Authorize impl that fetches
+    // identity from the env and produces a ForkInvocation.
+    At::Fork<Fx>: SiteFork<Self, Site = At, Effect = Fx> + ConditionalSend,
+    Fx: Effect + 'static,
+    // Needed to flatten AuthorizeError into effect error via FromAuthError
+    Fx::Output: FromAuthError,
+    // Required by async_trait for Send futures
+    Fork<At, Fx>: ConditionalSend,
+    ForkInvocation<At, Fx>: ConditionalSend,
+    // Network dispatches the authorized invocation to the site provider
+    Network: Provider<ForkInvocation<At, Fx>> + ConditionalSync,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(&self, input: Fork<At, Fx>) -> Fx::Output {
+        match input.authorize(self).await {
+            Ok(invocation) => invocation.perform(&self.network).await,
+            Err(e) => FromAuthError::from_auth_error(e),
         }
     }
 }

--- a/rust/dialog-operator/src/operator/fork.rs
+++ b/rust/dialog-operator/src/operator/fork.rs
@@ -1,0 +1,79 @@
+//! Fork dispatch providers for Operator.
+
+use super::Operator;
+use dialog_capability::Capability;
+use dialog_capability::Provider;
+use dialog_capability::access::{AuthorizeError, Prove, Retain};
+use dialog_capability::fork::{Fork, ForkInvocation};
+use dialog_capability::{Constraint, Effect};
+use dialog_common::{ConditionalSend, ConditionalSync};
+
+use crate::network::Network;
+
+#[cfg(feature = "s3")]
+mod s3 {
+    use super::*;
+    use dialog_remote_s3::S3;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl<S, Fx> Provider<Fork<S3, Fx>> for Operator<S>
+    where
+        S: Clone + ConditionalSend + ConditionalSync + 'static,
+        Fx: Effect + 'static,
+        Fx::Of: Constraint,
+        Fx::Output: ConditionalSend,
+        Fork<S3, Fx>: ConditionalSend,
+        ForkInvocation<S3, Fx>: ConditionalSend,
+        Network: Provider<ForkInvocation<S3, Fx>> + ConditionalSync,
+        Self: ConditionalSend + ConditionalSync,
+    {
+        async fn execute(&self, input: Fork<S3, Fx>) -> Result<Fx::Output, AuthorizeError> {
+            let (capability, address) = input.into_parts();
+            let invocation = ForkInvocation::new(capability, address, ());
+            Ok(invocation.perform(&self.network).await)
+        }
+    }
+}
+
+mod ucan {
+    use super::*;
+    use dialog_capability::Ability;
+    use dialog_capability::access::{self, Authorization as _, Proof as _};
+    use dialog_remote_ucan_s3::UcanSite;
+    use dialog_storage::provider::space::SpaceProvider;
+    use dialog_ucan::scope::Scope as UcanScope;
+    use dialog_ucan::{Ucan, UcanProofChain};
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl<S, Fx> Provider<Fork<UcanSite, Fx>> for Operator<S>
+    where
+        S: SpaceProvider + Clone + 'static + Provider<Prove<Ucan>> + Provider<Retain<Ucan>>,
+        Fx: Effect + Clone + ConditionalSend + 'static,
+        Fx::Of: Constraint,
+        Capability<Fx>: Ability + ConditionalSend + ConditionalSync,
+        Fork<UcanSite, Fx>: ConditionalSend,
+        ForkInvocation<UcanSite, Fx>: ConditionalSend,
+        Network: Provider<ForkInvocation<UcanSite, Fx>> + ConditionalSync,
+        Self: ConditionalSend + ConditionalSync,
+    {
+        async fn execute(&self, input: Fork<UcanSite, Fx>) -> Result<Fx::Output, AuthorizeError> {
+            let (capability, address) = input.into_parts();
+
+            let scope = UcanScope::invoke(&capability);
+
+            let proof_chain: UcanProofChain = dialog_capability::Subject::from(self.profile_did())
+                .attenuate(access::Access)
+                .invoke(access::Prove::<Ucan>::new(self.did(), scope))
+                .perform(self)
+                .await?;
+
+            let authorization = proof_chain.claim(self.authority.operator_signer().clone())?;
+            let ucan_invocation = authorization.invoke().await?;
+
+            let invocation = ForkInvocation::new(capability, address, ucan_invocation);
+            Ok(invocation.perform(&self.network).await)
+        }
+    }
+}

--- a/rust/dialog-operator/src/operator/space.rs
+++ b/rust/dialog-operator/src/operator/space.rs
@@ -1,0 +1,71 @@
+//! Space capability providers for Operator.
+
+use super::Operator;
+use dialog_capability::{Capability, Policy, Provider, Subject};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_effects::space as space_fx;
+use dialog_effects::storage::{self as storage_fx, LocationExt as _};
+use dialog_storage::provider::storage::Storage;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S> Provider<space_fx::Load> for Operator<S>
+where
+    S: Clone + ConditionalSend + ConditionalSync + 'static,
+    Storage<S>: Provider<storage_fx::Load>,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        input: Capability<space_fx::Load>,
+    ) -> Result<dialog_credentials::Credential, storage_fx::StorageError> {
+        let subject = input.subject();
+        if *subject != self.profile_did() {
+            return Err(storage_fx::StorageError::Storage(format!(
+                "space load denied: subject {subject} does not match profile {}",
+                self.profile_did()
+            )));
+        }
+
+        let name = &space_fx::Space::of(&input).name;
+        let location = storage_fx::Location::new(self.directory.clone(), name);
+        Subject::from(dialog_capability::did!("local:storage"))
+            .attenuate(storage_fx::Storage)
+            .attenuate(location)
+            .load()
+            .perform(&self.storage)
+            .await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S> Provider<space_fx::Create> for Operator<S>
+where
+    S: Clone + ConditionalSend + ConditionalSync + 'static,
+    Storage<S>: Provider<storage_fx::Create>,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        input: Capability<space_fx::Create>,
+    ) -> Result<dialog_credentials::Credential, storage_fx::StorageError> {
+        let subject = input.subject();
+        if *subject != self.profile_did() {
+            return Err(storage_fx::StorageError::Storage(format!(
+                "space create denied: subject {subject} does not match profile {}",
+                self.profile_did()
+            )));
+        }
+
+        let name = &space_fx::Space::of(&input).name;
+        let credential = space_fx::Create::of(&input).credential.clone();
+        let location = storage_fx::Location::new(self.directory.clone(), name);
+        Subject::from(dialog_capability::did!("local:storage"))
+            .attenuate(storage_fx::Storage)
+            .attenuate(location)
+            .create(credential)
+            .perform(&self.storage)
+            .await
+    }
+}

--- a/rust/dialog-operator/src/operator/test.rs
+++ b/rust/dialog-operator/src/operator/test.rs
@@ -1,0 +1,709 @@
+use crate::helpers::unique_name;
+use crate::network::Network;
+use crate::profile::Profile;
+use dialog_storage::provider::storage::{Storage, VolatileSpace};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_builds_operator_from_profile() {
+        let storage = Storage::volatile();
+
+        let profile = Profile::open(unique_name("test"))
+            .perform(&storage)
+            .await
+            .unwrap();
+
+        let operator = profile
+            .derive(b"test")
+            .network(Network)
+            .build(storage)
+            .await
+            .unwrap();
+
+        assert!(!operator.did().to_string().is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_derives_different_operators_from_different_contexts() {
+        let storage1 = Storage::volatile();
+        let profile1 = Profile::open(unique_name("ctx1"))
+            .perform(&storage1)
+            .await
+            .unwrap();
+        let op1 = profile1
+            .derive(b"context-a")
+            .network(Network)
+            .build(storage1)
+            .await
+            .unwrap();
+
+        let storage2 = Storage::volatile();
+        let profile2 = Profile::open(unique_name("ctx2"))
+            .perform(&storage2)
+            .await
+            .unwrap();
+        let op2 = profile2
+            .derive(b"context-b")
+            .network(Network)
+            .build(storage2)
+            .await
+            .unwrap();
+
+        assert_ne!(op1.did(), op2.did());
+    }
+
+    mod delegation_tests {
+        use super::*;
+        use dialog_capability::Subject;
+        use dialog_capability::access::{self as cap_access, Access, AuthorizeError};
+        use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt};
+        use dialog_ucan::scope::Scope;
+        use dialog_ucan::{Ucan, UcanProof};
+
+        async fn claim_access(
+            operator: &super::super::super::Operator<VolatileSpace>,
+            capability: &impl dialog_capability::Ability,
+        ) -> Result<UcanProof, AuthorizeError> {
+            let scope = Scope::from(capability);
+
+            Subject::from(operator.profile_did())
+                .attenuate(Access)
+                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+                .perform(operator)
+                .await
+        }
+
+        #[dialog_common::test]
+        async fn self_grant_produces_delegation() {
+            let storage = Storage::volatile();
+
+            let profile = Profile::open(unique_name("self"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"alice")
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            let cap = Subject::from(operator.did()).archive().catalog("index");
+            let result = claim_access(&operator, &cap).await;
+
+            assert!(
+                result.is_ok(),
+                "self-grant should succeed: {:?}",
+                result.err()
+            );
+        }
+
+        #[dialog_common::test]
+        async fn powerline_self_grant_produces_delegation() {
+            let storage = Storage::volatile();
+
+            let profile = Profile::open(unique_name("psg"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"alice")
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            let cap = Subject::from(operator.did());
+            let result = claim_access(&operator, &cap).await;
+
+            assert!(
+                result.is_ok(),
+                "powerline self-grant should succeed: {:?}",
+                result.err()
+            );
+        }
+
+        #[dialog_common::test]
+        async fn scoped_delegation_found() {
+            let storage = Storage::volatile();
+
+            let profile = Profile::open(unique_name("found"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"alice")
+                .allow(Subject::any().archive().catalog("index"))
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            let cap = Subject::from(profile.did()).archive().catalog("index");
+            let result = claim_access(&operator, &cap).await;
+
+            assert!(
+                result.is_ok(),
+                "should find delegation for archive/index: {:?}",
+                result.err()
+            );
+        }
+
+        #[dialog_common::test]
+        async fn scoped_delegation_denied() {
+            let storage = Storage::volatile();
+
+            let profile = Profile::open(unique_name("deny"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"alice")
+                .allow(Subject::any().archive().catalog("index"))
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            let cap = Subject::from(profile.did()).archive().catalog("secret");
+            let result = claim_access(&operator, &cap).await;
+
+            assert!(result.is_err(), "should deny non-delegated archive/secret");
+        }
+
+        #[dialog_common::test]
+        async fn powerline_delegation_allows_anything() {
+            let storage = Storage::volatile();
+
+            let profile = Profile::open(unique_name("power"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            use dialog_effects::storage as fx_storage;
+            let operator = profile
+                .derive(b"admin")
+                .allow(Subject::any())
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            let cap = Subject::from(profile.did()).attenuate(fx_storage::Storage);
+            let result = claim_access(&operator, &cap).await;
+
+            assert!(
+                result.is_ok(),
+                "powerline should allow any capability: {:?}",
+                result.err()
+            );
+        }
+
+        #[dialog_common::test]
+        async fn no_delegation_fails() {
+            let storage = Storage::volatile();
+
+            let profile = Profile::open(unique_name("none"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"alice")
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            let cap = Subject::from(profile.did()).archive().catalog("index");
+            let result = claim_access(&operator, &cap).await;
+
+            assert!(result.is_err(), "should fail with no delegations");
+        }
+
+        #[dialog_common::test]
+        async fn no_issuer_uses_profile_did() {
+            let storage = Storage::volatile();
+
+            let profile = Profile::open(unique_name("nois"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"alice")
+                .allow(Subject::any().archive().catalog("index"))
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            let cap = Subject::from(profile.did()).archive().catalog("index");
+            let result = claim_access(&operator, &cap).await;
+
+            assert!(
+                result.is_ok(),
+                "should find chain via profile DID: {:?}",
+                result.err()
+            );
+        }
+    }
+
+    mod time_bound_tests {
+        use super::*;
+        use crate::profile::Profile;
+        use dialog_capability::Subject;
+        use dialog_capability::access::{
+            self as cap_access, Access, Authorization as _, Proof as _, TimeRange,
+        };
+        use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt};
+        use dialog_ucan::Ucan;
+        use dialog_ucan::scope::Scope;
+        use dialog_ucan_core::time::Timestamp;
+        use dialog_ucan_core::time::timestamp::{Duration, UNIX_EPOCH};
+
+        fn ts(secs: u64) -> Timestamp {
+            Timestamp::new(UNIX_EPOCH + Duration::from_secs(secs)).unwrap()
+        }
+
+        async fn build_operator_with_profile()
+        -> (super::super::super::Operator<VolatileSpace>, Profile) {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name("time"))
+                .perform(&storage)
+                .await
+                .unwrap();
+            let operator = profile
+                .derive(b"test")
+                .allow(Subject::any())
+                .build(storage)
+                .await
+                .unwrap();
+            (operator, profile)
+        }
+
+        /// Build an operator WITHOUT a powerline delegation.
+        /// Only explicitly delegated capabilities will be available.
+        async fn build_restricted_operator_with_profile()
+        -> (super::super::super::Operator<VolatileSpace>, Profile) {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name("time-restricted"))
+                .perform(&storage)
+                .await
+                .unwrap();
+            let operator = profile.derive(b"test").build(storage).await.unwrap();
+            (operator, profile)
+        }
+
+        #[dialog_common::test]
+        async fn time_bounded_delegation_sets_proof_duration() {
+            let (operator, profile) = build_operator_with_profile().await;
+
+            // Delegate with time bounds: valid from 1000 to 5000
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("index"))
+                .not_before(ts(1000))
+                .expires(ts(5000))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Claim with unbounded duration (I don't care)
+            let cap = Subject::from(profile.did()).archive().catalog("index");
+            let scope = Scope::from(&cap);
+            let proof = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Proof duration should reflect the certificate bounds
+            let duration = proof.duration();
+            assert_eq!(duration.not_before, Some(1000));
+            assert_eq!(duration.expiration, Some(5000));
+        }
+
+        #[dialog_common::test]
+        async fn prove_rejects_cert_that_expires_too_early() {
+            let (operator, profile) = build_restricted_operator_with_profile().await;
+
+            // Delegate with expiration at 1000
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("data"))
+                .expires(ts(1000))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Request authorization valid until 5000 - should fail
+            let cap = Subject::from(profile.did()).archive().catalog("data");
+            let scope = Scope::from(&cap);
+            let mut claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
+            claim.duration = TimeRange {
+                not_before: None,
+                expiration: Some(5000),
+            };
+
+            let result = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(claim)
+                .perform(&operator)
+                .await;
+
+            assert!(
+                result.is_err(),
+                "should reject: cert expires at 1000 but requested until 5000"
+            );
+        }
+
+        #[dialog_common::test]
+        async fn prove_rejects_cert_starting_too_late() {
+            let (operator, profile) = build_restricted_operator_with_profile().await;
+
+            // Delegate with not_before at 5000
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("data"))
+                .not_before(ts(5000))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Request authorization valid from 1000 - should fail
+            let cap = Subject::from(profile.did()).archive().catalog("data");
+            let scope = Scope::from(&cap);
+            let mut claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
+            claim.duration = TimeRange {
+                not_before: Some(1000),
+                expiration: None,
+            };
+
+            let result = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(claim)
+                .perform(&operator)
+                .await;
+
+            assert!(
+                result.is_err(),
+                "should reject: cert starts at 5000 but requested from 1000"
+            );
+        }
+
+        #[dialog_common::test]
+        async fn prove_accepts_cert_covering_requested_window() {
+            let (operator, profile) = build_restricted_operator_with_profile().await;
+
+            // Delegate valid from 100 to 10000
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("data"))
+                .not_before(ts(100))
+                .expires(ts(10000))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Request authorization valid from 500 to 5000 - cert covers this
+            let cap = Subject::from(profile.did()).archive().catalog("data");
+            let scope = Scope::from(&cap);
+            let mut claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
+            claim.duration = TimeRange {
+                not_before: Some(500),
+                expiration: Some(5000),
+            };
+
+            let result = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(claim)
+                .perform(&operator)
+                .await;
+
+            assert!(
+                result.is_ok(),
+                "should accept: cert covers requested window: {:?}",
+                result.err()
+            );
+        }
+
+        #[dialog_common::test]
+        async fn prove_unbounded_request_accepts_any_cert() {
+            let (operator, profile) = build_restricted_operator_with_profile().await;
+
+            // Delegate with short window
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("data"))
+                .not_before(ts(100))
+                .expires(ts(200))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Request with no time constraints ("I don't care")
+            let cap = Subject::from(profile.did()).archive().catalog("data");
+            let scope = Scope::from(&cap);
+            let claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
+
+            let result = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(claim)
+                .perform(&operator)
+                .await;
+
+            assert!(
+                result.is_ok(),
+                "unbounded request should accept any cert: {:?}",
+                result.err()
+            );
+
+            // But the proof should carry the cert's actual bounds
+            let proof = result.unwrap();
+            assert_eq!(proof.duration().not_before, Some(100));
+            assert_eq!(proof.duration().expiration, Some(200));
+        }
+
+        #[dialog_common::test]
+        async fn authorization_rejects_widening_expiration() {
+            let (operator, profile) = build_restricted_operator_with_profile().await;
+
+            // Delegate expiring at 1000
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("data"))
+                .expires(ts(1000))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Get proof
+            let cap = Subject::from(profile.did()).archive().catalog("data");
+            let scope = Scope::from(&cap);
+            let proof = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            let signer = dialog_credentials::Ed25519Signer::from(profile.credential().clone());
+            let authorization = proof.claim(signer).unwrap();
+
+            // Try to set expiration beyond proof bounds
+            let result = authorization.expires(5000);
+            assert!(
+                result.is_err(),
+                "should reject widening expiration beyond proof"
+            );
+        }
+
+        #[dialog_common::test]
+        async fn authorization_rejects_widening_not_before() {
+            let (operator, profile) = build_restricted_operator_with_profile().await;
+
+            // Delegate starting at 1000
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("data"))
+                .not_before(ts(1000))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Get proof
+            let cap = Subject::from(profile.did()).archive().catalog("data");
+            let scope = Scope::from(&cap);
+            let proof = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            let signer = dialog_credentials::Ed25519Signer::from(profile.credential().clone());
+            let authorization = proof.claim(signer).unwrap();
+
+            // Try to set not_before earlier than proof bounds
+            let result = authorization.not_before(500);
+            assert!(
+                result.is_err(),
+                "should reject widening not_before before proof"
+            );
+        }
+
+        #[dialog_common::test]
+        async fn authorization_accepts_narrowing() {
+            let (operator, profile) = build_restricted_operator_with_profile().await;
+
+            // Delegate valid from 100 to 10000
+            let chain = profile
+                .access()
+                .claim(Subject::from(profile.did()).archive().catalog("data"))
+                .not_before(ts(100))
+                .expires(ts(10000))
+                .delegate(operator.did())
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            profile
+                .access()
+                .save(chain)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Get proof
+            let cap = Subject::from(profile.did()).archive().catalog("data");
+            let scope = Scope::from(&cap);
+            let proof = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            let signer = dialog_credentials::Ed25519Signer::from(profile.credential().clone());
+            let authorization = proof.claim(signer).unwrap();
+
+            // Narrow the window - should succeed
+            let result = authorization.not_before(500).unwrap().expires(5000);
+
+            assert!(
+                result.is_ok(),
+                "narrowing should succeed: {:?}",
+                result.err()
+            );
+        }
+    }
+
+    mod space_tests {
+        use super::*;
+        use dialog_capability::Subject;
+        use dialog_effects::space::{self as space_fx, SpaceExt as _};
+
+        #[dialog_common::test]
+        async fn it_denies_space_load_for_wrong_subject() {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name("space-deny"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"test")
+                .allow(Subject::any())
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            // Use a wrong DID as subject
+            let wrong_did = dialog_capability::did!("key:z6MkWrongDid");
+            let result: Result<_, _> = Subject::from(wrong_did)
+                .attenuate(space_fx::Space::new("repo"))
+                .load()
+                .perform(&operator)
+                .await;
+
+            assert!(result.is_err(), "should deny space load for wrong subject");
+        }
+
+        #[dialog_common::test]
+        async fn it_allows_space_for_profile_subject() {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name("space-allow"))
+                .perform(&storage)
+                .await
+                .unwrap();
+
+            let operator = profile
+                .derive(b"test")
+                .allow(Subject::any())
+                .network(Network)
+                .build(storage)
+                .await
+                .unwrap();
+
+            // Use the correct profile DID as subject
+            let result: Result<_, _> = Subject::from(operator.profile_did())
+                .attenuate(space_fx::Space::new("repo"))
+                .load()
+                .perform(&operator)
+                .await;
+
+            // Will fail with NotFound (no space created), not with access denied
+            let err = result.unwrap_err();
+            assert!(
+                err.to_string().contains("not found") || err.to_string().contains("Not found"),
+                "should fail with not-found, not access denied: {err}"
+            );
+        }
+    }
+}

--- a/rust/dialog-operator/src/operator/test.rs
+++ b/rust/dialog-operator/src/operator/test.rs
@@ -18,7 +18,7 @@ mod tests {
 
         let operator = profile
             .derive(b"test")
-            .network(Network)
+            .network(Network::default())
             .build(storage)
             .await
             .unwrap();
@@ -35,7 +35,7 @@ mod tests {
             .unwrap();
         let op1 = profile1
             .derive(b"context-a")
-            .network(Network)
+            .network(Network::default())
             .build(storage1)
             .await
             .unwrap();
@@ -47,7 +47,7 @@ mod tests {
             .unwrap();
         let op2 = profile2
             .derive(b"context-b")
-            .network(Network)
+            .network(Network::default())
             .build(storage2)
             .await
             .unwrap();
@@ -58,23 +58,7 @@ mod tests {
     mod delegation_tests {
         use super::*;
         use dialog_capability::Subject;
-        use dialog_capability::access::{self as cap_access, Access, AuthorizeError};
         use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt};
-        use dialog_ucan::scope::Scope;
-        use dialog_ucan::{Ucan, UcanProof};
-
-        async fn claim_access(
-            operator: &super::super::super::Operator<VolatileSpace>,
-            capability: &impl dialog_capability::Ability,
-        ) -> Result<UcanProof, AuthorizeError> {
-            let scope = Scope::from(capability);
-
-            Subject::from(operator.profile_did())
-                .attenuate(Access)
-                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
-                .perform(operator)
-                .await
-        }
 
         #[dialog_common::test]
         async fn self_grant_produces_delegation() {
@@ -87,13 +71,17 @@ mod tests {
 
             let operator = profile
                 .derive(b"alice")
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
 
-            let cap = Subject::from(operator.did()).archive().catalog("index");
-            let result = claim_access(&operator, &cap).await;
+            let result = profile
+                .access()
+                .prove(Subject::from(operator.did()).archive().catalog("index"))
+                .audience(&operator)
+                .perform(&operator)
+                .await;
 
             assert!(
                 result.is_ok(),
@@ -113,13 +101,17 @@ mod tests {
 
             let operator = profile
                 .derive(b"alice")
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
 
-            let cap = Subject::from(operator.did());
-            let result = claim_access(&operator, &cap).await;
+            let result = profile
+                .access()
+                .prove(Subject::from(operator.did()))
+                .audience(&operator)
+                .perform(&operator)
+                .await;
 
             assert!(
                 result.is_ok(),
@@ -140,13 +132,17 @@ mod tests {
             let operator = profile
                 .derive(b"alice")
                 .allow(Subject::any().archive().catalog("index"))
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
 
-            let cap = Subject::from(profile.did()).archive().catalog("index");
-            let result = claim_access(&operator, &cap).await;
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("index"))
+                .audience(&operator)
+                .perform(&operator)
+                .await;
 
             assert!(
                 result.is_ok(),
@@ -167,13 +163,17 @@ mod tests {
             let operator = profile
                 .derive(b"alice")
                 .allow(Subject::any().archive().catalog("index"))
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
 
-            let cap = Subject::from(profile.did()).archive().catalog("secret");
-            let result = claim_access(&operator, &cap).await;
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("secret"))
+                .audience(&operator)
+                .perform(&operator)
+                .await;
 
             assert!(result.is_err(), "should deny non-delegated archive/secret");
         }
@@ -191,13 +191,17 @@ mod tests {
             let operator = profile
                 .derive(b"admin")
                 .allow(Subject::any())
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
 
-            let cap = Subject::from(profile.did()).attenuate(fx_storage::Storage);
-            let result = claim_access(&operator, &cap).await;
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).attenuate(fx_storage::Storage))
+                .audience(&operator)
+                .perform(&operator)
+                .await;
 
             assert!(
                 result.is_ok(),
@@ -217,13 +221,17 @@ mod tests {
 
             let operator = profile
                 .derive(b"alice")
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
 
-            let cap = Subject::from(profile.did()).archive().catalog("index");
-            let result = claim_access(&operator, &cap).await;
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("index"))
+                .audience(&operator)
+                .perform(&operator)
+                .await;
 
             assert!(result.is_err(), "should fail with no delegations");
         }
@@ -240,13 +248,17 @@ mod tests {
             let operator = profile
                 .derive(b"alice")
                 .allow(Subject::any().archive().catalog("index"))
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
 
-            let cap = Subject::from(profile.did()).archive().catalog("index");
-            let result = claim_access(&operator, &cap).await;
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("index"))
+                .audience(&operator)
+                .perform(&operator)
+                .await;
 
             assert!(
                 result.is_ok(),
@@ -260,12 +272,8 @@ mod tests {
         use super::*;
         use crate::profile::Profile;
         use dialog_capability::Subject;
-        use dialog_capability::access::{
-            self as cap_access, Access, Authorization as _, Proof as _, TimeRange,
-        };
+        use dialog_capability::access::{Authorization as _, Proof as _};
         use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt};
-        use dialog_ucan::Ucan;
-        use dialog_ucan::scope::Scope;
         use dialog_ucan_core::time::Timestamp;
         use dialog_ucan_core::time::timestamp::{Duration, UNIX_EPOCH};
 
@@ -325,11 +333,10 @@ mod tests {
                 .unwrap();
 
             // Claim with unbounded duration (I don't care)
-            let cap = Subject::from(profile.did()).archive().catalog("index");
-            let scope = Scope::from(&cap);
-            let proof = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+            let proof = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("index"))
+                .audience(&operator)
                 .perform(&operator)
                 .await
                 .unwrap();
@@ -362,17 +369,11 @@ mod tests {
                 .unwrap();
 
             // Request authorization valid until 5000 - should fail
-            let cap = Subject::from(profile.did()).archive().catalog("data");
-            let scope = Scope::from(&cap);
-            let mut claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
-            claim.duration = TimeRange {
-                not_before: None,
-                expiration: Some(5000),
-            };
-
-            let result = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(claim)
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("data"))
+                .audience(&operator)
+                .expires(ts(5000))
                 .perform(&operator)
                 .await;
 
@@ -404,17 +405,11 @@ mod tests {
                 .unwrap();
 
             // Request authorization valid from 1000 - should fail
-            let cap = Subject::from(profile.did()).archive().catalog("data");
-            let scope = Scope::from(&cap);
-            let mut claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
-            claim.duration = TimeRange {
-                not_before: Some(1000),
-                expiration: None,
-            };
-
-            let result = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(claim)
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("data"))
+                .audience(&operator)
+                .not_before(ts(1000))
                 .perform(&operator)
                 .await;
 
@@ -447,17 +442,12 @@ mod tests {
                 .unwrap();
 
             // Request authorization valid from 500 to 5000 - cert covers this
-            let cap = Subject::from(profile.did()).archive().catalog("data");
-            let scope = Scope::from(&cap);
-            let mut claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
-            claim.duration = TimeRange {
-                not_before: Some(500),
-                expiration: Some(5000),
-            };
-
-            let result = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(claim)
+            let result = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("data"))
+                .audience(&operator)
+                .not_before(ts(500))
+                .expires(ts(5000))
                 .perform(&operator)
                 .await;
 
@@ -491,24 +481,15 @@ mod tests {
                 .unwrap();
 
             // Request with no time constraints ("I don't care")
-            let cap = Subject::from(profile.did()).archive().catalog("data");
-            let scope = Scope::from(&cap);
-            let claim = cap_access::Prove::<Ucan>::new(operator.did(), scope);
-
-            let result = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(claim)
+            let proof = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("data"))
+                .audience(&operator)
                 .perform(&operator)
-                .await;
-
-            assert!(
-                result.is_ok(),
-                "unbounded request should accept any cert: {:?}",
-                result.err()
-            );
+                .await
+                .unwrap();
 
             // But the proof should carry the cert's actual bounds
-            let proof = result.unwrap();
             assert_eq!(proof.duration().not_before, Some(100));
             assert_eq!(proof.duration().expiration, Some(200));
         }
@@ -534,17 +515,15 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Get proof
-            let cap = Subject::from(profile.did()).archive().catalog("data");
-            let scope = Scope::from(&cap);
-            let proof = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+            let proof = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("data"))
+                .audience(&operator)
                 .perform(&operator)
                 .await
                 .unwrap();
 
-            let signer = dialog_credentials::Ed25519Signer::from(profile.credential().clone());
+            let signer = dialog_credentials::Ed25519Signer::from(profile.signer().clone());
             let authorization = proof.claim(signer).unwrap();
 
             // Try to set expiration beyond proof bounds
@@ -576,17 +555,15 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Get proof
-            let cap = Subject::from(profile.did()).archive().catalog("data");
-            let scope = Scope::from(&cap);
-            let proof = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+            let proof = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("data"))
+                .audience(&operator)
                 .perform(&operator)
                 .await
                 .unwrap();
 
-            let signer = dialog_credentials::Ed25519Signer::from(profile.credential().clone());
+            let signer = dialog_credentials::Ed25519Signer::from(profile.signer().clone());
             let authorization = proof.claim(signer).unwrap();
 
             // Try to set not_before earlier than proof bounds
@@ -619,17 +596,15 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Get proof
-            let cap = Subject::from(profile.did()).archive().catalog("data");
-            let scope = Scope::from(&cap);
-            let proof = Subject::from(profile.did())
-                .attenuate(Access)
-                .invoke(cap_access::Prove::<Ucan>::new(operator.did(), scope))
+            let proof = profile
+                .access()
+                .prove(Subject::from(profile.did()).archive().catalog("data"))
+                .audience(&operator)
                 .perform(&operator)
                 .await
                 .unwrap();
 
-            let signer = dialog_credentials::Ed25519Signer::from(profile.credential().clone());
+            let signer = dialog_credentials::Ed25519Signer::from(profile.signer().clone());
             let authorization = proof.claim(signer).unwrap();
 
             // Narrow the window - should succeed
@@ -640,6 +615,166 @@ mod tests {
                 "narrowing should succeed: {:?}",
                 result.err()
             );
+        }
+    }
+
+    mod s3_credential_tests {
+        use super::*;
+        use crate::network::NetworkAddress as SiteAddress;
+        use dialog_capability::Subject;
+        use dialog_common::Blake3Hash;
+        use dialog_effects::archive::prelude::*;
+        use dialog_effects::credential::Secret;
+        use dialog_remote_s3::helpers::S3Address;
+        use dialog_remote_s3::{Address, S3Credential};
+
+        fn address_from(s3: &S3Address) -> SiteAddress {
+            SiteAddress::S3(
+                Address::builder(&s3.endpoint)
+                    .region("us-east-1")
+                    .bucket(&s3.bucket)
+                    .build()
+                    .unwrap(),
+            )
+        }
+
+        #[dialog_common::test]
+        fn credential_roundtrips_through_secret() {
+            let cred = S3Credential::new("test-access-key", "test-secret-key");
+            let secret: Secret = cred.clone().into();
+            let restored: S3Credential = secret.try_into().unwrap();
+
+            assert_eq!(restored.access_key_id(), cred.access_key_id());
+            assert_eq!(restored.secret_access_key(), cred.secret_access_key());
+        }
+
+        #[dialog_common::test]
+        async fn fork_fails_without_saved_credential(s3: S3Address) -> anyhow::Result<()> {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name("s3-no-cred"))
+                .perform(&storage)
+                .await
+                .unwrap();
+            let operator = profile
+                .derive(b"test")
+                .allow(Subject::any())
+                .network(Network::default())
+                .build(storage)
+                .await
+                .unwrap();
+
+            let address = address_from(&s3);
+
+            // Fork without saving credentials: should fail with credential not found
+            let result = Subject::from(operator.profile_did())
+                .archive()
+                .catalog("data")
+                .get(Blake3Hash::hash(b"test"))
+                .fork(&address)
+                .perform(&operator)
+                .await;
+
+            let err = result.unwrap_err();
+            assert!(
+                err.to_string().contains("not found")
+                    || err.to_string().contains("Credential not found"),
+                "should fail with credential not found, got: {err}"
+            );
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn fork_loads_saved_credential_for_get(s3: S3Address) -> anyhow::Result<()> {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name("s3-get"))
+                .perform(&storage)
+                .await
+                .unwrap();
+            let operator = profile
+                .derive(b"test")
+                .allow(Subject::any())
+                .network(Network::default())
+                .build(storage)
+                .await
+                .unwrap();
+
+            let address = address_from(&s3);
+            let credential = S3Credential::new(&s3.access_key_id, &s3.secret_access_key);
+
+            profile
+                .credential()
+                .site(&address)
+                .save(credential)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Fork get: credential is loaded, request reaches the S3 server,
+            // returns None because the content doesn't exist (not an auth error).
+            let result = Subject::from(operator.profile_did())
+                .archive()
+                .catalog("cred-test")
+                .get(Blake3Hash::hash(b"nonexistent"))
+                .fork(&address)
+                .perform(&operator)
+                .await;
+
+            let content = result?;
+            assert!(content.is_none(), "content should not exist");
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn fork_loads_saved_credential_for_put_and_get(s3: S3Address) -> anyhow::Result<()> {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name("s3-put-get"))
+                .perform(&storage)
+                .await
+                .unwrap();
+            let operator = profile
+                .derive(b"test")
+                .allow(Subject::any())
+                .network(Network::default())
+                .build(storage)
+                .await
+                .unwrap();
+
+            let address = address_from(&s3);
+            let authorization = S3Credential::new(&s3.access_key_id, &s3.secret_access_key);
+
+            profile
+                .credential()
+                .site(&address)
+                .save(authorization)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            let content = b"hello from operator".to_vec();
+            let digest = Blake3Hash::hash(&content);
+
+            // Put content via fork
+            Subject::from(operator.profile_did())
+                .archive()
+                .catalog("cred-roundtrip")
+                .put(digest.clone(), content.clone())
+                .fork(&address)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            // Get it back via fork
+            let retrieved = Subject::from(operator.profile_did())
+                .archive()
+                .catalog("cred-roundtrip")
+                .get(digest)
+                .fork(&address)
+                .perform(&operator)
+                .await
+                .unwrap();
+
+            assert_eq!(retrieved, Some(content));
+            Ok(())
         }
     }
 
@@ -659,7 +794,7 @@ mod tests {
             let operator = profile
                 .derive(b"test")
                 .allow(Subject::any())
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();
@@ -686,7 +821,7 @@ mod tests {
             let operator = profile
                 .derive(b"test")
                 .allow(Subject::any())
-                .network(Network)
+                .network(Network::default())
                 .build(storage)
                 .await
                 .unwrap();

--- a/rust/dialog-operator/src/profile.rs
+++ b/rust/dialog-operator/src/profile.rs
@@ -12,10 +12,14 @@ pub use save::SaveDelegation;
 pub use space::SpaceHandle;
 
 use crate::operator::OperatorBuilder;
-use dialog_capability::{Capability, Subject};
+use dialog_capability::{Capability, Provider, SiteId, Subject};
+use dialog_common::ConditionalSync;
 use dialog_credentials::SignerCredential;
+use dialog_effects::credential::prelude::*;
+use dialog_effects::credential::{self, CredentialError, Secret};
 use dialog_ucan::UcanDelegation;
 use dialog_varsig::{Did, Principal};
+use std::marker::PhantomData;
 
 /// An opened profile — holds a signing credential.
 #[derive(Debug, Clone)]
@@ -45,8 +49,13 @@ impl Profile {
     }
 
     /// The signing credential.
-    pub fn credential(&self) -> &SignerCredential {
+    pub fn signer(&self) -> &SignerCredential {
         &self.credential
+    }
+
+    /// Get a credential handle for saving/loading site secrets.
+    pub fn credential(&self) -> CredentialHandle {
+        CredentialHandle { did: self.did() }
     }
 
     /// Store a delegation chain under this profile's DID.
@@ -76,6 +85,112 @@ impl Profile {
             profile_did: self.did(),
             name: name.into(),
         }
+    }
+}
+
+/// Handle for credential operations scoped to a profile's DID.
+///
+/// Created via [`Profile::credential()`].
+pub struct CredentialHandle {
+    did: Did,
+}
+
+impl CredentialHandle {
+    /// Select a site credential by address identifier.
+    pub fn site(self, id: impl Into<SiteId>) -> CredentialSite {
+        CredentialSite {
+            did: self.did,
+            key: id.into(),
+        }
+    }
+}
+
+/// A site credential handle ready for save/load operations.
+///
+/// Created via [`CredentialHandle::site()`].
+pub struct CredentialSite {
+    did: Did,
+    key: SiteId,
+}
+
+impl CredentialSite {
+    /// Save a site credential to the credential store.
+    ///
+    /// The credential is converted to [`Secret`] via [`TryInto`] during
+    /// [`perform()`](SaveSiteCredential::perform).
+    pub fn save<T: TryInto<Secret>>(self, credential: T) -> SaveSiteCredential<T> {
+        SaveSiteCredential {
+            did: self.did,
+            key: self.key,
+            credential,
+        }
+    }
+
+    /// Load a site credential from the credential store.
+    ///
+    /// The loaded [`Secret`] is converted to `T` via [`TryFrom`] during
+    /// [`perform()`](LoadSiteCredential::perform).
+    pub fn load<T: TryFrom<Secret>>(self) -> LoadSiteCredential<T> {
+        LoadSiteCredential {
+            did: self.did,
+            key: self.key,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Saves a site credential. Created via [`CredentialSite::save()`].
+pub struct SaveSiteCredential<T> {
+    did: Did,
+    key: SiteId,
+    credential: T,
+}
+
+impl<T> SaveSiteCredential<T>
+where
+    T: TryInto<Secret>,
+    T::Error: Into<CredentialError>,
+{
+    /// Serialize the credential and save it to the store.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), CredentialError>
+    where
+        Env: Provider<credential::Save<Secret>> + ConditionalSync,
+    {
+        let secret = self.credential.try_into().map_err(Into::into)?;
+        self.did
+            .credential()
+            .site(&self.key)
+            .save(secret)
+            .perform(env)
+            .await
+    }
+}
+
+/// Loads a site credential. Created via [`CredentialSite::load()`].
+pub struct LoadSiteCredential<T> {
+    did: Did,
+    key: SiteId,
+    _marker: PhantomData<T>,
+}
+
+impl<T> LoadSiteCredential<T>
+where
+    T: TryFrom<Secret>,
+    T::Error: Into<CredentialError>,
+{
+    /// Load the credential from the store and deserialize it.
+    pub async fn perform<Env>(self, env: &Env) -> Result<T, CredentialError>
+    where
+        Env: Provider<credential::Load<Secret>> + ConditionalSync,
+    {
+        let secret = self
+            .did
+            .credential()
+            .site(&self.key)
+            .load()
+            .perform(env)
+            .await?;
+        secret.try_into().map_err(Into::into)
     }
 }
 

--- a/rust/dialog-operator/src/profile.rs
+++ b/rust/dialog-operator/src/profile.rs
@@ -1,0 +1,240 @@
+//! Profile — a named identity backed by a signing credential.
+
+pub mod access;
+mod error;
+mod open;
+mod save;
+mod space;
+
+pub use error::ProfileError;
+pub use open::OpenProfile;
+pub use save::SaveDelegation;
+pub use space::SpaceHandle;
+
+use crate::operator::OperatorBuilder;
+use dialog_capability::{Capability, Subject};
+use dialog_credentials::SignerCredential;
+use dialog_ucan::UcanDelegation;
+use dialog_varsig::{Did, Principal};
+
+/// An opened profile — holds a signing credential.
+#[derive(Debug, Clone)]
+pub struct Profile {
+    credential: SignerCredential,
+}
+
+impl Profile {
+    /// Open a profile — loads existing or creates new.
+    pub fn open(name: impl Into<String>) -> OpenProfile {
+        OpenProfile::open(name.into())
+    }
+
+    /// Load an existing profile — fails if not found.
+    pub fn load(name: impl Into<String>) -> OpenProfile {
+        OpenProfile::load(name.into())
+    }
+
+    /// Create a new profile — fails if one already exists.
+    pub fn create(name: impl Into<String>) -> OpenProfile {
+        OpenProfile::create(name.into())
+    }
+
+    /// The profile's DID.
+    pub fn did(&self) -> Did {
+        self.credential.did()
+    }
+
+    /// The signing credential.
+    pub fn credential(&self) -> &SignerCredential {
+        &self.credential
+    }
+
+    /// Store a delegation chain under this profile's DID.
+    pub fn save(&self, chain: UcanDelegation) -> SaveDelegation {
+        SaveDelegation {
+            did: self.did(),
+            chain,
+        }
+    }
+
+    /// Get an access handle for claiming and delegating capabilities.
+    pub fn access(&self) -> access::Access<'_> {
+        access::Access::new(&self.credential)
+    }
+
+    /// Derive an operator from this profile with the given context seed.
+    pub fn derive(&self, context: impl Into<Vec<u8>>) -> OperatorBuilder {
+        OperatorBuilder::new(self, context.into())
+    }
+
+    /// Get a handle to a named repository space under this profile.
+    ///
+    /// The returned handle can open, load, or create a repository
+    /// through an operator that verifies the profile DID.
+    pub fn repository(&self, name: impl Into<String>) -> SpaceHandle {
+        SpaceHandle {
+            profile_did: self.did(),
+            name: name.into(),
+        }
+    }
+}
+
+impl From<&Profile> for Capability<Subject> {
+    fn from(p: &Profile) -> Self {
+        Subject::from(p.credential.did()).into()
+    }
+}
+
+impl Principal for Profile {
+    fn did(&self) -> Did {
+        self.credential.did()
+    }
+}
+
+impl TryFrom<dialog_credentials::Credential> for Profile {
+    type Error = ProfileError;
+
+    fn try_from(credential: dialog_credentials::Credential) -> Result<Self, ProfileError> {
+        match credential {
+            dialog_credentials::Credential::Signer(s) => Ok(Profile { credential: s }),
+            dialog_credentials::Credential::Verifier(_) => Err(ProfileError::Key(
+                "profile credential is verifier-only".into(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_storage::provider::storage::Storage;
+
+    #[dialog_common::test]
+    async fn it_opens_profile() {
+        let storage = Storage::volatile();
+
+        let profile = Profile::open("alice").perform(&storage).await.unwrap();
+        assert!(!profile.did().to_string().is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_opens_same_profile_twice() {
+        let storage = Storage::volatile();
+
+        let first = Profile::open("bob").perform(&storage).await.unwrap();
+        let second = Profile::open("bob").perform(&storage).await.unwrap();
+
+        assert_eq!(first.did(), second.did());
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_then_loads() {
+        let storage = Storage::volatile();
+
+        let created = Profile::create("charlie").perform(&storage).await.unwrap();
+        let loaded = Profile::load("charlie").perform(&storage).await.unwrap();
+
+        assert_eq!(created.did(), loaded.did());
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_to_create_duplicate() {
+        let storage = Storage::volatile();
+
+        Profile::create("dave").perform(&storage).await.unwrap();
+        let result = Profile::create("dave").perform(&storage).await;
+
+        assert!(result.is_err());
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_to_load_missing() {
+        let storage = Storage::volatile();
+
+        let result = Profile::load("missing").perform(&storage).await;
+        assert!(result.is_err());
+    }
+
+    #[dialog_common::test]
+    async fn it_opens_profile_at_temp() {
+        use dialog_effects::storage::Directory;
+
+        let storage = Storage::volatile();
+
+        let profile = Profile::open("temp-alice")
+            .at(Directory::Temp)
+            .perform(&storage)
+            .await
+            .unwrap();
+
+        assert!(!profile.did().to_string().is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_isolates_profiles_across_directories() {
+        use dialog_effects::storage::Directory;
+
+        let storage = Storage::volatile();
+
+        let profile = Profile::open("same-name")
+            .at(Directory::Profile)
+            .perform(&storage)
+            .await
+            .unwrap();
+
+        let temp = Profile::open("same-name")
+            .at(Directory::Temp)
+            .perform(&storage)
+            .await
+            .unwrap();
+
+        assert_ne!(
+            profile.did(),
+            temp.did(),
+            "same name in different directories should produce different profiles"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_and_loads_at_temp() {
+        use dialog_effects::storage::Directory;
+
+        let storage = Storage::volatile();
+
+        let created = Profile::create("temp-load")
+            .at(Directory::Temp)
+            .perform(&storage)
+            .await
+            .unwrap();
+
+        let loaded = Profile::load("temp-load")
+            .at(Directory::Temp)
+            .perform(&storage)
+            .await
+            .unwrap();
+
+        assert_eq!(created.did(), loaded.did());
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_find_temp_profile_in_default_directory() {
+        use dialog_effects::storage::Directory;
+
+        let storage = Storage::volatile();
+
+        Profile::create("only-in-temp")
+            .at(Directory::Temp)
+            .perform(&storage)
+            .await
+            .unwrap();
+
+        let result = Profile::load("only-in-temp").perform(&storage).await;
+        assert!(
+            result.is_err(),
+            "profile created at temp should not be found in default directory"
+        );
+    }
+}

--- a/rust/dialog-operator/src/profile/access.rs
+++ b/rust/dialog-operator/src/profile/access.rs
@@ -6,7 +6,7 @@ use dialog_capability::access::{self, Authorization as _, AuthorizeError, Proof 
 use dialog_capability::{Ability, Capability, Constraint, Provider, Subject};
 use dialog_common::ConditionalSync;
 use dialog_credentials::SignerCredential;
-use dialog_ucan::scope::Scope;
+use dialog_ucan::Scope;
 use dialog_ucan::{Ucan, UcanDelegation, UcanProof};
 use dialog_ucan_core::time::Timestamp;
 use dialog_varsig::{Did, Principal};
@@ -31,6 +31,20 @@ impl<'a> Access<'a> {
         Claim {
             by: self.credential,
             capability: capability.into(),
+            not_before: None,
+            expiration: None,
+        }
+    }
+
+    /// Prove access to a capability, returning a proof chain.
+    ///
+    /// The audience defaults to the profile DID but can be overridden
+    /// via [`.audience()`](Prove::audience) for operator-scoped proofs.
+    pub fn prove<C: Constraint>(&self, capability: impl Into<Capability<C>>) -> Prove<'a, C> {
+        Prove {
+            by: self.credential,
+            capability: capability.into(),
+            audience: None,
             not_before: None,
             expiration: None,
         }
@@ -168,5 +182,65 @@ where
             authorization = authorization.expires(exp)?;
         }
         authorization.delegate(self.audience).await
+    }
+}
+
+/// A proof request for a capability with optional audience and time bounds.
+///
+/// Created via [`Access::prove()`]. Defaults the audience to the profile DID.
+/// Override with [`.audience()`](Prove::audience) for operator-scoped proofs.
+pub struct Prove<'a, C: Constraint> {
+    by: &'a SignerCredential,
+    capability: Capability<C>,
+    audience: Option<Did>,
+    not_before: Option<Timestamp>,
+    expiration: Option<Timestamp>,
+}
+
+impl<'a, C: Constraint> Prove<'a, C> {
+    /// Set the audience (who is requesting access).
+    ///
+    /// Defaults to the profile DID if not set.
+    pub fn audience(mut self, audience: &impl Principal) -> Self {
+        self.audience = Some(audience.did());
+        self
+    }
+
+    /// Set the earliest time the proof is valid.
+    pub fn not_before(mut self, not_before: Timestamp) -> Self {
+        self.not_before = Some(not_before);
+        self
+    }
+
+    /// Set when the proof expires.
+    pub fn expires(mut self, expiration: Timestamp) -> Self {
+        self.expiration = Some(expiration);
+        self
+    }
+}
+
+impl<C: Constraint> Prove<'_, C>
+where
+    Capability<C>: Ability,
+{
+    /// Execute the proof request, returning a proof chain.
+    pub async fn perform<Env>(self, env: &Env) -> Result<UcanProof, AuthorizeError>
+    where
+        Env: Provider<access::Prove<Ucan>> + ConditionalSync,
+    {
+        let by_did = self.by.did();
+        let audience = self.audience.unwrap_or_else(|| by_did.clone());
+        let scope = Scope::from(&self.capability);
+        let duration = access::TimeRange {
+            not_before: self.not_before.map(|t| t.to_unix()),
+            expiration: self.expiration.map(|t| t.to_unix()),
+        };
+        let mut prove = access::Prove::<Ucan>::new(audience, scope);
+        prove.duration = duration;
+        Subject::from(by_did)
+            .attenuate(access::Access)
+            .invoke(prove)
+            .perform(env)
+            .await
     }
 }

--- a/rust/dialog-operator/src/profile/access.rs
+++ b/rust/dialog-operator/src/profile/access.rs
@@ -1,0 +1,172 @@
+//! Access API for profile-based UCAN delegation.
+//!
+//! Provides a fluent builder chain for claiming authority and delegating.
+
+use dialog_capability::access::{self, Authorization as _, AuthorizeError, Proof as _};
+use dialog_capability::{Ability, Capability, Constraint, Provider, Subject};
+use dialog_common::ConditionalSync;
+use dialog_credentials::SignerCredential;
+use dialog_ucan::scope::Scope;
+use dialog_ucan::{Ucan, UcanDelegation, UcanProof};
+use dialog_ucan_core::time::Timestamp;
+use dialog_varsig::{Did, Principal};
+
+/// Access handle scoped to a profile's credential.
+///
+/// Created via [`Profile::access()`](super::Profile::access).
+pub struct Access<'a> {
+    credential: &'a SignerCredential,
+}
+
+impl<'a> Access<'a> {
+    /// Create an access handle from a signer credential.
+    pub fn new(credential: &'a SignerCredential) -> Self {
+        Self { credential }
+    }
+}
+
+impl<'a> Access<'a> {
+    /// Claim authority over a capability.
+    pub fn claim<C: Constraint>(&self, capability: impl Into<Capability<C>>) -> Claim<'a, C> {
+        Claim {
+            by: self.credential,
+            capability: capability.into(),
+            not_before: None,
+            expiration: None,
+        }
+    }
+
+    /// Save a delegation chain under this profile.
+    pub fn save(&self, chain: UcanDelegation) -> super::SaveDelegation {
+        super::SaveDelegation {
+            did: self.credential.did(),
+            chain,
+        }
+    }
+}
+
+/// A claimed capability with optional time bounds.
+///
+/// Can be executed directly via [`.perform()`](Claim::perform) to get a
+/// proof chain, or chained into [`.delegate()`](Claim::delegate) to
+/// produce a delegation.
+pub struct Claim<'a, C: Constraint> {
+    by: &'a SignerCredential,
+    capability: Capability<C>,
+    not_before: Option<Timestamp>,
+    expiration: Option<Timestamp>,
+}
+
+impl<'a, C: Constraint> Claim<'a, C> {
+    /// Set the earliest time the claim is valid.
+    pub fn not_before(mut self, not_before: Timestamp) -> Self {
+        self.not_before = Some(not_before);
+        self
+    }
+
+    /// Set when the claim expires.
+    pub fn expires(mut self, expiration: Timestamp) -> Self {
+        self.expiration = Some(expiration);
+        self
+    }
+
+    /// Chain into a delegation to the given audience.
+    pub fn delegate(self, audience: impl Into<Did>) -> Delegate<'a, C> {
+        Delegate {
+            claim: self,
+            audience: audience.into(),
+        }
+    }
+
+    /// Chain into an invocation.
+    pub fn invoke(self) -> Invoke<'a, C> {
+        Invoke { claim: self }
+    }
+}
+
+impl<C: Constraint> Claim<'_, C>
+where
+    Capability<C>: Ability,
+{
+    fn duration(&self) -> access::TimeRange {
+        access::TimeRange {
+            not_before: self.not_before.map(|t| t.to_unix()),
+            expiration: self.expiration.map(|t| t.to_unix()),
+        }
+    }
+
+    /// Execute the claim, returning a proof chain.
+    pub async fn perform<Env>(self, env: &Env) -> Result<UcanProof, AuthorizeError>
+    where
+        Env: Provider<access::Prove<Ucan>> + ConditionalSync,
+    {
+        let scope = Scope::from(&self.capability);
+        let duration = self.duration();
+        let mut claim = access::Prove::<Ucan>::new(self.by.did(), scope);
+        claim.duration = duration;
+        Subject::from(self.by.did())
+            .attenuate(access::Access)
+            .invoke(claim)
+            .perform(env)
+            .await
+    }
+}
+
+/// An invocation request combining a claim with signing.
+///
+/// Execute via [`.perform()`](Invoke::perform) to claim authority,
+/// bind the profile signer, and produce a signed UCAN invocation.
+pub struct Invoke<'a, C: Constraint> {
+    claim: Claim<'a, C>,
+}
+
+impl<C: Constraint> Invoke<'_, C>
+where
+    Capability<C>: Ability,
+{
+    /// Claim authority, sign, and produce a UCAN invocation.
+    pub async fn perform<Env>(
+        self,
+        env: &Env,
+    ) -> Result<dialog_ucan::UcanInvocation, AuthorizeError>
+    where
+        Env: Provider<access::Prove<Ucan>> + ConditionalSync,
+    {
+        let signer = self.claim.by.signer().clone();
+        let proof_chain = self.claim.perform(env).await?;
+        let authorization = proof_chain.claim(signer)?;
+        authorization.invoke().await
+    }
+}
+
+/// A delegation request combining a claim with a target audience.
+///
+/// Execute via [`.perform()`](Delegate::perform) to claim authority,
+/// bind the profile signer, and produce a signed delegation chain.
+pub struct Delegate<'a, C: Constraint> {
+    claim: Claim<'a, C>,
+    audience: Did,
+}
+
+impl<C: Constraint> Delegate<'_, C>
+where
+    Capability<C>: Ability,
+{
+    /// Claim authority, sign a delegation, and return the chain.
+    pub async fn perform<Env>(self, env: &Env) -> Result<UcanDelegation, AuthorizeError>
+    where
+        Env: Provider<access::Prove<Ucan>> + ConditionalSync,
+    {
+        let signer = self.claim.by.signer().clone();
+        let duration = self.claim.duration();
+        let proof_chain = self.claim.perform(env).await?;
+        let mut authorization = proof_chain.claim(signer)?;
+        if let Some(nbf) = duration.not_before {
+            authorization = authorization.not_before(nbf)?;
+        }
+        if let Some(exp) = duration.expiration {
+            authorization = authorization.expires(exp)?;
+        }
+        authorization.delegate(self.audience).await
+    }
+}

--- a/rust/dialog-operator/src/profile/error.rs
+++ b/rust/dialog-operator/src/profile/error.rs
@@ -1,0 +1,19 @@
+/// Errors that can occur when opening a profile.
+#[derive(Debug, thiserror::Error)]
+pub enum ProfileError {
+    /// Storage operation failed.
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    /// Key generation or import failed.
+    #[error("Key error: {0}")]
+    Key(String),
+
+    /// Profile already exists (for create).
+    #[error("Profile already exists")]
+    AlreadyExists,
+
+    /// Profile not found (for load).
+    #[error("Profile not found")]
+    NotFound,
+}

--- a/rust/dialog-operator/src/profile/open.rs
+++ b/rust/dialog-operator/src/profile/open.rs
@@ -1,0 +1,110 @@
+use dialog_capability::Provider;
+use dialog_common::ConditionalSync;
+use dialog_credentials::{Ed25519Signer, SignerCredential};
+use dialog_effects::storage::{self as storage_fx, Directory, Location, LocationExt};
+
+use super::{Profile, ProfileError};
+
+enum OpenMode {
+    OpenOrCreate,
+    Load,
+    Create,
+}
+
+/// Command to open, load, or create a profile.
+pub struct OpenProfile {
+    name: String,
+    directory: Directory,
+    mode: OpenMode,
+}
+
+impl OpenProfile {
+    pub(super) fn open(name: String) -> Self {
+        Self {
+            name,
+            directory: Directory::Profile,
+            mode: OpenMode::OpenOrCreate,
+        }
+    }
+
+    pub(super) fn load(name: String) -> Self {
+        Self {
+            name,
+            directory: Directory::Profile,
+            mode: OpenMode::Load,
+        }
+    }
+
+    pub(super) fn create(name: String) -> Self {
+        Self {
+            name,
+            directory: Directory::Profile,
+            mode: OpenMode::Create,
+        }
+    }
+
+    /// Set the directory for this profile.
+    ///
+    /// Defaults to `Directory::Profile` (the platform profile directory).
+    /// Use `Directory::Temp` for testing or ephemeral profiles.
+    pub fn at(mut self, directory: Directory) -> Self {
+        self.directory = directory;
+        self
+    }
+
+    fn location(&self) -> dialog_capability::Capability<Location> {
+        dialog_capability::Subject::from(dialog_capability::did!("local:storage"))
+            .attenuate(storage_fx::Storage)
+            .attenuate(Location::new(self.directory.clone(), &self.name))
+    }
+
+    /// Execute against a storage provider.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Profile, ProfileError>
+    where
+        Env: Provider<storage_fx::Load> + Provider<storage_fx::Create> + ConditionalSync,
+    {
+        let credential = match self.mode {
+            OpenMode::Load => self
+                .location()
+                .load()
+                .perform(env)
+                .await
+                .map_err(|e| ProfileError::Storage(e.to_string()))?,
+            OpenMode::Create => {
+                let signer = Ed25519Signer::generate()
+                    .await
+                    .map_err(|e| ProfileError::Key(e.to_string()))?;
+                let credential =
+                    dialog_credentials::Credential::Signer(SignerCredential::from(signer));
+
+                self.location()
+                    .create(credential)
+                    .perform(env)
+                    .await
+                    .map_err(|e| ProfileError::Storage(e.to_string()))?
+            }
+            OpenMode::OpenOrCreate => {
+                let load_result = self.location().load().perform(env).await;
+
+                match load_result {
+                    Ok(cred) => cred,
+                    Err(_) => {
+                        let signer = Ed25519Signer::generate()
+                            .await
+                            .map_err(|e| ProfileError::Key(e.to_string()))?;
+                        let credential =
+                            dialog_credentials::Credential::Signer(SignerCredential::from(signer));
+
+                        self.location()
+                            .create(credential)
+                            .perform(env)
+                            .await
+                            .map_err(|e| ProfileError::Storage(e.to_string()))?
+                    }
+                }
+            }
+        };
+
+        Profile::try_from(credential)
+    }
+}

--- a/rust/dialog-operator/src/profile/save.rs
+++ b/rust/dialog-operator/src/profile/save.rs
@@ -1,0 +1,30 @@
+use dialog_capability::access::{Access, Retain as AccessRetain};
+use dialog_capability::{Provider, Subject};
+use dialog_common::ConditionalSync;
+use dialog_ucan::{Ucan, UcanDelegation};
+use dialog_varsig::Did;
+
+use super::ProfileError;
+
+type RetainUcan = AccessRetain<Ucan>;
+
+/// Command to store a delegation chain under a profile's DID.
+pub struct SaveDelegation {
+    pub(super) did: Did,
+    pub(super) chain: UcanDelegation,
+}
+
+impl SaveDelegation {
+    /// Execute against the environment.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), ProfileError>
+    where
+        Env: Provider<RetainUcan> + ConditionalSync,
+    {
+        Subject::from(self.did)
+            .attenuate(Access)
+            .invoke(AccessRetain::<Ucan>::new(self.chain))
+            .perform(env)
+            .await
+            .map_err(|e| ProfileError::Storage(e.to_string()))
+    }
+}

--- a/rust/dialog-operator/src/profile/space.rs
+++ b/rust/dialog-operator/src/profile/space.rs
@@ -1,0 +1,13 @@
+use dialog_varsig::Did;
+
+/// Handle to a named space under a profile.
+///
+/// Knows the profile DID and space name. Use `.open()`, `.load()`,
+/// or `.create()` to build a command, then `.perform(&operator)` to
+/// execute it.
+pub struct SpaceHandle {
+    /// The profile DID that owns this space.
+    pub profile_did: Did,
+    /// The space name.
+    pub name: String,
+}


### PR DESCRIPTION
## Summary

Adds the `dialog-operator` crate — the runtime that ties together the storage, capability, and network layers. The Operator dispatches capability invocations: local effects flow to the Storage runtime, fork invocations flow to the Network for transport. The Profile sits on top with a fluent API for credential management and capability proofs.

The first commit replays the original PR #292's introducing commit (`feat: add dialog-operator crate`). The trailing `chore: sync …` commit brings the crate forward to the cleanup-branch state so it compiles against the v3 stack: `network.rs` becomes a thin re-export of `dialog-network`'s composite Network; qualified `dialog_capability::{site,fork}::` paths collapse to the re-exports; `Authorize` trait references rename to `SiteFork`; `Scope` comes from the `dialog_ucan` crate root; and the intermediate `SiteAuthorization`/`Authorizer` refactors from the original PR are squashed into the cleaner `SiteFork` model. Adds Profile credential APIs and S3 credential integration tests from later original-PR commits.

The 3 intermediate refactor commits (`fix: adapt operator to new authorization model`, `feat: scheme-parameterized fork authorization with Authorizer trait`, `feat: add Profile credential/prove APIs and S3 credential integration tests`) and the wasm test fix from the original PR are intentionally omitted: they're built on APIs that didn't survive the cleanup branch, and replaying them would only churn the tree before the sync rewrites it.