### PR TITLE
feat: cardinality one assertions

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -441,60 +441,85 @@ where
 
                         let datum = Datum::from(artifact);
 
-                        if let Some(cause) = &datum.cause {
-                            let ancestor_key = {
-                                let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
-                                    .set_entity(entity_key.entity())
-                                    .set_attribute(entity_key.attribute())
-                                    .into_key();
-                                let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
-                                    .set_entity(entity_key.entity())
-                                    .set_attribute(entity_key.attribute())
-                                    .into_key();
+                        // TODO: Make it concurrent / parallel
+                        index
+                            .set(
+                                entity_key.into_key(),
+                                State::Added(datum.clone()),
+                                &mut self.storage,
+                            )
+                            .await?;
+                        index
+                            .set(
+                                attribute_key.into_key(),
+                                State::Added(datum.clone()),
+                                &mut self.storage,
+                            )
+                            .await?;
+                        index
+                            .set(value_key.into_key(), State::Added(datum), &mut self.storage)
+                            .await?;
+                    }
+                    Instruction::Replace(artifact) => {
+                        let entity_key = EntityKey::from(&artifact);
 
-                                let search_stream =
-                                    index.stream_range(search_start..search_end, &self.storage);
+                        // Scan priors at this (entity, attribute). Same-valued
+                        // priors already represent the desired state; only
+                        // different-valued ones need superseding.
+                        let mut superseded_keys: Vec<Key> = Vec::new();
+                        let mut found_same_value = false;
+                        {
+                            let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
+                                .set_entity(entity_key.entity())
+                                .set_attribute(entity_key.attribute())
+                                .into_key();
+                            let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
+                                .set_entity(entity_key.entity())
+                                .set_attribute(entity_key.attribute())
+                                .into_key();
 
-                                let mut ancestor_key = None;
+                            let search_stream =
+                                index.stream_range(search_start..search_end, &self.storage);
+                            tokio::pin!(search_stream);
 
-                                tokio::pin!(search_stream);
-
-                                while let Some(candidate) = search_stream.try_next().await? {
-                                    if let State::Added(current_element) = candidate.value {
-                                        let current_artifact = Artifact::try_from(current_element)?;
-                                        let current_artifact_reference =
-                                            Cause::from(&current_artifact);
-
-                                        if cause == &current_artifact_reference {
-                                            ancestor_key = Some(candidate.key);
-                                            break;
-                                        }
+                            while let Some(candidate) = search_stream.try_next().await? {
+                                if let State::Added(current_element) = candidate.value {
+                                    let current = Artifact::try_from(current_element)?;
+                                    if current.is == artifact.is {
+                                        found_same_value = true;
+                                    } else {
+                                        superseded_keys.push(candidate.key);
                                     }
                                 }
-
-                                ancestor_key
-                            };
-
-                            if let Some(key) = ancestor_key {
-                                // Prune the old entry from the indexes
-                                let entity_key = EntityKey(key);
-                                let value_key = ValueKey::from_key(&entity_key);
-                                let attribute_key = AttributeKey::from_key(&entity_key);
-
-                                // TODO: Make it concurrent / parallel
-                                index
-                                    .delete(&entity_key.into_key(), &mut self.storage)
-                                    .await?;
-                                index
-                                    .delete(&value_key.into_key(), &mut self.storage)
-                                    .await?;
-                                index
-                                    .delete(&attribute_key.into_key(), &mut self.storage)
-                                    .await?;
                             }
                         }
 
-                        // TODO: Make it concurrent / parallel
+                        for key in superseded_keys {
+                            let entity_key = EntityKey(key);
+                            let value_key = ValueKey::from_key(&entity_key);
+                            let attribute_key = AttributeKey::from_key(&entity_key);
+
+                            index
+                                .delete(&entity_key.into_key(), &mut self.storage)
+                                .await?;
+                            index
+                                .delete(&value_key.into_key(), &mut self.storage)
+                                .await?;
+                            index
+                                .delete(&attribute_key.into_key(), &mut self.storage)
+                                .await?;
+                        }
+
+                        // Skip insert if a same-value prior is already in place.
+                        if found_same_value {
+                            continue;
+                        }
+
+                        let entity_key = EntityKey::from(&artifact);
+                        let value_key = ValueKey::from_key(&entity_key);
+                        let attribute_key = AttributeKey::from_key(&entity_key);
+                        let datum = Datum::from(artifact);
+
                         index
                             .set(
                                 entity_key.into_key(),
@@ -1005,20 +1030,24 @@ mod tests {
         let attribute = Attribute::from_str("test/attribute")?;
         let entity = Entity::new()?;
         let artifact = Artifact {
-            the: attribute,
+            the: attribute.clone(),
             of: entity.clone(),
             is: Value::Boolean(false),
             cause: None,
         };
 
-        artifacts
-            .commit([Instruction::Assert(artifact.clone())])
-            .await?;
+        artifacts.commit([Instruction::Assert(artifact)]).await?;
 
-        let updated_artifact = artifact.update(Value::Boolean(true));
+        // Replace supersedes priors at (entity, attribute) regardless of value.
+        let updated_artifact = Artifact {
+            the: attribute,
+            of: entity.clone(),
+            is: Value::Boolean(true),
+            cause: None,
+        };
 
         artifacts
-            .commit([Instruction::Assert(updated_artifact.clone())])
+            .commit([Instruction::Replace(updated_artifact.clone())])
             .await?;
 
         let results = artifacts

--- a/rust/dialog-artifacts/src/artifacts/artifact.rs
+++ b/rust/dialog-artifacts/src/artifacts/artifact.rs
@@ -41,19 +41,6 @@ pub struct Artifact {
     pub cause: Option<Cause>,
 }
 
-impl Artifact {
-    /// Change the value of the [`Artifact`], assigning the hash of its
-    /// antecedent as the `cause`.
-    pub fn update(self, value: Value) -> Self {
-        let cause = Some(Cause::from(&self));
-        Self {
-            is: value,
-            cause,
-            ..self
-        }
-    }
-}
-
 impl Debug for Artifact {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("Artifact")
@@ -85,33 +72,5 @@ impl TryFrom<Datum> for Artifact {
             is: Value::try_from((ValueDataType::from(value.value_type), value.value))?,
             cause: value.cause,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use anyhow::Result;
-
-    use crate::{Attribute, Cause, Entity, Value};
-
-    use super::Artifact;
-
-    #[test]
-    fn it_points_to_causal_ancestor_when_updated() -> Result<()> {
-        let artifact = Artifact {
-            the: Attribute::from_str("test/predicate")?,
-            of: Entity::new()?,
-            is: Value::Boolean(false),
-            cause: None,
-        };
-        let causal_reference = Cause::from(&artifact);
-        let descendent = artifact.update(Value::Boolean(true));
-
-        assert_eq!(descendent.is, Value::Boolean(true));
-        assert_eq!(descendent.cause, Some(causal_reference));
-
-        Ok(())
     }
 }

--- a/rust/dialog-artifacts/src/artifacts/instruction.rs
+++ b/rust/dialog-artifacts/src/artifacts/instruction.rs
@@ -10,8 +10,16 @@ use crate::ArtifactStoreMut;
 
 /// The instruction variants that are accepted by [`ArtifactStoreMut::commit`].
 pub enum Instruction {
-    /// Assert a [`Artifact`], persisting it in the [`ArtifactStoreMut`]
+    /// Add this [`Artifact`] to the [`ArtifactStoreMut`]. Purely additive:
+    /// any prior entries at the same `(entity, attribute)` are left in
+    /// place. Use [`Instruction::Replace`] for cardinality-one supersession.
     Assert(Artifact),
+    /// Replace any prior artifact at the same `(entity, attribute)` with this
+    /// one, regardless of value. Every existing entry for the pair is
+    /// removed from all three indexes; the new artifact's `cause` is
+    /// populated from the first prior found. Asserting the same value that
+    /// already exists is a no-op.
+    Replace(Artifact),
     /// Retract a [`Artifact`], removing it from the [`ArtifactStoreMut`]
     Retract(Artifact),
 }

--- a/rust/dialog-artifacts/src/artifacts/update.rs
+++ b/rust/dialog-artifacts/src/artifacts/update.rs
@@ -8,8 +8,11 @@ use std::vec::IntoIter;
 /// A single write operation on an `(entity, attribute)` pair.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Change {
-    /// Assert a value for an entity-attribute pair.
+    /// Assert a value for an entity-attribute pair (cardinality-many).
     Assert(Value),
+    /// Replace any prior value(s) at this `(entity, attribute)` with this one
+    /// (cardinality-one). Supersession of priors happens at commit time.
+    Replace(Value),
     /// Retract a value from an entity-attribute pair.
     Retract(Value),
 }
@@ -89,6 +92,12 @@ impl Changes {
                             is: value,
                             cause: None,
                         }),
+                        Change::Replace(value) => Instruction::Replace(Artifact {
+                            the: attribute.clone(),
+                            of: entity.clone(),
+                            is: value,
+                            cause: None,
+                        }),
                         Change::Retract(value) => Instruction::Retract(Artifact {
                             the: attribute.clone(),
                             of: entity.clone(),
@@ -118,7 +127,7 @@ impl Update for Changes {
         self.0
             .entry(of)
             .or_default()
-            .insert(the, vec![Change::Assert(is)]);
+            .insert(the, vec![Change::Replace(is)]);
     }
 
     fn dissociate(&mut self, the: Attribute, of: Entity, is: Value) {

--- a/rust/dialog-artifacts/src/web.rs
+++ b/rust/dialog-artifacts/src/web.rs
@@ -450,18 +450,6 @@ impl From<Cause> for JsValue {
 impl TryFrom<Artifact> for JsValue {
     type Error = JsError;
     fn try_from(artifact: Artifact) -> Result<Self, Self::Error> {
-        let current_version = artifact.clone();
-
-        let update = Closure::<dyn Fn(JsValue) -> JsValue>::new(move |value: JsValue| {
-            if let Ok(value) = Value::try_from(value) {
-                JsValue::try_from(current_version.clone().update(value))
-                    .unwrap_or(JsValue::undefined())
-            } else {
-                JsValue::undefined()
-            }
-        })
-        .into_js_value();
-
         let object = JsValue::from(Object::new());
         let attribute = JsValue::from(artifact.the);
         let entity = JsValue::from(artifact.of);
@@ -470,7 +458,6 @@ impl TryFrom<Artifact> for JsValue {
         Reflect::set(&object, &"the".into(), &attribute).map_err(js_value_to_error)?;
         Reflect::set(&object, &"of".into(), &entity).map_err(js_value_to_error)?;
         Reflect::set(&object, &"is".into(), &value).map_err(js_value_to_error)?;
-        Reflect::set(&object, &"update".into(), &update).map_err(js_value_to_error)?;
 
         if let Some(cause) = artifact.cause {
             Reflect::set(&object, &"cause".into(), &JsValue::from(cause))

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -929,6 +929,74 @@ mod tests {
 
             Ok(())
         }
+
+        #[dialog_common::test]
+        async fn it_is_noop_when_reasserting_same_cardinality_one_value() -> anyhow::Result<()> {
+            // Reasserting the same value for a cardinality-one attribute
+            // must be a no-op at the storage layer: the tree must not
+            // change, so the revision's tree hash stays the same.
+            #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("dialog.meta")]
+            pub struct NamedEntity(pub Entity);
+
+            #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            pub struct Name {
+                pub this: Entity,
+                pub entity: NamedEntity,
+            }
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            let id_page: Entity = "id:page".parse()?;
+            let page_v1: Entity =
+                "concept:Fx8sv1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?;
+
+            let r1 = branch
+                .transaction()
+                .assert(Name {
+                    this: id_page.clone(),
+                    entity: NamedEntity(page_v1.clone()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            let r2 = branch
+                .transaction()
+                .assert(Name {
+                    this: id_page.clone(),
+                    entity: NamedEntity(page_v1.clone()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            assert_eq!(
+                r1.tree, r2.tree,
+                "reasserting the same value must not change the tree"
+            );
+
+            // And the query must still yield exactly the one claim.
+            assert_eq!(
+                branch
+                    .query()
+                    .select(Query::<Name> {
+                        this: id_page.clone().into(),
+                        entity: Term::var("entity"),
+                    })
+                    .perform(&operator)
+                    .try_vec()
+                    .await?,
+                vec![Name {
+                    this: id_page.clone(),
+                    entity: NamedEntity(page_v1.clone()),
+                }]
+            );
+
+            Ok(())
+        }
     }
 
     mod profile_as_repository {

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -865,6 +865,70 @@ mod tests {
 
             Ok(())
         }
+
+        #[dialog_common::test]
+        async fn it_accumulates_two_cardinality_many_values_in_one_tx() -> anyhow::Result<()> {
+            // Regression guard: asserting two distinct values for the same
+            // (entity, attribute) inside a single transaction must keep
+            // both — cardinality-many accumulates, it does not collapse.
+            #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[cardinality(many)]
+            #[domain("dialog.meta")]
+            pub struct Tag(pub String);
+
+            #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            pub struct Tagged {
+                pub this: Entity,
+                pub tag: Tag,
+            }
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            let post: Entity = "id:post".parse()?;
+
+            branch
+                .transaction()
+                .assert(Tagged {
+                    this: post.clone(),
+                    tag: Tag("red".into()),
+                })
+                .assert(Tagged {
+                    this: post.clone(),
+                    tag: Tag("blue".into()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            let mut results: Vec<Tagged> = branch
+                .query()
+                .select(Query::<Tagged> {
+                    this: post.clone().into(),
+                    tag: Term::var("tag"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+            results.sort();
+
+            assert_eq!(
+                results,
+                vec![
+                    Tagged {
+                        this: post.clone(),
+                        tag: Tag("blue".into()),
+                    },
+                    Tagged {
+                        this: post.clone(),
+                        tag: Tag("red".into()),
+                    },
+                ]
+            );
+
+            Ok(())
+        }
     }
 
     mod profile_as_repository {

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -768,6 +768,103 @@ mod tests {
             assert_eq!(results.len(), 2);
             Ok(())
         }
+
+        #[dialog_common::test]
+        async fn it_resolves_only_latest_name_target_via_name_concept() -> anyhow::Result<()> {
+            /// The `dialog.meta/named-entity` attribute — the entity a
+            /// name currently points at. Cardinality `one` (the derive
+            /// default), so re-pointing a name supersedes the prior
+            /// claim instead of accumulating.
+            #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("dialog.meta")]
+            pub struct NamedEntity(pub Entity);
+
+            /// A user-published name — an `id:<n>` entity carrying a
+            /// single `entity` claim that points at the target the name
+            /// currently identifies.
+            #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            pub struct Name {
+                /// The name entity — `id:<n>` for user-published names,
+                /// `db:<n>` for built-ins.
+                pub this: Entity,
+                /// The target this name currently identifies.
+                pub entity: NamedEntity,
+            }
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            // Use the `concept:` scheme for targets — this matches
+            // the real-world case where `concept!: &page` derives a
+            // content-hashed `concept:…` entity URI for each body.
+            // Same supersession path, different value scheme; this
+            // catches a bug where the cardinality-one filter was
+            // sensitive to the value's URI scheme.
+            let id_page: Entity = "id:page".parse()?;
+            let page_v1: Entity =
+                "concept:Fx8sv1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?;
+            let page_v2: Entity =
+                "concept:AfmLeBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".parse()?;
+
+            // tx1 — point id:page at v1.
+            let v1 = branch
+                .transaction()
+                .assert(Name {
+                    this: id_page.clone(),
+                    entity: NamedEntity(page_v1.clone()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            assert_eq!(
+                branch
+                    .query()
+                    .select(Query::<Name> {
+                        this: id_page.clone().into(),
+                        entity: Term::var("entity"),
+                    })
+                    .perform(&operator)
+                    .try_vec()
+                    .await?,
+                vec![Name {
+                    this: id_page.clone(),
+                    entity: NamedEntity(page_v1.clone())
+                }]
+            );
+
+            // tx2 — point id:page at v2. Cardinality-one supersedes v1.
+            let v2 = branch
+                .transaction()
+                .assert(Name {
+                    this: id_page.clone(),
+                    entity: NamedEntity(page_v2.clone()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            assert_ne!(v1, v2);
+
+            assert_eq!(
+                branch
+                    .query()
+                    .select(Query::<Name> {
+                        this: id_page.clone().into(),
+                        entity: Term::var("entity"),
+                    })
+                    .perform(&operator)
+                    .try_vec()
+                    .await?,
+                vec![Name {
+                    this: id_page.clone(),
+                    entity: NamedEntity(page_v2.clone())
+                }]
+            );
+
+            Ok(())
+        }
     }
 
     mod profile_as_repository {

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -3,8 +3,8 @@ use crate::{
     RepositoryMemoryExt, Revision, TreeReference, Upstream,
 };
 use dialog_artifacts::{
-    Artifact, AttributeKey, Cause, Datum, EntityKey, FromKey, Instruction, Key, KeyView,
-    KeyViewConstruct, KeyViewMut, State, ValueKey,
+    Artifact, AttributeKey, Datum, EntityKey, FromKey, Instruction, Key, KeyView, KeyViewConstruct,
+    KeyViewMut, State, ValueKey,
 };
 use dialog_capability::{Fork, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
@@ -96,52 +96,73 @@ where
 
                     let datum = Datum::from(artifact);
 
-                    // When asserting with a cause, find and remove the
-                    // ancestor so the new version replaces it in all
-                    // three indexes.
-                    if let Some(cause) = &datum.cause {
-                        let ancestor_key = {
-                            let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
-                                .set_entity(entity_key.entity())
-                                .set_attribute(entity_key.attribute())
-                                .into_key();
-                            let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
-                                .set_entity(entity_key.entity())
-                                .set_attribute(entity_key.attribute())
-                                .into_key();
+                    tree.set(
+                        entity_key.into_key(),
+                        State::Added(datum.clone()),
+                        &mut store,
+                    )
+                    .await?;
+                    tree.set(
+                        attribute_key.into_key(),
+                        State::Added(datum.clone()),
+                        &mut store,
+                    )
+                    .await?;
+                    tree.set(value_key.into_key(), State::Added(datum), &mut store)
+                        .await?;
+                }
+                Instruction::Replace(artifact) => {
+                    let entity_key = EntityKey::from(&artifact);
 
-                            // Pinned because `stream_range` borrows from `tree` and
-                            // `store` across await points below.
-                            let search_stream = tree.stream_range(search_start..search_end, &store);
-                            tokio::pin!(search_stream);
+                    // Scan priors at this (entity, attribute). Same-valued
+                    // priors already represent the desired state; only
+                    // different-valued ones need superseding.
+                    let mut superseded_keys: Vec<Key> = Vec::new();
+                    let mut found_same_value = false;
+                    {
+                        let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
+                            .set_entity(entity_key.entity())
+                            .set_attribute(entity_key.attribute())
+                            .into_key();
+                        let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
+                            .set_entity(entity_key.entity())
+                            .set_attribute(entity_key.attribute())
+                            .into_key();
 
-                            let mut ancestor_key = None;
-                            while let Some(candidate) = search_stream.try_next().await? {
-                                if let State::Added(current_element) = candidate.value {
-                                    let current_artifact = Artifact::try_from(current_element)?;
-                                    let current_artifact_reference = Cause::from(&current_artifact);
+                        let search_stream = tree.stream_range(search_start..search_end, &store);
+                        tokio::pin!(search_stream);
 
-                                    if cause == &current_artifact_reference {
-                                        ancestor_key = Some(candidate.key);
-                                        break;
-                                    }
+                        while let Some(candidate) = search_stream.try_next().await? {
+                            if let State::Added(current_element) = candidate.value {
+                                let current = Artifact::try_from(current_element)?;
+                                if current.is == artifact.is {
+                                    found_same_value = true;
+                                } else {
+                                    superseded_keys.push(candidate.key);
                                 }
                             }
-
-                            ancestor_key
-                        };
-
-                        if let Some(key) = ancestor_key {
-                            let entity_key = EntityKey(key);
-                            let value_key: ValueKey<Key> = ValueKey::from_key(&entity_key);
-                            let attribute_key: AttributeKey<Key> =
-                                AttributeKey::from_key(&entity_key);
-
-                            tree.delete(&entity_key.into_key(), &mut store).await?;
-                            tree.delete(&value_key.into_key(), &mut store).await?;
-                            tree.delete(&attribute_key.into_key(), &mut store).await?;
                         }
                     }
+
+                    for key in superseded_keys {
+                        let entity_key = EntityKey(key);
+                        let value_key = ValueKey::from_key(&entity_key);
+                        let attribute_key = AttributeKey::from_key(&entity_key);
+
+                        tree.delete(&entity_key.into_key(), &mut store).await?;
+                        tree.delete(&value_key.into_key(), &mut store).await?;
+                        tree.delete(&attribute_key.into_key(), &mut store).await?;
+                    }
+
+                    // Skip insert if a same-value prior is already in place.
+                    if found_same_value {
+                        continue;
+                    }
+
+                    let entity_key = EntityKey::from(&artifact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+                    let datum = Datum::from(artifact);
 
                     tree.set(
                         entity_key.into_key(),


### PR DESCRIPTION
## Summary

Cardinality-one assertions did not actually supersede prior values across commits. Originally the design imagined callers would populate `cause` on a new assertion to point at the prior fact they intended to retract — and supersession would key off that. In practice you often *don't* know the prior value at write time, so nothing ever set `cause`, and cardinality-one wasn't behaving as cardinality-one. I keep forgetting this myself and getting surprised by it; the cardinality declaration on the attribute is a better expression of intent than caller-supplied `cause`.

This PR makes `cardinality: one` actually mean "this attribute holds one value per entity," which also lines up more naturally with the planned [version-control design](https://github.com/dialog-db/dialog-db/pull/240/changes) — where `Cause` becomes a `Vec<Version>` of *automatically captured* superseded priors rather than something the caller hand-fills.

## What changed

Add `Change::Replace` / `Instruction::Replace` as the single signal for cardinality-one supersession. `Statement::assert` already routes cardinality-one writes through `Update::associate_unique`, which now lowers to `Replace`. Both commit handlers (`dialog-repository/src/repository/branch/commit.rs` and the in-memory store in `dialog-artifacts/src/artifacts.rs`) implement `Replace` by scanning `(entity, attribute)`, deleting every prior whose value differs, and skipping the insert when a same-value prior is already present (so reasserting the same value doesn't change the tree hash).

`Instruction::Assert` is now purely additive. The dead `cause`-gated branch is gone, along with `Artifact::update` and the WASM `Artifact.update(value)` closure that depended on it. `Artifact.cause` is left as a vestigial field; the version-control work will repurpose it.

## Tests

- `it_resolves_only_latest_name_target_via_name_concept` — was failing; now passes.
- `it_accumulates_two_cardinality_many_values_in_one_tx` — regression guard; cardinality-many still accumulates.
- `it_is_noop_when_reasserting_same_cardinality_one_value` — `r1.tree == r2.tree` on identical reassert.