### PR TITLE
fix: Search tree ranking and deletion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -228,6 +228,11 @@
         inherit (menuHelpers) makeMenu makeDevShellHook menuTestCommand;
 
         commands = {
+          "bench" = {
+            description = "Run all benchmarks";
+            command = "cargo bench";
+          };
+
           "lint" = {
             description = "Lint the full source tree";
             command = "nix flake check";
@@ -337,6 +342,7 @@
 
         devShells = with pkgs; {
           default = mkShell {
+            name = "dialog";
             env = developmentEnvVars;
             nativeBuildInputs = menu.commands ++ developmentBuildInputs;
             shellHook = makeDevShellHook menu;

--- a/rust/dialog-search-tree/src/accessor.rs
+++ b/rust/dialog-search-tree/src/accessor.rs
@@ -1,0 +1,90 @@
+use dialog_common::{Blake3Hash, ConditionalSend};
+use dialog_storage::{DialogStorageError, StorageBackend};
+use rkyv::{
+    Deserialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+use crate::{
+    Buffer, Cache, ContentAddressedStorage, Delta, DialogSearchTreeError, Key, Node, SymmetryWith,
+    Value,
+};
+
+/// Accessor for retrieving nodes from a three-tier storage hierarchy.
+///
+/// The accessor checks for nodes in the following order:
+/// 1. Cache - recently accessed nodes
+/// 2. Delta - uncommitted in-memory changes
+/// 3. Storage - persistent content-addressed storage backend
+#[derive(Clone)]
+pub struct Accessor<Backend>
+where
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+{
+    delta: Delta<Blake3Hash, Buffer>,
+    cache: Cache<Blake3Hash, Buffer>,
+    storage: ContentAddressedStorage<Backend>,
+}
+
+impl<Backend> Accessor<Backend>
+where
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+        + ConditionalSend
+        + 'static,
+{
+    /// Creates a new accessor with the provided delta, cache, and storage backend.
+    pub fn new(
+        delta: Delta<Blake3Hash, Buffer>,
+        cache: Cache<Blake3Hash, Buffer>,
+        storage: ContentAddressedStorage<Backend>,
+    ) -> Self {
+        Self {
+            delta,
+            cache,
+            storage,
+        }
+    }
+
+    /// Retrieves a node by its content hash.
+    ///
+    /// Checks the cache first, then the delta, and finally the storage backend.
+    /// Returns an error if the node is not found in any layer.
+    pub async fn get_node<Key, Value>(
+        &self,
+        hash: &Blake3Hash,
+    ) -> Result<Node<Key, Value>, DialogSearchTreeError>
+    where
+        Key: self::Key,
+        Key::Archived: for<'a> CheckBytes<
+                Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+            > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>
+            + PartialOrd<Key>
+            + PartialEq<Key>
+            + SymmetryWith<Key>
+            + Ord,
+        Value: self::Value,
+        Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        >,
+    {
+        self.cache
+            .get_or_fetch(hash, async |key| {
+                if let Some(buffer) = self.delta.get(hash) {
+                    Ok(Some(buffer))
+                } else {
+                    self.storage
+                        .retrieve(key)
+                        .await
+                        .map(|maybe_bytes| maybe_bytes.map(Buffer::from))
+                }
+            })
+            .await?
+            .ok_or_else(|| {
+                DialogSearchTreeError::Node(format!("Blob not found in storage: {}", hash))
+            })
+            .map(|buffer| Node::new(buffer))
+    }
+}

--- a/rust/dialog-search-tree/src/body.rs
+++ b/rust/dialog-search-tree/src/body.rs
@@ -59,6 +59,11 @@ where
             entries: vec![entry],
         }
     }
+
+    /// Returns the key of the last entry in this segment.
+    pub fn upper_bound(&self) -> Option<&Key> {
+        self.entries.last().map(|entry| &entry.key)
+    }
 }
 
 impl<Key, Value> ArchivedSegment<Key, Value>

--- a/rust/dialog-search-tree/src/buffer.rs
+++ b/rust/dialog-search-tree/src/buffer.rs
@@ -15,6 +15,16 @@ impl Buffer {
     pub fn blake3_hash(&self) -> &Blake3Hash {
         self.0.1.get_or_init(|| Blake3Hash::hash(&self.0.0))
     }
+
+    /// Converts this [`Buffer`] into an owned `Vec<u8>`. This method will try
+    /// to unwrap the interior smart pointer and pass back the bytes (rather than
+    /// naively cloning them) in the case that there are no other strong references
+    /// to them.
+    pub fn into_vec(self) -> Vec<u8> {
+        Arc::try_unwrap(self.0)
+            .map(|(bytes, _)| bytes)
+            .unwrap_or_else(|arc| arc.0.clone())
+    }
 }
 
 impl AsRef<[u8]> for Buffer {

--- a/rust/dialog-search-tree/src/cache.rs
+++ b/rust/dialog-search-tree/src/cache.rs
@@ -15,20 +15,23 @@ const CACHE_CAPACITY: usize = 2048;
 #[derive(Clone)]
 pub struct Cache<K, V>
 where
-    K: Eq + Hash + Clone + ConditionalSend + ConditionalSync,
-    V: Clone + ConditionalSend + ConditionalSync,
+    K: Eq + Hash + Clone + ConditionalSync,
+    V: Clone + ConditionalSync,
 {
     #[cfg(not(target_arch = "wasm32"))]
     cache: SieveCache<K, V>,
 
+    // NOTE: On "native" we use `SharedSieveCache` which internally wraps
+    // the cached values in an `Arc`. On web we use `SieveCache`, which is
+    // `Clone` but would deep-clone the cache without the wrapping `Rc`.
     #[cfg(target_arch = "wasm32")]
     cache: Rc<RefCell<SieveCache<K, V>>>,
 }
 
 impl<K, V> std::fmt::Debug for Cache<K, V>
 where
-    K: Eq + Hash + Clone + ConditionalSend + ConditionalSync,
-    V: Clone + ConditionalSend + ConditionalSync,
+    K: Eq + Hash + Clone + ConditionalSync,
+    V: Clone + ConditionalSync,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Cache");
@@ -44,8 +47,8 @@ where
 
 impl<K, V> Default for Cache<K, V>
 where
-    K: Eq + Hash + Clone + ConditionalSend + ConditionalSync,
-    V: Clone + ConditionalSend + ConditionalSync,
+    K: Eq + Hash + Clone + ConditionalSync,
+    V: Clone + ConditionalSync,
 {
     fn default() -> Self {
         Self::new()

--- a/rust/dialog-search-tree/src/delta.rs
+++ b/rust/dialog-search-tree/src/delta.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use std::sync::Arc;
 
 use hashbrown::HashMap;
@@ -6,7 +6,7 @@ use hashbrown::HashMap;
 /// A thread-safe accumulator of pending changes to tree nodes.
 #[derive(Clone, Debug)]
 pub struct Delta<K, V> {
-    contents: Arc<Mutex<HashMap<K, V>>>,
+    contents: Arc<RwLock<HashMap<K, V>>>,
 }
 
 impl<K, V> Delta<K, V>
@@ -24,13 +24,13 @@ where
     /// Creates a new delta that contains a copy of this delta's contents.
     pub fn branch(&self) -> Self {
         Self {
-            contents: Arc::new(Mutex::new(self.contents.lock().clone())),
+            contents: Arc::new(RwLock::new(self.contents.read().clone())),
         }
     }
 
     /// Adds a key-value pair to this delta.
     pub fn add(&mut self, key: K, value: V) {
-        let mut contents = self.contents.lock();
+        let mut contents = self.contents.write();
         contents.insert(key.clone(), value);
     }
 
@@ -39,24 +39,24 @@ where
     where
         Entries: Iterator<Item = (K, V)>,
     {
-        let mut contents = self.contents.lock();
+        let mut contents = self.contents.write();
         for (key, value) in entries {
             contents.insert(key.clone(), value);
         }
     }
 
     /// Removes a key from this delta.
-    pub fn subtract(&mut self, key: &K) {
-        let mut contents = self.contents.lock();
+    pub fn remove(&mut self, key: &K) {
+        let mut contents = self.contents.write();
         contents.remove(key);
     }
 
     /// Removes multiple keys from this delta.
-    pub fn subtract_all<'a, Keys>(&'a mut self, keys: Keys)
+    pub fn remove_all<'a, Keys>(&'a mut self, keys: Keys)
     where
         Keys: Iterator<Item = &'a K>,
     {
-        let mut contents = self.contents.lock();
+        let mut contents = self.contents.write();
         for key in keys {
             contents.remove(key);
         }
@@ -64,13 +64,23 @@ where
 
     /// Retrieves the value associated with a key from this delta.
     pub fn get(&self, key: &K) -> Option<V> {
-        let contents = self.contents.lock();
+        let contents = self.contents.write();
         contents.get(key).cloned()
+    }
+
+    /// Returns the number of entries currently in this delta.
+    pub fn len(&self) -> usize {
+        self.contents.read().len()
+    }
+
+    /// Returns `true` if this delta has no pending entries.
+    pub fn is_empty(&self) -> bool {
+        self.contents.read().is_empty()
     }
 
     /// Drains all entries from this delta and returns them as an iterator.
     pub fn flush(&mut self) -> impl Iterator<Item = (K, V)> {
-        std::mem::take(&mut *self.contents.lock()).into_iter()
+        std::mem::take(&mut *self.contents.write()).into_iter()
     }
 }
 
@@ -161,7 +171,7 @@ mod tests {
         assert_eq!(delta.get(&1), Some("value1".to_string()));
         assert_eq!(delta.get(&2), Some("value2".to_string()));
 
-        delta.subtract(&1);
+        delta.remove(&1);
 
         assert_eq!(delta.get(&1), None);
         assert_eq!(delta.get(&2), Some("value2".to_string()));
@@ -176,7 +186,7 @@ mod tests {
         delta.add(1, "value1".to_string());
 
         // Subtracting non-existent key should not panic
-        delta.subtract(&999);
+        delta.remove(&999);
 
         assert_eq!(delta.get(&1), Some("value1".to_string()));
 
@@ -193,7 +203,7 @@ mod tests {
         delta.add(4, "value4".to_string());
 
         let keys_to_remove = [1, 3];
-        delta.subtract_all(keys_to_remove.iter());
+        delta.remove_all(keys_to_remove.iter());
 
         assert_eq!(delta.get(&1), None);
         assert_eq!(delta.get(&2), Some("value2".to_string()));
@@ -218,7 +228,7 @@ mod tests {
 
         // Modify delta2
         delta2.add(3, "value3".to_string());
-        delta2.subtract(&1);
+        delta2.remove(&1);
 
         // Verify delta1 is unchanged
         assert_eq!(delta1.get(&1), Some("value1".to_string()));
@@ -318,7 +328,7 @@ mod tests {
         delta.add(2, "updated2".to_string());
 
         // Remove one
-        delta.subtract(&1);
+        delta.remove(&1);
 
         // Add more
         delta.add(4, "value4".to_string());
@@ -347,7 +357,7 @@ mod tests {
         assert_eq!(delta.get(&key1), Some(value1));
         assert_eq!(delta.get(&key2), Some(value2));
 
-        delta.subtract(&key1);
+        delta.remove(&key1);
         assert_eq!(delta.get(&key1), None);
         assert_eq!(delta.get(&key2), Some(vec![5, 6, 7, 8]));
 
@@ -370,7 +380,7 @@ mod tests {
 
         // Remove every other entry
         for i in (0..1000).step_by(2) {
-            delta.subtract(&i);
+            delta.remove(&i);
         }
 
         // Verify removals

--- a/rust/dialog-search-tree/src/error.rs
+++ b/rust/dialog-search-tree/src/error.rs
@@ -4,10 +4,6 @@ use thiserror::Error;
 /// Errors that can occur when working with search trees.
 #[derive(Error, Debug)]
 pub enum DialogSearchTreeError {
-    /// An error that occurs when working with a tree entry.
-    #[error("Problem with tree entry: {0}")]
-    Entry(String),
-
     /// An error that occurs when accessing a node.
     #[error("Problem accessing node: {0}")]
     Node(String),

--- a/rust/dialog-search-tree/src/kv.rs
+++ b/rust/dialog-search-tree/src/kv.rs
@@ -1,3 +1,4 @@
+use dialog_common::ConditionalSend;
 use rkyv::Archive;
 use std::fmt::Debug;
 
@@ -7,7 +8,17 @@ use crate::SymmetryWith;
 ///
 /// Keys must be fixed-size, comparable, and serializable.
 pub trait Key:
-    Clone + Debug + Sized + AsRef<[u8]> + std::hash::Hash + PartialOrd + Ord + PartialEq + Eq + Archive
+    Clone
+    + Debug
+    + Sized
+    + AsRef<[u8]>
+    + std::hash::Hash
+    + PartialOrd
+    + Ord
+    + PartialEq
+    + Eq
+    + Archive
+    + ConditionalSend
 where
     Self: PartialOrd<Self::Archived>,
     Self::Archived: PartialOrd<Self> + PartialEq<Self> + SymmetryWith<Self> + Ord,
@@ -39,6 +50,6 @@ impl<const N: usize> SymmetryWith<[u8; N]> for [u8; N] {}
 /// Trait for types that can be used as values in a search tree.
 ///
 /// Values must be cloneable and serializable.
-pub trait Value: Clone + Debug + Sized + Archive {}
+pub trait Value: Clone + Debug + Sized + Archive + ConditionalSend {}
 
 impl Value for Vec<u8> {}

--- a/rust/dialog-search-tree/src/lib.rs
+++ b/rust/dialog-search-tree/src/lib.rs
@@ -114,6 +114,9 @@
 //! # })
 //! ```
 
+mod accessor;
+pub use accessor::*;
+
 mod buffer;
 pub use buffer::*;
 

--- a/rust/dialog-search-tree/src/link.rs
+++ b/rust/dialog-search-tree/src/link.rs
@@ -1,3 +1,4 @@
+use crate::{Key, SymmetryWith};
 use dialog_common::Blake3Hash;
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -11,4 +12,15 @@ pub struct Link<Key> {
     pub upper_bound: Key,
     /// The [`Blake3Hash`] of the referenced node.
     pub node: Blake3Hash,
+}
+
+impl<Key> Link<Key>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+{
+    /// Computes the [`Blake3Hash`] of the entry's key.
+    pub fn upper_bound_hash(&self) -> Blake3Hash {
+        Blake3Hash::hash(self.upper_bound.as_ref())
+    }
 }

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -5,9 +5,10 @@
 //! from the read-only [`Tree`] interface, we achieve clearer separation of
 //! concerns and make the codebase more maintainable.
 
-use std::marker::PhantomData;
+use std::{collections::VecDeque, marker::PhantomData};
 
 use dialog_common::Blake3Hash;
+use hashbrown::HashMap;
 use nonempty::NonEmpty;
 use rkyv::{
     Deserialize, Serialize,
@@ -20,12 +21,74 @@ use rkyv::{
 };
 
 use crate::{
-    Buffer, Delta, DialogSearchTreeError, Entry, Key, Link, Node, NodeBody, Rank, SearchResult,
-    Segment, SymmetryWith, TreeLayer, Value, distribution, into_owned,
+    Buffer, Delta, DialogSearchTreeError, Entry, Key, Link, Node, NodeBody, Rank, RightNeighbor,
+    SearchResult, Segment, SymmetryWith, TreeLayer, Value, distribution, into_owned,
 };
 
 /// A collection of nodes with their ranks.
 type RankedNodes<Key, Value> = NonEmpty<(Node<Key, Value>, Rank)>;
+
+const BOTTOM_RANK: Rank = 1;
+
+/// The stateful side-effects of tree mutations are compartmentalized
+/// to a MutationContext. Key ranking is intermediated by the MutationContext
+/// so that ranks may be cached by key (avoiding redundant hashing and rank
+/// computation). Ideally this rank cache would be kept at a higher layer of
+/// abstraction so that it could be shared across mutations, but holding the
+/// cache in the mutation context is a low-hanging fruit.
+struct MutationContext<Key>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + crate::SymmetryWith<Key> + Ord,
+{
+    delta: Delta<Blake3Hash, Buffer>,
+    rank_cache: HashMap<Key, Rank>,
+}
+
+impl<Key> MutationContext<Key>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + crate::SymmetryWith<Key> + Ord,
+{
+    pub fn new(delta: Delta<Blake3Hash, Buffer>) -> Self {
+        Self {
+            delta,
+            rank_cache: HashMap::new(),
+        }
+    }
+
+    pub fn rank(&mut self, key: &Key) -> Rank {
+        if let Some(rank) = self.rank_cache.get(key) {
+            *rank
+        } else {
+            let key_hash = Blake3Hash::hash(key.as_ref());
+            let rank = distribution::geometric::rank(&key_hash);
+            self.rank_cache.insert(key.clone(), rank);
+            rank
+        }
+    }
+
+    pub fn delta(&mut self) -> &mut Delta<Blake3Hash, Buffer> {
+        &mut self.delta
+    }
+
+    pub fn take_delta(self) -> Delta<Blake3Hash, Buffer> {
+        self.delta
+    }
+}
+
+impl<Key> From<MutationContext<Key>> for Delta<Blake3Hash, Buffer>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + crate::SymmetryWith<Key> + Ord,
+{
+    fn from(value: MutationContext<Key>) -> Self {
+        value.delta
+    }
+}
 
 /// Handles tree construction and modification operations.
 ///
@@ -96,7 +159,7 @@ where
     /// 1. Extracts the entries from the segment
     /// 2. Performs binary search to find insertion point or existing key
     /// 3. Inserts the new entry or updates existing value
-    /// 4. Ranks all entries and distributes them into new nodes
+    /// 4. Redistributes all entries by their intrinsic ranks
     /// 5. Rebuilds the tree path up to the root
     ///
     /// For empty trees, it simply creates a single-entry segment.
@@ -108,16 +171,14 @@ where
         new_entry: Entry<Key, Value>,
         search_result: Option<SearchResult<Key, Value>>,
     ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        let new_entry_key = &new_entry.key;
+
         let (entries, search_result) = match search_result {
             Some(search_result) => {
-                let key = new_entry.key.to_owned();
-                let segment = search_result.leaf.as_segment()?;
+                let segment = into_owned::<Segment<Key, Value>>(search_result.leaf.as_segment()?)?;
+                let mut entries: Vec<Entry<Key, Value>> = segment.entries;
 
-                // Extract and modify entries
-                let mut entries: Vec<Entry<Key, Value>> =
-                    into_owned::<Segment<Key, Value>>(segment)?.entries;
-
-                match entries.binary_search_by(|probe| probe.key.cmp(&key)) {
+                match entries.binary_search_by(|probe| probe.key.cmp(new_entry_key)) {
                     // Entry was found; update the value.
                     Ok(index) => {
                         let Some(previous_entry) = entries.get_mut(index) else {
@@ -142,44 +203,35 @@ where
 
                 (entries, Some(search_result))
             }
-            None => {
-                // Empty tree; just a single entry
-                (NonEmpty::singleton(new_entry), None)
-            }
+
+            None => (NonEmpty::singleton(new_entry), None),
         };
 
-        // Rank the entries and distribute
-        let next_entries = entries
-            .into_iter()
-            .map(|entry| {
-                let rank = distribution::geometric::rank(&Blake3Hash::hash(entry.key.as_ref()));
-                (entry, rank)
-            })
-            .collect::<Vec<_>>();
-
-        let Some(next_entries) = NonEmpty::from_vec(next_entries) else {
-            return Err(DialogSearchTreeError::Operation(
-                "Insertion resulted in empty set of entries".into(),
-            ));
-        };
-
-        self.distribute(next_entries, search_result)
+        self.distribute(entries, search_result)
     }
 
     /// Removes an entry from the tree, returning the new root hash and delta.
     ///
     /// This method takes a search result pointing to the leaf segment
-    /// containing the key to remove. It handles three cases:
+    /// containing the key to remove. It handles four cases:
     ///
     /// 1. **Key doesn't exist in segment**: Returns the current root unchanged
     ///    with the original delta (no-op).
     ///
-    /// 2. **Segment still has entries after removal**: Creates a new segment
-    ///    with the remaining entries (no redistribution needed since ranks
-    ///    haven't changed), and updates the tree path with new hashes.
-    ///
-    /// 3. **Segment becomes empty**: Removes the empty segment by merging its
+    /// 2. **Segment becomes empty**: Removes the empty segment by merging its
     ///    siblings at the parent level, then rebuilds the tree upward.
+    ///
+    /// 3. **Boundary-delete overflow**: The deleted entry was the segment's
+    ///    last entry (its boundary), the segment still has orphan entries, and
+    ///    a right-adjacent segment exists. The orphans are merged with the
+    ///    right-adjacent segment's entries; the combined list is redistributed
+    ///    and the two affected subtrees are stitched back together at their
+    ///    lowest common ancestor. Requires the `right_neighbor` prefetch on
+    ///    the search result.
+    ///
+    /// 4. **Ordinary shrink**: The segment still has entries after removal and
+    ///    there is no overflow. The remaining entries are redistributed using
+    ///    their intrinsic ranks and the tree path is rebuilt.
     pub fn delete(
         self,
         key: &Key,
@@ -198,68 +250,226 @@ where
             }
         };
 
+        let entry_count = segment.entries.len();
+        let deleted_boundary = removal_index == entry_count - 1;
+
         let mut segment = into_owned::<Segment<Key, Value>>(segment)?;
         segment.entries.remove(removal_index);
 
-        if !segment.entries.is_empty() {
-            // Still have entries; create new segment and merge up the path
-            let new_segment_node = Node::<Key, Value>::new(Buffer::from(
-                NodeBody::try_from(segment.entries)?.as_bytes()?,
-            ));
-
-            let mut delta = self.delta.branch();
-            delta.subtract(search_result.leaf.hash());
-
-            Self::merge_with_path(
-                NonEmpty::singleton((new_segment_node, 1)),
+        // Boundary-delete with non-empty orphans and a right-adjacent segment
+        // triggers overflow: the orphans must fold into the next segment so
+        // the resulting tree matches a from-scratch build.
+        if deleted_boundary
+            && !segment.entries.is_empty()
+            && let Some(right_neighbor) = search_result.right_neighbor
+        {
+            let main_leaf_hash = search_result.leaf.hash().clone();
+            return self.absorb_orphans_into_right_neighbor(
+                segment.entries,
+                main_leaf_hash,
                 search_result.path,
-                delta,
-            )
-        } else {
-            // Segment is now empty; remove it from parent
-            self.remove_from_path(search_result.path)
+                right_neighbor,
+            );
+        }
+
+        match NonEmpty::from_vec(segment.entries) {
+            Some(entries) => self.distribute(entries, Some(search_result)),
+            None => self.remove_from_path(search_result.path),
         }
     }
 
-    /// Distributes children into a new tree structure based on their ranks,
+    /// Resolves a boundary-delete overflow using the prefetched right-adjacent
+    /// segment.
+    ///
+    /// See case (3) in [`Self::delete`] for the high-level contract.
+    ///
+    /// Key invariant: when a rank-R entry is deleted, it was simultaneously a
+    /// boundary at levels 0..R-2, and each of those boundaries dissolves. At
+    /// every level below the LCA, the main subtree's rebuild and the
+    /// right-adjacent subtree's rebuild therefore fuse into a *single* index
+    /// rather than remaining as siblings. The tree above the LCA is unaffected
+    /// and handed off to the standard merge routine.
+    ///
+    /// By construction of the search (main descent follows the boundary
+    /// rightward at every level; the right-adjacent descent takes leftmost
+    /// children) we can rely on:
+    /// - `main_layer.right_siblings == None` for every layer below the LCA, and
+    /// - `right_layer.left_siblings == None` for every layer below the LCA.
+    ///
+    /// The fold at each level is therefore just
+    /// `[main_layer.left_siblings | unified | right_layer.right_siblings]`.
+    fn absorb_orphans_into_right_neighbor(
+        self,
+        orphans: Vec<Entry<Key, Value>>,
+        main_leaf_hash: Blake3Hash,
+        main_path: Vec<TreeLayer<Key, Value>>,
+        right_neighbor: RightNeighbor<Key, Value>,
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        let RightNeighbor {
+            lca_depth,
+            diverged_path,
+            leaf: right_leaf,
+        } = right_neighbor;
+
+        let mut context = MutationContext::<Key>::new(self.delta.branch());
+
+        // Both original leaves are replaced; clear any lingering delta entries.
+        context.delta().remove(&main_leaf_hash);
+        context.delta().remove(right_leaf.hash());
+
+        // Merge orphans with the right-adjacent segment's entries and
+        // redistribute by intrinsic rank.
+        let right_segment = into_owned::<Segment<Key, Value>>(right_leaf.as_segment()?)?;
+        let mut combined_entries = orphans;
+        combined_entries.extend(right_segment.entries);
+        let combined = NonEmpty::from_vec(combined_entries).ok_or_else(|| {
+            DialogSearchTreeError::Operation("Overflow merge produced empty entry list".into())
+        })?;
+        let ranked = combined.map(|entry| {
+            let rank = context.rank(&entry.key);
+            (entry, rank)
+        });
+        let mut unified = Self::collect::<Entry<Key, Value>>(ranked, BOTTOM_RANK)?;
+
+        // Split main_path into [above-LCA | LCA | below-LCA].
+        let mut above_and_lca = main_path;
+        let main_below = above_and_lca.split_off(lca_depth + 1);
+        let lca_layer = above_and_lca.pop().ok_or_else(|| {
+            DialogSearchTreeError::Operation("Main path was shorter than lca_depth".into())
+        })?;
+        let above_lca = above_and_lca;
+
+        // Fuse the two subtrees level-by-level below the LCA. At every such
+        // level the boundary that separated them has dissolved, so their
+        // children flatten into one unified index.
+        //
+        // Nodes live at level 0 after the entry merge; building a level-1
+        // parent uses minimum_rank 2 (level L uses minimum_rank L + 1).
+        let mut level_minimum_rank: Rank = 2;
+        for (main_layer, right_layer) in main_below
+            .into_iter()
+            .rev()
+            .zip(diverged_path.into_iter().rev())
+        {
+            context.delta().remove(main_layer.host.hash());
+            context.delta().remove(right_layer.host.hash());
+
+            debug_assert!(
+                main_layer.right_siblings.is_none(),
+                "main descent follows the rightmost path; no right siblings below LCA"
+            );
+            debug_assert!(
+                right_layer.left_siblings.is_none(),
+                "right-adjacent descent is leftmost; no left siblings below LCA"
+            );
+
+            let unified_links = promote_to_ranked_links(unified, &mut context)?;
+
+            let mut parts: Vec<NonEmpty<(Link<Key>, Rank)>> = Vec::new();
+            if let Some(left) = main_layer.left_siblings {
+                parts.push(into_ranked_links(left, &mut context));
+            }
+            parts.push(unified_links);
+            if let Some(right) = right_layer.right_siblings {
+                parts.push(into_ranked_links(right, &mut context));
+            }
+
+            let combined_links = concat_nonempty(parts)?;
+            unified = Self::collect::<Link<_>>(combined_links, level_minimum_rank)?;
+            level_minimum_rank += 1;
+        }
+
+        // At the LCA, the first right sibling was the right-descent target; it
+        // has been subsumed by the unified subtree. The remaining right
+        // siblings stay as peers of the unified subtree at this level.
+        let right_siblings_at_lca = lca_layer.right_siblings.ok_or_else(|| {
+            DialogSearchTreeError::Operation(
+                "LCA layer had no right siblings during overflow".into(),
+            )
+        })?;
+        let modified_right_siblings =
+            NonEmpty::from_vec(right_siblings_at_lca.into_iter().skip(1).collect());
+
+        let lca_has_own_siblings =
+            lca_layer.left_siblings.is_some() || modified_right_siblings.is_some();
+
+        if !lca_has_own_siblings {
+            // The LCA's only children were the main- and right-descent targets;
+            // both were subsumed by the unified subtree. The LCA node itself
+            // disappears from the canonical tree.
+            context.delta().remove(lca_layer.host.hash());
+
+            if above_lca.is_empty() {
+                // The LCA was the tree root; the unified subtree is the new
+                // root. Forcing another collect here would inject an extra
+                // level (a 1-child index) that never appears in a from-scratch
+                // build.
+                context.delta().add_all(
+                    unified
+                        .iter()
+                        .map(|(n, _)| (n.hash().clone(), n.buffer().clone())),
+                );
+                return Ok((unified.head.0.hash().clone(), context.take_delta()));
+            }
+
+            // Promote the unified subtree to the LCA's level so it can slot
+            // into the LCA's parent as a replacement child, then continue the
+            // normal upward merge.
+            let unified_links = promote_to_ranked_links(unified, &mut context)?;
+            let promoted = Self::collect::<Link<_>>(unified_links, level_minimum_rank)?;
+            return Self::merge_with_path(promoted, above_lca, context, level_minimum_rank + 1);
+        }
+
+        // LCA has genuine siblings: rebuild the LCA around the unified subtree
+        // and the preserved siblings, then hand off to the standard merge.
+        let modified_lca_layer = TreeLayer {
+            host: lca_layer.host,
+            left_siblings: lca_layer.left_siblings,
+            right_siblings: modified_right_siblings,
+        };
+        let mut final_path = above_lca;
+        final_path.push(modified_lca_layer);
+
+        Self::merge_with_path(unified, final_path, context, level_minimum_rank)
+    }
+
+    /// Redistributes a non-empty list of entries into a new tree structure,
     /// rebuilding the path from leaves to root.
     ///
-    /// This is the core method for tree construction and modification. It takes
-    /// a collection of ranked children (either entries or links) and organizes
-    /// them into a tree hierarchy where node boundaries are determined by the
-    /// rank distribution.
+    /// This is the core method for tree construction and modification. It
+    /// computes each entry's intrinsic rank (via the [`MutationContext`] cache),
+    /// groups entries into leaf segments via [`Self::collect`], and then
+    /// propagates the new segments up the search path, merging with unchanged
+    /// sibling links at each level.
     ///
-    /// The algorithm proceeds in iterations:
-    /// 1. Collect children into nodes where ranks exceed the current minimum
-    /// 2. Convert nodes to links and merge with siblings from the search path
-    /// 3. Increment the minimum rank and repeat until a single root is formed
-    ///
-    /// When a search result is provided, the method reconstructs only the
-    /// affected path through the tree, merging new nodes with unchanged sibling
-    /// references. This enables efficient structural sharing where unmodified
-    /// portions of the tree remain unchanged.
+    /// When a `search_result` is provided, only the affected path is rebuilt;
+    /// unchanged subtrees are preserved by reference for structural sharing.
+    /// When `None`, the input entries become the first segment of a new tree.
     ///
     /// Returns the new root hash and a delta containing all newly created
     /// nodes.
-    fn distribute<Child>(
+    fn distribute(
         self,
-        children: NonEmpty<(Child, Rank)>,
+        entries: NonEmpty<Entry<Key, Value>>,
         search_result: Option<SearchResult<Key, Value>>,
-    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError>
-    where
-        NodeBody<Key, Value>: TryFrom<Vec<Child>, Error = DialogSearchTreeError>,
-    {
-        let nodes = Self::collect(children, 1)?;
+    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
+        let mut context = MutationContext::<Key>::new(self.delta.branch());
+        let ranked_entries = entries.map(|entry| {
+            let rank = context.rank(&entry.key);
+            (entry, rank)
+        });
+        let nodes = Self::collect(ranked_entries, BOTTOM_RANK)?;
 
-        let mut delta = self.delta.branch();
         let search_path = if let Some(search_result) = search_result {
-            delta.subtract(search_result.leaf.hash());
+            context.delta().remove(search_result.leaf.hash());
             search_result.path
         } else {
             vec![]
         };
 
-        Self::merge_with_path(nodes, search_path, delta)
+        // Nodes start at level 0 (segments); the first level-up collect uses
+        // minimum_rank 2 (the level-1 threshold).
+        Self::merge_with_path(nodes, search_path, context, 2)
     }
 
     /// Merges a collection of nodes with a search path, rebuilding from leaves
@@ -273,19 +483,27 @@ where
     /// 3. Collects the merged links into new nodes based on rank
     /// 4. Continues until a single root node is formed
     ///
+    /// Sibling link ranks are recomputed from their `upper_bound` keys via the
+    /// supplied [`MutationContext`], so the rank cache is reused across levels
+    /// when the same boundary key appears more than once.
+    ///
+    /// `initial_level_minimum_rank` is the rank threshold to apply at the first
+    /// level of the walk. Callers that start from raw leaf segments pass `2`;
+    /// the overflow path passes a higher value when it picks up mid-walk.
+    ///
     /// This is the shared path-reconstruction logic used by both insert (after
     /// distributing entries) and delete (after modifying a segment).
-    pub fn merge_with_path(
+    fn merge_with_path(
         mut nodes: NonEmpty<(Node<Key, Value>, Rank)>,
         mut search_path: Vec<TreeLayer<Key, Value>>,
-        mut delta: Delta<Blake3Hash, Buffer>,
+        mut context: MutationContext<Key>,
+        initial_level_minimum_rank: Rank,
     ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
-        const MINIMUM_RANK: u32 = 2;
-        let mut minimum_rank = MINIMUM_RANK;
+        let mut level_minimum_rank = initial_level_minimum_rank;
 
         loop {
             let links = {
-                delta.add_all(
+                context.delta().add_all(
                     nodes
                         .iter()
                         .map(|(node, _)| (node.hash().clone(), node.buffer().clone())),
@@ -302,13 +520,13 @@ where
 
                 match search_path.pop() {
                     Some(layer) => {
-                        delta.subtract(layer.host.hash());
-                        // TBD if we must recompute rank for siblings references
-                        // when building up the tree. Attempt to try setting
-                        // rank to `0` for references outside of the modified
-                        // path.
-                        let ranked_left_siblings = layer.left_siblings.map(into_ranked_links);
-                        let ranked_right_siblings = layer.right_siblings.map(into_ranked_links);
+                        context.delta().remove(layer.host.hash());
+                        let ranked_left_siblings = layer
+                            .left_siblings
+                            .map(|links| into_ranked_links(links, &mut context));
+                        let ranked_right_siblings = layer
+                            .right_siblings
+                            .map(|links| into_ranked_links(links, &mut context));
 
                         match (ranked_left_siblings, ranked_right_siblings) {
                             (None, None) => ranked_links,
@@ -331,22 +549,22 @@ where
                 }
             };
 
-            nodes = Self::collect::<Link<_>>(links, minimum_rank)?;
+            nodes = Self::collect::<Link<_>>(links, level_minimum_rank)?;
 
             if search_path.is_empty() && nodes.len() == 1 {
                 break;
             }
 
-            minimum_rank += 1;
+            level_minimum_rank += 1;
         }
 
-        delta.add_all(
+        context.delta().add_all(
             nodes
                 .iter()
                 .map(|(node, _)| (node.hash().clone(), node.buffer().clone())),
         );
 
-        Ok((nodes.head.0.hash().to_owned(), delta))
+        Ok((nodes.head.0.hash().to_owned(), context.take_delta()))
     }
 
     /// Removes a segment from the tree when it becomes empty after deletion.
@@ -362,29 +580,29 @@ where
         self,
         path: Vec<TreeLayer<Key, Value>>,
     ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
-        let delta = self.delta.branch();
+        let context = MutationContext::<Key>::new(self.delta.branch());
 
-        Self::remove_from_path_with_delta(path, delta)
+        Self::remove_from_path_with_context(path.into(), context)
     }
 
-    /// Internal helper for `remove_from_path` that works with a delta directly.
+    /// Internal helper for `remove_from_path` that works with a
+    /// [`MutationContext`] directly.
     ///
-    /// This allows recursive calls to reuse the same delta without
-    /// re-branching.
-    fn remove_from_path_with_delta(
-        mut path: Vec<TreeLayer<Key, Value>>,
-        mut delta: Delta<Blake3Hash, Buffer>,
+    /// Takes a [`VecDeque`] rather than [`Vec`] so recursive/cascading removal
+    /// can `pop_front` each layer in O(1); a `Vec::remove(0)` here would push
+    /// the shift cost to O(H²) across a chain of collapsed ancestors.
+    fn remove_from_path_with_context(
+        mut path: VecDeque<TreeLayer<Key, Value>>,
+        mut context: MutationContext<Key>,
     ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
         use dialog_common::NULL_BLAKE3_HASH;
 
         // If there's no parent, the tree becomes empty
-        if path.is_empty() {
+        let Some(layer) = path.pop_front() else {
             return Ok((NULL_BLAKE3_HASH.clone(), Delta::zero()));
-        }
+        };
 
-        let layer = path.remove(0); // Take the parent layer
-
-        delta.subtract(layer.host.hash());
+        context.delta().remove(layer.host.hash());
 
         // Collect left and right siblings, excluding the removed segment
         let mut links = Vec::new();
@@ -402,33 +620,27 @@ where
         // If no siblings remain, propagate the removal upward
         if links.is_empty() {
             return if path.is_empty() {
-                Ok((NULL_BLAKE3_HASH.clone(), delta))
+                Ok((NULL_BLAKE3_HASH.clone(), context.take_delta()))
             } else {
-                // Continue removing up the path with the same delta
-                Self::remove_from_path_with_delta(path, delta)
+                // Continue removing up the path with the same context
+                Self::remove_from_path_with_context(path, context)
             };
         }
 
         // We have siblings; rebuild with them
-        let ranked_links = links
-            .into_iter()
-            .map(|link| {
-                let rank = distribution::geometric::rank(&link.node);
-                (link, rank)
-            })
-            .collect::<Vec<_>>();
-
-        let Some(ranked_links) = NonEmpty::from_vec(ranked_links) else {
+        let Some(links) = NonEmpty::from_vec(links) else {
             return Err(DialogSearchTreeError::Node(
                 "Unexpectedly empty link list".into(),
             ));
         };
+        let ranked_links = into_ranked_links(links, &mut context);
 
         // Create nodes from the remaining links
         let nodes = Self::collect::<Link<_>>(ranked_links, 1)?;
 
-        // Merge up the remaining path
-        Self::merge_with_path(nodes, path, delta)
+        // Merge up the remaining path. `merge_with_path` pops from the back,
+        // so hand it back a `Vec` of the still-pending ancestors.
+        Self::merge_with_path(nodes, path.into(), context, 2)
     }
 
     /// Collects a sequence of ranked children into nodes based on a minimum
@@ -486,32 +698,534 @@ where
     }
 }
 
+/// Persists the given ranked nodes to the delta and converts them into ranked
+/// links, preserving the rank that was assigned by `collect`.
+///
+/// This is the shared helper used when a rebuild hands off its output up one
+/// level: the nodes become children of a new higher-level index, so we must
+/// both commit them to the delta (by hash) and convert them to links.
+fn promote_to_ranked_links<Key, Value>(
+    nodes: NonEmpty<(Node<Key, Value>, Rank)>,
+    context: &mut MutationContext<Key>,
+) -> Result<NonEmpty<(Link<Key>, Rank)>, DialogSearchTreeError>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key>
+        + PartialEq<Key>
+        + crate::SymmetryWith<Key>
+        + Ord
+        + for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+{
+    context.delta().add_all(
+        nodes
+            .iter()
+            .map(|(node, _)| (node.hash().clone(), node.buffer().clone())),
+    );
+    let links: Vec<(Link<Key>, Rank)> = nodes
+        .into_iter()
+        .map(|(node, rank)| node.to_link().map(|link| (link, rank)))
+        .collect::<Result<_, DialogSearchTreeError>>()?;
+    NonEmpty::from_vec(links).ok_or_else(|| DialogSearchTreeError::Node("Empty link list".into()))
+}
+
 /// Converts a collection of links into ranked links by computing each link's
 /// rank from its node hash.
-///
-/// This helper function is used when merging sibling references during tree
-/// reconstruction. The rank is computed using a geometric distribution over the
-/// node hash, ensuring consistent rank assignment for the same content.
-fn into_ranked_links<Key>(links: NonEmpty<Link<Key>>) -> NonEmpty<(Link<Key>, Rank)> {
+fn into_ranked_links<Key>(
+    links: NonEmpty<Link<Key>>,
+    context: &mut MutationContext<Key>,
+) -> NonEmpty<(Link<Key>, Rank)>
+where
+    Key: self::Key,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + crate::SymmetryWith<Key> + Ord,
+{
     links.map(|link| {
-        let rank = distribution::geometric::rank(&link.node);
+        let rank = context.rank(&link.upper_bound);
         (link, rank)
     })
 }
 
 /// Concatenates multiple non-empty lists into a single non-empty list.
-///
-/// This utility function flattens a vector of [`NonEmpty`] collections into a
-/// single [`NonEmpty`] collection. Returns an error if the input vector is
-/// empty.
-///
-/// Used during tree reconstruction when merging left siblings, modified nodes,
-/// and right siblings into a single collection for the next level of the tree.
-///
+//
 /// TODO: Improve. Possibly remove NonEmpty as it introduces some overhead
 /// compared to index comparison with slices.
 fn concat_nonempty<T>(list: Vec<NonEmpty<T>>) -> Result<NonEmpty<T>, DialogSearchTreeError> {
     Ok(NonEmpty::flatten(NonEmpty::from_vec(list).ok_or(
         DialogSearchTreeError::Node("Empty child list".into()),
     )?))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use anyhow::Result;
+    use dialog_common::Blake3Hash;
+    use dialog_storage::MemoryStorageBackend;
+    use nonempty::NonEmpty;
+
+    use super::TreeShaper;
+    use crate::{ContentAddressedStorage, Entry, Rank, Tree, distribution, into_owned};
+
+    type TestTree = Tree<[u8; 4], Vec<u8>>;
+    type TestStorage = ContentAddressedStorage<MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    /// Compute the prolly-tree rank for a key given as a u32.
+    fn rank_of(key: u32) -> Rank {
+        distribution::geometric::rank(&Blake3Hash::hash(&key.to_le_bytes()))
+    }
+
+    /// Return keys in `range` that act as segment boundaries (rank > 1).
+    fn boundary_keys(range: std::ops::Range<u32>) -> Vec<u32> {
+        range.filter(|&i| rank_of(i) > 1).collect()
+    }
+
+    /// Return keys in `range` that are NOT segment boundaries (rank <= 1).
+    fn interior_keys(range: std::ops::Range<u32>) -> Vec<u32> {
+        range.filter(|&i| rank_of(i) <= 1).collect()
+    }
+
+    /// Build a tree by inserting the given keys in order, then flush.
+    async fn build_and_flush(keys: &[u32], storage: &mut TestStorage) -> Result<TestTree> {
+        let mut tree = TestTree::empty();
+        for &k in keys {
+            tree = tree
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), storage)
+                .await?;
+        }
+        for (hash, buf) in tree.flush() {
+            storage.store(buf.as_ref().to_vec(), &hash).await?;
+        }
+        Ok(tree)
+    }
+
+    #[dialog_common::test]
+    async fn it_partitions_entries_at_rank_boundaries() -> Result<()> {
+        let entries: Vec<_> = (0..1000u32)
+            .map(|i| {
+                let key = i.to_le_bytes();
+                let rank = rank_of(i);
+                (
+                    Entry {
+                        key,
+                        value: vec![i as u8],
+                    },
+                    rank,
+                )
+            })
+            .collect();
+
+        let boundary_count = entries.iter().filter(|(_, r)| *r > 1).count();
+        assert!(boundary_count > 0, "Need at least one boundary in 0..1000");
+
+        let nodes = TreeShaper::<[u8; 4], Vec<u8>>::collect(
+            NonEmpty::from_vec(entries.clone()).unwrap(),
+            1,
+        )?;
+
+        // One segment per boundary, plus a trailing segment when the
+        // last entry is not itself a boundary.
+        let last_is_boundary = entries.last().map(|(_, r)| *r > 1).unwrap_or(false);
+        let expected = if last_is_boundary {
+            boundary_count
+        } else {
+            boundary_count + 1
+        };
+        assert_eq!(nodes.len(), expected, "Wrong number of segments");
+
+        // Non-trailing segments carry the rank of their boundary entry
+        // (> 1). The trailing segment receives rank = minimum_rank = 1.
+        for (i, (_, rank)) in nodes.iter().enumerate() {
+            if i < nodes.len() - 1 || last_is_boundary {
+                assert!(
+                    *rank > 1,
+                    "Segment {i} should end with a boundary (rank > 1), got {rank}"
+                );
+            } else {
+                assert_eq!(*rank, 1, "Trailing segment should have rank = minimum_rank");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_entry_order_within_and_across_segments() -> Result<()> {
+        // Build entries sorted by [u8; 4] byte order (not u32 order),
+        // since the tree's key comparison is lexicographic on bytes.
+        let mut keys: Vec<[u8; 4]> = (0..500u32).map(|i| i.to_le_bytes()).collect();
+        keys.sort();
+
+        let entries: Vec<_> = keys
+            .iter()
+            .map(|key| {
+                let rank = distribution::geometric::rank(&Blake3Hash::hash(key));
+                (
+                    Entry {
+                        key: *key,
+                        value: key.to_vec(),
+                    },
+                    rank,
+                )
+            })
+            .collect();
+
+        let nodes =
+            TreeShaper::<[u8; 4], Vec<u8>>::collect(NonEmpty::from_vec(entries).unwrap(), 1)?;
+
+        let mut prev_upper: Option<[u8; 4]> = None;
+        for (node, _) in nodes.iter() {
+            let segment = node.as_segment()?;
+
+            // Entries within a segment must be sorted.
+            for pair in segment.entries.windows(2) {
+                assert!(pair[0].key < pair[1].key);
+            }
+
+            // Segments must not overlap and must be in ascending order.
+            if let (Some(prev), Some(first)) = (prev_upper, segment.entries.first()) {
+                let first_key: [u8; 4] = into_owned(&first.key)?;
+                assert!(prev < first_key, "Segments must be in ascending key order");
+            }
+            if let Some(last) = segment.entries.last() {
+                prev_upper = Some(into_owned(&last.key)?);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_total_entry_count_across_segments() -> Result<()> {
+        let n = 1000u32;
+        let entries: Vec<_> = (0..n)
+            .map(|i| {
+                let key = i.to_le_bytes();
+                let rank = rank_of(i);
+                (
+                    Entry {
+                        key,
+                        value: i.to_le_bytes().to_vec(),
+                    },
+                    rank,
+                )
+            })
+            .collect();
+
+        let nodes =
+            TreeShaper::<[u8; 4], Vec<u8>>::collect(NonEmpty::from_vec(entries).unwrap(), 1)?;
+
+        let total: usize = nodes
+            .iter()
+            .map(|(node, _)| node.as_segment().unwrap().entries.len())
+            .sum();
+        assert_eq!(total, n as usize);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_after_deleting_a_boundary_entry() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let all_keys: Vec<u32> = (0..1000).collect();
+        let boundaries = boundary_keys(0..1000);
+        assert!(
+            boundaries.len() >= 2,
+            "Need at least 2 boundary keys for a meaningful test; got {}",
+            boundaries.len()
+        );
+
+        let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
+
+        for &bk in boundaries.iter().take(5) {
+            let mut tree_via_delete = full_tree.delete(&bk.to_le_bytes(), &storage).await?;
+            for (h, b) in tree_via_delete.flush() {
+                storage.store(b.as_ref().to_vec(), &h).await?;
+            }
+
+            let remaining: Vec<u32> = all_keys.iter().copied().filter(|&k| k != bk).collect();
+            let tree_from_scratch = build_and_flush(&remaining, &mut storage).await?;
+
+            assert_eq!(
+                tree_via_delete.root(),
+                tree_from_scratch.root(),
+                "Deleting boundary key {bk} should produce the same root \
+                 as building from scratch without it"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_after_deleting_a_non_boundary_entry() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let all_keys: Vec<u32> = (0..1000).collect();
+        let non_boundaries = interior_keys(0..1000);
+        assert!(!non_boundaries.is_empty());
+
+        let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
+
+        for &key in non_boundaries.iter().take(5) {
+            let mut tree_via_delete = full_tree.delete(&key.to_le_bytes(), &storage).await?;
+            for (h, b) in tree_via_delete.flush() {
+                storage.store(b.as_ref().to_vec(), &h).await?;
+            }
+
+            let remaining: Vec<u32> = all_keys.iter().copied().filter(|&k| k != key).collect();
+            let tree_from_scratch = build_and_flush(&remaining, &mut storage).await?;
+
+            assert_eq!(
+                tree_via_delete.root(),
+                tree_from_scratch.root(),
+                "Deleting non-boundary key {key} should produce the same root \
+                 as building from scratch without it"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_after_bulk_deletion() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let final_keys: Vec<u32> = (0..200).collect();
+        let extra_keys: Vec<u32> = (200..400).collect();
+
+        let mut all_keys = final_keys.clone();
+        all_keys.extend(&extra_keys);
+
+        let tree_direct = build_and_flush(&final_keys, &mut storage).await?;
+
+        let mut tree_pruned = build_and_flush(&all_keys, &mut storage).await?;
+        for &ek in &extra_keys {
+            tree_pruned = tree_pruned.delete(&ek.to_le_bytes(), &storage).await?;
+        }
+        for (h, b) in tree_pruned.flush() {
+            storage.store(b.as_ref().to_vec(), &h).await?;
+        }
+
+        assert_eq!(
+            tree_direct.root(),
+            tree_pruned.root(),
+            "Build-then-prune must converge to the same root as a direct build"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_restores_original_root_after_delete_then_reinsert() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let all_keys: Vec<u32> = (0..500).collect();
+        let mut original = build_and_flush(&all_keys, &mut storage).await?;
+
+        // Mix of boundary and non-boundary keys
+        let test_keys: Vec<u32> = {
+            let mut keys = boundary_keys(0..500);
+            keys.extend(interior_keys(0..500).into_iter().take(3));
+            keys.truncate(6);
+            keys
+        };
+
+        for &key in &test_keys {
+            let mut after_delete = original.delete(&key.to_le_bytes(), &storage).await?;
+            for (h, b) in after_delete.flush() {
+                storage.store(b.as_ref().to_vec(), &h).await?;
+            }
+
+            let mut restored = after_delete
+                .insert(key.to_le_bytes(), key.to_le_bytes().to_vec(), &storage)
+                .await?;
+            for (h, b) in restored.flush() {
+                storage.store(b.as_ref().to_vec(), &h).await?;
+            }
+
+            assert_eq!(
+                original.root(),
+                restored.root(),
+                "Delete then re-insert of key {key} should restore the original root"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_converges_to_same_root_regardless_of_operation_history() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        // History A: insert 0..100 directly
+        let tree_a = build_and_flush(&(0..100).collect::<Vec<_>>(), &mut storage).await?;
+
+        // History B: insert 0..200, then delete 100..200
+        let mut tree_b = build_and_flush(&(0..200).collect::<Vec<_>>(), &mut storage).await?;
+        for i in 100..200u32 {
+            tree_b = tree_b.delete(&i.to_le_bytes(), &storage).await?;
+        }
+        for (h, b) in tree_b.flush() {
+            storage.store(b.as_ref().to_vec(), &h).await?;
+        }
+
+        assert_eq!(
+            tree_a.root(),
+            tree_b.root(),
+            "Insert-only vs insert-then-delete must converge for the same entry set"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_after_emptying_a_segment() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        // Find a boundary key whose segment contains only one entry
+        // (the boundary itself). To guarantee this, look for adjacent
+        // boundary keys with no interior keys between them, or just
+        // find a boundary that is immediately preceded by another
+        // boundary.
+        let all_keys: Vec<u32> = (0..2000).collect();
+        let boundaries = boundary_keys(0..2000);
+
+        // Sort boundaries by byte order (same order as the tree)
+        let mut byte_boundaries: Vec<(u32, [u8; 4])> =
+            boundaries.iter().map(|&k| (k, k.to_le_bytes())).collect();
+        byte_boundaries.sort_by(|a, b| a.1.cmp(&b.1));
+
+        // Find a boundary that forms a single-entry segment:
+        // its predecessor in byte order is also a boundary.
+        let mut solo_boundary = None;
+        for pair in byte_boundaries.windows(2) {
+            let (_, prev_bytes) = pair[0];
+            let (curr_u32, curr_bytes) = pair[1];
+
+            // Count entries between prev and curr (exclusive) in byte order
+            let entries_between = all_keys
+                .iter()
+                .filter(|&&k| {
+                    let kb = k.to_le_bytes();
+                    kb > prev_bytes && kb < curr_bytes
+                })
+                .count();
+
+            if entries_between == 0 {
+                solo_boundary = Some(curr_u32);
+                break;
+            }
+        }
+
+        // If no single-entry segment exists, skip (unlikely with 2000 keys)
+        let Some(solo_key) = solo_boundary else {
+            return Ok(());
+        };
+
+        let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
+
+        let mut tree_via_delete = full_tree.delete(&solo_key.to_le_bytes(), &storage).await?;
+        for (h, b) in tree_via_delete.flush() {
+            storage.store(b.as_ref().to_vec(), &h).await?;
+        }
+
+        let remaining: Vec<u32> = all_keys
+            .iter()
+            .copied()
+            .filter(|&k| k != solo_key)
+            .collect();
+        let tree_from_scratch = build_and_flush(&remaining, &mut storage).await?;
+
+        assert_eq!(
+            tree_via_delete.root(),
+            tree_from_scratch.root(),
+            "Deleting sole entry in segment (key {solo_key}) should produce canonical tree"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_after_deleting_first_entry() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let all_keys: Vec<u32> = (0..1000).collect();
+
+        // The first key in byte-lexicographic order
+        let mut sorted: Vec<[u8; 4]> = all_keys.iter().map(|k| k.to_le_bytes()).collect();
+        sorted.sort();
+        let first_key = sorted[0];
+        let first_u32 = u32::from_le_bytes(first_key);
+
+        let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
+
+        let mut tree_via_delete = full_tree.delete(&first_key, &storage).await?;
+        for (h, b) in tree_via_delete.flush() {
+            storage.store(b.as_ref().to_vec(), &h).await?;
+        }
+
+        let remaining: Vec<u32> = all_keys
+            .iter()
+            .copied()
+            .filter(|&k| k != first_u32)
+            .collect();
+        let tree_from_scratch = build_and_flush(&remaining, &mut storage).await?;
+
+        assert_eq!(
+            tree_via_delete.root(),
+            tree_from_scratch.root(),
+            "Deleting first entry (key {first_u32}) should produce canonical tree"
+        );
+
+        Ok(())
+    }
+
+    /// Deleting the last entry (largest key in byte order) must
+    /// produce a canonical tree. The rightmost segment is always a
+    /// tail, so this verifies tails at the end are left intact.
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_after_deleting_last_entry() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let all_keys: Vec<u32> = (0..1000).collect();
+
+        let mut sorted: Vec<[u8; 4]> = all_keys.iter().map(|k| k.to_le_bytes()).collect();
+        sorted.sort();
+        let last_key = *sorted.last().unwrap();
+        let last_u32 = u32::from_le_bytes(last_key);
+
+        let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
+
+        let mut tree_via_delete = full_tree.delete(&last_key, &storage).await?;
+        for (h, b) in tree_via_delete.flush() {
+            storage.store(b.as_ref().to_vec(), &h).await?;
+        }
+
+        let remaining: Vec<u32> = all_keys
+            .iter()
+            .copied()
+            .filter(|&k| k != last_u32)
+            .collect();
+        let tree_from_scratch = build_and_flush(&remaining, &mut storage).await?;
+
+        assert_eq!(
+            tree_via_delete.root(),
+            tree_from_scratch.root(),
+            "Deleting last entry (key {last_u32}) should produce canonical tree"
+        );
+
+        Ok(())
+    }
 }

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -5,7 +5,7 @@
 //! from the read-only [`Tree`] interface, we achieve clearer separation of
 //! concerns and make the codebase more maintainable.
 
-use std::{collections::VecDeque, marker::PhantomData};
+use std::marker::PhantomData;
 
 use dialog_common::Blake3Hash;
 use hashbrown::HashMap;
@@ -232,20 +232,26 @@ where
     /// 1. **Key doesn't exist in segment**: Returns the current root unchanged
     ///    with the original delta (no-op).
     ///
-    /// 2. **Segment becomes empty**: Removes the empty segment by merging its
-    ///    siblings at the parent level, then rebuilds the tree upward.
+    /// 2. **Boundary-delete overflow**: The deleted entry was the segment's
+    ///    last entry (its boundary) and a right-adjacent segment exists. The
+    ///    right-adjacent segment adopts the orphans (possibly none, when the
+    ///    deletion emptied the segment): the combined entries are
+    ///    redistributed and the two affected subtrees are stitched back
+    ///    together at their lowest common ancestor. Requires the
+    ///    `right_neighbor` prefetch on the search result. See
+    ///    `Self::let_right_neighbor_adopt_orphans`.
     ///
-    /// 3. **Boundary-delete overflow**: The deleted entry was the segment's
-    ///    last entry (its boundary), the segment still has orphan entries, and
-    ///    a right-adjacent segment exists. The right-adjacent segment adopts
-    ///    the orphans: the combined entries are redistributed and the two
-    ///    affected subtrees are stitched back together at their lowest common
-    ///    ancestor. Requires the `right_neighbor` prefetch on the search
-    ///    result. See `Self::let_right_neighbor_adopt_orphans`.
+    /// 3. **Rightmost segment becomes empty**: There is no right-adjacent
+    ///    segment to adopt anything, so the empty segment is removed from its
+    ///    parent and the tree is rebuilt upward.
     ///
     /// 4. **Ordinary shrink**: The segment still has entries after removal and
     ///    there is no overflow. The remaining entries are redistributed using
     ///    their intrinsic ranks and the tree path is rebuilt.
+    ///
+    /// A deletion can leave a stale chain of single-child index nodes at the
+    /// root (when the deleted key's rank was what demanded those levels);
+    /// callers must collapse it, see `Tree::collapse_root_chain`.
     pub fn delete(
         self,
         key: &Key,
@@ -270,13 +276,13 @@ where
         let mut segment = into_owned::<Segment<Key, Value>>(segment)?;
         segment.entries.remove(removal_index);
 
-        // Boundary-delete with non-empty orphans and a right-adjacent segment
-        // triggers overflow: the orphans must fold into the next segment so
-        // the resulting tree matches a from-scratch build.
-        if deleted_boundary
-            && !segment.entries.is_empty()
-            && let Some(right_neighbor) = search_result.right_neighbor
-        {
+        // Boundary-delete with a right-adjacent segment triggers overflow:
+        // the dissolved boundary demands fusion with the right-adjacent
+        // subtree so the resulting tree matches a from-scratch build. This
+        // applies even when the deletion emptied the segment (zero orphans):
+        // the boundary may have terminated index groups at several levels,
+        // and all of them fuse with their right-adjacent peers.
+        if deleted_boundary && let Some(right_neighbor) = search_result.right_neighbor {
             let main_leaf_hash = search_result.leaf.hash().clone();
             return self.let_right_neighbor_adopt_orphans(
                 segment.entries,
@@ -291,18 +297,25 @@ where
         // remaining entries redistribute in place), a boundary delete with no
         // right-adjacent segment (the segment was the rightmost in the tree,
         // so there is no neighbor to adopt the remaining entries and they
-        // redistribute in place), or a delete that emptied the segment
-        // entirely (the segment itself must be removed from its parent).
+        // redistribute in place), or a delete that emptied the rightmost
+        // segment entirely (the segment itself must be removed from its
+        // parent).
         match NonEmpty::from_vec(segment.entries) {
             Some(entries) => self.distribute(entries, Some(search_result)),
-            None => self.remove_from_path(search_result.path),
+            None => {
+                let main_leaf_hash = search_result.leaf.hash().clone();
+                self.remove_from_path(main_leaf_hash, search_result.path)
+            }
         }
     }
 
     /// Resolves a boundary-delete overflow by letting the prefetched
     /// right-adjacent segment adopt the orphaned entries.
     ///
-    /// See case (3) in [`Self::delete`] for the high-level contract.
+    /// See case (2) in [`Self::delete`] for the high-level contract. The
+    /// `orphans` list may be empty (the deletion emptied the segment); the
+    /// fusion below the lowest common ancestor is required regardless,
+    /// because it is driven by the dissolved boundary, not by the orphans.
     ///
     /// Throughout this method "LCA" stands for *lowest common ancestor*: the
     /// deepest node on the search path that is an ancestor of both the
@@ -460,16 +473,12 @@ where
             context.delta().remove(lca_layer.host.hash());
 
             if above_lca.is_empty() {
-                // The LCA was the tree root; the unified subtree is the new
-                // root. Forcing another collect here would inject an extra
-                // level (a 1-child index) that never appears in a from-scratch
-                // build.
-                context.delta().add_all(
-                    unified
-                        .iter()
-                        .map(|(n, _)| (n.hash().clone(), n.buffer().clone())),
-                );
-                return Ok((unified.head.0.hash().clone(), context.take_delta()));
+                // The LCA was the tree root; the unified subtree becomes the
+                // new root via the standard merge with nothing left to merge
+                // against. This can leave a stale single-child wrapper on
+                // top (the merge cannot know that nothing above demands the
+                // level); `Tree::collapse_root_chain` strips it.
+                return Self::merge_with_path(unified, vec![], context, level_minimum_rank);
             }
 
             // Promote the unified subtree to the LCA's level so it can slot
@@ -631,77 +640,61 @@ where
     /// Removes a segment from the tree when it becomes empty after deletion.
     ///
     /// This method handles the case where deleting an entry leaves a segment
-    /// with no entries. It removes the segment by merging its left and right
-    /// siblings at the parent level, then rebuilds the tree upward.
+    /// with no entries. It removes the segment from its parent (the deepest
+    /// layer of the path), regroups the parent's surviving children, and
+    /// rebuilds the tree upward.
     ///
     /// If the removed segment was the only child (no siblings), the removal
-    /// propagates upward. If it was the last segment in the entire tree, the
-    /// tree becomes empty.
+    /// cascades: the now-childless parent is removed from *its* parent, and
+    /// so on toward the root. Because the path is ordered root-first, the
+    /// cascade pops layers from the back, and it tracks how many levels it
+    /// has climbed so the survivors are regrouped with the rank threshold of
+    /// the level actually being rebuilt. If the cascade consumes the whole
+    /// path, the tree has become empty.
     fn remove_from_path(
         self,
-        path: Vec<TreeLayer<Key, Value>>,
-    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
-        let context = MutationContext::<Key>::new(self.delta.branch());
-
-        Self::remove_from_path_with_context(path.into(), context)
-    }
-
-    /// Internal helper for `remove_from_path` that works with a
-    /// [`MutationContext`] directly.
-    ///
-    /// Takes a [`VecDeque`] rather than [`Vec`] so recursive/cascading removal
-    /// can `pop_front` each layer in O(1); a `Vec::remove(0)` here would push
-    /// the shift cost to O(H²) across a chain of collapsed ancestors.
-    fn remove_from_path_with_context(
-        mut path: VecDeque<TreeLayer<Key, Value>>,
-        mut context: MutationContext<Key>,
+        leaf_hash: Blake3Hash,
+        mut path: Vec<TreeLayer<Key, Value>>,
     ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
         use dialog_common::NULL_BLAKE3_HASH;
 
-        // If there's no parent, the tree becomes empty
-        let Some(layer) = path.pop_front() else {
-            return Ok((NULL_BLAKE3_HASH.clone(), Delta::zero()));
-        };
+        let mut context = MutationContext::<Key>::new(self.delta.branch());
+        context.delta().remove(&leaf_hash);
 
-        context.delta().remove(layer.host.hash());
+        // The level of the removed child at the layer currently being
+        // popped; the leaf's parent hosts level-0 children (segments).
+        let mut level: Rank = 0;
 
-        // Collect left and right siblings, excluding the removed segment
-        let mut links = Vec::new();
+        while let Some(layer) = path.pop() {
+            context.delta().remove(layer.host.hash());
 
-        if let Some(left_siblings) = layer.left_siblings {
-            links.extend(left_siblings);
-        }
+            // Collect left and right siblings, excluding the removed child
+            let mut links = Vec::new();
+            if let Some(left_siblings) = layer.left_siblings {
+                links.extend(left_siblings);
+            }
+            if let Some(right_siblings) = layer.right_siblings {
+                links.extend(right_siblings);
+            }
 
-        // Note: we skip the removed segment's link here
-
-        if let Some(right_siblings) = layer.right_siblings {
-            links.extend(right_siblings);
-        }
-
-        // If no siblings remain, propagate the removal upward
-        if links.is_empty() {
-            return if path.is_empty() {
-                Ok((NULL_BLAKE3_HASH.clone(), context.take_delta()))
-            } else {
-                // Continue removing up the path with the same context
-                Self::remove_from_path_with_context(path, context)
+            let Some(links) = NonEmpty::from_vec(links) else {
+                // The removed child was the layer's only child; the layer's
+                // host dissolves and the removal cascades one level up.
+                level += 1;
+                continue;
             };
+
+            // The survivors are level-`level` nodes; regroup them into
+            // parents one level up and continue the standard merge from
+            // there. Both thresholds follow the "level `L` is built with
+            // threshold `L + 1`" rule.
+            let ranked_links = into_ranked_links(links, &mut context);
+            let nodes = Self::collect::<Link<_>>(ranked_links, FIRST_INDEX_RANK + level)?;
+            return Self::merge_with_path(nodes, path, context, FIRST_INDEX_RANK + level + 1);
         }
 
-        // We have siblings; rebuild with them
-        let Some(links) = NonEmpty::from_vec(links) else {
-            return Err(DialogSearchTreeError::Node(
-                "Unexpectedly empty link list".into(),
-            ));
-        };
-        let ranked_links = into_ranked_links(links, &mut context);
-
-        // Create nodes from the remaining links
-        let nodes = Self::collect::<Link<_>>(ranked_links, 1)?;
-
-        // Merge up the remaining path. `merge_with_path` pops from the back,
-        // so hand it back a `Vec` of the still-pending ancestors.
-        Self::merge_with_path(nodes, path.into(), context, FIRST_INDEX_RANK)
+        // Every layer cascaded away: the tree is empty.
+        Ok((NULL_BLAKE3_HASH.clone(), context.take_delta()))
     }
 
     /// Collects a sequence of ranked children into nodes based on a minimum

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -28,7 +28,21 @@ use crate::{
 /// A collection of nodes with their ranks.
 type RankedNodes<Key, Value> = NonEmpty<(Node<Key, Value>, Rank)>;
 
+/// The rank threshold for grouping entries into leaf segments (level 0 of
+/// the tree). Every key has a rank of at least 1; an entry whose key's rank
+/// exceeds this threshold ends the segment it belongs to (it is a segment
+/// *boundary*).
 const BOTTOM_RANK: Rank = 1;
+
+/// The rank threshold for grouping leaf segments (level 0) into the first
+/// level of index nodes (level 1).
+///
+/// Each level of the tree uses a threshold one higher than the level below
+/// it: level `L` is built by grouping level `L - 1` nodes, ending a group
+/// whenever a node's rank exceeds `BOTTOM_RANK + L`. Walks that rebuild the
+/// tree from the leaves up start at this threshold and increment it once per
+/// level (see `TreeShaper::merge_with_path`).
+const FIRST_INDEX_RANK: Rank = BOTTOM_RANK + 1;
 
 /// The stateful side-effects of tree mutations are compartmentalized
 /// to a MutationContext. Key ranking is intermediated by the MutationContext
@@ -223,11 +237,11 @@ where
     ///
     /// 3. **Boundary-delete overflow**: The deleted entry was the segment's
     ///    last entry (its boundary), the segment still has orphan entries, and
-    ///    a right-adjacent segment exists. The orphans are merged with the
-    ///    right-adjacent segment's entries; the combined list is redistributed
-    ///    and the two affected subtrees are stitched back together at their
-    ///    lowest common ancestor. Requires the `right_neighbor` prefetch on
-    ///    the search result.
+    ///    a right-adjacent segment exists. The right-adjacent segment adopts
+    ///    the orphans: the combined entries are redistributed and the two
+    ///    affected subtrees are stitched back together at their lowest common
+    ///    ancestor. Requires the `right_neighbor` prefetch on the search
+    ///    result. See `Self::let_right_neighbor_adopt_orphans`.
     ///
     /// 4. **Ordinary shrink**: The segment still has entries after removal and
     ///    there is no overflow. The remaining entries are redistributed using
@@ -264,7 +278,7 @@ where
             && let Some(right_neighbor) = search_result.right_neighbor
         {
             let main_leaf_hash = search_result.leaf.hash().clone();
-            return self.absorb_orphans_into_right_neighbor(
+            return self.let_right_neighbor_adopt_orphans(
                 segment.entries,
                 main_leaf_hash,
                 search_result.path,
@@ -272,33 +286,76 @@ where
             );
         }
 
+        // The adoption path above did not apply, which leaves three cases:
+        // a non-boundary delete (the segment's boundary still stands, so the
+        // remaining entries redistribute in place), a boundary delete with no
+        // right-adjacent segment (the segment was the rightmost in the tree,
+        // so there is no neighbor to adopt the remaining entries and they
+        // redistribute in place), or a delete that emptied the segment
+        // entirely (the segment itself must be removed from its parent).
         match NonEmpty::from_vec(segment.entries) {
             Some(entries) => self.distribute(entries, Some(search_result)),
             None => self.remove_from_path(search_result.path),
         }
     }
 
-    /// Resolves a boundary-delete overflow using the prefetched right-adjacent
-    /// segment.
+    /// Resolves a boundary-delete overflow by letting the prefetched
+    /// right-adjacent segment adopt the orphaned entries.
     ///
     /// See case (3) in [`Self::delete`] for the high-level contract.
     ///
-    /// Key invariant: when a rank-R entry is deleted, it was simultaneously a
-    /// boundary at levels 0..R-2, and each of those boundaries dissolves. At
-    /// every level below the LCA, the main subtree's rebuild and the
-    /// right-adjacent subtree's rebuild therefore fuse into a *single* index
-    /// rather than remaining as siblings. The tree above the LCA is unaffected
-    /// and handed off to the standard merge routine.
+    /// Throughout this method "LCA" stands for *lowest common ancestor*: the
+    /// deepest node on the search path that is an ancestor of both the
+    /// modified leaf and its right-adjacent leaf. It is the node where the
+    /// two descents fork into different children; below it they run through
+    /// disjoint subtrees.
     ///
-    /// By construction of the search (main descent follows the boundary
-    /// rightward at every level; the right-adjacent descent takes leftmost
-    /// children) we can rely on:
+    /// Consider deleting `x`, a rank-3 key. Because every index inherits its
+    /// upper bound from its last child, `x` is simultaneously the boundary of
+    /// its segment *and* the upper bound of every index on the main descent
+    /// below the LCA (`D` here). The right-adjacent leaf `[y]` is reached by
+    /// descending leftmost from the LCA's next child (`E`):
+    ///
+    /// ```text
+    ///                     ( LCA )
+    ///                    /   |   \
+    ///                  D     E     F        index nodes
+    ///                /  \    |  \
+    ///           [u v] [w x] [y] [z ...]     leaf segments
+    ///                    ^   ^
+    ///                    |   right-adjacent leaf
+    ///                    main descent target: x is deleted, w is orphaned
+    /// ```
+    ///
+    /// Deleting `x` dissolves that boundary at every one of those levels at
+    /// once. A from-scratch build of the remaining keys would place the
+    /// orphan `w` at the start of the *next* segment, and would never split
+    /// `D` from `E` because no boundary separates their keys anymore. The
+    /// rebuilt region must therefore fuse pairwise, level by level, into a
+    /// single node at each level below the LCA:
+    ///
+    /// ```text
+    ///                     ( LCA' )
+    ///                     /     \
+    ///                   DE       F
+    ///                 /  |  \
+    ///            [u v] [w y] [z ...]
+    /// ```
+    ///
+    /// By construction of the two descents (the main descent follows the
+    /// boundary rightward at every level, so the boundary's host is always
+    /// the last child; the right-adjacent descent takes leftmost children)
+    /// we can rely on:
     /// - `main_layer.right_siblings == None` for every layer below the LCA, and
     /// - `right_layer.left_siblings == None` for every layer below the LCA.
     ///
-    /// The fold at each level is therefore just
+    /// The fold that produces each fused node (`[w y]`, then `DE`) is
+    /// therefore just
     /// `[main_layer.left_siblings | unified | right_layer.right_siblings]`.
-    fn absorb_orphans_into_right_neighbor(
+    ///
+    /// The tree above the LCA is unaffected and handed off to the standard
+    /// merge routine.
+    fn let_right_neighbor_adopt_orphans(
         self,
         orphans: Vec<Entry<Key, Value>>,
         main_leaf_hash: Blake3Hash,
@@ -340,12 +397,15 @@ where
         let above_lca = above_and_lca;
 
         // Fuse the two subtrees level-by-level below the LCA. At every such
-        // level the boundary that separated them has dissolved, so their
-        // children flatten into one unified index.
+        // level the boundary that separated them has dissolved, so the
+        // children of the main-descent node and of the right-descent node
+        // flatten into one unified index node (`D` and `E` becoming `DE` in
+        // the diagram above).
         //
-        // Nodes live at level 0 after the entry merge; building a level-1
-        // parent uses minimum_rank 2 (level L uses minimum_rank L + 1).
-        let mut level_minimum_rank: Rank = 2;
+        // The unified nodes start out as leaf segments (level 0), so the
+        // first fused parent is built with the level-1 threshold; each
+        // further level up increments the threshold by one.
+        let mut level_minimum_rank: Rank = FIRST_INDEX_RANK;
         for (main_layer, right_layer) in main_below
             .into_iter()
             .rev()
@@ -468,8 +528,8 @@ where
         };
 
         // Nodes start at level 0 (segments); the first level-up collect uses
-        // minimum_rank 2 (the level-1 threshold).
-        Self::merge_with_path(nodes, search_path, context, 2)
+        // the level-1 threshold.
+        Self::merge_with_path(nodes, search_path, context, FIRST_INDEX_RANK)
     }
 
     /// Merges a collection of nodes with a search path, rebuilding from leaves
@@ -488,8 +548,9 @@ where
     /// when the same boundary key appears more than once.
     ///
     /// `initial_level_minimum_rank` is the rank threshold to apply at the first
-    /// level of the walk. Callers that start from raw leaf segments pass `2`;
-    /// the overflow path passes a higher value when it picks up mid-walk.
+    /// level of the walk. Callers that start from raw leaf segments pass
+    /// [`FIRST_INDEX_RANK`]; the overflow path passes a higher value when it
+    /// picks up mid-walk.
     ///
     /// This is the shared path-reconstruction logic used by both insert (after
     /// distributing entries) and delete (after modifying a segment).
@@ -640,7 +701,7 @@ where
 
         // Merge up the remaining path. `merge_with_path` pops from the back,
         // so hand it back a `Vec` of the still-pending ancestors.
-        Self::merge_with_path(nodes, path.into(), context, 2)
+        Self::merge_with_path(nodes, path.into(), context, FIRST_INDEX_RANK)
     }
 
     /// Collects a sequence of ranked children into nodes based on a minimum

--- a/rust/dialog-search-tree/src/storage.rs
+++ b/rust/dialog-search-tree/src/storage.rs
@@ -1,10 +1,11 @@
-use dialog_common::Blake3Hash;
+use dialog_common::{Blake3Hash, ConditionalSend};
 
 use dialog_storage::{DialogStorageError, StorageBackend};
 
 /// Content-addressed storage wrapper for tree nodes.
 ///
 /// Provides hash-verified storage and retrieval operations.
+#[derive(Clone, Debug)]
 pub struct ContentAddressedStorage<Backend>
 where
     Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
@@ -14,11 +15,23 @@ where
 
 impl<Backend> ContentAddressedStorage<Backend>
 where
-    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+        + ConditionalSend
+        + 'static,
 {
     /// Creates a new content-addressed storage wrapper.
     pub fn new(backend: Backend) -> Self {
         Self { backend }
+    }
+
+    /// Get a reference to the interior `StorageBackend`
+    pub fn backend(&self) -> &Backend {
+        &self.backend
+    }
+
+    /// Get a mutable reference to the interior `StorageBackend`
+    pub fn backend_mut(&mut self) -> &mut Backend {
+        &mut self.backend
     }
 
     /// Stores bytes under their content hash, verifying the hash matches.

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, ops::RangeBounds};
 
-use dialog_common::{Blake3Hash, NULL_BLAKE3_HASH};
+use dialog_common::{Blake3Hash, ConditionalSend, ConditionalSync, NULL_BLAKE3_HASH};
 use dialog_storage::{DialogStorageError, StorageBackend};
 use futures_core::Stream;
 use rkyv::{
@@ -14,8 +14,8 @@ use rkyv::{
 };
 
 use crate::{
-    Buffer, Cache, ContentAddressedStorage, Delta, DialogSearchTreeError, Entry, Key, Node,
-    SearchResult, SymmetryWith, TreeShaper, TreeWalker, Value, into_owned,
+    Accessor, Buffer, Cache, ContentAddressedStorage, Delta, DialogSearchTreeError, Entry, Key,
+    SearchOptions, SearchResult, SymmetryWith, TreeShaper, TreeWalker, Value, into_owned,
 };
 
 /// A key-value store backed by a ranked prolly tree with content-addressed
@@ -31,6 +31,16 @@ use crate::{
 /// maintains a [`Delta`] of pending changes that can be flushed to storage in
 /// batches, and uses a [`Cache`] for frequently accessed nodes to minimize
 /// storage I/O operations.
+///
+/// ## Clone Semantics
+///
+/// Cloning a [`Tree`] does **not** fork the internal state. Instead, it shares
+/// the cache and delta via reference counting. Mutations
+/// ([`insert`](Self::insert), [`delete`](Self::delete)) implicitly fork the
+/// tree by returning a new instance with a branched [`Delta`] (independent
+/// copy) and an updated root hash, while continuing to share the [`Cache`].
+/// This enables efficient versioning where multiple tree versions share the
+/// same cache for read operations, but maintain independent mutation state.
 #[derive(Debug, Clone)]
 pub struct Tree<Key, Value>
 where
@@ -50,23 +60,32 @@ where
 
 impl<Key, Value> Tree<Key, Value>
 where
-    Key: self::Key,
-    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
-    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
-    Key::Archived: for<'a> CheckBytes<
-        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
-    >,
-    Key::Archived: Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
-    Key: for<'a> Serialize<
-        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
-    >,
-    Value: self::Value,
+    Key: self::Key
+        + ConditionalSync
+        + 'static
+        + PartialOrd<Key::Archived>
+        + PartialEq<Key::Archived>
+        + for<'a> Serialize<
+            Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+        >,
+    Key::Archived: PartialOrd<Key>
+        + PartialEq<Key>
+        + SymmetryWith<Key>
+        + Ord
+        + ConditionalSync
+        + for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: self::Value
+        + ConditionalSync
+        + 'static
+        + for<'a> Serialize<
+            Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+        >,
     Value::Archived: for<'a> CheckBytes<
             Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
-        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>,
-    Value: for<'a> Serialize<
-        Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
-    >,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
 {
     /// Returns the [`Blake3Hash`] of the root node of this tree.
     ///
@@ -120,9 +139,11 @@ where
         storage: &ContentAddressedStorage<Backend>,
     ) -> Result<Option<Value>, DialogSearchTreeError>
     where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
     {
-        if let Some(result) = self.search(key, storage).await? {
+        if let Some(result) = self.search(key, storage, SearchOptions::default()).await? {
             if let Some(entry) = result.leaf.body()?.find_entry(key)? {
                 into_owned(&entry.value).map(|value| Some(value))
             } else {
@@ -145,9 +166,11 @@ where
         storage: &ContentAddressedStorage<Backend>,
     ) -> Result<Self, DialogSearchTreeError>
     where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
     {
-        let search_result = self.search(&key, storage).await?;
+        let search_result = self.search(&key, storage, SearchOptions::default()).await?;
         let shaper = TreeShaper::new(self.root.clone(), self.delta.clone());
         let (next_root, delta) = shaper.insert(Entry { key, value }, search_result)?;
 
@@ -164,9 +187,14 @@ where
         storage: &ContentAddressedStorage<Backend>,
     ) -> Result<Self, DialogSearchTreeError>
     where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
     {
-        if let Some(search_result) = self.search(key, storage).await? {
+        let options = SearchOptions {
+            prefetch_right_neighbor: true,
+        };
+        if let Some(search_result) = self.search(key, storage, options).await? {
             let shaper = TreeShaper::new(self.root.clone(), self.delta.clone());
             let (next_root, delta) = shaper.delete(key, search_result)?;
             Ok(self.advance(next_root, delta))
@@ -189,7 +217,9 @@ where
         storage: &'a ContentAddressedStorage<Backend>,
     ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + 'a
     where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
     {
         self.stream_range(
             <Key as self::Key>::min()..<Key as self::Key>::max(),
@@ -202,19 +232,20 @@ where
     ///
     /// The range can be bounded or unbounded on either end, following Rust's
     /// standard [`RangeBounds`] trait. Entries are yielded in sorted order.
-    pub fn stream_range<'a, R, Backend>(
-        &'a self,
+    pub fn stream_range<R, Backend>(
+        &self,
         range: R,
-        storage: &'a ContentAddressedStorage<Backend>,
-    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + 'a
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + ConditionalSend + 'static
     where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
-        R: RangeBounds<Key> + 'a,
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
+        R: RangeBounds<Key> + ConditionalSend + 'static,
     {
-        TreeWalker::new(self.root.clone(), async |hash| {
-            self.get_node(hash, storage).await
-        })
-        .stream(range)
+        let accessor = Accessor::new(self.delta.clone(), self.node_cache.clone(), storage.clone());
+
+        TreeWalker::new(self.root.clone()).stream(range, accessor)
     }
 
     /// Flushes all pending changes, returning an iterator of nodes to be
@@ -245,41 +276,6 @@ where
         }
     }
 
-    /// Retrieves a node from cache, delta, or storage.
-    ///
-    /// This method implements a multi-level lookup strategy:
-    /// 1. Check the node cache for a previously loaded node
-    /// 2. Check the delta for a recently created/modified node
-    /// 3. Fetch from persistent storage as a last resort
-    ///
-    /// Fetched nodes are automatically added to the cache for future access.
-    /// This layered approach minimizes expensive storage I/O operations.
-    async fn get_node<Backend>(
-        &self,
-        hash: &Blake3Hash,
-        storage: &ContentAddressedStorage<Backend>,
-    ) -> Result<Node<Key, Value>, DialogSearchTreeError>
-    where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
-    {
-        self.node_cache
-            .get_or_fetch(hash, async move |key| {
-                if let Some(buffer) = self.delta.get(hash) {
-                    Ok(Some(buffer))
-                } else {
-                    storage
-                        .retrieve(key)
-                        .await
-                        .map(|maybe_bytes| maybe_bytes.map(Buffer::from))
-                }
-            })
-            .await?
-            .ok_or_else(|| {
-                DialogSearchTreeError::Node(format!("Blob not found in storage: {}", hash))
-            })
-            .map(|buffer| Node::new(buffer))
-    }
-
     /// Searches for the leaf segment that would contain `key`, recording the
     /// path taken through the tree.
     ///
@@ -297,23 +293,26 @@ where
         &self,
         key: &Key,
         storage: &ContentAddressedStorage<Backend>,
+        options: SearchOptions,
     ) -> Result<Option<SearchResult<Key, Value>>, DialogSearchTreeError>
     where
-        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
     {
-        TreeWalker::new(self.root.clone(), async |hash| {
-            self.get_node(hash, storage).await
-        })
-        .search(key)
-        .await
+        let accessor = Accessor::new(self.delta.clone(), self.node_cache.clone(), storage.clone());
+
+        TreeWalker::new(self.root.clone())
+            .search(key, accessor, options)
+            .await
     }
 }
 
 impl<Key, Value> From<Blake3Hash> for Tree<Key, Value>
 where
-    Key: self::Key,
+    Key: self::Key + ConditionalSync + 'static,
     Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
-    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord + ConditionalSync,
     Key::Archived: for<'a> CheckBytes<
         Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
     >,
@@ -321,10 +320,11 @@ where
     Key: for<'a> Serialize<
         Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
     >,
-    Value: self::Value,
+    Value: self::Value + ConditionalSync + 'static,
     Value::Archived: for<'a> CheckBytes<
             Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
-        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
     Value: for<'a> Serialize<
         Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
     >,
@@ -1155,6 +1155,676 @@ mod tests {
             let value = tree.get(&key, &storage).await?;
             assert_eq!(value, Some(expected_value));
         }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_restores_tree_from_persisted_root_hash() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        for i in 0..100u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+
+        let root = tree.root().clone();
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Reconstruct from just the root hash — no shared delta or cache
+        let restored = Tree::<[u8; 4], Vec<u8>>::from_hash(root);
+
+        for i in 0..100u32 {
+            let value = restored.get(&i.to_le_bytes(), &storage).await?;
+            assert_eq!(
+                value,
+                Some(i.to_le_bytes().to_vec()),
+                "Key {} should be retrievable from restored tree",
+                i
+            );
+        }
+
+        assert_eq!(restored.get(&200u32.to_le_bytes(), &storage).await?, None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_unflushed_insertions() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert and flush a base set
+        for i in 0..10u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Insert more WITHOUT flushing
+        for i in 10..20u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+
+        // Stream should include both flushed and unflushed entries
+        let stream = tree.stream(&storage);
+        futures_util::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+
+        assert_eq!(
+            count, 20,
+            "Stream should yield all entries including unflushed"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_unflushed_deletions() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Build and flush
+        for i in 0..20u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Delete some entries WITHOUT flushing
+        for i in (0..20u32).step_by(2) {
+            tree = tree.delete(&i.to_le_bytes(), &storage).await?;
+        }
+
+        // Stream should reflect deletions even without flush
+        let stream = tree.stream(&storage);
+        futures_util::pin_mut!(stream);
+
+        let mut keys = Vec::new();
+        while let Some(entry) = stream.next().await {
+            let entry = entry?;
+            keys.push(u32::from_le_bytes(entry.key));
+        }
+
+        let expected: Vec<u32> = (1..20u32).step_by(2).collect();
+        assert_eq!(keys, expected, "Stream should exclude unflushed deletions");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_all_entries_after_boundary_deletion() -> Result<()> {
+        use crate::distribution;
+        use dialog_common::Blake3Hash;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let all_keys: Vec<u32> = (0..1000).collect();
+
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        for &k in &all_keys {
+            tree = tree
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Find boundary keys
+        let boundaries: Vec<u32> = all_keys
+            .iter()
+            .copied()
+            .filter(|&i| distribution::geometric::rank(&Blake3Hash::hash(&i.to_le_bytes())) > 1)
+            .collect();
+
+        for &bk in boundaries.iter().take(3) {
+            let mut after_delete = tree.delete(&bk.to_le_bytes(), &storage).await?;
+            for (h, b) in after_delete.flush() {
+                storage.store(b.as_ref().to_vec(), &h).await?;
+            }
+
+            // Deleted key should be gone
+            assert_eq!(
+                after_delete.get(&bk.to_le_bytes(), &storage).await?,
+                None,
+                "Deleted boundary key {bk} should not be found"
+            );
+
+            // Every other key must still return the correct value
+            for &k in &all_keys {
+                if k == bk {
+                    continue;
+                }
+                let value = after_delete.get(&k.to_le_bytes(), &storage).await?;
+                assert_eq!(
+                    value,
+                    Some(k.to_le_bytes().to_vec()),
+                    "Key {k} should still be accessible after deleting boundary {bk}"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_to_null_root_after_sequential_deletion_of_many_entries() -> Result<()> {
+        use dialog_common::NULL_BLAKE3_HASH;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        for i in 0..500u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Delete all entries one at a time
+        for i in 0..500u32 {
+            tree = tree.delete(&i.to_le_bytes(), &storage).await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        assert_eq!(
+            tree.root(),
+            &NULL_BLAKE3_HASH.clone(),
+            "Tree should be empty after deleting all entries"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_root_when_upserting_identical_value() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        for i in 0..50u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        let root_before = tree.root().clone();
+
+        // Re-insert key 25 with the same value
+        tree = tree
+            .insert(25u32.to_le_bytes(), vec![25u8], &storage)
+            .await?;
+
+        assert_eq!(
+            tree.root(),
+            &root_before,
+            "Upserting the same key+value should not change the root"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_entries_in_byte_lexicographic_order() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Insert keys whose byte and numeric orders differ.
+        // 1u32 = [1,0,0,0], 256u32 = [0,1,0,0], 512u32 = [0,2,0,0]
+        // Byte order: [0,1,0,0] < [0,2,0,0] < [1,0,0,0]
+        // Numeric order: 1 < 256 < 512
+        let numeric_keys: Vec<u32> = vec![1, 256, 512, 2, 257, 0];
+
+        for &k in &numeric_keys {
+            tree = tree
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        let stream = tree.stream(&storage);
+        futures_util::pin_mut!(stream);
+
+        let mut keys_out: Vec<[u8; 4]> = Vec::new();
+        while let Some(entry) = stream.next().await {
+            keys_out.push(entry?.key);
+        }
+
+        // Verify byte-lexicographic order
+        for pair in keys_out.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "Keys should be in byte-lexicographic order: {:?} should precede {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+
+        // Verify the specific expected order
+        let mut expected = numeric_keys
+            .iter()
+            .map(|k| k.to_le_bytes())
+            .collect::<Vec<_>>();
+        expected.sort();
+        assert_eq!(keys_out, expected);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_range_with_excluded_start() -> Result<()> {
+        use futures_util::StreamExt;
+        use std::ops::Bound;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        for i in 0..20u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Excluded start: should not include key 5
+        let range = (
+            Bound::Excluded(5u32.to_le_bytes()),
+            Bound::Included(10u32.to_le_bytes()),
+        );
+        let stream = tree.stream_range(range, &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut keys = Vec::new();
+        while let Some(entry) = stream.next().await {
+            keys.push(u32::from_le_bytes(entry?.key));
+        }
+
+        assert_eq!(
+            keys,
+            vec![6, 7, 8, 9, 10],
+            "Excluded start should skip key 5"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_range_with_unbounded_end() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        for i in 0..20u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // start.. (unbounded end)
+        let stream = tree.stream_range(15u32.to_le_bytes().., &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut keys = Vec::new();
+        while let Some(entry) = stream.next().await {
+            keys.push(u32::from_le_bytes(entry?.key));
+        }
+
+        assert_eq!(keys, vec![15, 16, 17, 18, 19]);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_streams_single_point_range() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        for i in 0..20u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in tree.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // key..=key should return exactly one entry
+        let k = 10u32.to_le_bytes();
+        let stream = tree.stream_range(k..=k, &storage);
+        futures_util::pin_mut!(stream);
+
+        let mut keys = Vec::new();
+        while let Some(entry) = stream.next().await {
+            keys.push(u32::from_le_bytes(entry?.key));
+        }
+
+        assert_eq!(keys, vec![10], "Single-point range should yield one entry");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_canonical_structure_regardless_of_insertion_order() -> Result<()> {
+        use crate::distribution;
+        use dialog_common::Blake3Hash;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let keys: Vec<u32> = (0..1000).collect();
+
+        // Sanity check: with 1000 keys we expect ~8 boundary entries
+        // (rank > 1). If none exist, the test can't exercise the bug.
+        let boundary_count = keys
+            .iter()
+            .filter(|&&k| distribution::geometric::rank(&Blake3Hash::hash(&k.to_le_bytes())) > 1)
+            .count();
+        assert!(
+            boundary_count > 0,
+            "Test requires at least one boundary key to be meaningful"
+        );
+
+        // Build tree A: forward insertion order
+        let mut tree_a = Tree::<[u8; 4], Vec<u8>>::empty();
+        for &k in &keys {
+            tree_a = tree_a
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for (key, value) in tree_a.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Build tree B: reverse insertion order
+        let mut tree_b = Tree::<[u8; 4], Vec<u8>>::empty();
+        for &k in keys.iter().rev() {
+            tree_b = tree_b
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for (key, value) in tree_b.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // A canonical prolly tree must produce the same structure — and
+        // therefore the same root hash — for the same set of entries,
+        // regardless of insertion order.
+        assert_eq!(
+            tree_a.root(),
+            tree_b.root(),
+            "Trees with identical entries should have the same root \
+             regardless of insertion order ({boundary_count} boundary \
+             keys in dataset)"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_interleaved_operations_across_tree_versions() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        // Create base tree
+        let mut base = Tree::<[u8; 4], Vec<u8>>::empty();
+        for i in 0..20u32 {
+            base = base
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        for (key, value) in base.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Create two branches
+        let mut branch_a = base.clone();
+        let mut branch_b = base.clone();
+
+        // Interleave operations
+        branch_a = branch_a
+            .insert(100u32.to_le_bytes(), vec![100], &storage)
+            .await?;
+        branch_b = branch_b.delete(&5u32.to_le_bytes(), &storage).await?;
+        branch_a = branch_a
+            .insert(101u32.to_le_bytes(), vec![101], &storage)
+            .await?;
+        branch_b = branch_b.delete(&10u32.to_le_bytes(), &storage).await?;
+
+        // Flush both
+        for (key, value) in branch_a.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+        for (key, value) in branch_b.flush() {
+            storage.store(value.as_ref().to_vec(), &key).await?;
+        }
+
+        // Branch A: base + 100, 101
+        assert_eq!(
+            branch_a.get(&100u32.to_le_bytes(), &storage).await?,
+            Some(vec![100])
+        );
+        assert_eq!(
+            branch_a.get(&101u32.to_le_bytes(), &storage).await?,
+            Some(vec![101])
+        );
+        assert_eq!(
+            branch_a.get(&5u32.to_le_bytes(), &storage).await?,
+            Some(vec![5]),
+            "Branch A should still have key 5"
+        );
+
+        // Branch B: base - 5, 10
+        assert_eq!(branch_b.get(&5u32.to_le_bytes(), &storage).await?, None);
+        assert_eq!(branch_b.get(&10u32.to_le_bytes(), &storage).await?, None);
+        assert_eq!(branch_b.get(&100u32.to_le_bytes(), &storage).await?, None);
+
+        // Base unchanged
+        assert_eq!(
+            base.get(&5u32.to_le_bytes(), &storage).await?,
+            Some(vec![5])
+        );
+        assert_eq!(base.get(&100u32.to_le_bytes(), &storage).await?, None);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_unflushed_entries_after_boundary_delete() -> Result<()> {
+        use crate::distribution;
+        use dialog_common::Blake3Hash;
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let all_keys: Vec<u32> = (0..1000).collect();
+
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        for &k in &all_keys {
+            tree = tree
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for (h, b) in tree.flush() {
+            storage.store(b.as_ref().to_vec(), &h).await?;
+        }
+
+        let boundaries: Vec<u32> = all_keys
+            .iter()
+            .copied()
+            .filter(|&i| distribution::geometric::rank(&Blake3Hash::hash(&i.to_le_bytes())) > 1)
+            .collect();
+        assert!(
+            !boundaries.is_empty(),
+            "test requires at least one boundary"
+        );
+
+        for &bk in boundaries.iter().take(3) {
+            let after_delete = tree.delete(&bk.to_le_bytes(), &storage).await?;
+
+            // Read every surviving key WITHOUT flushing. Any missing new
+            // node in the delta surfaces here as a node-not-found error.
+            for &k in &all_keys {
+                if k == bk {
+                    assert_eq!(after_delete.get(&k.to_le_bytes(), &storage).await?, None);
+                    continue;
+                }
+                assert_eq!(
+                    after_delete.get(&k.to_le_bytes(), &storage).await?,
+                    Some(k.to_le_bytes().to_vec()),
+                    "key {k} should be readable from unflushed tree after deleting boundary {bk}"
+                );
+            }
+
+            // Stream the whole tree too; same guarantee, different path.
+            let expected_count = all_keys.len() - 1;
+            let stream = after_delete.stream(&storage);
+            futures_util::pin_mut!(stream);
+            let mut count = 0;
+            while let Some(entry) = stream.next().await {
+                entry?;
+                count += 1;
+            }
+            assert_eq!(
+                count, expected_count,
+                "stream should yield {expected_count} entries from unflushed tree after deleting boundary {bk}"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_removes_orphaned_hashes_from_delta_after_mutation() -> Result<()> {
+        let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // After a single insert into an empty tree the delta holds
+        // exactly the root's new subtree (here: one level-1 index and
+        // one leaf segment). Record its root hash.
+        tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
+        let root_after_first = tree.root().clone();
+        assert!(
+            tree.delta.get(&root_after_first).is_some(),
+            "root of just-inserted tree should be in the delta"
+        );
+
+        // A second insert replaces the root and (because the insert
+        // rewrites the only leaf) the old leaf segment too. The
+        // pre-mutation root hash is unreachable from the new tree and
+        // must not linger in the delta.
+        tree = tree.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
+        assert!(
+            tree.delta.get(&root_after_first).is_none(),
+            "old root hash should be evicted from delta after follow-up insert",
+        );
+
+        // Update-in-place (same key, new value): the old leaf and old
+        // root are replaced; both should be evicted.
+        let root_before_update = tree.root().clone();
+        tree = tree.insert(1u32.to_le_bytes(), vec![99], &storage).await?;
+        assert!(
+            tree.delta.get(&root_before_update).is_none(),
+            "old root hash should be evicted from delta after update-in-place",
+        );
+
+        // Non-boundary delete: rewrites the leaf + root along the path,
+        // previous root must be gone.
+        let root_before_delete = tree.root().clone();
+        tree = tree.delete(&2u32.to_le_bytes(), &storage).await?;
+        assert!(
+            tree.delta.get(&root_before_delete).is_none(),
+            "old root hash should be evicted from delta after non-boundary delete",
+        );
+
+        // Delete-to-empty: the remaining leaf vanishes; tree root becomes
+        // the null hash and the last lingering content root must go.
+        let root_before_empty = tree.root().clone();
+        tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
+        assert!(
+            tree.delta.get(&root_before_empty).is_none(),
+            "old root hash should be evicted from delta after delete-to-empty",
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_delta_bounded_across_unflushed_mutations() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+
+        // Build and flush a baseline so the delta starts empty.
+        let base_size: u32 = 200;
+        for i in 0..base_size {
+            tree = tree
+                .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for (h, b) in tree.flush() {
+            storage.store(b.as_ref().to_vec(), &h).await?;
+        }
+        assert_eq!(tree.delta.len(), 0);
+
+        // Update each existing key in place many times. Entry count and
+        // tree shape stay the same, so delta size should stabilize near
+        // the affected-path cost (≈ tree height × a small constant per
+        // modified key, with boundary keys possibly touching a few more
+        // ancestors). If orphan-removal regresses, this grows linearly
+        // with the number of updates.
+        let mutations: u32 = 400;
+        for i in 0..mutations {
+            let key = (i % base_size).to_le_bytes();
+            tree = tree.insert(key, vec![(i % 255) as u8], &storage).await?;
+        }
+
+        // Loose but informative upper bound: the entire live tree
+        // (every segment plus every index) can't exceed `base_size`
+        // nodes, since each node holds at least one entry. Any linear
+        // accumulation would blow past this threshold for 400 updates
+        // against 200 entries.
+        let live_upper_bound = base_size as usize;
+        assert!(
+            tree.delta.len() <= live_upper_bound,
+            "delta grew to {} after {mutations} updates against {base_size} entries; \
+             expected ≤ {live_upper_bound} (tree's live node count)",
+            tree.delta.len(),
+        );
 
         Ok(())
     }

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -14,8 +14,9 @@ use rkyv::{
 };
 
 use crate::{
-    Accessor, Buffer, Cache, ContentAddressedStorage, Delta, DialogSearchTreeError, Entry, Key,
-    SearchOptions, SearchResult, SymmetryWith, TreeShaper, TreeWalker, Value, into_owned,
+    Accessor, ArchivedNodeBody, Buffer, Cache, ContentAddressedStorage, Delta,
+    DialogSearchTreeError, Entry, Key, Node, SearchOptions, SearchResult, SymmetryWith, TreeShaper,
+    TreeWalker, Value, into_owned,
 };
 
 /// A key-value store backed by a ranked prolly tree with content-addressed
@@ -196,12 +197,67 @@ where
         };
         if let Some(search_result) = self.search(key, storage, options).await? {
             let shaper = TreeShaper::new(self.root.clone(), self.delta.clone());
-            let (next_root, delta) = shaper.delete(key, search_result)?;
+            let (next_root, mut delta) = shaper.delete(key, search_result)?;
+            let next_root = Self::collapse_root_chain(next_root, &mut delta, storage).await?;
             Ok(self.advance(next_root, delta))
         } else {
             // Key not found in tree - nothing to delete
             Ok(self.clone())
         }
+    }
+
+    /// Collapses a stale chain of single-child index nodes at the root after
+    /// a deletion.
+    ///
+    /// A canonical tree never has an index root whose only child is another
+    /// index: building from scratch stops at the first level that holds a
+    /// single node (the only legitimate single-child root is an index over a
+    /// lone segment). Such chains can survive a delete when the deleted key's
+    /// rank was what created the upper levels: with the boundary gone, the
+    /// levels it terminated dissolve, but the rebuild works bottom-up along
+    /// the search path and cannot see that nothing above demanded them.
+    /// Walking down from the root and discarding wrappers restores the
+    /// canonical shape.
+    async fn collapse_root_chain<Backend>(
+        mut root: Blake3Hash,
+        delta: &mut Delta<Blake3Hash, Buffer>,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Blake3Hash, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
+    {
+        if &root == NULL_BLAKE3_HASH {
+            return Ok(root);
+        }
+
+        // The accessor shares `delta` by reference counting, so removals
+        // below remain visible to it.
+        let accessor = Accessor::new(delta.clone(), Cache::new(), storage.clone());
+
+        loop {
+            let node: Node<Key, Value> = accessor.get_node(&root).await?;
+            let child_hash = match node.body()? {
+                ArchivedNodeBody::Index(index) if index.links.len() == 1 => {
+                    <&Blake3Hash>::from(&index.links[0].node).clone()
+                }
+                _ => break,
+            };
+
+            let child: Node<Key, Value> = accessor.get_node(&child_hash).await?;
+            match child.body()? {
+                ArchivedNodeBody::Index(_) => {
+                    // The wrapper is unreachable in the new tree; drop it
+                    // from the pending changes if it originated there.
+                    delta.remove(&root);
+                    root = child_hash;
+                }
+                ArchivedNodeBody::Segment(_) => break,
+            }
+        }
+
+        Ok(root)
     }
 
     /// Returns an async stream over all entries in the tree.
@@ -221,10 +277,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        self.stream_range(
-            <Key as self::Key>::min()..<Key as self::Key>::max(),
-            storage,
-        )
+        self.stream_range(.., storage)
     }
 
     /// Returns an async stream over entries with keys within the provided
@@ -1825,6 +1878,222 @@ mod tests {
              expected ≤ {live_upper_bound} (tree's live node count)",
             tree.delta.len(),
         );
+
+        Ok(())
+    }
+
+    /// Builds a tree by inserting the given u32 keys (little-endian encoded)
+    /// in order and flushing the result to storage.
+    async fn build_and_flush_u32(
+        keys: &[u32],
+        storage: &mut ContentAddressedStorage<
+            MemoryStorageBackend<dialog_common::Blake3Hash, Vec<u8>>,
+        >,
+    ) -> Result<Tree<[u8; 4], Vec<u8>>> {
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        for &k in keys {
+            tree = tree
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), storage)
+                .await?;
+        }
+        for (hash, buffer) in tree.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+        Ok(tree)
+    }
+
+    /// Deleting a boundary whose removal collapses the root must produce the
+    /// same tree as building the remaining keys from scratch.
+    ///
+    /// Regression guard: in this dataset the tree has exactly two segments
+    /// under the root and 69161 is the boundary of the first one. Deleting
+    /// it makes the right segment adopt the orphans and the root's two
+    /// children fuse into one. `let_right_neighbor_adopt_orphans` used to
+    /// return the fused node at whatever level the fold reached (here: a
+    /// bare segment as the tree root, where a canonical tree always has an
+    /// index root) instead of collapsing to the canonical height.
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_when_boundary_delete_collapses_the_root() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let keys: Vec<u32> = vec![69161, 101527, 102790, 164389, 171478, 193283];
+
+        let mut tree = build_and_flush_u32(&keys, &mut storage).await?;
+        let mut after = tree.delete(&69161u32.to_le_bytes(), &storage).await?;
+        for (hash, buffer) in after.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+
+        let remaining: Vec<u32> = keys.iter().copied().filter(|&k| k != 69161).collect();
+        let scratch = build_and_flush_u32(&remaining, &mut storage).await?;
+
+        assert_eq!(
+            after.root(),
+            scratch.root(),
+            "boundary delete that collapses the root should be canonical"
+        );
+        Ok(())
+    }
+
+    /// Deleting the sole entry of a segment must leave every other entry
+    /// readable and produce the canonical tree.
+    ///
+    /// Regression guard: in this dataset 198936 is a boundary that forms a
+    /// single-entry segment in a tree of height two, so deleting it walks a
+    /// multi-layer search path through the empty-segment repair.
+    /// `TreeShaper::remove_from_path` used to process the layers in
+    /// root-to-leaf order while `merge_with_path` consumes them leaf-to-root,
+    /// so the rebuilt subtrees came out in the wrong key order: keys 10554,
+    /// 83265 and 167706 landed to the right of larger keys and became
+    /// unreachable through search.
+    #[dialog_common::test]
+    async fn it_keeps_entries_readable_after_a_delete_empties_a_segment() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let keys: Vec<u32> = vec![
+            10554, 28619, 40390, 43764, 45237, 48124, 64082, 66285, 67399, 67838, 81131, 83265,
+            92896, 94186, 98645, 103270, 110189, 114100, 123267, 127869, 135162, 136309, 147808,
+            153518, 154310, 156529, 161523, 167706, 172145, 172489, 176828, 187970, 189253, 198936,
+        ];
+
+        let mut tree = build_and_flush_u32(&keys, &mut storage).await?;
+        let mut after = tree.delete(&198936u32.to_le_bytes(), &storage).await?;
+        for (hash, buffer) in after.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+
+        let mut unreadable = vec![];
+        for &k in keys.iter().filter(|&&k| k != 198936) {
+            if after.get(&k.to_le_bytes(), &storage).await?.is_none() {
+                unreadable.push(k);
+            }
+        }
+        assert!(
+            unreadable.is_empty(),
+            "live keys unreadable after emptying a segment: {unreadable:?}"
+        );
+
+        let remaining: Vec<u32> = keys.iter().copied().filter(|&k| k != 198936).collect();
+        let scratch = build_and_flush_u32(&remaining, &mut storage).await?;
+        assert_eq!(
+            after.root(),
+            scratch.root(),
+            "emptying a segment should produce the canonical tree"
+        );
+        Ok(())
+    }
+
+    /// A range with an unbounded start bound must stream every entry below
+    /// the end bound. Regression guard: `TreeWalker::stream` used to return
+    /// immediately on `Bound::Unbounded`, yielding nothing.
+    #[dialog_common::test]
+    async fn it_streams_ranges_with_unbounded_start() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let tree = build_and_flush_u32(&(0..10).collect::<Vec<_>>(), &mut storage).await?;
+
+        let stream = tree.stream_range(..5u32.to_le_bytes(), &storage);
+        futures_util::pin_mut!(stream);
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 5, "..end range should yield entries below end");
+        Ok(())
+    }
+
+    /// Streaming the whole tree must include an entry whose key is the
+    /// maximum key. Regression guard: `Tree::stream` used to delegate to
+    /// `stream_range(Key::min()..Key::max())`, whose exclusive end bound
+    /// dropped the maximum key.
+    #[dialog_common::test]
+    async fn it_streams_the_maximum_key() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        for i in 0..5u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        tree = tree.insert([0xFF; 4], vec![0xFF], &storage).await?;
+        for (hash, buffer) in tree.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+
+        let stream = tree.stream(&storage);
+        futures_util::pin_mut!(stream);
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 6, "stream should include the maximum key");
+        Ok(())
+    }
+
+    /// After every mutation, the tree must be byte-identical to a tree built
+    /// from scratch over the same logical content. This is the invariant the
+    /// whole crate is built around: same entries, same root hash, regardless
+    /// of the operation history. Random insert/delete sequences over random
+    /// key sets exercise every mutation path (in-place redistribution,
+    /// orphan adoption across parents, empty-segment removal, cascade
+    /// collapse, root chain stripping) without hand-picking datasets.
+    #[dialog_common::test]
+    async fn it_converges_to_canonical_form_after_every_operation() -> Result<()> {
+        use std::collections::BTreeSet;
+
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+
+        let mut rng = StdRng::seed_from_u64(0x_D1A1_06DB);
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        for trial in 0..2 {
+            // Seed the tree with a random key set.
+            let mut live = BTreeSet::new();
+            let initial_size = rng.gen_range(40..120);
+            while live.len() < initial_size {
+                live.insert(rng.gen_range(0..200_000u32));
+            }
+            let initial: Vec<u32> = live.iter().copied().collect();
+            let mut tree = build_and_flush_u32(&initial, &mut storage).await?;
+
+            for op in 0..120 {
+                // Half deletes of present keys, half inserts of fresh keys
+                // (which occasionally hit a present key and become updates).
+                if !live.is_empty() && rng.gen_bool(0.5) {
+                    let index = rng.gen_range(0..live.len());
+                    let key = *live.iter().nth(index).expect("index is in range");
+                    tree = tree.delete(&key.to_le_bytes(), &storage).await?;
+                    live.remove(&key);
+                } else {
+                    let key = rng.gen_range(0..200_000u32);
+                    tree = tree
+                        .insert(key.to_le_bytes(), key.to_le_bytes().to_vec(), &storage)
+                        .await?;
+                    live.insert(key);
+                }
+
+                // Flush periodically so both the delta-resident and the
+                // storage-resident read paths get exercised.
+                if op % 10 == 9 {
+                    for (hash, buffer) in tree.flush() {
+                        storage.store(buffer.as_ref().to_vec(), &hash).await?;
+                    }
+                }
+
+                let content: Vec<u32> = live.iter().copied().collect();
+                let scratch = build_and_flush_u32(&content, &mut storage).await?;
+                assert_eq!(
+                    tree.root(),
+                    scratch.root(),
+                    "trial {trial}, operation {op}: tree diverged from the \
+                     canonical form of its {} entries",
+                    content.len(),
+                );
+            }
+        }
 
         Ok(())
     }

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use async_stream::try_stream;
-use dialog_common::{Blake3Hash, NULL_BLAKE3_HASH};
+use dialog_common::{Blake3Hash, ConditionalSend, ConditionalSync, NULL_BLAKE3_HASH};
+use dialog_storage::{DialogStorageError, StorageBackend};
 use futures_core::Stream;
 use nonempty::NonEmpty;
 use rkyv::{
@@ -16,63 +17,70 @@ use rkyv::{
 };
 
 use crate::{
-    ArchivedNodeBody, DialogSearchTreeError, Entry, Key, Link, Node, SymmetryWith, Value,
+    Accessor, ArchivedNodeBody, DialogSearchTreeError, Entry, Key, Link, Node, SymmetryWith, Value,
     into_owned,
 };
 
 /// A traversal mechanism for walking through a tree structure.
-pub struct TreeWalker<Key, Value, GetNode>
+pub struct TreeWalker<Key, Value>
 where
     Key: self::Key,
     Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
     Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
-    Value: self::Value,
+    Value: self::Value + ConditionalSync + 'static,
     Value::Archived: for<'a> CheckBytes<
-        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
-    >,
-    GetNode: AsyncFn(&Blake3Hash) -> Result<Node<Key, Value>, DialogSearchTreeError>,
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + ConditionalSync,
 {
     root: Blake3Hash,
-    get_node: GetNode,
 
     key: PhantomData<Key>,
     value: PhantomData<Value>,
 }
 
-impl<Key, Value, GetNode> TreeWalker<Key, Value, GetNode>
+impl<Key, Value> TreeWalker<Key, Value>
 where
-    Key: self::Key,
-    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
-    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
-    Key::Archived: for<'b> CheckBytes<
-        Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
-    >,
-    Key::Archived: Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
-    Value: self::Value,
+    Key: self::Key
+        + ConditionalSync
+        + 'static
+        + PartialOrd<Key::Archived>
+        + PartialEq<Key::Archived>
+        + std::fmt::Debug,
+    Key::Archived: PartialOrd<Key>
+        + PartialEq<Key>
+        + SymmetryWith<Key>
+        + Ord
+        + ConditionalSync
+        + for<'b> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: self::Value + ConditionalSync + 'static,
     Value::Archived: for<'b> CheckBytes<
-        Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
-    >,
-    Value::Archived: Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>,
-    GetNode: AsyncFn(&Blake3Hash) -> Result<Node<Key, Value>, DialogSearchTreeError>,
+            Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
 {
     /// Creates a new [`TreeWalker`] with the given root hash and node fetcher.
-    pub fn new(root: Blake3Hash, get_node: GetNode) -> Self {
+    pub fn new(root: Blake3Hash) -> Self {
         Self {
             root,
-            get_node,
+
             key: PhantomData,
             value: PhantomData,
         }
     }
 
     /// Returns a stream of entries within the specified key range.
-    pub fn stream<'a, R>(
+    pub fn stream<R, Backend>(
         self,
         range: R,
-    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + 'a
+        accessor: Accessor<Backend>,
+    ) -> impl Stream<Item = Result<Entry<Key, Value>, DialogSearchTreeError>> + ConditionalSend + 'static
     where
-        Self: 'a,
-        R: RangeBounds<Key> + 'a,
+        R: RangeBounds<Key> + ConditionalSend + 'static,
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
     {
         try_stream! {
             // Get the start key. Included/Excluded ranges are identical here,
@@ -86,7 +94,10 @@ where
                     return;
                 },
             };
-            let Some(search_result) = self.search(&start_key).await? else {
+            let Some(search_result) = self
+                .search(&start_key, accessor.clone(), SearchOptions::default())
+                .await?
+            else {
                 return;
             };
             let mut search_path = search_result.into_indexed()?;
@@ -103,7 +114,7 @@ where
 
                         match index.links.get(child_index) {
                             Some(link) => {
-                                let next_node = (self.get_node)(<&Blake3Hash>::from(&link.node)).await?;
+                                let next_node = accessor.get_node(<&Blake3Hash>::from(&link.node)).await?;
                                 search_path.push((node, Some(child_index)));
                                 search_path.push((next_node, None));
                             }
@@ -121,7 +132,7 @@ where
                                 yield into_owned(entry)?;
                             } else if entered_range {
                                 // We've surpassed the range; abort.
-                                break;
+                                return;
                             }
                         }
                     },
@@ -131,10 +142,17 @@ where
     }
 
     /// Searches for the leaf segment that would contain the given key.
-    pub async fn search(
+    pub async fn search<Backend>(
         &self,
         key: &Key,
-    ) -> Result<Option<SearchResult<Key, Value>>, DialogSearchTreeError> {
+        accessor: Accessor<Backend>,
+        options: SearchOptions,
+    ) -> Result<Option<SearchResult<Key, Value>>, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
+    {
         if &self.root == NULL_BLAKE3_HASH {
             return Ok(None);
         }
@@ -153,7 +171,7 @@ where
                 )));
             }
 
-            let node = (self.get_node)(&next_node).await?;
+            let node = accessor.get_node(&next_node).await?;
 
             match node.body()? {
                 ArchivedNodeBody::Index(index) => {
@@ -201,11 +219,138 @@ where
                         .and_then(into_owned)?;
                 }
                 ArchivedNodeBody::Segment(_) => {
-                    return Ok(Some(SearchResult { leaf: node, path }));
+                    let right_neighbor = if options.prefetch_right_neighbor {
+                        prefetch_right_neighbor(key, &node, &path, accessor).await?
+                    } else {
+                        None
+                    };
+                    return Ok(Some(SearchResult {
+                        leaf: node,
+                        path,
+                        right_neighbor,
+                    }));
                 }
             }
         }
     }
+}
+
+/// Walks the narrow "overflow" path for [`RightNeighbor`] prefetching.
+///
+/// Called when [`TreeWalker::search`] lands on a leaf whose last entry matches
+/// the searched key — a necessary condition for boundary-delete overflow. If
+/// the search path contains any layer with a right sibling, we follow the
+/// leftmost descent from the first such sibling down to the next leaf. This
+/// lets [`TreeShaper::delete`] absorb orphan entries into that leaf in one
+/// pass when the deleted entry turns out to be the segment boundary.
+///
+/// Returns `None` when either the key is not the leaf's last entry or the leaf
+/// has no right-adjacent neighbor (the leaf is the rightmost segment in the
+/// tree).
+async fn prefetch_right_neighbor<Key, Value, Backend>(
+    key: &Key,
+    leaf: &Node<Key, Value>,
+    path: &[TreeLayer<Key, Value>],
+    accessor: Accessor<Backend>,
+) -> Result<Option<RightNeighbor<Key, Value>>, DialogSearchTreeError>
+where
+    Key: self::Key
+        + ConditionalSync
+        + 'static
+        + PartialOrd<Key::Archived>
+        + PartialEq<Key::Archived>,
+    Key::Archived: PartialOrd<Key>
+        + PartialEq<Key>
+        + SymmetryWith<Key>
+        + Ord
+        + ConditionalSync
+        + for<'b> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Key, Strategy<Pool, rkyv::rancor::Error>>,
+    Value: self::Value + ConditionalSync + 'static,
+    Value::Archived: for<'b> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+        + ConditionalSync
+        + 'static,
+{
+    // Only prefetch when the caller's key matches the leaf's last entry;
+    // boundary-delete overflow can't happen otherwise.
+    let Some(leaf_upper_bound) = leaf.upper_bound()? else {
+        return Ok(None);
+    };
+    if key != leaf_upper_bound {
+        return Ok(None);
+    }
+
+    // Find the deepest ancestor with a right sibling: that's the lowest common
+    // ancestor of the main descent and the right-adjacent descent.
+    let Some(lca_depth) = path
+        .iter()
+        .rposition(|layer| layer.right_siblings.is_some())
+    else {
+        // The leaf is the rightmost segment in the tree; nothing to prefetch.
+        return Ok(None);
+    };
+
+    // Safe to unwrap: `rposition` only matches layers whose right_siblings are
+    // `Some(_)`.
+    let first_right_link = &path[lca_depth]
+        .right_siblings
+        .as_ref()
+        .expect("rposition guarantees right_siblings is Some")
+        .head;
+    let mut next_hash: Blake3Hash = first_right_link.node.clone();
+    let mut diverged_path: Vec<TreeLayer<Key, Value>> = Vec::new();
+
+    let right_leaf = loop {
+        let node: Node<Key, Value> = accessor.get_node(&next_hash).await?;
+        match node.body()? {
+            ArchivedNodeBody::Index(index) => {
+                let mut links = index.links.iter();
+                let first = links.next().ok_or_else(|| {
+                    DialogSearchTreeError::Node(
+                        "Empty index node during right-neighbor descent".into(),
+                    )
+                })?;
+                let child_hash: Blake3Hash = into_owned(&first.node)?;
+                let rest: Vec<Link<Key>> = links
+                    .map(into_owned)
+                    .collect::<Result<_, DialogSearchTreeError>>()?;
+
+                diverged_path.push(TreeLayer {
+                    host: node.clone(),
+                    left_siblings: None,
+                    right_siblings: NonEmpty::from_vec(rest),
+                });
+                next_hash = child_hash;
+            }
+            ArchivedNodeBody::Segment(_) => break node,
+        }
+    };
+
+    Ok(Some(RightNeighbor {
+        lca_depth,
+        diverged_path,
+        leaf: right_leaf,
+    }))
+}
+
+/// Options controlling the behavior of [`TreeWalker::search`].
+///
+/// `prefetch_right_neighbor` is only consumed by [`TreeShaper::delete`] to
+/// resolve boundary-delete overflow. All other call sites (reads, inserts,
+/// range streams) should leave it at its default of `false` to avoid the extra
+/// leftmost descent that the prefetch can trigger.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SearchOptions {
+    /// When `true`, [`TreeWalker::search`] will additionally descend to the
+    /// leaf immediately right-adjacent to the found leaf when the searched key
+    /// matches that leaf's last entry, populating
+    /// [`SearchResult::right_neighbor`].
+    pub prefetch_right_neighbor: bool,
 }
 
 /// A layer in the tree traversal path, containing a node and its sibling links.
@@ -245,6 +390,47 @@ where
     pub leaf: Node<Key, Value>,
     /// The path from root to leaf.
     pub path: SearchPath<Key, Value>,
+    /// Prefetched right-adjacent segment, populated when the searched key
+    /// matched the leaf's last entry and a right neighbor exists. Used by
+    /// [`TreeShaper::delete`] to resolve boundary-delete overflow in one pass.
+    pub right_neighbor: Option<RightNeighbor<Key, Value>>,
+}
+
+/// Prefetched information about the leaf segment immediately to the right of a
+/// [`SearchResult::leaf`].
+///
+/// This is populated by [`TreeWalker::search`] only when the search key lands
+/// on the main leaf's last entry (a boundary-delete candidate) and a
+/// right-adjacent leaf exists. Its shape captures where the right-adjacent
+/// descent diverges from the main descent so [`TreeShaper::delete`] can rebuild
+/// both subtrees and stitch them together at the lowest common ancestor.
+///
+/// For the common "same-parent" overflow case (the right-adjacent leaf shares
+/// a parent with the main leaf), `lca_depth == SearchResult.path.len() - 1`
+/// and `diverged_path` is empty. For cross-parent overflow, `lca_depth` points
+/// deeper in the shared ancestor chain and `diverged_path` records the
+/// leftmost descent from there down to `leaf`'s parent.
+pub struct RightNeighbor<Key, Value>
+where
+    Key: self::Key,
+    Key::Archived: PartialOrd<Key> + PartialEq<Key> + SymmetryWith<Key> + Ord,
+    Key: PartialOrd<Key::Archived> + PartialEq<Key::Archived>,
+    Value: self::Value,
+    Value::Archived: for<'a> CheckBytes<
+        Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+    >,
+{
+    /// Depth in the main search path at which the right-adjacent descent
+    /// diverges. Main and right-adjacent descents share hosts at depths
+    /// `0..=lca_depth` (this depth's host is the same node in both
+    /// descents, but they descend to different children).
+    pub lca_depth: usize,
+    /// Tree layers traversed during the leftmost descent from the first right
+    /// sibling at `lca_depth` down to `leaf`'s parent. Empty when the main
+    /// leaf and the right-adjacent leaf share a parent.
+    pub diverged_path: Vec<TreeLayer<Key, Value>>,
+    /// The right-adjacent leaf segment.
+    pub leaf: Node<Key, Value>,
 }
 
 impl<Key, Value> SearchResult<Key, Value>

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -241,7 +241,7 @@ where
 /// the searched key — a necessary condition for boundary-delete overflow. If
 /// the search path contains any layer with a right sibling, we follow the
 /// leftmost descent from the first such sibling down to the next leaf. This
-/// lets [`TreeShaper::delete`] absorb orphan entries into that leaf in one
+/// lets [`TreeShaper::delete`] fold orphan entries into that leaf in one
 /// pass when the deleted entry turns out to be the segment boundary.
 ///
 /// Returns `None` when either the key is not the leaf's last entry or the leaf

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -86,13 +86,12 @@ where
             // Get the start key. Included/Excluded ranges are identical here,
             // the check if key is in range is below, and this will at most read
             // one unnecessary segment iff `Bound::Excluded(K)` and `K` is a
-            // boundary node.
+            // boundary node. An unbounded start begins at the leftmost leaf,
+            // which searching for the minimum key descends to.
             let start_key = match range.start_bound() {
                 Bound::Included(start) => start.clone(),
                 Bound::Excluded(start) => start.clone(),
-                Bound::Unbounded => {
-                    return;
-                },
+                Bound::Unbounded => <Key as crate::Key>::min(),
             };
             let Some(search_result) = self
                 .search(&start_key, accessor.clone(), SearchOptions::default())


### PR DESCRIPTION
This fix addresses two major issues with the new search tree.

1. Ranking was incorrectly adapted in the first pass. The diff reveals the discrepency, but the short explanation is that we assumed all keys in a grouping share the same rank as the boundary and everything past that was built on an incorrect assumption.
2. When deleting a boundary, we were not collapsing nodes to properly reparent the entries of the boundary's segment.

Both of these issues are addressed in this change. Additionally:

- Replace `Tree::get_node` with `Accessor` which serves as a `Sync` shared lookup cache for nodes
- Introduce localized caching of key ranks (there is headroom for further improvement down the road)
- Added a bunch of missing test coverage for the tree and other constructs