### PR TITLE
feat(dialog-query): add InductiveRule sibling of DeductiveRule

### DIFF
--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -638,7 +638,7 @@ mod tests {
         let rule = DeductiveRule::from(&predicate);
 
         let analyzer_error = AnalyzerError::UnusedParameter {
-            rule: rule.clone(),
+            rule: Box::new(rule.clone().into()),
             parameter: "test_param".to_string(),
         };
 

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -1,8 +1,12 @@
 //! Per-concept rule management with adornment-keyed plan caching.
 //!
-//! Each `ConceptRules` owns the rules for a single concept entity and caches
-//! execution plans keyed by adornment (binding pattern). This is the per-concept
-//! counterpart to the registry-level indexing in `RuleRegistry`.
+//! Each `ConceptRules` owns the *deductive* rules for a single
+//! concept entity and caches execution plans keyed by adornment
+//! (binding pattern). This is the per-concept counterpart to the
+//! registry-level indexing in `RuleRegistry`. Inductive rules
+//! ([`InductiveRule`](crate::rule::InductiveRule)) participate in
+//! transactions rather than queries and will be installed via a
+//! separate path in the future.
 
 use std::iter;
 

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use crate::artifact::{ArtifactTypeError, DialogArtifactsError, Type, Value};
 pub use crate::environment::Environment;
 pub use crate::proposition::Proposition;
+pub use crate::rule::Rule;
 pub use crate::rule::deductive::DeductiveRule;
 use crate::term::Term;
 use crate::types::Any;
@@ -49,7 +50,7 @@ pub enum TypeError {
     #[error("Rule {rule} does not use parameter \"{parameter}\"")]
     UnusedParameter {
         /// The rule containing the unused parameter.
-        rule: Box<DeductiveRule>,
+        rule: Box<Rule>,
         /// Name of the unused parameter.
         parameter: String,
     },
@@ -58,7 +59,7 @@ pub enum TypeError {
     #[error("Rule {rule} does not bind variable \"{variable}\"")]
     UnboundVariable {
         /// The rule with the unbound variable.
-        rule: Box<DeductiveRule>,
+        rule: Box<Rule>,
         /// Name of the unbound variable.
         variable: String,
     },
@@ -67,7 +68,7 @@ pub enum TypeError {
     #[error("Rule {rule} application omits required parameter \"{parameter}\"")]
     OmittedParameter {
         /// The rule missing the parameter.
-        rule: Box<DeductiveRule>,
+        rule: Box<Rule>,
         /// Name of the omitted parameter.
         parameter: String,
     },
@@ -76,7 +77,7 @@ pub enum TypeError {
     #[error("Rule {rule} uses local {variable} that no premise can provide")]
     RequiredLocalVariable {
         /// The rule with the unprovided local variable.
-        rule: Box<DeductiveRule>,
+        rule: Box<Rule>,
         /// Name of the local variable.
         variable: String,
     },
@@ -85,7 +86,7 @@ pub enum TypeError {
     #[error("Rule {rule} passes unbound {term} into required parameter \"{parameter}\"")]
     UnboundRuleParameter {
         /// The rule with the unbound parameter.
-        rule: Box<DeductiveRule>,
+        rule: Box<Rule>,
         /// Name of the required parameter.
         parameter: String,
         /// The unbound term.
@@ -165,26 +166,20 @@ pub enum TypeError {
 impl From<AnalyzerError> for TypeError {
     fn from(error: AnalyzerError) -> Self {
         match error {
-            AnalyzerError::UnusedParameter { rule, parameter } => TypeError::UnusedParameter {
-                rule: Box::new(rule),
-                parameter,
-            },
-            AnalyzerError::UnboundVariable { rule, variable } => TypeError::UnboundVariable {
-                rule: Box::new(rule),
-                variable,
-            },
-            AnalyzerError::RequiredParameter { rule, parameter } => TypeError::OmittedParameter {
-                rule: Box::new(rule),
-                parameter,
-            },
+            AnalyzerError::UnusedParameter { rule, parameter } => {
+                TypeError::UnusedParameter { rule, parameter }
+            }
+            AnalyzerError::UnboundVariable { rule, variable } => {
+                TypeError::UnboundVariable { rule, variable }
+            }
+            AnalyzerError::RequiredParameter { rule, parameter } => {
+                TypeError::OmittedParameter { rule, parameter }
+            }
             AnalyzerError::OmitsRequiredCell { formula, cell } => {
                 TypeError::OmittedCell { formula, cell }
             }
             AnalyzerError::RequiredLocalVariable { rule, variable } => {
-                TypeError::RequiredLocalVariable {
-                    rule: Box::new(rule),
-                    variable,
-                }
+                TypeError::RequiredLocalVariable { rule, variable }
             }
         }
     }
@@ -368,7 +363,7 @@ pub enum AnalyzerError {
     #[error("Rule {rule} does not makes use of the \"{parameter}\" parameter")]
     UnusedParameter {
         /// The rule containing the unused parameter.
-        rule: DeductiveRule,
+        rule: Box<Rule>,
         /// Name of the unused parameter.
         parameter: String,
     },
@@ -376,7 +371,7 @@ pub enum AnalyzerError {
     #[error("Rule {rule} application omits required parameter \"{parameter}\"")]
     RequiredParameter {
         /// The rule missing the parameter.
-        rule: DeductiveRule,
+        rule: Box<Rule>,
         /// Name of the required parameter.
         parameter: String,
     },
@@ -392,7 +387,7 @@ pub enum AnalyzerError {
     #[error("Rule {rule} makes use of local {variable} that no premise can provide")]
     RequiredLocalVariable {
         /// The rule with the unprovided local variable.
-        rule: DeductiveRule,
+        rule: Box<Rule>,
         /// Name of the local variable.
         variable: String,
     },
@@ -400,7 +395,7 @@ pub enum AnalyzerError {
     #[error("Rule {rule} does not bind a variable \"{variable}\"")]
     UnboundVariable {
         /// The rule with the unbound variable.
-        rule: DeductiveRule,
+        rule: Box<Rule>,
         /// Name of the unbound variable.
         variable: String,
     },

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -1,12 +1,31 @@
-//! Rule-based deduction system
+//! Rule-based deduction and induction system.
 //!
-//! This module implements the core rule system for dialog-query, allowing
-//! declarative specification of derived facts through logical rules.
+//! Two rule kinds share the same analysis pipeline and differ only at
+//! evaluation time:
 //!
-//! The design follows the patterns described in notes/rules.md.
+//! - [`DeductiveRule`] derives new facts on demand when its body is
+//!   queried. Standard Datalog semantics.
+//! - [`InductiveRule`] (a.k.a. *effect*) asserts its head facts when
+//!   its body matches during commit-time evaluation. Fires the
+//!   reactor's fixpoint loop; trigger facts on `effect:system` are
+//!   ephemeral.
+//!
+//! The [`Rule`] enum carries either variant and is what compile-time
+//! analysis errors (in [`TypeError`](crate::TypeError) and
+//! [`AnalyzerError`](crate::AnalyzerError)) reference, so error
+//! reporting is uniform across both kinds.
+
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::error::TypeError;
+use crate::planner::{Conjunction, Planner};
+use crate::premise::Premise;
+use crate::{Environment, Type};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Deductive rule definitions for deriving new facts.
 pub mod deductive;
+/// Inductive rule definitions (a.k.a. effects).
+pub mod inductive;
 /// Premises collection type.
 pub mod premises;
 /// When trait and tuple implementations.
@@ -14,8 +33,114 @@ pub mod when;
 
 pub use deductive::DeductiveRule;
 pub use deductive::descriptor::DeductiveRuleDescriptor;
+pub use inductive::InductiveRule;
+pub use inductive::descriptor::InductiveRuleDescriptor;
 pub use premises::*;
 pub use when::*;
+
+/// A compiled rule — either deductive or inductive.
+///
+/// Both variants share the same head ([`ConceptDescriptor`]) and
+/// body ([`Conjunction`]); they differ in what the evaluator does
+/// with a matching body. Errors raised during compile-time analysis
+/// reference the in-progress rule via this enum so the same error
+/// type works for both kinds.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Rule {
+    /// A deductive rule — yields tuples on query.
+    Deductive(DeductiveRule),
+    /// An inductive rule — asserts head facts on commit.
+    Inductive(InductiveRule),
+}
+
+impl Rule {
+    /// The conclusion (head) of this rule.
+    pub fn conclusion(&self) -> &ConceptDescriptor {
+        match self {
+            Rule::Deductive(r) => r.conclusion(),
+            Rule::Inductive(r) => r.conclusion(),
+        }
+    }
+}
+
+impl Display for Rule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Rule::Deductive(r) => Display::fmt(r, f),
+            Rule::Inductive(r) => Display::fmt(r, f),
+        }
+    }
+}
+
+impl From<DeductiveRule> for Rule {
+    fn from(r: DeductiveRule) -> Self {
+        Rule::Deductive(r)
+    }
+}
+
+impl From<InductiveRule> for Rule {
+    fn from(r: InductiveRule) -> Self {
+        Rule::Inductive(r)
+    }
+}
+
+/// Common construction surface for both rule kinds.
+///
+/// Implementors are constructible from a head + planned body via
+/// [`from_parts`](Compile::from_parts), and convertible into a
+/// [`Rule`] so analysis errors can refer to the in-progress rule
+/// uniformly. The default [`compile`](Compile::compile) runs the
+/// shared analysis pipeline (planner + unbound-variable check).
+pub trait Compile: Sized + Into<Rule> {
+    /// Build the rule from its compiled parts. Called by
+    /// [`compile`](Self::compile) once analysis passes.
+    fn from_parts(conclusion: ConceptDescriptor, join: Conjunction) -> Self;
+
+    /// Plan the premises and verify every head variable is bound.
+    /// Default impl is identical for deductive and inductive
+    /// rules; the only difference between the kinds lives at
+    /// evaluation time, not compile time.
+    fn compile(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
+        // Plan the order of premises in a scope where none of the
+        // rule parameters are bound to find the optimal execution
+        // order, or to discover unsatisfiable premises (e.g. a
+        // formula whose required cell is never derived by another
+        // premise).
+        let join = Planner::from(premises).plan(&Environment::new())?;
+
+        // Verify that every conclusion parameter is derived by one
+        // of the premises; otherwise the rule could never fully
+        // bind its output. Build `Self` only when needed for the
+        // error path so the happy path doesn't allocate twice.
+        let unbound = conclusion
+            .operands()
+            .find(|name| !join.binds.contains(name))
+            .map(String::from);
+        if let Some(variable) = unbound {
+            let in_progress = Self::from_parts(conclusion, join);
+            return Err(TypeError::UnboundVariable {
+                rule: Box::new(in_progress.into()),
+                variable,
+            });
+        }
+
+        Ok(Self::from_parts(conclusion, join))
+    }
+}
+
+/// Helper for the [`Display`] impls on [`DeductiveRule`] and
+/// [`InductiveRule`] — both render their schema the same way.
+pub(crate) fn fmt_rule_schema(conclusion: &ConceptDescriptor, f: &mut Formatter<'_>) -> FmtResult {
+    write!(f, "{} {{", conclusion.this())?;
+    write!(f, "this: {},", Type::Entity)?;
+    for (name, attribute) in conclusion.with().iter() {
+        match attribute.content_type() {
+            Some(ty) => write!(f, "{}: {},", name, ty)?,
+            None => write!(f, "{}: Any,", name)?,
+        }
+    }
+    write!(f, "}}")
+}
 
 /// Macro for creating When collections with clean array-like syntax
 ///

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -7,8 +7,9 @@ use crate::negation::Negation;
 pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
+use crate::rule::{Compile, fmt_rule_schema};
 pub use crate::{Attribute, Cardinality, Parameters, Proposition, Requirement, Value};
-use crate::{Environment, Term, Type};
+use crate::{Environment, Term};
 use descriptor::DeductiveRuleDescriptor;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -24,35 +25,19 @@ pub struct DeductiveRule {
     /// evaluation. Produced by [`Planner::plan`] during compilation.
     join: Conjunction,
 }
+impl Compile for DeductiveRule {
+    fn from_parts(conclusion: ConceptDescriptor, join: Conjunction) -> Self {
+        DeductiveRule { conclusion, join }
+    }
+}
+
 impl DeductiveRule {
     /// Compile a rule from a conclusion and premises.
     ///
     /// Plans the optimal premise execution order and validates that every
     /// conclusion variable is grounded by at least one positive premise.
     pub fn new(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
-        // Plan the order of premises in a scope where none of the rule
-        // parameters are bound to find the optimal execution order, or to
-        // discover unsatisfiable premises (e.g. a formula whose required
-        // cell is never derived by another premise).
-        let join = Planner::from(premises).plan(&Environment::new())?;
-        let rule = DeductiveRule { conclusion, join };
-
-        // Verify that every conclusion parameter is derived by one of the
-        // premises; otherwise the rule could never fully bind its output.
-        let unbound = rule
-            .conclusion
-            .operands()
-            .find(|name| !rule.join.binds.contains(name))
-            .map(String::from);
-
-        if let Some(variable) = unbound {
-            return Err(TypeError::UnboundVariable {
-                rule: Box::new(rule),
-                variable,
-            });
-        }
-
-        Ok(rule)
+        <Self as Compile>::compile(conclusion, premises)
     }
 
     /// Returns the conclusion predicate for this rule.
@@ -122,15 +107,7 @@ impl<'de> Deserialize<'de> for DeductiveRule {
 
 impl Display for DeductiveRule {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{} {{", self.conclusion.this())?;
-        write!(f, "this: {},", Type::Entity)?;
-        for (name, attribute) in self.conclusion.with().iter() {
-            match attribute.content_type() {
-                Some(ty) => write!(f, "{}: {},", name, ty)?,
-                None => write!(f, "{}: Any,", name)?,
-            }
-        }
-        write!(f, "}}")
+        fmt_rule_schema(&self.conclusion, f)
     }
 }
 

--- a/rust/dialog-query/src/rule/inductive.rs
+++ b/rust/dialog-query/src/rule/inductive.rs
@@ -1,0 +1,214 @@
+//! Inductive rules — assert head facts when the body matches.
+//!
+//! An inductive rule (a.k.a. *effect*) has the same shape as a
+//! [`DeductiveRule`](crate::rule::DeductiveRule) but different
+//! evaluation semantics: instead of yielding tuples on query, it
+//! commits its head as new facts whenever its body produces
+//! bindings. The reactor's fixpoint loop drives evaluation.
+//!
+//! Compilation reuses the deductive analysis pipeline (planner
+//! ordering, unsatisfiable-premise detection, conclusion-variable
+//! grounding); the inductive variant adds no extra structural
+//! checks today. The two kinds are siblings in the
+//! [`Rule`](crate::rule::Rule) enum so the compile-time error
+//! types ([`TypeError`](crate::TypeError),
+//! [`AnalyzerError`](crate::AnalyzerError)) are uniform.
+
+/// Serializable inductive-rule descriptor.
+pub mod descriptor;
+
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::error::TypeError;
+use crate::negation::Negation;
+use crate::planner::Conjunction;
+use crate::premise::Premise;
+use crate::rule::{Compile, fmt_rule_schema};
+use crate::{Environment, Parameters, Proposition};
+use descriptor::InductiveRuleDescriptor;
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+/// A compiled inductive rule. Assertion-shaped sibling of
+/// [`DeductiveRule`](crate::rule::DeductiveRule).
+#[derive(Debug, Clone, PartialEq)]
+pub struct InductiveRule {
+    /// Concept this rule asserts when its body matches.
+    conclusion: ConceptDescriptor,
+    /// Planned execution order for the body's premises.
+    join: Conjunction,
+}
+
+impl Compile for InductiveRule {
+    fn from_parts(conclusion: ConceptDescriptor, join: Conjunction) -> Self {
+        InductiveRule { conclusion, join }
+    }
+}
+
+impl InductiveRule {
+    /// Compile a rule from a head concept and body premises.
+    ///
+    /// Runs the shared analysis pipeline (planner + unbound-variable
+    /// check). The only semantic difference from
+    /// [`DeductiveRule::new`](crate::rule::DeductiveRule::new) is what
+    /// the evaluator does at runtime; compile-time checks are
+    /// identical today.
+    pub fn new(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
+        <Self as Compile>::compile(conclusion, premises)
+    }
+
+    /// The concept this rule asserts when its body matches.
+    pub fn conclusion(&self) -> &ConceptDescriptor {
+        &self.conclusion
+    }
+
+    /// Re-plan this rule's premises against a new scope; falls back
+    /// to the original plan if replanning fails.
+    pub fn plan(&self, scope: &Environment) -> Conjunction {
+        self.join.plan(scope).unwrap_or_else(|_| self.join.clone())
+    }
+
+    /// Operand names of the head.
+    pub fn operands(&self) -> impl Iterator<Item = &str> {
+        self.conclusion.operands()
+    }
+
+    /// Bind concrete parameters into the head and produce the
+    /// resulting proposition.
+    pub fn apply(&self, parameters: Parameters) -> Result<Proposition, TypeError> {
+        self.conclusion.apply(parameters)
+    }
+
+    /// Round-trip this rule back to its serializable form.
+    pub fn descriptor(&self) -> InductiveRuleDescriptor {
+        let mut when = Vec::new();
+        let mut unless = Vec::new();
+
+        for step in &self.join.steps {
+            match &step.premise {
+                Premise::Assert(proposition) => when.push(proposition.clone()),
+                Premise::Unless(Negation(proposition)) => unless.push(proposition.clone()),
+            }
+        }
+
+        InductiveRuleDescriptor {
+            description: None,
+            assert: self.conclusion.clone(),
+            when,
+            unless,
+        }
+    }
+}
+
+impl Serialize for InductiveRule {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.descriptor().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for InductiveRule {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let definition = InductiveRuleDescriptor::deserialize(deserializer)?;
+        definition.compile().map_err(D::Error::custom)
+    }
+}
+
+impl Display for InductiveRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        fmt_rule_schema(&self.conclusion, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests exercise the increment-counter effect: when an
+    //! `increment` command targets a counter that already has a
+    //! count, the rule asserts a new counter row with `count + 1`.
+    //! This mirrors the shape we expect real effects to take —
+    //! head differs from any single body premise, formulas
+    //! contribute derived values, and the trigger lives on
+    //! `effect:system`.
+
+    use super::*;
+    use crate::Term;
+    use crate::artifact::{Entity, Type, Value};
+    use crate::attribute::query::AttributeQuery;
+    use crate::attribute::{AttributeDescriptor, Cardinality};
+    use crate::formula::Formula;
+    use crate::formula::math::Sum;
+    use crate::parameters::Parameters;
+    use crate::the;
+
+    /// Build the head: a counter row with a `count` field.
+    fn counter_head() -> ConceptDescriptor {
+        ConceptDescriptor::from(vec![(
+            "count",
+            AttributeDescriptor::new(
+                the!("counter/count"),
+                "",
+                Cardinality::One,
+                Some(Type::UnsignedInt),
+            ),
+        )])
+    }
+
+    /// Body premises:
+    ///   - read the existing counter's count into ?prev
+    ///   - derive ?count = ?prev + 1 via math/sum
+    fn increment_body() -> Vec<Premise> {
+        let this = Term::<Entity>::var("this");
+        let mut sum_terms = Parameters::new();
+        sum_terms.insert("of".to_string(), Term::var("prev"));
+        sum_terms.insert("with".to_string(), Term::constant(1u64));
+        sum_terms.insert("is".to_string(), Term::var("count"));
+        vec![
+            AttributeQuery::new(
+                Term::Constant(Value::from(the!("counter/count"))),
+                this,
+                Term::var("prev"),
+                Term::blank(),
+                Some(Cardinality::One),
+            )
+            .into(),
+            Sum::apply(sum_terms)
+                .expect("Sum::apply should succeed")
+                .into(),
+        ]
+    }
+
+    #[dialog_common::test]
+    fn it_compiles_with_valid_premises() {
+        let result = InductiveRule::new(counter_head(), increment_body());
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_unbound_head_variable() {
+        // Head adds a `name` field that no premise binds.
+        let head = ConceptDescriptor::from(vec![
+            (
+                "count",
+                AttributeDescriptor::new(
+                    the!("counter/count"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::UnsignedInt),
+                ),
+            ),
+            (
+                "name",
+                AttributeDescriptor::new(
+                    the!("counter/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                ),
+            ),
+        ]);
+        let result = InductiveRule::new(head, increment_body());
+        assert!(matches!(result, Err(TypeError::UnboundVariable { .. })));
+        if let Err(TypeError::UnboundVariable { variable, .. }) = result {
+            assert_eq!(variable, "name");
+        }
+    }
+}

--- a/rust/dialog-query/src/rule/inductive/descriptor.rs
+++ b/rust/dialog-query/src/rule/inductive/descriptor.rs
@@ -1,0 +1,316 @@
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::error::TypeError;
+use crate::negation::Negation;
+use crate::premise::Premise;
+use crate::proposition::Proposition;
+use serde::{Deserialize, Serialize};
+
+use super::InductiveRule;
+
+/// An inductive-rule definition in the formal notation, suitable
+/// for serialization.
+///
+/// Mirrors [`DeductiveRuleDescriptor`](crate::rule::DeductiveRuleDescriptor)
+/// modulo the head field name: deductive rules use `assert` (the
+/// head is *derived* on query, no commit); inductive rules use
+/// `assert!` (the head is *asserted* into the branch when the body
+/// matches, mirroring the tonk-yaml `!` convention for
+/// mutation-producing operations).
+///
+/// ```json
+/// {
+///   "description": "...",
+///   "assert!": { "with": { ... } },
+///   "when":    [ { "assert": ..., "where": ... }, ... ],
+///   "unless":  [ { "assert": ..., "where": ... }, ... ]
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InductiveRuleDescriptor {
+    /// Human-readable description of the rule.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The head: a concept the rule asserts when its body is
+    /// satisfied. Serialized as `assert!` to mark the
+    /// transaction-time commit semantics.
+    #[serde(rename = "assert!")]
+    pub assert: ConceptDescriptor,
+
+    /// Conjunction of positive premises. All must be satisfied for
+    /// the rule to fire.
+    pub when: Vec<Proposition>,
+
+    /// Negative premises. If any can be satisfied, the firing is
+    /// filtered out.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unless: Vec<Proposition>,
+}
+
+impl InductiveRuleDescriptor {
+    /// Compile this definition into an [`InductiveRule`] ready for
+    /// evaluation.
+    pub fn compile(self) -> Result<InductiveRule, TypeError> {
+        let mut premises: Vec<Premise> = self.when.into_iter().map(Premise::Assert).collect();
+
+        for proposition in self.unless {
+            premises.push(Premise::Unless(Negation::not(proposition)));
+        }
+
+        InductiveRule::new(self.assert, premises)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[dialog_common::test]
+    fn it_deserializes_increment_counter_rule() {
+        // Realistic shape: read existing counter's count into ?prev,
+        // derive ?count = ?prev + 1, assert a new counter row with
+        // the incremented count.
+        let json = json!({
+            "description": "Increment a counter on increment command",
+            "assert!": {
+                "with": {
+                    "count": { "the": "counter/count", "as": "UnsignedInteger" }
+                }
+            },
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "count": { "the": "counter/count", "as": "UnsignedInteger" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "count": { "?": { "name": "prev" } }
+                    }
+                },
+                {
+                    "assert": "math/sum",
+                    "where": {
+                        "of": { "?": { "name": "prev" } },
+                        "with": 1,
+                        "is": { "?": { "name": "count" } }
+                    }
+                }
+            ]
+        });
+
+        let def: InductiveRuleDescriptor = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            def.description.as_deref(),
+            Some("Increment a counter on increment command")
+        );
+        assert_eq!(def.assert.with().iter().count(), 1);
+        assert_eq!(def.when.len(), 2);
+        assert!(def.unless.is_empty());
+    }
+
+    #[dialog_common::test]
+    fn it_compiles_to_inductive_rule() {
+        // Asserts a counter row whose count is the previous count
+        // plus one — derived via `math/sum`. The head differs from
+        // the body premise, so each firing produces a genuinely
+        // new fact.
+        let json = json!({
+            "assert!": {
+                "with": {
+                    "count": { "the": "counter/count", "as": "UnsignedInteger" }
+                }
+            },
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "count": { "the": "counter/count", "as": "UnsignedInteger" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "count": { "?": { "name": "prev" } }
+                    }
+                },
+                {
+                    "assert": "math/sum",
+                    "where": {
+                        "of": { "?": { "name": "prev" } },
+                        "with": 1,
+                        "is": { "?": { "name": "count" } }
+                    }
+                }
+            ]
+        });
+
+        let def: InductiveRuleDescriptor = serde_json::from_value(json).unwrap();
+        let rule = def.compile().expect("rule should compile");
+        assert_eq!(rule.conclusion().with().iter().count(), 1);
+    }
+
+    #[dialog_common::test]
+    fn it_round_trips_rule_with_unless() {
+        let json = json!({
+            "description": "Promote pending todos that aren't blocked",
+            "assert!": {
+                "with": {
+                    "status": { "the": "todo/status", "as": "Text" }
+                }
+            },
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "status": { "the": "todo/status", "as": "Text" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "status": { "?": { "name": "status" } }
+                    }
+                }
+            ],
+            "unless": [
+                {
+                    "assert": {
+                        "with": {
+                            "blocked": { "the": "todo/blocked", "as": "Boolean" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "blocked": true
+                    }
+                }
+            ]
+        });
+
+        let def: InductiveRuleDescriptor = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(def.when.len(), 1);
+        assert_eq!(def.unless.len(), 1);
+
+        let reserialized = serde_json::to_value(&def).unwrap();
+        assert!(reserialized["unless"].is_array());
+        assert_eq!(reserialized["unless"].as_array().unwrap().len(), 1);
+
+        let reparsed: InductiveRuleDescriptor = serde_json::from_value(reserialized).unwrap();
+        assert_eq!(reparsed.unless.len(), 1);
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_unbound_variable_in_unless_on_deserialize() {
+        // The unless clause references ?other which is never bound
+        // by a positive premise — analysis should reject.
+        let json = json!({
+            "assert!": {
+                "with": {
+                    "status": { "the": "todo/status", "as": "Text" }
+                }
+            },
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "status": { "the": "todo/status", "as": "Text" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "status": { "?": { "name": "status" } }
+                    }
+                }
+            ],
+            "unless": [
+                {
+                    "assert": {
+                        "with": {
+                            "blocked": { "the": "todo/blocked", "as": "Boolean" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "other" } },
+                        "blocked": true
+                    }
+                }
+            ]
+        });
+
+        let result: Result<InductiveRule, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "Should reject rule where unless references unbound variable ?other"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_round_trips_inductive_rule() {
+        let json = json!({
+            "assert!": {
+                "with": {
+                    "count": { "the": "counter/count", "as": "UnsignedInteger" }
+                }
+            },
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "count": { "the": "counter/count", "as": "UnsignedInteger" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "count": { "?": { "name": "prev" } }
+                    }
+                },
+                {
+                    "assert": "math/sum",
+                    "where": {
+                        "of": { "?": { "name": "prev" } },
+                        "with": 1,
+                        "is": { "?": { "name": "count" } }
+                    }
+                }
+            ]
+        });
+
+        let rule: InductiveRule = serde_json::from_value(json).unwrap();
+        let serialized = serde_json::to_value(&rule).unwrap();
+        assert!(serialized["assert!"]["with"].is_object());
+        assert!(serialized["when"].is_array());
+        assert_eq!(serialized["when"].as_array().unwrap().len(), 2);
+
+        let reparsed: InductiveRule = serde_json::from_value(serialized).unwrap();
+        assert_eq!(reparsed.conclusion().with().iter().count(), 1);
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_unbound_head_on_deserialize() {
+        let json = json!({
+            "assert!": {
+                "with": {
+                    "count": { "the": "counter/count", "as": "UnsignedInteger" },
+                    "name": { "the": "counter/name", "as": "Text" }
+                }
+            },
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "count": { "the": "counter/count", "as": "UnsignedInteger" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "count": { "?": { "name": "count" } }
+                    }
+                }
+            ]
+        });
+
+        let result: Result<InductiveRule, _> = serde_json::from_value(json);
+        assert!(result.is_err(), "Expected unbound 'name' to fail");
+    }
+}

--- a/rust/dialog-query/src/session/rule_registry.rs
+++ b/rust/dialog-query/src/session/rule_registry.rs
@@ -6,7 +6,12 @@ use crate::rule::deductive::DeductiveRule;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-/// Thread-safe registry of deductive rules, keyed by the conclusion entity.
+/// Thread-safe registry of *deductive* rules, keyed by the
+/// conclusion entity. Inductive rules
+/// ([`InductiveRule`](crate::rule::InductiveRule)) have a
+/// different lifecycle — they participate in transactions rather
+/// than queries, and will be installed via a separate path in the
+/// future.
 ///
 /// Both [`Session`](super::Session) and [`QuerySession`](super::QuerySession)
 /// hold a `RuleRegistry`. When a concept query needs rules, the registry


### PR DESCRIPTION
InductiveRule shares the head + body shape and compile-time analysis (planner + unbound-variable check) of DeductiveRule via a new Compile trait. The two kinds differ only at evaluation time: deductive yields tuples on query, inductive asserts head facts during a transaction. Wire-format descriptor uses `assert!:` for the inductive head, mirroring the Scheme/Clojure `!` mutation marker.

Error variants that previously carried `Box<DeductiveRule>` now carry `Box<Rule>` (new enum over both kinds) so compile-time diagnostics report uniformly across the two.