### PR TITLE
23.1 📬 feat: add dialog-repository crate (base)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-repository"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base58",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-effects",
+ "dialog-operator",
+ "dialog-prolly-tree",
+ "dialog-storage",
+ "dialog-varsig",
+ "getrandom 0.2.16",
+ "parking_lot",
+ "reqwest",
+ "serde",
+ "serde_ipld_dagcbor",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "rust/dialog-remote-ucan-s3",
     "rust/dialog-network",
     "rust/dialog-operator",
+    "rust/dialog-repository",
     "rust/dialog-varsig",
     "rust/dialog-blobs",
 ]
@@ -206,3 +207,6 @@ path = "./rust/dialog-remote-ucan-s3"
 
 [workspace.dependencies.dialog-operator]
 path = "./rust/dialog-operator"
+
+[workspace.dependencies.dialog-repository]
+path = "./rust/dialog-repository"

--- a/rust/dialog-effects/src/space.rs
+++ b/rust/dialog-effects/src/space.rs
@@ -14,7 +14,7 @@
 //!
 //! `Create` resolves the name and delegates to `storage::Create`.
 
-use dialog_capability::{Attenuate, Attenuation, Capability, Effect, Subject};
+use dialog_capability::{Attenuate, Attenuation, Capability, Did, Effect, Subject};
 use dialog_credentials::Credential;
 use serde::{Deserialize, Serialize};
 
@@ -39,6 +39,29 @@ impl Space {
 
 impl Attenuation for Space {
     type Of = Subject;
+}
+
+/// Extension trait to start a space capability chain from a [`Subject`] or
+/// [`Did`]. Attaches a [`Space`] attenuation for the named space.
+pub trait SpaceSubjectExt {
+    /// The resulting space chain type.
+    type Space;
+    /// Scope to a named space under this subject.
+    fn space(self, name: impl Into<String>) -> Self::Space;
+}
+
+impl SpaceSubjectExt for Subject {
+    type Space = Capability<Space>;
+    fn space(self, name: impl Into<String>) -> Capability<Space> {
+        self.attenuate(Space::new(name))
+    }
+}
+
+impl SpaceSubjectExt for Did {
+    type Space = Capability<Space>;
+    fn space(self, name: impl Into<String>) -> Capability<Space> {
+        Subject::from(self).attenuate(Space::new(name))
+    }
 }
 
 /// Extension trait adding `.load()` and `.create()` sugar on Space capabilities.

--- a/rust/dialog-repository/Cargo.toml
+++ b/rust/dialog-repository/Cargo.toml
@@ -1,0 +1,65 @@
+[package]
+name = "dialog-repository"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+# Enable integration tests (tests with service provisioning)
+integration-tests = ["dialog-common/integration-tests"]
+# Enable web integration tests
+web-integration-tests = ["dialog-common/web-integration-tests"]
+
+[dependencies]
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true }
+dialog-operator = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-effects = { workspace = true }
+dialog-storage = { workspace = true }
+dialog-prolly-tree = { workspace = true }
+dialog-varsig = { workspace = true }
+parking_lot = { workspace = true }
+
+async-trait = { workspace = true }
+base58 = { workspace = true }
+serde = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+dialog-storage = { workspace = true, features = ["helpers"] }
+dialog-common = { workspace = true, features = ["helpers"] }
+anyhow = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["sync", "macros", "io-util", "fs"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+reqwest = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = [
+    "io-util",
+    "io-std",
+    "sync",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }
+
+[lints.rust]
+# This cfg is used by the dialog_common::test proc macro for wasm inner tests
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(dialog_test_wasm_integration)"] }

--- a/rust/dialog-repository/README.md
+++ b/rust/dialog-repository/README.md
@@ -1,0 +1,98 @@
+# dialog-repository
+
+A git-like interface for Dialog-DB.
+
+Provides repositories with branches, remotes, push/pull, and merge, but for structured data instead of files. Each repository has its own identity (keypair), named branches with revision history, and remotes for replication. Information is stored as claims: `{ the, of, is, cause }` facts where `the` is the relation, `of` is the entity, `is` is the value, and `cause` is the provenance. Claims can be queried with typed concepts or deductive rules. Same name under the same profile always yields the same repository identity.
+
+## Usage
+
+```rust
+use dialog_capability::Subject;
+use dialog_operator::Profile;
+use dialog_repository::RepositoryExt;
+use dialog_storage::Storage;
+
+// Target-appropriate default storage: filesystem on native, IndexedDB on web.
+let storage = Storage::default();
+
+// Open (load-or-create) the profile.
+let profile = Profile::open("alice").perform(&storage).await?;
+
+// Derive an operator scoped to this application.
+let operator = profile
+    .derive(b"my-app")
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+
+// Open or create a repository.
+let contacts = profile
+    .repository("contacts")
+    .open()
+    .perform(&operator)
+    .await?;
+
+// Work with branches.
+let main = contacts
+    .branch("main")
+    .open()
+    .perform(&operator)
+    .await?;
+
+// Define a concept with typed attributes.
+#[derive(Concept)]
+struct Employee {
+    this: Entity,
+    name: employee::Name,
+    role: employee::Role,
+}
+
+// Commit data.
+main.transaction()
+    .assert(Employee {
+        this: Entity::new()?,
+        name: employee::Name("Alice".into()),
+        role: employee::Role("Engineer".into()),
+    })
+    .commit()
+    .perform(&operator)
+    .await?;
+
+// Query.
+let results: Vec<Employee> = main
+    .query()
+    .select(Query::<Employee> {
+        this: Term::var("this"),
+        name: Term::var("name"),
+        role: Term::var("role"),
+    })
+    .perform(&operator)
+    .try_vec()
+    .await?;
+
+// Add a remote and sync. `.create(...)` takes `impl Into<SiteAddress>`,
+// so concrete variants like UcanAddress or S3 Address can be passed
+// directly — here we point at a UCAN-gated access service in front of
+// an S3 bucket.
+use dialog_remote_ucan_s3::UcanAddress;
+
+let origin = contacts
+    .remote("origin")
+    .create(UcanAddress::new("https://access.example.com"))
+    .perform(&operator)
+    .await?;
+
+let upstream = origin
+    .branch("main")
+    .open()
+    .perform(&operator)
+    .await?;
+
+main
+    .set_upstream(upstream)
+    .perform(&operator)
+    .await?;
+
+main.push().perform(&operator).await?;
+main.pull().perform(&operator).await?;
+```

--- a/rust/dialog-repository/src/lib.rs
+++ b/rust/dialog-repository/src/lib.rs
@@ -1,0 +1,36 @@
+//! Repository layer for Dialog-DB.
+//!
+//! This crate layers a capability-based repository abstraction on top of
+//! the operator (`dialog-operator`) and effect (`dialog-effects`) crates.
+//! It provides:
+//!
+//! - [`Repository`] — a subject-scoped handle over a space, generic over
+//!   the credential type so the same surface covers both signers (full
+//!   access, can delegate) and verifiers (read-only).
+//! - [`RepositoryExt`] on `SpaceHandle` — `.open()` / `.load()` /
+//!   `.create()` commands that turn into `Repository` values once
+//!   performed against an operator.
+//! - [`Cell`], [`Retain`], and their `Publish` / `Resolve` commands —
+//!   transactional memory cells with built-in edition tracking, plus
+//!   `.fork(&address)` variants that retarget the same commands at a
+//!   remote site.
+//! - [`RepositoryArchiveExt`] and [`LocalIndex`] — extensions and CAS
+//!   adapters that bridge archive capabilities with the prolly tree's
+//!   `ContentAddressedStorage` trait.
+//!
+//! Branches, remotes, and sync operations build on this base in
+//! follow-up crates / PRs.
+
+#![warn(missing_docs)]
+#![warn(clippy::absolute_paths)]
+#![warn(clippy::default_trait_access)]
+#![warn(clippy::fallible_impl_from)]
+#![warn(clippy::panicking_unwrap)]
+#![warn(clippy::unused_async)]
+#![deny(clippy::partial_pub_fields)]
+#![deny(clippy::unnecessary_self_imports)]
+#![cfg_attr(not(test), warn(clippy::large_futures))]
+#![cfg_attr(not(test), deny(clippy::panic))]
+
+mod repository;
+pub use repository::*;

--- a/rust/dialog-repository/src/lib.rs
+++ b/rust/dialog-repository/src/lib.rs
@@ -15,7 +15,7 @@
 //!   `.fork(&address)` variants that retarget the same commands at a
 //!   remote site.
 //! - [`RepositoryArchiveExt`] and [`LocalIndex`] — extensions and CAS
-//!   adapters that bridge archive capabilities with the prolly tree's
+//!   adapters that bridge archive capabilities with the search tree's
 //!   `ContentAddressedStorage` trait.
 //!
 //! Branches, remotes, and sync operations build on this base in

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -107,14 +107,12 @@ impl From<SignerCredential> for Repository<SignerCredential> {
 }
 
 impl TryFrom<Credential> for Repository<SignerCredential> {
-    type Error = RepositoryError;
+    type Error = SignerRequiredError;
 
-    fn try_from(credential: Credential) -> Result<Self, RepositoryError> {
+    fn try_from(credential: Credential) -> Result<Self, SignerRequiredError> {
         match credential {
             Credential::Signer(s) => Ok(Self::new(s)),
-            Credential::Verifier(_) => Err(RepositoryError::StorageError(
-                "repository credential is verifier-only".into(),
-            )),
+            Credential::Verifier(_) => Err(SignerRequiredError),
         }
     }
 }

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -1,0 +1,154 @@
+//! Capability-based repository system.
+//!
+//! This module provides a repository abstraction built on top of the
+//! capability-based effect system (`dialog-capability` / `dialog-effects`).
+//!
+//! - [`archive`] — CAS adapter bridging capabilities with prolly tree storage
+//! - [`memory`] — Transactional memory cells with edition tracking
+//! - [`revision`] — Revision tracking and logical timestamps
+
+mod archive;
+mod create;
+mod error;
+mod load;
+mod memory;
+mod open;
+mod revision;
+mod tree;
+
+pub use archive::*;
+pub use create::*;
+pub use error::*;
+pub use load::*;
+pub use memory::*;
+pub use open::*;
+pub use revision::*;
+pub use tree::*;
+
+use dialog_capability::{Capability, Did, Subject};
+use dialog_credentials::Ed25519Signer;
+use dialog_credentials::credential::{Credential, SignerCredential};
+use dialog_effects::space::SpaceSubjectExt;
+use dialog_operator::SpaceHandle;
+use dialog_operator::access::Access as ProfileAccess;
+use dialog_varsig::Principal;
+
+/// A repository scoped to a specific subject.
+///
+/// The credential type parameter determines access level:
+/// - `Repository<SignerCredential>` -- owns the keypair, can delegate
+/// - `Repository<Credential>` -- either signer or verifier, determined at runtime
+pub struct Repository<C: Principal = Credential> {
+    credential: C,
+}
+
+impl<C: Principal> Repository<C> {
+    fn new(credential: C) -> Self {
+        Self { credential }
+    }
+
+    /// Get the credential.
+    pub fn credential(&self) -> &C {
+        &self.credential
+    }
+
+    /// The subject DID.
+    pub fn did(&self) -> Did {
+        self.credential.did()
+    }
+
+    /// The subject.
+    pub fn subject(&self) -> Subject {
+        self.did().into()
+    }
+}
+
+impl<C: Principal> Principal for Repository<C> {
+    fn did(&self) -> Did {
+        self.credential.did()
+    }
+}
+
+impl<C: Principal> From<&Repository<C>> for Capability<Subject> {
+    fn from(r: &Repository<C>) -> Self {
+        Subject::from(r.did()).into()
+    }
+}
+
+impl Repository<SignerCredential> {
+    /// Access handle for claiming and delegating capabilities.
+    pub fn access(&self) -> ProfileAccess<'_> {
+        ProfileAccess::new(&self.credential)
+    }
+}
+
+impl Repository {
+    /// Access handle for claiming and delegating capabilities.
+    ///
+    /// Returns `None` if the credential is verifier-only.
+    pub fn try_access(&self) -> Option<ProfileAccess<'_>> {
+        match &self.credential {
+            Credential::Signer(s) => Some(ProfileAccess::new(s)),
+            Credential::Verifier(_) => None,
+        }
+    }
+}
+
+impl From<Credential> for Repository {
+    fn from(credential: Credential) -> Self {
+        Self::new(credential)
+    }
+}
+
+impl From<SignerCredential> for Repository<SignerCredential> {
+    fn from(credential: SignerCredential) -> Self {
+        Self::new(credential)
+    }
+}
+
+impl TryFrom<Credential> for Repository<SignerCredential> {
+    type Error = RepositoryError;
+
+    fn try_from(credential: Credential) -> Result<Self, RepositoryError> {
+        match credential {
+            Credential::Signer(s) => Ok(Self::new(s)),
+            Credential::Verifier(_) => Err(RepositoryError::StorageError(
+                "repository credential is verifier-only".into(),
+            )),
+        }
+    }
+}
+
+impl From<Ed25519Signer> for Repository<SignerCredential> {
+    fn from(signer: Ed25519Signer) -> Self {
+        SignerCredential::from(signer).into()
+    }
+}
+
+/// Extension trait for opening repositories from a [`SpaceHandle`].
+///
+/// Enables `profile.repository("name").open().perform(&operator)`.
+pub trait RepositoryExt {
+    /// Open or create a repository, loading existing or creating new.
+    fn open(self) -> OpenRepository;
+
+    /// Load an existing repository, failing if not found.
+    fn load(self) -> LoadRepository;
+
+    /// Create a new repository, failing if one already exists.
+    fn create(self) -> CreateRepository;
+}
+
+impl RepositoryExt for SpaceHandle {
+    fn open(self) -> OpenRepository {
+        OpenRepository(self.profile_did.space(self.name))
+    }
+
+    fn load(self) -> LoadRepository {
+        LoadRepository(self.profile_did.space(self.name))
+    }
+
+    fn create(self) -> CreateRepository {
+        CreateRepository(self.profile_did.space(self.name))
+    }
+}

--- a/rust/dialog-repository/src/repository/archive.rs
+++ b/rust/dialog-repository/src/repository/archive.rs
@@ -1,0 +1,26 @@
+//! Archive capabilities and CAS adapters.
+//!
+//! - [`RepositoryArchiveExt`] -- extension trait adding `.index()` to archive capabilities
+//! - [`local`] -- local CAS adapter for prolly tree storage
+
+/// Local CAS adapter bridging capabilities with prolly tree's ContentAddressedStorage.
+pub mod local;
+
+use dialog_capability::Capability;
+use dialog_effects::archive::prelude::ArchiveExt;
+use dialog_effects::archive::{Archive, Catalog};
+
+/// Extension trait for archive capabilities in the repository context.
+///
+/// Extends the base `ArchiveExt` from `dialog-effects` with repository-specific
+/// helpers.
+pub trait RepositoryArchiveExt: ArchiveExt {
+    /// The index catalog used for search tree node storage.
+    fn index(self) -> Capability<Catalog>;
+}
+
+impl RepositoryArchiveExt for Capability<Archive> {
+    fn index(self) -> Capability<Catalog> {
+        self.catalog("index")
+    }
+}

--- a/rust/dialog-repository/src/repository/archive.rs
+++ b/rust/dialog-repository/src/repository/archive.rs
@@ -1,14 +1,14 @@
 //! Archive capabilities and CAS adapters.
 //!
 //! - [`RepositoryArchiveExt`] -- extension trait adding `.index()` to archive capabilities
-//! - [`local`] -- local CAS adapter for prolly tree storage
-
-/// Local CAS adapter bridging capabilities with prolly tree's ContentAddressedStorage.
-pub mod local;
-
+//! - [`local`] -- local CAS adapter for search tree storage
 use dialog_capability::Capability;
 use dialog_effects::archive::prelude::ArchiveExt;
 use dialog_effects::archive::{Archive, Catalog};
+
+/// Local CAS adapter bridging capabilities with search tree's ContentAddressedStorage.
+pub mod local;
+pub use local::*;
 
 /// Extension trait for archive capabilities in the repository context.
 ///

--- a/rust/dialog-repository/src/repository/archive/local.rs
+++ b/rust/dialog-repository/src/repository/archive/local.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 
 /// Local content-addressed index backed by archive capabilities.
 ///
-/// Bridges the capability system (`Get`/`Put` effects) with the prolly
+/// Bridges the capability system (`Get`/`Put` effects) with the search
 /// tree's `ContentAddressedStorage` trait. All reads and writes go to
 /// the local archive only.
 pub struct LocalIndex<'a, Env> {
@@ -122,6 +122,7 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
+    use anyhow::Result;
     use dialog_capability::Subject;
     use dialog_storage::provider::Volatile;
     use dialog_varsig::did;
@@ -139,7 +140,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_writes_and_reads_block() -> anyhow::Result<()> {
+    async fn it_writes_and_reads_block() -> Result<()> {
         let env = Volatile::new();
         let mut archive = LocalIndex::new(&env, test_catalog("index"));
 
@@ -156,7 +157,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_returns_none_for_missing_hash() -> anyhow::Result<()> {
+    async fn it_returns_none_for_missing_hash() -> Result<()> {
         let env = Volatile::new();
         let archive = LocalIndex::new(&env, test_catalog("index"));
 
@@ -168,7 +169,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_isolates_catalogs() -> anyhow::Result<()> {
+    async fn it_isolates_catalogs() -> Result<()> {
         let env = Volatile::new();
 
         let block = TestBlock {

--- a/rust/dialog-repository/src/repository/archive/local.rs
+++ b/rust/dialog-repository/src/repository/archive/local.rs
@@ -1,0 +1,198 @@
+use async_trait::async_trait;
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::prelude::*;
+use dialog_effects::archive::{Catalog, Get, Put};
+use dialog_storage::{
+    Blake3Hash, CborEncoder, ContentAddressedStorage, DialogStorageError, Encoder,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use std::fmt::Debug;
+
+/// Local content-addressed index backed by archive capabilities.
+///
+/// Bridges the capability system (`Get`/`Put` effects) with the prolly
+/// tree's `ContentAddressedStorage` trait. All reads and writes go to
+/// the local archive only.
+pub struct LocalIndex<'a, Env> {
+    env: &'a Env,
+    encoder: CborEncoder,
+    catalog: Capability<Catalog>,
+}
+
+impl<Env> Clone for LocalIndex<'_, Env> {
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env,
+            encoder: self.encoder.clone(),
+            catalog: self.catalog.clone(),
+        }
+    }
+}
+
+impl<'a, Env> LocalIndex<'a, Env> {
+    /// Create a local index for the given catalog capability.
+    pub fn new(env: &'a Env, catalog: Capability<Catalog>) -> Self {
+        Self {
+            env,
+            encoder: CborEncoder,
+            catalog,
+        }
+    }
+
+    /// The catalog capability this index operates on.
+    pub fn catalog(&self) -> &Capability<Catalog> {
+        &self.catalog
+    }
+
+    /// The environment reference.
+    pub fn env(&self) -> &'a Env {
+        self.env
+    }
+
+    /// The encoder used for serialization.
+    pub fn encoder(&self) -> &CborEncoder {
+        &self.encoder
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> ContentAddressedStorage for LocalIndex<'_, Env>
+where
+    Env: Provider<Get> + Provider<Put> + ConditionalSync + 'static,
+{
+    type Hash = Blake3Hash;
+    type Error = DialogStorageError;
+
+    async fn read<T>(&self, hash: &Self::Hash) -> Result<Option<T>, Self::Error>
+    where
+        T: DeserializeOwned + ConditionalSync,
+    {
+        let result: Option<Vec<u8>> = self.catalog.clone().get(*hash).perform(self.env).await?;
+
+        match result {
+            Some(bytes) => Ok(Some(self.encoder.decode(&bytes).await?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn write<T>(&mut self, block: &T) -> Result<Self::Hash, Self::Error>
+    where
+        T: Serialize + ConditionalSync + Debug,
+    {
+        let (hash, bytes) = self.encoder.encode(block).await?;
+        self.catalog
+            .clone()
+            .put(hash, bytes)
+            .perform(self.env)
+            .await?;
+        Ok(hash)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> Encoder for LocalIndex<'_, Env>
+where
+    Env: ConditionalSync + 'static,
+{
+    type Bytes = Vec<u8>;
+    type Hash = Blake3Hash;
+    type Error = DialogStorageError;
+
+    async fn encode<T>(&self, block: &T) -> Result<(Self::Hash, Self::Bytes), Self::Error>
+    where
+        T: Serialize + ConditionalSync + Debug,
+    {
+        self.encoder.encode(block).await
+    }
+
+    async fn decode<T>(&self, bytes: &[u8]) -> Result<T, Self::Error>
+    where
+        T: DeserializeOwned + ConditionalSync,
+    {
+        self.encoder.decode(bytes).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_capability::Subject;
+    use dialog_storage::provider::Volatile;
+    use dialog_varsig::did;
+
+    fn test_catalog(name: &str) -> Capability<Catalog> {
+        Subject::from(did!("key:zArchiveCasTest"))
+            .archive()
+            .catalog(name)
+    }
+
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestBlock {
+        value: u32,
+        label: String,
+    }
+
+    #[dialog_common::test]
+    async fn it_writes_and_reads_block() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let mut archive = LocalIndex::new(&env, test_catalog("index"));
+
+        let block = TestBlock {
+            value: 42,
+            label: "hello".into(),
+        };
+
+        let hash = archive.write(&block).await?;
+        let result: Option<TestBlock> = archive.read(&hash).await?;
+
+        assert_eq!(result, Some(block));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_none_for_missing_hash() -> anyhow::Result<()> {
+        let env = Volatile::new();
+        let archive = LocalIndex::new(&env, test_catalog("index"));
+
+        let missing_hash = [0u8; 32];
+        let result: Option<TestBlock> = archive.read(&missing_hash).await?;
+
+        assert!(result.is_none());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_isolates_catalogs() -> anyhow::Result<()> {
+        let env = Volatile::new();
+
+        let block = TestBlock {
+            value: 99,
+            label: "isolated".into(),
+        };
+
+        let hash = {
+            let mut archive = LocalIndex::new(&env, test_catalog("a"));
+            archive.write(&block).await?
+        };
+
+        {
+            let archive = LocalIndex::new(&env, test_catalog("b"));
+            let result: Option<TestBlock> = archive.read(&hash).await?;
+            assert!(result.is_none());
+        }
+
+        {
+            let archive = LocalIndex::new(&env, test_catalog("a"));
+            let result: Option<TestBlock> = archive.read(&hash).await?;
+            assert_eq!(result, Some(block));
+        }
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/create.rs
+++ b/rust/dialog-repository/src/repository/create.rs
@@ -1,12 +1,9 @@
+use crate::{CreateRepositoryError, Repository};
 use dialog_capability::{Capability, Provider};
 use dialog_common::ConditionalSync;
 use dialog_credentials::Ed25519Signer;
 use dialog_credentials::credential::{Credential, SignerCredential};
-use dialog_effects::space;
-use dialog_effects::space::SpaceExt;
-
-use super::Repository;
-use super::error::RepositoryError;
+use dialog_effects::space::{self, SpaceExt};
 
 /// Command to create a new repository.
 ///
@@ -19,12 +16,15 @@ impl CreateRepository {
     pub async fn perform<Env>(
         self,
         env: &Env,
-    ) -> Result<Repository<SignerCredential>, RepositoryError>
+    ) -> Result<Repository<SignerCredential>, CreateRepositoryError>
     where
         Env: Provider<space::Create> + ConditionalSync,
     {
-        let signer = Ed25519Signer::generate().await?;
-        let credential = Credential::Signer(SignerCredential::from(signer));
-        self.0.create(credential).perform(env).await?.try_into()
+        let signer = SignerCredential::from(Ed25519Signer::generate().await?);
+        self.0
+            .create(Credential::Signer(signer.clone()))
+            .perform(env)
+            .await?;
+        Ok(Repository::from(signer))
     }
 }

--- a/rust/dialog-repository/src/repository/create.rs
+++ b/rust/dialog-repository/src/repository/create.rs
@@ -1,0 +1,30 @@
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_credentials::Ed25519Signer;
+use dialog_credentials::credential::{Credential, SignerCredential};
+use dialog_effects::space;
+use dialog_effects::space::SpaceExt;
+
+use super::Repository;
+use super::error::RepositoryError;
+
+/// Command to create a new repository.
+///
+/// Returns `Repository<SignerCredential>` since a freshly generated
+/// credential always has a private key.
+pub struct CreateRepository(pub Capability<space::Space>);
+
+impl CreateRepository {
+    /// Execute against an operator.
+    pub async fn perform<Env>(
+        self,
+        env: &Env,
+    ) -> Result<Repository<SignerCredential>, RepositoryError>
+    where
+        Env: Provider<space::Create> + ConditionalSync,
+    {
+        let signer = Ed25519Signer::generate().await?;
+        let credential = Credential::Signer(SignerCredential::from(signer));
+        self.0.create(credential).perform(env).await?.try_into()
+    }
+}

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -1,60 +1,181 @@
 use dialog_credentials::Ed25519SignerError;
-use dialog_effects::archive::ArchiveError;
-use dialog_effects::memory::MemoryError;
+use dialog_effects::memory::{MemoryError, Version};
 use dialog_effects::storage::StorageError;
 use dialog_storage::DialogStorageError;
-use serde::{Deserialize, Serialize};
+use std::io;
 use thiserror::Error;
 
-/// The common error type used by repository operations.
-#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// The umbrella error type for the repository API.
+///
+/// Each variant wraps a command-specific error type. Callers doing
+/// multiple operations can `?` them into a single
+/// `Result<_, RepositoryError>` without juggling per-command error
+/// types. Pattern match on variants (or use
+/// [`source()`](std::error::Error::source)) when specific handling is
+/// needed.
+///
+/// Downstream crates layer additional variants on this same pattern
+/// for branch/remote/sync operations.
+#[derive(Error, Debug)]
 pub enum RepositoryError {
-    /// A storage operation failed
-    #[error("Storage error {0}")]
-    StorageError(String),
+    /// Open-repository command failed.
+    #[error(transparent)]
+    Open(#[from] OpenRepositoryError),
 
-    /// Repository not found
-    #[error("Repository '{0}' not found")]
-    NotFound(String),
+    /// Load-repository command failed.
+    #[error(transparent)]
+    Load(#[from] LoadRepositoryError),
 
-    /// Repository already exists
-    #[error("Repository '{0}' already exists")]
-    AlreadyExists(String),
+    /// Create-repository command failed.
+    #[error(transparent)]
+    Create(#[from] CreateRepositoryError),
 
-    /// Invalid internal state (should never happen in normal operation)
-    #[error("Invalid state: {message}")]
-    InvalidState {
-        /// Description of the invalid state
-        message: String,
+    /// Cell publish failed (outside a command context).
+    #[error(transparent)]
+    Publish(#[from] PublishError),
+
+    /// Cell resolve failed (outside a command context).
+    #[error(transparent)]
+    Resolve(#[from] ResolveError),
+
+    /// A verifier-only credential was used where a signer was required.
+    #[error(transparent)]
+    SignerRequired(#[from] SignerRequiredError),
+}
+
+/// Attempted to use a verifier-only credential where a signer was
+/// required.
+#[derive(Error, Debug)]
+#[error("Expected signer credential, got verifier-only")]
+pub struct SignerRequiredError;
+
+/// Errors returned by the open repository command.
+#[derive(Error, Debug)]
+pub enum OpenRepositoryError {
+    /// Generating a new signer for the fresh repository failed.
+    #[error("Failed to generate signer for new repository: {0}")]
+    Signer(#[from] Ed25519SignerError),
+
+    /// Backend storage failed during load-or-create.
+    #[error("Storage failed during open: {0}")]
+    Storage(#[from] StorageError),
+}
+
+/// Errors returned by the load repository command.
+#[derive(Error, Debug)]
+pub enum LoadRepositoryError {
+    /// Backend storage failed during load.
+    #[error("Storage failed during load: {0}")]
+    Storage(#[from] StorageError),
+}
+
+/// Errors returned by the create repository command.
+#[derive(Error, Debug)]
+pub enum CreateRepositoryError {
+    /// Generating a new signer for the repository failed.
+    #[error("Failed to generate signer for new repository: {0}")]
+    Signer(#[from] Ed25519SignerError),
+
+    /// Backend storage failed during create.
+    #[error("Storage failed during create: {0}")]
+    Storage(#[from] StorageError),
+}
+
+/// Errors returned by cell resolve operations.
+#[derive(Error, Debug)]
+pub enum ResolveError {
+    /// CAS edition mismatch — the backing store saw a different edition.
+    #[error("Version mismatch: expected {expected:?}, got {actual:?}")]
+    VersionMismatch {
+        /// The edition we held locally.
+        expected: Option<Version>,
+        /// The edition the backing store actually had.
+        actual: Option<Version>,
     },
+
+    /// Storage backend failure.
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    /// Authorization denied.
+    #[error("Authorization error: {0}")]
+    Authorization(String),
+
+    /// IO failure.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Failed to decode the resolved bytes.
+    #[error("Decode error: {0}")]
+    Decode(String),
 }
 
-impl From<StorageError> for RepositoryError {
-    fn from(e: StorageError) -> Self {
-        Self::StorageError(e.to_string())
+impl From<MemoryError> for ResolveError {
+    fn from(error: MemoryError) -> Self {
+        match error {
+            MemoryError::VersionMismatch { expected, actual } => {
+                Self::VersionMismatch { expected, actual }
+            }
+            MemoryError::Storage(message) => Self::Storage(message),
+            MemoryError::Authorization(message) => Self::Authorization(message),
+            MemoryError::Io(error) => Self::Io(error),
+        }
     }
 }
 
-impl From<ArchiveError> for RepositoryError {
-    fn from(e: ArchiveError) -> Self {
-        Self::StorageError(e.to_string())
+/// Errors returned by cell publish operations.
+#[derive(Error, Debug)]
+pub enum PublishError {
+    /// CAS edition mismatch — another writer won the race.
+    #[error("Version mismatch: expected {expected:?}, got {actual:?}")]
+    VersionMismatch {
+        /// The edition we held locally.
+        expected: Option<Version>,
+        /// The edition the backing store actually had.
+        actual: Option<Version>,
+    },
+
+    /// Storage backend failure.
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    /// Authorization denied.
+    #[error("Authorization error: {0}")]
+    Authorization(String),
+
+    /// IO failure.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Failed to encode the value before publishing.
+    #[error("Encode error: {0}")]
+    Encode(String),
+}
+
+impl From<MemoryError> for PublishError {
+    fn from(error: MemoryError) -> Self {
+        match error {
+            MemoryError::VersionMismatch { expected, actual } => {
+                Self::VersionMismatch { expected, actual }
+            }
+            MemoryError::Storage(message) => Self::Storage(message),
+            MemoryError::Authorization(message) => Self::Authorization(message),
+            MemoryError::Io(error) => Self::Io(error),
+        }
     }
 }
 
-impl From<MemoryError> for RepositoryError {
-    fn from(e: MemoryError) -> Self {
-        Self::StorageError(e.to_string())
+// Temporary: `archive/local.rs` uses `DialogStorageError` from the
+// prolly-tree integration; keep `From<DialogStorageError>` alias so
+// call sites that haven't been typed yet still compile.
+impl From<DialogStorageError> for PublishError {
+    fn from(error: DialogStorageError) -> Self {
+        Self::Storage(error.to_string())
     }
 }
 
-impl From<DialogStorageError> for RepositoryError {
-    fn from(e: DialogStorageError) -> Self {
-        Self::StorageError(e.to_string())
-    }
-}
-
-impl From<Ed25519SignerError> for RepositoryError {
-    fn from(e: Ed25519SignerError) -> Self {
-        Self::StorageError(e.to_string())
+impl From<DialogStorageError> for ResolveError {
+    fn from(error: DialogStorageError) -> Self {
+        Self::Storage(error.to_string())
     }
 }

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -1,0 +1,60 @@
+use dialog_credentials::Ed25519SignerError;
+use dialog_effects::archive::ArchiveError;
+use dialog_effects::memory::MemoryError;
+use dialog_effects::storage::StorageError;
+use dialog_storage::DialogStorageError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// The common error type used by repository operations.
+#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RepositoryError {
+    /// A storage operation failed
+    #[error("Storage error {0}")]
+    StorageError(String),
+
+    /// Repository not found
+    #[error("Repository '{0}' not found")]
+    NotFound(String),
+
+    /// Repository already exists
+    #[error("Repository '{0}' already exists")]
+    AlreadyExists(String),
+
+    /// Invalid internal state (should never happen in normal operation)
+    #[error("Invalid state: {message}")]
+    InvalidState {
+        /// Description of the invalid state
+        message: String,
+    },
+}
+
+impl From<StorageError> for RepositoryError {
+    fn from(e: StorageError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<ArchiveError> for RepositoryError {
+    fn from(e: ArchiveError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<MemoryError> for RepositoryError {
+    fn from(e: MemoryError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<DialogStorageError> for RepositoryError {
+    fn from(e: DialogStorageError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<Ed25519SignerError> for RepositoryError {
+    fn from(e: Ed25519SignerError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}

--- a/rust/dialog-repository/src/repository/load.rs
+++ b/rust/dialog-repository/src/repository/load.rs
@@ -1,0 +1,23 @@
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::space;
+use dialog_effects::space::SpaceExt;
+
+use super::Repository;
+use super::error::RepositoryError;
+
+/// Command to load an existing repository.
+///
+/// Returns `Repository<Credential>` since the credential
+/// may be verifier-only.
+pub struct LoadRepository(pub Capability<space::Space>);
+
+impl LoadRepository {
+    /// Execute against an operator.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, RepositoryError>
+    where
+        Env: Provider<space::Load> + ConditionalSync,
+    {
+        Ok(Repository::from(self.0.load().perform(env).await?))
+    }
+}

--- a/rust/dialog-repository/src/repository/load.rs
+++ b/rust/dialog-repository/src/repository/load.rs
@@ -1,10 +1,7 @@
+use crate::{LoadRepositoryError, Repository};
 use dialog_capability::{Capability, Provider};
 use dialog_common::ConditionalSync;
-use dialog_effects::space;
-use dialog_effects::space::SpaceExt;
-
-use super::Repository;
-use super::error::RepositoryError;
+use dialog_effects::space::{self, SpaceExt};
 
 /// Command to load an existing repository.
 ///
@@ -14,7 +11,7 @@ pub struct LoadRepository(pub Capability<space::Space>);
 
 impl LoadRepository {
     /// Execute against an operator.
-    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, RepositoryError>
+    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, LoadRepositoryError>
     where
         Env: Provider<space::Load> + ConditionalSync,
     {

--- a/rust/dialog-repository/src/repository/memory.rs
+++ b/rust/dialog-repository/src/repository/memory.rs
@@ -1,9 +1,10 @@
 //! Memory capabilities: cells, publish/resolve commands, and caching.
 
 mod cell;
-mod publish;
-mod resolve;
-
 pub use cell::*;
+
+mod publish;
 pub use publish::*;
+
+mod resolve;
 pub use resolve::*;

--- a/rust/dialog-repository/src/repository/memory.rs
+++ b/rust/dialog-repository/src/repository/memory.rs
@@ -1,0 +1,9 @@
+//! Memory capabilities: cells, publish/resolve commands, and caching.
+
+mod cell;
+mod publish;
+mod resolve;
+
+pub use cell::*;
+pub use publish::*;
+pub use resolve::*;

--- a/rust/dialog-repository/src/repository/memory/cell.rs
+++ b/rust/dialog-repository/src/repository/memory/cell.rs
@@ -1,19 +1,13 @@
-use std::sync::Arc;
-
-use parking_lot::RwLock;
-
+use crate::{Publish, PublishError, Resolve, ResolveError, RetainPublish, RetainResolve};
 use dialog_capability::{Capability, Did, Policy};
 use dialog_common::ConditionalSync;
-use dialog_effects::memory;
 use dialog_effects::memory::prelude::CellExt;
-use dialog_effects::memory::{Edition, Version};
-use dialog_storage::{CborEncoder, Encoder};
+use dialog_effects::memory::{self, Edition, Version};
+use dialog_storage::{CborEncoder, DialogStorageError, Encoder};
+use parking_lot::RwLock;
 use serde::{Serialize, de::DeserializeOwned};
 use std::fmt::Debug;
-
-use super::publish::{Publish, RetainPublish};
-use super::resolve::{Resolve, RetainResolve};
-use crate::RepositoryError;
+use std::sync::Arc;
 
 /// Cached [`Edition`] behind a shared lock.
 pub type SharedState<T> = Arc<RwLock<Option<Edition<T>>>>;
@@ -69,8 +63,11 @@ where
     Codec: Encoder + Clone,
 {
     /// Decode bytes into a typed value.
-    pub async fn decode(&self, bytes: &[u8]) -> Result<T, RepositoryError> {
-        Ok(self.codec.decode(bytes).await.map_err(Into::into)?)
+    pub async fn decode(&self, bytes: &[u8]) -> Result<T, ResolveError> {
+        self.codec.decode(bytes).await.map_err(|error| {
+            let error: DialogStorageError = error.into();
+            ResolveError::Decode(error.to_string())
+        })
     }
 }
 
@@ -84,7 +81,7 @@ where
     pub async fn apply(
         &self,
         edition: Option<memory::Edition<Vec<u8>>>,
-    ) -> Result<(), RepositoryError> {
+    ) -> Result<(), ResolveError> {
         match edition {
             None => self.clear(),
             Some(raw) => {
@@ -104,8 +101,11 @@ where
     Codec: Encoder<Bytes = Vec<u8>> + Clone,
 {
     /// Encode a value into bytes.
-    pub async fn encode(&self, value: &T) -> Result<Vec<u8>, RepositoryError> {
-        let (_hash, content) = self.codec.encode(value).await.map_err(Into::into)?;
+    pub async fn encode(&self, value: &T) -> Result<Vec<u8>, PublishError> {
+        let (_hash, content) = self.codec.encode(value).await.map_err(|error| {
+            let error: DialogStorageError = error.into();
+            PublishError::Encode(error.to_string())
+        })?;
         Ok(content)
     }
 }
@@ -293,17 +293,14 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
+    use anyhow::Result;
     use dialog_capability::Subject;
     use dialog_effects::memory::prelude::*;
     use dialog_storage::provider::Volatile;
     use dialog_varsig::did;
 
-    fn test_subject() -> Subject {
-        Subject::from(did!("key:zCellTests"))
-    }
-
     fn test_cell<T>(name: &str) -> Cell<T> {
-        test_subject()
+        Subject::from(did!("key:zCellTests"))
             .memory()
             .space("branch/test")
             .cell(name)
@@ -326,7 +323,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_resolves_empty_cell() -> anyhow::Result<()> {
+    async fn it_resolves_empty_cell() -> Result<()> {
         let provider = Volatile::new();
         let cell: Cell<TestValue> = test_cell("missing");
 
@@ -337,7 +334,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_publishes_then_resolves() -> anyhow::Result<()> {
+    async fn it_publishes_then_resolves() -> Result<()> {
         let provider = Volatile::new();
         let cell: Cell<TestValue> = test_cell("test");
 
@@ -356,7 +353,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_updates_with_automatic_edition() -> anyhow::Result<()> {
+    async fn it_updates_with_automatic_edition() -> Result<()> {
         let provider = Volatile::new();
         let cell: Cell<TestValue> = test_cell("update");
 
@@ -379,7 +376,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_caches_on_resolve() -> anyhow::Result<()> {
+    async fn it_caches_on_resolve() -> Result<()> {
         let provider = Volatile::new();
         let cell: Cell<TestValue> = test_cell("cache");
 
@@ -402,7 +399,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn clones_share_published_state() -> anyhow::Result<()> {
+    async fn clones_share_published_state() -> Result<()> {
         let provider = Volatile::new();
         let cell: Cell<TestValue> = test_cell("shared");
         let clone = cell.clone();
@@ -419,7 +416,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn publish_on_clone_visible_from_original() -> anyhow::Result<()> {
+    async fn publish_on_clone_visible_from_original() -> Result<()> {
         let provider = Volatile::new();
         let original: Cell<TestValue> = test_cell("shared-reverse");
         let clone = original.clone();
@@ -436,7 +433,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn equipped_publishes_and_reads() -> anyhow::Result<()> {
+    async fn equipped_publishes_and_reads() -> Result<()> {
         let provider = Volatile::new();
         let equipped = test_cell::<TestValue>("equipped-pub").retain(TestValue::default());
 
@@ -460,7 +457,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn equipped_updates_on_resolve() -> anyhow::Result<()> {
+    async fn equipped_updates_on_resolve() -> Result<()> {
         let provider = Volatile::new();
 
         let cell: Cell<TestValue> = test_cell("equipped-update");
@@ -487,7 +484,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn equipped_retains_value_when_remote_empty() -> anyhow::Result<()> {
+    async fn equipped_retains_value_when_remote_empty() -> Result<()> {
         let provider = Volatile::new();
 
         let cell: Cell<TestValue> = test_cell("equipped-retain");
@@ -519,14 +516,14 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn equipped_returns_none_before_any_value() -> anyhow::Result<()> {
+    fn equipped_returns_none_before_any_value() -> Result<()> {
         let equipped = test_cell::<TestValue>("equipped-empty").retain(TestValue::default());
         assert_eq!(*equipped.get(), TestValue::default());
         Ok(())
     }
 
     #[dialog_common::test]
-    async fn publish_preserves_edition_for_subsequent_publish() -> anyhow::Result<()> {
+    async fn publish_preserves_edition_for_subsequent_publish() -> Result<()> {
         let provider = Volatile::new();
         let cell: Cell<TestValue> = test_cell("edition");
 
@@ -556,7 +553,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn edition_mismatch_fails_publish() -> anyhow::Result<()> {
+    async fn edition_mismatch_fails_publish() -> Result<()> {
         let provider = Volatile::new();
         let cell_a: Cell<TestValue> = test_cell("conflict");
         let cell_b: Cell<TestValue> = test_cell("conflict");

--- a/rust/dialog-repository/src/repository/memory/cell.rs
+++ b/rust/dialog-repository/src/repository/memory/cell.rs
@@ -1,0 +1,585 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use dialog_capability::{Capability, Did, Policy};
+use dialog_common::ConditionalSync;
+use dialog_effects::memory;
+use dialog_effects::memory::prelude::CellExt;
+use dialog_effects::memory::{Edition, Version};
+use dialog_storage::{CborEncoder, Encoder};
+use serde::{Serialize, de::DeserializeOwned};
+use std::fmt::Debug;
+
+use super::publish::{Publish, RetainPublish};
+use super::resolve::{Resolve, RetainResolve};
+use crate::RepositoryError;
+
+/// Cached [`Edition`] behind a shared lock.
+pub type SharedState<T> = Arc<RwLock<Option<Edition<T>>>>;
+
+/// Typed cache over shared state. Handles encode/decode and cache updates.
+#[derive(Debug)]
+pub struct Cache<T, Codec: Clone = CborEncoder> {
+    /// The encoder used to serialize values written to the cell.
+    pub codec: Codec,
+    /// Shared state holding the last-known edition for this cell.
+    pub state: SharedState<T>,
+}
+
+impl<T, Codec: Clone> Clone for Cache<T, Codec> {
+    fn clone(&self) -> Self {
+        Self {
+            codec: self.codec.clone(),
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl<T: Clone, Codec: Clone> Cache<T, Codec> {
+    /// Read the cached content.
+    pub fn content(&self) -> Option<T> {
+        self.state.read().as_ref().map(|e| e.content.clone())
+    }
+
+    /// Read the full cached edition.
+    pub fn edition(&self) -> Option<Edition<T>> {
+        self.state.read().clone()
+    }
+
+    /// Read just the cached version.
+    pub fn version(&self) -> Option<Version> {
+        self.state.read().as_ref().map(|e| e.version.clone())
+    }
+
+    /// Update the cache with a new edition.
+    pub fn update(&self, edition: Edition<T>) {
+        *self.state.write() = Some(edition);
+    }
+
+    /// Clear the cache.
+    pub fn clear(&self) {
+        *self.state.write() = None;
+    }
+}
+
+impl<T, Codec> Cache<T, Codec>
+where
+    T: DeserializeOwned + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Decode bytes into a typed value.
+    pub async fn decode(&self, bytes: &[u8]) -> Result<T, RepositoryError> {
+        Ok(self.codec.decode(bytes).await.map_err(Into::into)?)
+    }
+}
+
+impl<T, Codec> Cache<T, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Apply a raw edition to the cache, decoding the content in place.
+    /// Clears the cache if the edition is empty.
+    pub async fn apply(
+        &self,
+        edition: Option<memory::Edition<Vec<u8>>>,
+    ) -> Result<(), RepositoryError> {
+        match edition {
+            None => self.clear(),
+            Some(raw) => {
+                self.update(memory::Edition {
+                    content: self.decode(&raw.content).await?,
+                    version: raw.version,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T, Codec> Cache<T, Codec>
+where
+    T: Serialize + ConditionalSync + Debug,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Encode a value into bytes.
+    pub async fn encode(&self, value: &T) -> Result<Vec<u8>, RepositoryError> {
+        let (_hash, content) = self.codec.encode(value).await.map_err(Into::into)?;
+        Ok(content)
+    }
+}
+
+/// A transactional memory cell that stores a typed value with edition tracking.
+///
+/// `Cell<T>` wraps a capability chain (`Subject -> Memory -> Space -> Cell`) and
+/// manages its own cached value + edition internally. This eliminates the need
+/// for callers to thread editions through publish/resolve calls.
+///
+/// The cached state is stored behind `Arc<RwLock<>>`, so clones share state
+/// and writes propagate to all references.
+///
+/// - [`get`](Cell::get) reads the cache synchronously, returning a cloned `T`
+/// - [`resolve`](Cell::resolve) returns a [`Resolve`] command to fetch from env
+/// - [`publish`](Cell::publish) returns a [`Publish`] command to write a value
+#[derive(Debug, Clone)]
+pub struct Cell<T, Codec: Clone = CborEncoder> {
+    capability: Capability<memory::Cell>,
+    cache: Cache<T, Codec>,
+}
+
+impl<T> Cell<T> {
+    /// Returns the name of this cell.
+    pub fn name(&self) -> &str {
+        &memory::Cell::of(&self.capability).cell
+    }
+}
+
+impl<T> From<Capability<memory::Cell>> for Cell<T> {
+    fn from(capability: Capability<memory::Cell>) -> Self {
+        Self {
+            capability,
+            cache: Cache {
+                codec: CborEncoder,
+                state: SharedState::default(),
+            },
+        }
+    }
+}
+
+impl<T, Codec: Clone> Cell<T, Codec>
+where
+    T: Clone,
+{
+    /// Read the cached value without hitting env.
+    /// Returns `None` if the cell has not been resolved or published yet.
+    pub fn content(&self) -> Option<T> {
+        self.cache.content()
+    }
+
+    /// Read the cached edition (content + version) without hitting env.
+    /// Returns `None` if the cell has not been resolved or published yet.
+    pub fn edition(&self) -> Option<Edition<T>> {
+        self.cache.edition()
+    }
+
+    /// Reset the in-memory cache to a known edition, without hitting the
+    /// backend. Used to restore cache state across sessions.
+    pub fn reset(&self, edition: Edition<T>) {
+        self.cache.update(edition);
+    }
+
+    /// Returns the subject DID from the capability chain.
+    pub fn subject(&self) -> &Did {
+        self.capability.subject()
+    }
+}
+
+impl<T, Codec> Cell<T, Codec>
+where
+    T: DeserializeOwned + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Create a command to fetch the cell value from env.
+    ///
+    /// Call `.perform(&env)` for local, or `.fork(&address).perform(&env)`
+    /// for remote.
+    pub fn resolve(&self) -> Resolve<T, Codec> {
+        Resolve {
+            effect: self.capability.clone().resolve(),
+            cache: self.cache.clone(),
+        }
+    }
+}
+
+impl<T, Codec> Cell<T, Codec>
+where
+    T: Serialize + Clone,
+    Codec: Clone,
+{
+    /// Create a command to publish a new value to this cell.
+    ///
+    /// Call `.perform(&env)` for local, or `.fork(&address).perform(&env)`
+    /// for remote.
+    pub fn publish(&self, content: T) -> Publish<T, Codec> {
+        Publish {
+            capability: self.capability.clone(),
+            cache: self.cache.clone(),
+            content,
+        }
+    }
+}
+
+/// A cell that always has a value.
+///
+/// Constructed with an initial value via [`Cell::retain`]. On resolve,
+/// updates to the latest remote value, but if the remote is empty (deleted),
+/// the last known value is retained. [`get()`](Retain::get) always returns `T`.
+#[derive(Debug, Clone)]
+pub struct Retain<T, Codec: Clone = CborEncoder> {
+    cell: Cell<T, Codec>,
+    value: Arc<RwLock<T>>,
+}
+
+impl<T: Clone> Retain<T> {
+    /// Read the current value, syncing from the inner cell first.
+    ///
+    /// If the cell has a newer value, the sticky cache is updated.
+    /// Returns a read guard that derefs to `&T`.
+    pub fn get(&self) -> parking_lot::RwLockReadGuard<'_, T> {
+        if let Some(value) = self.cell.content() {
+            *self.value.write() = value;
+        }
+        self.value.read()
+    }
+
+    /// Returns the name of the underlying cell.
+    pub fn name(&self) -> &str {
+        self.cell.name()
+    }
+
+    /// Returns the subject DID from the capability chain.
+    pub fn subject(&self) -> &Did {
+        self.cell.subject()
+    }
+}
+
+impl<T, Codec> Retain<T, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Create a command to resolve from the environment.
+    ///
+    /// If the remote has a value, the local cache is updated.
+    /// If the remote is empty (deleted), the current value is retained.
+    pub fn resolve(&self) -> RetainResolve<'_, T, Codec> {
+        RetainResolve {
+            inner: self.cell.resolve(),
+            value: &self.value,
+        }
+    }
+}
+
+impl<T, Codec> Retain<T, Codec>
+where
+    T: Serialize + Clone,
+    Codec: Clone,
+{
+    /// Create a command to publish a new value.
+    pub fn publish(&self, value: T) -> RetainPublish<'_, T, Codec> {
+        RetainPublish {
+            inner: self.cell.publish(value.clone()),
+            sticky: &self.value,
+            value,
+        }
+    }
+}
+
+impl<T> Cell<T> {
+    /// Equip this cell with an initial value, creating a [`Retain`]
+    /// that always has a value and never drops back to empty.
+    pub fn retain(self, initial: T) -> Retain<T> {
+        Retain {
+            cell: self,
+            value: Arc::new(RwLock::new(initial)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_capability::Subject;
+    use dialog_effects::memory::prelude::*;
+    use dialog_storage::provider::Volatile;
+    use dialog_varsig::did;
+
+    fn test_subject() -> Subject {
+        Subject::from(did!("key:zCellTests"))
+    }
+
+    fn test_cell<T>(name: &str) -> Cell<T> {
+        test_subject()
+            .memory()
+            .space("branch/test")
+            .cell(name)
+            .into()
+    }
+
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestValue {
+        count: u32,
+        name: String,
+    }
+
+    impl Default for TestValue {
+        fn default() -> Self {
+            Self {
+                count: 0,
+                name: "default".into(),
+            }
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_empty_cell() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("missing");
+
+        cell.resolve().perform(&provider).await?;
+        assert!(cell.content().is_none());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_publishes_then_resolves() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("test");
+
+        let value = TestValue {
+            count: 42,
+            name: "hello".into(),
+        };
+
+        cell.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value.clone()));
+
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_updates_with_automatic_edition() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("update");
+
+        let v1 = TestValue {
+            count: 1,
+            name: "first".into(),
+        };
+        cell.publish(v1).perform(&provider).await?;
+
+        let v2 = TestValue {
+            count: 2,
+            name: "second".into(),
+        };
+        cell.publish(v2.clone()).perform(&provider).await?;
+
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(v2));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_caches_on_resolve() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("cache");
+
+        let value = TestValue {
+            count: 7,
+            name: "cached".into(),
+        };
+
+        let writer: Cell<TestValue> = test_cell("cache");
+        writer.publish(value.clone()).perform(&provider).await?;
+
+        assert!(cell.content().is_none());
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value.clone()));
+
+        cell.resolve().perform(&provider).await?;
+        assert_eq!(cell.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn clones_share_published_state() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("shared");
+        let clone = cell.clone();
+
+        let value = TestValue {
+            count: 42,
+            name: "shared".into(),
+        };
+
+        cell.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(clone.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn publish_on_clone_visible_from_original() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let original: Cell<TestValue> = test_cell("shared-reverse");
+        let clone = original.clone();
+
+        let value = TestValue {
+            count: 99,
+            name: "from clone".into(),
+        };
+
+        clone.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(original.content(), Some(value));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn equipped_publishes_and_reads() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let equipped = test_cell::<TestValue>("equipped-pub").retain(TestValue::default());
+
+        assert_eq!(
+            *equipped.get(),
+            TestValue::default(),
+            "empty before publish"
+        );
+
+        let value = TestValue {
+            count: 42,
+            name: "equipped".into(),
+        };
+        equipped.publish(value.clone()).perform(&provider).await?;
+        assert_eq!(*equipped.get(), value.clone());
+
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), value);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn equipped_updates_on_resolve() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+
+        let cell: Cell<TestValue> = test_cell("equipped-update");
+        let v1 = TestValue {
+            count: 1,
+            name: "first".into(),
+        };
+        cell.publish(v1.clone()).perform(&provider).await?;
+
+        let equipped = test_cell::<TestValue>("equipped-update").retain(TestValue::default());
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), v1);
+
+        let v2 = TestValue {
+            count: 2,
+            name: "second".into(),
+        };
+        cell.publish(v2.clone()).perform(&provider).await?;
+
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), v2);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn equipped_retains_value_when_remote_empty() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+
+        let cell: Cell<TestValue> = test_cell("equipped-retain");
+        let value = TestValue {
+            count: 42,
+            name: "retained".into(),
+        };
+        cell.publish(value.clone()).perform(&provider).await?;
+
+        let equipped = test_cell::<TestValue>("equipped-retain").retain(TestValue::default());
+        equipped.resolve().perform(&provider).await?;
+        assert_eq!(*equipped.get(), value.clone());
+
+        let empty_equipped = test_cell::<TestValue>("nonexistent").retain(TestValue::default());
+        empty_equipped.resolve().perform(&provider).await?;
+        assert_eq!(
+            *empty_equipped.get(),
+            TestValue::default(),
+            "equipped on nonexistent cell retains default"
+        );
+
+        assert_eq!(
+            *equipped.get(),
+            value,
+            "equipped retains value independently"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    fn equipped_returns_none_before_any_value() -> anyhow::Result<()> {
+        let equipped = test_cell::<TestValue>("equipped-empty").retain(TestValue::default());
+        assert_eq!(*equipped.get(), TestValue::default());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn publish_preserves_edition_for_subsequent_publish() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell: Cell<TestValue> = test_cell("edition");
+
+        let v1 = TestValue {
+            count: 1,
+            name: "first".into(),
+        };
+        cell.publish(v1).perform(&provider).await?;
+
+        // Second publish should use the edition from the first
+        let v2 = TestValue {
+            count: 2,
+            name: "second".into(),
+        };
+        cell.publish(v2.clone()).perform(&provider).await?;
+
+        // Resolve from a separate cell to verify the value was written
+        let reader: Cell<TestValue> = test_cell("edition");
+        reader.resolve().perform(&provider).await?;
+        assert_eq!(
+            reader.content(),
+            Some(v2),
+            "second publish should succeed with correct edition"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn edition_mismatch_fails_publish() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let cell_a: Cell<TestValue> = test_cell("conflict");
+        let cell_b: Cell<TestValue> = test_cell("conflict");
+
+        // Both resolve to get the same (empty) edition
+        cell_a.resolve().perform(&provider).await?;
+        cell_b.resolve().perform(&provider).await?;
+
+        // A publishes successfully
+        let v1 = TestValue {
+            count: 1,
+            name: "from A".into(),
+        };
+        cell_a.publish(v1).perform(&provider).await?;
+
+        // B tries to publish with the stale edition -- should fail
+        let v2 = TestValue {
+            count: 2,
+            name: "from B".into(),
+        };
+        let result = cell_b.publish(v2).perform(&provider).await;
+        assert!(result.is_err(), "publish with stale edition should fail");
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/memory/publish.rs
+++ b/rust/dialog-repository/src/repository/memory/publish.rs
@@ -1,0 +1,128 @@
+//! Publish command for writing a cell value.
+
+use dialog_capability::{Capability, Fork, Provider, SiteAddress};
+use dialog_common::ConditionalSync;
+use dialog_effects::memory;
+use dialog_effects::memory::prelude::CellExt;
+use dialog_storage::Encoder;
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::fmt::Debug;
+
+use super::cell::Cache;
+use crate::RepositoryError;
+
+/// Command to publish a cell value.
+///
+/// Created by [`Cell::publish`](super::Cell::publish). Invoke `.perform(&env)`
+/// to run against the local environment, or `.fork(&address)` to build a
+/// [`ForkPublish`] that runs against a remote site.
+pub struct Publish<T, Codec: Clone> {
+    /// Capability chain targeting the cell to publish to.
+    pub capability: Capability<memory::Cell>,
+    /// Cached edition used for edition tracking and cache updates.
+    pub cache: Cache<T, Codec>,
+    /// Value to publish.
+    pub content: T,
+}
+
+impl<T, Codec> Publish<T, Codec>
+where
+    T: Serialize + Clone + ConditionalSync + Debug,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Perform the publish against the local environment.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<memory::Publish>,
+    {
+        let content = self.cache.encode(&self.content).await?;
+        let when = self.cache.version();
+        let version = self.capability.publish(content, when).perform(env).await?;
+        self.cache.update(memory::Edition {
+            content: self.content,
+            version,
+        });
+        Ok(())
+    }
+
+    /// Build a remote-site version of this command.
+    ///
+    /// The returned [`ForkPublish`] can be executed against an environment
+    /// that knows how to reach the remote site identified by `address`.
+    pub fn fork<A: SiteAddress>(self, address: &A) -> ForkPublish<T, A, Codec> {
+        ForkPublish {
+            capability: self.capability,
+            cache: self.cache,
+            content: self.content,
+            address: address.clone(),
+        }
+    }
+}
+
+/// A [`Publish`] retargeted at a remote site. Execute via `.perform(&env)`
+/// against an environment configured with the matching site provider.
+///
+/// The remote's edition comes from the local cache, so call
+/// `cell.resolve().fork(&addr).perform(&env)` first to sync the remote's
+/// current edition if you do not already hold it.
+pub struct ForkPublish<T, A: SiteAddress, Codec: Clone> {
+    capability: Capability<memory::Cell>,
+    cache: Cache<T, Codec>,
+    content: T,
+    address: A,
+}
+
+impl<T, A, Codec> ForkPublish<T, A, Codec>
+where
+    T: Serialize + Clone + ConditionalSync + Debug,
+    A: SiteAddress,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Perform the publish against the remote site.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<Fork<A::Site, memory::Publish>> + ConditionalSync,
+    {
+        let content = self.cache.encode(&self.content).await?;
+        let when = self.cache.version();
+        let version = self
+            .capability
+            .publish(content, when)
+            .fork(&self.address)
+            .perform(env)
+            .await?;
+        self.cache.update(memory::Edition {
+            content: self.content,
+            version,
+        });
+        Ok(())
+    }
+}
+
+/// Command to publish to a retained cell.
+pub struct RetainPublish<'a, T, Codec: Clone> {
+    /// Inner publish command.
+    pub inner: Publish<T, Codec>,
+    /// Sticky cache updated on successful publish.
+    pub sticky: &'a RwLock<T>,
+    /// Value to publish and retain.
+    pub value: T,
+}
+
+impl<T, Codec> RetainPublish<'_, T, Codec>
+where
+    T: Serialize + Clone + ConditionalSync + Debug,
+    Codec: Encoder<Bytes = Vec<u8>> + Clone,
+{
+    /// Perform the publish against the local environment. On success the
+    /// sticky cache is updated to reflect the new value.
+    pub async fn perform(
+        self,
+        env: &(impl Provider<memory::Publish> + ConditionalSync),
+    ) -> Result<(), RepositoryError> {
+        self.inner.perform(env).await?;
+        *self.sticky.write() = self.value;
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/memory/publish.rs
+++ b/rust/dialog-repository/src/repository/memory/publish.rs
@@ -1,16 +1,14 @@
 //! Publish command for writing a cell value.
 
+use super::cell::Cache;
+use crate::PublishError;
 use dialog_capability::{Capability, Fork, Provider, SiteAddress};
 use dialog_common::ConditionalSync;
-use dialog_effects::memory;
-use dialog_effects::memory::prelude::CellExt;
+use dialog_effects::memory::{self, prelude::CellExt};
 use dialog_storage::Encoder;
 use parking_lot::RwLock;
 use serde::Serialize;
 use std::fmt::Debug;
-
-use super::cell::Cache;
-use crate::RepositoryError;
 
 /// Command to publish a cell value.
 ///
@@ -32,7 +30,7 @@ where
     Codec: Encoder<Bytes = Vec<u8>> + Clone,
 {
     /// Perform the publish against the local environment.
-    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), PublishError>
     where
         Env: Provider<memory::Publish>,
     {
@@ -80,7 +78,7 @@ where
     Codec: Encoder<Bytes = Vec<u8>> + Clone,
 {
     /// Perform the publish against the remote site.
-    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), PublishError>
     where
         Env: Provider<Fork<A::Site, memory::Publish>> + ConditionalSync,
     {
@@ -120,7 +118,7 @@ where
     pub async fn perform(
         self,
         env: &(impl Provider<memory::Publish> + ConditionalSync),
-    ) -> Result<(), RepositoryError> {
+    ) -> Result<(), PublishError> {
         self.inner.perform(env).await?;
         *self.sticky.write() = self.value;
         Ok(())

--- a/rust/dialog-repository/src/repository/memory/resolve.rs
+++ b/rust/dialog-repository/src/repository/memory/resolve.rs
@@ -1,0 +1,101 @@
+//! Resolve command for fetching a cell value.
+
+use dialog_capability::{Capability, Fork, Provider, Site, SiteAddress};
+use dialog_common::ConditionalSync;
+use dialog_effects::memory;
+use dialog_storage::Encoder;
+use parking_lot::RwLock;
+use serde::de::DeserializeOwned;
+
+use super::cell::Cache;
+use crate::RepositoryError;
+
+/// Command to resolve (fetch) a cell value.
+///
+/// Created by [`Cell::resolve`](super::Cell::resolve). Invoke `.perform(&env)`
+/// to run against the local environment, or `.fork(&address)` to build a
+/// [`ForkResolve`] that runs against a remote site.
+pub struct Resolve<T, Codec: Clone> {
+    /// Capability chain resolving a cell's latest edition.
+    pub effect: Capability<memory::Resolve>,
+    /// Cache to populate with the resolved edition.
+    pub cache: Cache<T, Codec>,
+}
+
+impl<T, Codec> Resolve<T, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Perform the resolve against the local environment.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<memory::Resolve>,
+    {
+        let edition = self.effect.perform(env).await?;
+        self.cache.apply(edition).await
+    }
+
+    /// Build a remote-site version of this command.
+    ///
+    /// The returned [`ForkResolve`] can be executed against an environment
+    /// that knows how to reach the remote site identified by `address`.
+    pub fn fork<A: SiteAddress>(self, address: &A) -> ForkResolve<T, A::Site, Codec> {
+        ForkResolve {
+            fork: self.effect.fork(address),
+            cache: self.cache,
+        }
+    }
+}
+
+/// A [`Resolve`] retargeted at a remote site. Execute via `.perform(&env)`
+/// against an environment configured with the matching site provider.
+pub struct ForkResolve<T, S: Site, Codec: Clone> {
+    fork: Fork<S, memory::Resolve>,
+    cache: Cache<T, Codec>,
+}
+
+impl<T, S, Codec> ForkResolve<T, S, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    S: Site,
+    Codec: Encoder + Clone,
+{
+    /// Perform the resolve against the remote site.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    where
+        Env: Provider<Fork<S, memory::Resolve>> + ConditionalSync,
+    {
+        let edition = self.fork.perform(env).await?;
+        self.cache.apply(edition).await
+    }
+}
+
+/// Command to resolve a retained cell.
+pub struct RetainResolve<'a, T, Codec: Clone> {
+    /// Inner resolve command.
+    pub inner: Resolve<T, Codec>,
+    /// Sticky cache updated when the resolved edition is non-empty.
+    pub value: &'a RwLock<T>,
+}
+
+impl<T, Codec> RetainResolve<'_, T, Codec>
+where
+    T: DeserializeOwned + Clone + ConditionalSync,
+    Codec: Encoder + Clone,
+{
+    /// Perform the resolve against the local environment. On success the
+    /// sticky cache is updated with the resolved value; an empty remote
+    /// leaves the retained value untouched.
+    pub async fn perform(
+        self,
+        env: &(impl Provider<memory::Resolve> + ConditionalSync),
+    ) -> Result<(), RepositoryError> {
+        let cache = self.inner.cache.clone();
+        self.inner.perform(env).await?;
+        if let Some(value) = cache.content() {
+            *self.value.write() = value;
+        }
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/memory/resolve.rs
+++ b/rust/dialog-repository/src/repository/memory/resolve.rs
@@ -1,14 +1,13 @@
 //! Resolve command for fetching a cell value.
 
+use super::cell::Cache;
+use crate::ResolveError;
 use dialog_capability::{Capability, Fork, Provider, Site, SiteAddress};
 use dialog_common::ConditionalSync;
 use dialog_effects::memory;
 use dialog_storage::Encoder;
 use parking_lot::RwLock;
 use serde::de::DeserializeOwned;
-
-use super::cell::Cache;
-use crate::RepositoryError;
 
 /// Command to resolve (fetch) a cell value.
 ///
@@ -28,7 +27,7 @@ where
     Codec: Encoder + Clone,
 {
     /// Perform the resolve against the local environment.
-    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), ResolveError>
     where
         Env: Provider<memory::Resolve>,
     {
@@ -62,7 +61,7 @@ where
     Codec: Encoder + Clone,
 {
     /// Perform the resolve against the remote site.
-    pub async fn perform<Env>(self, env: &Env) -> Result<(), RepositoryError>
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), ResolveError>
     where
         Env: Provider<Fork<S, memory::Resolve>> + ConditionalSync,
     {
@@ -90,7 +89,7 @@ where
     pub async fn perform(
         self,
         env: &(impl Provider<memory::Resolve> + ConditionalSync),
-    ) -> Result<(), RepositoryError> {
+    ) -> Result<(), ResolveError> {
         let cache = self.inner.cache.clone();
         self.inner.perform(env).await?;
         if let Some(value) = cache.content() {

--- a/rust/dialog-repository/src/repository/open.rs
+++ b/rust/dialog-repository/src/repository/open.rs
@@ -1,0 +1,34 @@
+use dialog_capability::{Capability, Provider};
+use dialog_common::ConditionalSync;
+use dialog_credentials::Ed25519Signer;
+use dialog_credentials::credential::{Credential, SignerCredential};
+use dialog_effects::space;
+use dialog_effects::space::SpaceExt;
+
+use super::Repository;
+use super::error::RepositoryError;
+
+/// Command to open (load-or-create) a repository.
+///
+/// Returns `Repository<Credential>` since the loaded credential
+/// may be verifier-only.
+pub struct OpenRepository(pub Capability<space::Space>);
+
+impl OpenRepository {
+    /// Execute against an operator.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, RepositoryError>
+    where
+        Env: Provider<space::Load> + Provider<space::Create> + ConditionalSync,
+    {
+        let credential = match self.0.clone().load().perform(env).await {
+            Ok(credential) => credential,
+            Err(_) => {
+                let signer = Ed25519Signer::generate().await?;
+                let credential = Credential::Signer(SignerCredential::from(signer));
+                self.0.create(credential).perform(env).await?
+            }
+        };
+
+        Ok(Repository::from(credential))
+    }
+}

--- a/rust/dialog-repository/src/repository/open.rs
+++ b/rust/dialog-repository/src/repository/open.rs
@@ -1,12 +1,9 @@
+use crate::{OpenRepositoryError, Repository};
 use dialog_capability::{Capability, Provider};
 use dialog_common::ConditionalSync;
 use dialog_credentials::Ed25519Signer;
 use dialog_credentials::credential::{Credential, SignerCredential};
-use dialog_effects::space;
-use dialog_effects::space::SpaceExt;
-
-use super::Repository;
-use super::error::RepositoryError;
+use dialog_effects::space::{self, SpaceExt};
 
 /// Command to open (load-or-create) a repository.
 ///
@@ -16,7 +13,7 @@ pub struct OpenRepository(pub Capability<space::Space>);
 
 impl OpenRepository {
     /// Execute against an operator.
-    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, RepositoryError>
+    pub async fn perform<Env>(self, env: &Env) -> Result<Repository, OpenRepositoryError>
     where
         Env: Provider<space::Load> + Provider<space::Create> + ConditionalSync,
     {

--- a/rust/dialog-repository/src/repository/revision.rs
+++ b/rust/dialog-repository/src/repository/revision.rs
@@ -1,0 +1,31 @@
+use dialog_capability::Did;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+use super::tree::TreeReference;
+
+/// A revision represents a concrete state of the repository at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Revision {
+    /// DID of the repository this revision belongs to.
+    pub subject: Did,
+
+    /// DID of the operator (ephemeral session key) that created this revision.
+    pub issuer: Did,
+
+    /// DID of the profile (long-lived key) that authorized this revision.
+    pub authority: Did,
+
+    /// Root of the search tree at this revision.
+    pub tree: TreeReference,
+
+    /// Parent tree roots this revision is based on. Empty for the first revision.
+    pub cause: HashSet<TreeReference>,
+
+    /// Period counter. Increments when a different issuer commits (sync boundary).
+    pub period: usize,
+
+    /// Moment counter. Increments on each commit within the same period by
+    /// the same issuer. Resets to 0 when period advances.
+    pub moment: usize,
+}

--- a/rust/dialog-repository/src/repository/revision.rs
+++ b/rust/dialog-repository/src/repository/revision.rs
@@ -1,8 +1,7 @@
+use crate::TreeReference;
 use dialog_capability::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-
-use super::tree::TreeReference;
 
 /// A revision represents a concrete state of the repository at a point in time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -28,4 +27,69 @@ pub struct Revision {
     /// Moment counter. Increments on each commit within the same period by
     /// the same issuer. Resets to 0 when period advances.
     pub moment: usize,
+}
+
+impl Revision {
+    /// Build the first revision of a branch, with no causal ancestor and
+    /// the logical clock reset to zero.
+    pub fn new(tree: TreeReference, subject: Did, issuer: Did, authority: Did) -> Self {
+        Self {
+            subject,
+            issuer,
+            authority,
+            tree,
+            cause: HashSet::new(),
+            period: 0,
+            moment: 0,
+        }
+    }
+
+    /// Build the revision that follows `self`, advancing the logical clock.
+    ///
+    /// When the same issuer commits again the `moment` counter increments;
+    /// a different issuer bumps `period` and resets `moment` to zero (this
+    /// marks a sync boundary). The previous revision's tree root is
+    /// recorded in `cause`.
+    pub fn advance(&self, tree: TreeReference, issuer: Did, authority: Did) -> Self {
+        let (period, moment) = if self.issuer == issuer {
+            (self.period, self.moment + 1)
+        } else {
+            (self.period + 1, 0)
+        };
+        Self {
+            subject: self.subject.clone(),
+            issuer,
+            authority,
+            tree,
+            cause: HashSet::from([self.tree.clone()]),
+            period,
+            moment,
+        }
+    }
+
+    /// Build a merge revision combining `self` with `upstream`.
+    ///
+    /// A merge is a forced sync boundary: the new `period` jumps past both
+    /// sides and `moment` resets to zero so later commits from either
+    /// issuer compare cleanly against the merged state. The upstream
+    /// tree is recorded as the causal ancestor; the branch's own prior
+    /// tree is dropped from `cause` because it is now subsumed by the
+    /// merged tree.
+    pub fn merge(
+        &self,
+        upstream: &Revision,
+        tree: TreeReference,
+        issuer: Did,
+        authority: Did,
+    ) -> Self {
+        Self {
+            subject: self.subject.clone(),
+            issuer,
+            authority,
+            tree,
+            cause: HashSet::from([upstream.tree.clone()]),
+            period: self.period.max(upstream.period) + 1,
+            moment: 0,
+        }
+    }
 }

--- a/rust/dialog-repository/src/repository/tree.rs
+++ b/rust/dialog-repository/src/repository/tree.rs
@@ -4,7 +4,7 @@ use dialog_storage::Blake3Hash;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
-/// Reference to a prolly tree by its root hash.
+/// Reference to a search tree by its root hash.
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TreeReference(Blake3Hash);
 

--- a/rust/dialog-repository/src/repository/tree.rs
+++ b/rust/dialog-repository/src/repository/tree.rs
@@ -1,0 +1,49 @@
+use base58::ToBase58;
+use dialog_prolly_tree::EMPT_TREE_HASH;
+use dialog_storage::Blake3Hash;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+
+/// Reference to a prolly tree by its root hash.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TreeReference(Blake3Hash);
+
+impl TreeReference {
+    /// Returns a reference to the underlying hash.
+    pub fn hash(&self) -> &Blake3Hash {
+        &self.0
+    }
+}
+
+impl Default for TreeReference {
+    /// By default, a [`TreeReference`] points at the empty search tree.
+    fn default() -> Self {
+        Self(EMPT_TREE_HASH)
+    }
+}
+
+impl Display for TreeReference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let bytes: &[u8] = self.hash();
+        write!(f, "#{}", ToBase58::to_base58(bytes))
+    }
+}
+
+impl Debug for TreeReference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self, f)
+    }
+}
+
+impl From<Blake3Hash> for TreeReference {
+    fn from(hash: Blake3Hash) -> Self {
+        Self(hash)
+    }
+}
+
+impl From<TreeReference> for Blake3Hash {
+    fn from(value: TreeReference) -> Self {
+        let TreeReference(hash) = value;
+        hash
+    }
+}

--- a/rust/dialog-storage/src/error.rs
+++ b/rust/dialog-storage/src/error.rs
@@ -1,3 +1,5 @@
+use dialog_effects::archive::ArchiveError;
+use dialog_effects::memory::MemoryError;
 use thiserror::Error;
 
 /// The common error type used by this crate
@@ -18,4 +20,16 @@ pub enum DialogStorageError {
     /// An error that occurs when byte hash verification fails
     #[error("Byte hash verification failed: {0}")]
     Verification(String),
+}
+
+impl From<ArchiveError> for DialogStorageError {
+    fn from(e: ArchiveError) -> Self {
+        Self::StorageBackend(e.to_string())
+    }
+}
+
+impl From<MemoryError> for DialogStorageError {
+    fn from(e: MemoryError) -> Self {
+        Self::StorageBackend(e.to_string())
+    }
 }


### PR DESCRIPTION
Introduces `dialog-repository` with git-like data model where repositories identified by did:key have named branches with revision history, and remotes for replication. This PR lays down the foundation; branches, remotes, and sync land in the follow-ups.

The three primitives here are what everything downstream composes:

- **`Repository<C>`** — credential-scoped handle. Signer can write and delegate; verifier is read-only. Branches and remotes will attach cells under this subject, so the credential story is settled once.
- **Transactional memory cells with edition tracking.** Branches will be cells holding a revision; remotes will be cells holding an address. `Cell` / `Retain` plus `Publish` / `Resolve` (and their `.fork(&address)` remote variants) are the machinery every later feature reuses.
- **CAS adapter bridging archive capabilities with the prolly tree's `ContentAddressedStorage`.** Commit, select, pull, and push all read and write tree nodes through this.

## Stack

1. **`feat/repository-base`** (this PR) — foundation
2. #322 `feat/repository-branch` — Branch module + `RepositoryMemoryExt`
3. #323 `feat/repository-remote` — remote module, networked archive, branch fetch + `claims().select(...)`
4. #324 `feat/repository-sync` — pull / push / set_upstream / integration tests + `helpers`