### PR TITLE
🔁 feat: add dialog-repository crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-repository"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base58",
+ "dialog-artifacts",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-effects",
+ "dialog-operator",
+ "dialog-prolly-tree",
+ "dialog-remote-s3",
+ "dialog-remote-ucan-s3",
+ "dialog-storage",
+ "dialog-ucan",
+ "dialog-ucan-core",
+ "dialog-varsig",
+ "futures-util",
+ "getrandom 0.2.16",
+ "parking_lot",
+ "reqwest",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "rust/dialog-remote-ucan-s3",
     "rust/dialog-network",
     "rust/dialog-operator",
+    "rust/dialog-repository",
     "rust/dialog-varsig",
     "rust/dialog-blobs",
 ]
@@ -206,3 +207,6 @@ path = "./rust/dialog-remote-ucan-s3"
 
 [workspace.dependencies.dialog-operator]
 path = "./rust/dialog-operator"
+
+[workspace.dependencies.dialog-repository]
+path = "./rust/dialog-repository"

--- a/rust/dialog-repository/Cargo.toml
+++ b/rust/dialog-repository/Cargo.toml
@@ -1,0 +1,81 @@
+[package]
+name = "dialog-repository"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+helpers = ["dep:anyhow", "dialog-operator/helpers"]
+# Enable integration tests (tests with service provisioning)
+integration-tests = ["dialog-common/integration-tests"]
+# Enable web integration tests
+web-integration-tests = ["dialog-common/web-integration-tests"]
+
+[dependencies]
+dialog-artifacts = { workspace = true }
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true }
+dialog-operator = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-effects = { workspace = true }
+dialog-ucan = { workspace = true }
+dialog-ucan-core = { workspace = true }
+dialog-remote-s3 = { workspace = true }
+dialog-remote-ucan-s3 = { workspace = true }
+dialog-storage = { workspace = true }
+dialog-prolly-tree = { workspace = true }
+dialog-varsig = { workspace = true }
+parking_lot = { workspace = true }
+
+anyhow = { workspace = true, optional = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+base58 = { workspace = true }
+futures-util = { workspace = true }
+serde = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "io-util"] }
+url = { workspace = true, features = ["serde"] }
+
+[dev-dependencies]
+dialog-ucan = { workspace = true }
+dialog-operator = { workspace = true, features = ["helpers"] }
+dialog-storage = { workspace = true, features = ["helpers"] }
+dialog-remote-s3 = { workspace = true, features = ["helpers"] }
+dialog-remote-ucan-s3 = { workspace = true, features = ["helpers"] }
+dialog-common = { workspace = true, features = ["helpers"] }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["sync", "macros", "io-util", "fs"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+reqwest = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = [
+    "io-util",
+    "io-std",
+    "sync",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }
+
+[lints.rust]
+# This cfg is used by the dialog_common::test proc macro for wasm inner tests
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(dialog_test_wasm_integration)"] }

--- a/rust/dialog-repository/README.md
+++ b/rust/dialog-repository/README.md
@@ -1,0 +1,86 @@
+# dialog-repository
+
+A git-like interface for Dialog-DB.
+
+Provides repositories with branches, remotes, push/pull, and merge, but for structured data instead of files. Each repository has its own identity (keypair), named branches with revision history, and remotes for replication. Information is stored as claims: `{ the, of, is, cause }` facts where `the` is the relation, `of` is the entity, `is` is the value, and `cause` is the provenance. Claims can be queried with typed concepts or deductive rules. Same name under the same profile always yields the same repository identity.
+
+## Usage
+
+```rust
+use dialog_repository::RepositoryExt;
+use dialog_operator::profile::Profile;
+use dialog_storage::provider::environment::Storage;
+use dialog_capability::Subject;
+
+// Setup
+let storage = Storage::default();
+let profile = Profile::open("alice").perform(&storage).await?;
+let operator = profile
+    .derive(b"my-app")
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+
+// Open or create a repository
+let contacts = profile.repository("contacts")
+    .open()
+    .perform(&operator)
+    .await?;
+
+// Work with branches
+let main = contacts
+    .branch("main")
+    .open()
+    .perform(&operator)
+    .await?;
+
+// Define a concept with typed attributes
+#[derive(Concept)]
+struct Employee {
+    this: Entity,
+    name: employee::Name,
+    role: employee::Role,
+}
+
+// Commit data
+main.transaction()
+    .assert(Employee {
+        this: Entity::new()?,
+        name: employee::Name("Alice".into()),
+        role: employee::Role("Engineer".into()),
+    })
+    .commit()
+    .perform(&operator)
+    .await?;
+
+// Query
+let results: Vec<Employee> = main
+    .query()
+    .select(Query::<Employee> {
+        this: Term::var("this"),
+        name: Term::var("name"),
+        role: Term::var("role"),
+    })
+    .perform(&operator)
+    .try_vec()
+    .await?;
+
+// Add a remote and sync
+let origin = contacts.remote("origin")
+    .create(address)
+    .perform(&operator)
+    .await?;
+
+let upstream = origin
+    .branch("main")
+    .open()
+    .perform(&operator)
+    .await?;
+main
+    .set_upstream(upstream)
+    .perform(&operator)
+    .await?;
+
+main.push().perform(&operator).await?;
+main.pull().perform(&operator).await?;
+```

--- a/rust/dialog-repository/src/helpers.rs
+++ b/rust/dialog-repository/src/helpers.rs
@@ -1,0 +1,24 @@
+// Re-export operator-level helpers.
+pub use dialog_operator::helpers::{
+    generate_data, test_operator, test_operator_with_profile, unique_name,
+};
+
+use crate::Repository;
+use crate::repository::RepositoryExt as _;
+use dialog_credentials::Credential;
+use dialog_operator::Operator;
+use dialog_operator::profile::Profile;
+use dialog_storage::provider::storage::VolatileSpace;
+
+/// Create a test repository using the given operator and profile.
+pub async fn test_repo(
+    operator: &Operator<VolatileSpace>,
+    profile: &Profile,
+) -> Repository<Credential> {
+    profile
+        .repository(unique_name("repo"))
+        .open()
+        .perform(operator)
+        .await
+        .expect("test_repo: failed to open repository")
+}

--- a/rust/dialog-repository/src/lib.rs
+++ b/rust/dialog-repository/src/lib.rs
@@ -1,0 +1,50 @@
+#![warn(missing_docs)]
+#![warn(clippy::absolute_paths)]
+#![warn(clippy::default_trait_access)]
+#![warn(clippy::fallible_impl_from)]
+#![warn(clippy::panicking_unwrap)]
+#![warn(clippy::unused_async)]
+#![deny(clippy::partial_pub_fields)]
+#![deny(clippy::unnecessary_self_imports)]
+#![cfg_attr(not(test), warn(clippy::large_futures))]
+#![cfg_attr(not(test), deny(clippy::panic))]
+
+//! Repository layer for Dialog-DB.
+//!
+//! This crate provides the capability-based repository system built on top
+//! of the operator layer (`dialog-operator`). It re-exports operator types
+//! and adds the repository abstraction with branches, remotes, and archives.
+
+// Re-export everything from dialog-operator for backwards compatibility.
+pub use dialog_operator::{
+    Artifact, ArtifactSelector, ArtifactStore, ArtifactStoreMut, Artifacts, Attribute,
+    AttributeKey, Authority, Cause, Datum, DialogArtifactsError, Entity, EntityKey, FromKey,
+    Instruction, Key, KeyView, KeyViewConstruct, KeyViewMut, Network, Operator, State, Value,
+    ValueKey,
+};
+
+/// Authority — opened profile with signers and authority chain.
+pub use dialog_operator::authority;
+
+/// Profile — named identity with signing credential.
+pub use dialog_operator::profile;
+
+/// Operator — operating environment built from a profile.
+pub use dialog_operator::operator;
+
+/// Network dispatch for fork invocations.
+pub use dialog_operator::network;
+
+/// Capability-based repository system.
+mod repository;
+pub use repository::branch::BranchReference;
+pub use repository::memory::MemoryExt;
+pub use repository::{
+    Branch, BranchName, CreateRemote, CreateRepository, LoadBranch, LoadRemote, LoadRepository,
+    OpenBranch, OpenRepository, RemoteAddress, RemoteName, RemoteReference, RemoteRepository,
+    Repository, RepositoryError, RepositoryExt, SiteAddress, UpstreamState,
+};
+
+/// Test helpers for setting up profiles, operators, repositories, and test data.
+#[cfg(any(test, feature = "helpers"))]
+pub mod helpers;

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -1,0 +1,698 @@
+//! Capability-based repository system.
+//!
+//! This module provides a repository abstraction built on top of the
+//! capability-based effect system (`dialog-capability` / `dialog-effects`).
+//!
+//! - [`archive`] — CAS adapter bridging capabilities with prolly tree storage
+//! - [`branch`] — Branch operations (open, load, commit, select, reset, pull)
+//! - [`cell`] — Transactional memory cells with edition tracking
+//! - [`revision`] — Revision tracking and logical timestamps
+
+/// Archive capabilities and CAS adapters.
+pub mod archive;
+/// Capability-based branch operations (command pattern).
+pub mod branch;
+/// Command to create a new repository.
+mod create;
+/// Repository error types.
+pub mod error;
+/// Command to load an existing repository.
+mod load;
+/// Memory capability wrapper (`Subject -> Memory -> Space -> Cell`).
+pub mod memory;
+/// Node reference type for tree root hashes.
+pub mod node_reference;
+/// Command to open (load-or-create) a repository.
+mod open;
+/// Remote site / repository / branch cursor hierarchy.
+pub mod remote;
+/// Revision type and edition tracking.
+pub mod revision;
+
+use dialog_capability::{Capability, Did, Subject};
+use dialog_credentials::Ed25519Signer;
+use dialog_credentials::credential::{Credential, SignerCredential};
+use dialog_effects::space as space_fx;
+use dialog_operator::profile::access::Access as ProfileAccess;
+use dialog_varsig::Principal;
+use memory::MemoryExt;
+
+pub use branch::*;
+pub use create::CreateRepository;
+pub use error::*;
+pub use load::LoadRepository;
+pub use open::OpenRepository;
+pub use remote::*;
+
+/// A repository scoped to a specific subject.
+///
+/// The credential type parameter determines access level:
+/// - `Repository<SignerCredential>` -- owns the keypair, can delegate
+/// - `Repository<Credential>` -- either signer or verifier, determined at runtime
+pub struct Repository<C: Principal = Credential> {
+    credential: C,
+}
+
+impl<C: Principal> Repository<C> {
+    fn new(credential: C) -> Self {
+        Self { credential }
+    }
+
+    /// Get the credential.
+    pub fn credential(&self) -> &C {
+        &self.credential
+    }
+
+    /// The subject DID.
+    pub fn did(&self) -> Did {
+        self.credential.did()
+    }
+
+    /// The subject.
+    pub fn subject(&self) -> Subject {
+        self.did().into()
+    }
+
+    /// Get a branch reference for the given name.
+    ///
+    /// Call `.open()` or `.load()` on the returned reference.
+    pub fn branch(&self, name: impl Into<branch::BranchName>) -> branch::BranchReference {
+        self.subject().branch(name)
+    }
+
+    /// Get a remote reference for the given name.
+    ///
+    /// Call `.create(address)` or `.load()` on the returned reference.
+    pub fn remote(&self, name: impl Into<remote::RemoteName>) -> remote::RemoteReference {
+        self.subject().remote(name)
+    }
+}
+
+impl<C: Principal> Principal for Repository<C> {
+    fn did(&self) -> Did {
+        self.credential.did()
+    }
+}
+
+impl<C: Principal> From<&Repository<C>> for Capability<Subject> {
+    fn from(r: &Repository<C>) -> Self {
+        Subject::from(r.did()).into()
+    }
+}
+
+impl Repository<SignerCredential> {
+    /// Access handle for claiming and delegating capabilities.
+    pub fn access(&self) -> ProfileAccess<'_> {
+        ProfileAccess::new(&self.credential)
+    }
+}
+
+impl Repository {
+    /// Access handle for claiming and delegating capabilities.
+    ///
+    /// Returns `None` if the credential is verifier-only.
+    pub fn try_access(&self) -> Option<ProfileAccess<'_>> {
+        match &self.credential {
+            Credential::Signer(s) => Some(ProfileAccess::new(s)),
+            Credential::Verifier(_) => None,
+        }
+    }
+}
+
+impl From<Credential> for Repository {
+    fn from(credential: Credential) -> Self {
+        Self::new(credential)
+    }
+}
+
+impl From<SignerCredential> for Repository<SignerCredential> {
+    fn from(credential: SignerCredential) -> Self {
+        Self::new(credential)
+    }
+}
+
+impl TryFrom<Credential> for Repository<SignerCredential> {
+    type Error = RepositoryError;
+
+    fn try_from(credential: Credential) -> Result<Self, RepositoryError> {
+        match credential {
+            Credential::Signer(s) => Ok(Self::new(s)),
+            Credential::Verifier(_) => Err(RepositoryError::StorageError(
+                "repository credential is verifier-only".into(),
+            )),
+        }
+    }
+}
+
+impl From<Ed25519Signer> for Repository<SignerCredential> {
+    fn from(signer: Ed25519Signer) -> Self {
+        SignerCredential::from(signer).into()
+    }
+}
+
+use dialog_operator::profile::SpaceHandle;
+
+/// Extension trait for opening repositories from a [`SpaceHandle`].
+///
+/// Enables `profile.repository("name").open().perform(&operator)`.
+pub trait RepositoryExt {
+    /// Open or create a repository, loading existing or creating new.
+    fn open(self) -> OpenRepository;
+
+    /// Load an existing repository, failing if not found.
+    fn load(self) -> LoadRepository;
+
+    /// Create a new repository, failing if one already exists.
+    fn create(self) -> CreateRepository;
+}
+
+impl RepositoryExt for SpaceHandle {
+    fn open(self) -> OpenRepository {
+        OpenRepository(Subject::from(self.profile_did).attenuate(space_fx::Space::new(self.name)))
+    }
+
+    fn load(self) -> LoadRepository {
+        LoadRepository(Subject::from(self.profile_did).attenuate(space_fx::Space::new(self.name)))
+    }
+
+    fn create(self) -> CreateRepository {
+        CreateRepository(Subject::from(self.profile_did).attenuate(space_fx::Space::new(self.name)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::helpers::{test_operator_with_profile, test_repo, unique_name};
+    use crate::{Artifact, ArtifactSelector, Instruction, Value};
+    use dialog_remote_s3::Address as S3Address;
+    use futures_util::StreamExt;
+    use futures_util::stream;
+
+    fn test_site_address() -> SiteAddress {
+        SiteAddress::S3(
+            S3Address::builder("https://s3.us-east-1.amazonaws.com")
+                .region("us-east-1")
+                .bucket("bucket")
+                .build()
+                .unwrap(),
+        )
+    }
+
+    #[dialog_common::test]
+    async fn open_creates_repository() {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = profile
+            .repository(unique_name("open"))
+            .open()
+            .perform(&operator)
+            .await
+            .unwrap();
+
+        assert!(!repo.did().to_string().is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn create_then_load() {
+        let (operator, profile) = test_operator_with_profile().await;
+        let name = unique_name("create-load");
+
+        let created = profile
+            .repository(name.clone())
+            .create()
+            .perform(&operator)
+            .await
+            .unwrap();
+
+        let loaded = profile
+            .repository(name)
+            .load()
+            .perform(&operator)
+            .await
+            .unwrap();
+        assert_eq!(created.did(), loaded.did());
+    }
+
+    #[dialog_common::test]
+    async fn it_opens_branch_via_repository() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        assert_eq!(branch.name().as_str(), "main");
+        assert!(
+            branch.revision().is_none(),
+            "New branch should have no revision"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_loads_branch_via_repository() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let _branch = repo.branch("main").open().perform(&operator).await?;
+        let branch = repo.branch("main").load().perform(&operator).await?;
+        assert_eq!(branch.name().as_str(), "main");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_commits_via_repository() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("main").open().perform(&operator).await?;
+        let artifact = Artifact {
+            the: "user/name".parse()?,
+            of: "user:123".parse()?,
+            is: Value::String("Alice".to_string()),
+            cause: None,
+        };
+        let _hash = branch
+            .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+            .perform(&operator)
+            .await?;
+
+        assert!(
+            branch.revision().is_some(),
+            "Branch should have a revision after commit"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_adds_and_loads_remote_via_repository() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let site = repo
+            .remote("origin")
+            .create(test_site_address())
+            .perform(&operator)
+            .await?;
+        assert_eq!(site.site().name(), "origin");
+
+        let loaded = repo.remote("origin").load().perform(&operator).await?;
+        assert_eq!(loaded.site().name(), "origin");
+        assert_eq!(loaded.address().site(), &test_site_address());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_opens_repository_by_name() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+
+        let repo = profile
+            .repository(unique_name("home"))
+            .open()
+            .perform(&operator)
+            .await?;
+        assert!(
+            !repo.subject().to_string().is_empty(),
+            "should produce a valid subject DID"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reopens_same_repository() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let name = unique_name("home");
+
+        let did1 = profile
+            .repository(name.clone())
+            .open()
+            .perform(&operator)
+            .await?
+            .subject();
+        let did2 = profile
+            .repository(name)
+            .open()
+            .perform(&operator)
+            .await?
+            .subject();
+
+        assert_eq!(did1, did2, "reopening should return same subject DID");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_isolates_repositories_by_name() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+
+        let repo1 = profile
+            .repository(unique_name("home"))
+            .open()
+            .perform(&operator)
+            .await?;
+        let repo2 = profile
+            .repository(unique_name("work"))
+            .open()
+            .perform(&operator)
+            .await?;
+
+        assert_ne!(
+            repo1.subject(),
+            repo2.subject(),
+            "different names should produce different subjects"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_commits_and_selects_by_attribute() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let artifacts = vec![
+            Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:1".parse()?,
+                is: Value::String("Alice".into()),
+                cause: None,
+            }),
+            Instruction::Assert(Artifact {
+                the: "user/email".parse()?,
+                of: "user:1".parse()?,
+                is: Value::String("alice@example.com".into()),
+                cause: None,
+            }),
+            Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:2".parse()?,
+                is: Value::String("Bob".into()),
+                cause: None,
+            }),
+        ];
+
+        branch
+            .commit(stream::iter(artifacts))
+            .perform(&operator)
+            .await?;
+
+        let results: Vec<_> = branch
+            .claims()
+            .select(ArtifactSelector::new().the("user/name".parse()?))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        assert_eq!(results.len(), 2, "should find 2 user/name artifacts");
+        let names: Vec<_> = results.iter().map(|a| &a.is).collect();
+        assert!(
+            names.contains(&&Value::String("Alice".into())),
+            "should contain Alice"
+        );
+        assert!(
+            names.contains(&&Value::String("Bob".into())),
+            "should contain Bob"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_commits_and_selects_by_entity() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let artifacts = vec![
+            Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:alice".parse()?,
+                is: Value::String("Alice".into()),
+                cause: None,
+            }),
+            Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:bob".parse()?,
+                is: Value::String("Bob".into()),
+                cause: None,
+            }),
+            Instruction::Assert(Artifact {
+                the: "user/email".parse()?,
+                of: "user:alice".parse()?,
+                is: Value::String("alice@example.com".into()),
+                cause: None,
+            }),
+        ];
+
+        branch
+            .commit(stream::iter(artifacts))
+            .perform(&operator)
+            .await?;
+
+        let results: Vec<_> = branch
+            .claims()
+            .select(ArtifactSelector::new().of("user:alice".parse()?))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        assert_eq!(results.len(), 2, "should find 2 artifacts for user:alice");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_selects_empty_branch() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let results: Vec<_> = branch
+            .claims()
+            .select(ArtifactSelector::new().the("user/name".parse()?))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        assert_eq!(results.len(), 0, "empty branch should have no artifacts");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_retracts_artifact() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let artifact = Artifact {
+            the: "user/name".parse()?,
+            of: "user:1".parse()?,
+            is: Value::String("Alice".into()),
+            cause: None,
+        };
+
+        branch
+            .commit(stream::iter(vec![Instruction::Assert(artifact.clone())]))
+            .perform(&operator)
+            .await?;
+
+        // Verify it's there
+        let before: Vec<_> = branch
+            .claims()
+            .select(ArtifactSelector::new().the("user/name".parse()?))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(before.len(), 1, "should have 1 artifact before retract");
+
+        // Retract it
+        branch
+            .commit(stream::iter(vec![Instruction::Retract(artifact)]))
+            .perform(&operator)
+            .await?;
+
+        let after: Vec<_> = branch
+            .claims()
+            .select(ArtifactSelector::new().the("user/name".parse()?))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(after.len(), 0, "should have 0 artifacts after retract");
+
+        Ok(())
+    }
+
+    mod delegation_tests {
+        use super::*;
+        use crate::helpers::{test_operator_with_profile, unique_name};
+        use dialog_effects::memory as fx_memory;
+
+        #[dialog_common::test]
+        async fn it_delegates_repo_to_profile_and_claims() -> anyhow::Result<()> {
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = profile
+                .repository(unique_name("home"))
+                .create()
+                .perform(&operator)
+                .await?;
+
+            // Repo delegates full ownership to the profile
+            let chain = repo
+                .access()
+                .claim(&repo)
+                .delegate(profile.did())
+                .perform(&operator)
+                .await?;
+            profile.access().save(chain).perform(&operator).await?;
+
+            // Profile should be able to claim access to any memory space
+            let capability = repo
+                .subject()
+                .attenuate(fx_memory::Memory)
+                .attenuate(fx_memory::Space::new("data"));
+
+            let result = profile.access().claim(capability).perform(&operator).await;
+            assert!(
+                result.is_ok(),
+                "should find delegation chain: {:?}",
+                result.err()
+            );
+
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_enforces_scoped_delegation_policy() -> anyhow::Result<()> {
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = profile
+                .repository(unique_name("home"))
+                .create()
+                .perform(&operator)
+                .await?;
+
+            // Repo delegates only memory/space("data") to the profile
+            let scoped_cap = repo
+                .subject()
+                .attenuate(fx_memory::Memory)
+                .attenuate(fx_memory::Space::new("data"));
+            let chain = repo
+                .access()
+                .claim(scoped_cap)
+                .delegate(profile.did())
+                .perform(&operator)
+                .await?;
+            profile.access().save(chain).perform(&operator).await?;
+
+            // Claiming "data" space should succeed
+            let data_cap = repo
+                .subject()
+                .attenuate(fx_memory::Memory)
+                .attenuate(fx_memory::Space::new("data"));
+            let result = profile.access().claim(data_cap).perform(&operator).await;
+            assert!(
+                result.is_ok(),
+                "claim on delegated space 'data' should succeed: {:?}",
+                result.err()
+            );
+
+            // Claiming "secret" space should fail
+            let secret_cap = repo
+                .subject()
+                .attenuate(fx_memory::Memory)
+                .attenuate(fx_memory::Space::new("secret"));
+            let result = profile.access().claim(secret_cap).perform(&operator).await;
+            assert!(
+                result.is_err(),
+                "claim on non-delegated space 'secret' should be denied"
+            );
+
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_validates_delegation_against_policy() -> anyhow::Result<()> {
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = profile
+                .repository(unique_name("home"))
+                .create()
+                .perform(&operator)
+                .await?;
+
+            // Repo delegates memory/space("data") to the profile
+            let scoped_cap = repo
+                .subject()
+                .attenuate(fx_memory::Memory)
+                .attenuate(fx_memory::Space::new("data"));
+            let chain = repo
+                .access()
+                .claim(scoped_cap)
+                .delegate(profile.did())
+                .perform(&operator)
+                .await?;
+            profile.access().save(chain).perform(&operator).await?;
+
+            // Profile can re-delegate "data" space to operator
+            let data_cap = repo
+                .subject()
+                .attenuate(fx_memory::Memory)
+                .attenuate(fx_memory::Space::new("data"));
+            let result = profile
+                .access()
+                .claim(data_cap)
+                .delegate(operator.did())
+                .perform(&operator)
+                .await;
+            assert!(
+                result.is_ok(),
+                "delegation for space 'data' should succeed: {:?}",
+                result.err()
+            );
+
+            // Profile cannot delegate "secret" space (no chain)
+            let secret_cap = repo
+                .subject()
+                .attenuate(fx_memory::Memory)
+                .attenuate(fx_memory::Space::new("secret"));
+            let result = profile
+                .access()
+                .claim(secret_cap)
+                .delegate(operator.did())
+                .perform(&operator)
+                .await;
+            assert!(
+                result.is_err(),
+                "delegation for non-delegated space 'secret' should fail"
+            );
+
+            Ok(())
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/archive.rs
+++ b/rust/dialog-repository/src/repository/archive.rs
@@ -1,0 +1,26 @@
+//! Archive capabilities and CAS adapters.
+//!
+//! - [`ArchiveExt`] -- extension trait adding `.index()` to archive capabilities
+//! - [`local`] -- local CAS adapter for prolly tree storage
+//! - [`networked`] -- CAS adapter with transparent remote replication
+
+/// Local CAS adapter bridging capabilities with prolly tree's ContentAddressedStorage.
+pub mod local;
+/// Networked index: local reads with remote fallback and caching.
+pub mod networked;
+
+use dialog_capability::Capability;
+use dialog_effects::archive as fx;
+use dialog_effects::archive::prelude::ArchiveExt as _;
+
+/// Extension trait for archive capabilities in the repository context.
+pub trait ArchiveExt {
+    /// The index catalog used for search tree node storage.
+    fn index(self) -> Capability<fx::Catalog>;
+}
+
+impl ArchiveExt for Capability<fx::Archive> {
+    fn index(self) -> Capability<fx::Catalog> {
+        self.catalog("index")
+    }
+}

--- a/rust/dialog-repository/src/repository/archive/local.rs
+++ b/rust/dialog-repository/src/repository/archive/local.rs
@@ -1,0 +1,203 @@
+use async_trait::async_trait;
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::prelude::CatalogExt;
+use dialog_effects::archive::{Catalog, Get, Put};
+use dialog_storage::{
+    Blake3Hash, CborEncoder, ContentAddressedStorage, DialogStorageError, Encoder,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use std::fmt::Debug;
+
+/// Local content-addressed index backed by archive capabilities.
+///
+/// Bridges the capability system (`Get`/`Put` effects) with the prolly
+/// tree's `ContentAddressedStorage` trait. All reads and writes go to
+/// the local archive only.
+pub struct LocalIndex<'a, Env> {
+    env: &'a Env,
+    encoder: CborEncoder,
+    catalog: Capability<Catalog>,
+}
+
+impl<Env> Clone for LocalIndex<'_, Env> {
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env,
+            encoder: self.encoder.clone(),
+            catalog: self.catalog.clone(),
+        }
+    }
+}
+
+impl<'a, Env> LocalIndex<'a, Env> {
+    /// Create a local index for the given catalog capability.
+    pub fn new(env: &'a Env, catalog: Capability<Catalog>) -> Self {
+        Self {
+            env,
+            encoder: CborEncoder,
+            catalog,
+        }
+    }
+
+    /// The catalog capability this index operates on.
+    pub fn catalog(&self) -> &Capability<Catalog> {
+        &self.catalog
+    }
+
+    /// The environment reference.
+    pub fn env(&self) -> &'a Env {
+        self.env
+    }
+
+    /// The encoder used for serialization.
+    pub fn encoder(&self) -> &CborEncoder {
+        &self.encoder
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> ContentAddressedStorage for LocalIndex<'_, Env>
+where
+    Env: Provider<Get> + Provider<Put> + ConditionalSync + 'static,
+{
+    type Hash = Blake3Hash;
+    type Error = DialogStorageError;
+
+    async fn read<T>(&self, hash: &Self::Hash) -> Result<Option<T>, Self::Error>
+    where
+        T: DeserializeOwned + ConditionalSync,
+    {
+        let result: Option<Vec<u8>> = self.catalog.clone().get(*hash).perform(self.env).await?;
+
+        match result {
+            Some(bytes) => {
+                let value: T = self
+                    .encoder
+                    .decode(&bytes)
+                    .await
+                    .map_err(|e| DialogStorageError::DecodeFailed(e.to_string()))?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn write<T>(&mut self, block: &T) -> Result<Self::Hash, Self::Error>
+    where
+        T: Serialize + ConditionalSync + Debug,
+    {
+        let (hash, bytes) = self.encoder.encode(block).await?;
+        self.catalog
+            .clone()
+            .put(hash, bytes)
+            .perform(self.env)
+            .await?;
+        Ok(hash)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> Encoder for LocalIndex<'_, Env>
+where
+    Env: ConditionalSync + 'static,
+{
+    type Bytes = Vec<u8>;
+    type Hash = Blake3Hash;
+    type Error = DialogStorageError;
+
+    async fn encode<T>(&self, block: &T) -> Result<(Self::Hash, Self::Bytes), Self::Error>
+    where
+        T: Serialize + ConditionalSync + Debug,
+    {
+        self.encoder.encode(block).await
+    }
+
+    async fn decode<T>(&self, bytes: &[u8]) -> Result<T, Self::Error>
+    where
+        T: DeserializeOwned + ConditionalSync,
+    {
+        self.encoder.decode(bytes).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_capability::{Did, Subject};
+    use dialog_effects::archive::Archive;
+    use dialog_storage::provider::Volatile;
+
+    fn test_catalog(name: &str) -> Capability<Catalog> {
+        let did: Did = "did:test:archive-cas".parse().unwrap();
+        Subject::from(did)
+            .attenuate(Archive)
+            .attenuate(Catalog::new(name))
+    }
+
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestBlock {
+        value: u32,
+        label: String,
+    }
+
+    #[dialog_common::test]
+    async fn it_writes_and_reads_block() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let mut archive = LocalIndex::new(&env, test_catalog("index"));
+
+        let block = TestBlock {
+            value: 42,
+            label: "hello".into(),
+        };
+
+        let hash = archive.write(&block).await?;
+        let result: Option<TestBlock> = archive.read(&hash).await?;
+
+        assert_eq!(result, Some(block));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_none_for_missing_hash() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let archive = LocalIndex::new(&env, test_catalog("index"));
+
+        let missing_hash = [0u8; 32];
+        let result: Option<TestBlock> = archive.read(&missing_hash).await?;
+
+        assert!(result.is_none());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_isolates_catalogs() -> anyhow::Result<()> {
+        let env = Volatile::new();
+
+        let block = TestBlock {
+            value: 99,
+            label: "isolated".into(),
+        };
+
+        let hash = {
+            let mut archive = LocalIndex::new(&env, test_catalog("a"));
+            archive.write(&block).await?
+        };
+
+        {
+            let archive = LocalIndex::new(&env, test_catalog("b"));
+            let result: Option<TestBlock> = archive.read(&hash).await?;
+            assert!(result.is_none());
+        }
+
+        {
+            let archive = LocalIndex::new(&env, test_catalog("a"));
+            let result: Option<TestBlock> = archive.read(&hash).await?;
+            assert_eq!(result, Some(block));
+        }
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/archive/networked.rs
+++ b/rust/dialog-repository/src/repository/archive/networked.rs
@@ -1,0 +1,133 @@
+use crate::repository::remote::address::RemoteSite;
+use async_trait::async_trait;
+use dialog_capability::Fork;
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt, CatalogExt};
+use dialog_effects::archive::{Catalog, Get, Put};
+use dialog_storage::{Blake3Hash, ContentAddressedStorage, DialogStorageError, Encoder};
+use serde::{Serialize, de::DeserializeOwned};
+use std::fmt::Debug;
+
+use super::local::LocalIndex;
+use crate::repository::remote::RemoteRepository;
+
+/// Content-addressed index with on-demand remote replication.
+///
+/// Wraps a [`LocalIndex`] and adds transparent remote fallback: reads
+/// that miss locally are fetched from the remote and cached. Writes
+/// always go to the local index only.
+///
+/// When no remote is configured, behaves identically to [`LocalIndex`].
+pub struct NetworkedIndex<'a, Env> {
+    local: LocalIndex<'a, Env>,
+    remote: Option<RemoteRepository>,
+}
+
+impl<Env> Clone for NetworkedIndex<'_, Env> {
+    fn clone(&self) -> Self {
+        Self {
+            local: self.local.clone(),
+            remote: self.remote.clone(),
+        }
+    }
+}
+
+impl<'a, Env> NetworkedIndex<'a, Env> {
+    /// Create a networked index. If `remote` is `Some`, reads that miss
+    /// locally will fall back to the remote and cache the result.
+    pub fn new(env: &'a Env, index: Capability<Catalog>, remote: Option<RemoteRepository>) -> Self {
+        Self {
+            local: LocalIndex::new(env, index),
+            remote,
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> ContentAddressedStorage for NetworkedIndex<'_, Env>
+where
+    Env:
+        Provider<Get> + Provider<Put> + Provider<Fork<RemoteSite, Get>> + ConditionalSync + 'static,
+{
+    type Hash = Blake3Hash;
+    type Error = DialogStorageError;
+
+    async fn read<T>(&self, hash: &Self::Hash) -> Result<Option<T>, Self::Error>
+    where
+        T: DeserializeOwned + ConditionalSync,
+    {
+        // Try local first
+        if let Some(value) = self.local.read::<T>(hash).await? {
+            return Ok(Some(value));
+        }
+
+        // Fall back to offloaded nodes
+        let remote = match &self.remote {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        let address = remote.address();
+        let remote_catalog = address.subject.clone().archive().catalog("index");
+
+        let env = self.local.env();
+        let remote_result = remote_catalog
+            .clone()
+            .get(*hash)
+            .fork(&address.address)
+            .perform(env)
+            .await
+            .map_err(|e| DialogStorageError::StorageBackend(e.to_string()))?;
+
+        match remote_result {
+            Some(bytes) => {
+                // Cache locally
+                let cache = self.local.catalog().clone().put(*hash, bytes.clone());
+                let _: Result<(), _> = cache.perform(self.local.env()).await;
+
+                let value: T = self
+                    .local
+                    .encoder()
+                    .decode(&bytes)
+                    .await
+                    .map_err(|e| DialogStorageError::DecodeFailed(e.to_string()))?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn write<T>(&mut self, block: &T) -> Result<Self::Hash, Self::Error>
+    where
+        T: Serialize + ConditionalSync + Debug,
+    {
+        self.local.write(block).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> Encoder for NetworkedIndex<'_, Env>
+where
+    Env: ConditionalSync + 'static,
+{
+    type Bytes = Vec<u8>;
+    type Hash = Blake3Hash;
+    type Error = DialogStorageError;
+
+    async fn encode<T>(&self, block: &T) -> Result<(Self::Hash, Self::Bytes), Self::Error>
+    where
+        T: Serialize + ConditionalSync + Debug,
+    {
+        self.local.encoder().encode(block).await
+    }
+
+    async fn decode<T>(&self, bytes: &[u8]) -> Result<T, Self::Error>
+    where
+        T: DeserializeOwned + ConditionalSync,
+    {
+        self.local.encoder().decode(bytes).await
+    }
+}

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -1,0 +1,82 @@
+use dialog_capability::{Capability, Did, Subject};
+use dialog_effects::archive as archive_fx;
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+use dialog_prolly_tree::{GeometricDistribution, Tree};
+use dialog_storage::Blake3Hash;
+
+use dialog_artifacts::Datum;
+
+use crate::{Key, State};
+
+/// Branch name newtype.
+pub mod name;
+/// Upstream tracking state.
+pub mod upstream;
+
+mod claims;
+mod commit;
+mod fetch;
+#[cfg(all(test, feature = "integration-tests"))]
+mod integration_tests;
+mod load;
+mod novelty;
+mod open;
+mod pull;
+mod push;
+pub mod reference;
+mod reset;
+mod select;
+mod set_upstream;
+mod transaction;
+
+pub use load::LoadBranch;
+pub use open::OpenBranch;
+pub use reference::BranchReference;
+
+use super::memory::Cell;
+
+use super::revision::Revision;
+pub use name::BranchName;
+pub use upstream::UpstreamState;
+
+/// Type alias for the prolly tree index.
+pub type Index = Tree<GeometricDistribution, Key, State<Datum>, Blake3Hash>;
+
+/// A branch represents a named line of development within a repository.
+///
+/// Holds a [`BranchReference`] (scoped to `branch/{name}`) plus separate
+/// cells for revision and upstream state.
+#[derive(Debug, Clone)]
+pub struct Branch {
+    reference: BranchReference,
+    revision: Cell<Option<Revision>>,
+    upstream: Cell<Option<UpstreamState>>,
+}
+
+impl Branch {
+    /// Returns the branch name.
+    pub fn name(&self) -> BranchName {
+        self.reference.name()
+    }
+
+    /// Returns the current revision of this branch, or `None` if the branch
+    /// has no commits yet (equivalent to an orphan branch in git).
+    pub fn revision(&self) -> Option<Revision> {
+        self.revision.content().flatten()
+    }
+
+    /// Returns the upstream state.
+    pub fn upstream(&self) -> Option<UpstreamState> {
+        self.upstream.content().flatten()
+    }
+
+    /// Returns the subject DID.
+    pub fn subject(&self) -> &Did {
+        self.reference.subject()
+    }
+
+    /// Archive capability for this branch's subject.
+    pub fn archive(&self) -> Capability<archive_fx::Archive> {
+        Subject::from(self.subject().clone()).archive()
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/claims.rs
+++ b/rust/dialog-repository/src/repository/branch/claims.rs
@@ -1,0 +1,31 @@
+use dialog_artifacts::ArtifactSelector;
+use dialog_artifacts::selector::Constrained;
+
+use super::Branch;
+use super::select::Select;
+
+/// The branch's artifact index with remote fallback.
+///
+/// Created by [`Branch::index`]. Queries will replicate blocks
+/// from the remote on demand if the branch has a remote upstream.
+pub struct BranchClaims<'a> {
+    branch: &'a Branch,
+}
+
+impl<'a> BranchClaims<'a> {
+    /// Select artifacts matching the selector.
+    pub fn select(self, selector: ArtifactSelector<Constrained>) -> Select<'a> {
+        Select::new(self.branch, selector)
+    }
+}
+
+impl Branch {
+    /// The branch's artifact index.
+    ///
+    /// Use `.select(selector).perform(&env)` to query artifacts.
+    /// If the branch has a remote upstream, missing blocks are
+    /// replicated on demand.
+    pub fn claims(&self) -> BranchClaims<'_> {
+        BranchClaims { branch: self }
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -1,0 +1,259 @@
+use dialog_capability::{Policy, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_effects::archive as archive_fx;
+use dialog_effects::authority;
+use dialog_effects::memory as memory_fx;
+use dialog_prolly_tree::{EMPT_TREE_HASH, Tree};
+use dialog_storage::Blake3Hash;
+use futures_util::{Stream, StreamExt, TryStreamExt};
+use std::collections::HashSet;
+
+use super::{Branch, Index};
+use crate::repository::archive::ArchiveExt as _;
+use crate::repository::archive::local::LocalIndex;
+use crate::repository::node_reference::NodeReference;
+use crate::repository::revision::Revision;
+use crate::{
+    AttributeKey, DialogArtifactsError, EntityKey, FromKey, Key, KeyView, KeyViewConstruct,
+    KeyViewMut, State, ValueKey,
+};
+use dialog_artifacts::{Artifact, Cause, Datum, Instruction};
+
+/// Command struct for committing instructions to a branch.
+pub struct Commit<'a, I> {
+    branch: &'a Branch,
+    instructions: I,
+}
+
+impl<'a, I> Commit<'a, I> {
+    fn new(branch: &'a Branch, instructions: I) -> Self {
+        Self {
+            branch,
+            instructions,
+        }
+    }
+}
+
+impl Branch {
+    /// Commit a stream of instructions to this branch.
+    pub fn commit<I>(&self, instructions: I) -> Commit<'_, I> {
+        Commit::new(self, instructions)
+    }
+}
+
+impl<I> Commit<'_, I>
+where
+    I: Stream<Item = Instruction> + ConditionalSend,
+{
+    /// Execute the commit operation, returning the tree hash.
+    ///
+    /// Loads the prolly tree from the current revision, applies all
+    /// instructions (assert inserts into three indexes, retract marks
+    /// as removed), then creates a new revision with updated logical
+    /// clock and publishes it to the branch's revision cell.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Blake3Hash, DialogArtifactsError>
+    where
+        Env: Provider<archive_fx::Get>
+            + Provider<archive_fx::Put>
+            + Provider<memory_fx::Resolve>
+            + Provider<memory_fx::Publish>
+            + Provider<authority::Identify>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let instructions = self.instructions;
+        let base_revision = branch.revision();
+
+        let mut store = LocalIndex::new(env, branch.archive().index());
+
+        // Load tree from current revision hash (empty tree if no revision yet)
+        let base_tree_hash = base_revision
+            .as_ref()
+            .map(|rev| *rev.tree.hash())
+            .unwrap_or(EMPT_TREE_HASH);
+
+        let mut tree: Index = Tree::from_hash(&base_tree_hash, &store).await?;
+
+        // Apply instructions
+        tokio::pin!(instructions);
+
+        while let Some(instruction) = instructions.next().await {
+            match instruction {
+                Instruction::Assert(artifact) => {
+                    let entity_key = EntityKey::from(&artifact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+
+                    let datum = Datum::from(artifact);
+
+                    // When asserting with a cause, find and remove the ancestor
+                    // so the new version replaces it in all three indexes.
+                    if let Some(cause) = &datum.cause {
+                        let ancestor_key = {
+                            let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
+                                .set_entity(entity_key.entity())
+                                .set_attribute(entity_key.attribute())
+                                .into_key();
+                            let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
+                                .set_entity(entity_key.entity())
+                                .set_attribute(entity_key.attribute())
+                                .into_key();
+
+                            let search_stream = tree.stream_range(search_start..search_end, &store);
+
+                            let mut ancestor_key = None;
+
+                            tokio::pin!(search_stream);
+
+                            while let Some(candidate) = search_stream.try_next().await? {
+                                if let State::Added(current_element) = candidate.value {
+                                    let current_artifact = Artifact::try_from(current_element)?;
+                                    let current_artifact_reference = Cause::from(&current_artifact);
+
+                                    if cause == &current_artifact_reference {
+                                        ancestor_key = Some(candidate.key);
+                                        break;
+                                    }
+                                }
+                            }
+
+                            ancestor_key
+                        };
+
+                        if let Some(key) = ancestor_key {
+                            let entity_key = EntityKey(key);
+                            let value_key: ValueKey<Key> = ValueKey::from_key(&entity_key);
+                            let attribute_key: AttributeKey<Key> =
+                                AttributeKey::from_key(&entity_key);
+
+                            tree.delete(&entity_key.into_key(), &mut store).await?;
+                            tree.delete(&value_key.into_key(), &mut store).await?;
+                            tree.delete(&attribute_key.into_key(), &mut store).await?;
+                        }
+                    }
+
+                    tree.set(
+                        entity_key.into_key(),
+                        State::Added(datum.clone()),
+                        &mut store,
+                    )
+                    .await?;
+                    tree.set(
+                        attribute_key.into_key(),
+                        State::Added(datum.clone()),
+                        &mut store,
+                    )
+                    .await?;
+                    tree.set(value_key.into_key(), State::Added(datum), &mut store)
+                        .await?;
+                }
+                Instruction::Retract(fact) => {
+                    let entity_key = EntityKey::from(&fact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+
+                    tree.set(entity_key.into_key(), State::Removed, &mut store)
+                        .await?;
+                    tree.set(attribute_key.into_key(), State::Removed, &mut store)
+                        .await?;
+                    tree.set(value_key.into_key(), State::Removed, &mut store)
+                        .await?;
+                }
+            }
+        }
+
+        // Get the tree hash
+        let tree_hash = *tree
+            .hash()
+            .ok_or_else(|| DialogArtifactsError::Storage("Failed to get tree hash".to_string()))?;
+
+        let tree_reference = NodeReference::from(tree_hash);
+
+        // Discover identity from the environment
+        let auth = authority::Identify
+            .perform(env)
+            .await
+            .map_err(|e| DialogArtifactsError::Storage(format!("Identify failed: {}", e)))?;
+        let subject_did = auth.subject().clone();
+        let authority_did = authority::Profile::of(&auth).profile.clone();
+        let issuer_did = authority::Operator::of(&auth).operator.clone();
+
+        // Advance the logical clock: period increments when a different
+        // issuer commits, moment increments for the same issuer.
+        let (period, moment, cause) = match &base_revision {
+            Some(rev) => {
+                let (p, m) = if rev.issuer == issuer_did {
+                    (rev.period, rev.moment + 1)
+                } else {
+                    (rev.period + 1, 0)
+                };
+                (p, m, HashSet::from([rev.tree.clone()]))
+            }
+            None => (0, 0, HashSet::new()),
+        };
+
+        let new_revision = Revision {
+            subject: subject_did,
+            issuer: issuer_did,
+            authority: authority_did,
+            tree: tree_reference,
+            cause,
+            period,
+            moment,
+        };
+
+        // Publish updated revision
+        branch
+            .revision
+            .publish(Some(new_revision))
+            .perform(env)
+            .await
+            .map_err(|e| DialogArtifactsError::Storage(format!("{:?}", e)))?;
+
+        Ok(tree_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use crate::{Artifact, ArtifactSelector, Instruction, Value};
+    use dialog_prolly_tree::EMPT_TREE_HASH;
+    use futures_util::{StreamExt, stream};
+
+    #[dialog_common::test]
+    async fn it_commits_and_selects() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let artifact = Artifact {
+            the: "user/name".parse()?,
+            of: "user:123".parse()?,
+            is: Value::String("Alice".to_string()),
+            cause: None,
+        };
+
+        let instructions = stream::iter(vec![Instruction::Assert(artifact.clone())]);
+
+        let hash = branch.commit(instructions).perform(&operator).await?;
+        assert_ne!(hash, EMPT_TREE_HASH);
+
+        // Select should find the artifact
+        let selector = ArtifactSelector::new().the("user/name".parse()?);
+        let stream = branch.claims().select(selector).perform(&operator).await?;
+        tokio::pin!(stream);
+
+        let results: Vec<_> = stream.filter_map(|r| async { r.ok() }).collect().await;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].the, artifact.the);
+        assert_eq!(results[0].is, artifact.is);
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/fetch.rs
+++ b/rust/dialog-repository/src/repository/branch/fetch.rs
@@ -1,0 +1,166 @@
+use crate::repository::memory::MemoryExt;
+use crate::repository::remote::address::RemoteSite;
+use dialog_capability::Fork;
+use dialog_capability::Provider;
+use dialog_capability::Subject;
+use dialog_common::ConditionalSync;
+use dialog_effects::memory as memory_fx;
+
+use super::Branch;
+use super::upstream::UpstreamState;
+use crate::repository::error::RepositoryError;
+use crate::repository::revision::Revision;
+
+/// Command struct for fetching the upstream branch's current revision.
+///
+/// Borrows `&Branch` (non-consuming). Reads the branch's upstream to
+/// dispatch to local or remote fetch logic.
+///
+/// Does NOT modify local state (only reads from upstream).
+pub struct Fetch<'a> {
+    branch: &'a Branch,
+}
+
+impl<'a> Fetch<'a> {
+    fn new(branch: &'a Branch) -> Self {
+        Self { branch }
+    }
+}
+
+impl Branch {
+    /// Create a command to fetch the upstream branch's current revision.
+    ///
+    /// Does NOT modify local state, only reads from upstream.
+    pub fn fetch(&self) -> Fetch<'_> {
+        Fetch::new(self)
+    }
+}
+
+impl Fetch<'_> {
+    /// Execute the fetch operation, returning the upstream revision.
+    ///
+    /// Returns `None` if the upstream has no revision yet.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Option<Revision>, RepositoryError>
+    where
+        Env: Provider<memory_fx::Resolve>
+            + Provider<memory_fx::Publish>
+            + Provider<Fork<RemoteSite, memory_fx::Resolve>>
+            + ConditionalSync,
+    {
+        let upstream =
+            self.branch
+                .upstream()
+                .ok_or_else(|| RepositoryError::BranchHasNoUpstream {
+                    name: self.branch.name().clone(),
+                })?;
+
+        match &upstream {
+            UpstreamState::Local { branch: name, .. } => {
+                let upstream = Subject::from(self.branch.subject().clone())
+                    .branch(name.clone())
+                    .load()
+                    .perform(env)
+                    .await?;
+                Ok(upstream.revision())
+            }
+            UpstreamState::Remote {
+                name,
+                branch: branch_name,
+                ..
+            } => {
+                let remote_repo = Subject::from(self.branch.subject().clone())
+                    .remote(name.clone())
+                    .load()
+                    .perform(env)
+                    .await?;
+                let remote_branch = remote_repo
+                    .branch(branch_name.clone())
+                    .open()
+                    .perform(env)
+                    .await?;
+                remote_branch.fetch().perform(env).await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use crate::repository::branch::upstream::UpstreamState;
+    use crate::repository::node_reference::NodeReference;
+    use crate::{Artifact, Instruction, Value};
+    use futures_util::stream;
+
+    #[dialog_common::test]
+    async fn it_fetches_local_upstream_revision() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let _hash = main
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:main".parse()?,
+                is: Value::String("Main data".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+        let main_revision = main.revision().expect("main should have a revision");
+
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        feature
+            .set_upstream(UpstreamState::Local {
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+            .perform(&operator)
+            .await?;
+
+        let fetched = feature.fetch().perform(&operator).await?;
+
+        assert!(fetched.is_some());
+        assert_eq!(fetched.unwrap().tree, main_revision.tree);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_modify_local_state_on_fetch() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let _hash = main
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:main".parse()?,
+                is: Value::String("Main data".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        feature
+            .set_upstream(UpstreamState::Local {
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+            .perform(&operator)
+            .await?;
+
+        let feature_revision_before = feature.revision();
+
+        let _fetched = feature.fetch().perform(&operator).await?;
+
+        // Fetch should not modify local state
+        assert_eq!(feature.revision(), feature_revision_before);
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -1,0 +1,866 @@
+//! Integration tests using provisioned S3 and UCAN test servers.
+//!
+//! These tests require `--features integration-tests` and spin up real
+//! local S3 (and UCAN access) servers via `#[dialog_common::test]`.
+
+use crate::SiteAddress;
+use crate::helpers::{test_operator_with_profile, unique_name};
+use crate::repository::branch::Branch;
+use crate::repository::branch::upstream::UpstreamState;
+use crate::repository::node_reference::NodeReference;
+use crate::repository::{Repository, RepositoryExt as _};
+use crate::{Artifact, ArtifactSelector, Instruction, Operator, Value};
+use dialog_credentials::SignerCredential;
+use dialog_operator::profile::Profile;
+use dialog_remote_s3::helpers::S3Address;
+use dialog_remote_s3::{Address as S3SiteAddress, S3Credential};
+use dialog_storage::provider::storage::VolatileSpace;
+use futures_util::StreamExt;
+use futures_util::stream;
+
+fn s3_site_address(s3: &S3Address) -> S3SiteAddress {
+    S3SiteAddress::builder(&s3.endpoint)
+        .region("us-east-1")
+        .bucket(&s3.bucket)
+        .build()
+        .unwrap()
+}
+
+async fn setup_repo_with_s3_remote(
+    operator: &Operator<VolatileSpace>,
+    profile: &Profile,
+    s3: &S3Address,
+    name: &str,
+) -> anyhow::Result<(Repository<SignerCredential>, Branch)> {
+    let repo = profile
+        .repository(unique_name(name))
+        .create()
+        .perform(operator)
+        .await?;
+
+    let site_address = s3_site_address(s3);
+
+    // Save S3 credentials so the Operator can authorize fork requests
+    let authorization = S3Credential::new(&s3.access_key_id, &s3.secret_access_key);
+    profile
+        .credential()
+        .site(&site_address)
+        .save(authorization)
+        .perform(operator)
+        .await?;
+
+    let origin = repo
+        .remote("origin")
+        .create(site_address)
+        .perform(operator)
+        .await?;
+
+    let branch = repo.branch("main").open().perform(operator).await?;
+    let remote_branch = origin.branch("main").open().perform(operator).await?;
+    branch.set_upstream(remote_branch).perform(operator).await?;
+
+    Ok((repo, branch))
+}
+
+#[dialog_common::test]
+async fn it_pushes_to_s3_remote(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let (_repo, branch) = setup_repo_with_s3_remote(&operator, &profile, &s3, "push").await?;
+
+    let artifact = Artifact {
+        the: "user/name".parse()?,
+        of: "user:1".parse()?,
+        is: Value::String("Alice".into()),
+        cause: None,
+    };
+    branch
+        .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+        .perform(&operator)
+        .await?;
+
+    let result = branch.push().perform(&operator).await?;
+    assert!(result.is_some(), "push should succeed");
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_fetches_from_s3_remote(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let (_repo, branch) = setup_repo_with_s3_remote(&operator, &profile, &s3, "fetch").await?;
+
+    let artifact = Artifact {
+        the: "user/name".parse()?,
+        of: "user:1".parse()?,
+        is: Value::String("Alice".into()),
+        cause: None,
+    };
+    branch
+        .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+        .perform(&operator)
+        .await?;
+
+    branch.push().perform(&operator).await?;
+
+    let fetched = branch.fetch().perform(&operator).await?;
+    assert!(fetched.is_some(), "fetch should find remote state");
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_push_and_pull_roundtrip(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let (_repo, branch) = setup_repo_with_s3_remote(&operator, &profile, &s3, "roundtrip").await?;
+
+    let artifact = Artifact {
+        the: "user/name".parse()?,
+        of: "user:1".parse()?,
+        is: Value::String("Alice".into()),
+        cause: None,
+    };
+    branch
+        .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+        .perform(&operator)
+        .await?;
+
+    branch.push().perform(&operator).await?;
+
+    assert!(
+        branch.upstream().is_some(),
+        "should have upstream after push"
+    );
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_pull_returns_none_when_no_changes(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let (_repo, branch) = setup_repo_with_s3_remote(&operator, &profile, &s3, "no-change").await?;
+
+    let artifact = Artifact {
+        the: "user/name".parse()?,
+        of: "user:1".parse()?,
+        is: Value::String("Alice".into()),
+        cause: None,
+    };
+    branch
+        .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+        .perform(&operator)
+        .await?;
+
+    branch.push().perform(&operator).await?;
+
+    // Pull immediately after push — no new changes
+    let pull_result = branch.pull().perform(&operator).await?;
+    assert!(
+        pull_result.is_none(),
+        "pull with no changes should return None"
+    );
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_pushes_and_pulls_data_between_repos(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+
+    // Alice creates repo, commits, and pushes
+    let (alice_repo, alice_branch) =
+        setup_repo_with_s3_remote(&operator, &profile, &s3, "alice").await?;
+
+    let artifact = Artifact {
+        the: "user/name".parse()?,
+        of: "user:alice".parse()?,
+        is: Value::String("Alice".into()),
+        cause: None,
+    };
+    alice_branch
+        .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+        .perform(&operator)
+        .await?;
+
+    alice_branch.push().perform(&operator).await?;
+
+    // Bob opens a second repo sharing Alice's subject, pulls
+    let bob_repo = profile
+        .repository(unique_name("bob"))
+        .open()
+        .perform(&operator)
+        .await?;
+
+    let origin = bob_repo
+        .remote("origin")
+        .create(s3_site_address(&s3))
+        .subject(alice_repo.did())
+        .perform(&operator)
+        .await?;
+
+    let bob_branch = bob_repo.branch("main").open().perform(&operator).await?;
+    let remote_branch = origin.branch("main").open().perform(&operator).await?;
+    bob_branch
+        .set_upstream(remote_branch)
+        .perform(&operator)
+        .await?;
+
+    let pull_result = bob_branch.pull().perform(&operator).await?;
+    assert!(pull_result.is_some(), "Bob's pull should find Alice's data");
+
+    // Verify Bob can query Alice's artifact
+    let results: Vec<_> = bob_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(results.len(), 1, "Bob should have Alice's artifact");
+    assert_eq!(
+        results[0].is,
+        Value::String("Alice".into()),
+        "artifact value should match"
+    );
+
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_two_party_convergence(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+
+    // Alice commits and pushes
+    let (alice_repo, alice_branch) =
+        setup_repo_with_s3_remote(&operator, &profile, &s3, "conv-alice").await?;
+
+    alice_branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:alice".parse()?,
+            is: Value::String("Alice".into()),
+            cause: None,
+        })]))
+        .perform(&operator)
+        .await?;
+
+    alice_branch.push().perform(&operator).await?;
+
+    // Bob sets up repo pointing at same remote subject
+    let bob_repo = profile
+        .repository(unique_name("conv-bob"))
+        .open()
+        .perform(&operator)
+        .await?;
+
+    let origin = bob_repo
+        .remote("origin")
+        .create(s3_site_address(&s3))
+        .subject(alice_repo.did())
+        .perform(&operator)
+        .await?;
+
+    let bob_branch = bob_repo.branch("main").open().perform(&operator).await?;
+    let remote_branch = origin.branch("main").open().perform(&operator).await?;
+    bob_branch
+        .set_upstream(remote_branch)
+        .perform(&operator)
+        .await?;
+
+    // Bob pulls Alice's changes
+    bob_branch.pull().perform(&operator).await?;
+
+    // Bob commits his own artifact
+    bob_branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:bob".parse()?,
+            is: Value::String("Bob".into()),
+            cause: None,
+        })]))
+        .perform(&operator)
+        .await?;
+
+    // Bob pushes
+    bob_branch.push().perform(&operator).await?;
+
+    // Alice pulls Bob's changes
+    alice_branch.pull().perform(&operator).await?;
+
+    // Both should have both artifacts
+    let alice_results: Vec<_> = alice_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let bob_results: Vec<_> = bob_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(
+        alice_results.len(),
+        2,
+        "Alice should have both artifacts after pull"
+    );
+    assert_eq!(
+        bob_results.len(),
+        2,
+        "Bob should have both artifacts after push"
+    );
+
+    Ok(())
+}
+
+// UCAN integration tests
+
+use dialog_remote_ucan_s3::UcanAddress;
+use dialog_remote_ucan_s3::helpers::UcanS3Address;
+
+/// Alice creates a repo, delegates to Bob, Bob pulls, commits, pushes,
+/// then Alice pulls Bob's changes.
+#[dialog_common::test]
+async fn it_collaborates_via_ucan_delegation(ucan: UcanS3Address) -> anyhow::Result<()> {
+    // Alice: create profile, operator, repo
+    let (alice_operator, alice_profile) = test_operator_with_profile().await;
+    let alice_repo = alice_profile
+        .repository(unique_name("collab-alice"))
+        .create()
+        .perform(&alice_operator)
+        .await?;
+
+    // Delegate repo ownership to Alice's profile
+    let alice_access = alice_repo.access();
+    let ownership_chain = alice_access
+        .claim(&alice_repo)
+        .delegate(alice_profile.did())
+        .perform(&alice_operator)
+        .await?;
+    alice_profile
+        .access()
+        .save(ownership_chain)
+        .perform(&alice_operator)
+        .await?;
+
+    // Set up UCAN remote on Alice's repo
+    let ucan_site = SiteAddress::Ucan(UcanAddress::new(&ucan.access_service_url));
+    let alice_origin = alice_repo
+        .remote("origin")
+        .create(ucan_site.clone())
+        .perform(&alice_operator)
+        .await?;
+
+    let alice_branch = alice_repo
+        .branch("main")
+        .open()
+        .perform(&alice_operator)
+        .await?;
+    let remote_branch = alice_origin
+        .branch("main")
+        .open()
+        .perform(&alice_operator)
+        .await?;
+    alice_branch
+        .set_upstream(remote_branch)
+        .perform(&alice_operator)
+        .await?;
+
+    // Alice commits and pushes initial data
+    alice_branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:alice".parse()?,
+            is: Value::String("Alice".into()),
+            cause: None,
+        })]))
+        .perform(&alice_operator)
+        .await?;
+
+    alice_branch.push().perform(&alice_operator).await?;
+
+    // Bob: create profile, operator
+    let (bob_operator, bob_profile) = test_operator_with_profile().await;
+
+    // Alice delegates repo access to Bob's profile
+    let delegation_to_bob = alice_profile
+        .access()
+        .claim(&alice_repo)
+        .delegate(bob_profile.did())
+        .perform(&alice_operator)
+        .await?;
+
+    // Bob saves the delegation chain under his profile
+    bob_profile
+        .access()
+        .save(delegation_to_bob)
+        .perform(&bob_operator)
+        .await?;
+
+    // Bob creates his own repo (different DID) and adds Alice's remote
+    let bob_repo = bob_profile
+        .repository(unique_name("collab-bob"))
+        .open()
+        .perform(&bob_operator)
+        .await?;
+
+    let bob_origin = bob_repo
+        .remote("origin")
+        .create(ucan_site)
+        .subject(alice_repo.did())
+        .perform(&bob_operator)
+        .await?;
+
+    let bob_branch = bob_repo
+        .branch("main")
+        .open()
+        .perform(&bob_operator)
+        .await?;
+    let remote_branch = bob_origin
+        .branch("main")
+        .open()
+        .perform(&bob_operator)
+        .await?;
+    bob_branch
+        .set_upstream(remote_branch)
+        .perform(&bob_operator)
+        .await?;
+
+    // Bob pulls Alice's data
+    let pull_result = bob_branch.pull().perform(&bob_operator).await?;
+    assert!(pull_result.is_some(), "Bob should pull Alice's data");
+
+    // Verify Bob has Alice's artifact
+    let bob_results: Vec<_> = bob_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&bob_operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(bob_results.len(), 1, "Bob should have Alice's artifact");
+
+    // Bob commits his own change
+    bob_branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:bob".parse()?,
+            is: Value::String("Bob".into()),
+            cause: None,
+        })]))
+        .perform(&bob_operator)
+        .await?;
+
+    // Bob pushes
+    let push_result = bob_branch.push().perform(&bob_operator).await?;
+    assert!(push_result.is_some(), "Bob should push successfully");
+
+    // Alice pulls Bob's changes
+    let alice_pull = alice_branch.pull().perform(&alice_operator).await?;
+    assert!(alice_pull.is_some(), "Alice should pull Bob's changes");
+
+    // Alice should have both artifacts
+    let alice_results: Vec<_> = alice_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&alice_operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        alice_results.len(),
+        2,
+        "Alice should have both artifacts after pulling Bob's changes"
+    );
+
+    Ok(())
+}
+
+/// Push and pull via UCAN access service.
+#[dialog_common::test]
+async fn it_pushes_and_pulls_via_ucan(ucan: UcanS3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+
+    // Create repo and delegate ownership to the profile
+    let repo = profile
+        .repository(unique_name("ucan-repo"))
+        .create()
+        .perform(&operator)
+        .await?;
+
+    let repo_access = repo.access();
+    let chain = repo_access
+        .claim(&repo)
+        .delegate(profile.did())
+        .perform(&operator)
+        .await?;
+    profile.access().save(chain).perform(&operator).await?;
+
+    // Set up UCAN remote
+    let origin = repo
+        .remote("origin")
+        .create(SiteAddress::Ucan(UcanAddress::new(
+            &ucan.access_service_url,
+        )))
+        .perform(&operator)
+        .await?;
+
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    let remote_branch = origin.branch("main").open().perform(&operator).await?;
+    branch
+        .set_upstream(remote_branch)
+        .perform(&operator)
+        .await?;
+
+    // Commit and push via UCAN
+    branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:ucan-test".parse()?,
+            is: Value::String("UCAN User".into()),
+            cause: None,
+        })]))
+        .perform(&operator)
+        .await?;
+
+    let push_result = branch.push().perform(&operator).await?;
+    assert!(push_result.is_some(), "UCAN push should succeed");
+
+    // Pull should find no changes (just pushed)
+    let pull_result = branch.pull().perform(&operator).await?;
+    assert!(pull_result.is_none(), "pull after push should return None");
+
+    // Verify data survives select
+    let results: Vec<_> = branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(results.len(), 1, "should have the pushed artifact");
+    assert_eq!(results[0].is, Value::String("UCAN User".into()));
+
+    Ok(())
+}
+
+/// Query an empty local replica. Data replicates on demand from the
+/// remote. After removing the upstream, data is still available locally.
+#[dialog_common::test]
+async fn it_replicates_on_demand_and_caches_locally(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+
+    // Alice: create repo, commit data, push to remote
+    let (alice_repo, alice_branch) =
+        setup_repo_with_s3_remote(&operator, &profile, &s3, "replicate-alice").await?;
+
+    alice_branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:alice".parse()?,
+            is: Value::String("Alice".into()),
+            cause: None,
+        })]))
+        .perform(&operator)
+        .await?;
+    alice_branch.push().perform(&operator).await?;
+    let alice_revision = alice_branch.revision().expect("should have revision");
+
+    // Bob: empty repo pointing at Alice's remote
+    let bob_repo = profile
+        .repository(unique_name("replicate-bob"))
+        .open()
+        .perform(&operator)
+        .await?;
+
+    let origin = bob_repo
+        .remote("origin")
+        .create(s3_site_address(&s3))
+        .subject(alice_repo.did())
+        .perform(&operator)
+        .await?;
+
+    let bob_branch = bob_repo.branch("main").open().perform(&operator).await?;
+    let remote_branch = origin.branch("main").open().perform(&operator).await?;
+    bob_branch
+        .set_upstream(remote_branch)
+        .perform(&operator)
+        .await?;
+
+    // Set Bob's revision to Alice's without pulling blocks
+    bob_branch.reset(alice_revision).perform(&operator).await?;
+
+    // First, remove upstream so select has no remote to fall back to.
+    // This should fail because tree blocks aren't local.
+    bob_branch
+        .set_upstream(UpstreamState::Local {
+            branch: "nowhere".into(),
+            tree: NodeReference::default(),
+        })
+        .perform(&operator)
+        .await?;
+
+    let no_remote_result = bob_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&operator)
+        .await;
+    assert!(
+        no_remote_result.is_err(),
+        "select should fail without remote when blocks aren't local"
+    );
+
+    // Restore upstream so fallback can reach the remote
+    let remote_branch = origin.branch("main").open().perform(&operator).await?;
+    bob_branch
+        .set_upstream(remote_branch)
+        .perform(&operator)
+        .await?;
+
+    // Now query replicates tree blocks on demand from the remote
+    let results: Vec<_> = bob_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(results.len(), 1, "should replicate and find Alice's data");
+    assert_eq!(results[0].is, Value::String("Alice".into()));
+
+    // Remove upstream (simulates remote going away) by pointing
+    // at a non-existent local branch instead
+    bob_branch
+        .set_upstream(UpstreamState::Local {
+            branch: "nowhere".into(),
+            tree: NodeReference::default(),
+        })
+        .perform(&operator)
+        .await?;
+
+    // Query again with no remote. Data should be cached locally.
+    let cached_results: Vec<_> = bob_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(
+        cached_results.len(),
+        1,
+        "data should be available from local cache"
+    );
+    assert_eq!(cached_results[0].is, Value::String("Alice".into()));
+
+    Ok(())
+}
+
+/// Delegate repo to profile, push data to S3, pull from a new operator.
+#[dialog_common::test]
+async fn it_delegates_and_pushes_to_s3(s3: S3Address) -> anyhow::Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = profile
+        .repository(unique_name("deleg-push"))
+        .create()
+        .perform(&operator)
+        .await?;
+
+    // Delegate repo ownership to the profile
+    let chain = repo
+        .access()
+        .claim(&repo)
+        .delegate(profile.did())
+        .perform(&operator)
+        .await?;
+    profile.access().save(chain).perform(&operator).await?;
+
+    // Save S3 credentials and set up remote
+    let site_address = s3_site_address(&s3);
+    let authorization = S3Credential::new(&s3.access_key_id, &s3.secret_access_key);
+    profile
+        .credential()
+        .site(&site_address)
+        .save(authorization)
+        .perform(&operator)
+        .await?;
+
+    let origin = repo
+        .remote("origin")
+        .create(site_address)
+        .perform(&operator)
+        .await?;
+
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    let remote_branch = origin.branch("main").open().perform(&operator).await?;
+    branch
+        .set_upstream(remote_branch)
+        .perform(&operator)
+        .await?;
+
+    // Commit and push
+    branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:delegated".parse()?,
+            is: Value::String("Delegated Push".into()),
+            cause: None,
+        })]))
+        .perform(&operator)
+        .await?;
+
+    let result = branch.push().perform(&operator).await?;
+    assert!(result.is_some(), "push with delegation should succeed");
+
+    Ok(())
+}
+
+/// Alice delegates, pushes to S3; Bob pulls and verifies data arrived.
+#[dialog_common::test]
+async fn it_delegates_pushes_and_pulls_via_s3(s3: S3Address) -> anyhow::Result<()> {
+    let (alice_operator, alice_profile) = test_operator_with_profile().await;
+    let alice_repo = alice_profile
+        .repository(unique_name("deleg-pull-a"))
+        .create()
+        .perform(&alice_operator)
+        .await?;
+
+    // Delegate repo to Alice's profile
+    let chain = alice_repo
+        .access()
+        .claim(&alice_repo)
+        .delegate(alice_profile.did())
+        .perform(&alice_operator)
+        .await?;
+    alice_profile
+        .access()
+        .save(chain)
+        .perform(&alice_operator)
+        .await?;
+
+    // Save S3 credentials for Alice and set up remote
+    let site_address = s3_site_address(&s3);
+    let authorization = S3Credential::new(&s3.access_key_id, &s3.secret_access_key);
+    alice_profile
+        .credential()
+        .site(&site_address)
+        .save(authorization)
+        .perform(&alice_operator)
+        .await?;
+
+    let alice_origin = alice_repo
+        .remote("origin")
+        .create(site_address)
+        .perform(&alice_operator)
+        .await?;
+
+    let alice_branch = alice_repo
+        .branch("main")
+        .open()
+        .perform(&alice_operator)
+        .await?;
+    let remote_branch = alice_origin
+        .branch("main")
+        .open()
+        .perform(&alice_operator)
+        .await?;
+    alice_branch
+        .set_upstream(remote_branch)
+        .perform(&alice_operator)
+        .await?;
+
+    alice_branch
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "user/name".parse()?,
+            of: "user:alice".parse()?,
+            is: Value::String("Alice Delegated".into()),
+            cause: None,
+        })]))
+        .perform(&alice_operator)
+        .await?;
+
+    let push_result = alice_branch.push().perform(&alice_operator).await?;
+    assert!(push_result.is_some(), "push should succeed");
+
+    // Bob: fresh operator pulls from the same S3 remote
+    let (bob_operator, bob_profile) = test_operator_with_profile().await;
+    let bob_repo = bob_profile
+        .repository(unique_name("deleg-pull-b"))
+        .open()
+        .perform(&bob_operator)
+        .await?;
+
+    // Save S3 credentials for Bob
+    let bob_site_address = s3_site_address(&s3);
+    let bob_authorization = S3Credential::new(&s3.access_key_id, &s3.secret_access_key);
+    bob_profile
+        .credential()
+        .site(&bob_site_address)
+        .save(bob_authorization)
+        .perform(&bob_operator)
+        .await?;
+
+    let bob_origin = bob_repo
+        .remote("origin")
+        .create(bob_site_address)
+        .subject(alice_repo.did())
+        .perform(&bob_operator)
+        .await?;
+
+    let bob_branch = bob_repo
+        .branch("main")
+        .open()
+        .perform(&bob_operator)
+        .await?;
+    let remote_branch = bob_origin
+        .branch("main")
+        .open()
+        .perform(&bob_operator)
+        .await?;
+    bob_branch
+        .set_upstream(remote_branch)
+        .perform(&bob_operator)
+        .await?;
+
+    let pull_result = bob_branch.pull().perform(&bob_operator).await?;
+    assert!(pull_result.is_some(), "pull should find Alice's data");
+
+    let results: Vec<_> = bob_branch
+        .claims()
+        .select(ArtifactSelector::new().the("user/name".parse()?))
+        .perform(&bob_operator)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(results.len(), 1, "should have Alice's artifact");
+    assert_eq!(results[0].is, Value::String("Alice Delegated".into()));
+
+    Ok(())
+}

--- a/rust/dialog-repository/src/repository/branch/load.rs
+++ b/rust/dialog-repository/src/repository/branch/load.rs
@@ -1,0 +1,80 @@
+use dialog_capability::Provider;
+use dialog_effects::memory as memory_fx;
+
+use super::Branch;
+use super::reference::BranchReference;
+use super::upstream::UpstreamState;
+use crate::repository::error::RepositoryError;
+use crate::repository::memory::Cell;
+use crate::repository::revision::Revision;
+
+/// Command to load an existing branch, returning an error if not found.
+pub struct LoadBranch {
+    branch: BranchReference,
+}
+
+impl LoadBranch {
+    /// Create from a branch reference.
+    pub fn new(branch: BranchReference) -> Self {
+        Self { branch }
+    }
+
+    /// Execute the load operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Branch, RepositoryError>
+    where
+        Env: Provider<memory_fx::Resolve>,
+    {
+        let revision: Cell<Option<Revision>> = self.branch.cell("revision");
+        revision.resolve().perform(env).await?;
+
+        if revision.content().is_none() {
+            return Err(RepositoryError::BranchNotFound {
+                name: self.branch.name(),
+            });
+        }
+
+        let upstream: Cell<Option<UpstreamState>> = self.branch.cell("upstream");
+        upstream.resolve().perform(env).await?;
+
+        Ok(Branch {
+            reference: self.branch,
+            revision,
+            upstream,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use crate::repository::error::RepositoryError;
+
+    #[dialog_common::test]
+    async fn it_loads_existing_branch() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let _ = repo.branch("main").open().perform(&operator).await?;
+        let branch = repo.branch("main").load().perform(&operator).await?;
+
+        assert_eq!(branch.name().as_str(), "main");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_loading_missing_branch() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let result = repo.branch("nonexistent").load().perform(&operator).await;
+
+        assert!(matches!(
+            result,
+            Err(RepositoryError::BranchNotFound { .. })
+        ));
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/name.rs
+++ b/rust/dialog-repository/src/repository/branch/name.rs
@@ -1,0 +1,60 @@
+use dialog_prolly_tree::KeyType;
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    string::FromUtf8Error,
+};
+
+/// Unique name for the branch
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct BranchName(String);
+
+impl BranchName {
+    /// Creates a new branch name from a string.
+    pub fn new(name: String) -> Self {
+        BranchName(name)
+    }
+
+    /// Returns a reference to the branch name string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl KeyType for BranchName {
+    fn bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl TryFrom<Vec<u8>> for BranchName {
+    type Error = FromUtf8Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(BranchName(String::from_utf8(bytes)?))
+    }
+}
+
+impl Display for BranchName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&BranchName> for BranchName {
+    fn from(value: &BranchName) -> Self {
+        value.clone()
+    }
+}
+
+impl From<&str> for BranchName {
+    fn from(value: &str) -> Self {
+        BranchName(value.to_string())
+    }
+}
+
+impl From<String> for BranchName {
+    fn from(value: String) -> Self {
+        BranchName(value)
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/novelty.rs
+++ b/rust/dialog-repository/src/repository/branch/novelty.rs
@@ -1,0 +1,39 @@
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive as archive_fx;
+use dialog_prolly_tree::{Node, Tree, TreeDifference};
+use dialog_storage::Blake3Hash;
+use futures_util::Stream;
+
+use super::Index;
+use crate::repository::archive::local::LocalIndex;
+use crate::{DialogArtifactsError, Key, State};
+use dialog_artifacts::Datum;
+
+/// Create a stream of novel nodes representing local changes since the last sync.
+///
+/// These are tree nodes that exist in the current tree but not in the base tree.
+/// Used during push to send only the new nodes to the remote.
+pub fn novelty<'a, Env>(
+    base_hash: Blake3Hash,
+    current_hash: Blake3Hash,
+    env: &'a Env,
+    catalog: Capability<archive_fx::Catalog>,
+) -> impl Stream<Item = Result<Node<Key, State<Datum>, Blake3Hash>, DialogArtifactsError>> + 'a
+where
+    Env: Provider<archive_fx::Get> + Provider<archive_fx::Put> + ConditionalSync + 'static,
+{
+    async_stream::try_stream! {
+        let store = LocalIndex::new(env, catalog);
+
+        let base: Index = Tree::from_hash(&base_hash, &store).await?;
+
+        let current: Index = Tree::from_hash(&current_hash, &store).await?;
+
+        let difference = TreeDifference::compute(&base, &current, &store, &store).await?;
+
+        for await node in difference.novel_nodes() {
+            yield node?;
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/open.rs
+++ b/rust/dialog-repository/src/repository/branch/open.rs
@@ -1,0 +1,65 @@
+use dialog_capability::Provider;
+use dialog_effects::memory as memory_fx;
+
+use super::Branch;
+use super::reference::BranchReference;
+use super::upstream::UpstreamState;
+use crate::repository::error::RepositoryError;
+use crate::repository::memory::Cell;
+use crate::repository::revision::Revision;
+
+/// Command to open a branch, creating it with defaults if it doesn't exist.
+pub struct OpenBranch {
+    branch: BranchReference,
+}
+
+impl OpenBranch {
+    /// Create from a branch reference.
+    pub fn new(branch: BranchReference) -> Self {
+        Self { branch }
+    }
+
+    /// Execute the open operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Branch, RepositoryError>
+    where
+        Env: Provider<memory_fx::Resolve> + Provider<memory_fx::Publish>,
+    {
+        let revision: Cell<Option<Revision>> = self.branch.cell("revision");
+        revision.resolve().perform(env).await?;
+        if revision.content().is_none() {
+            revision.publish(None).perform(env).await?;
+        }
+
+        let upstream: Cell<Option<UpstreamState>> = self.branch.cell("upstream");
+        upstream.resolve().perform(env).await?;
+
+        Ok(Branch {
+            reference: self.branch,
+            revision,
+            upstream,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+
+    #[dialog_common::test]
+    async fn it_opens_new_branch() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        assert_eq!(branch.name().as_str(), "main");
+        assert!(
+            branch.revision().is_none(),
+            "New branch should have no revision"
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/pull.rs
+++ b/rust/dialog-repository/src/repository/branch/pull.rs
@@ -1,0 +1,370 @@
+use crate::repository::memory::MemoryExt;
+use crate::repository::remote::address::RemoteSite;
+use dialog_capability::Fork;
+use dialog_capability::Subject;
+use dialog_capability::{Policy, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive as archive_fx;
+use dialog_effects::authority;
+use dialog_effects::memory as memory_fx;
+use dialog_prolly_tree::{EMPT_TREE_HASH, Tree};
+use dialog_storage::{Blake3Hash, ContentAddressedStorage, DialogStorageError, Encoder};
+use futures_util::StreamExt;
+use std::collections::HashSet;
+
+use super::Branch;
+use super::Index;
+use super::upstream::UpstreamState;
+use crate::DialogArtifactsError;
+use crate::repository::archive::ArchiveExt as _;
+use crate::repository::archive::local::LocalIndex;
+use crate::repository::archive::networked::NetworkedIndex;
+use crate::repository::node_reference::NodeReference;
+use crate::repository::revision::Revision;
+
+/// Command struct for merging an explicit upstream revision.
+///
+/// Performs a three-way merge between the current branch, the base
+/// (last sync point), and the upstream revision.
+pub struct PullLocal<'a> {
+    branch: &'a Branch,
+    upstream_revision: Revision,
+}
+
+impl<'a> PullLocal<'a> {
+    fn new(branch: &'a Branch, upstream_revision: Revision) -> Self {
+        Self {
+            branch,
+            upstream_revision,
+        }
+    }
+}
+
+impl PullLocal<'_> {
+    /// Execute the merge, returning the new revision (or None if no changes).
+    pub async fn perform<Env>(self, env: &Env) -> Result<Option<Revision>, DialogArtifactsError>
+    where
+        Env: Provider<archive_fx::Get>
+            + Provider<archive_fx::Put>
+            + Provider<memory_fx::Resolve>
+            + Provider<memory_fx::Publish>
+            + Provider<authority::Identify>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let upstream_revision = self.upstream_revision;
+
+        let branch_base = branch
+            .upstream()
+            .map(|u| u.tree().clone())
+            .unwrap_or_default();
+
+        if branch_base == upstream_revision.tree {
+            return Ok(None);
+        }
+
+        let store = LocalIndex::new(env, branch.archive().index());
+        three_way_merge(branch, upstream_revision, store, env).await
+    }
+}
+
+/// Command struct for pulling from upstream (auto-dispatches local/remote).
+pub struct Pull<'a> {
+    branch: &'a Branch,
+}
+
+impl<'a> Pull<'a> {
+    fn new(branch: &'a Branch) -> Self {
+        Self { branch }
+    }
+}
+
+impl Branch {
+    /// Pull from the configured upstream.
+    pub fn pull(&self) -> Pull<'_> {
+        Pull::new(self)
+    }
+
+    /// Merge an explicit upstream revision into this branch.
+    pub fn merge(&self, upstream_revision: Revision) -> PullLocal<'_> {
+        PullLocal::new(self, upstream_revision)
+    }
+}
+
+impl Pull<'_> {
+    /// Execute the pull operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Option<Revision>, DialogArtifactsError>
+    where
+        Env: Provider<archive_fx::Get>
+            + Provider<archive_fx::Put>
+            + Provider<memory_fx::Resolve>
+            + Provider<memory_fx::Publish>
+            + Provider<authority::Identify>
+            + Provider<Fork<RemoteSite, archive_fx::Get>>
+            + Provider<Fork<RemoteSite, memory_fx::Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let upstream = branch.upstream().ok_or_else(|| {
+            DialogArtifactsError::Storage(format!("Branch {} has no upstream", branch.name()))
+        })?;
+
+        match upstream {
+            UpstreamState::Local { branch: id, .. } => {
+                let upstream_branch = Subject::from(branch.subject().clone())
+                    .branch(id)
+                    .load()
+                    .perform(env)
+                    .await
+                    .map_err(|e| DialogArtifactsError::Storage(format!("{:?}", e)))?;
+
+                match upstream_branch.revision() {
+                    Some(rev) => branch.merge(rev).perform(env).await,
+                    None => Ok(None),
+                }
+            }
+            UpstreamState::Remote {
+                name,
+                branch: branch_name,
+                ..
+            } => {
+                let remote_repo = Subject::from(branch.subject().clone())
+                    .remote(name)
+                    .load()
+                    .perform(env)
+                    .await
+                    .map_err(|e| DialogArtifactsError::Storage(format!("{:?}", e)))?;
+
+                let remote_branch = remote_repo
+                    .branch(branch_name)
+                    .open()
+                    .perform(env)
+                    .await
+                    .map_err(|e| DialogArtifactsError::Storage(format!("{:?}", e)))?;
+
+                let upstream_revision = remote_branch.fetch().perform(env).await.map_err(|e| {
+                    DialogArtifactsError::Storage(format!("Failed to fetch remote: {:?}", e))
+                })?;
+
+                let upstream_revision = match upstream_revision {
+                    Some(rev) => rev,
+                    None => return Ok(None),
+                };
+
+                let branch_base = branch
+                    .upstream()
+                    .map(|u| u.tree().clone())
+                    .unwrap_or_default();
+
+                if branch_base == upstream_revision.tree {
+                    return Ok(None);
+                }
+
+                let store =
+                    NetworkedIndex::new(env, branch.archive().index(), Some(remote_repo.clone()));
+
+                let result = three_way_merge(branch, upstream_revision, store.clone(), env).await?;
+
+                // Replicate all tree blocks to local storage
+                if let Some(rev) = branch.revision() {
+                    let target: Index = Tree::from_hash(rev.tree.hash(), &store).await?;
+                    let stream = target.stream(&store);
+                    tokio::pin!(stream);
+                    while let Some(r) = stream.next().await {
+                        r?;
+                    }
+                }
+
+                Ok(result)
+            }
+        }
+    }
+}
+
+/// Three-way merge: applies changes between base and current onto the
+/// upstream revision's tree. Publishes the resulting revision and updates
+/// the upstream tracking state.
+async fn three_way_merge<S>(
+    branch: &Branch,
+    upstream_revision: Revision,
+    store: S,
+    env: &(
+         impl Provider<memory_fx::Resolve>
+         + Provider<memory_fx::Publish>
+         + Provider<authority::Identify>
+         + ConditionalSync
+     ),
+) -> Result<Option<Revision>, DialogArtifactsError>
+where
+    S: ContentAddressedStorage<Hash = Blake3Hash, Error = DialogStorageError>
+        + Encoder<Hash = Blake3Hash, Error = DialogStorageError>
+        + Clone
+        + ConditionalSync,
+{
+    let branch_base = branch
+        .upstream()
+        .map(|u| u.tree().clone())
+        .unwrap_or_default();
+    let branch_revision = branch.revision();
+
+    let mut target: Index = Tree::from_hash(upstream_revision.tree.hash(), &store).await?;
+
+    let base: Index = Tree::from_hash(branch_base.hash(), &store).await?;
+    let current_tree_hash = branch_revision
+        .as_ref()
+        .map(|rev| *rev.tree.hash())
+        .unwrap_or(EMPT_TREE_HASH);
+    let current: Index = Tree::from_hash(&current_tree_hash, &store).await?;
+
+    let diff_store = store.clone();
+    let changes = base.differentiate(&current, &diff_store, &diff_store);
+    let mut write_store = store;
+    Box::pin(target.integrate(changes, &mut write_store)).await?;
+
+    let hash = target.hash().cloned().unwrap_or(EMPT_TREE_HASH);
+
+    let new_revision = if &hash == upstream_revision.tree.hash() {
+        upstream_revision.clone()
+    } else {
+        let auth = authority::Identify
+            .perform(env)
+            .await
+            .map_err(|e| DialogArtifactsError::Storage(format!("Identify failed: {}", e)))?;
+
+        let branch_period = branch_revision.as_ref().map(|r| r.period).unwrap_or(0);
+
+        Revision {
+            subject: auth.subject().clone(),
+            issuer: authority::Operator::of(&auth).operator.clone(),
+            authority: authority::Profile::of(&auth).profile.clone(),
+            tree: NodeReference::from(hash),
+            cause: HashSet::from([upstream_revision.tree.clone()]),
+            period: upstream_revision.period.max(branch_period) + 1,
+            moment: 0,
+        }
+    };
+
+    branch
+        .revision
+        .publish(Some(new_revision.clone()))
+        .perform(env)
+        .await
+        .map_err(|e| DialogArtifactsError::Storage(format!("{:?}", e)))?;
+
+    if let Some(upstream) = branch.upstream() {
+        branch
+            .upstream
+            .publish(Some(upstream.with_tree(upstream_revision.tree.clone())))
+            .perform(env)
+            .await
+            .map_err(|e| DialogArtifactsError::Storage(format!("{:?}", e)))?;
+    }
+
+    Ok(Some(new_revision))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use crate::{Artifact, Instruction, Value};
+    use futures_util::stream;
+
+    #[dialog_common::test]
+    async fn it_pulls_from_local_upstream_no_changes() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let artifact = Artifact {
+            the: "user/name".parse()?,
+            of: "user:seed".parse()?,
+            is: Value::String("Seed".to_string()),
+            cause: None,
+        };
+        let _hash = main
+            .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+            .perform(&operator)
+            .await?;
+        let upstream_revision = main.revision().expect("main should have a revision");
+
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        let pulled = feature.merge(upstream_revision).perform(&operator).await?;
+        assert!(pulled.is_some());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_pulls_upstream_changes_without_local_changes() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let _hash = main
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:main".parse()?,
+                is: Value::String("Main data".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+        let main_revision = main.revision().expect("main should have a revision");
+
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        let pulled = feature
+            .merge(main_revision.clone())
+            .perform(&operator)
+            .await?;
+        assert!(pulled.is_some());
+        let feature_rev = feature
+            .revision()
+            .expect("feature should have a revision after pull");
+        assert_eq!(feature_rev.tree, main_revision.tree);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_pulls_and_merges_with_both_sides_changed() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let _hash = main
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:main".parse()?,
+                is: Value::String("Main data".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+        let main_revision = main.revision().expect("main should have a revision");
+
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        let _hash = feature
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/email".parse()?,
+                of: "user:feature".parse()?,
+                is: Value::String("feature@test.com".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+
+        let pulled = feature
+            .merge(main_revision.clone())
+            .perform(&operator)
+            .await?;
+        assert!(pulled.is_some());
+        let feature_rev = feature
+            .revision()
+            .expect("feature should have a revision after merge");
+        assert_ne!(feature_rev.tree, main_revision.tree);
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/push.rs
+++ b/rust/dialog-repository/src/repository/branch/push.rs
@@ -1,0 +1,275 @@
+use crate::repository::memory::MemoryExt;
+use crate::repository::remote::address::RemoteSite;
+use dialog_capability::Fork;
+use dialog_capability::Provider;
+use dialog_capability::Subject;
+use dialog_common::ConditionalSync;
+use dialog_effects::archive as archive_fx;
+use dialog_effects::memory as memory_fx;
+
+use super::Branch;
+use super::novelty::novelty;
+use super::upstream::UpstreamState;
+use crate::repository::archive::ArchiveExt as _;
+use crate::repository::error::RepositoryError;
+use crate::repository::revision::Revision;
+
+/// Command struct for pushing local changes to an upstream branch.
+///
+/// Borrows `&Branch` (non-consuming). Reads the branch's upstream to
+/// dispatch to local or remote push logic.
+pub struct Push<'a> {
+    branch: &'a Branch,
+}
+
+impl<'a> Push<'a> {
+    fn new(branch: &'a Branch) -> Self {
+        Self { branch }
+    }
+}
+
+impl Branch {
+    /// Create a command to push local changes to the upstream branch.
+    ///
+    /// Reads the upstream configuration from branch state and dispatches
+    /// to local or remote push logic.
+    pub fn push(&self) -> Push<'_> {
+        Push::new(self)
+    }
+}
+
+impl Push<'_> {
+    /// Execute the push operation.
+    ///
+    /// Returns `Some(revision)` on success, `None` if the push could not
+    /// fast-forward (diverged).
+    pub async fn perform<Env>(self, env: &Env) -> Result<Option<Revision>, RepositoryError>
+    where
+        Env: Provider<archive_fx::Get>
+            + Provider<archive_fx::Put>
+            + Provider<memory_fx::Resolve>
+            + Provider<memory_fx::Publish>
+            + Provider<Fork<RemoteSite, archive_fx::Get>>
+            + Provider<Fork<RemoteSite, archive_fx::Put>>
+            + Provider<Fork<RemoteSite, memory_fx::Resolve>>
+            + Provider<Fork<RemoteSite, memory_fx::Publish>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let upstream = branch
+            .upstream()
+            .ok_or_else(|| RepositoryError::BranchHasNoUpstream {
+                name: branch.name().clone(),
+            })?;
+
+        match &upstream {
+            UpstreamState::Local {
+                branch: upstream_name,
+                ..
+            } => {
+                // Fast-forward push to local upstream
+                let upstream_branch = Subject::from(branch.subject().clone())
+                    .branch(upstream_name.clone())
+                    .load()
+                    .perform(env)
+                    .await?;
+
+                let branch_revision = match branch.revision() {
+                    Some(rev) => rev,
+                    None => return Ok(None),
+                };
+                let branch_base = branch
+                    .upstream()
+                    .map(|u| u.tree().clone())
+                    .unwrap_or_default();
+
+                let upstream_tree = upstream_branch
+                    .revision()
+                    .map(|r| r.tree.clone())
+                    .unwrap_or_default();
+
+                // Can only fast-forward if upstream hasn't diverged
+                if upstream_tree != branch_base {
+                    return Ok(None);
+                }
+
+                upstream_branch
+                    .reset(branch_revision.clone())
+                    .perform(env)
+                    .await?;
+
+                Ok(Some(branch_revision))
+            }
+            UpstreamState::Remote {
+                name: remote_name,
+                branch: upstream_branch_name,
+                ..
+            } => {
+                let branch_revision = match branch.revision() {
+                    Some(rev) => rev,
+                    None => return Ok(None),
+                };
+                let branch_base = branch
+                    .upstream()
+                    .map(|u| u.tree().clone())
+                    .unwrap_or_default();
+
+                // Load remote repository and open remote branch
+                let remote_repo = Subject::from(branch.subject().clone())
+                    .remote(remote_name.clone())
+                    .load()
+                    .perform(env)
+                    .await?;
+                let remote_branch = remote_repo
+                    .branch(upstream_branch_name.clone())
+                    .open()
+                    .perform(env)
+                    .await?;
+
+                // Compute and upload novel blocks
+                let nodes = novelty(
+                    *branch_base.hash(),
+                    *branch_revision.tree.hash(),
+                    env,
+                    branch.archive().index(),
+                );
+
+                let local_catalog = branch.archive().index();
+                Box::pin(
+                    remote_repo
+                        .archive()
+                        .index()
+                        .upload(nodes, local_catalog)
+                        .perform(env),
+                )
+                .await?;
+
+                // Publish revision to remote
+                remote_branch
+                    .publish(branch_revision.clone())
+                    .perform(env)
+                    .await?;
+
+                // Update local upstream state
+                if let Some(upstream) = branch.upstream() {
+                    branch
+                        .upstream
+                        .publish(Some(upstream.with_tree(branch_revision.tree.clone())))
+                        .perform(env)
+                        .await
+                        .map_err(|e| RepositoryError::PushFailed {
+                            cause: format!("Failed to update upstream state: {:?}", e),
+                        })?;
+                }
+
+                Ok(Some(branch_revision))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use crate::repository::branch::upstream::UpstreamState;
+    use crate::repository::node_reference::NodeReference;
+    use crate::{Artifact, Instruction, Value};
+    use futures_util::stream;
+
+    #[dialog_common::test]
+    async fn it_pushes_to_local_upstream() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let _main = repo.branch("main").open().perform(&operator).await?;
+
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        feature
+            .set_upstream(UpstreamState::Local {
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+            .perform(&operator)
+            .await?;
+
+        let artifact = Artifact {
+            the: "user/name".parse()?,
+            of: "user:123".parse()?,
+            is: Value::String("Alice".to_string()),
+            cause: None,
+        };
+        let _hash = feature
+            .commit(stream::iter(vec![Instruction::Assert(artifact)]))
+            .perform(&operator)
+            .await?;
+
+        let feature_revision = feature.revision().expect("feature should have a revision");
+
+        let result = feature.push().perform(&operator).await?;
+        assert!(result.is_some());
+
+        let main_reloaded = repo.branch("main").load().perform(&operator).await?;
+        let main_rev = main_reloaded
+            .revision()
+            .expect("main should have a revision after push");
+        assert_eq!(main_rev.tree, feature_revision.tree);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_none_when_local_upstream_diverged() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let _hash = main
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:main".parse()?,
+                is: Value::String("Main data".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        feature
+            .set_upstream(UpstreamState::Local {
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+            .perform(&operator)
+            .await?;
+
+        let _hash = feature
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/email".parse()?,
+                of: "user:feature".parse()?,
+                is: Value::String("feature@example.com".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+
+        let result = feature.push().perform(&operator).await?;
+        assert!(result.is_none(), "Push should return None when diverged");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_has_no_upstream_by_default() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("feature").open().perform(&operator).await?;
+
+        assert!(branch.upstream().is_none());
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/reference.rs
+++ b/rust/dialog-repository/src/repository/branch/reference.rs
@@ -1,0 +1,56 @@
+use dialog_capability::{Capability, Did, Policy};
+use dialog_effects::memory as fx;
+use dialog_effects::memory::prelude::SpaceExt;
+
+use crate::repository::branch::name::BranchName;
+use crate::repository::branch::{LoadBranch, OpenBranch};
+use crate::repository::memory::Cell;
+
+/// A reference to a named branch within a repository's memory.
+///
+/// Wraps `Capability<fx::Space>` scoped to `branch/{name}`.
+/// Use `.open()` or `.load()` to create a command, then `.perform(&env)`.
+#[derive(Debug, Clone)]
+pub struct BranchReference(Capability<fx::Space>);
+
+impl From<Capability<fx::Space>> for BranchReference {
+    fn from(space: Capability<fx::Space>) -> Self {
+        Self(space)
+    }
+}
+
+impl BranchReference {
+    /// The subject DID this branch belongs to.
+    pub fn subject(&self) -> &Did {
+        self.0.subject()
+    }
+
+    /// The branch name, extracted from the space path.
+    pub fn name(&self) -> BranchName {
+        fx::Space::of(&self.0)
+            .space
+            .strip_prefix("branch/")
+            .unwrap_or("")
+            .into()
+    }
+
+    /// Open the branch, creating it if it doesn't exist.
+    pub fn open(&self) -> OpenBranch {
+        OpenBranch::new(self.clone())
+    }
+
+    /// Load the branch, returning an error if it doesn't exist.
+    pub fn load(&self) -> LoadBranch {
+        LoadBranch::new(self.clone())
+    }
+
+    /// Create a typed cell within this branch's space.
+    pub fn cell<T>(&self, cell_name: impl Into<String>) -> Cell<T> {
+        self.cell_capability(cell_name).into()
+    }
+
+    /// Return the raw cell capability without wrapping in [`Cell<T>`].
+    pub fn cell_capability(&self, cell_name: impl Into<String>) -> Capability<fx::Cell> {
+        self.0.clone().cell(cell_name)
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/reset.rs
+++ b/rust/dialog-repository/src/repository/branch/reset.rs
@@ -1,0 +1,41 @@
+use dialog_capability::Provider;
+use dialog_effects::memory as memory_fx;
+
+use super::Branch;
+use crate::repository::error::RepositoryError;
+use crate::repository::revision::Revision;
+
+/// Command struct for resetting a branch to a given revision.
+pub struct Reset<'a> {
+    branch: &'a Branch,
+    revision: Revision,
+}
+
+impl<'a> Reset<'a> {
+    fn new(branch: &'a Branch, revision: Revision) -> Self {
+        Self { branch, revision }
+    }
+}
+
+impl Branch {
+    /// Create a command to reset the branch to a given revision.
+    pub fn reset(&self, revision: Revision) -> Reset<'_> {
+        Reset::new(self, revision)
+    }
+}
+
+impl Reset<'_> {
+    /// Execute the reset operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<memory_fx::Publish>,
+    {
+        self.branch
+            .revision
+            .publish(Some(self.revision))
+            .perform(env)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/select.rs
+++ b/rust/dialog-repository/src/repository/branch/select.rs
@@ -1,0 +1,143 @@
+use crate::repository::memory::MemoryExt;
+use crate::repository::remote::address::RemoteSite;
+use dialog_capability::Fork;
+use dialog_capability::Subject;
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive as archive_fx;
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+use dialog_effects::memory as memory_fx;
+use dialog_prolly_tree::{EMPT_TREE_HASH, Entry, Tree};
+use dialog_storage::{Blake3Hash, ContentAddressedStorage, DialogStorageError};
+use futures_util::Stream;
+use std::ops::Range;
+
+use super::{Branch, Index};
+use crate::repository::archive::ArchiveExt as _;
+use crate::repository::archive::networked::NetworkedIndex;
+use crate::repository::branch::upstream::UpstreamState;
+use crate::{
+    AttributeKey, DialogArtifactsError, EntityKey, Key, KeyViewConstruct, KeyViewMut, State,
+    ValueKey,
+};
+use dialog_artifacts::selector::Constrained;
+use dialog_artifacts::{Artifact, ArtifactSelector, Datum, MatchCandidate};
+
+/// Command struct for selecting artifacts from a branch.
+pub struct Select<'a> {
+    branch: &'a Branch,
+    selector: ArtifactSelector<Constrained>,
+}
+
+impl<'a> Select<'a> {
+    pub fn new(branch: &'a Branch, selector: ArtifactSelector<Constrained>) -> Self {
+        Self { branch, selector }
+    }
+
+    fn tree_hash(&self) -> Blake3Hash {
+        self.branch
+            .revision()
+            .as_ref()
+            .map(|rev| *rev.tree.hash())
+            .unwrap_or(EMPT_TREE_HASH)
+    }
+
+    fn catalog(&self) -> Capability<archive_fx::Catalog> {
+        Subject::from(self.branch.subject().clone())
+            .archive()
+            .index()
+    }
+}
+
+impl Select<'_> {
+    /// Execute the select, using fallback to remote if the branch has
+    /// a remote upstream.
+    pub async fn perform<Env>(
+        self,
+        env: &Env,
+    ) -> Result<impl Stream<Item = Result<Artifact, DialogArtifactsError>>, DialogArtifactsError>
+    where
+        Env: Provider<archive_fx::Get>
+            + Provider<archive_fx::Put>
+            + Provider<memory_fx::Resolve>
+            + Provider<Fork<RemoteSite, archive_fx::Get>>
+            + Provider<Fork<RemoteSite, memory_fx::Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let remote = match self.branch.upstream() {
+            Some(UpstreamState::Remote { name, .. }) => {
+                Subject::from(self.branch.subject().clone())
+                    .remote(name)
+                    .load()
+                    .perform(env)
+                    .await
+                    .ok()
+            }
+            _ => None,
+        };
+
+        let store = NetworkedIndex::new(env, self.catalog(), remote);
+        self.execute(store).await
+    }
+
+    async fn execute<'s, S>(
+        self,
+        store: S,
+    ) -> Result<impl Stream<Item = Result<Artifact, DialogArtifactsError>> + 's, DialogArtifactsError>
+    where
+        S: ContentAddressedStorage<Hash = Blake3Hash, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync
+            + 's,
+    {
+        let tree: Index = Tree::from_hash(&self.tree_hash(), &store).await?;
+
+        let selector = self.selector;
+
+        Ok(async_stream::try_stream! {
+            if selector.entity().is_some() {
+                let start = <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
+                let end = <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
+                let stream = tree.stream_range(Range { start, end }, &store);
+                tokio::pin!(stream);
+                for await item in stream {
+                    let entry: Entry<Key, State<Datum>> = item?;
+                    if entry.matches_selector(&selector)
+                        && let Entry { value: State::Added(datum), .. } = entry
+                    {
+                        yield Artifact::try_from(datum)?;
+                    }
+                }
+            } else if selector.value().is_some() {
+                let start = <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
+                let end = <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
+                let stream = tree.stream_range(Range { start, end }, &store);
+                tokio::pin!(stream);
+                for await item in stream {
+                    let entry: Entry<Key, State<Datum>> = item?;
+                    if entry.matches_selector(&selector)
+                        && let Entry { value: State::Added(datum), .. } = entry
+                    {
+                        yield Artifact::try_from(datum)?;
+                    }
+                }
+            } else if selector.attribute().is_some() {
+                let start = <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
+                let end = <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
+                let stream = tree.stream_range(Range { start, end }, &store);
+                tokio::pin!(stream);
+                for await item in stream {
+                    let entry: Entry<Key, State<Datum>> = item?;
+                    if entry.matches_selector(&selector)
+                        && let Entry { value: State::Added(datum), .. } = entry
+                    {
+                        yield Artifact::try_from(datum)?;
+                    }
+                }
+            } else {
+                unreachable!("ArtifactSelector will always have at least one field specified")
+            };
+        })
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/set_upstream.rs
+++ b/rust/dialog-repository/src/repository/branch/set_upstream.rs
@@ -1,0 +1,144 @@
+use dialog_capability::Provider;
+use dialog_effects::memory as memory_fx;
+
+use super::Branch;
+use super::upstream::UpstreamState;
+use crate::repository::error::RepositoryError;
+
+/// Command struct for setting a branch's upstream.
+pub struct SetUpstream<'a> {
+    branch: &'a Branch,
+    upstream: UpstreamState,
+}
+
+impl<'a> SetUpstream<'a> {
+    fn new(branch: &'a Branch, upstream: UpstreamState) -> Self {
+        Self { branch, upstream }
+    }
+}
+
+impl Branch {
+    /// Create a command to set the upstream for this branch.
+    ///
+    /// Accepts both `UpstreamState` and `RemoteBranch` directly via
+    /// `impl Into<UpstreamState>`.
+    pub fn set_upstream(&self, upstream: impl Into<UpstreamState>) -> SetUpstream<'_> {
+        SetUpstream::new(self, upstream.into())
+    }
+}
+
+impl SetUpstream<'_> {
+    /// Execute the set_upstream operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<memory_fx::Publish>,
+    {
+        // Validate: upstream must not be this branch itself
+        if let UpstreamState::Local { ref branch, .. } = self.upstream
+            && *branch == self.branch.name()
+        {
+            return Err(RepositoryError::BranchUpstreamIsItself {
+                name: self.branch.name(),
+            });
+        }
+
+        self.branch
+            .upstream
+            .publish(Some(self.upstream))
+            .perform(env)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::repository::branch::upstream::UpstreamState;
+    use crate::repository::error::RepositoryError;
+    use crate::repository::node_reference::NodeReference;
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+
+    #[dialog_common::test]
+    async fn it_sets_local_upstream() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let branch = repo.branch("feature").open().perform(&operator).await?;
+
+        // Create upstream branch
+        let _main = repo.branch("main").open().perform(&operator).await?;
+
+        branch
+            .set_upstream(UpstreamState::Local {
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+            .perform(&operator)
+            .await?;
+
+        let upstream = branch.upstream();
+        assert_eq!(
+            upstream,
+            Some(UpstreamState::Local {
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_sets_remote_upstream() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        branch
+            .set_upstream(UpstreamState::Remote {
+                name: "origin".into(),
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+            .perform(&operator)
+            .await?;
+
+        let upstream = branch.upstream();
+        match upstream {
+            Some(UpstreamState::Remote { name, branch, .. }) => {
+                assert_eq!(name, "origin");
+                assert_eq!(branch.as_str(), "main");
+            }
+            _ => panic!("Expected Remote upstream"),
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_errors_setting_upstream_to_self() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let result = branch
+            .set_upstream(UpstreamState::Local {
+                branch: "main".into(),
+                tree: NodeReference::default(),
+            })
+            .perform(&operator)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(RepositoryError::BranchUpstreamIsItself { .. })
+        ));
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -1,0 +1,45 @@
+use dialog_artifacts::{ChangeStream, Changes, Statement};
+
+use super::Branch;
+use super::commit::Commit;
+
+/// A transaction on a branch.
+///
+/// Created by [`Branch::edit`]. Accumulates changes via `.assert()` and
+/// `.retract()`, then commits atomically via `.commit().perform(&env)`.
+pub struct Transaction<'a> {
+    branch: &'a Branch,
+    changes: Changes,
+}
+
+impl<'a> Transaction<'a> {
+    /// Assert a claim into this transaction.
+    pub fn assert<C: Statement>(mut self, claim: C) -> Self {
+        self.changes.assert(claim);
+        self
+    }
+
+    /// Retract a claim from this transaction.
+    pub fn retract<C: Statement>(mut self, claim: C) -> Self {
+        self.changes.retract(claim);
+        self
+    }
+
+    /// Finalize the transaction into a commit command.
+    pub fn commit(self) -> Commit<'a, ChangeStream> {
+        self.branch.commit(self.changes.into_stream())
+    }
+}
+
+impl Branch {
+    /// Start a transaction on this branch.
+    ///
+    /// Use `.assert()` and `.retract()` to accumulate changes,
+    /// then `.commit().perform(&env)` to apply them.
+    pub fn transaction(&self) -> Transaction<'_> {
+        Transaction {
+            branch: self,
+            changes: Changes::new(),
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/upstream.rs
+++ b/rust/dialog-repository/src/repository/branch/upstream.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+use super::name::BranchName;
+use crate::repository::node_reference::NodeReference;
+use crate::repository::remote::RemoteName;
+
+/// Upstream represents some branch being tracked.
+///
+/// The `tree` field stores the upstream's tree root at the time of last
+/// sync, used as the base for three-way merge when rebasing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UpstreamState {
+    /// A local branch upstream
+    Local {
+        /// Branch name
+        branch: BranchName,
+        /// Tree root at last sync point
+        tree: NodeReference,
+    },
+    /// A remote branch upstream
+    Remote {
+        /// Remote name (e.g., "origin")
+        name: RemoteName,
+        /// Branch name
+        branch: BranchName,
+        /// Tree root at last sync point
+        tree: NodeReference,
+    },
+}
+
+impl UpstreamState {
+    /// Returns the branch name of this upstream.
+    pub fn branch(&self) -> &BranchName {
+        match self {
+            Self::Local { branch, .. } => branch,
+            Self::Remote { branch, .. } => branch,
+        }
+    }
+
+    /// Returns the tree root at the last sync point.
+    pub fn tree(&self) -> &NodeReference {
+        match self {
+            Self::Local { tree, .. } => tree,
+            Self::Remote { tree, .. } => tree,
+        }
+    }
+
+    /// Returns a new upstream with the tree updated to the given value.
+    pub fn with_tree(self, tree: NodeReference) -> Self {
+        match self {
+            Self::Local { branch, .. } => Self::Local { branch, tree },
+            Self::Remote { name, branch, .. } => Self::Remote { name, branch, tree },
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/create.rs
+++ b/rust/dialog-repository/src/repository/create.rs
@@ -1,0 +1,34 @@
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_credentials::Ed25519Signer;
+use dialog_credentials::credential::{Credential, SignerCredential};
+use dialog_effects::space as space_fx;
+use dialog_effects::space::SpaceExt as _;
+
+use super::Repository;
+use super::error::RepositoryError;
+
+/// Command to create a new repository.
+///
+/// Returns `Repository<SignerCredential>` since a freshly generated
+/// credential always has a private key.
+pub struct CreateRepository(pub Capability<space_fx::Space>);
+
+impl CreateRepository {
+    /// Execute against an operator.
+    pub async fn perform<Env>(
+        self,
+        env: &Env,
+    ) -> Result<Repository<SignerCredential>, RepositoryError>
+    where
+        Env: Provider<space_fx::Create> + ConditionalSync,
+    {
+        let signer = Ed25519Signer::generate()
+            .await
+            .map_err(|e| RepositoryError::StorageError(e.to_string()))?;
+        let cred = Credential::Signer(SignerCredential::from(signer));
+
+        let credential = self.0.create(cred).perform(env).await?;
+        Repository::try_from(credential)
+    }
+}

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -1,0 +1,103 @@
+use dialog_effects::archive::ArchiveError;
+use dialog_effects::memory::MemoryError;
+use dialog_effects::storage::StorageError;
+use dialog_storage::DialogStorageError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::branch::BranchName;
+use super::remote::RemoteName;
+
+/// The common error type used by repository operations.
+#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RepositoryError {
+    /// Branch with the given name was not found
+    #[error("Branch {name} not found")]
+    BranchNotFound {
+        /// The name of the branch that was not found
+        name: BranchName,
+    },
+
+    /// A storage operation failed
+    #[error("Storage error {0}")]
+    StorageError(String),
+
+    /// Branch has no configured upstream
+    #[error("Branch {name} has no upstream")]
+    BranchHasNoUpstream {
+        /// The name of the branch that has no upstream
+        name: BranchName,
+    },
+
+    /// Pushing a revision failed
+    #[error("Pushing revision failed: {cause}")]
+    PushFailed {
+        /// The underlying error message
+        cause: String,
+    },
+
+    /// Remote repository not found
+    #[error("Remote {remote} not found")]
+    RemoteNotFound {
+        /// Remote site name
+        remote: RemoteName,
+    },
+    /// Remote repository already exists
+    #[error("Remote {remote} already exist")]
+    RemoteAlreadyExists {
+        /// Remote site name
+        remote: RemoteName,
+    },
+    /// Connection to remote repository failed
+    #[error("Connection to remote {remote} failed")]
+    RemoteConnectionError {
+        /// Remote site name
+        remote: RemoteName,
+    },
+
+    /// Repository not found
+    #[error("Repository '{0}' not found")]
+    NotFound(String),
+
+    /// Repository already exists
+    #[error("Repository '{0}' already exists")]
+    AlreadyExists(String),
+
+    /// Branch upstream is set to itself
+    #[error("Upsteam of local {name} is set to itself")]
+    BranchUpstreamIsItself {
+        /// Branch name
+        name: BranchName,
+    },
+
+    /// Invalid internal state (should never happen in normal operation)
+    #[error("Invalid state: {message}")]
+    InvalidState {
+        /// Description of the invalid state
+        message: String,
+    },
+}
+
+impl From<StorageError> for RepositoryError {
+    fn from(e: StorageError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<ArchiveError> for RepositoryError {
+    fn from(e: ArchiveError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<MemoryError> for RepositoryError {
+    fn from(e: MemoryError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<DialogStorageError> for RepositoryError {
+    fn from(e: DialogStorageError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}

--- a/rust/dialog-repository/src/repository/load.rs
+++ b/rust/dialog-repository/src/repository/load.rs
@@ -1,0 +1,24 @@
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::space as space_fx;
+use dialog_effects::space::SpaceExt as _;
+
+use super::Repository;
+use super::error::RepositoryError;
+
+/// Command to load an existing repository.
+///
+/// Returns `Repository<Credential>` since the credential
+/// may be verifier-only.
+pub struct LoadRepository(pub Capability<space_fx::Space>);
+
+impl LoadRepository {
+    /// Execute against an operator.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, RepositoryError>
+    where
+        Env: Provider<space_fx::Load> + ConditionalSync,
+    {
+        let credential = self.0.load().perform(env).await?;
+        Ok(Repository::from(credential))
+    }
+}

--- a/rust/dialog-repository/src/repository/memory.rs
+++ b/rust/dialog-repository/src/repository/memory.rs
@@ -1,0 +1,46 @@
+//! Extension trait on [`Subject`] for repository memory navigation.
+
+use dialog_capability::Subject;
+use dialog_effects::memory::prelude::{MemoryExt as _, MemorySubjectExt};
+
+use super::branch::BranchReference;
+use super::branch::name::BranchName;
+use super::remote::RemoteName;
+use super::remote::RemoteReference;
+
+mod cell;
+/// Publish command for writing cell values.
+pub mod publish;
+/// Resolve command for fetching cell values.
+pub mod resolve;
+
+pub use cell::*;
+
+/// Extension trait on [`Subject`] for repository memory navigation.
+///
+/// Provides `.branch("name")` and `.remote("name")` methods that
+/// create scoped references for repository operations.
+pub trait MemoryExt {
+    /// Access branch scoped to `branch/{name}`.
+    fn branch(&self, branch: impl Into<BranchName>) -> BranchReference;
+
+    /// Access remote scoped to `remote/{name}`.
+    fn remote(&self, name: impl Into<RemoteName>) -> RemoteReference;
+}
+
+impl MemoryExt for Subject {
+    fn branch(&self, branch: impl Into<BranchName>) -> BranchReference {
+        let name: BranchName = branch.into();
+        let space = self.clone().memory().space(format!("branch/{}", name));
+        space.into()
+    }
+
+    fn remote(&self, name: impl Into<RemoteName>) -> RemoteReference {
+        let name: RemoteName = name.into();
+        let space = self
+            .clone()
+            .memory()
+            .space(format!("remote/{}", name.as_str()));
+        space.into()
+    }
+}

--- a/rust/dialog-repository/src/repository/memory/cell.rs
+++ b/rust/dialog-repository/src/repository/memory/cell.rs
@@ -1,0 +1,558 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use dialog_capability::{Capability, Did, Policy};
+use dialog_common::ConditionalSync;
+use dialog_effects::memory;
+use dialog_effects::memory::prelude::CellExt;
+use dialog_effects::memory::{Edition, Version};
+use dialog_storage::{CborEncoder, DialogStorageError, Encoder};
+use serde::{Serialize, de::DeserializeOwned};
+use std::fmt::Debug;
+
+use super::publish::{Publish, RetainPublish};
+use super::resolve::{Resolve, RetainResolve};
+use crate::RepositoryError;
+
+/// Cached [`Edition`] behind a shared lock.
+pub type SharedState<T> = Arc<RwLock<Option<Edition<T>>>>;
+
+/// Typed cache over shared state. Handles encode/decode and cache updates.
+#[derive(Debug)]
+pub struct Cache<T, Codec: Clone = CborEncoder> {
+    pub codec: Codec,
+    pub state: SharedState<T>,
+}
+
+impl<T, Codec: Clone> Clone for Cache<T, Codec> {
+    fn clone(&self) -> Self {
+        Self {
+            codec: self.codec.clone(),
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl<T: Clone, Codec: Clone> Cache<T, Codec> {
+    /// Read the cached content.
+    pub fn content(&self) -> Option<T> {
+        self.state.read().as_ref().map(|e| e.content.clone())
+    }
+
+    /// Read the full cached edition.
+    pub fn edition(&self) -> Option<Edition<T>> {
+        self.state.read().clone()
+    }
+
+    /// Read just the cached version.
+    pub fn version(&self) -> Option<Version> {
+        self.state.read().as_ref().map(|e| e.version.clone())
+    }
+
+    /// Update the cache with a new edition.
+    pub fn update(&self, edition: Edition<T>) {
+        *self.state.write() = Some(edition);
+    }
+
+    /// Clear the cache.
+    pub fn clear(&self) {
+        *self.state.write() = None;
+    }
+}
+
+impl<T, Codec> Cache<T, Codec>
+where
+    T: DeserializeOwned + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Decode bytes into a typed value.
+    pub async fn decode(&self, bytes: &[u8]) -> Result<T, RepositoryError> {
+        self.codec.decode(bytes).await.map_err(|e| {
+            let storage_err: DialogStorageError = e.into();
+            RepositoryError::from(storage_err)
+        })
+    }
+}
+
+impl<T, Codec> Cache<T, Codec>
+where
+    T: Serialize + ConditionalSync + Debug,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Encode a value into bytes.
+    pub async fn encode(&self, value: &T) -> Result<Vec<u8>, RepositoryError> {
+        let (_hash, content) = self.codec.encode(value).await.map_err(|e| {
+            let storage_err: DialogStorageError = e.into();
+            RepositoryError::from(storage_err)
+        })?;
+        Ok(content)
+    }
+}
+
+/// A transactional memory cell that stores a typed value with edition tracking.
+///
+/// `Cell<T>` wraps a capability chain (`Subject -> Memory -> Space -> Cell`) and
+/// manages its own cached value + edition internally. This eliminates the need
+/// for callers to thread editions through publish/resolve calls.
+///
+/// The cached state is stored behind `Arc<RwLock<>>`, so clones share state
+/// and writes propagate to all references.
+///
+/// - [`get`](Cell::get) reads the cache synchronously, returning a cloned `T`
+/// - [`resolve`](Cell::resolve) returns a [`Resolve`] command to fetch from env
+/// - [`publish`](Cell::publish) returns a [`Publish`] command to write a value
+#[derive(Debug, Clone)]
+pub struct Cell<T, Codec: Clone = CborEncoder> {
+    capability: Capability<memory::Cell>,
+    cache: Cache<T, Codec>,
+}
+
+impl<T> Cell<T> {
+    /// Returns the name of this cell.
+    pub fn name(&self) -> &str {
+        &memory::Cell::of(&self.capability).cell
+    }
+}
+
+impl<T> From<Capability<memory::Cell>> for Cell<T> {
+    fn from(capability: Capability<memory::Cell>) -> Self {
+        Self {
+            capability,
+            cache: Cache {
+                codec: CborEncoder,
+                state: SharedState::default(),
+            },
+        }
+    }
+}
+
+impl<T, Codec: Clone> Cell<T, Codec>
+where
+    T: Clone,
+{
+    /// Read the cached value without hitting env.
+    /// Returns `None` if the cell has not been resolved or published yet.
+    pub fn content(&self) -> Option<T> {
+        self.cache.content()
+    }
+
+    /// Read the cached edition (content + version) without hitting env.
+    /// Returns `None` if the cell has not been resolved or published yet.
+    pub fn edition(&self) -> Option<Edition<T>> {
+        self.cache.edition()
+    }
+
+    /// Reset the in-memory cache to a known edition, without hitting the
+    /// backend. Used to restore cache state across sessions.
+    pub fn reset(&self, edition: Edition<T>) {
+        self.cache.update(edition);
+    }
+
+    /// Returns the subject DID from the capability chain.
+    pub fn subject(&self) -> &Did {
+        self.capability.subject()
+    }
+}
+
+impl<T, Codec> Cell<T, Codec>
+where
+    T: DeserializeOwned + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Create a command to fetch the cell value from env.
+    ///
+    /// Call `.perform(&env)` for local, or `.fork(&address).perform(&env)`
+    /// for remote.
+    pub fn resolve(&self) -> Resolve<T, Codec> {
+        Resolve {
+            effect: self.capability.clone().resolve(),
+            cache: self.cache.clone(),
+        }
+    }
+}
+
+impl<T, Codec> Cell<T, Codec>
+where
+    T: Serialize + Clone,
+    Codec: Clone,
+{
+    /// Create a command to publish a new value to this cell.
+    ///
+    /// Call `.perform(&env)` for local, or `.fork(&address).perform(&env)`
+    /// for remote.
+    pub fn publish(&self, content: T) -> Publish<T, Codec> {
+        Publish {
+            capability: self.capability.clone(),
+            cache: self.cache.clone(),
+            content,
+        }
+    }
+}
+
+/// A cell that always has a value.
+///
+/// Constructed with an initial value via [`Cell::retain`]. On resolve,
+/// updates to the latest remote value, but if the remote is empty (deleted),
+/// the last known value is retained. [`get()`](Retain::get) always returns `T`.
+#[derive(Debug, Clone)]
+pub struct Retain<T, Codec: Clone = CborEncoder> {
+    cell: Cell<T, Codec>,
+    value: Arc<RwLock<T>>,
+}
+
+impl<T: Clone> Retain<T> {
+    /// Read the current value, syncing from the inner cell first.
+    ///
+    /// If the cell has a newer value, the sticky cache is updated.
+    /// Returns a read guard that derefs to `&T`.
+    pub fn get(&self) -> parking_lot::RwLockReadGuard<'_, T> {
+        if let Some(value) = self.cell.content() {
+            *self.value.write() = value;
+        }
+        self.value.read()
+    }
+
+    /// Returns the name of the underlying cell.
+    pub fn name(&self) -> &str {
+        self.cell.name()
+    }
+
+    /// Returns the subject DID from the capability chain.
+    pub fn subject(&self) -> &Did {
+        self.cell.subject()
+    }
+}
+
+impl<T, Codec> Retain<T, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Create a command to resolve from the environment.
+    ///
+    /// If the remote has a value, the local cache is updated.
+    /// If the remote is empty (deleted), the current value is retained.
+    pub fn resolve(&self) -> RetainResolve<'_, T, Codec> {
+        RetainResolve {
+            inner: self.cell.resolve(),
+            value: &self.value,
+        }
+    }
+}
+
+impl<T, Codec> Retain<T, Codec>
+where
+    T: Serialize + Clone,
+    Codec: Clone,
+{
+    /// Create a command to publish a new value.
+    pub fn publish(&self, value: T) -> RetainPublish<'_, T, Codec> {
+        RetainPublish {
+            inner: self.cell.publish(value.clone()),
+            sticky: &self.value,
+            value,
+        }
+    }
+}
+
+impl<T> Cell<T> {
+    /// Equip this cell with an initial value, creating a [`Retain`]
+    /// that always has a value and never drops back to empty.
+    pub fn retain(self, initial: T) -> Retain<T> {
+        Retain {
+            cell: self,
+            value: Arc::new(RwLock::new(initial)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::memory::MemoryExt;
+    use dialog_capability::{Did, Subject};
+    use dialog_storage::provider::Volatile;
+
+    fn test_subject() -> Subject {
+        let did: Did = "did:test:cell-tests".parse().unwrap();
+        Subject::from(did)
+    }
+
+    fn test_cell<T>(name: &str) -> Cell<T> {
+        test_subject().branch("test").cell(name)
+    }
+
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestValue {
+        count: u32,
+        name: String,
+    }
+
+    impl Default for TestValue {
+        fn default() -> Self {
+            Self {
+                count: 0,
+                name: "default".into(),
+            }
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_empty_cell() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("missing");
+
+        cell.resolve().perform(&provider).await?;
+        assert!(cell.content().is_none());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_publishes_then_resolves() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("test");
+
+        let value = TestValue {
+            count: 42,
+            name: "hello".into(),
+        };
+
+        cell.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value.clone()));
+
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_updates_with_automatic_edition() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("update");
+
+        let v1 = TestValue {
+            count: 1,
+            name: "first".into(),
+        };
+        cell.publish(v1).perform(&provider).await?;
+
+        let v2 = TestValue {
+            count: 2,
+            name: "second".into(),
+        };
+        cell.publish(v2.clone()).perform(&provider).await?;
+
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(v2));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_caches_on_resolve() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("cache");
+
+        let value = TestValue {
+            count: 7,
+            name: "cached".into(),
+        };
+
+        let writer: Cell<TestValue> = test_cell("cache");
+        writer.publish(value.clone()).perform(&provider).await?;
+
+        assert!(cell.content().is_none());
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value.clone()));
+
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn clones_share_published_state() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("shared");
+        let clone = cell.clone();
+
+        let value = TestValue {
+            count: 42,
+            name: "shared".into(),
+        };
+
+        cell.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(clone.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn publish_on_clone_visible_from_original() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let original: Cell<TestValue> = test_cell("shared-reverse");
+        let clone = original.clone();
+
+        let value = TestValue {
+            count: 99,
+            name: "from clone".into(),
+        };
+
+        clone.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(original.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn equipped_publishes_and_reads() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let equipped = test_cell::<TestValue>("equipped-pub").retain(TestValue::default());
+
+        assert_eq!(
+            *equipped.get(),
+            TestValue::default(),
+            "empty before publish"
+        );
+
+        let value = TestValue {
+            count: 42,
+            name: "equipped".into(),
+        };
+        equipped.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(*equipped.get(), value.clone());
+
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), value);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn equipped_updates_on_resolve() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+
+        let cell: Cell<TestValue> = test_cell("equipped-update");
+        let v1 = TestValue {
+            count: 1,
+            name: "first".into(),
+        };
+        cell.publish(v1.clone()).perform(&provider).await?;
+
+        let equipped = test_cell::<TestValue>("equipped-update").retain(TestValue::default());
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), v1);
+
+        let v2 = TestValue {
+            count: 2,
+            name: "second".into(),
+        };
+        cell.publish(v2.clone()).perform(&provider).await?;
+
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), v2);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn equipped_retains_value_when_remote_empty() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+
+        let cell: Cell<TestValue> = test_cell("equipped-retain");
+        let value = TestValue {
+            count: 42,
+            name: "retained".into(),
+        };
+        cell.publish(value.clone()).perform(&provider).await?;
+
+        let equipped = test_cell::<TestValue>("equipped-retain").retain(TestValue::default());
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), value.clone());
+
+        let empty_equipped = test_cell::<TestValue>("nonexistent").retain(TestValue::default());
+        empty_equipped.resolve().perform(&provider).await?;
+        assert_eq!(
+            *empty_equipped.get(),
+            TestValue::default(),
+            "equipped on nonexistent cell retains default"
+        );
+
+        assert_eq!(
+            *equipped.get(),
+            value,
+            "equipped retains value independently"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    fn equipped_returns_none_before_any_value() -> anyhow::Result<()> {
+        let equipped = test_cell::<TestValue>("equipped-empty").retain(TestValue::default());
+        assert_eq!(*equipped.get(), TestValue::default());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn publish_preserves_edition_for_subsequent_publish() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("edition");
+
+        let v1 = TestValue {
+            count: 1,
+            name: "first".into(),
+        };
+        cell.publish(v1).perform(&provider).await?;
+
+        // Second publish should use the edition from the first
+        let v2 = TestValue {
+            count: 2,
+            name: "second".into(),
+        };
+        cell.publish(v2.clone()).perform(&provider).await?;
+
+        // Resolve from a separate cell to verify the value was written
+        let reader: Cell<TestValue> = test_cell("edition");
+        reader.resolve().perform(&provider).await?;
+        assert_eq!(
+            reader.content(),
+            Some(v2),
+            "second publish should succeed with correct edition"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn edition_mismatch_fails_publish() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell_a: Cell<TestValue> = test_cell("conflict");
+        let cell_b: Cell<TestValue> = test_cell("conflict");
+
+        // Both resolve to get the same (empty) edition
+        cell_a.resolve().perform(&provider).await?;
+        cell_b.resolve().perform(&provider).await?;
+
+        // A publishes successfully
+        let v1 = TestValue {
+            count: 1,
+            name: "from A".into(),
+        };
+        cell_a.publish(v1).perform(&provider).await?;
+
+        // B tries to publish with the stale edition -- should fail
+        let v2 = TestValue {
+            count: 2,
+            name: "from B".into(),
+        };
+        let result = cell_b.publish(v2).perform(&provider).await;
+        assert!(result.is_err(), "publish with stale edition should fail");
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/memory/publish.rs
+++ b/rust/dialog-repository/src/repository/memory/publish.rs
@@ -1,0 +1,117 @@
+//! Publish command for writing a cell value.
+
+use dialog_capability::Fork;
+use dialog_capability::SiteAddress;
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::memory;
+use dialog_effects::memory::prelude::CellExt;
+use dialog_storage::Encoder;
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::fmt::Debug;
+
+use super::cell::Cache;
+use crate::RepositoryError;
+
+/// Command to publish a cell value.
+///
+/// Created by [`Cell::publish`](super::Cell::publish). Execute with
+/// `.perform(&env)` for local or `.fork(&address).perform(&env)` for remote.
+pub struct Publish<T, Codec: Clone> {
+    pub capability: Capability<memory::Cell>,
+    pub cache: Cache<T, Codec>,
+    pub content: T,
+}
+
+impl<T, Codec> Publish<T, Codec>
+where
+    T: Serialize + Clone + ConditionalSync + Debug,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Execute locally.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<memory::Publish>,
+    {
+        let content = self.cache.encode(&self.content).await?;
+        let when = self.cache.version();
+        let version = self.capability.publish(content, when).perform(env).await?;
+        self.cache.update(memory::Edition {
+            content: self.content,
+            version,
+        });
+        Ok(())
+    }
+
+    /// Fork to a remote site.
+    pub fn fork<A: SiteAddress>(self, address: &A) -> ForkPublish<T, A, Codec> {
+        ForkPublish {
+            capability: self.capability,
+            cache: self.cache,
+            content: self.content,
+            address: address.clone(),
+        }
+    }
+}
+
+/// Command to publish a cell value to a remote site.
+pub struct ForkPublish<T, A: SiteAddress, Codec: Clone> {
+    capability: Capability<memory::Cell>,
+    cache: Cache<T, Codec>,
+    content: T,
+    address: A,
+}
+
+impl<T, A, Codec> ForkPublish<T, A, Codec>
+where
+    T: Serialize + Clone + ConditionalSync + Debug,
+    A: SiteAddress,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Execute against a remote site.
+    ///
+    /// Uses the cached edition from the last resolve. Call
+    /// `cell.resolve().fork(&addr).perform(&env)` first to sync the edition.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<Fork<A::Site, memory::Publish>> + ConditionalSync,
+    {
+        let content = self.cache.encode(&self.content).await?;
+        let when = self.cache.version();
+        let version = self
+            .capability
+            .publish(content, when)
+            .fork(&self.address)
+            .perform(env)
+            .await?;
+        self.cache.update(memory::Edition {
+            content: self.content,
+            version,
+        });
+        Ok(())
+    }
+}
+
+/// Command to publish to a retained cell.
+pub struct RetainPublish<'a, T, Codec: Clone> {
+    pub inner: Publish<T, Codec>,
+    pub sticky: &'a RwLock<T>,
+    pub value: T,
+}
+
+impl<T, Codec> RetainPublish<'_, T, Codec>
+where
+    T: Serialize + Clone + ConditionalSync + Debug,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Execute locally.
+    pub async fn perform(
+        self,
+        env: &(impl Provider<memory::Publish> + ConditionalSync),
+    ) -> Result<(), RepositoryError> {
+        self.inner.perform(env).await?;
+        *self.sticky.write() = self.value;
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/memory/resolve.rs
+++ b/rust/dialog-repository/src/repository/memory/resolve.rs
@@ -1,0 +1,113 @@
+//! Resolve command for fetching a cell value.
+
+use dialog_capability::Fork;
+use dialog_capability::{Capability, Provider};
+use dialog_capability::{Site, SiteAddress};
+use dialog_common::ConditionalSync;
+use dialog_effects::memory;
+use dialog_storage::Encoder;
+use parking_lot::RwLock;
+use serde::de::DeserializeOwned;
+
+use super::cell::Cache;
+use crate::RepositoryError;
+
+/// Command to resolve (fetch) a cell value.
+///
+/// Created by [`Cell::resolve`](super::Cell::resolve). Execute with
+/// `.perform(&env)` for local or `.fork(&address).perform(&env)` for remote.
+pub struct Resolve<T, Codec: Clone> {
+    pub effect: Capability<memory::Resolve>,
+    pub cache: Cache<T, Codec>,
+}
+
+impl<T, Codec> Resolve<T, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Execute locally.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<memory::Resolve>,
+    {
+        let publication = self.effect.perform(env).await?;
+        apply(&self.cache, publication).await
+    }
+
+    /// Fork to a remote site.
+    pub fn fork<A: SiteAddress>(self, address: &A) -> ForkResolve<T, A::Site, Codec> {
+        ForkResolve {
+            fork: self.effect.fork(address),
+            cache: self.cache,
+        }
+    }
+}
+
+/// Command to resolve a cell value from a remote site.
+pub struct ForkResolve<T, S: Site, Codec: Clone> {
+    fork: Fork<S, memory::Resolve>,
+    cache: Cache<T, Codec>,
+}
+
+impl<T, S, Codec> ForkResolve<T, S, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    S: Site,
+    Codec: Encoder + Clone,
+{
+    /// Execute against a remote site.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<Fork<S, memory::Resolve>> + ConditionalSync,
+    {
+        let publication = self.fork.perform(env).await?;
+        apply(&self.cache, publication).await
+    }
+}
+
+/// Decode a publication and update the cache.
+async fn apply<T, Codec>(
+    cache: &Cache<T, Codec>,
+    edition: Option<memory::Edition<Vec<u8>>>,
+) -> Result<(), RepositoryError>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    match edition {
+        None => cache.clear(),
+        Some(pub_data) => {
+            cache.update(memory::Edition {
+                content: cache.decode(&pub_data.content).await?,
+                version: pub_data.version,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Command to resolve a retained cell.
+pub struct RetainResolve<'a, T, Codec: Clone> {
+    pub inner: Resolve<T, Codec>,
+    pub value: &'a RwLock<T>,
+}
+
+impl<T, Codec> RetainResolve<'_, T, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Execute locally.
+    pub async fn perform(
+        self,
+        env: &(impl Provider<memory::Resolve> + ConditionalSync),
+    ) -> Result<(), RepositoryError> {
+        let cache = self.inner.cache.clone();
+        self.inner.perform(env).await?;
+        if let Some(value) = cache.content() {
+            *self.value.write() = value;
+        }
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/node_reference.rs
+++ b/rust/dialog-repository/src/repository/node_reference.rs
@@ -1,0 +1,49 @@
+use base58::ToBase58;
+use dialog_prolly_tree::EMPT_TREE_HASH;
+use dialog_storage::Blake3Hash;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+
+/// We reference a tree by the root hash.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NodeReference(Blake3Hash);
+
+impl NodeReference {
+    /// Returns a reference to the underlying hash.
+    pub fn hash(&self) -> &Blake3Hash {
+        &self.0
+    }
+}
+
+impl Default for NodeReference {
+    /// By default, a [`NodeReference`] is created to empty search tree.
+    fn default() -> Self {
+        Self(EMPT_TREE_HASH)
+    }
+}
+
+impl Display for NodeReference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let bytes: &[u8] = self.hash();
+        write!(f, "#{}", ToBase58::to_base58(bytes))
+    }
+}
+
+impl Debug for NodeReference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self, f)
+    }
+}
+
+impl From<Blake3Hash> for NodeReference {
+    fn from(hash: Blake3Hash) -> Self {
+        Self(hash)
+    }
+}
+
+impl From<NodeReference> for Blake3Hash {
+    fn from(value: NodeReference) -> Self {
+        let NodeReference(hash) = value;
+        hash
+    }
+}

--- a/rust/dialog-repository/src/repository/open.rs
+++ b/rust/dialog-repository/src/repository/open.rs
@@ -1,0 +1,39 @@
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_credentials::Ed25519Signer;
+use dialog_credentials::credential::{Credential, SignerCredential};
+use dialog_effects::space as space_fx;
+use dialog_effects::space::SpaceExt as _;
+
+use super::Repository;
+use super::error::RepositoryError;
+
+/// Command to open (load-or-create) a repository.
+///
+/// Returns `Repository<Credential>` since the loaded credential
+/// may be verifier-only.
+pub struct OpenRepository(pub Capability<space_fx::Space>);
+
+impl OpenRepository {
+    /// Execute against an operator.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, RepositoryError>
+    where
+        Env: Provider<space_fx::Load> + Provider<space_fx::Create> + ConditionalSync,
+    {
+        let load_result = self.0.clone().load().perform(env).await;
+
+        let credential = match load_result {
+            Ok(cred) => cred,
+            Err(_) => {
+                let signer = Ed25519Signer::generate()
+                    .await
+                    .map_err(|e| RepositoryError::StorageError(e.to_string()))?;
+                let cred = Credential::Signer(SignerCredential::from(signer));
+
+                self.0.create(cred).perform(env).await?
+            }
+        };
+
+        Ok(Repository::from(credential))
+    }
+}

--- a/rust/dialog-repository/src/repository/remote.rs
+++ b/rust/dialog-repository/src/repository/remote.rs
@@ -1,0 +1,30 @@
+//! Remote repository navigation and operations.
+//!
+//! ```text
+//! repo.remote("origin").load().perform(&env)  → RemoteRepository
+//!   └── .branch("main")                    → RemoteBranchReference
+//! ```
+
+/// Serializable remote address configuration.
+pub mod address;
+/// Remote archive operations (upload blocks).
+pub mod archive;
+/// Remote branch cursor with resolve/publish/upload operations.
+pub mod branch;
+/// Command to create a new remote.
+mod create;
+/// Command to load an existing remote.
+mod load;
+/// Remote name newtype.
+pub mod name;
+/// Selectors for navigating remote sites, repositories, and branches.
+mod reference;
+/// Remote repository cursor.
+pub mod repository;
+
+pub use address::*;
+pub use create::*;
+pub use load::*;
+pub use name::*;
+pub use reference::*;
+pub use repository::RemoteRepository;

--- a/rust/dialog-repository/src/repository/remote/address.rs
+++ b/rust/dialog-repository/src/repository/remote/address.rs
@@ -1,0 +1,38 @@
+//! Remote address types.
+//!
+//! Re-exports [`NetworkAddress`] and [`Network`] from dialog-operator.
+//! [`RemoteAddress`] pairs a site address with a subject DID to identify
+//! a specific remote repository.
+
+use dialog_capability::Did;
+
+pub use dialog_operator::network::Network as RemoteSite;
+pub use dialog_operator::network::NetworkAddress as SiteAddress;
+
+/// A remote repository address -- connection info plus subject DID.
+///
+/// This is what gets stored in the `remote/{name}/address` cell.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+pub struct RemoteAddress {
+    /// How to connect to the remote.
+    pub address: SiteAddress,
+    /// Which repository (subject DID) at that site.
+    pub subject: Did,
+}
+
+impl RemoteAddress {
+    /// Create a new remote address.
+    pub fn new(address: SiteAddress, subject: Did) -> Self {
+        Self { address, subject }
+    }
+
+    /// The site connection info.
+    pub fn site(&self) -> &SiteAddress {
+        &self.address
+    }
+
+    /// The subject DID of the remote repository.
+    pub fn subject(&self) -> &Did {
+        &self.subject
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/archive.rs
+++ b/rust/dialog-repository/src/repository/remote/archive.rs
@@ -1,0 +1,185 @@
+//! Remote archive operations -- upload blocks to remote storage.
+
+use super::address::RemoteSite;
+use dialog_capability::Fork;
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive as archive_fx;
+use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt, CatalogExt};
+use dialog_prolly_tree::Node;
+use dialog_storage::Blake3Hash;
+use futures_util::{Stream, StreamExt, TryStreamExt};
+
+use super::repository::RemoteRepository;
+use crate::repository::error::RepositoryError;
+use crate::{DialogArtifactsError, Key, State};
+use dialog_artifacts::Datum;
+
+/// Remote archive scoped to a remote repository.
+pub struct RemoteArchive<'a> {
+    repository: &'a RemoteRepository,
+}
+
+impl<'a> RemoteArchive<'a> {
+    /// The index catalog for tree node storage.
+    pub fn index(&self) -> RemoteArchiveIndex<'a> {
+        let address = self.repository.address();
+        let catalog = address.subject.clone().archive().catalog("index");
+
+        RemoteArchiveIndex {
+            repository: self.repository,
+            catalog,
+        }
+    }
+}
+
+/// Remote archive index for tree node uploads.
+pub struct RemoteArchiveIndex<'a> {
+    repository: &'a RemoteRepository,
+    catalog: Capability<archive_fx::Catalog>,
+}
+
+impl RemoteArchiveIndex<'_> {
+    /// Read a block from the remote archive by hash.
+    pub fn get(&self, hash: Blake3Hash) -> RemoteGet<'_> {
+        RemoteGet { index: self, hash }
+    }
+
+    /// Write a block to the remote archive.
+    pub fn put(&self, hash: Blake3Hash, bytes: Vec<u8>) -> RemotePut<'_> {
+        RemotePut {
+            index: self,
+            hash,
+            bytes,
+        }
+    }
+}
+
+/// Command to read a block from the remote archive.
+pub struct RemoteGet<'a> {
+    index: &'a RemoteArchiveIndex<'a>,
+    hash: Blake3Hash,
+}
+
+impl RemoteGet<'_> {
+    /// Execute the get operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Option<Vec<u8>>, RepositoryError>
+    where
+        Env: Provider<Fork<RemoteSite, archive_fx::Get>> + ConditionalSync,
+    {
+        let address = self.index.repository.address();
+        Ok(self
+            .index
+            .catalog
+            .clone()
+            .get(self.hash)
+            .fork(address.site())
+            .perform(env)
+            .await?)
+    }
+}
+
+/// Command to write a block to the remote archive.
+pub struct RemotePut<'a> {
+    index: &'a RemoteArchiveIndex<'a>,
+    hash: Blake3Hash,
+    bytes: Vec<u8>,
+}
+
+impl RemotePut<'_> {
+    /// Execute the put operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<Fork<RemoteSite, archive_fx::Put>> + ConditionalSync,
+    {
+        let address = self.index.repository.address();
+        self.index
+            .catalog
+            .clone()
+            .put(self.hash, self.bytes)
+            .fork(address.site())
+            .perform(env)
+            .await?;
+        Ok(())
+    }
+}
+
+impl RemoteArchiveIndex<'_> {
+    /// Upload a stream of novel nodes to the remote.
+    ///
+    /// `local_catalog` is used to read raw bytes from local storage.
+    pub fn upload<'a, S>(
+        &'a self,
+        nodes: S,
+        local_catalog: Capability<archive_fx::Catalog>,
+    ) -> Upload<'a, S>
+    where
+        S: Stream<Item = Result<Node<Key, State<Datum>, Blake3Hash>, DialogArtifactsError>>,
+    {
+        Upload {
+            index: self,
+            nodes,
+            local_catalog,
+        }
+    }
+}
+
+/// Command to upload novel nodes to a remote archive.
+pub struct Upload<'a, S> {
+    index: &'a RemoteArchiveIndex<'a>,
+    nodes: S,
+    local_catalog: Capability<archive_fx::Catalog>,
+}
+
+const UPLOAD_CONCURRENCY: usize = 16;
+
+impl<S> Upload<'_, S>
+where
+    S: Stream<Item = Result<Node<Key, State<Datum>, Blake3Hash>, DialogArtifactsError>>,
+{
+    /// Execute the upload, reading blocks locally and writing to remote
+    /// with up to 16 concurrent uploads.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<archive_fx::Get>
+            + Provider<Fork<RemoteSite, archive_fx::Put>>
+            + ConditionalSync,
+    {
+        let index = self.index;
+        let local_catalog = &self.local_catalog;
+
+        self.nodes
+            .map(|node_result| async move {
+                let node = node_result.map_err(|e| RepositoryError::PushFailed {
+                    cause: format!("Failed to compute novelty: {}", e),
+                })?;
+
+                let hash = *node.hash();
+
+                let bytes: Option<Vec<u8>> = local_catalog
+                    .clone()
+                    .get(hash)
+                    .perform(env)
+                    .await
+                    .map_err(|e| RepositoryError::PushFailed {
+                        cause: format!("Failed to read local block: {}", e),
+                    })?;
+
+                if let Some(bytes) = bytes {
+                    index.put(hash, bytes).perform(env).await?;
+                }
+
+                Ok(())
+            })
+            .buffer_unordered(UPLOAD_CONCURRENCY)
+            .try_collect::<()>()
+            .await
+    }
+}
+
+impl RemoteRepository {
+    /// Get the remote archive for this repository.
+    pub fn archive(&self) -> RemoteArchive<'_> {
+        RemoteArchive { repository: self }
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/branch.rs
+++ b/rust/dialog-repository/src/repository/remote/branch.rs
@@ -1,0 +1,63 @@
+mod fetch;
+mod load;
+mod open;
+mod publish;
+mod reference;
+
+use std::ops::Deref;
+
+use crate::repository::branch::upstream::UpstreamState;
+use crate::repository::node_reference::NodeReference;
+use crate::repository::revision::Revision;
+use fetch::Fetch;
+use publish::Publish;
+
+pub use reference::RemoteBranchReference;
+
+/// A loaded remote branch.
+///
+/// Wraps a [`RemoteBranchReference`] that has been resolved (the revision
+/// cell has been fetched from storage).
+#[derive(Debug, Clone)]
+pub struct RemoteBranch(RemoteBranchReference);
+
+impl RemoteBranch {
+    /// Create from a resolved reference.
+    pub fn new(reference: RemoteBranchReference) -> Self {
+        Self(reference)
+    }
+
+    /// Fetch the latest revision from the remote.
+    pub fn fetch(&self) -> Fetch<'_> {
+        Fetch::new(self)
+    }
+
+    /// Publish a revision to the remote.
+    pub fn publish(&self, revision: Revision) -> Publish<'_> {
+        Publish::new(self, revision)
+    }
+}
+
+impl Deref for RemoteBranch {
+    type Target = RemoteBranchReference;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<&RemoteBranch> for UpstreamState {
+    fn from(rb: &RemoteBranch) -> Self {
+        UpstreamState::Remote {
+            name: rb.repository.site().name(),
+            branch: rb.name(),
+            tree: NodeReference::default(),
+        }
+    }
+}
+
+impl From<RemoteBranch> for UpstreamState {
+    fn from(rb: RemoteBranch) -> Self {
+        UpstreamState::from(&rb)
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/branch/fetch.rs
+++ b/rust/dialog-repository/src/repository/remote/branch/fetch.rs
@@ -1,0 +1,51 @@
+//! Fetch command for remote branches.
+
+use dialog_capability::Fork;
+use dialog_capability::Provider;
+use dialog_common::ConditionalSync;
+use dialog_effects::memory as memory_fx;
+
+use super::RemoteBranch;
+use crate::repository::error::RepositoryError;
+use crate::repository::remote::address::RemoteSite;
+use crate::repository::revision::Revision;
+
+/// Command to fetch the latest revision from the remote.
+///
+/// Resolves the remote branch revision via Fork and persists the resulting
+/// (revision, edition) pair to the local snapshot cache.
+pub struct Fetch<'a> {
+    branch: &'a RemoteBranch,
+}
+
+impl<'a> Fetch<'a> {
+    /// Create a new fetch command.
+    pub fn new(branch: &'a RemoteBranch) -> Self {
+        Self { branch }
+    }
+
+    /// Execute the fetch.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Option<Revision>, RepositoryError>
+    where
+        Env: Provider<Fork<RemoteSite, memory_fx::Resolve>>
+            + Provider<memory_fx::Publish>
+            + ConditionalSync,
+    {
+        let address = self.branch.repository.address();
+        self.branch
+            .remote
+            .resolve()
+            .fork(address.site())
+            .perform(env)
+            .await?;
+
+        // Persist the new remote edition if the remote has one.
+        let Some(edition) = self.branch.remote.edition() else {
+            return Ok(None);
+        };
+        let revision = edition.content.clone();
+        self.branch.cache.publish(edition).perform(env).await?;
+
+        Ok(Some(revision))
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/branch/load.rs
+++ b/rust/dialog-repository/src/repository/remote/branch/load.rs
@@ -1,0 +1,35 @@
+//! Command to load an existing remote branch.
+
+use dialog_capability::Provider;
+use dialog_effects::memory as memory_fx;
+
+use super::RemoteBranch;
+use super::reference::RemoteBranchReference;
+use crate::repository::error::RepositoryError;
+
+/// Command to load an existing remote branch.
+///
+/// Resolves the persisted snapshot; errors if the branch has no revision.
+pub struct LoadRemoteBranch(RemoteBranchReference);
+
+impl LoadRemoteBranch {
+    /// Create from a remote branch reference.
+    pub fn new(reference: RemoteBranchReference) -> Self {
+        Self(reference)
+    }
+
+    /// Execute the load operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<RemoteBranch, RepositoryError>
+    where
+        Env: Provider<memory_fx::Resolve>,
+    {
+        self.0.cache.resolve().perform(env).await?;
+        let Some(edition) = self.0.cache.content() else {
+            return Err(RepositoryError::BranchNotFound {
+                name: self.0.name(),
+            });
+        };
+        self.0.remote.reset(edition);
+        Ok(RemoteBranch::new(self.0))
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/branch/open.rs
+++ b/rust/dialog-repository/src/repository/remote/branch/open.rs
@@ -1,0 +1,33 @@
+//! Command to open a remote branch.
+
+use dialog_capability::Provider;
+use dialog_effects::memory as memory_fx;
+
+use super::RemoteBranch;
+use super::reference::RemoteBranchReference;
+use crate::repository::error::RepositoryError;
+
+/// Command to open a remote branch.
+///
+/// Resolves the persisted snapshot; does not error if the branch has no
+/// revision (does not exist) yet.
+pub struct OpenRemoteBranch(RemoteBranchReference);
+
+impl OpenRemoteBranch {
+    /// Create from a remote branch reference.
+    pub fn new(reference: RemoteBranchReference) -> Self {
+        Self(reference)
+    }
+
+    /// Execute the open operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<RemoteBranch, RepositoryError>
+    where
+        Env: Provider<memory_fx::Resolve>,
+    {
+        self.0.cache.resolve().perform(env).await?;
+        if let Some(edition) = self.0.cache.content() {
+            self.0.remote.reset(edition);
+        }
+        Ok(RemoteBranch::new(self.0))
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/branch/publish.rs
+++ b/rust/dialog-repository/src/repository/remote/branch/publish.rs
@@ -1,0 +1,55 @@
+//! Publish command for remote branches.
+
+use dialog_capability::Fork;
+use dialog_capability::Provider;
+use dialog_common::ConditionalSync;
+use dialog_effects::memory as memory_fx;
+
+use super::RemoteBranch;
+use crate::repository::error::RepositoryError;
+use crate::repository::remote::address::RemoteSite;
+use crate::repository::revision::Revision;
+
+/// Command to publish a revision to the remote.
+///
+/// Publishes the revision to the remote memory via Fork and persists the
+/// new remote edition to the local snapshot cache.
+pub struct Publish<'a> {
+    branch: &'a RemoteBranch,
+    revision: Revision,
+}
+
+impl<'a> Publish<'a> {
+    /// Create a new publish command.
+    pub fn new(branch: &'a RemoteBranch, revision: Revision) -> Self {
+        Self { branch, revision }
+    }
+
+    /// Execute the publish.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<Fork<RemoteSite, memory_fx::Publish>>
+            + Provider<memory_fx::Publish>
+            + ConditionalSync,
+    {
+        let address = self.branch.repository.address();
+
+        // Publish to remote via fork. The in-memory `remote` cell picks up
+        // the new CAS edition internally; we then snapshot it below.
+        self.branch
+            .remote
+            .publish(self.revision)
+            .fork(address.site())
+            .perform(env)
+            .await?;
+
+        // Persist the remote edition so that a future RemoteBranchReference
+        // can hydrate its in-memory `remote` cache without a round trip.
+        let edition = self.branch.remote.edition().ok_or_else(|| {
+            RepositoryError::StorageError("remote cell missing edition after publish".into())
+        })?;
+        self.branch.cache.publish(edition).perform(env).await?;
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/branch/reference.rs
+++ b/rust/dialog-repository/src/repository/remote/branch/reference.rs
@@ -1,0 +1,75 @@
+//! Reference for navigating to a remote branch.
+
+use dialog_capability::Subject;
+use dialog_effects::memory::Edition;
+
+use super::load::LoadRemoteBranch;
+use super::open::OpenRemoteBranch;
+use crate::repository::branch::BranchName;
+use crate::repository::memory::{Cell, MemoryExt};
+use crate::repository::remote::repository::RemoteRepository;
+use crate::repository::revision::Revision;
+
+/// Cached snapshot of the remote branch's last known state: the remote
+/// revision paired with the remote's CAS version, so that fresh
+/// [`RemoteBranchReference`] instances can prime the in-memory remote cell
+/// cache without hitting the network.
+pub type RemoteEdition = Edition<Revision>;
+
+/// A reference to a named branch in a remote repository.
+///
+/// Holds a persistent cache of the last known remote state (revision +
+/// edition) plus an in-memory remote cell for fork-based resolve/publish.
+#[derive(Debug, Clone)]
+pub struct RemoteBranchReference {
+    pub repository: RemoteRepository,
+    /// Persistent cache of the last known remote state.
+    /// Path: `remote/{name}/branch/{branch}/revision`.
+    pub cache: Cell<RemoteEdition>,
+    /// Remote subject's cell: `branch/{branch}/revision` at the remote subject.
+    /// In-memory cache only; hydrate from `cache` on open/load.
+    pub remote: Cell<Revision>,
+}
+
+impl RemoteBranchReference {
+    /// The branch name, derived from the cache cell's path.
+    pub fn name(&self) -> BranchName {
+        let cell_name = self.cache.name();
+        cell_name
+            .strip_prefix("branch/")
+            .and_then(|s| s.strip_suffix("/revision"))
+            .unwrap_or(cell_name)
+            .into()
+    }
+
+    /// The cached revision, if the snapshot has been resolved.
+    pub fn revision(&self) -> Option<Revision> {
+        self.cache.content().map(|e| e.content)
+    }
+
+    /// Open the remote branch (resolves local cache, no error if missing).
+    pub fn open(self) -> OpenRemoteBranch {
+        OpenRemoteBranch::new(self)
+    }
+
+    /// Load the remote branch (error if local cache has no revision).
+    pub fn load(self) -> LoadRemoteBranch {
+        LoadRemoteBranch::new(self)
+    }
+}
+
+impl RemoteRepository {
+    /// Get a branch reference at this remote repository.
+    pub fn branch(&self, name: impl Into<BranchName>) -> RemoteBranchReference {
+        let name = name.into();
+        let cache = self
+            .site()
+            .cell(format!("branch/{}/revision", name.as_str()));
+        let remote = Subject::from(self.did()).branch(name).cell("revision");
+        RemoteBranchReference {
+            repository: self.clone(),
+            cache,
+            remote,
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/create.rs
+++ b/rust/dialog-repository/src/repository/remote/create.rs
@@ -1,0 +1,117 @@
+//! Command to create a new remote repository.
+
+use dialog_capability::{Did, Provider};
+use dialog_effects::memory as memory_fx;
+
+use super::reference::RemoteReference;
+use super::repository::RemoteRepository;
+use crate::RemoteAddress;
+use crate::repository::error::RepositoryError;
+
+/// Command to create a new remote repository, persisting its configuration.
+pub struct CreateRemote {
+    address: RemoteAddress,
+    reference: RemoteReference,
+}
+
+impl CreateRemote {
+    /// Create from a remote reference and address.
+    pub fn new(reference: RemoteReference, address: RemoteAddress) -> Self {
+        Self { reference, address }
+    }
+
+    /// Override the subject DID for the remote repository.
+    ///
+    /// By default, the subject is the creating repository's own DID.
+    pub fn subject(mut self, subject: impl Into<Did>) -> Self {
+        self.address.subject = subject.into();
+        self
+    }
+
+    /// Execute the create operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<RemoteRepository, RepositoryError>
+    where
+        Env: Provider<memory_fx::Resolve> + Provider<memory_fx::Publish>,
+    {
+        let cell = self.reference.address();
+        cell.resolve().perform(env).await?;
+        if cell.content().is_some() {
+            return Err(RepositoryError::RemoteAlreadyExists {
+                remote: self.reference.name(),
+            });
+        }
+
+        cell.publish(self.address.clone()).perform(env).await?;
+
+        Ok(RemoteRepository::new(
+            cell.retain(self.address),
+            self.reference,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_credentials::Ed25519Signer;
+    use dialog_remote_s3::Address;
+    use dialog_storage::provider::Volatile;
+
+    use crate::SiteAddress;
+    use crate::repository::Repository;
+    use crate::repository::error::RepositoryError;
+
+    fn test_site_address() -> SiteAddress {
+        SiteAddress::S3(
+            Address::builder("https://s3.us-east-1.amazonaws.com")
+                .region("us-east-1")
+                .bucket("my-bucket")
+                .build()
+                .unwrap(),
+        )
+    }
+
+    async fn test_signer() -> Ed25519Signer {
+        Ed25519Signer::import(&[44; 32]).await.unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_remote() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let repo = Repository::from(test_signer().await);
+
+        let remote = repo
+            .remote("origin")
+            .create(test_site_address())
+            .perform(&env)
+            .await?;
+
+        assert_eq!(remote.site().name(), "origin");
+        assert_eq!(remote.address().site(), &test_site_address());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_errors_adding_duplicate_remote() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let repo = Repository::from(test_signer().await);
+
+        repo.remote("origin")
+            .create(test_site_address())
+            .perform(&env)
+            .await?;
+
+        let result = repo
+            .remote("origin")
+            .create(test_site_address())
+            .perform(&env)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(RepositoryError::RemoteAlreadyExists { .. })
+        ));
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/load.rs
+++ b/rust/dialog-repository/src/repository/remote/load.rs
@@ -1,0 +1,89 @@
+//! Command to load an existing remote repository.
+
+use dialog_capability::Provider;
+use dialog_effects::memory as memory_fx;
+
+use super::reference::RemoteReference;
+use super::repository::RemoteRepository;
+use crate::repository::error::RepositoryError;
+
+/// Command to load an existing remote repository.
+pub struct LoadRemote(RemoteReference);
+
+impl LoadRemote {
+    /// Create from a remote reference.
+    pub fn new(reference: RemoteReference) -> Self {
+        Self(reference)
+    }
+
+    /// Execute the load operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<RemoteRepository, RepositoryError>
+    where
+        Env: Provider<memory_fx::Resolve>,
+    {
+        let cell = self.0.address();
+        cell.resolve().perform(env).await?;
+        match cell.content() {
+            Some(address) => Ok(RemoteRepository::new(cell.retain(address), self.0)),
+            None => Err(RepositoryError::RemoteNotFound {
+                remote: self.0.name(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_credentials::Ed25519Signer;
+    use dialog_remote_s3::Address;
+    use dialog_storage::provider::Volatile;
+
+    use crate::SiteAddress;
+    use crate::repository::Repository;
+    use crate::repository::error::RepositoryError;
+
+    fn test_site_address() -> SiteAddress {
+        SiteAddress::S3(
+            Address::builder("https://s3.us-east-1.amazonaws.com")
+                .region("us-east-1")
+                .bucket("my-bucket")
+                .build()
+                .unwrap(),
+        )
+    }
+
+    async fn test_signer() -> Ed25519Signer {
+        Ed25519Signer::import(&[44; 32]).await.unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_loads_existing_remote() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let repo = Repository::from(test_signer().await);
+
+        repo.remote("origin")
+            .create(test_site_address())
+            .perform(&env)
+            .await?;
+
+        let loaded = repo.remote("origin").load().perform(&env).await?;
+        assert_eq!(loaded.site().name(), "origin");
+        assert_eq!(loaded.address().site(), &test_site_address());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_errors_loading_missing_remote() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let repo = Repository::from(test_signer().await);
+
+        let result = repo.remote("nonexistent").load().perform(&env).await;
+        assert!(matches!(
+            result,
+            Err(RepositoryError::RemoteNotFound { .. })
+        ));
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/name.rs
+++ b/rust/dialog-repository/src/repository/remote/name.rs
@@ -1,0 +1,56 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use serde::{Deserialize, Serialize};
+
+/// Named identifier for a remote site (e.g., "origin", "backup").
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RemoteName(String);
+
+impl RemoteName {
+    /// Returns the site name as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for RemoteName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl PartialEq<str> for RemoteName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for RemoteName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl From<&RemoteName> for RemoteName {
+    fn from(value: &RemoteName) -> Self {
+        value.clone()
+    }
+}
+
+impl From<&str> for RemoteName {
+    fn from(value: &str) -> Self {
+        RemoteName(value.to_string())
+    }
+}
+
+impl From<String> for RemoteName {
+    fn from(value: String) -> Self {
+        RemoteName(value)
+    }
+}
+
+impl From<&RemoteName> for String {
+    fn from(value: &RemoteName) -> Self {
+        value.0.clone()
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/reference.rs
+++ b/rust/dialog-repository/src/repository/remote/reference.rs
@@ -1,0 +1,75 @@
+use dialog_capability::{Capability, Did, Policy};
+use dialog_effects::memory as fx;
+use dialog_effects::memory::prelude::SpaceExt;
+
+use super::address::SiteAddress;
+use super::create::CreateRemote;
+use super::load::LoadRemote;
+use crate::RemoteAddress;
+use crate::RemoteName;
+use crate::repository::memory::Cell;
+
+/// A reference to a named remote within a repository.
+///
+/// Wraps a `Capability<fx::Space>` scoped to `remote/{name}`.
+/// The subject DID is derived from the capability chain.
+#[derive(Debug, Clone)]
+pub struct RemoteReference(Capability<fx::Space>);
+
+impl From<Capability<fx::Space>> for RemoteReference {
+    fn from(space: Capability<fx::Space>) -> Self {
+        Self(space)
+    }
+}
+
+impl From<RemoteReference> for Capability<fx::Space> {
+    fn from(reference: RemoteReference) -> Self {
+        reference.0
+    }
+}
+
+impl RemoteReference {
+    /// The subject DID this remote belongs to.
+    pub fn subject(&self) -> &Did {
+        self.0.subject()
+    }
+
+    /// Name of this remote, extracted from the space path.
+    pub fn name(&self) -> RemoteName {
+        fx::Space::of(&self.0)
+            .space
+            .strip_prefix("remote/")
+            .unwrap_or("")
+            .into()
+    }
+
+    /// Cell for the remote address configuration.
+    pub fn address(&self) -> Cell<RemoteAddress> {
+        self.0.clone().cell("address").into()
+    }
+
+    /// Create a typed cell within this remote's space.
+    pub fn cell<T>(&self, cell_name: impl Into<String>) -> Cell<T> {
+        self.0.clone().cell(cell_name).into()
+    }
+
+    /// Return the raw cell capability without wrapping in [`Cell<T>`].
+    pub fn cell_capability(&self, cell_name: impl Into<String>) -> Capability<fx::Cell> {
+        self.0.clone().cell(cell_name)
+    }
+
+    /// Create a new remote with a site address.
+    ///
+    /// Uses the repository's own DID as the subject. Call `.subject(did)`
+    /// on the returned builder to target a different repository.
+    pub fn create(self, address: impl Into<SiteAddress>) -> CreateRemote {
+        let subject = self.0.subject().clone();
+        let remote = RemoteAddress::new(address.into(), subject);
+        CreateRemote::new(self, remote)
+    }
+
+    /// Load an existing remote.
+    pub fn load(self) -> LoadRemote {
+        LoadRemote::new(self)
+    }
+}

--- a/rust/dialog-repository/src/repository/remote/repository.rs
+++ b/rust/dialog-repository/src/repository/remote/repository.rs
@@ -1,0 +1,49 @@
+//! Remote repository -- a loaded remote with address and branch navigation.
+
+use dialog_capability::Did;
+use dialog_varsig::Principal;
+
+use super::reference::RemoteReference;
+use crate::RemoteAddress;
+use crate::repository::memory::Retain;
+
+/// A loaded remote repository.
+///
+/// Holds the retained address and a remote reference scoped to
+/// `remote/{name}`, used for branch revision cells.
+#[derive(Debug, Clone)]
+pub struct RemoteRepository {
+    site: RemoteReference,
+    address: Retain<RemoteAddress>,
+}
+
+impl RemoteRepository {
+    /// Construct from a retained address cell and its remote reference.
+    pub fn new(address: Retain<RemoteAddress>, remote: RemoteReference) -> Self {
+        Self {
+            address,
+            site: remote,
+        }
+    }
+
+    /// The subject DID of the remote repository.
+    pub fn did(&self) -> Did {
+        self.address.get().subject.clone()
+    }
+
+    /// The full remote address (site + subject).
+    pub fn address(&self) -> RemoteAddress {
+        self.address.get().clone()
+    }
+
+    /// The site of the remote this repository is on.
+    pub fn site(&self) -> &RemoteReference {
+        &self.site
+    }
+}
+
+impl Principal for RemoteRepository {
+    fn did(&self) -> Did {
+        self.address.get().subject.clone()
+    }
+}

--- a/rust/dialog-repository/src/repository/revision.rs
+++ b/rust/dialog-repository/src/repository/revision.rs
@@ -1,0 +1,31 @@
+use dialog_capability::Did;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+use super::node_reference::NodeReference;
+
+/// A revision represents a concrete state of the repository at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Revision {
+    /// DID of the repository this revision belongs to.
+    pub subject: Did,
+
+    /// DID of the operator (ephemeral session key) that created this revision.
+    pub issuer: Did,
+
+    /// DID of the profile (long-lived key) that authorized this revision.
+    pub authority: Did,
+
+    /// Root of the search tree at this revision.
+    pub tree: NodeReference,
+
+    /// Parent tree roots this revision is based on. Empty for the first revision.
+    pub cause: HashSet<NodeReference>,
+
+    /// Period counter. Increments when a different issuer commits (sync boundary).
+    pub period: usize,
+
+    /// Moment counter. Increments on each commit within the same period by
+    /// the same issuer. Resets to 0 when period advances.
+    pub moment: usize,
+}

--- a/rust/dialog-storage/src/error.rs
+++ b/rust/dialog-storage/src/error.rs
@@ -1,3 +1,5 @@
+use dialog_effects::archive::ArchiveError;
+use dialog_effects::memory::MemoryError;
 use thiserror::Error;
 
 /// The common error type used by this crate
@@ -18,4 +20,16 @@ pub enum DialogStorageError {
     /// An error that occurs when byte hash verification fails
     #[error("Byte hash verification failed: {0}")]
     Verification(String),
+}
+
+impl From<ArchiveError> for DialogStorageError {
+    fn from(e: ArchiveError) -> Self {
+        Self::StorageBackend(e.to_string())
+    }
+}
+
+impl From<MemoryError> for DialogStorageError {
+    fn from(e: MemoryError) -> Self {
+        Self::StorageBackend(e.to_string())
+    }
 }


### PR DESCRIPTION
## Summary

Adds the `dialog-repository` crate — the user-facing abstraction on top of Operator + Storage. A Repository owns a Branch (the local writable head) and a set of Remotes (addressable peers it can push/pull/fetch from). Local archive + memory adapters route through the Operator's capability dispatch; networked archive uses a fallback store for fetching missing blocks from remotes.

Branch operations include commit, select, fetch, publish, retract, reset, and upstream tracking. Remote types cover address, branch, repository, name, reference, and revision. Helpers include a credentials roundtrip fixture and integration test setup.

The crate ports straight from the cleanup branch's final state in a single commit (rather than replaying the original PR #293's intermediate refactors, which used APIs that didn't survive the cleanup). Also adds `From<ArchiveError>` / `From<MemoryError>` impls to `DialogStorageError` so the repository's local adapters can use `?` against the v3 stack's effect errors.