### PR TITLE
fix(dialog-macros): strip raw-identifier prefix from field names

### DIFF
--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -71,6 +71,7 @@
 //! // PersonQuery → Parameters, Premise, Proposition, ConceptQuery
 //! ```
 
+use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::ext::IdentExt;
@@ -142,12 +143,15 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
     for field in fields {
         let field_name = field.ident.as_ref().unwrap();
-        // `unraw()` drops the `r#` prefix on raw identifiers so a field
-        // declared as `r#type` appears in the descriptor as `"type"`.
-        let field_name_str = field_name.unraw().to_string();
+        // The Rust field name is normalized for the descriptor / query
+        // surface: `unraw()` drops any `r#` raw-identifier prefix, then
+        // `to_case(Case::Kebab)` matches the formal-notation convention
+        // used by attribute names elsewhere.
+        let raw_field_name = field_name.unraw().to_string();
+        let field_name_str = raw_field_name.to_case(Case::Kebab);
 
         // Skip the 'this' field - it's handled specially
-        if field_name_str == "this" {
+        if raw_field_name == "this" {
             continue;
         }
 

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -73,6 +73,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::ext::IdentExt;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 use super::helpers::extract_doc_comments;
@@ -141,7 +142,9 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
     for field in fields {
         let field_name = field.ident.as_ref().unwrap();
-        let field_name_str = field_name.to_string();
+        // `unraw()` drops the `r#` prefix on raw identifiers so a field
+        // declared as `r#type` appears in the descriptor as `"type"`.
+        let field_name_str = field_name.unraw().to_string();
 
         // Skip the 'this' field - it's handled specially
         if field_name_str == "this" {

--- a/rust/dialog-macros/src/query/formula.rs
+++ b/rust/dialog-macros/src/query/formula.rs
@@ -68,6 +68,7 @@
 //! // Formula::write() for FullNameFormula (writes output cells to bindings)
 //! ```
 
+use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::ext::IdentExt;
@@ -214,15 +215,17 @@ pub fn derive(input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    // `unraw()` drops the `r#` prefix on raw identifiers so a field
-    // declared as `r#type` appears in parameter names as `"type"`.
+    // The Rust field name is normalized for the parameter surface:
+    // `unraw()` drops any `r#` raw-identifier prefix, then
+    // `to_case(Case::Kebab)` matches the formal-notation convention
+    // used by attribute names elsewhere.
 
     // Generate field names for Input TryFrom
     let input_field_names: Vec<_> = input_fields.iter().map(|(name, _, _)| name).collect();
     let input_field_name_lits: Vec<_> = input_fields
         .iter()
         .map(|(name, _, _)| {
-            let name_str = name.unraw().to_string();
+            let name_str = name.unraw().to_string().to_case(Case::Kebab);
             syn::LitStr::new(&name_str, proc_macro2::Span::call_site())
         })
         .collect();
@@ -232,7 +235,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let all_field_name_lits: Vec<_> = all_fields
         .iter()
         .map(|(name, _, _, _, _)| {
-            let name_str = name.unraw().to_string();
+            let name_str = name.unraw().to_string().to_case(Case::Kebab);
             syn::LitStr::new(&name_str, proc_macro2::Span::call_site())
         })
         .collect();

--- a/rust/dialog-macros/src/query/formula.rs
+++ b/rust/dialog-macros/src/query/formula.rs
@@ -70,6 +70,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::ext::IdentExt;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 use super::helpers::{extract_doc_comments, parse_output_attribute, type_to_value_data_type};
@@ -213,12 +214,15 @@ pub fn derive(input: TokenStream) -> TokenStream {
         })
         .collect();
 
+    // `unraw()` drops the `r#` prefix on raw identifiers so a field
+    // declared as `r#type` appears in parameter names as `"type"`.
+
     // Generate field names for Input TryFrom
     let input_field_names: Vec<_> = input_fields.iter().map(|(name, _, _)| name).collect();
     let input_field_name_lits: Vec<_> = input_fields
         .iter()
         .map(|(name, _, _)| {
-            let name_str = name.to_string();
+            let name_str = name.unraw().to_string();
             syn::LitStr::new(&name_str, proc_macro2::Span::call_site())
         })
         .collect();
@@ -228,7 +232,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let all_field_name_lits: Vec<_> = all_fields
         .iter()
         .map(|(name, _, _, _, _)| {
-            let name_str = name.to_string();
+            let name_str = name.unraw().to_string();
             syn::LitStr::new(&name_str, proc_macro2::Span::call_site())
         })
         .collect();

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -1222,6 +1222,49 @@ mod tests {
     }
 
     #[dialog_common::test]
+    fn it_strips_raw_identifier_prefix_from_concept_field_names() {
+        use crate as dialog_query;
+        use crate::{Attribute, Concept, Entity};
+
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("test")]
+        pub struct TypeAttr(pub String);
+
+        #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct Sample {
+            pub this: Entity,
+            /// `type` is a Rust keyword so the field has to be written
+            /// `r#type` — but the descriptor's `with` map key must be
+            /// the cooked name `"type"`, not `"r#type"`.
+            pub r#type: TypeAttr,
+        }
+
+        let descriptor: ConceptDescriptor =
+            <Sample as crate::Predicate>::Application::default().into();
+
+        // Round-trip the descriptor through JSON and assert the field
+        // key in the `with` map is `type`, not `r#type`.
+        let json = serde_json::to_value(&descriptor).expect("serialize");
+        let with = json["with"].as_object().expect("with map");
+
+        assert!(
+            with.contains_key("type"),
+            "descriptor should expose `type`, got keys: {:?}",
+            with.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !with.contains_key("r#type"),
+            "descriptor should NOT expose raw-ident `r#type`",
+        );
+
+        let round_tripped: ConceptDescriptor = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(
+            round_tripped, descriptor,
+            "JSON round-trip must be lossless"
+        );
+    }
+
+    #[dialog_common::test]
     fn it_deserializes_empty_maybe_as_none() {
         let json = r#"{
             "with": {

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -39,8 +39,13 @@ use std::ops::Not;
 ///
 /// Serializes to the formal notation:
 /// ```json
-/// { "description": "...", "with": { "fieldName": { "the": "domain/name", ... } } }
+/// { "description": "...", "with": { "field-name": { "the": "domain/name", ... } } }
 /// ```
+///
+/// Field-name keys follow the kebab-case convention used elsewhere in the
+/// formal notation; Rust field names are normalized on derive (e.g. a
+/// `display_name`, `displayName`, or `DisplayName` field all serialize as
+/// `"display-name"`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConceptDescriptor {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1227,7 +1232,7 @@ mod tests {
         use crate::{Attribute, Concept, Entity};
 
         #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-        #[domain("test")]
+        #[domain("dialog.test")]
         pub struct TypeAttr(pub String);
 
         #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -1259,8 +1264,77 @@ mod tests {
 
         let round_tripped: ConceptDescriptor = serde_json::from_value(json).expect("deserialize");
         assert_eq!(
-            round_tripped, descriptor,
-            "JSON round-trip must be lossless"
+            round_tripped.this(),
+            descriptor.this(),
+            "JSON round-trip must preserve the concept's content hash"
+        );
+    }
+
+    #[dialog_common::test]
+    #[allow(nonstandard_style)]
+    fn it_kebab_cases_concept_field_names() {
+        use crate as dialog_query;
+        use crate::{Attribute, Concept, Entity};
+
+        // The descriptor's `with` map keys follow the formal-notation
+        // convention: lower-case kebab. snake_case, camelCase, and
+        // PascalCase field names all collapse to kebab-case. A field
+        // already in single-word lower form is unchanged.
+
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dialog.test")]
+        pub struct A(pub String);
+
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dialog.test")]
+        pub struct B(pub String);
+
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dialog.test")]
+        pub struct C(pub String);
+
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dialog.test")]
+        pub struct D(pub String);
+
+        #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct Sample {
+            pub this: Entity,
+            /// snake_case → kebab
+            pub display_name: A,
+            /// camelCase → kebab
+            pub firstName: B,
+            /// PascalCase → kebab
+            pub LastName: C,
+            /// already lowercase single-word → unchanged
+            pub email: D,
+        }
+
+        let descriptor: ConceptDescriptor =
+            <Sample as crate::Predicate>::Application::default().into();
+
+        let json = serde_json::to_value(&descriptor).expect("serialize");
+        let with = json["with"].as_object().expect("with map");
+        let keys: Vec<&String> = with.keys().collect();
+
+        for expected in ["display-name", "first-name", "last-name", "email"] {
+            assert!(
+                with.contains_key(expected),
+                "descriptor should expose `{expected}`, got keys: {keys:?}",
+            );
+        }
+        for unexpected in ["display_name", "firstName", "LastName"] {
+            assert!(
+                !with.contains_key(unexpected),
+                "descriptor should NOT expose raw `{unexpected}`",
+            );
+        }
+
+        let round_tripped: ConceptDescriptor = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(
+            round_tripped.this(),
+            descriptor.this(),
+            "JSON round-trip must preserve the concept's content hash"
         );
     }
 

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 /// This is a transparent wrapper around `Vec<(String, AttributeDescriptor)>` that
 /// enforces non-emptiness — you cannot create a `NamedAttributes` with zero entries.
 ///
-/// Serializes as a JSON map: `{ "fieldName": { "the": "domain/name", ... } }`
+/// Serializes as a JSON map: `{ "field-name": { "the": "domain/name", ... } }`
 #[repr(transparent)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct NamedAttributes(Vec<(String, AttributeDescriptor)>);


### PR DESCRIPTION
## Summary

Rust field names leaked into derive-macro output verbatim, breaking two conventions the formal notation relies on:

1. **Raw-identifier prefix.** A field declared `r#type` produced descriptor key `"r#type"` instead of `"type"`.
2. **Casing.** Fields like `display_name`, `firstName`, or `LastName` produced descriptor keys identical to the Rust source instead of the kebab-case form (`display-name`, `first-name`, `last-name`) used elsewhere (attribute names, concept names, …).

Both surface in `ConceptDescriptor.with` map keys, `Term::var(...)` query variable names, and the parameter map populated by the generated `From<...> for Parameters` impls.

## Fix

Normalize once at derive time in both `Concept` and `Formula` derives:

```rust
let name = field.ident.as_ref().unwrap()
    .unraw()                    // drop r# prefix
    .to_string()
    .to_case(Case::Kebab);      // snake/camel/Pascal → kebab
```

`syn::ext::IdentExt::unraw` + `convert_case::Case::Kebab` (workspace dep already in use by `dialog-macros`). Single-word lowercase names are unchanged.

## Tests

In `dialog-query/src/concept/descriptor.rs`:

- `it_strips_raw_identifier_prefix_from_concept_field_names` — `r#type` field round-trips through JSON as `"type"`.
- `it_kebab_cases_concept_field_names` — `display_name`, `firstName`, `LastName`, `email` fields serialize as `display-name`, `first-name`, `last-name`, `email` respectively.

Both verify round-trip preserves the concept's content hash (`descriptor.this()`).