### PR TITLE
fix(dialog-ucan): preserve chain order in `UcanProof::from_chain`

### DIFF
--- a/rust/dialog-ucan-core/src/container/delegation.rs
+++ b/rust/dialog-ucan-core/src/container/delegation.rs
@@ -103,9 +103,29 @@ impl DelegationChain {
         &self.proof_cids
     }
 
-    /// Get the delegations map for building InvocationChain.
-    pub fn delegations(&self) -> &HashMap<Cid, Arc<Delegation<Ed25519Signature>>> {
-        &self.delegations
+    /// Iterate the chain's delegations in root-to-leaf order.
+    pub fn proofs(&self) -> impl Iterator<Item = &Delegation<Ed25519Signature>> {
+        self.proof_cids
+            .iter()
+            .map(|cid| self.proof_for_cid(cid).as_ref())
+    }
+
+    /// Iterate `(cid, arc)` pairs in root-to-leaf order, cloning the
+    /// inner `Arc`s.
+    ///
+    /// For constructing a delegation lookup table — most commonly to
+    /// hand to `InvocationChain::new`. Collect into a `HashMap` at
+    /// the call site.
+    pub fn export(&self) -> impl Iterator<Item = (Cid, Arc<Delegation<Ed25519Signature>>)> + '_ {
+        self.proof_cids
+            .iter()
+            .map(|cid| (*cid, self.proof_for_cid(cid).clone()))
+    }
+
+    fn proof_for_cid(&self, cid: &Cid) -> &Arc<Delegation<Ed25519Signature>> {
+        self.delegations
+            .get(cid)
+            .expect("proof_cids and delegations are kept in sync by construction")
     }
 
     /// Get the audience of the last delegation in the chain (closest to invoker).
@@ -378,7 +398,6 @@ mod tests {
 
         let chain = DelegationChain::new(delegation);
         assert_eq!(chain.proof_cids().len(), 1);
-        assert_eq!(chain.delegations().len(), 1);
         assert_eq!(chain.audience(), &operator_signer.did());
         assert_eq!(chain.subject(), Some(&space_did));
     }
@@ -413,7 +432,6 @@ mod tests {
         // Subject-first order: root delegation first, leaf delegation last
         let chain = DelegationChain::try_from(vec![delegation1, delegation2]).unwrap();
         assert_eq!(chain.proof_cids().len(), 2);
-        assert_eq!(chain.delegations().len(), 2);
     }
 
     #[dialog_common::test]
@@ -451,7 +469,6 @@ mod tests {
 
         // Extended chain should have 2 delegations
         assert_eq!(extended_chain.proof_cids().len(), 2);
-        assert_eq!(extended_chain.delegations().len(), 2);
 
         // Original chain should be unchanged
         assert_eq!(chain.proof_cids().len(), 1);

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -103,24 +103,8 @@ impl UcanProof {
     /// Build a permit from a delegation chain and scope.
     ///
     /// Used when importing externally-built delegation chains.
-    ///
-    /// Proofs are collected in root-to-leaf order by iterating
-    /// `chain.proof_cids()` and looking each delegation up in the
-    /// map. Iterating `chain.delegations().values()` instead would
-    /// yield an unspecified order, because `DelegationChain`'s
-    /// internal map is a `HashMap`. Downstream [`Proof::claim`]
-    /// rebuilds the chain via `DelegationChain::new` + `push`, which
-    /// rejects any ordering other than root-to-leaf with a principal
-    /// alignment error — so the iteration order here has to match
-    /// the canonical order the chain documents.
     pub fn from_chain(chain: &DelegationChain, scope: Scope) -> Self {
-        let delegations = chain.delegations();
-        let proofs = chain
-            .proof_cids()
-            .iter()
-            .filter_map(|cid| delegations.get(cid))
-            .map(|d| UcanCertificate(d.as_ref().clone()))
-            .collect();
+        let proofs = chain.proofs().map(|d| UcanCertificate(d.clone())).collect();
         let duration = TimeRange {
             not_before: chain.not_before().map(|t| t.to_unix()),
             expiration: chain.expiration().map(|t| t.to_unix()),
@@ -281,7 +265,7 @@ impl Authorization<Ucan> for UcanAuthorization {
         let args = self.scope.parameters.args();
 
         let (proofs, delegations_map) = match &self.chain {
-            Some(chain) => (chain.proof_cids().into(), chain.delegations().clone()),
+            Some(chain) => (chain.proof_cids().into(), chain.export().collect()),
             None => (vec![], Default::default()),
         };
 
@@ -346,9 +330,8 @@ impl AccessDelegation for UcanDelegation {
 
     fn certificates(&self) -> Vec<UcanCertificate> {
         self.0
-            .delegations()
-            .values()
-            .map(|d| UcanCertificate(d.as_ref().clone()))
+            .proofs()
+            .map(|d| UcanCertificate(d.clone()))
             .collect()
     }
 }
@@ -391,12 +374,12 @@ mod tests {
     }
 
     /// `UcanProof::from_chain` must yield proofs in root-to-leaf
-    /// order. Before the fix it iterated `chain.delegations().values()`,
-    /// which walks a `HashMap` in unspecified order — so for
-    /// multi-hop chains, `Proof::claim` would intermittently fail
-    /// with a principal alignment error when `chain.push` tried to
-    /// chain a delegation whose issuer didn't match the current
-    /// chain's audience.
+    /// order. Before `DelegationChain::proofs` existed, callers
+    /// iterated `chain.delegations().values()` — a `HashMap` walk in
+    /// unspecified order — so for multi-hop chains `Proof::claim`
+    /// would intermittently fail with a principal alignment error
+    /// when `chain.push` saw a delegation whose issuer didn't match
+    /// the current chain's audience.
     #[dialog_common::test]
     async fn from_chain_preserves_root_to_leaf_order_for_multi_hop_chains() {
         // root -> mid -> leaf, all scoped to `subject`.

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -103,10 +103,22 @@ impl UcanProof {
     /// Build a permit from a delegation chain and scope.
     ///
     /// Used when importing externally-built delegation chains.
+    ///
+    /// Proofs are collected in root-to-leaf order by iterating
+    /// `chain.proof_cids()` and looking each delegation up in the
+    /// map. Iterating `chain.delegations().values()` instead would
+    /// yield an unspecified order, because `DelegationChain`'s
+    /// internal map is a `HashMap`. Downstream [`Proof::claim`]
+    /// rebuilds the chain via `DelegationChain::new` + `push`, which
+    /// rejects any ordering other than root-to-leaf with a principal
+    /// alignment error — so the iteration order here has to match
+    /// the canonical order the chain documents.
     pub fn from_chain(chain: &DelegationChain, scope: Scope) -> Self {
+        let delegations = chain.delegations();
         let proofs = chain
-            .delegations()
-            .values()
+            .proof_cids()
+            .iter()
+            .filter_map(|cid| delegations.get(cid))
             .map(|d| UcanCertificate(d.as_ref().clone()))
             .collect();
         let duration = TimeRange {
@@ -349,4 +361,72 @@ impl Protocol for Ucan {
     type Invocation = UcanInvocation;
     type Proof = UcanProof;
     type Authorization = UcanAuthorization;
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_varsig::Principal;
+
+    async fn signer(seed: u8) -> Ed25519Signer {
+        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    }
+
+    async fn build_delegation(
+        issuer: Ed25519Signer,
+        audience: &Did,
+        subject: &Did,
+    ) -> Delegation<Ed25519Signature> {
+        DelegationBuilder::new()
+            .issuer(issuer)
+            .audience(audience)
+            .subject(UcanSubject::Specific(subject.clone()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap()
+    }
+
+    /// `UcanProof::from_chain` must yield proofs in root-to-leaf
+    /// order. Before the fix it iterated `chain.delegations().values()`,
+    /// which walks a `HashMap` in unspecified order — so for
+    /// multi-hop chains, `Proof::claim` would intermittently fail
+    /// with a principal alignment error when `chain.push` tried to
+    /// chain a delegation whose issuer didn't match the current
+    /// chain's audience.
+    #[dialog_common::test]
+    async fn from_chain_preserves_root_to_leaf_order_for_multi_hop_chains() {
+        // root -> mid -> leaf, all scoped to `subject`.
+        let root = signer(1).await;
+        let mid = signer(2).await;
+        let leaf_did = signer(3).await.did();
+        let subject_did = signer(9).await.did();
+
+        let mid_did = mid.did();
+        let first = build_delegation(root, &mid_did, &subject_did).await;
+        let chain = DelegationChain::new(first);
+        let second = build_delegation(mid, &leaf_did, &subject_did).await;
+        let chain = chain.push(second).unwrap();
+        assert_eq!(chain.proof_cids().len(), 2);
+
+        // Run repeatedly — `HashMap` iteration order can vary across
+        // process boots; building the proof and claiming it from the
+        // same process is deterministic, but repeated runs under the
+        // same seed would surface regressions reintroducing the
+        // iteration-order dependency.
+        for _ in 0..8 {
+            let scope = crate::Scope::from_chain(&chain);
+            let proof = UcanProof::from_chain(&chain, scope);
+            assert_eq!(proof.proofs.len(), 2);
+            // The leaf signer is allowed to claim — that exercises
+            // `Proof::claim` which rebuilds the chain via
+            // `DelegationChain::new` + `push`, rejecting misordered
+            // proofs.
+            let leaf_signer = signer(3).await;
+            Proof::claim(proof, leaf_signer).expect("chain must rebuild in root-to-leaf order");
+        }
+    }
 }


### PR DESCRIPTION
`UcanProof::from_chain` built its `proofs: Vec<UcanCertificate>` by iterating `chain.delegations().values()` which is unordered due to the HashMap. `Proof::claim` then rebuilt the delegation chain by calling `DelegationChain::new(first)` followed by `chain.push(next)` for each subsequent proof, and `push` rejects anything where the new delegation's issuer doesn't match the current chain's leaf audience.

For single-hop chains this was doesn't matter because there's only one element but for multi-hop chains it was more random, depending on however the entries got hashed. Since `RandomState` is seeded once per process, I could fail to claim an invite once, wipe the state and try again, then it works.

Simple fix by iterating `DelegationChain::proof_cids` instead, added regression tests as well.