### PR TITLE
fix: synthesize docs on Concept/Formula derive-generated items

### DIFF
--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -156,9 +156,20 @@ pub fn derive(input: TokenStream) -> TokenStream {
         field_types.push(field_type);
         field_name_lits.push(field_name_lit.clone());
 
-        // Extract doc comment from the field (for Query struct docs)
-        let doc_comment = extract_doc_comments(&field.attrs);
-        let doc_comment_lit = syn::LitStr::new(&doc_comment, proc_macro2::Span::call_site());
+        // Forward the user's field doc when present, otherwise synthesize a
+        // fallback so `#![deny(missing_docs)]` in consumer crates is happy.
+        let user_doc = extract_doc_comments(&field.attrs);
+        let query_field_doc = if user_doc.is_empty() {
+            format!("Term matching the `{field_name_str}` field of [`{struct_name}`].",)
+        } else {
+            user_doc
+        };
+        let query_field_doc_lit =
+            syn::LitStr::new(&query_field_doc, proc_macro2::Span::call_site());
+        let terms_method_doc =
+            format!("Variable term for the `{field_name_str}` field of [`{struct_name}`].",);
+        let terms_method_doc_lit =
+            syn::LitStr::new(&terms_method_doc, proc_macro2::Span::call_site());
 
         // Extract the inner type from Attribute - the field type implements Attribute
         // and we need <FieldType as Attribute>::Type for the Term wrapper
@@ -166,11 +177,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
         // Generate Query field (Term<InnerType>) where InnerType is the Attribute's Type
         query_fields.push(quote! {
-            #[doc = #doc_comment_lit]
+            #[doc = #query_field_doc_lit]
             pub #field_name: dialog_query::Term<#inner_type>
         });
 
         terms_methods.push(quote! {
+            #[doc = #terms_method_doc_lit]
             pub fn #field_name() -> dialog_query::Term<#inner_type> {
                 dialog_query::Term::<#inner_type>::var(#field_name_lit)
             }
@@ -212,6 +224,32 @@ pub fn derive(input: TokenStream) -> TokenStream {
         struct_name.span(),
     );
 
+    // Synthesized docs for generated types so consumer crates can enable
+    // `#![deny(missing_docs)]` without the lint firing on code they did
+    // not author. We only document items we fabricate; the user's own
+    // struct is left untouched so rustc can still warn if they forgot
+    // docs on their own concept.
+    let query_struct_doc = syn::LitStr::new(
+        &format!(
+            "Query pattern for [`{struct_name}`]. Each field is a [`dialog_query::Term`] used to match or bind that field when running the concept query.",
+        ),
+        proc_macro2::Span::call_site(),
+    );
+    let terms_struct_doc = syn::LitStr::new(
+        &format!(
+            "Typed variable-term accessors for [`{struct_name}`]. Each associated function returns a named `Term` variable for the corresponding concept field.",
+        ),
+        proc_macro2::Span::call_site(),
+    );
+    let terms_this_doc = syn::LitStr::new(
+        &format!("Variable term for the `this` field of [`{struct_name}`]."),
+        proc_macro2::Span::call_site(),
+    );
+    let query_this_field_doc = syn::LitStr::new(
+        &format!("Term matching the `this` entity of [`{struct_name}`]."),
+        proc_macro2::Span::call_site(),
+    );
+
     let expanded = quote! {
         // Compile-time validation that all fields (except 'this') implement Attribute + Descriptor
         const _: () = {
@@ -221,9 +259,10 @@ pub fn derive(input: TokenStream) -> TokenStream {
             }
         };
 
+        #[doc = #query_struct_doc]
         #[derive(Debug, Clone, PartialEq)]
         pub struct #query_name {
-            /// The entity being matched
+            #[doc = #query_this_field_doc]
             pub this: dialog_query::Term<dialog_query::Entity>,
             #(#query_fields),*
         }
@@ -237,9 +276,11 @@ pub fn derive(input: TokenStream) -> TokenStream {
             }
         }
 
+        #[doc = #terms_struct_doc]
         #[derive(Debug, Clone, PartialEq)]
         pub struct #terms_name {}
         impl #terms_name {
+            #[doc = #terms_this_doc]
             pub fn this() -> dialog_query::Term<dialog_query::Entity> {
                 dialog_query::Term::<dialog_query::Entity>::var("this")
             }

--- a/rust/dialog-macros/src/query/formula.rs
+++ b/rust/dialog-macros/src/query/formula.rs
@@ -149,11 +149,18 @@ pub fn derive(input: TokenStream) -> TokenStream {
         struct_name.span(),
     );
 
-    // Generate Input struct fields (only non-output fields)
+    // Generate Input struct fields (only non-output fields). Forward the
+    // user's field doc when present; otherwise synthesize a fallback so
+    // downstream crates with `#![deny(missing_docs)]` still compile.
     let input_struct_fields: Vec<_> = input_fields
         .iter()
         .map(|(name, ty, doc)| {
-            let doc_lit = syn::LitStr::new(doc, proc_macro2::Span::call_site());
+            let doc_text = if doc.is_empty() {
+                format!("The `{name}` input to [`{struct_name}`].")
+            } else {
+                doc.clone()
+            };
+            let doc_lit = syn::LitStr::new(&doc_text, proc_macro2::Span::call_site());
             quote! {
                 #[doc = #doc_lit]
                 pub #name: #ty
@@ -165,7 +172,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let query_struct_fields: Vec<_> = all_fields
         .iter()
         .map(|(name, ty, doc, _is_output, _cost)| {
-            let doc_lit = syn::LitStr::new(doc, proc_macro2::Span::call_site());
+            let doc_text = if doc.is_empty() {
+                format!("Term matching the `{name}` field of [`{struct_name}`].")
+            } else {
+                doc.clone()
+            };
+            let doc_lit = syn::LitStr::new(&doc_text, proc_macro2::Span::call_site());
             quote! {
                 #[doc = #doc_lit]
                 pub #name: dialog_query::Term<#ty>
@@ -245,11 +257,25 @@ pub fn derive(input: TokenStream) -> TokenStream {
         })
         .collect();
 
+    let input_struct_doc = syn::LitStr::new(
+        &format!(
+            "Input structure for the [`{struct_name}`] formula. Holds only the required (non-output) fields that must be provided to compute the formula.",
+        ),
+        proc_macro2::Span::call_site(),
+    );
+    let query_struct_doc = syn::LitStr::new(
+        &format!(
+            "Query pattern for the [`{struct_name}`] formula. Holds every field (input and output) as a [`dialog_query::Term`] for pattern matching.",
+        ),
+        proc_macro2::Span::call_site(),
+    );
+
     let expanded = quote! {
             /// Input structure for #struct_name formula
             ///
             /// Contains only the required (non-output) fields that must be provided
             /// to compute the formula.
+            #[doc = #input_struct_doc]
             #[derive(Debug, Clone)]
             pub struct #input_name {
                 #(#input_struct_fields),*
@@ -258,6 +284,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
             /// Query pattern for #struct_name formula.
             ///
             /// Contains all fields (both input and output) as Term<T> for pattern matching.
+            #[doc = #query_struct_doc]
             #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             pub struct #query_name {
                 #(#query_struct_fields),*

--- a/rust/dialog-query/tests/missing_docs.rs
+++ b/rust/dialog-query/tests/missing_docs.rs
@@ -1,0 +1,75 @@
+//! Regression test for missing-docs warnings in derive-generated code.
+//!
+//! Every `pub` item emitted by `#[derive(Attribute)]` and
+//! `#[derive(Concept)]` must carry a doc attribute so downstream crates
+//! can enable `#![deny(missing_docs)]` without the lint firing on code
+//! they didn't write.
+//!
+//! This test exercises each derive with a fully-documented user struct.
+//! If a future macro change emits a new undocumented `pub` item, this
+//! test stops compiling.
+//!
+//! `#[derive(Formula)]` is not exercised here: its generated code depends
+//! on `From<_> for FormulaQuery` impls that only exist for formulas
+//! defined inside `dialog-query` itself, so a downstream consumer cannot
+//! derive it. Formula regressions are caught by the dialog-query crate's
+//! own lints (see `#![warn(missing_docs)]` in `dialog_query::lib`).
+
+#![deny(missing_docs)]
+
+use dialog_query::{Attribute, Concept, Entity};
+
+/// A person's given name. Domain derived from the module path.
+#[derive(Attribute, Clone, PartialEq)]
+pub struct Name(pub String);
+
+/// A person's age in years. Domain set via a string literal.
+#[derive(Attribute, Clone, PartialEq)]
+#[domain("io.gozala.person")]
+pub struct Age(pub u32);
+
+/// A person's nickname. Domain set via an identifier.
+#[derive(Attribute, Clone, PartialEq)]
+#[domain(custom)]
+pub struct Nickname(pub String);
+
+/// A person modeled as a concept, with every field documented.
+#[derive(Concept, Debug, Clone, PartialEq)]
+pub struct Person {
+    /// The entity this person describes.
+    pub this: Entity,
+    /// The person's name.
+    pub name: Name,
+    /// The person's age.
+    pub age: Age,
+    /// The person's nickname.
+    pub nickname: Nickname,
+}
+
+#[test]
+fn it_compiles_under_deny_missing_docs() {
+    // The real assertion is that this file compiles under
+    // `#![deny(missing_docs)]`. Reference the generated items so dead-code
+    // analysis does not elide them from the test binary and so removing a
+    // doc attribute from any of them trips the lint.
+
+    // `#[derive(Concept)]`: mirror structs and term accessors.
+    let _ = PersonQuery::default();
+    let _this = PersonTerms::this();
+    let _name = PersonTerms::name();
+    let _age = PersonTerms::age();
+    let _nickname = PersonTerms::nickname();
+
+    // `#[derive(Attribute)]`: every inherent `pub fn` the macro emits,
+    // exercised across all three domain paths (derived, string literal,
+    // identifier) so a regression on any branch trips the lint.
+    let _ = Name::of::<Entity>;
+    let _ = Name::descriptor();
+    let _ = Name::the();
+    let _ = Name::cardinality();
+    let _ = Name::content_type();
+    let _ = Age::of::<Entity>;
+    let _ = Age::descriptor();
+    let _ = Nickname::of::<Entity>;
+    let _ = Nickname::descriptor();
+}


### PR DESCRIPTION
The `#[derive(Concept)]` and `#[derive(Formula)]` macros emitted `pub` items (mirror structs, terms accessors, field positions) with no `#[doc]` attribute, which tripped `#![warn(missing_docs)]` in consumer crates on code they did not author.

Synthesize fallback doc attributes on every generated item, forwarding the user's field-level docs when provided. The user's original struct is left untouched so rustc still warns them for their own missing docs.

Adds `rust/dialog-query/tests/missing_docs.rs` as a regression guard: compiled under `#![deny(missing_docs)]`, it stops building if a future macro change emits a new undocumented `pub` item. Exercises `Concept` mirror types plus the three `Attribute` domain paths (derived from module path, string literal, identifier).