### PR TITLE
fix: use different directory resolution in tests without altering behavior in tests

### DIFF
--- a/rust/dialog-storage/src/helpers.rs
+++ b/rust/dialog-storage/src/helpers.rs
@@ -16,6 +16,11 @@ use crate::IndexedDbStorageBackend;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use base58::ToBase58;
 
+#[cfg(not(target_arch = "wasm32"))]
+mod fs;
+#[cfg(not(target_arch = "wasm32"))]
+pub use fs::*;
+
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 type MakeTargetStorageOutput<K> = (IndexedDbStorageBackend<K, Vec<u8>>, ());
 #[cfg(not(target_arch = "wasm32"))]

--- a/rust/dialog-storage/src/helpers/fs.rs
+++ b/rust/dialog-storage/src/helpers/fs.rs
@@ -1,0 +1,206 @@
+//! Temp-dir-redirecting FileSystem wrapper for tests.
+//!
+//! This module is intentionally test-flavoured. It is available only
+//! when the `helpers` feature is enabled (or under `cfg(test)` inside
+//! this crate) and is not intended for production use.
+
+use std::env;
+use std::ops::Deref;
+
+use async_trait::async_trait;
+use dialog_capability::{Command, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::storage::{Directory, Location};
+
+use crate::provider::{FileSystem, FileSystemError, Space, Storage};
+use crate::resource::Resource;
+
+/// Subdirectory under the platform temp directory used to namespace
+/// every [`TempFileSystem`]-rooted path.
+const STORAGE_NAMESPACE: &str = "dialog";
+
+/// A [`FileSystem`] provider that redirects every [`Location`] into a
+/// disambiguated subdirectory of the platform temp directory.
+///
+/// **This is not a general-purpose abstraction.** It exists so tests
+/// that bootstrap through the real `Storage`/`Space` machinery can do
+/// so without touching real user profile or working directories. If
+/// you need ephemeral storage outside a test, reach for
+/// [`tempfile::tempdir`] or the `Volatile` provider instead.
+///
+/// Each input location is rewritten to a unique path under
+/// `{env::temp_dir()}/dialog/`. The original [`Directory`] variant
+/// becomes a top-level segment so distinct inputs never collide; the
+/// [`Location::name`] is preserved on the rewritten location:
+///
+/// | Input directory          | Rewritten base under `{temp}/dialog/` |
+/// |--------------------------|---------------------------------------|
+/// | [`Directory::Profile`]   | `profile`                             |
+/// | [`Directory::Current`]   | `current`                             |
+/// | [`Directory::Temp`]      | `temp`                                |
+/// | [`Directory::At("p")`]   | `at/p`                                |
+/// | [`Directory::At("/p")`]  | `at/./p`                              |
+///
+/// [`Directory::At`] paths are treated as URI-ish segments: a leading
+/// `/` is prefixed with `.` so `PathBuf::join` doesn't discard the
+/// temp base. Further containment (e.g. `..` escapes) is enforced by
+/// [`FileSystemHandle`](crate::provider::FileSystemHandle) at open
+/// time.
+///
+/// After resolution, all further filesystem operations delegate to the
+/// wrapped [`FileSystem`] — the only difference is where the root
+/// lives.
+#[derive(Clone, Debug)]
+#[repr(transparent)]
+pub struct TempFileSystem {
+    inner: FileSystem,
+}
+
+impl Deref for TempFileSystem {
+    type Target = FileSystem;
+
+    fn deref(&self) -> &FileSystem {
+        &self.inner
+    }
+}
+
+/// Forward every command the wrapped [`FileSystem`] can handle. Keeps
+/// [`TempFileSystem`] in sync as the inner [`FileSystem`] gains (or
+/// loses) [`Provider`] impls without touching this file.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<C> Provider<C> for TempFileSystem
+where
+    C: Command,
+    C::Input: ConditionalSync + 'static,
+    FileSystem: Provider<C> + ConditionalSync,
+{
+    async fn execute(&self, input: C::Input) -> C::Output {
+        self.inner.execute(input).await
+    }
+}
+
+#[async_trait]
+impl Resource<Location> for TempFileSystem {
+    type Error = FileSystemError;
+
+    async fn open(location: &Location) -> Result<Self, FileSystemError> {
+        let path = match &location.directory {
+            Directory::Profile => "profile".to_string(),
+            Directory::Current => "current".to_string(),
+            Directory::Temp => "temp".to_string(),
+            Directory::At(path) => {
+                // Prefix `.` to a leading `/` so PathBuf::join does not
+                // discard our temp base; containment of `..` etc. is
+                // enforced downstream by FileSystemHandle.
+                let relative = if let Some(rest) = path.strip_prefix('/') {
+                    format!("./{rest}")
+                } else {
+                    path.clone()
+                };
+                format!("at/{relative}")
+            }
+        };
+        let root = env::temp_dir().join(STORAGE_NAMESPACE).join(path);
+        let rewritten = Location::new(
+            Directory::At(root.to_string_lossy().into_owned()),
+            location.name.clone(),
+        );
+        Ok(Self {
+            inner: FileSystem::open(&rewritten).await?,
+        })
+    }
+}
+
+/// A [`Space`] that routes every field through [`TempFileSystem`].
+///
+/// Use via [`Storage::temp`] to get a filesystem-backed storage whose
+/// roots live entirely under the platform temp directory.
+pub type NativeTempSpace = Space<TempFileSystem, TempFileSystem, TempFileSystem, TempFileSystem>;
+
+impl Storage<NativeTempSpace> {
+    /// Create a filesystem-backed storage whose roots live under the
+    /// platform temp directory, via [`TempFileSystem`] redirection.
+    ///
+    /// This is only available when the `helpers` feature is enabled
+    /// (or inside the crate's own tests) and is intended exclusively
+    /// for tests that need to exercise the real `Storage` / `Space`
+    /// pipeline without touching real user profile or working
+    /// directories.
+    pub fn temp() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    async fn open_root(location: Location) -> PathBuf {
+        TempFileSystem::open(&location)
+            .await
+            .unwrap()
+            .handle()
+            .clone()
+            .try_into()
+            .unwrap()
+    }
+
+    fn temp_base() -> PathBuf {
+        env::temp_dir().join(STORAGE_NAMESPACE)
+    }
+
+    #[tokio::test]
+    async fn it_opens_profile_under_temp() {
+        assert_eq!(
+            open_root(Location::new(Directory::Profile, "alice")).await,
+            temp_base().join("profile").join("alice"),
+        );
+    }
+
+    #[tokio::test]
+    async fn it_opens_current_under_temp() {
+        assert_eq!(
+            open_root(Location::new(Directory::Current, "app")).await,
+            temp_base().join("current").join("app"),
+        );
+    }
+
+    #[tokio::test]
+    async fn it_opens_temp_under_namespaced_subdir() {
+        assert_eq!(
+            open_root(Location::new(Directory::Temp, "scratch")).await,
+            temp_base().join("temp").join("scratch"),
+        );
+    }
+
+    #[tokio::test]
+    async fn it_opens_at_under_temp() {
+        assert_eq!(
+            open_root(Location::new(Directory::At("foo/bar".into()), "runtime")).await,
+            temp_base().join("at/foo/bar").join("runtime"),
+        );
+    }
+
+    #[tokio::test]
+    async fn it_neutralizes_leading_slash_in_at_path() {
+        // Absolute `At("/etc")` becomes `at/./etc`; after normalization
+        // by PathBuf / the OS this is equivalent to `at/etc`, still
+        // under temp_dir() rather than escaping to the real `/etc`.
+        let root = open_root(Location::new(Directory::At("/etc".into()), "runtime")).await;
+        assert!(
+            root.starts_with(temp_base()),
+            "{root:?} should live under {:?}",
+            temp_base()
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_at_paths_produce_distinct_roots() {
+        let a = open_root(Location::new(Directory::At("foo/bar".into()), "")).await;
+        let b = open_root(Location::new(Directory::At("whatever".into()), "")).await;
+        assert_ne!(a, b);
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -70,11 +70,7 @@ impl Resource<Location> for FileSystem {
     }
 }
 
-/// Resolve a `Location` (Directory + name) to a filesystem `Location`.
-///
-/// In test mode, all directories resolve under the platform temp dir
-/// to avoid polluting real profile or workspace directories.
-#[cfg(not(test))]
+/// Resolve a `Location` (Directory + name) to a filesystem handle.
 impl TryFrom<&Location> for FileSystemHandle {
     type Error = FileSystemError;
 
@@ -97,30 +93,6 @@ impl TryFrom<&Location> for FileSystemHandle {
             base
         } else {
             base.join(&location.name)
-        };
-
-        path.try_into()
-    }
-}
-
-/// Test mode: all directories resolve under temp dir to avoid
-/// polluting real profile or workspace directories.
-#[cfg(test)]
-impl TryFrom<&Location> for FileSystemHandle {
-    type Error = FileSystemError;
-
-    fn try_from(location: &Location) -> Result<Self, FileSystemError> {
-        let base = env::temp_dir().join(STORAGE_NAMESPACE);
-        let suffix = match &location.directory {
-            Directory::Profile => ".profile",
-            Directory::Current => ".space",
-            _ => "",
-        };
-
-        let path = if location.name.is_empty() {
-            base
-        } else {
-            base.join(format!("{}{suffix}", location.name))
         };
 
         path.try_into()
@@ -444,15 +416,54 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn test_mode_resolves_under_temp_dir() {
-        let location = StorageLocation::new(Directory::Profile, "test-alice");
+    async fn it_resolves_profile_under_platform_data_dir() {
+        let name = unique_name("profile-resolve");
+        let location = StorageLocation::new(Directory::Profile, &name);
         let space = FileSystem::open(&location).await.unwrap();
-        let archive = space.archive().unwrap();
-        let path = archive.path();
-        assert!(
-            path.contains("dialog") && path.contains("test-alice") && path.ends_with("/archive"),
-            "profile location should resolve under temp/dialog with .profile suffix: {path}"
-        );
+
+        let root: PathBuf = space.handle().clone().try_into().unwrap();
+        let expected = dirs::data_dir()
+            .expect("platform data dir is required for this test")
+            .join(STORAGE_NAMESPACE)
+            .join(&name);
+        assert_eq!(root, expected);
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_current_under_working_directory() {
+        let name = unique_name("current-resolve");
+        let location = StorageLocation::new(Directory::Current, &name);
+        let space = FileSystem::open(&location).await.unwrap();
+
+        let root: PathBuf = space.handle().clone().try_into().unwrap();
+        let expected = env::current_dir()
+            .expect("current working directory must be accessible")
+            .join(&name);
+        assert_eq!(root, expected);
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_temp_under_platform_temp_dir() {
+        let name = unique_name("temp-resolve");
+        let location = StorageLocation::new(Directory::Temp, &name);
+        let space = FileSystem::open(&location).await.unwrap();
+
+        let root: PathBuf = space.handle().clone().try_into().unwrap();
+        let expected = env::temp_dir().join(&name);
+        assert_eq!(root, expected);
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_at_under_explicit_path() {
+        // Use a tempdir as the explicit base so the test doesn't depend
+        // on any fixed filesystem layout.
+        let base = env::temp_dir().join(unique_name("at-base"));
+        let name = unique_name("at-resolve");
+        let location = StorageLocation::new(Directory::At(base.to_string_lossy().into()), &name);
+        let space = FileSystem::open(&location).await.unwrap();
+
+        let root: PathBuf = space.handle().clone().try_into().unwrap();
+        assert_eq!(root, base.join(&name));
     }
 
     #[dialog_common::test]

--- a/rust/dialog-storage/src/storage/provider/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/storage.rs
@@ -303,35 +303,37 @@ mod tests {
         use super::*;
         use crate::helpers::unique_name;
 
-        type NativeStorage = Storage<NativeSpace>;
-
         #[dialog_common::test]
         async fn it_creates_and_loads_on_filesystem() {
-            let env = NativeStorage::default();
+            let env = Storage::temp();
             let name = unique_name("fs-create-load");
 
             let credential = test_credential().await;
             let expected_did = credential.did();
 
-            let cred = StorageFx::temp(&name)
+            let cred = StorageFx::profile(&name)
                 .create(credential)
                 .perform(&env)
                 .await
                 .unwrap();
             assert_eq!(cred.did(), expected_did);
 
-            let loaded = StorageFx::temp(&name).load().perform(&env).await.unwrap();
+            let loaded = StorageFx::profile(&name)
+                .load()
+                .perform(&env)
+                .await
+                .unwrap();
             assert_eq!(loaded.did(), expected_did);
         }
 
         #[dialog_common::test]
         async fn it_persists_archive_on_filesystem() {
-            let env = NativeStorage::default();
+            let env = Storage::temp();
             let name = unique_name("fs-archive");
 
             let credential = test_credential().await;
 
-            let did = StorageFx::temp(&name)
+            let did = StorageFx::profile(&name)
                 .create(credential)
                 .perform(&env)
                 .await
@@ -361,18 +363,18 @@ mod tests {
 
         #[dialog_common::test]
         async fn it_rejects_duplicate_create_on_filesystem() {
-            let env = NativeStorage::default();
+            let env = Storage::temp();
             let name = unique_name("fs-dup");
 
             let credential = test_credential().await;
 
-            StorageFx::temp(&name)
+            StorageFx::profile(&name)
                 .create(credential.clone())
                 .perform(&env)
                 .await
                 .unwrap();
 
-            let result = StorageFx::temp(&name)
+            let result = StorageFx::profile(&name)
                 .create(credential)
                 .perform(&env)
                 .await;


### PR DESCRIPTION
This addresses https://github.com/dialog-db/dialog-db/pull/279/changes#diff-7ff3c8ad535795a04c7901a32a9e6025058e109ff3b33907adba3841044a8700