### PR TITLE
23.2 📬 feat: add Branch module to dialog-repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,8 +1265,10 @@ name = "dialog-repository"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "base58",
+ "dialog-artifacts",
  "dialog-capability",
  "dialog-common",
  "dialog-credentials",
@@ -1275,6 +1277,7 @@ dependencies = [
  "dialog-prolly-tree",
  "dialog-storage",
  "dialog-varsig",
+ "futures-util",
  "getrandom 0.2.16",
  "parking_lot",
  "reqwest",

--- a/rust/dialog-repository/Cargo.toml
+++ b/rust/dialog-repository/Cargo.toml
@@ -16,6 +16,7 @@ integration-tests = ["dialog-common/integration-tests"]
 web-integration-tests = ["dialog-common/web-integration-tests"]
 
 [dependencies]
+dialog-artifacts = { workspace = true }
 dialog-capability = { workspace = true }
 dialog-common = { workspace = true }
 dialog-operator = { workspace = true }
@@ -26,11 +27,14 @@ dialog-prolly-tree = { workspace = true }
 dialog-varsig = { workspace = true }
 parking_lot = { workspace = true }
 
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 base58 = { workspace = true }
+futures-util = { workspace = true }
 serde = { workspace = true }
 serde_ipld_dagcbor = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "io-util"] }
 
 [dev-dependencies]
 dialog-storage = { workspace = true, features = ["helpers"] }
@@ -38,7 +42,7 @@ dialog-common = { workspace = true, features = ["helpers"] }
 anyhow = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["sync", "macros", "io-util", "fs"] }
+tokio = { workspace = true, features = ["fs"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["js"] }

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -8,6 +8,7 @@
 //! - [`revision`] — Revision tracking and logical timestamps
 
 mod archive;
+mod branch;
 mod create;
 mod error;
 mod load;
@@ -17,6 +18,7 @@ mod revision;
 mod tree;
 
 pub use archive::*;
+pub use branch::*;
 pub use create::*;
 pub use error::*;
 pub use load::*;
@@ -60,6 +62,13 @@ impl<C: Principal> Repository<C> {
     /// The subject.
     pub fn subject(&self) -> Subject {
         self.did().into()
+    }
+
+    /// Get a branch reference for the given name.
+    ///
+    /// Call `.open()` or `.load()` on the returned reference.
+    pub fn branch(&self, name: impl Into<String>) -> BranchReference {
+        self.subject().branch(name)
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -1,0 +1,76 @@
+use super::memory::Cell;
+use crate::Revision;
+use dialog_artifacts::{Datum, Key, State};
+use dialog_capability::{Capability, Did, Subject};
+use dialog_effects::archive::Archive;
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+use dialog_prolly_tree::{GeometricDistribution, Tree};
+use dialog_storage::Blake3Hash;
+
+mod commit;
+pub use commit::*;
+
+mod load;
+pub use load::*;
+
+mod open;
+pub use open::*;
+
+mod reference;
+pub use reference::*;
+
+mod reset;
+pub use reset::*;
+
+mod transaction;
+pub use transaction::*;
+
+mod upstream;
+pub use upstream::*;
+
+/// Type alias for the search tree index.
+pub type Index = Tree<GeometricDistribution, Key, State<Datum>, Blake3Hash>;
+
+/// A branch represents a named line of development within a repository.
+///
+/// Holds a [`BranchReference`] (scoped to `branch/{name}`) plus cells
+/// for the branch's latest revision and optional upstream tracking.
+#[derive(Debug, Clone)]
+pub struct Branch {
+    reference: BranchReference,
+    revision: Cell<Revision>,
+    upstream: Cell<Upstream>,
+}
+
+impl Branch {
+    /// Returns the branch name.
+    pub fn name(&self) -> &str {
+        self.reference.name()
+    }
+
+    /// Returns the current revision of this branch, or `None` if the branch
+    /// has no commits yet (equivalent to an orphan branch in git).
+    pub fn revision(&self) -> Option<Revision> {
+        self.revision.content()
+    }
+
+    /// Returns the upstream state, or `None` if no upstream is configured.
+    pub fn upstream(&self) -> Option<Upstream> {
+        self.upstream.content()
+    }
+
+    /// Returns the DID of the host repository.
+    pub fn of(&self) -> &Did {
+        self.reference.of()
+    }
+
+    /// The subject (repository) this branch lives in.
+    pub fn subject(&self) -> Subject {
+        self.reference.subject()
+    }
+
+    /// Archive capability for this branch's subject.
+    pub fn archive(&self) -> Capability<Archive> {
+        self.subject().archive()
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -1,0 +1,191 @@
+use crate::{
+    Branch, CommitError, Index, LocalIndex, RepositoryArchiveExt as _, Revision, TreeReference,
+};
+use dialog_artifacts::{
+    Artifact, AttributeKey, Cause, Datum, EntityKey, FromKey, Instruction, Key, KeyView,
+    KeyViewConstruct, KeyViewMut, State, ValueKey,
+};
+use dialog_capability::Provider;
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::authority::{Identify, OperatorExt};
+use dialog_effects::memory::{Publish, Resolve};
+use dialog_prolly_tree::{EMPT_TREE_HASH, Tree};
+use futures_util::{Stream, StreamExt, TryStreamExt};
+
+/// Command that commits a stream of changes (assert/retract) to a branch.
+///
+/// Created by [`Branch::commit`]. Execute with `.perform(&env)`.
+pub struct Commit<'a, Changes> {
+    branch: &'a Branch,
+    changes: Changes,
+}
+
+impl<'a, Changes> Commit<'a, Changes> {
+    fn new(branch: &'a Branch, changes: Changes) -> Self {
+        Self { branch, changes }
+    }
+}
+
+impl Branch {
+    /// Commit a stream of changes to this branch.
+    pub fn commit<Changes>(&self, changes: Changes) -> Commit<'_, Changes> {
+        Commit::new(self, changes)
+    }
+}
+
+impl<Changes> Commit<'_, Changes>
+where
+    Changes: Stream<Item = Instruction> + ConditionalSend,
+{
+    /// Execute the commit, returning the newly-published [`Revision`].
+    ///
+    /// Load the branch's current search tree, apply every change in the
+    /// stream to the three (entity / attribute / value) indexes, then
+    /// publish a new [`Revision`] to the branch's revision cell with the
+    /// updated logical clock.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Revision, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let changes = self.changes;
+        let base_revision = branch.revision();
+
+        // `LocalIndex` adapts the archive `Get`/`Put` capabilities into
+        // the search tree's `ContentAddressedStorage` trait, so tree
+        // operations below read and write tree blocks through the
+        // capability system.
+        let mut store = LocalIndex::new(env, branch.archive().index());
+
+        // Walk forward from the current revision's tree root, or from
+        // the empty tree if the branch has no commits yet.
+        let base_tree_hash = base_revision
+            .as_ref()
+            .map(|rev| *rev.tree.hash())
+            .unwrap_or(EMPT_TREE_HASH);
+
+        let mut tree: Index = Tree::from_hash(&base_tree_hash, &store).await?;
+
+        // `changes` is a user-provided `Stream`; pinning it on the stack
+        // lets us advance it with `.next().await` below without moving
+        // self-referential state.
+        tokio::pin!(changes);
+
+        while let Some(change) = changes.next().await {
+            match change {
+                Instruction::Assert(artifact) => {
+                    let entity_key = EntityKey::from(&artifact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+
+                    let datum = Datum::from(artifact);
+
+                    // When asserting with a cause, find and remove the
+                    // ancestor so the new version replaces it in all
+                    // three indexes.
+                    if let Some(cause) = &datum.cause {
+                        let ancestor_key = {
+                            let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
+                                .set_entity(entity_key.entity())
+                                .set_attribute(entity_key.attribute())
+                                .into_key();
+                            let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
+                                .set_entity(entity_key.entity())
+                                .set_attribute(entity_key.attribute())
+                                .into_key();
+
+                            // Pinned because `stream_range` borrows from `tree` and
+                            // `store` across await points below.
+                            let search_stream = tree.stream_range(search_start..search_end, &store);
+                            tokio::pin!(search_stream);
+
+                            let mut ancestor_key = None;
+                            while let Some(candidate) = search_stream.try_next().await? {
+                                if let State::Added(current_element) = candidate.value {
+                                    let current_artifact = Artifact::try_from(current_element)?;
+                                    let current_artifact_reference = Cause::from(&current_artifact);
+
+                                    if cause == &current_artifact_reference {
+                                        ancestor_key = Some(candidate.key);
+                                        break;
+                                    }
+                                }
+                            }
+
+                            ancestor_key
+                        };
+
+                        if let Some(key) = ancestor_key {
+                            let entity_key = EntityKey(key);
+                            let value_key: ValueKey<Key> = ValueKey::from_key(&entity_key);
+                            let attribute_key: AttributeKey<Key> =
+                                AttributeKey::from_key(&entity_key);
+
+                            tree.delete(&entity_key.into_key(), &mut store).await?;
+                            tree.delete(&value_key.into_key(), &mut store).await?;
+                            tree.delete(&attribute_key.into_key(), &mut store).await?;
+                        }
+                    }
+
+                    tree.set(
+                        entity_key.into_key(),
+                        State::Added(datum.clone()),
+                        &mut store,
+                    )
+                    .await?;
+                    tree.set(
+                        attribute_key.into_key(),
+                        State::Added(datum.clone()),
+                        &mut store,
+                    )
+                    .await?;
+                    tree.set(value_key.into_key(), State::Added(datum), &mut store)
+                        .await?;
+                }
+                Instruction::Retract(fact) => {
+                    let entity_key = EntityKey::from(&fact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+
+                    tree.set(entity_key.into_key(), State::Removed, &mut store)
+                        .await?;
+                    tree.set(attribute_key.into_key(), State::Removed, &mut store)
+                        .await?;
+                    tree.set(value_key.into_key(), State::Removed, &mut store)
+                        .await?;
+                }
+            }
+        }
+
+        // `tree.hash()` returns `None` only when the tree is empty, which
+        // we represent as the canonical empty-tree hash.
+        let tree = TreeReference::from(tree.hash().copied().unwrap_or(EMPT_TREE_HASH));
+
+        // Discover who we are so the revision can be attributed to the
+        // correct profile / operator. The subject comes from the branch
+        // itself, not the identity chain.
+        let authority = Identify.perform(env).await?;
+        let issuer = authority.did();
+        let profile = authority.profile().clone();
+
+        let revision = match base_revision {
+            Some(base) => base.advance(tree, issuer, profile),
+            None => Revision::new(tree, branch.of().clone(), issuer, profile),
+        };
+
+        branch
+            .revision
+            .publish(revision.clone())
+            .perform(env)
+            .await?;
+
+        Ok(revision)
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/load.rs
+++ b/rust/dialog-repository/src/repository/branch/load.rs
@@ -1,0 +1,63 @@
+use crate::{Branch, LoadBranchError, OpenBranch};
+use dialog_capability::Provider;
+use dialog_effects::memory::Resolve;
+
+/// Command to load an existing branch, erroring if it has no revision yet.
+///
+/// Behaves like [`OpenBranch`] but errors if the branch has no
+/// revision published yet (i.e. has never been committed to).
+pub struct LoadBranch {
+    open: OpenBranch,
+}
+
+impl<T> From<T> for LoadBranch
+where
+    T: Into<OpenBranch>,
+{
+    fn from(value: T) -> Self {
+        Self { open: value.into() }
+    }
+}
+
+impl LoadBranch {
+    /// Execute the load operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Branch, LoadBranchError>
+    where
+        Env: Provider<Resolve>,
+    {
+        let branch = self.open.perform(env).await?;
+        if branch.revision().is_none() {
+            return Err(LoadBranchError::NotFound {
+                name: branch.name().to_string(),
+            });
+        }
+        Ok(branch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use anyhow::Result;
+    use dialog_capability::Subject;
+    use dialog_storage::provider::Volatile;
+    use dialog_varsig::did;
+
+    use crate::{LoadBranchError, RepositoryMemoryExt};
+
+    #[dialog_common::test]
+    async fn it_fails_loading_missing_branch() -> Result<()> {
+        let provider = Volatile::new();
+
+        let result = Subject::from(did!("key:zBranchLoadTest"))
+            .branch("nonexistent")
+            .load()
+            .perform(&provider)
+            .await;
+
+        assert!(matches!(result, Err(LoadBranchError::NotFound { .. })));
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/open.rs
+++ b/rust/dialog-repository/src/repository/branch/open.rs
@@ -1,0 +1,75 @@
+use crate::{Branch, BranchReference, ResolveError};
+use dialog_capability::Provider;
+use dialog_effects::memory::Resolve;
+
+/// Command to open a branch. Resolves the branch's revision and upstream
+/// cells without ever erroring on a missing revision — a freshly-opened
+/// branch that has never been committed to simply has `None` revision.
+pub struct OpenBranch {
+    branch: BranchReference,
+}
+
+impl From<BranchReference> for OpenBranch {
+    fn from(branch: BranchReference) -> Self {
+        Self { branch }
+    }
+}
+
+impl OpenBranch {
+    /// Execute the open operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Branch, ResolveError>
+    where
+        Env: Provider<Resolve>,
+    {
+        let revision = self.branch.revision();
+        revision.resolve().perform(env).await?;
+
+        let upstream = self.branch.upstream();
+        upstream.resolve().perform(env).await?;
+
+        Ok(Branch {
+            reference: self.branch,
+            revision,
+            upstream,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use anyhow::Result;
+    use dialog_capability::Subject;
+    use dialog_storage::provider::Volatile;
+    use dialog_varsig::did;
+
+    use crate::RepositoryMemoryExt;
+
+    #[dialog_common::test]
+    async fn it_opens_branch_with_no_revision() -> Result<()> {
+        let provider = Volatile::new();
+        let branch = Subject::from(did!("key:zBranchOpenTest"))
+            .branch("main")
+            .open()
+            .perform(&provider)
+            .await?;
+
+        assert_eq!(branch.name(), "main");
+        assert!(branch.revision().is_none());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reopens_same_branch() -> Result<()> {
+        let provider = Volatile::new();
+        let subject = Subject::from(did!("key:zBranchReopenTest"));
+
+        subject.branch("main").open().perform(&provider).await?;
+        let branch = subject.branch("main").open().perform(&provider).await?;
+
+        assert_eq!(branch.name(), "main");
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/reference.rs
+++ b/rust/dialog-repository/src/repository/branch/reference.rs
@@ -1,0 +1,63 @@
+use dialog_capability::{Capability, Did, Policy, Subject};
+use dialog_effects::memory::Space;
+use dialog_effects::memory::prelude::SpaceExt;
+
+use crate::{Cell, LoadBranch, OpenBranch, Revision, Upstream};
+
+/// A reference to a named branch within a repository's memory.
+///
+/// Wraps `Capability<Space>` scoped to `branch/{name}`.
+/// Use `.open()` or `.load()` to create a command, then `.perform(&env)`.
+#[derive(Debug, Clone)]
+pub struct BranchReference(Capability<Space>);
+
+impl From<Capability<Space>> for BranchReference {
+    fn from(space: Capability<Space>) -> Self {
+        Self(space)
+    }
+}
+
+impl BranchReference {
+    /// The DID of the repository this branch belongs to.
+    pub fn of(&self) -> &Did {
+        self.0.subject()
+    }
+
+    /// The subject (repository) this branch belongs to.
+    pub fn subject(&self) -> Subject {
+        Subject::from(self.of().clone())
+    }
+
+    /// The branch name, extracted from the space path.
+    pub fn name(&self) -> &str {
+        Space::of(&self.0)
+            .space
+            .strip_prefix("branch/")
+            .unwrap_or("")
+    }
+
+    /// Open the branch, creating it if it doesn't exist.
+    pub fn open(self) -> OpenBranch {
+        self.into()
+    }
+
+    /// Load the branch, returning an error if it doesn't exist.
+    pub fn load(self) -> LoadBranch {
+        self.into()
+    }
+
+    /// The cell holding this branch's latest [`Revision`].
+    pub fn revision(&self) -> Cell<Revision> {
+        self.cell("revision")
+    }
+
+    /// The cell holding this branch's [`UpstreamBranch`], if any.
+    pub fn upstream(&self) -> Cell<Upstream> {
+        self.cell("upstream")
+    }
+
+    /// Create a typed cell within this branch's space.
+    pub fn cell<T>(&self, cell_name: impl Into<String>) -> Cell<T> {
+        self.0.clone().cell(cell_name).into()
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/reset.rs
+++ b/rust/dialog-repository/src/repository/branch/reset.rs
@@ -1,0 +1,76 @@
+use dialog_capability::Provider;
+use dialog_effects::memory::Publish;
+
+use crate::{Branch, PublishError, Revision};
+
+/// Command that resets a branch to a given revision.
+pub struct Reset<'a> {
+    branch: &'a Branch,
+    revision: Revision,
+}
+
+impl<'a> Reset<'a> {
+    fn new(branch: &'a Branch, revision: Revision) -> Self {
+        Self { branch, revision }
+    }
+}
+
+impl Branch {
+    /// Create a command to reset the branch to a given revision.
+    pub fn reset(&self, revision: Revision) -> Reset<'_> {
+        Reset::new(self, revision)
+    }
+}
+
+impl Reset<'_> {
+    /// Execute the reset operation.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), PublishError>
+    where
+        Env: Provider<Publish>,
+    {
+        self.branch
+            .revision
+            .publish(self.revision)
+            .perform(env)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use anyhow::Result;
+    use std::collections::HashSet;
+
+    use dialog_capability::Subject;
+    use dialog_prolly_tree::EMPT_TREE_HASH;
+    use dialog_storage::provider::Volatile;
+    use dialog_varsig::did;
+
+    use crate::{RepositoryMemoryExt, Revision, TreeReference};
+
+    #[dialog_common::test]
+    async fn it_sets_revision() -> Result<()> {
+        let provider = Volatile::new();
+        let subject = Subject::from(did!("key:zBranchResetTest"));
+
+        let branch = subject.branch("main").open().perform(&provider).await?;
+        assert!(branch.revision().is_none());
+
+        let revision = Revision {
+            subject: subject.did().clone(),
+            issuer: subject.did().clone(),
+            authority: subject.did().clone(),
+            tree: TreeReference::from(EMPT_TREE_HASH),
+            cause: HashSet::new(),
+            period: 0,
+            moment: 0,
+        };
+        branch.reset(revision.clone()).perform(&provider).await?;
+
+        assert_eq!(branch.revision(), Some(revision));
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -1,0 +1,43 @@
+use crate::{Branch, Commit};
+use dialog_artifacts::{ChangeStream, Changes, Statement};
+
+/// A transaction on a branch.
+///
+/// Created by [`Branch::transaction`]. Accumulates changes via `.assert()`
+/// and `.retract()`, then commits atomically via `.commit().perform(&env)`.
+pub struct Transaction<'a> {
+    branch: &'a Branch,
+    changes: Changes,
+}
+
+impl<'a> Transaction<'a> {
+    /// Assert a claim into this transaction.
+    pub fn assert<C: Statement>(mut self, claim: C) -> Self {
+        self.changes.assert(claim);
+        self
+    }
+
+    /// Retract a claim from this transaction.
+    pub fn retract<C: Statement>(mut self, claim: C) -> Self {
+        self.changes.retract(claim);
+        self
+    }
+
+    /// Finalize the transaction into a commit command.
+    pub fn commit(self) -> Commit<'a, ChangeStream> {
+        self.branch.commit(self.changes.into_stream())
+    }
+}
+
+impl Branch {
+    /// Start a transaction on this branch.
+    ///
+    /// Use `.assert()` and `.retract()` to accumulate changes,
+    /// then `.commit().perform(&env)` to apply them.
+    pub fn transaction(&self) -> Transaction<'_> {
+        Transaction {
+            branch: self,
+            changes: Changes::new(),
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/upstream.rs
+++ b/rust/dialog-repository/src/repository/branch/upstream.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+
+use crate::TreeReference;
+
+/// The persisted form of a branch's upstream tracking state.
+///
+/// Stored in the branch's `upstream` cell. The `tree` field captures
+/// the upstream's tree root at the time of last sync, used as the
+/// divergence base for three-way merge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Upstream {
+    /// A local branch upstream.
+    Local {
+        /// Branch name.
+        branch: String,
+        /// Tree root at last sync point.
+        tree: TreeReference,
+    },
+    /// A remote branch upstream.
+    Remote {
+        /// Remote name (e.g., "origin").
+        remote: String,
+        /// Branch name on the remote.
+        branch: String,
+        /// Tree root at last sync point.
+        tree: TreeReference,
+    },
+}
+
+impl Upstream {
+    /// Returns the branch name of this upstream.
+    pub fn branch(&self) -> &str {
+        match self {
+            Self::Local { branch, .. } => branch,
+            Self::Remote { branch, .. } => branch,
+        }
+    }
+
+    /// Returns the tree root at the last sync point.
+    pub fn tree(&self) -> &TreeReference {
+        match self {
+            Self::Local { tree, .. } => tree,
+            Self::Remote { tree, .. } => tree,
+        }
+    }
+
+    /// Returns a new upstream with the tree updated to the given value.
+    pub fn with_tree(self, tree: TreeReference) -> Self {
+        match self {
+            Self::Local { branch, .. } => Self::Local { branch, tree },
+            Self::Remote { remote, branch, .. } => Self::Remote {
+                remote,
+                branch,
+                tree,
+            },
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -1,6 +1,9 @@
+use dialog_artifacts::DialogArtifactsError;
 use dialog_credentials::Ed25519SignerError;
+use dialog_effects::authority::AuthorityError;
 use dialog_effects::memory::{MemoryError, Version};
 use dialog_effects::storage::StorageError;
+use dialog_prolly_tree::DialogProllyTreeError;
 use dialog_storage::DialogStorageError;
 use std::io;
 use thiserror::Error;
@@ -29,6 +32,14 @@ pub enum RepositoryError {
     /// Create-repository command failed.
     #[error(transparent)]
     Create(#[from] CreateRepositoryError),
+
+    /// Load-branch command failed.
+    #[error(transparent)]
+    LoadBranch(#[from] LoadBranchError),
+
+    /// Commit command failed.
+    #[error(transparent)]
+    Commit(#[from] CommitError),
 
     /// Cell publish failed (outside a command context).
     #[error(transparent)]
@@ -178,4 +189,39 @@ impl From<DialogStorageError> for ResolveError {
     fn from(error: DialogStorageError) -> Self {
         Self::Storage(error.to_string())
     }
+}
+
+/// Errors returned by the load branch command.
+#[derive(Error, Debug)]
+pub enum LoadBranchError {
+    /// The branch has no revision yet (nothing to load).
+    #[error("Branch {name} not found")]
+    NotFound {
+        /// The branch name.
+        name: String,
+    },
+
+    /// Failed to resolve the branch's cells.
+    #[error("Failed to resolve branch cells: {0}")]
+    Resolve(#[from] ResolveError),
+}
+
+/// Errors specific to a commit operation.
+#[derive(Error, Debug)]
+pub enum CommitError {
+    /// A search-tree operation during commit failed.
+    #[error("Tree operation failed during commit: {0}")]
+    Tree(#[from] DialogProllyTreeError),
+
+    /// An artifact decode during commit failed.
+    #[error("Artifact decode failed during commit: {0}")]
+    Artifact(#[from] DialogArtifactsError),
+
+    /// Identifying the current authority for the new revision failed.
+    #[error("Failed to identify authority for commit: {0}")]
+    Authority(#[from] AuthorityError),
+
+    /// Publishing the new revision failed.
+    #[error("Failed to publish new revision: {0}")]
+    Publish(#[from] PublishError),
 }

--- a/rust/dialog-repository/src/repository/memory.rs
+++ b/rust/dialog-repository/src/repository/memory.rs
@@ -8,3 +8,24 @@ pub use publish::*;
 
 mod resolve;
 pub use resolve::*;
+
+use dialog_capability::Subject;
+use dialog_effects::memory::prelude::{MemoryExt, MemorySubjectExt};
+
+use crate::BranchReference;
+
+/// Extension trait for repository memory navigation.
+///
+/// Extends [`MemorySubjectExt`] with repository-specific helpers for
+/// addressing branches by name.
+pub trait RepositoryMemoryExt: MemorySubjectExt {
+    /// Access a branch scoped to `branch/{name}`.
+    fn branch(&self, name: impl Into<String>) -> BranchReference;
+}
+
+impl RepositoryMemoryExt for Subject {
+    fn branch(&self, name: impl Into<String>) -> BranchReference {
+        let name = name.into();
+        self.clone().memory().space(format!("branch/{name}")).into()
+    }
+}


### PR DESCRIPTION
Adds named branches on top of the repository core — each branch is a line of development under a repository subject, with its own revision history and an optional upstream pointer. This is the first layer that turns `Repository` from a bare credential handle into something you can actually commit against.

A branch here is just two cells scoped to `branch/{name}` under the repository subject: one for its latest `Revision` and one for its `UpstreamState`. That reuse of the base cell primitives is what keeps this PR small — `open` / `load` / `reset` / `commit` are thin orchestrators over `Cell::resolve` and `Cell::publish`.

New surface:
- `Branch`, `BranchName`, `BranchReference`, `UpstreamState`
- `RepositoryMemoryExt: MemorySubjectExt` adds `.branch(name)` on `Subject`; `Repository::branch(name)` forwards to it
- Commands: `OpenBranch`, `LoadBranch`, `Commit`, `Reset`, `Transaction`
- `novelty()` helper used later by push

`UpstreamState::Remote` references a `RemoteName`, so a minimal `remote::RemoteName` newtype also lives here. The full remote machinery (addresses, archives, remote branches) lands in #323.

## Stack

1. #321 `feat/repository-base` — foundation
2. **`feat/repository-branch`** (this PR) — branches
3. #323 `feat/repository-remote` — remote module, networked archive, branch fetch + `claims().select(...)`
4. #324 `feat/repository-sync` — pull / push / set_upstream / integration tests + `helpers`