### PR TITLE
feat(dialog-repository): implement layer abstraction enabling layered

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -20,7 +20,7 @@ mod store;
 pub use store::*;
 
 mod update;
-pub use update::{Change, ChangeStream, Changes, Statement, Update};
+pub use update::{Change, ChangeStream, Changes, SortKey, Statement, Update, sort_key};
 
 mod attribute;
 pub use attribute::*;
@@ -48,8 +48,8 @@ pub use dialog_storage::{
     Blake3Hash, CborEncoder, ContentAddressedStorage, DialogStorageError, Encoder, HashType,
     MemoryStorageBackend, Storage, StorageBackend,
 };
-use futures_util::{Stream, StreamExt};
-use std::{ops::Range, sync::Arc};
+use futures_util::Stream;
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[cfg(feature = "csv")]
@@ -61,10 +61,9 @@ use async_stream::stream;
 #[cfg(feature = "csv")]
 use tokio::io::{AsyncRead, AsyncWrite};
 
+use crate::tree::ArtifactTreeExt;
 use crate::{
-    AttributeKey, DialogArtifactsError, EntityKey, FromKey, HASH_SIZE, Key, KeyView,
-    KeyViewConstruct, KeyViewMut, State, ValueKey, artifacts::selector::Constrained,
-    make_reference,
+    DialogArtifactsError, HASH_SIZE, Key, State, artifacts::selector::Constrained, make_reference,
 };
 
 /// An alias type that describes the [`Tree`]-based prolly tree that is
@@ -349,63 +348,15 @@ where
         let storage = self.storage.clone();
 
         try_stream! {
-            // We clone to "pin" the indexes at a version for the lifetime of the stream
-            let index = index.read().await.clone();
-
-            if selector.entity().is_some() {
-                let start = <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
-                let end = <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
-
-                let stream = index.stream_range(Range { start, end }, &storage);
-
-                tokio::pin!(stream);
-
-                for await item in stream {
-                    let entry = item?;
-
-                    if entry.matches_selector(&selector)
-                        && let Entry { value: State::Added(datum), .. } = entry
-                    {
-                        yield Artifact::try_from(datum)?;
-                    }
-                }
-            } else if selector.value().is_some() {
-                let start = <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
-                let end = <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
-
-                let stream = index.stream_range(Range { start, end }, &storage);
-
-                tokio::pin!(stream);
-
-                for await item in stream {
-                    let entry = item?;
-
-                    if entry.matches_selector(&selector)
-                        && let Entry { value: State::Added(datum), .. } = entry
-                    {
-                        yield Artifact::try_from(datum)?;
-                    }
-                }
-            } else if selector.attribute().is_some() {
-                let start = <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
-                let end = <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
-
-                let stream = index.stream_range(Range { start, end }, &storage);
-
-                tokio::pin!(stream);
-
-                for await item in stream {
-                    let entry = item?;
-
-                    if entry.matches_selector(&selector)
-                        && let Entry { value: State::Added(datum), .. } = entry
-                    {
-                        yield Artifact::try_from(datum)?;
-                    }
-                }
-            } else {
-                unreachable!("ArtifactSelector will always have at least one field specified")
-            };
+            // Clone the tree under the read lock to "pin" it at a
+            // version for the stream's lifetime, then hand off to the
+            // shared `ArtifactTreeExt::scan` for EAV/AEV/VAE dispatch.
+            let tree = index.read().await.clone();
+            let scanned = tree.scan(storage, selector);
+            tokio::pin!(scanned);
+            for await artifact in scanned {
+                yield artifact?;
+            }
         }
     }
 }
@@ -430,132 +381,13 @@ where
         let transaction_result = async {
             let mut index = self.index.write().await;
 
-            tokio::pin!(instructions);
-
-            while let Some(instruction) = instructions.next().await {
-                match instruction {
-                    Instruction::Assert(artifact) => {
-                        let entity_key = EntityKey::from(&artifact);
-                        let value_key = ValueKey::from_key(&entity_key);
-                        let attribute_key = AttributeKey::from_key(&entity_key);
-
-                        let datum = Datum::from(artifact);
-
-                        // TODO: Make it concurrent / parallel
-                        index
-                            .set(
-                                entity_key.into_key(),
-                                State::Added(datum.clone()),
-                                &mut self.storage,
-                            )
-                            .await?;
-                        index
-                            .set(
-                                attribute_key.into_key(),
-                                State::Added(datum.clone()),
-                                &mut self.storage,
-                            )
-                            .await?;
-                        index
-                            .set(value_key.into_key(), State::Added(datum), &mut self.storage)
-                            .await?;
-                    }
-                    Instruction::Replace(artifact) => {
-                        let entity_key = EntityKey::from(&artifact);
-
-                        // Scan priors at this (entity, attribute). Same-valued
-                        // priors already represent the desired state; only
-                        // different-valued ones need superseding.
-                        let mut superseded_keys: Vec<Key> = Vec::new();
-                        let mut found_same_value = false;
-                        {
-                            let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
-                                .set_entity(entity_key.entity())
-                                .set_attribute(entity_key.attribute())
-                                .into_key();
-                            let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
-                                .set_entity(entity_key.entity())
-                                .set_attribute(entity_key.attribute())
-                                .into_key();
-
-                            let search_stream =
-                                index.stream_range(search_start..search_end, &self.storage);
-                            tokio::pin!(search_stream);
-
-                            while let Some(candidate) = search_stream.try_next().await? {
-                                if let State::Added(current_element) = candidate.value {
-                                    let current = Artifact::try_from(current_element)?;
-                                    if current.is == artifact.is {
-                                        found_same_value = true;
-                                    } else {
-                                        superseded_keys.push(candidate.key);
-                                    }
-                                }
-                            }
-                        }
-
-                        for key in superseded_keys {
-                            let entity_key = EntityKey(key);
-                            let value_key = ValueKey::from_key(&entity_key);
-                            let attribute_key = AttributeKey::from_key(&entity_key);
-
-                            index
-                                .delete(&entity_key.into_key(), &mut self.storage)
-                                .await?;
-                            index
-                                .delete(&value_key.into_key(), &mut self.storage)
-                                .await?;
-                            index
-                                .delete(&attribute_key.into_key(), &mut self.storage)
-                                .await?;
-                        }
-
-                        // Skip insert if a same-value prior is already in place.
-                        if found_same_value {
-                            continue;
-                        }
-
-                        let entity_key = EntityKey::from(&artifact);
-                        let value_key = ValueKey::from_key(&entity_key);
-                        let attribute_key = AttributeKey::from_key(&entity_key);
-                        let datum = Datum::from(artifact);
-
-                        index
-                            .set(
-                                entity_key.into_key(),
-                                State::Added(datum.clone()),
-                                &mut self.storage,
-                            )
-                            .await?;
-                        index
-                            .set(
-                                attribute_key.into_key(),
-                                State::Added(datum.clone()),
-                                &mut self.storage,
-                            )
-                            .await?;
-                        index
-                            .set(value_key.into_key(), State::Added(datum), &mut self.storage)
-                            .await?;
-                    }
-                    Instruction::Retract(fact) => {
-                        let entity_key = EntityKey::from(&fact);
-                        let value_key = ValueKey::from_key(&entity_key);
-                        let attribute_key = AttributeKey::from_key(&entity_key);
-
-                        // TODO: Make it concurrent / parallel
-                        index
-                            .set(entity_key.into_key(), State::Removed, &mut self.storage)
-                            .await?;
-                        index
-                            .set(attribute_key.into_key(), State::Removed, &mut self.storage)
-                            .await?;
-                        index
-                            .set(value_key.into_key(), State::Removed, &mut self.storage)
-                            .await?;
-                    }
-                }
-            }
+            // The per-instruction EAV/AEV/VAE key writes (and
+            // cardinality-one supersession) are the shared
+            // `ArtifactTreeExt::apply`. `commit` adds only the
+            // surrounding transaction bookkeeping — base-revision
+            // capture, revision persistence, pointer advance, and the
+            // rollback below.
+            index.apply(&mut self.storage, instructions).await?;
 
             let next_revision = index.hash().map(Revision::new);
 

--- a/rust/dialog-artifacts/src/artifacts/entity.rs
+++ b/rust/dialog-artifacts/src/artifacts/entity.rs
@@ -38,6 +38,12 @@ where
         .map_err(|error| de::Error::custom(format!("{error:?}")))
 }
 
+impl AsRef<Entity> for Entity {
+    fn as_ref(&self) -> &Entity {
+        self
+    }
+}
+
 impl Deref for Entity {
     type Target = Uri;
 

--- a/rust/dialog-artifacts/src/artifacts/update.rs
+++ b/rust/dialog-artifacts/src/artifacts/update.rs
@@ -1,5 +1,13 @@
-use crate::{Artifact, Attribute, Entity, Instruction, Value};
+use crate::artifacts::query::Select;
+use crate::selector::Constrained;
+use crate::{
+    Artifact, ArtifactSelector, ArtifactStream, Attribute, DialogArtifactsError, Entity,
+    Instruction, Value,
+};
+use async_trait::async_trait;
+use dialog_capability::Provider;
 use futures_util::Stream;
+use futures_util::stream;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -48,7 +56,7 @@ pub trait Statement: Sized {
 }
 
 /// A batch of pending writes, organized by entity and attribute.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Changes(HashMap<Entity, HashMap<Attribute, Vec<Change>>>);
 
 impl Changes {
@@ -77,6 +85,18 @@ impl Changes {
     /// Convert to an instruction stream.
     pub fn into_stream(self) -> ChangeStream {
         ChangeStream::from(self)
+    }
+
+    /// Borrowing iterator over every recorded `(entity, attribute,
+    /// change)` triple. Use this when you need to inspect the batch
+    /// without consuming it — e.g. to extract tombstones from
+    /// retracts without cloning the whole structure.
+    pub fn iter(&self) -> impl Iterator<Item = (&Entity, &Attribute, &Change)> {
+        self.0.iter().flat_map(|(entity, attrs)| {
+            attrs
+                .iter()
+                .flat_map(move |(attr, changes)| changes.iter().map(move |c| (entity, attr, c)))
+        })
     }
 
     /// Convert to a vec of instructions.
@@ -167,5 +187,345 @@ impl Stream for ChangeStream {
 
     fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(self.iter.next())
+    }
+}
+
+/// The full sort key for an [`Artifact`] — `(the, of, value_type,
+/// value_reference)`.
+///
+/// - `the` / `of` — raw attribute / entity key bytes (fixed length,
+///   so tuple comparison equals lexicographic byte comparison of the
+///   concatenation).
+/// - `value_type` — the `ValueDataType` discriminant byte.
+/// - `value_reference` — `blake3(value.to_bytes())`, the same hash
+///   the tree keys carry.
+///
+/// # Why this exact component order
+///
+/// The artifact prolly tree keeps three indexes, each a fixed-layout
+/// byte key (see `dialog_artifacts::key`):
+///
+/// ```text
+///   EAV:  tag | entity    | attribute | value_type | value_reference
+///   AEV:  tag | attribute | entity    | value_type | value_reference
+///   VAE:  tag | value_type | value_reference | attribute | entity
+/// ```
+///
+/// A query scan pins whichever dimension the selector constrains and
+/// streams the rest in that index's byte order. The pinned dimension
+/// is constant across the whole scan, so it drops out of the
+/// comparison — what's left is the index's *residual* order:
+///
+/// ```text
+///   .of(entity)    → EAV → residual (attribute, value_type, value_reference)
+///   .the(attr)     → AEV → residual (entity,    value_type, value_reference)
+///   .is(value)     → VAE → residual (attribute, entity)
+/// ```
+///
+/// `SortKey = (attribute, entity, value_type, value_reference)` is the
+/// **unique** total order whose restriction (delete the pinned
+/// component) reproduces every one of those residuals:
+///
+/// - lock `entity`  → `attribute` is the next live component ✓ (EAV)
+/// - lock `value`   → `value_type`+`value_reference` drop out,
+///   `attribute` is next ✓ (VAE)
+/// - lock `attribute` → `attribute` itself drops out, `entity` is
+///   next ✓ (AEV)
+///
+/// In every mode the next live component after the pinned one is
+/// exactly the dimension that index sorts by next. So sorting any
+/// source's output by `SortKey` yields the same order the tree's
+/// scan would for that selector — which is what lets the query
+/// layer's k-way merge interleave a branch scan and a `Changes`
+/// overlay (or two branches) into the order a single physical tree
+/// containing all of them would produce. It also holds for
+/// multi-constraint selectors:
+/// pinning two dimensions just removes both from the comparison.
+///
+/// The four-component key (vs. the bare `(the, of)` group key) also
+/// fixes interleaving *within* a cardinality-many group: same-`(the,
+/// of)` items from different streams order by `value_reference`
+/// rather than by stream index.
+pub type SortKey = (Vec<u8>, Vec<u8>, u8, [u8; 32]);
+
+/// Compute the [`SortKey`] for an artifact.
+///
+/// Uses the same `key_bytes()` / `data_type()` / `to_reference()`
+/// the tree's own index keys are built from
+/// (`EntityKey::from(&Artifact)` and friends), so a `SortKey` sort
+/// reproduces the tree's byte order exactly — not just an
+/// approximation of it. See [`SortKey`] for why the component order
+/// is correct across all three scan modes.
+pub fn sort_key(artifact: &Artifact) -> SortKey {
+    (
+        artifact.the.key_bytes().to_vec(),
+        artifact.of.key_bytes().to_vec(),
+        artifact.is.data_type().into(),
+        artifact.is.to_reference(),
+    )
+}
+
+/// `Statement` for a [`Changes`] batch — replays every recorded
+/// [`Change`] into the target [`Update`].
+///
+/// Lets a `Changes` value act anywhere a single statement does: e.g.
+/// folding pre-built changes into another transaction, or asserting
+/// a changes-shaped overlay into a query session. `Assert` and
+/// `Replace` map to `associate` / `associate_unique` on the target;
+/// `Retract` maps to `dissociate`.
+impl Statement for Changes {
+    fn assert(self, update: &mut impl Update) {
+        for instruction in self.into_instructions() {
+            match instruction {
+                Instruction::Assert(a) => update.associate(a.the, a.of, a.is),
+                Instruction::Replace(a) => update.associate_unique(a.the, a.of, a.is),
+                Instruction::Retract(a) => update.dissociate(a.the, a.of, a.is),
+            }
+        }
+    }
+
+    fn retract(self, update: &mut impl Update) {
+        // Inverse: asserts/replaces become retracts; existing
+        // retracts become asserts. Symmetric so `c.assert(t);
+        // c.retract(t);` round-trips when `t` is a fresh target.
+        for instruction in self.into_instructions() {
+            match instruction {
+                Instruction::Assert(a) | Instruction::Replace(a) => {
+                    update.dissociate(a.the, a.of, a.is)
+                }
+                Instruction::Retract(a) => update.associate(a.the, a.of, a.is),
+            }
+        }
+    }
+}
+
+/// `Provider<Select>` for an in-memory [`Changes`] batch.
+///
+/// Treats `Changes` as a queryable source: `Assert` and `Replace`
+/// entries surface as [`Artifact`]s matching the [`ArtifactSelector`]'s
+/// `the` / `of` / `is` constraints (whichever are present), sorted by
+/// [`sort_key`] so the result interleaves cleanly with branch / layer
+/// scans in a `merge_grouped`-style union.
+///
+/// `Retract` entries are **deliberately not yielded**. A retract in a
+/// changes batch means "this fact should not appear" — a negative
+/// signal that doesn't fit `ArtifactStream`'s positive `Result<Artifact, _>`
+/// shape. Tombstone filtering against another source is a separate
+/// concern handled by the composition layer that owns the merge.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<'a> Provider<Select<'a>> for Changes {
+    async fn execute(
+        &self,
+        input: ArtifactSelector<Constrained>,
+    ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
+        let the = input.attribute();
+        let of = input.entity();
+        let is = input.value();
+
+        // Linear filter over the batch. A `Changes` overlay is small
+        // by construction — a few auto-injected metadata facts plus
+        // whatever the caller asserted via `.with(...)` — so scanning
+        // it per query is negligible and not worth indexing.
+        let mut matched: Vec<Artifact> = Vec::new();
+        for (entity, attrs) in &self.0 {
+            if let Some(of_target) = of
+                && entity != of_target
+            {
+                continue;
+            }
+            for (attribute, changes) in attrs {
+                if let Some(the_target) = the
+                    && attribute != the_target
+                {
+                    continue;
+                }
+                for change in changes {
+                    let value = match change {
+                        Change::Assert(v) | Change::Replace(v) => v,
+                        // Retracts don't surface from a Changes-as-source
+                        // view — see impl docs.
+                        Change::Retract(_) => continue,
+                    };
+                    if let Some(is_target) = is
+                        && value != is_target
+                    {
+                        continue;
+                    }
+                    matched.push(Artifact {
+                        the: attribute.clone(),
+                        of: entity.clone(),
+                        is: value.clone(),
+                        cause: None,
+                    });
+                }
+            }
+        }
+        // Sort by `sort_key` so this overlay's output is in the same
+        // order the prolly tree would scan for this selector — see
+        // `SortKey` docs. That's the precondition `merge_grouped`
+        // relies on when it unions this stream with a branch scan.
+        matched.sort_by_key(sort_key);
+        Ok(Box::pin(stream::iter(matched.into_iter().map(Ok))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use futures_util::StreamExt as _;
+
+    fn alice() -> Entity {
+        "id:alice".parse().expect("valid entity")
+    }
+    fn bob() -> Entity {
+        "id:bob".parse().expect("valid entity")
+    }
+    fn name_attr() -> Attribute {
+        "test/name".parse().expect("valid attribute")
+    }
+    fn role_attr() -> Attribute {
+        "test/role".parse().expect("valid attribute")
+    }
+
+    #[dialog_common::test]
+    fn it_replays_changes_into_a_target_via_statement_assert() {
+        let mut source = Changes::new();
+        source.associate(name_attr(), alice(), Value::String("Alice".into()));
+        source.dissociate(name_attr(), bob(), Value::String("Bob".into()));
+
+        let mut target = Changes::new();
+        source.assert(&mut target);
+
+        // Replay produced one Assert + one Retract on `target`.
+        let instructions: Vec<_> = target.into_instructions();
+        assert_eq!(instructions.len(), 2);
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(i, Instruction::Assert(_)))
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(i, Instruction::Retract(_)))
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_inverts_changes_under_statement_retract() {
+        let mut source = Changes::new();
+        source.associate(name_attr(), alice(), Value::String("Alice".into()));
+
+        let mut target = Changes::new();
+        source.retract(&mut target);
+
+        let instructions: Vec<_> = target.into_instructions();
+        assert_eq!(instructions.len(), 1);
+        assert!(matches!(instructions[0], Instruction::Retract(_)));
+    }
+
+    async fn artifacts(
+        changes: &Changes,
+        selector: ArtifactSelector<Constrained>,
+    ) -> Vec<Artifact> {
+        let stream = Provider::<Select<'_>>::execute(changes, selector)
+            .await
+            .expect("execute");
+        stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect")
+    }
+
+    #[dialog_common::test]
+    async fn it_yields_asserts_as_artifacts() {
+        let mut changes = Changes::new();
+        changes.associate(name_attr(), alice(), Value::String("Alice".into()));
+
+        let results = artifacts(&changes, ArtifactSelector::new().the(name_attr())).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].of, alice());
+        assert_eq!(results[0].is, Value::String("Alice".into()));
+    }
+
+    #[dialog_common::test]
+    async fn it_yields_replaces_as_artifacts() {
+        let mut changes = Changes::new();
+        changes.associate_unique(name_attr(), alice(), Value::String("Alicia".into()));
+
+        let results = artifacts(&changes, ArtifactSelector::new().of(alice())).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].is, Value::String("Alicia".into()));
+    }
+
+    #[dialog_common::test]
+    async fn it_omits_retracts_from_the_selection() {
+        let mut changes = Changes::new();
+        changes.associate(name_attr(), alice(), Value::String("Alice".into()));
+        changes.dissociate(name_attr(), bob(), Value::String("Bob".into()));
+
+        // Only the assert should surface. Retracts are deliberately
+        // dropped because there's no negative-fact channel in
+        // ArtifactStream.
+        let results = artifacts(&changes, ArtifactSelector::new().the(name_attr())).await;
+        let entities: Vec<&Entity> = results.iter().map(|a| &a.of).collect();
+        assert_eq!(entities, vec![&alice()]);
+    }
+
+    #[dialog_common::test]
+    async fn it_filters_by_the_of_and_is() {
+        let mut changes = Changes::new();
+        changes.associate(name_attr(), alice(), Value::String("Alice".into()));
+        changes.associate(name_attr(), bob(), Value::String("Bob".into()));
+        changes.associate(role_attr(), alice(), Value::String("Engineer".into()));
+
+        // Filter by `the` only
+        let by_attr = artifacts(&changes, ArtifactSelector::new().the(name_attr())).await;
+        assert_eq!(by_attr.len(), 2);
+
+        // Filter by `the` + `of`
+        let by_attr_entity = artifacts(
+            &changes,
+            ArtifactSelector::new().the(name_attr()).of(alice()),
+        )
+        .await;
+        assert_eq!(by_attr_entity.len(), 1);
+        assert_eq!(by_attr_entity[0].of, alice());
+
+        // Filter by `is`
+        let by_value = artifacts(
+            &changes,
+            ArtifactSelector::new()
+                .the(name_attr())
+                .is(Value::String("Bob".into())),
+        )
+        .await;
+        assert_eq!(by_value.len(), 1);
+        assert_eq!(by_value[0].of, bob());
+    }
+
+    #[dialog_common::test]
+    async fn it_emits_artifacts_in_sort_key_order() {
+        // Insert in deliberately wrong order; expect output sorted by
+        // sort_key so cross-source merges interleave consistently.
+        let mut changes = Changes::new();
+        // Different attributes — sort by attribute key first.
+        changes.associate(role_attr(), alice(), Value::String("Engineer".into()));
+        changes.associate(name_attr(), alice(), Value::String("Alice".into()));
+
+        let results = artifacts(&changes, ArtifactSelector::new().of(alice())).await;
+        assert_eq!(results.len(), 2);
+        // Attributes ordered by their key bytes — verify by checking
+        // the output is monotonic under sort_key.
+        let keys: Vec<_> = results.iter().map(sort_key).collect();
+        let mut sorted_keys = keys.clone();
+        sorted_keys.sort();
+        assert_eq!(keys, sorted_keys);
     }
 }

--- a/rust/dialog-artifacts/src/lib.rs
+++ b/rust/dialog-artifacts/src/lib.rs
@@ -76,6 +76,9 @@ pub use constants::*;
 mod key;
 pub use key::*;
 
+/// Shared tree-ops on the artifact prolly tree.
+pub mod tree;
+
 mod uri;
 pub use uri::*;
 

--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -1,0 +1,266 @@
+//! Shared tree-ops on the artifact prolly tree.
+//!
+//! Both [`Artifacts`](crate::Artifacts) and the higher-level branch
+//! abstractions in `dialog-repository` and `dialog-query` operate on the
+//! same EAV/AEV/VAE prolly tree. The per-instruction mutation loop and the
+//! selector → key-range scan dispatch are identical across all of them, so
+//! they live here as an extension trait on [`ArtifactTree`], parameterized
+//! over any [`ContentAddressedStorage<Hash=Blake3Hash, Error=DialogStorageError>`].
+//!
+//! Callers responsible for revisions, upstreams, remote fallback, or any
+//! other branch specifics keep that logic on their side and call
+//! [`ArtifactTreeExt::apply`] / [`ArtifactTreeExt::scan`] for the actual
+//! key writes and range scans.
+//!
+//! `ArtifactTree` is a type alias for a `dialog_prolly_tree::Tree`, so the
+//! orphan rule rules out inherent methods — the operations are exposed as
+//! an extension trait instead.
+
+use std::ops::Range;
+
+use async_stream::try_stream;
+use async_trait::async_trait;
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_prolly_tree::{Entry, GeometricDistribution, Tree};
+use dialog_storage::{Blake3Hash, ContentAddressedStorage, DialogStorageError};
+use futures_util::{Stream, StreamExt, TryStreamExt};
+
+use crate::{
+    Artifact, ArtifactSelector, AttributeKey, Datum, DialogArtifactsError, EntityKey, FromKey,
+    Instruction, Key, KeyView, KeyViewConstruct, KeyViewMut, MatchCandidate, State, ValueKey,
+    selector::Constrained,
+};
+
+/// The concrete prolly-tree type the artifact indexes use.
+pub type ArtifactTree = Tree<GeometricDistribution, Key, State<Datum>, Blake3Hash>;
+
+/// Shared mutation + scan operations on an [`ArtifactTree`].
+///
+/// An extension trait rather than inherent methods because
+/// `ArtifactTree` aliases a foreign `dialog_prolly_tree::Tree` — the
+/// orphan rule forbids `impl ArtifactTree { .. }`. Uses
+/// `#[async_trait]` (matching [`ArtifactStore`](crate::ArtifactStore))
+/// so the async `apply` desugars to a boxed future rather than a
+/// bound-less native `async fn`.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait ArtifactTreeExt {
+    /// Drain a stream of [`Instruction`]s into the tree, applying the
+    /// same key writes that a branch commit or `Artifacts::commit`
+    /// would.
+    ///
+    /// Each instruction touches all three EAV/AEV/VAE indexes;
+    /// `Replace` additionally scans the `(entity, attribute)` range to
+    /// supersede any different-valued priors (and skips inserting when
+    /// a same-valued prior is already in place — that's the
+    /// cardinality-one no-op).
+    ///
+    /// Callers own everything else: building the change stream,
+    /// choosing a base tree root, persisting a `Revision`, etc.
+    async fn apply<S, I>(
+        &mut self,
+        store: &mut S,
+        instructions: I,
+    ) -> Result<(), DialogArtifactsError>
+    where
+        S: ContentAddressedStorage<Hash = Blake3Hash, Error = DialogStorageError> + ConditionalSync,
+        I: Stream<Item = Instruction> + ConditionalSend;
+
+    /// Scan the tree for [`Artifact`]s matching the given constrained
+    /// selector.
+    ///
+    /// Picks the EAV/AEV/VAE index based on which field of the
+    /// selector is constrained (entity / value / attribute, in that
+    /// priority order), then streams the matching key range. Items in
+    /// the range that don't fully satisfy the selector and items in
+    /// the `Removed` state are filtered out.
+    ///
+    /// Consumes `self` (the tree is moved into the returned stream to
+    /// pin its root); `store` is the [`ContentAddressedStorage`]
+    /// backing it.
+    fn scan<'s, S>(
+        self,
+        store: S,
+        selector: ArtifactSelector<Constrained>,
+    ) -> impl Stream<Item = Result<Artifact, DialogArtifactsError>> + 's + ConditionalSend
+    where
+        Self: Sized,
+        S: ContentAddressedStorage<Hash = Blake3Hash, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync
+            + 's;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl ArtifactTreeExt for ArtifactTree {
+    async fn apply<S, I>(
+        &mut self,
+        store: &mut S,
+        instructions: I,
+    ) -> Result<(), DialogArtifactsError>
+    where
+        S: ContentAddressedStorage<Hash = Blake3Hash, Error = DialogStorageError> + ConditionalSync,
+        I: Stream<Item = Instruction> + ConditionalSend,
+    {
+        tokio::pin!(instructions);
+        while let Some(instruction) = instructions.next().await {
+            match instruction {
+                Instruction::Assert(artifact) => {
+                    let entity_key = EntityKey::from(&artifact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+
+                    let datum = Datum::from(artifact);
+                    self.set(entity_key.into_key(), State::Added(datum.clone()), store)
+                        .await?;
+                    self.set(attribute_key.into_key(), State::Added(datum.clone()), store)
+                        .await?;
+                    self.set(value_key.into_key(), State::Added(datum), store)
+                        .await?;
+                }
+                Instruction::Replace(artifact) => {
+                    let entity_key = EntityKey::from(&artifact);
+
+                    // Scan priors at this (entity, attribute).
+                    // Same-valued priors already represent the
+                    // desired state; only different-valued ones
+                    // need superseding.
+                    let mut superseded_keys: Vec<Key> = Vec::new();
+                    let mut found_same_value = false;
+                    {
+                        let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
+                            .set_entity(entity_key.entity())
+                            .set_attribute(entity_key.attribute())
+                            .into_key();
+                        let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
+                            .set_entity(entity_key.entity())
+                            .set_attribute(entity_key.attribute())
+                            .into_key();
+                        let search_stream = self.stream_range(search_start..search_end, store);
+                        tokio::pin!(search_stream);
+                        while let Some(candidate) = search_stream.try_next().await? {
+                            if let State::Added(current_element) = candidate.value {
+                                let current = Artifact::try_from(current_element)?;
+                                if current.is == artifact.is {
+                                    found_same_value = true;
+                                } else {
+                                    superseded_keys.push(candidate.key);
+                                }
+                            }
+                        }
+                    }
+
+                    for key in superseded_keys {
+                        let entity_key = EntityKey(key);
+                        let value_key = ValueKey::from_key(&entity_key);
+                        let attribute_key = AttributeKey::from_key(&entity_key);
+
+                        self.delete(&entity_key.into_key(), store).await?;
+                        self.delete(&value_key.into_key(), store).await?;
+                        self.delete(&attribute_key.into_key(), store).await?;
+                    }
+
+                    if found_same_value {
+                        continue;
+                    }
+
+                    let entity_key = EntityKey::from(&artifact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+                    let datum = Datum::from(artifact);
+                    self.set(entity_key.into_key(), State::Added(datum.clone()), store)
+                        .await?;
+                    self.set(attribute_key.into_key(), State::Added(datum.clone()), store)
+                        .await?;
+                    self.set(value_key.into_key(), State::Added(datum), store)
+                        .await?;
+                }
+                Instruction::Retract(artifact) => {
+                    let entity_key = EntityKey::from(&artifact);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+
+                    self.set(entity_key.into_key(), State::Removed, store)
+                        .await?;
+                    self.set(attribute_key.into_key(), State::Removed, store)
+                        .await?;
+                    self.set(value_key.into_key(), State::Removed, store)
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn scan<'s, S>(
+        self,
+        store: S,
+        selector: ArtifactSelector<Constrained>,
+    ) -> impl Stream<Item = Result<Artifact, DialogArtifactsError>> + 's + ConditionalSend
+    where
+        S: ContentAddressedStorage<Hash = Blake3Hash, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync
+            + 's,
+    {
+        let tree = self;
+        try_stream! {
+            if selector.entity().is_some() {
+                let start = <EntityKey<Key> as KeyViewConstruct>::min()
+                    .apply_selector(&selector)
+                    .into_key();
+                let end = <EntityKey<Key> as KeyViewConstruct>::max()
+                    .apply_selector(&selector)
+                    .into_key();
+                let stream = tree.stream_range(Range { start, end }, &store);
+                tokio::pin!(stream);
+                for await item in stream {
+                    let entry: Entry<Key, State<Datum>> = item?;
+                    if entry.matches_selector(&selector)
+                        && let Entry { value: State::Added(datum), .. } = entry
+                    {
+                        yield Artifact::try_from(datum)?;
+                    }
+                }
+            } else if selector.value().is_some() {
+                let start = <ValueKey<Key> as KeyViewConstruct>::min()
+                    .apply_selector(&selector)
+                    .into_key();
+                let end = <ValueKey<Key> as KeyViewConstruct>::max()
+                    .apply_selector(&selector)
+                    .into_key();
+                let stream = tree.stream_range(Range { start, end }, &store);
+                tokio::pin!(stream);
+                for await item in stream {
+                    let entry: Entry<Key, State<Datum>> = item?;
+                    if entry.matches_selector(&selector)
+                        && let Entry { value: State::Added(datum), .. } = entry
+                    {
+                        yield Artifact::try_from(datum)?;
+                    }
+                }
+            } else if selector.attribute().is_some() {
+                let start = <AttributeKey<Key> as KeyViewConstruct>::min()
+                    .apply_selector(&selector)
+                    .into_key();
+                let end = <AttributeKey<Key> as KeyViewConstruct>::max()
+                    .apply_selector(&selector)
+                    .into_key();
+                let stream = tree.stream_range(Range { start, end }, &store);
+                tokio::pin!(stream);
+                for await item in stream {
+                    let entry: Entry<Key, State<Datum>> = item?;
+                    if entry.matches_selector(&selector)
+                        && let Entry { value: State::Added(datum), .. } = entry
+                    {
+                        yield Artifact::try_from(datum)?;
+                    }
+                }
+            } else {
+                // `Constrained` guarantees at least one field is set.
+                unreachable!("ArtifactSelector will always have at least one field specified")
+            }
+        }
+    }
+}

--- a/rust/dialog-common/src/helpers.rs
+++ b/rust/dialog-common/src/helpers.rs
@@ -464,7 +464,6 @@ mod tests {
         assert_eq!(value, "test");
     }
 
-    // --- Tests with actual native provider ---
     // These tests are native-only because TcpServer can't run in wasm.
     // They're also skipped in web integration mode (web-integration-tests feature) since
     // there's no wasm inner test to spawn.

--- a/rust/dialog-diagnose/src/state/artifacts.rs
+++ b/rust/dialog-diagnose/src/state/artifacts.rs
@@ -94,19 +94,17 @@ impl ArtifactsCursor {
                 None => Box::pin(tree.stream(&storage)),
             };
 
-            loop {
-                let Some(element) = stream.try_next().await? else {
-                    break;
-                };
-
+            while let Some(element) = stream.try_next().await? {
                 state.last_key = Some(element.key);
 
-                match tx.send(WorkerMessage::Fact {
-                    index: state.next_index,
-                    data: element.value,
-                }) {
-                    Ok(_) => (),
-                    Err(_) => break,
+                if tx
+                    .send(WorkerMessage::Fact {
+                        index: state.next_index,
+                        data: element.value,
+                    })
+                    .is_err()
+                {
+                    break;
                 }
 
                 state.next_index += 1;

--- a/rust/dialog-prolly-tree/src/tree.rs
+++ b/rust/dialog-prolly-tree/src/tree.rs
@@ -368,18 +368,13 @@ where
                         }
                     }
                     Change::Remove(entry) => {
-                        // Check if key exists
-                        match self.get(&entry.key, storage).await? {
-                            None => {
-                                // Key doesn't exist - no-op (already removed)
-                            }
-                            Some(existing_value) => {
-                                if existing_value == entry.value {
-                                    // Same value - remove it
-                                    self.delete(&entry.key, storage).await?;
-                                }
-                                // Else: different value - no-op (concurrent update)
-                            }
+                        // Remove only if the current value matches —
+                        // a different value means a concurrent update,
+                        // a missing key means already-removed.
+                        if let Some(existing_value) = self.get(&entry.key, storage).await?
+                            && existing_value == entry.value
+                        {
+                            self.delete(&entry.key, storage).await?;
                         }
                     }
                 }

--- a/rust/dialog-query/Cargo.toml
+++ b/rust/dialog-query/Cargo.toml
@@ -29,6 +29,7 @@ dialog-effects = { workspace = true }
 futures-util = { workspace = true }
 futures-core = { workspace = true }
 async-stream = { workspace = true }
+async-trait = { workspace = true }
 
 # Macro utilities
 dialog-macros = { workspace = true }
@@ -53,7 +54,6 @@ anyhow = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
 futures-util = { workspace = true }
 wasm-bindgen-test = { workspace = true }
-async-trait = { workspace = true }
 
 [features]
 default = []

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -51,6 +51,23 @@ impl ConceptRules {
         }
     }
 
+    /// The explicitly installed rules (does not include the implicit rule).
+    pub fn installed(&self) -> &[DeductiveRule] {
+        &self.installed
+    }
+
+    /// Install every rule from `other` into this `ConceptRules`.
+    ///
+    /// Used when combining two rule sources (e.g. a primary registry and an
+    /// overlay) so all installed rules contribute to planning. The implicit
+    /// rule is the same in both — it is derived from the concept descriptor —
+    /// so only the `installed` set is merged.
+    pub fn extend(&mut self, other: &ConceptRules) {
+        for rule in &other.installed {
+            self.install(rule.clone());
+        }
+    }
+
     /// Get or compute a cached plan for the given binding pattern.
     pub fn plan(&self, terms: &Parameters, matched: &Match) -> Arc<Disjunction> {
         let adornment = Adornment::derive(terms, matched);
@@ -68,5 +85,141 @@ impl ConceptRules {
         let fork = Arc::new(plan);
         self.plans.write().unwrap().insert(adornment, fork.clone());
         fork
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::Term;
+    use crate::attribute::query::AttributeQuery;
+    use crate::attribute::{AttributeDescriptor, Cardinality, Type};
+    use crate::the;
+
+    fn person_concept() -> ConceptDescriptor {
+        ConceptDescriptor::from([(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "person name",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+    }
+
+    fn alt_rule(descriptor: &ConceptDescriptor) -> DeductiveRule {
+        // Distinct rule body so install does not dedup against the implicit.
+        DeductiveRule::new(
+            descriptor.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("person/name")),
+                    Term::var("this"),
+                    Term::var("name"),
+                    Term::blank(),
+                    None,
+                )
+                .into(),
+            ],
+        )
+        .expect("alt rule compiles")
+    }
+
+    #[dialog_common::test]
+    fn it_returns_empty_installed_list_for_fresh_concept_rules() {
+        let rules = ConceptRules::new(&person_concept());
+        assert!(rules.installed().is_empty());
+    }
+
+    #[dialog_common::test]
+    fn it_lists_registered_rules_in_install_order() {
+        let descriptor = person_concept();
+        let mut rules = ConceptRules::new(&descriptor);
+        let a = alt_rule(&descriptor);
+        rules.install(a.clone());
+        assert_eq!(rules.installed(), &[a]);
+    }
+
+    #[dialog_common::test]
+    fn it_merges_installed_rules_from_another_registry() {
+        let descriptor = person_concept();
+        let mut a = ConceptRules::new(&descriptor);
+        let mut b = ConceptRules::new(&descriptor);
+
+        let rule = alt_rule(&descriptor);
+        b.install(rule.clone());
+        a.extend(&b);
+
+        assert_eq!(a.installed().len(), 1);
+        assert_eq!(a.installed()[0], rule);
+    }
+
+    #[dialog_common::test]
+    fn it_dedups_extended_rules_against_existing_installed() {
+        let descriptor = person_concept();
+        let rule = alt_rule(&descriptor);
+        let mut a = ConceptRules::new(&descriptor);
+        a.install(rule.clone());
+        let mut b = ConceptRules::new(&descriptor);
+        b.install(rule.clone());
+        a.extend(&b);
+        assert_eq!(
+            a.installed().len(),
+            1,
+            "duplicate rule must not be added twice"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_invalidates_plan_cache_when_extend_adds_rules() {
+        let descriptor = person_concept();
+        let mut rules = ConceptRules::new(&descriptor);
+
+        let mut terms = Parameters::new();
+        terms.insert("this".into(), Term::var("e"));
+        terms.insert("name".into(), Term::var("n"));
+
+        let candidate = Match::new();
+        let plan_before = rules.plan(&terms, &candidate);
+
+        let mut other = ConceptRules::new(&descriptor);
+        other.install(alt_rule(&descriptor));
+        rules.extend(&other);
+
+        let plan_after = rules.plan(&terms, &candidate);
+        assert!(
+            !Arc::ptr_eq(&plan_before, &plan_after),
+            "extend that adds a new rule must invalidate the plan cache"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_keeps_plan_cache_when_extend_adds_nothing() {
+        let descriptor = person_concept();
+        let rules = ConceptRules::new(&descriptor);
+
+        let mut terms = Parameters::new();
+        terms.insert("this".into(), Term::var("e"));
+        terms.insert("name".into(), Term::var("n"));
+
+        let candidate = Match::new();
+        let plan_before = rules.plan(&terms, &candidate);
+
+        // Extend with an empty other: no new installed rules, cache preserved.
+        let empty = ConceptRules::new(&descriptor);
+        let mut rules_clone = rules.clone();
+        rules_clone.extend(&empty);
+
+        // The clone shares the plan cache Arc with the original; planning the
+        // same adornment hits the cache.
+        let plan_after = rules_clone.plan(&terms, &candidate);
+        assert!(
+            Arc::ptr_eq(&plan_before, &plan_after),
+            "no-op extend must not clear cached plans"
+        );
     }
 }

--- a/rust/dialog-query/src/session/rule_registry.rs
+++ b/rust/dialog-query/src/session/rule_registry.rs
@@ -3,6 +3,8 @@ use crate::EvaluationError;
 use crate::concept::descriptor::ConceptDescriptor;
 use crate::concept::query::ConceptRules;
 use crate::rule::deductive::DeductiveRule;
+use crate::source::SelectRules;
+use dialog_capability::Provider;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -58,5 +60,135 @@ impl RuleRegistry {
             .entry(entity)
             .or_insert_with(|| ConceptRules::new(predicate))
             .clone())
+    }
+
+    /// Merge every per-concept rule set from `other` into this registry.
+    ///
+    /// Entries that exist on both sides are folded together via
+    /// [`ConceptRules::extend`] so installed rules from both contribute.
+    pub fn extend(&mut self, other: &RuleRegistry) -> Result<(), EvaluationError> {
+        let other_rules = other
+            .rules
+            .read()
+            .map_err(|e| EvaluationError::Store(e.to_string()))?;
+        let mut self_rules = self
+            .rules
+            .write()
+            .map_err(|e| EvaluationError::Store(e.to_string()))?;
+        for (entity, rules) in other_rules.iter() {
+            self_rules
+                .entry(entity.clone())
+                .and_modify(|existing| existing.extend(rules))
+                .or_insert_with(|| rules.clone());
+        }
+        Ok(())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Provider<SelectRules> for RuleRegistry {
+    async fn execute(&self, input: ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
+        self.acquire(&input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::attribute::{AttributeDescriptor, Cardinality, Type};
+    use crate::the;
+
+    fn person_concept() -> ConceptDescriptor {
+        ConceptDescriptor::from([(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "person name",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_implicit_rules_for_an_unseen_concept() {
+        let registry = RuleRegistry::new();
+        let descriptor = person_concept();
+        let rules = Provider::<SelectRules>::execute(&registry, descriptor)
+            .await
+            .expect("acquire should succeed");
+        assert!(
+            rules.installed().is_empty(),
+            "no rules installed, only implicit"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_surfaces_a_registered_rule_through_the_provider() {
+        let mut registry = RuleRegistry::new();
+        let descriptor = person_concept();
+        let rule = DeductiveRule::from(&descriptor);
+        registry.register(rule.clone()).unwrap();
+
+        let rules = Provider::<SelectRules>::execute(&registry, descriptor)
+            .await
+            .expect("acquire");
+        assert_eq!(rules.installed().len(), 1);
+        assert_eq!(rules.installed()[0], rule);
+    }
+
+    #[dialog_common::test]
+    async fn it_copies_entries_for_unseen_concepts_on_extend() {
+        let descriptor = person_concept();
+        let rule = DeductiveRule::from(&descriptor);
+        let mut src = RuleRegistry::new();
+        src.register(rule.clone()).unwrap();
+
+        let mut dst = RuleRegistry::new();
+        dst.extend(&src).unwrap();
+        assert_eq!(dst.acquire(&descriptor).unwrap().installed()[0], rule);
+    }
+
+    #[dialog_common::test]
+    async fn it_merges_installed_rules_for_a_shared_concept_on_extend() {
+        // Two registries with different rules for the same concept; extend
+        // should produce a registry where both rules are installed.
+        use crate::Term;
+        use crate::attribute::query::AttributeQuery;
+
+        let descriptor = person_concept();
+        let rule_a = DeductiveRule::from(&descriptor);
+        // Same conclusion, body uses `None` cardinality (`All` variant)
+        // instead of the implicit `One` — produces a distinct rule.
+        let rule_b = DeductiveRule::new(
+            descriptor.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("person/name")),
+                    Term::var("this"),
+                    Term::var("name"),
+                    Term::blank(),
+                    None,
+                )
+                .into(),
+            ],
+        )
+        .expect("rule_b is valid");
+        assert_ne!(rule_a, rule_b);
+
+        let mut a = RuleRegistry::new();
+        a.register(rule_a.clone()).unwrap();
+        let mut b = RuleRegistry::new();
+        b.register(rule_b.clone()).unwrap();
+
+        a.extend(&b).unwrap();
+        let merged = a.acquire(&descriptor).unwrap();
+        assert_eq!(merged.installed().len(), 2);
+        assert!(merged.installed().contains(&rule_a));
+        assert!(merged.installed().contains(&rule_b));
     }
 }

--- a/rust/dialog-repository/src/layer.rs
+++ b/rust/dialog-repository/src/layer.rs
@@ -1,0 +1,295 @@
+//! Streaming merge + tombstone helpers for query-time source composition.
+//!
+//! Everything here works on `Stream<Item = Result<Artifact, _>>` —
+//! [`ArtifactStream`]s — and is agnostic to where the streams came
+//! from (a branch's tree scan, a [`Changes`] overlay, anything else
+//! that implements `Provider<Select>`).
+//!
+//! - [`merge_grouped`] is the k-way merge that backs query-time
+//!   union of multiple sources. It preserves the "as-if merged into a
+//!   single physical tree" order via [`sort_key`](dialog_artifacts::sort_key)
+//!   and dedupes identical `(the, of, is, cause)` artifacts within
+//!   each `(the, of)` run.
+//! - [`tombstones_from`] + [`filter_tombstones`] lift retract
+//!   instructions out of a [`Changes`] overlay and apply them to a
+//!   source stream as a filter — the mechanism that lets a
+//!   [`Transaction::retract`](crate::repository::branch::Transaction::retract)
+//!   suppress facts in the underlying branch view.
+
+use std::collections::HashSet;
+
+use dialog_artifacts::{Artifact, ArtifactStream, Cause, Changes, SortKey, sort_key};
+use futures_util::{StreamExt, stream};
+
+/// The canonical group key for artifacts traveling through a query stream.
+///
+/// Consumers — notably the cardinality-one sliding window in
+/// [`AttributeQueryOnly::evaluate`](dialog_query::attribute::query::AttributeQuery) —
+/// assume that artifacts sharing the same `(the, of)` pair arrive
+/// consecutively. Anything that unions facts from multiple sources must
+/// preserve that invariant; this helper produces the comparable key used
+/// when grouping.
+pub(crate) fn group_key(artifact: &Artifact) -> (Vec<u8>, Vec<u8>) {
+    (
+        artifact.the.key_bytes().to_vec(),
+        artifact.of.key_bytes().to_vec(),
+    )
+}
+
+/// Merge sorted artifact streams into one stream whose order matches
+/// what a single physical prolly tree containing every input would
+/// produce, deduplicating identical claims that appear in more than one
+/// source.
+///
+/// Each input is assumed sorted by [`sort_key`] — true of branch
+/// scans by construction (the prolly tree stores entries in that
+/// order) and true of `Provider<Select> for Changes` by construction
+/// (it sorts its materialized vec). Implemented as a streaming k-way
+/// merge with peekable inputs.
+///
+/// # Order: "as-if merged into one tree"
+///
+/// The k-way merge picks the minimum head by [`sort_key`], not by
+/// [`group_key`]. That distinction matters within a `(the, of)` group
+/// with cardinality > 1: two items from different streams sharing the
+/// same `(the, of)` but different values would otherwise come out in
+/// arbitrary (stream-index) order. Concretely, two sources each
+/// holding `(alice, name, "Bob")` and `(alice, name, "Alice")` would
+/// yield `["Bob", "Alice"]` if the merge tiebroke on stream index,
+/// but a single physical tree yields `["Alice", "Bob"]` (sorted by
+/// `value_reference`).
+///
+/// `sort_key` works as the comparator here *for any selector* because
+/// it is the one total order consistent with all three tree index
+/// layouts — see the [`SortKey`](dialog_artifacts::SortKey) docs for
+/// the full why. Every stream reaching this merge was produced by the
+/// same selector, so they're all already in `sort_key` order; the
+/// merge just interleaves them.
+///
+/// # Dedup: "same claim from two sources is still one claim"
+///
+/// When the same `(the, of, is, cause)` artifact appears in multiple
+/// inputs, only the first occurrence within a `(the, of)` run is
+/// yielded. The dedup region is the `(the, of)` group, tracked via
+/// [`group_key`]; the fingerprint is `Cause::from(&artifact)` which
+/// hashes all four fields so position-independent duplicates collapse.
+pub(crate) fn merge_grouped<'a>(streams: Vec<ArtifactStream<'a>>) -> ArtifactStream<'a> {
+    use std::pin::Pin;
+
+    if streams.is_empty() {
+        return Box::pin(stream::empty());
+    }
+    if streams.len() == 1 {
+        // A single-stream merge can still surface duplicates if the
+        // caller passes an already-unioned stream, but for branch /
+        // overlay scans every key is unique within a single stream so
+        // the dedup pass would be pure overhead. Pass through unchanged.
+        return streams.into_iter().next().expect("len == 1");
+    }
+
+    let mut peekable: Vec<_> = streams.into_iter().map(StreamExt::peekable).collect();
+
+    Box::pin(async_stream::try_stream! {
+        // Fingerprints already yielded within the current (the, of) run.
+        // Cleared whenever the run advances to a new group_key.
+        let mut current_key: Option<(Vec<u8>, Vec<u8>)> = None;
+        let mut seen: HashSet<Cause> = HashSet::new();
+
+        loop {
+            let mut min_idx: Option<usize> = None;
+            let mut min_sort: Option<SortKey> = None;
+            for (i, s) in peekable.iter_mut().enumerate() {
+                match Pin::new(s).peek().await {
+                    None => continue,
+                    Some(Err(_)) => {
+                        min_idx = Some(i);
+                        break;
+                    }
+                    Some(Ok(head)) => {
+                        let sk = sort_key(head);
+                        if min_sort.as_ref().is_none_or(|cur| &sk < cur) {
+                            min_sort = Some(sk);
+                            min_idx = Some(i);
+                        }
+                    }
+                }
+            }
+            let Some(idx) = min_idx else { break };
+            let item = peekable[idx]
+                .next()
+                .await
+                .expect("peek returned Some, so next must too")?;
+
+            let key = group_key(&item);
+            if current_key.as_ref() != Some(&key) {
+                current_key = Some(key);
+                seen.clear();
+            }
+            // `Cause::from(&Artifact)` hashes (the, of, is, cause) — two
+            // artifacts with identical fields produce identical
+            // fingerprints.
+            if seen.insert(Cause::from(&item)) {
+                yield item;
+            }
+        }
+    })
+}
+
+/// Extract a tombstone set from a [`Changes`] overlay — one
+/// [`SortKey`] per retracted artifact.
+///
+/// Asserts and Replaces are ignored; only Retracts contribute. Used
+/// at query time to filter matching source facts out of branch
+/// streams before they reach the merge.
+pub(crate) fn tombstones_from(changes: &Changes) -> HashSet<SortKey> {
+    let mut tombstones = HashSet::new();
+    for (entity, attribute, change) in changes.iter() {
+        if let dialog_artifacts::Change::Retract(value) = change {
+            let artifact = Artifact {
+                the: attribute.clone(),
+                of: entity.clone(),
+                is: value.clone(),
+                cause: None,
+            };
+            tombstones.insert(sort_key(&artifact));
+        }
+    }
+    tombstones
+}
+
+/// Wrap an artifact stream in a filter that drops any item whose
+/// [`sort_key`] is in `tombstones`. No-op when the set is empty.
+pub(crate) fn filter_tombstones<'a>(
+    inner: ArtifactStream<'a>,
+    tombstones: HashSet<SortKey>,
+) -> ArtifactStream<'a> {
+    if tombstones.is_empty() {
+        return inner;
+    }
+    Box::pin(stream::unfold(
+        (inner, tombstones),
+        |(mut inner, tombstones)| async move {
+            loop {
+                match inner.next().await {
+                    None => return None,
+                    Some(Err(e)) => return Some((Err::<Artifact, _>(e), (inner, tombstones))),
+                    Some(Ok(artifact)) => {
+                        if tombstones.contains(&sort_key(&artifact)) {
+                            continue;
+                        }
+                        return Some((Ok(artifact), (inner, tombstones)));
+                    }
+                }
+            }
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_artifacts::{DialogArtifactsError, Entity, Update as _, Value};
+
+    fn artifact(of: &str, the: &str, is: &str) -> Artifact {
+        Artifact {
+            the: the.parse().expect("attribute"),
+            of: of.parse().expect("entity"),
+            is: Value::String(is.into()),
+            cause: None,
+        }
+    }
+
+    fn stream_of(items: Vec<Artifact>) -> ArtifactStream<'static> {
+        Box::pin(stream::iter(
+            items.into_iter().map(Ok::<_, DialogArtifactsError>),
+        ))
+    }
+
+    async fn collect(s: ArtifactStream<'_>) -> anyhow::Result<Vec<Artifact>> {
+        Ok(s.collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<_, _>>()?)
+    }
+
+    #[dialog_common::test]
+    async fn it_yields_empty_stream_when_no_inputs() -> anyhow::Result<()> {
+        let merged = merge_grouped(vec![]);
+        let items = collect(merged).await?;
+        assert!(items.is_empty());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_passes_single_stream_through_without_dedup() -> anyhow::Result<()> {
+        // A single input is returned as-is — even if it has duplicates,
+        // since branch / overlay scans are duplicate-free by
+        // construction.
+        let a = artifact("id:a", "test/name", "Alice");
+        let merged = merge_grouped(vec![stream_of(vec![a.clone(), a.clone()])]);
+        let items = collect(merged).await?;
+        assert_eq!(items.len(), 2);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_dedupes_identical_artifacts_across_streams() -> anyhow::Result<()> {
+        // Same artifact from two streams collapses to one in the
+        // merged output.
+        let a = artifact("id:a", "test/name", "Alice");
+        let merged = merge_grouped(vec![stream_of(vec![a.clone()]), stream_of(vec![a.clone()])]);
+        let items = collect(merged).await?;
+        assert_eq!(items.len(), 1);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    fn it_extracts_tombstones_from_retracts_only() -> anyhow::Result<()> {
+        let mut changes = Changes::new();
+        let alice: Entity = "id:alice".parse()?;
+        let bob: Entity = "id:bob".parse()?;
+        changes.associate(
+            "test/name".parse()?,
+            alice.clone(),
+            Value::String("Alice".into()),
+        );
+        changes.dissociate(
+            "test/name".parse()?,
+            bob.clone(),
+            Value::String("Bob".into()),
+        );
+
+        let tombstones = tombstones_from(&changes);
+        assert_eq!(tombstones.len(), 1, "only the retract contributes");
+        // The lone tombstone matches the retracted artifact.
+        let retracted = artifact("id:bob", "test/name", "Bob");
+        assert!(tombstones.contains(&sort_key(&retracted)));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_filters_matching_artifacts_via_tombstones() -> anyhow::Result<()> {
+        let keep = artifact("id:a", "test/name", "Keep");
+        let drop = artifact("id:b", "test/name", "Drop");
+        let mut tombstones = HashSet::new();
+        tombstones.insert(sort_key(&drop));
+
+        let filtered = filter_tombstones(stream_of(vec![keep.clone(), drop]), tombstones);
+        let items = collect(filtered).await?;
+        assert_eq!(items, vec![keep]);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_passes_stream_through_when_tombstones_are_empty() -> anyhow::Result<()> {
+        let a = artifact("id:a", "test/name", "Alice");
+        let b = artifact("id:b", "test/name", "Bob");
+        let filtered = filter_tombstones(stream_of(vec![a.clone(), b.clone()]), HashSet::new());
+        let items = collect(filtered).await?;
+        assert_eq!(items, vec![a, b]);
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/lib.rs
+++ b/rust/dialog-repository/src/lib.rs
@@ -35,6 +35,14 @@
 mod repository;
 pub use repository::*;
 
+/// Streaming-merge and tombstone helpers used by the query-session
+/// composition layer.
+pub(crate) mod layer;
+
+/// Typed schema for query-time facts about a repository's structure
+/// (origins, branches, branch revisions, sessions).
+pub mod schema;
+
 pub use dialog_artifacts::{Exporter, Importer};
 
 /// Test helpers for setting up profiles, operators, repositories, and test data.

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -16,7 +16,7 @@ use dialog_varsig::Principal;
 mod archive;
 pub use archive::*;
 
-mod branch;
+pub(crate) mod branch;
 pub use branch::*;
 
 mod create;
@@ -717,7 +717,7 @@ mod tests {
         use dialog_query::query::Output;
         use dialog_query::{Concept, Entity, Query, Term};
 
-        mod employee {
+        pub mod employee {
             #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
             pub struct Name(pub String);
 
@@ -727,9 +727,9 @@ mod tests {
 
         #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
         pub struct Employee {
-            this: Entity,
-            name: employee::Name,
-            role: employee::Role,
+            pub this: Entity,
+            pub name: employee::Name,
+            pub role: employee::Role,
         }
 
         #[dialog_common::test]
@@ -994,6 +994,852 @@ mod tests {
                     entity: NamedEntity(page_v1.clone()),
                 }]
             );
+
+            Ok(())
+        }
+    }
+
+    mod query_session {
+        use super::query_engine::{Employee, employee};
+        use crate::helpers::{test_operator_with_profile, test_repo};
+        use dialog_query::query::Output;
+        use dialog_query::{Concept, Entity, Query, Term, the};
+
+        mod branch_meta {
+            #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("dialog.meta")]
+            pub struct Name(pub String);
+
+            #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("dialog.meta")]
+            pub struct RevisionHash(pub String);
+        }
+
+        #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct BranchMeta {
+            this: Entity,
+            name: branch_meta::Name,
+        }
+
+        #[dialog_common::test]
+        async fn it_exposes_overlaid_concept_facts_via_with() -> anyhow::Result<()> {
+            // `branch.with(stmt)` folds a Statement (here a BranchMeta
+            // concept instance) into the session's overlay changes.
+            // The fact surfaces via `Provider<Select> for Changes`,
+            // alongside the branch's stored facts.
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            let synthetic: Entity = "id:branch".parse()?;
+            let results: Vec<BranchMeta> = branch
+                .with(BranchMeta {
+                    this: synthetic.clone(),
+                    name: branch_meta::Name("main".into()),
+                })
+                .select(Query::<BranchMeta> {
+                    this: synthetic.clone().into(),
+                    name: Term::var("name"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].this, synthetic);
+            assert_eq!(results[0].name.0, "main");
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_unions_two_branches_via_join() -> anyhow::Result<()> {
+            // `.join(&branch)` unions another branch into the session.
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let main = repo.branch("main").open().perform(&operator).await?;
+            let feature = repo.branch("feature").open().perform(&operator).await?;
+
+            main.transaction()
+                .assert(Employee {
+                    this: Entity::new()?,
+                    name: employee::Name("Alice".into()),
+                    role: employee::Role("Engineer".into()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            feature
+                .transaction()
+                .assert(Employee {
+                    this: Entity::new()?,
+                    name: employee::Name("Bob".into()),
+                    role: employee::Role("Designer".into()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            // Reload so the branch handles know about their revisions.
+            let main = repo.branch("main").load().perform(&operator).await?;
+            let feature = repo.branch("feature").load().perform(&operator).await?;
+
+            let mut names: Vec<String> = feature
+                .query()
+                .join(&main)
+                .select(Query::<Employee> {
+                    this: Term::var("this"),
+                    name: Term::var("name"),
+                    role: Term::var("role"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?
+                .into_iter()
+                .map(|e| e.name.0)
+                .collect();
+            names.sort();
+            assert_eq!(names, vec!["Alice".to_string(), "Bob".to_string()]);
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_chains_branch_join_with_statement_overlay() -> anyhow::Result<()> {
+            // `.join(&branch)` adds a branch source; `.with(stmt)`
+            // adds in-memory facts via the Changes overlay. Both
+            // compose on the same session.
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let main = repo.branch("main").open().perform(&operator).await?;
+            let scratch = repo.branch("scratch").open().perform(&operator).await?;
+
+            main.transaction()
+                .assert(Employee {
+                    this: Entity::new()?,
+                    name: employee::Name("Alice".into()),
+                    role: employee::Role("Engineer".into()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+            let main = repo.branch("main").load().perform(&operator).await?;
+
+            let mut names: Vec<String> = scratch
+                .query()
+                .join(&main)
+                .with(Employee {
+                    this: Entity::new()?,
+                    name: employee::Name("Synthetic".into()),
+                    role: employee::Role("Bot".into()),
+                })
+                .select(Query::<Employee> {
+                    this: Term::var("this"),
+                    name: Term::var("name"),
+                    role: Term::var("role"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?
+                .into_iter()
+                .map(|e| e.name.0)
+                .collect();
+            names.sort();
+            assert_eq!(names, vec!["Alice".to_string(), "Synthetic".to_string()]);
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn layer_facts_union_with_stored_facts() -> anyhow::Result<()> {
+            // Asserting a layered fact under the same attribute as a stored
+            // fact should yield both rows when queried.
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            let alice = Entity::new()?;
+            branch
+                .transaction()
+                .assert(
+                    the!("dialog.meta/name")
+                        .of(alice.clone())
+                        .is("Alice".to_string()),
+                )
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            let synthetic: Entity = "id:branch".parse()?;
+            let names: Vec<BranchMeta> = branch
+                .with(BranchMeta {
+                    this: synthetic,
+                    name: branch_meta::Name("main".into()),
+                })
+                .select(Query::<BranchMeta> {
+                    this: Term::var("this"),
+                    name: Term::var("name"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert_eq!(names.len(), 2);
+            let mut values: Vec<String> = names.into_iter().map(|m| m.name.0).collect();
+            values.sort();
+            assert_eq!(values, vec!["Alice".to_string(), "main".to_string()]);
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_auto_includes_schema_branch_in_metadata() -> anyhow::Result<()> {
+            // branch.query() should expose schema::Branch facts without
+            // any manual .with(...) overlay. The branch entity is
+            // content-derived from (profile, subject, name).
+            use crate::schema;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+            let origin = schema::Origin::new(profile.did(), branch.of().clone());
+            let expected = schema::Branch::new(&origin, "main");
+
+            let results: Vec<schema::Branch> = branch
+                .query()
+                .select(Query::<schema::Branch> {
+                    this: expected.this.clone().into(),
+                    name: Term::var("name"),
+                    origin: Term::var("origin"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert_eq!(results.len(), 1, "schema::Branch must auto-surface");
+            assert_eq!(results[0].this, expected.this);
+            assert_eq!(results[0].name.0, "main");
+            assert_eq!(results[0].origin.0, origin.this);
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_auto_includes_origin_in_metadata() -> anyhow::Result<()> {
+            // branch.query() should also auto-surface the schema::Origin
+            // anchoring the branch — entity is (profile, subject)-derived
+            // and carries the two DIDs as attributes.
+            use crate::schema;
+            use crate::schema::DidExt as _;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+            let expected = schema::Origin::new(profile.did(), branch.of().clone());
+
+            let results: Vec<schema::Origin> = branch
+                .query()
+                .select(Query::<schema::Origin> {
+                    this: expected.this.clone().into(),
+                    subject: Term::var("subject"),
+                    profile: Term::var("profile"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert_eq!(results.len(), 1, "schema::Origin must auto-surface");
+            assert_eq!(results[0].this, expected.this);
+            assert_eq!(results[0].subject.0, branch.of().this());
+            assert_eq!(results[0].profile.0, profile.did().this());
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_auto_includes_branch_revision_after_commit() -> anyhow::Result<()> {
+            // After a commit the branch has a revision, so the metadata
+            // overlay includes a BranchRevision fact carrying the tree
+            // hash + clock components.
+            use crate::schema;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+            branch
+                .transaction()
+                .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
+                .commit()
+                .perform(&operator)
+                .await?;
+            // Reload so the revision cell reflects the commit.
+            let branch = repo.branch("main").load().perform(&operator).await?;
+            let origin = schema::Origin::new(profile.did(), branch.of().clone());
+            let branch_concept = schema::Branch::new(&origin, "main");
+
+            let results: Vec<schema::BranchRevision> = branch
+                .query()
+                .select(Query::<schema::BranchRevision> {
+                    this: branch_concept.this.clone().into(),
+                    tree: Term::var("tree"),
+                    period: Term::var("period"),
+                    moment: Term::var("moment"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert_eq!(results.len(), 1, "BranchRevision must surface after commit");
+            assert_eq!(results[0].this, branch_concept.this);
+            assert!(
+                !results[0].tree.0.is_empty(),
+                "tree hash should be non-empty"
+            );
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_omits_branch_revision_before_any_commit() -> anyhow::Result<()> {
+            // A freshly-opened branch with no commits has no revision —
+            // so no BranchRevision fact should appear.
+            use crate::schema;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+            let origin = schema::Origin::new(profile.did(), branch.of().clone());
+            let branch_concept = schema::Branch::new(&origin, "main");
+
+            let results: Vec<schema::BranchRevision> = branch
+                .query()
+                .select(Query::<schema::BranchRevision> {
+                    this: branch_concept.this.into(),
+                    tree: Term::var("tree"),
+                    period: Term::var("period"),
+                    moment: Term::var("moment"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert!(
+                results.is_empty(),
+                "no BranchRevision should surface for a fresh branch"
+            );
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_reflects_latest_revision_after_a_commit() -> anyhow::Result<()> {
+            // Regression: after a commit, subsequent queries through
+            // the same branch handle must see the new BranchRevision —
+            // not a stale one cached from before commit. The Branch's
+            // revision Cell is publish/resolve-backed so the next
+            // metadata synthesis sees the post-commit revision.
+            use crate::schema;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+            let origin = schema::Origin::new(profile.did(), branch.of().clone());
+            let branch_concept = schema::Branch::new(&origin, "main");
+
+            // First commit.
+            branch
+                .transaction()
+                .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            let after_first: Vec<schema::BranchRevision> = repo
+                .branch("main")
+                .load()
+                .perform(&operator)
+                .await?
+                .query()
+                .select(Query::<schema::BranchRevision> {
+                    this: branch_concept.this.clone().into(),
+                    tree: Term::var("tree"),
+                    period: Term::var("period"),
+                    moment: Term::var("moment"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+            assert_eq!(after_first.len(), 1);
+            let first_tree = after_first[0].tree.0.clone();
+
+            // Second commit through the same branch handle.
+            branch
+                .transaction()
+                .assert(the!("user/name").of(Entity::new()?).is("Bob".to_string()))
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            let after_second: Vec<schema::BranchRevision> = repo
+                .branch("main")
+                .load()
+                .perform(&operator)
+                .await?
+                .query()
+                .select(Query::<schema::BranchRevision> {
+                    this: branch_concept.this.into(),
+                    tree: Term::var("tree"),
+                    period: Term::var("period"),
+                    moment: Term::var("moment"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+            assert_eq!(after_second.len(), 1);
+            assert_ne!(
+                after_second[0].tree.0, first_tree,
+                "tree hash must change after the second commit, not be the stale first one"
+            );
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_auto_includes_session_facts() -> anyhow::Result<()> {
+            // The metadata overlay also asserts a `Session` fact on
+            // `db:session` carrying the profile + operator DIDs.
+            use crate::schema;
+            use crate::schema::DidExt as _;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            let results: Vec<schema::Session> = branch
+                .query()
+                .select(Query::<schema::Session> {
+                    this: schema::Session::entity().into(),
+                    profile: Term::var("profile"),
+                    operator: Term::var("operator"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert_eq!(results.len(), 1, "Session must auto-surface");
+            assert_eq!(results[0].profile.0, profile.did().this());
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_lets_a_user_query_branch_origin_and_session_in_one_session()
+        -> anyhow::Result<()> {
+            // End-to-end use case: given a branch handle and an
+            // operator, a user can query for "what branch am I on /
+            // what's my origin / what's my session" through the same
+            // `branch.query()` session — no manual overlay needed.
+            // Demonstrates the full auto-injection contract.
+            use crate::schema;
+            use crate::schema::DidExt as _;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            // (1) Which branch am I on?
+            let branches: Vec<schema::Branch> = branch
+                .query()
+                .select(Query::<schema::Branch> {
+                    this: Term::var("this"),
+                    name: Term::var("name"),
+                    origin: Term::var("origin"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+            assert_eq!(branches.len(), 1);
+            assert_eq!(branches[0].name.0, "main");
+
+            // (2) What's my origin (subject, profile)?
+            let origins: Vec<schema::Origin> = branch
+                .query()
+                .select(Query::<schema::Origin> {
+                    this: branches[0].origin.0.clone().into(),
+                    subject: Term::var("subject"),
+                    profile: Term::var("profile"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+            assert_eq!(origins.len(), 1);
+            assert_eq!(origins[0].subject.0, branch.of().this());
+            assert_eq!(origins[0].profile.0, profile.did().this());
+
+            // (3) What's my session (profile + operator DIDs)?
+            let sessions: Vec<schema::Session> = branch
+                .query()
+                .select(Query::<schema::Session> {
+                    this: schema::Session::entity().into(),
+                    profile: Term::var("profile"),
+                    operator: Term::var("operator"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+            assert_eq!(sessions.len(), 1);
+            assert_eq!(sessions[0].profile.0, profile.did().this());
+
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_auto_includes_session_branch_attribute_per_branch_in_scope()
+        -> anyhow::Result<()> {
+            // `dialog.session/branch` is cardinality-many — one per
+            // branch in the session's scope (primary + joined). Query
+            // it directly via the schema attribute as an artifact
+            // search.
+            use crate::schema;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let main = repo.branch("main").open().perform(&operator).await?;
+            let feature = repo.branch("feature").open().perform(&operator).await?;
+
+            // Query both branches in scope by raw attribute lookup
+            // via the artifact selector.
+            let session_entity = schema::Session::entity();
+
+            // Build the expected branch entities for the two in-scope branches.
+            let origin = schema::Origin::new(profile.did(), main.of().clone());
+            let main_branch = schema::Branch::new(&origin, "main");
+            let feature_branch = schema::Branch::new(&origin, "feature");
+            let mut expected_branches = vec![main_branch.this.clone(), feature_branch.this.clone()];
+            expected_branches.sort();
+
+            // `dialog.session/branch` is cardinality-many, so a
+            // `Query<SessionBranch>` yields one row per branch in scope.
+            let rows: Vec<schema::SessionBranch> = feature
+                .query()
+                .join(&main)
+                .select(Query::<schema::SessionBranch> {
+                    this: session_entity.clone().into(),
+                    branch: Term::var("branch"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            let mut got: Vec<Entity> = rows.into_iter().map(|r| r.branch.0).collect();
+            got.sort();
+            assert_eq!(got, expected_branches);
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_keeps_metadata_facts_out_of_branch_tree() -> anyhow::Result<()> {
+            // The schema-shaped metadata is synthesized at query time
+            // into a per-query overlay; nothing is written to the
+            // branch's tree. Reading the branch's claims directly
+            // (bypassing the QuerySession overlay) should return no
+            // dialog.branch/* artifacts.
+            use dialog_artifacts::ArtifactSelector;
+            use futures_util::StreamExt as _;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+            // Commit something so the branch has a tree to scan.
+            branch
+                .transaction()
+                .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
+                .commit()
+                .perform(&operator)
+                .await?;
+            let branch = repo.branch("main").load().perform(&operator).await?;
+
+            // Scan the branch's underlying claims directly for the
+            // dialog.branch/name attribute — bypasses the QuerySession
+            // overlay so any hit would mean facts leaked into the tree.
+            let select = branch
+                .claims()
+                .select(ArtifactSelector::new().the("dialog.branch/name".parse()?));
+            let store = crate::NetworkedIndex::new(&operator, select.catalog(), None);
+            let stream = select.execute(store).await?;
+            let leaked: Vec<_> = stream.collect::<Vec<_>>().await;
+
+            assert!(
+                leaked.is_empty(),
+                "schema metadata must not leak into the branch tree; found {} artifact(s)",
+                leaked.len()
+            );
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_reflects_overlay_state_on_session_accessors() -> anyhow::Result<()> {
+            // A QueryLayer carries every branch (the one `query()` was
+            // called on plus any `.join`-ed) and the pending overlay
+            // changes. Verify both are visible through the accessors.
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let main = repo.branch("main").open().perform(&operator).await?;
+            let feature = repo.branch("feature").open().perform(&operator).await?;
+
+            let session = feature.query().join(&main).with(Employee {
+                this: Entity::new()?,
+                name: employee::Name("Synth".into()),
+                role: employee::Role("Bot".into()),
+            });
+            // `feature.query()` seeds `feature`; `.join(&main)` adds main.
+            assert_eq!(session.branches().len(), 2);
+            assert_eq!(session.branches()[0].name(), "feature");
+            assert_eq!(session.branches()[1].name(), "main");
+            assert!(
+                !session.changes().is_empty(),
+                "overlay changes must contain the asserted Employee"
+            );
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_starts_with_only_its_branch_and_empty_overlay() -> anyhow::Result<()> {
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            // A fresh `query()` holds exactly its own branch and no
+            // caller-supplied overlay changes.
+            let session = branch.query();
+            assert_eq!(session.branches().len(), 1);
+            assert_eq!(session.branches()[0].name(), "main");
+            assert!(session.changes().is_empty());
+            Ok(())
+        }
+
+        mod cardinality_one_attr {
+            #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("person")]
+            pub struct Nickname(pub String);
+        }
+
+        #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct WithNickname {
+            pub this: Entity,
+            pub nickname: cardinality_one_attr::Nickname,
+        }
+
+        #[dialog_common::test]
+        async fn cross_branch_layer_preserves_cardinality_one_winner() -> anyhow::Result<()> {
+            // Regression for the streaming merge: two branches both holding
+            // facts for the same (attribute, entity) pair under a
+            // cardinality-one attribute must still yield exactly one winner
+            // per entity when queried through a composed session. The
+            // sliding-window in `only.rs` assumes consecutive `(the, of)`
+            // grouping, so the composite env must merge — not chain —
+            // branch streams.
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let main = repo.branch("main").open().perform(&operator).await?;
+            let feature = repo.branch("feature").open().perform(&operator).await?;
+
+            let alice: Entity = "id:alice".parse()?;
+            let bob: Entity = "id:bob".parse()?;
+
+            main.transaction()
+                .assert(WithNickname {
+                    this: alice.clone(),
+                    nickname: cardinality_one_attr::Nickname("Ali".into()),
+                })
+                .assert(WithNickname {
+                    this: bob.clone(),
+                    nickname: cardinality_one_attr::Nickname("Bobby".into()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            feature
+                .transaction()
+                .assert(WithNickname {
+                    this: alice.clone(),
+                    nickname: cardinality_one_attr::Nickname("Ally".into()),
+                })
+                .assert(WithNickname {
+                    this: bob.clone(),
+                    nickname: cardinality_one_attr::Nickname("Rob".into()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+
+            let main = repo.branch("main").load().perform(&operator).await?;
+            let feature = repo.branch("feature").load().perform(&operator).await?;
+
+            let results: Vec<WithNickname> = feature
+                .query()
+                .join(&main)
+                .select(Query::<WithNickname> {
+                    this: Term::var("this"),
+                    nickname: Term::var("nickname"),
+                })
+                .perform(&operator)
+                .try_vec()
+                .await?;
+
+            assert_eq!(
+                results.len(),
+                2,
+                "cardinality-one across composed branches must yield one row per entity"
+            );
+            let mut entities: Vec<Entity> = results.into_iter().map(|w| w.this).collect();
+            entities.sort();
+            let mut expected = vec![alice, bob];
+            expected.sort();
+            assert_eq!(entities, expected);
+            Ok(())
+        }
+
+        #[dialog_common::test]
+        async fn it_orders_changes_consistently_with_branch_scans_in_every_mode()
+        -> anyhow::Result<()> {
+            // Load-bearing invariant for `merge_grouped`: `Provider<Select>
+            // for Changes` must yield artifacts in the same order the tree
+            // would for the same selector. If it doesn't, cross-source
+            // unions interleave incorrectly within a `(the, of)` group.
+            //
+            // For each scan mode we commit the same facts to a real
+            // branch and stage them in a Changes overlay, then compare
+            // the ordered `sort_key` sequence. `Cause` differs (real
+            // commit vs `None`) so we don't compare full artifacts.
+            use dialog_artifacts::selector::Constrained;
+            use dialog_artifacts::{
+                ArtifactSelector, ArtifactStream, Changes, DialogArtifactsError, Select, SortKey,
+                Update as _, Value, sort_key,
+            };
+            use dialog_capability::Provider;
+            use futures_util::StreamExt as _;
+
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            let alice: Entity = "id:alice".parse()?;
+            let bob: Entity = "id:bob".parse()?;
+            let charlie: Entity = "id:charlie".parse()?;
+            let name_attr = "test/name".parse::<dialog_artifacts::Attribute>()?;
+            let role_attr = "test/role".parse::<dialog_artifacts::Attribute>()?;
+
+            // Mix of:
+            //   - same entity, multiple attrs
+            //   - same entity, same attr, multiple values (cardinality-many)
+            //   - the "Shared" value asserted under DIFFERENT attributes
+            //     on entities whose sort order DISAGREES with the
+            //     attribute order: (charlie, name) and (alice, role).
+            //     entity order is alice < charlie; attribute order is
+            //     name < role. So the VAE residual order — which is
+            //     (attribute, entity) — must put (charlie, name) before
+            //     (alice, role). If `sort_key` mistakenly ordered VAE
+            //     output by entity it would flip these two, and this
+            //     test would catch it.
+            let facts: Vec<(Entity, dialog_artifacts::Attribute, Value)> = vec![
+                (
+                    alice.clone(),
+                    name_attr.clone(),
+                    Value::String("Alice".into()),
+                ),
+                (
+                    alice.clone(),
+                    name_attr.clone(),
+                    Value::String("Aly".into()),
+                ),
+                (
+                    alice.clone(),
+                    role_attr.clone(),
+                    Value::String("Engineer".into()),
+                ),
+                (bob.clone(), name_attr.clone(), Value::String("Bob".into())),
+                (
+                    bob.clone(),
+                    role_attr.clone(),
+                    Value::String("Engineer".into()),
+                ),
+                (
+                    charlie.clone(),
+                    name_attr.clone(),
+                    Value::String("Charlie".into()),
+                ),
+                // VAE probe: same value, different attributes,
+                // entity-order opposite to attribute-order.
+                (
+                    charlie.clone(),
+                    name_attr.clone(),
+                    Value::String("Shared".into()),
+                ),
+                (
+                    alice.clone(),
+                    role_attr.clone(),
+                    Value::String("Shared".into()),
+                ),
+            ];
+
+            // Build a single Changes batch with all facts, then drive
+            // both the branch commit and the overlay query from clones.
+            let mut changes = Changes::new();
+            for (e, a, v) in &facts {
+                changes.associate(a.clone(), e.clone(), v.clone());
+            }
+
+            // Commit a clone to the branch (Changes itself is a Statement now).
+            branch
+                .transaction()
+                .assert(changes.clone())
+                .commit()
+                .perform(&operator)
+                .await?;
+            let branch = repo.branch("main").load().perform(&operator).await?;
+
+            // Compare per scan mode: collect sort_keys from a raw
+            // branch scan and from the Changes overlay; they must
+            // match exactly. (Full Artifact equality would fail
+            // because cause is None on the overlay and Some on the
+            // committed branch entry.)
+            async fn keys_from_stream(s: ArtifactStream<'_>) -> anyhow::Result<Vec<SortKey>> {
+                let items: Vec<_> = s
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, DialogArtifactsError>>()?;
+                Ok(items.iter().map(sort_key).collect())
+            }
+
+            let scan_modes: &[(&str, ArtifactSelector<Constrained>)] = &[
+                ("EAV (.of)", ArtifactSelector::new().of(alice.clone())),
+                ("AEV (.the)", ArtifactSelector::new().the(name_attr.clone())),
+                // VAE: "Shared" lives under two different attributes
+                // (name on charlie, role on alice) — exercises the
+                // (attribute, entity) residual ordering, not just
+                // (entity) within one attribute.
+                (
+                    "VAE (.is)",
+                    ArtifactSelector::new().is(Value::String("Shared".into())),
+                ),
+            ];
+
+            for (label, sel) in scan_modes {
+                // Raw branch scan — bypass the QuerySession overlay so
+                // we see tree-order output without auto-metadata noise.
+                // The branch's prolly tree is the order ground truth.
+                let select = branch.claims().select(sel.clone());
+                let store = crate::NetworkedIndex::new(&operator, select.catalog(), None);
+                let branch_stream: ArtifactStream<'_> = Box::pin(select.execute(store).await?);
+                let branch_order = keys_from_stream(branch_stream).await?;
+
+                // Changes overlay scan via Provider<Select>.
+                let changes_stream = Provider::<Select<'_>>::execute(&changes, sel.clone()).await?;
+                let changes_order = keys_from_stream(changes_stream).await?;
+
+                assert!(
+                    branch_order.len() >= 2,
+                    "{label}: scan must return >=2 items for the ordering check to be meaningful"
+                );
+                assert_eq!(
+                    branch_order, changes_order,
+                    "{label}: Changes-as-source order must match branch-tree scan order"
+                );
+            }
 
             Ok(())
         }

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -26,6 +26,8 @@ pub use import::*;
 mod load;
 pub use load::*;
 
+mod metadata;
+
 mod open;
 pub use open::*;
 
@@ -45,6 +47,7 @@ mod select;
 pub use select::*;
 
 mod session;
+pub(crate) use session::select_from_branch;
 pub use session::*;
 
 mod set_upstream;

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -2,17 +2,15 @@ use crate::{
     Branch, CommitError, Index, NetworkedIndex, RemoteSite, RepositoryArchiveExt as _,
     RepositoryMemoryExt, Revision, TreeReference, Upstream,
 };
-use dialog_artifacts::{
-    Artifact, AttributeKey, Datum, EntityKey, FromKey, Instruction, Key, KeyView, KeyViewConstruct,
-    KeyViewMut, State, ValueKey,
-};
+use dialog_artifacts::Instruction;
+use dialog_artifacts::tree::ArtifactTreeExt as _;
 use dialog_capability::{Fork, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::{Identify, OperatorExt};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_prolly_tree::{EMPT_TREE_HASH, Tree};
-use futures_util::{Stream, StreamExt, TryStreamExt};
+use futures_util::Stream;
 
 /// Command that commits a stream of changes (assert/retract) to a branch.
 ///
@@ -82,117 +80,10 @@ where
 
         let mut tree: Index = Tree::from_hash(&base_tree_hash, &store).await?;
 
-        // `changes` is a user-provided `Stream`; pinning it on the stack
-        // lets us advance it with `.next().await` below without moving
-        // self-referential state.
-        tokio::pin!(changes);
-
-        while let Some(change) = changes.next().await {
-            match change {
-                Instruction::Assert(artifact) => {
-                    let entity_key = EntityKey::from(&artifact);
-                    let value_key = ValueKey::from_key(&entity_key);
-                    let attribute_key = AttributeKey::from_key(&entity_key);
-
-                    let datum = Datum::from(artifact);
-
-                    tree.set(
-                        entity_key.into_key(),
-                        State::Added(datum.clone()),
-                        &mut store,
-                    )
-                    .await?;
-                    tree.set(
-                        attribute_key.into_key(),
-                        State::Added(datum.clone()),
-                        &mut store,
-                    )
-                    .await?;
-                    tree.set(value_key.into_key(), State::Added(datum), &mut store)
-                        .await?;
-                }
-                Instruction::Replace(artifact) => {
-                    let entity_key = EntityKey::from(&artifact);
-
-                    // Scan priors at this (entity, attribute). Same-valued
-                    // priors already represent the desired state; only
-                    // different-valued ones need superseding.
-                    let mut superseded_keys: Vec<Key> = Vec::new();
-                    let mut found_same_value = false;
-                    {
-                        let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
-                            .set_entity(entity_key.entity())
-                            .set_attribute(entity_key.attribute())
-                            .into_key();
-                        let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
-                            .set_entity(entity_key.entity())
-                            .set_attribute(entity_key.attribute())
-                            .into_key();
-
-                        let search_stream = tree.stream_range(search_start..search_end, &store);
-                        tokio::pin!(search_stream);
-
-                        while let Some(candidate) = search_stream.try_next().await? {
-                            if let State::Added(current_element) = candidate.value {
-                                let current = Artifact::try_from(current_element)?;
-                                if current.is == artifact.is {
-                                    found_same_value = true;
-                                } else {
-                                    superseded_keys.push(candidate.key);
-                                }
-                            }
-                        }
-                    }
-
-                    for key in superseded_keys {
-                        let entity_key = EntityKey(key);
-                        let value_key = ValueKey::from_key(&entity_key);
-                        let attribute_key = AttributeKey::from_key(&entity_key);
-
-                        tree.delete(&entity_key.into_key(), &mut store).await?;
-                        tree.delete(&value_key.into_key(), &mut store).await?;
-                        tree.delete(&attribute_key.into_key(), &mut store).await?;
-                    }
-
-                    // Skip insert if a same-value prior is already in place.
-                    if found_same_value {
-                        continue;
-                    }
-
-                    let entity_key = EntityKey::from(&artifact);
-                    let value_key = ValueKey::from_key(&entity_key);
-                    let attribute_key = AttributeKey::from_key(&entity_key);
-                    let datum = Datum::from(artifact);
-
-                    tree.set(
-                        entity_key.into_key(),
-                        State::Added(datum.clone()),
-                        &mut store,
-                    )
-                    .await?;
-                    tree.set(
-                        attribute_key.into_key(),
-                        State::Added(datum.clone()),
-                        &mut store,
-                    )
-                    .await?;
-                    tree.set(value_key.into_key(), State::Added(datum), &mut store)
-                        .await?;
-                }
-                Instruction::Retract(fact) => {
-                    let entity_key = EntityKey::from(&fact);
-                    let value_key = ValueKey::from_key(&entity_key);
-                    let attribute_key = AttributeKey::from_key(&entity_key);
-
-                    tree.set(entity_key.into_key(), State::Removed, &mut store)
-                        .await?;
-                    tree.set(attribute_key.into_key(), State::Removed, &mut store)
-                        .await?;
-                    tree.set(value_key.into_key(), State::Removed, &mut store)
-                        .await?;
-                }
-            }
-        }
+        // Drain the change stream into the tree. EAV/AEV/VAE writes,
+        // cardinality-one supersession, and retraction live in the
+        // shared `ArtifactTreeExt::apply` so the key layout stays uniform.
+        tree.apply(&mut store, changes).await?;
 
         // `tree.hash()` returns `None` only when the tree is empty, which
         // we represent as the canonical empty-tree hash.

--- a/rust/dialog-repository/src/repository/branch/metadata.rs
+++ b/rust/dialog-repository/src/repository/branch/metadata.rs
@@ -1,0 +1,90 @@
+//! Branch metadata concepts.
+//!
+//! [`Branch::metadata`] turns a branch handle + the operator's
+//! identity into a typed [`BranchMetadata`] — the [`Origin`], the
+//! [`Branch`](BranchConcept) concept, and a [`BranchRevision`] when
+//! the branch has a commit. `BranchMetadata` implements [`Statement`],
+//! so it folds straight into a [`Changes`](dialog_artifacts::Changes)
+//! batch.
+//!
+//! The query layer composes these per-branch bundles (plus a
+//! [`Session`](crate::schema::Session)) into the overlay every
+//! `branch.query()` is evaluated against — see
+//! [`QueryLayer::metadata`](super::session::QueryLayer::metadata).
+
+use base58::ToBase58;
+use dialog_artifacts::{Statement, Update};
+use dialog_capability::Capability;
+use dialog_effects::authority::{Operator, OperatorExt as _};
+
+use crate::Branch;
+use crate::schema::Branch as BranchConcept;
+use crate::schema::branch::{Moment, Period, Tree};
+use crate::schema::{BranchRevision, Origin};
+
+/// The schema-shaped metadata for a single branch.
+///
+/// Bundles the [`Origin`] (`(profile, subject)`-derived), the
+/// [`Branch`](BranchConcept) concept (`(origin, name)`-derived), and
+/// the [`BranchRevision`] when the branch has a committed revision.
+///
+/// Implements [`Statement`]: asserting a `BranchMetadata` asserts all
+/// three (origin, branch, optional revision) into the target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchMetadata {
+    /// This device's view of the repository the branch lives in.
+    pub origin: Origin,
+    /// The branch concept — name + origin, content-derived entity.
+    pub branch: BranchConcept,
+    /// The current revision, present once the branch has a commit.
+    pub revision: Option<BranchRevision>,
+}
+
+impl Statement for BranchMetadata {
+    fn assert(self, update: &mut impl Update) {
+        self.origin.assert(update);
+        self.branch.assert(update);
+        if let Some(revision) = self.revision {
+            revision.assert(update);
+        }
+    }
+
+    fn retract(self, update: &mut impl Update) {
+        self.origin.retract(update);
+        self.branch.retract(update);
+        if let Some(revision) = self.revision {
+            revision.retract(update);
+        }
+    }
+}
+
+impl Branch {
+    /// The schema [`BranchMetadata`] for this branch under `operator`'s
+    /// identity.
+    ///
+    /// `operator` supplies the profile DID: [`Origin`] is
+    /// `(profile, subject)`-derived — and the [`Branch`](BranchConcept)
+    /// and [`BranchRevision`] entities inherit that derivation — but a
+    /// branch handle carries only its subject, not a profile. The
+    /// `Capability<Operator>` (from
+    /// [`Identify`](dialog_effects::authority::Identify)) carries both
+    /// the profile and operator DIDs.
+    pub fn metadata(&self, operator: &Capability<Operator>) -> BranchMetadata {
+        let origin = Origin::new(operator.profile().clone(), self.of().clone());
+        let branch = BranchConcept::new(&origin, self.name());
+        let revision = self.revision().map(|revision| {
+            let tree_bytes: &[u8] = revision.tree.hash();
+            BranchRevision {
+                this: branch.this.clone(),
+                tree: Tree(ToBase58::to_base58(tree_bytes)),
+                period: Period(revision.period as u128),
+                moment: Moment(revision.moment as u128),
+            }
+        });
+        BranchMetadata {
+            origin,
+            branch,
+            revision,
+        }
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/select.rs
+++ b/rust/dialog-repository/src/repository/branch/select.rs
@@ -1,19 +1,14 @@
 use dialog_artifacts::selector::Constrained;
-use dialog_artifacts::{
-    Artifact, ArtifactSelector, AttributeKey, Datum, DialogArtifactsError, EntityKey, Key,
-    KeyViewConstruct, KeyViewMut, MatchCandidate, State, ValueKey,
-};
+use dialog_artifacts::tree::ArtifactTreeExt as _;
+use dialog_artifacts::{Artifact, ArtifactSelector, DialogArtifactsError};
 use dialog_capability::{Capability, Fork, Provider};
 use dialog_common::ConditionalSync;
 use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
 use dialog_effects::archive::{Catalog, Get, Put};
 use dialog_effects::memory::Resolve;
-use dialog_prolly_tree::{EMPT_TREE_HASH, Entry, Tree};
+use dialog_prolly_tree::{DialogProllyTreeError, EMPT_TREE_HASH, Tree};
 use dialog_storage::{Blake3Hash, ContentAddressedStorage, DialogStorageError};
 use futures_util::Stream;
-use std::ops::Range;
-
-use dialog_prolly_tree::DialogProllyTreeError;
 
 use crate::{
     Branch, Index, NetworkedIndex, RemoteSite, RepositoryArchiveExt as _, RepositoryMemoryExt,
@@ -109,64 +104,10 @@ impl Select<'_> {
         // remote-only, which is why this is async and fallible up front.
         let tree: Index = Tree::from_hash(&self.tree_hash(), &store).await?;
 
-        let selector = self.selector;
-
-        // The tree indexes every datum under three parallel keys:
-        // `entity/…`, `attribute/…`, and `value/…`. We pick the prefix
-        // that matches the most specific constraint on the selector so
-        // `stream_range` can narrow the scan to the minimum key range;
-        // any remaining constraints are checked per-entry via
-        // `matches_selector`.
-        Ok(async_stream::try_stream! {
-            if selector.entity().is_some() {
-                let start = <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
-                let end = <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
-                let stream = tree.stream_range(Range { start, end }, &store);
-                tokio::pin!(stream);
-                for await item in stream {
-                    let entry: Entry<Key, State<Datum>> = item?;
-                    // Filter out entries in the range that don't
-                    // satisfy the full selector, and skip retracted
-                    // entries (`State::Removed`) — only `Added` datums
-                    // surface as artifacts.
-                    if entry.matches_selector(&selector)
-                        && let Entry { value: State::Added(datum), .. } = entry
-                    {
-                        yield Artifact::try_from(datum)?;
-                    }
-                }
-            } else if selector.value().is_some() {
-                let start = <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
-                let end = <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
-                let stream = tree.stream_range(Range { start, end }, &store);
-                tokio::pin!(stream);
-                for await item in stream {
-                    let entry: Entry<Key, State<Datum>> = item?;
-                    if entry.matches_selector(&selector)
-                        && let Entry { value: State::Added(datum), .. } = entry
-                    {
-                        yield Artifact::try_from(datum)?;
-                    }
-                }
-            } else if selector.attribute().is_some() {
-                let start = <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(&selector).into_key();
-                let end = <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(&selector).into_key();
-                let stream = tree.stream_range(Range { start, end }, &store);
-                tokio::pin!(stream);
-                for await item in stream {
-                    let entry: Entry<Key, State<Datum>> = item?;
-                    if entry.matches_selector(&selector)
-                        && let Entry { value: State::Added(datum), .. } = entry
-                    {
-                        yield Artifact::try_from(datum)?;
-                    }
-                }
-            } else {
-                // `Constrained` is a type-state marker that guarantees
-                // the selector has at least one of entity/value/
-                // attribute set, so this branch is unreachable.
-                unreachable!("ArtifactSelector will always have at least one field specified")
-            };
-        })
+        // EAV/AEV/VAE dispatch + per-entry filtering lives in the shared
+        // `ArtifactTreeExt::scan` so branch scans and Changes-overlay
+        // scans agree on key order — that adjacency invariant is what
+        // the cardinality-one sliding window relies on.
+        Ok(tree.scan(store, self.selector))
     }
 }

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -1,80 +1,184 @@
+use std::collections::HashSet;
+
 use dialog_artifacts::selector::Constrained;
-use dialog_artifacts::{ArtifactSelector, ArtifactStream, DialogArtifactsError, Select};
-use dialog_capability::{Fork, Provider};
+use dialog_artifacts::{
+    ArtifactSelector, ArtifactStream, Changes, DialogArtifactsError, Select, SortKey, Statement,
+};
+use dialog_capability::{Capability, Fork, Provider};
 use dialog_common::ConditionalSync;
 use dialog_effects::archive::{Get, Put};
+use dialog_effects::authority::{Identify, Operator, OperatorExt as _};
 use dialog_effects::memory::Resolve;
 use dialog_query::concept::descriptor::ConceptDescriptor;
 use dialog_query::concept::query::ConceptRules;
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output};
-use dialog_query::rule::When;
-use dialog_query::rule::deductive::DeductiveRule;
-use dialog_query::session::RuleRegistry;
 use dialog_query::source::SelectRules;
 
+use crate::layer::{filter_tombstones, merge_grouped, tombstones_from};
+use crate::schema::{DidExt as _, Session, SessionBranch, session};
 use crate::{Branch, NetworkedIndex, RemoteSite, RepositoryMemoryExt, Upstream};
 
-/// A query session on a branch.
+/// A composable query over one or more branches plus an in-memory
+/// overlay.
 ///
-/// Created by [`Branch::query`]. Install rules with `.install()`,
-/// then run queries with `.select(q).perform(&operator)`.
-pub struct QuerySession<'a> {
-    branch: &'a Branch,
-    rules: RuleRegistry,
+/// `branch.query()` returns a `QueryLayer` rooted at that branch.
+/// From there:
+///
+/// - [`with`](Self::with) folds any [`Statement`] (a concept
+///   instance, an attribute expression, a [`Changes`] batch) into the
+///   overlay — its asserts/replaces surface alongside branch facts,
+///   its retracts tombstone matching branch facts.
+/// - [`join`](Self::join) merges in another branch or `QueryLayer`.
+/// - [`select`](Self::select) stages a query; `.perform(&env)` runs it.
+///
+/// All branches in the layer are peers — there is no distinguished
+/// "primary". A query reads the union of every branch's facts plus
+/// the overlay.
+///
+/// # Auto-injected schema metadata
+///
+/// At `.perform(env)` the layer resolves the operator's identity via
+/// [`Identify`] and folds in [`metadata`](Self::metadata): one
+/// [`Origin`](crate::schema::Origin) + [`Branch`](crate::schema::Branch)
+/// (+ [`BranchRevision`](crate::schema::BranchRevision) when committed)
+/// per branch, plus a single [`Session`]. Callers don't pass the
+/// profile or operator DID, and nothing is written to any branch's
+/// tree.
+///
+/// ```ignore
+/// branch.query()
+///     .join(&other_branch)            // another branch source
+///     .with(custom_concept_instance)  // user-asserted overlay facts
+///     .select(query)
+///     .perform(&env);                 // metadata auto-injected
+/// ```
+#[derive(Default, Clone)]
+pub struct QueryLayer<'a> {
+    branches: Vec<&'a Branch>,
+    changes: Changes,
 }
 
-impl<'a> QuerySession<'a> {
-    /// Register a pre-built deductive rule.
-    pub fn register(mut self, rule: DeductiveRule) -> Result<Self, EvaluationError> {
-        self.rules.register(rule)?;
-        Ok(self)
+impl<'a> QueryLayer<'a> {
+    /// An empty layer — no branches, no overlay.
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Install a deductive rule from a function.
-    pub fn install<M, W>(mut self, rule: impl Fn(M) -> W) -> Result<Self, EvaluationError>
-    where
-        M: Application + Default + Into<ConceptDescriptor>,
-        W: When,
-    {
-        let query = M::default();
-        let concept: ConceptDescriptor = query.clone().into();
-        let when = rule(query).into_premises();
-        let premises = when.into_vec();
-        let rule =
-            DeductiveRule::new(concept, premises).map_err(|e| EvaluationError::Planning {
-                message: e.to_string(),
-            })?;
-        self.rules.register(rule)?;
-        Ok(self)
+    /// Fold a [`Statement`] into this layer's overlay changes.
+    ///
+    /// `Changes` itself implements `Statement`, so `.with(changes)`
+    /// merges an existing batch in. Any concept instance, attribute
+    /// expression, or other `Statement` works too. Chainable.
+    pub fn with<S: Statement>(mut self, statement: S) -> Self {
+        statement.assert(&mut self.changes);
+        self
     }
 
-    /// Select with a query application. Call `.perform(&operator)` to execute.
+    /// Merge another layer in: union the branches, fold the other
+    /// layer's changes via its `Statement` impl. Accepts anything
+    /// convertible into a `QueryLayer` — a `&Branch` or a `Changes`.
+    pub fn join(mut self, other: impl Into<QueryLayer<'a>>) -> Self {
+        let other = other.into();
+        self.branches.extend(other.branches);
+        other.changes.assert(&mut self.changes);
+        self
+    }
+
+    /// The branches this layer reads from.
+    pub fn branches(&self) -> &[&'a Branch] {
+        &self.branches
+    }
+
+    /// The caller-supplied overlay changes (no auto-injected metadata).
+    pub fn changes(&self) -> &Changes {
+        &self.changes
+    }
+
+    /// The schema-metadata [`Changes`] for this layer: every branch's
+    /// [`BranchMetadata`](super::metadata::BranchMetadata) plus a
+    /// single [`Session`] (with one cardinality-many
+    /// `dialog.session/branch` per branch in scope).
+    ///
+    /// `operator` (from [`Identify`]) supplies the profile + operator
+    /// DIDs the schema entities are derived from.
+    pub fn metadata(&self, operator: &Capability<Operator>) -> Changes {
+        let mut changes = Changes::new();
+
+        let mut branch_entities = Vec::with_capacity(self.branches.len());
+        for branch in &self.branches {
+            let metadata = branch.metadata(operator);
+            branch_entities.push(metadata.branch.this.clone());
+            metadata.assert(&mut changes);
+        }
+
+        let session_entity = Session::entity();
+        Session {
+            this: session_entity.clone(),
+            profile: session::Profile(operator.profile().this()),
+            operator: session::Operator(operator.did().this()),
+        }
+        .assert(&mut changes);
+        // One `SessionBranch` per branch — `dialog.session/branch` is
+        // cardinality-many, so the entries accumulate on `db:session`.
+        for branch_entity in branch_entities {
+            SessionBranch {
+                this: session_entity.clone(),
+                branch: session::Branch(branch_entity),
+            }
+            .assert(&mut changes);
+        }
+
+        changes
+    }
+
+    /// The full per-query overlay: this layer's own
+    /// [`changes`](Self::changes) with [`metadata`](Self::metadata)
+    /// folded in. This is exactly what `.select(..).perform(..)`
+    /// queries against alongside the branch streams.
+    pub fn overlay(&self, operator: &Capability<Operator>) -> Changes {
+        let mut overlay = self.changes.clone();
+        self.metadata(operator).assert(&mut overlay);
+        overlay
+    }
+
+    /// Stage a query application. Call `.perform(&operator)` to execute.
     pub fn select<Q: Application>(&self, query: Q) -> SelectQuery<'_, Q> {
-        SelectQuery::with_rules(self.branch, self.rules.clone(), query)
+        SelectQuery {
+            layer: self.clone(),
+            query,
+        }
+    }
+}
+
+impl<'a> From<&'a Branch> for QueryLayer<'a> {
+    fn from(branch: &'a Branch) -> Self {
+        Self {
+            branches: vec![branch],
+            changes: Changes::new(),
+        }
+    }
+}
+
+impl From<Changes> for QueryLayer<'_> {
+    fn from(changes: Changes) -> Self {
+        Self {
+            branches: Vec::new(),
+            changes,
+        }
     }
 }
 
 /// A query command ready to be performed against an environment.
 pub struct SelectQuery<'a, Q> {
-    branch: &'a Branch,
-    rules: RuleRegistry,
+    layer: QueryLayer<'a>,
     query: Q,
 }
 
 impl<'a, Q> SelectQuery<'a, Q> {
     pub(crate) fn new(branch: &'a Branch, query: Q) -> Self {
         Self {
-            branch,
-            rules: RuleRegistry::new(),
-            query,
-        }
-    }
-
-    fn with_rules(branch: &'a Branch, rules: RuleRegistry, query: Q) -> Self {
-        Self {
-            branch,
-            rules,
+            layer: QueryLayer::from(branch),
             query,
         }
     }
@@ -82,20 +186,40 @@ impl<'a, Q> SelectQuery<'a, Q> {
 
 impl<'a, Q: Application> SelectQuery<'a, Q> {
     /// Execute the query, returning a stream of results.
+    ///
+    /// Resolves the operator's identity via [`Identify`], builds the
+    /// query overlay (caller changes + auto-injected schema metadata)
+    /// via [`QueryLayer::overlay`], lifts any retracts in it into
+    /// tombstones, and unions every branch stream (tombstone-filtered)
+    /// with the overlay.
     pub fn perform<Env>(self, env: &'a Env) -> impl Output<Q::Conclusion> + 'a
     where
         Env: Provider<Get>
             + Provider<Put>
             + Provider<Resolve>
+            + Provider<Identify>
             + Provider<Fork<RemoteSite, Get>>
             + Provider<Fork<RemoteSite, Resolve>>
             + ConditionalSync
             + 'static,
     {
-        let source = QueryEnv::new(self.branch, env, self.rules);
-        let query = self.query;
+        let SelectQuery { layer, query } = self;
         async_stream::try_stream! {
-            let results = Box::pin(query.perform(&source));
+            let operator = Identify
+                .perform(env)
+                .await
+                .map_err(|e| DialogArtifactsError::Storage(format!("identify: {e}")))?;
+
+            let overlay = layer.overlay(&operator);
+            let tombstones = tombstones_from(&overlay);
+
+            let query_env = QueryEnv {
+                branches: layer.branches,
+                changes: overlay,
+                tombstones,
+                env,
+            };
+            let results = Box::pin(query.perform(&query_env));
             for await result in results {
                 yield result?;
             }
@@ -103,27 +227,64 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
     }
 }
 
-/// Bridges a Branch + Env + RuleRegistry for the query engine's Provider bounds.
+/// The runtime environment that bridges the layer's branches and
+/// per-query overlay changes into the query engine's Provider bounds.
+///
+/// Built fresh on each `.perform(env)`; the environment reference
+/// is never captured on the layer itself.
 pub(crate) struct QueryEnv<'a, Env> {
-    branch: &'a Branch,
+    branches: Vec<&'a Branch>,
+    /// All overlay facts — caller-asserted + auto-injected metadata —
+    /// merged into one batch. Queried via `Provider<Select> for Changes`.
+    changes: Changes,
+    /// `sort_key`s of every retracted fact in `changes`. Each branch
+    /// stream is filtered against these before the merge so retracts
+    /// in the overlay suppress matching facts in the source.
+    tombstones: HashSet<SortKey>,
     env: &'a Env,
-    rules: RuleRegistry,
-}
-
-impl<'a, Env> QueryEnv<'a, Env> {
-    pub(crate) fn new(branch: &'a Branch, env: &'a Env, rules: RuleRegistry) -> Self {
-        Self { branch, env, rules }
-    }
 }
 
 impl<Env> Clone for QueryEnv<'_, Env> {
     fn clone(&self) -> Self {
         Self {
-            branch: self.branch,
+            branches: self.branches.clone(),
+            changes: self.changes.clone(),
+            tombstones: self.tombstones.clone(),
             env: self.env,
-            rules: self.rules.clone(),
         }
     }
+}
+
+/// Execute a select against a single branch, transparently routing through
+/// the branch's remote upstream when configured. Extracted as a freestanding
+/// helper so both [`QueryEnv`] and the transaction-time `TransactionEnv`
+/// share the exact same branch-read path.
+pub(crate) async fn select_from_branch<'a, Env>(
+    branch: &'a Branch,
+    env: &'a Env,
+    input: ArtifactSelector<Constrained>,
+) -> Result<ArtifactStream<'a>, DialogArtifactsError>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let select = branch.claims().select(input);
+
+    let remote = match branch.upstream() {
+        Some(Upstream::Remote { remote: name, .. }) => {
+            branch.subject().remote(name).load().perform(env).await.ok()
+        }
+        _ => None,
+    };
+
+    let store = NetworkedIndex::new(env, select.catalog(), remote);
+    let stream = select.execute(store).await?;
+    Ok(Box::pin(stream))
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -142,23 +303,20 @@ where
         &self,
         input: ArtifactSelector<Constrained>,
     ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
-        let select = self.branch.claims().select(input);
+        let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.branches.len() + 1);
 
-        let remote = match self.branch.upstream() {
-            Some(Upstream::Remote { remote: name, .. }) => self
-                .branch
-                .subject()
-                .remote(name)
-                .load()
-                .perform(self.env)
-                .await
-                .ok(),
-            _ => None,
-        };
+        // Branch streams — each filtered by tombstones from the
+        // overlay's retracts so a `tx.retract(x)` (or any user-asserted
+        // retract in `with(..)`) suppresses matching source facts.
+        for branch in &self.branches {
+            let raw = select_from_branch(branch, self.env, input.clone()).await?;
+            streams.push(filter_tombstones(raw, self.tombstones.clone()));
+        }
 
-        let store = NetworkedIndex::new(self.env, select.catalog(), remote);
-        let stream = select.execute(store).await?;
-        Ok(Box::pin(stream))
+        // Overlay stream — Changes itself is a Provider<Select>.
+        streams.push(Provider::<Select<'a>>::execute(&self.changes, input).await?);
+
+        Ok(merge_grouped(streams))
     }
 }
 
@@ -166,16 +324,28 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<Env: ConditionalSync> Provider<SelectRules> for QueryEnv<'_, Env> {
     async fn execute(&self, input: ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
-        self.rules.acquire(&input)
+        // Surfaces only the implicit per-descriptor rule each
+        // `ConceptDescriptor` carries — the overlay holds facts only.
+        Ok(ConceptRules::new(&input))
     }
 }
 
 impl Branch {
-    /// Open a query session on this branch.
-    pub fn query(&self) -> QuerySession<'_> {
-        QuerySession {
-            branch: self,
-            rules: RuleRegistry::new(),
-        }
+    /// Open a query over this branch.
+    ///
+    /// Returns a [`QueryLayer`] rooted at the branch. Use
+    /// [`with`](QueryLayer::with) to fold in a [`Statement`]'s
+    /// changes, [`join`](QueryLayer::join) to add another branch or a
+    /// [`Changes`] overlay, then [`select`](QueryLayer::select) +
+    /// `.perform(&env)`. Schema metadata is auto-injected at perform
+    /// time — no manual overlay needed.
+    pub fn query(&self) -> QueryLayer<'_> {
+        QueryLayer::from(self)
+    }
+
+    /// Open a query over this branch with `statement` folded into the
+    /// overlay in one step. Shorthand for `self.query().with(stmt)`.
+    pub fn with<S: Statement>(&self, statement: S) -> QueryLayer<'_> {
+        self.query().with(statement)
     }
 }

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -2,7 +2,7 @@ mod query;
 pub use query::{TransactionQuery, TransactionSelectQuery};
 
 use crate::{Branch, Commit};
-use dialog_artifacts::{ChangeStream, Changes, Statement};
+use dialog_artifacts::{ChangeStream, Changes, Instruction, Statement, Update};
 
 /// A transaction on a branch.
 ///
@@ -26,6 +26,31 @@ impl<'a> Transaction<'a> {
     /// Retract a claim from this transaction.
     pub fn retract<C: Statement>(mut self, claim: C) -> Self {
         claim.retract(&mut self.changes);
+        self
+    }
+
+    /// Integrate an external [`Changes`] batch into this transaction.
+    ///
+    /// Each instruction is replayed as if it had been asserted or
+    /// retracted on the transaction directly — `Assert`/`Replace`
+    /// become additive entries, `Retract` becomes a retraction entry.
+    /// Useful for callers that build a [`Changes`] independently
+    /// (e.g. a reactor accumulating effect outputs across rounds) and
+    /// need to merge it into a running transaction.
+    pub fn integrate(mut self, changes: Changes) -> Self {
+        for instruction in changes.into_instructions() {
+            match instruction {
+                Instruction::Assert(a) => {
+                    Update::associate(&mut self.changes, a.the, a.of, a.is);
+                }
+                Instruction::Replace(a) => {
+                    Update::associate_unique(&mut self.changes, a.the, a.of, a.is);
+                }
+                Instruction::Retract(a) => {
+                    Update::dissociate(&mut self.changes, a.the, a.of, a.is);
+                }
+            }
+        }
         self
     }
 

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -1,3 +1,6 @@
+mod query;
+pub use query::{TransactionQuery, TransactionSelectQuery};
+
 use crate::{Branch, Commit};
 use dialog_artifacts::{ChangeStream, Changes, Statement};
 
@@ -13,14 +16,29 @@ pub struct Transaction<'a> {
 impl<'a> Transaction<'a> {
     /// Assert a claim into this transaction.
     pub fn assert<C: Statement>(mut self, claim: C) -> Self {
-        self.changes.assert(claim);
+        // Disambiguate from `Statement::assert` (which Changes now
+        // implements) by calling the claim's own assert into our
+        // changes buffer directly.
+        claim.assert(&mut self.changes);
         self
     }
 
     /// Retract a claim from this transaction.
     pub fn retract<C: Statement>(mut self, claim: C) -> Self {
-        self.changes.retract(claim);
+        claim.retract(&mut self.changes);
         self
+    }
+
+    /// Run queries against this transaction's "as-if committed" view of
+    /// the branch.
+    ///
+    /// Pending asserts and retracts are surfaced through a
+    /// [`TransactionQuery`] handle — assertions show up alongside the
+    /// branch's stored facts; retractions tombstone matching facts in
+    /// the branch's stream before the merge. The transaction itself
+    /// stays open and committable.
+    pub fn query(&self) -> TransactionQuery<'_> {
+        TransactionQuery::new(self.branch, &self.changes)
     }
 
     /// Finalize the transaction into a commit command.

--- a/rust/dialog-repository/src/repository/branch/transaction/query.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/query.rs
@@ -1,0 +1,322 @@
+//! Querying a transaction's uncommitted writes.
+//!
+//! [`Transaction::query`](crate::repository::branch::Transaction::query)
+//! returns a [`TransactionQuery`] that surfaces the transaction's
+//! pending writes against the underlying branch — "as-if committed"
+//! semantics so a caller can run normal queries mid-transaction.
+//!
+//! # Pending asserts and retracts
+//!
+//! The transaction's pending [`Changes`] flow directly into the query
+//! engine through `Provider<Select> for Changes` — no in-memory tree
+//! materialization. Asserts/Replaces surface as positive facts unioned
+//! with the branch's stream; Retracts lift into tombstones (via
+//! [`tombstones_from`]) that filter matching branch facts via
+//! [`filter_tombstones`] before the merge, so a `tx.retract(x)` shadows
+//! `x` in the underlying branch view without modifying the branch's
+//! persistent tree.
+//!
+//! # Tombstone scope: source-only
+//!
+//! Tombstones suppress facts only in the branch source, not the
+//! pending Changes overlay. So `tx.retract(X).assert(X)` correctly
+//! shows `X`: the pending Changes surface `X` via Provider<Select>;
+//! the branch's `X`, if any, is tombstoned but the overlay's `X`
+//! passes through unmodified.
+//!
+//! # Non-composable
+//!
+//! [`TransactionQuery`] intentionally has no `.with(...)` chain — a
+//! transaction's view is the branch plus its own pending changes,
+//! not a session you can layer more sources onto. To compose more
+//! sources, commit the transaction first and use
+//! [`Branch::query`](crate::Branch::query) (which gives full
+//! `.with(...)` / `.join(...)` composition on the session).
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use dialog_artifacts::selector::Constrained;
+use dialog_artifacts::{
+    ArtifactSelector, ArtifactStream, Changes, DialogArtifactsError, Select, SortKey,
+};
+use dialog_capability::{Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::memory::Resolve;
+use dialog_query::concept::descriptor::ConceptDescriptor;
+use dialog_query::concept::query::ConceptRules;
+use dialog_query::error::EvaluationError;
+use dialog_query::query::{Application, Output};
+use dialog_query::source::SelectRules;
+
+use crate::Branch;
+use crate::RemoteSite;
+use crate::layer::{filter_tombstones, merge_grouped, tombstones_from};
+use crate::repository::branch::select_from_branch;
+
+/// A non-composable query handle returned by
+/// [`Transaction::query`](crate::repository::branch::Transaction::query).
+///
+/// Holds an immutable snapshot of the transaction's pending changes
+/// plus a reference to the branch. The transaction itself remains
+/// open and committable.
+///
+/// See module docs for tombstone semantics.
+pub struct TransactionQuery<'a> {
+    branch: &'a Branch,
+    changes: Changes,
+    tombstones: HashSet<SortKey>,
+}
+
+impl<'a> TransactionQuery<'a> {
+    pub(crate) fn new(branch: &'a Branch, changes: &Changes) -> Self {
+        Self {
+            branch,
+            changes: changes.clone(),
+            tombstones: tombstones_from(changes),
+        }
+    }
+
+    /// Stage a query against this transaction's view. Call
+    /// [`perform`](TransactionSelectQuery::perform) to execute.
+    pub fn select<Q: Application>(self, query: Q) -> TransactionSelectQuery<'a, Q> {
+        TransactionSelectQuery {
+            branch: self.branch,
+            changes: self.changes,
+            tombstones: self.tombstones,
+            query,
+        }
+    }
+}
+
+/// A staged query on a [`TransactionQuery`].
+pub struct TransactionSelectQuery<'a, Q> {
+    branch: &'a Branch,
+    changes: Changes,
+    tombstones: HashSet<SortKey>,
+    query: Q,
+}
+
+impl<'a, Q: Application> TransactionSelectQuery<'a, Q> {
+    /// Execute the query against an env that unions the branch
+    /// (tombstone-filtered) with the transaction's pending changes.
+    pub fn perform<Env>(self, env: &'a Env) -> impl Output<Q::Conclusion> + 'a
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let TransactionSelectQuery {
+            branch,
+            changes,
+            tombstones,
+            query,
+        } = self;
+        async_stream::try_stream! {
+            let trans_env = TransactionEnv {
+                branch,
+                changes,
+                tombstones,
+                env,
+            };
+            let results = Box::pin(query.perform(&trans_env));
+            for await result in results {
+                yield result?;
+            }
+        }
+    }
+}
+
+/// The runtime env serving a [`TransactionSelectQuery`].
+///
+/// Unions the (tombstone-filtered) branch stream with the pending
+/// [`Changes`] overlay via `Provider<Select> for Changes`. Built per
+/// `.perform(env)` so the env reference is never captured on the
+/// outer [`TransactionQuery`].
+pub(crate) struct TransactionEnv<'a, Env> {
+    branch: &'a Branch,
+    changes: Changes,
+    tombstones: HashSet<SortKey>,
+    env: &'a Env,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<'a, Env> Provider<Select<'a>> for TransactionEnv<'a, Env>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    async fn execute(
+        &self,
+        input: ArtifactSelector<Constrained>,
+    ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
+        // Branch stream — filtered by tombstones from the pending
+        // retracts. Tombstones touch only the branch source; the
+        // overlay's facts (below) pass through unfiltered so a
+        // `retract(x).assert(x)` pattern surfaces `x` correctly.
+        let raw = select_from_branch(self.branch, self.env, input.clone()).await?;
+        let filtered_branch = filter_tombstones(raw, self.tombstones.clone());
+
+        // Pending changes overlay — Changes itself is a Provider<Select>.
+        let overlay = Provider::<Select<'a>>::execute(&self.changes, input).await?;
+
+        Ok(merge_grouped(vec![filtered_branch, overlay]))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env: ConditionalSync> Provider<SelectRules> for TransactionEnv<'_, Env> {
+    async fn execute(&self, input: ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
+        // Surfaces only the implicit per-descriptor rule each
+        // `ConceptDescriptor` carries.
+        Ok(ConceptRules::new(&input))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use dialog_artifacts::Entity;
+    use dialog_query::query::Output;
+    use dialog_query::{Concept, Query, Term, the};
+
+    mod people {
+        /// `test/name` attribute used by the Person concept tests.
+        #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("test")]
+        pub struct Name(
+            /// The person's name string.
+            pub String,
+        );
+    }
+
+    /// A simple concept used to exercise transaction-query semantics.
+    #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Person {
+        /// The person entity.
+        pub this: Entity,
+        /// Their `test/name` attribute.
+        pub name: people::Name,
+    }
+
+    #[dialog_common::test]
+    async fn it_surfaces_pending_asserts_through_transaction_query() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice: Entity = "id:alice".parse()?;
+        let tx = branch.transaction().assert(Person {
+            this: alice.clone(),
+            name: people::Name("Alice".into()),
+        });
+
+        let results: Vec<Person> = tx
+            .query()
+            .select(Query::<Person> {
+                this: alice.clone().into(),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].this, alice);
+        assert_eq!(results[0].name.0, "Alice");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_tombstones_pending_retracts_through_transaction_query() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice: Entity = "id:alice".parse()?;
+        let bob: Entity = "id:bob".parse()?;
+        branch
+            .transaction()
+            .assert(Person {
+                this: alice.clone(),
+                name: people::Name("Alice".into()),
+            })
+            .assert(Person {
+                this: bob.clone(),
+                name: people::Name("Bob".into()),
+            })
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let tx = branch
+            .transaction()
+            .retract(the!("test/name").of(alice.clone()).is("Alice".to_string()));
+
+        let names: Vec<String> = tx
+            .query()
+            .select(Query::<Person> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .map(|p| p.name.0)
+            .collect();
+        assert_eq!(names, vec!["Bob".to_string()]);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_value_when_retract_is_followed_by_assert() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice: Entity = "id:alice".parse()?;
+        branch
+            .transaction()
+            .assert(Person {
+                this: alice.clone(),
+                name: people::Name("Alice".into()),
+            })
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let stmt = the!("test/name").of(alice.clone()).is("Alice".to_string());
+        let tx = branch.transaction().retract(stmt.clone()).assert(stmt);
+
+        let names: Vec<String> = tx
+            .query()
+            .select(Query::<Person> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .map(|p| p.name.0)
+            .collect();
+        assert_eq!(names, vec!["Alice".to_string()]);
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/schema.rs
+++ b/rust/dialog-repository/src/schema.rs
@@ -1,0 +1,541 @@
+//! Typed schema for the facts a dialog-db repository writes about itself.
+//!
+//! Each branch carries a small, fixed set of facts describing its own
+//! structure — the [`Origin`] (this device's view of the repository),
+//! the [`Branch`] (name + origin), and the current [`BranchRevision`]
+//! when one exists. These facts are **synthesized at query time** from
+//! the branch handle plus the operator's identity (via
+//! [`Identify`](dialog_effects::authority::Identify)); they never live
+//! in the branch's persistent tree, which means user
+//! [`Transaction`](crate::repository::branch::Transaction)s cannot
+//! write or retract them.
+//!
+//! # Entity identity
+//!
+//! Two complementary identity schemes:
+//!
+//! - **Intrinsic** — for entities with their own cryptographic identity
+//!   (profiles, repository subjects). The entity URI is just the DID;
+//!   use [`DidExt::this`].
+//!
+//! - **Content-derived** — for entities defined by their inputs (an
+//!   origin is `(profile, subject)`, a branch is `(origin, name)`). The
+//!   entity URI is `did:key:z6Mk<base58(blake3(dag-cbor(inputs)))>`;
+//!   use [`EntityExt::of`]. Two parties independently describing the
+//!   same logical entity converge on the same URI.
+//!
+//! # Concept namespacing
+//!
+//! Per-concept attribute namespaces — [`branch`] holds the
+//! `dialog.branch/*` attributes for [`Branch`] + [`BranchRevision`];
+//! [`origin`] holds the `dialog.origin/*` attributes for [`Origin`].
+//! Separating them keeps a `Branch:` query from cross-matching an
+//! `Origin:` entity even though both could carry similar attribute
+//! names.
+
+use base58::ToBase58;
+use dialog_artifacts::Entity;
+use dialog_common::Blake3Hash;
+use dialog_query::{Attribute, Concept};
+use dialog_varsig::Did;
+use serde::Serialize;
+
+/// Derive an [`Entity`] from a serializable value.
+///
+/// `Entity` itself has no awareness of the content-derivation scheme
+/// the schema uses. [`EntityExt::of`] hashes the dag-cbor encoding of
+/// `value` and formats the result as a `did:key:z6Mk<base58>` URI.
+///
+/// # Canonical encoding
+///
+/// The hash is taken over `serde_ipld_dagcbor` bytes, so the resulting
+/// entity depends only on the value's semantic content. Field
+/// ordering, integer width, and map key sorting are fixed by the
+/// dag-cbor specification, so independent implementations that
+/// serialize the same logical value converge on the same entity.
+///
+/// # DID-key shape
+///
+/// The `did:key:z6Mk` prefix reuses the multibase/multicodec shape
+/// dialog-db already uses for randomly generated entity URIs. The
+/// `6Mk` prefix nominally indicates ed25519 key material, but nothing
+/// in dialog-db enforces that the bytes actually *are* an ed25519
+/// public key, so the same shape works for arbitrary 32-byte hashes.
+/// If a future version of dialog-db begins validating the multicodec
+/// prefix, this is the one place that would need to change.
+pub trait EntityExt {
+    /// Derive an `Entity` from the dag-cbor encoding of `value`.
+    fn of<T: Serialize>(value: &T) -> Entity;
+}
+
+impl EntityExt for Entity {
+    fn of<T: Serialize>(value: &T) -> Entity {
+        let bytes = serde_ipld_dagcbor::to_vec(value)
+            .expect("dag-cbor encoding should not fail for schema types");
+        let hash = Blake3Hash::hash(&bytes);
+        let encoded = hash.as_bytes().as_ref().to_base58();
+        format!("did:key:z6Mk{encoded}")
+            .parse()
+            .expect("did:key URI formed from a 32-byte hash is always valid")
+    }
+}
+
+/// View a [`Did`] as the entity it identifies.
+///
+/// DIDs and entities share the `did:method:identifier` URI shape, so
+/// a DID string always parses as a valid [`Entity`]. Dialog treats
+/// the two as distinct concerns — "a cryptographic identifier"
+/// vs. "the subject of artifacts" — but when a schema concept's
+/// identity *is* a DID (a profile, a repository subject), the DID is
+/// also the concept's `this` entity.
+pub trait DidExt {
+    /// Produce the [`Entity`] this DID identifies.
+    fn this(&self) -> Entity;
+}
+
+impl DidExt for Did {
+    fn this(&self) -> Entity {
+        self.as_str()
+            .parse()
+            .expect("DID string is always a valid Entity URI")
+    }
+}
+
+/// Attribute newtypes for [`Branch`] / [`BranchRevision`] entities.
+///
+/// All attributes here live under the `dialog.branch` domain. The
+/// kebab-cased struct name becomes the relation name —
+/// [`Name`](branch::Name) → `dialog.branch/name`, etc.
+pub mod branch {
+    use super::{Attribute, Entity};
+
+    /// `dialog.branch/name` — the human-readable branch name.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.branch")]
+    pub struct Name(
+        /// The branch name string.
+        pub String,
+    );
+
+    /// `dialog.branch/origin` — points at the
+    /// [`Origin`](super::Origin) entity this branch lives on.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.branch")]
+    pub struct Origin(
+        /// The origin entity URI.
+        pub Entity,
+    );
+
+    /// `dialog.branch/tree` — the current revision's tree hash,
+    /// base58-encoded.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.branch")]
+    pub struct Tree(
+        /// Base58-encoded Blake3 hash of the current revision's tree
+        /// root.
+        pub String,
+    );
+
+    /// `dialog.branch/period` — logical-clock period of the current
+    /// revision.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.branch")]
+    pub struct Period(
+        /// Period component of the revision's logical clock.
+        pub u128,
+    );
+
+    /// `dialog.branch/moment` — logical-clock moment of the current
+    /// revision.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.branch")]
+    pub struct Moment(
+        /// Moment component of the revision's logical clock.
+        pub u128,
+    );
+}
+
+/// Attribute newtypes for [`Origin`] entities.
+///
+/// All attributes here live under the `dialog.origin` domain.
+/// No `Name` field — dialog's `Origin` is identity-only. Downstream
+/// code that wants a display name can additionally assert
+/// `dialog.meta/name` on the same `Origin.this`.
+pub mod origin {
+    use super::{Attribute, Entity};
+
+    /// `dialog.origin/subject` — the repository this origin views.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.origin")]
+    pub struct Subject(
+        /// The repository subject entity (its DID as Entity).
+        pub Entity,
+    );
+
+    /// `dialog.origin/profile` — the profile that owns this origin.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.origin")]
+    pub struct Profile(
+        /// The profile entity (its DID as Entity).
+        pub Entity,
+    );
+}
+
+/// Attribute newtypes for the [`Session`] concept.
+///
+/// `Profile` / `Operator` are cardinality-one (one per session); the
+/// `Branch` attribute is cardinality-many — asserted once per layered
+/// branch the session is reading from. `Branch` deliberately isn't a
+/// field on the [`Session`] concept (concept fields are cardinality-
+/// one); query it separately as a standalone attribute on `db:session`
+/// to enumerate the branches in scope.
+pub mod session {
+    use super::{Attribute, Entity};
+
+    /// `dialog.session/profile` — the profile DID, as Entity.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.session")]
+    pub struct Profile(
+        /// Profile entity (the operator's `Identify`d profile DID).
+        pub Entity,
+    );
+
+    /// `dialog.session/operator` — the operator DID, as Entity.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.session")]
+    pub struct Operator(
+        /// Operator entity (the operator's own DID — the
+        /// session/ephemeral key, not the profile).
+        pub Entity,
+    );
+
+    /// `dialog.session/branch` — cardinality-many; one assertion per
+    /// branch the session has in scope (primary + each `.join(&b)`-ed
+    /// branch).
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.session")]
+    #[cardinality(many)]
+    pub struct Branch(
+        /// The branch entity (the `Branch.this` for that branch under
+        /// the session's current origin).
+        pub Entity,
+    );
+}
+
+/// Hash input for [`Origin::this`].
+///
+/// The single-variant enum shape tags the CBOR encoding with the
+/// concept name: two inputs with the same data but different
+/// concepts produce distinct hashes.
+#[derive(Debug, Clone, Serialize)]
+enum OriginHash<'a> {
+    Origin { subject: &'a Did, profile: &'a Did },
+}
+
+/// Hash input for [`Branch::this`].
+///
+/// `Branch` identity is `(origin, name)`. The concept-tag variant
+/// keeps a branch and an origin with the same field shapes from
+/// hashing to the same entity.
+#[derive(Serialize)]
+enum BranchHash<'a> {
+    Branch { origin: &'a Entity, name: &'a str },
+}
+
+/// This device's view of a specific repository.
+///
+/// `this` is content-derived from `(profile, subject)` (see
+/// [`OriginHash`]), so:
+///
+/// - two devices holding the same profile converge on the same
+///   origin entity for a given repository, and
+/// - different profiles produce different origin entities even when
+///   pointing at the same repository.
+///
+/// # Redundant by design
+///
+/// [`origin::Subject`] and [`origin::Profile`] carry the same two
+/// DIDs that went into the hash. The hash is one-way, so without
+/// these attributes it would be impossible to answer "find the
+/// origin this profile has for subject X" without re-hashing every
+/// candidate. The attributes make the relationships discoverable
+/// through normal queries.
+///
+/// # No name field
+///
+/// Dialog's `Origin` carries identity (`subject`, `profile`) only.
+/// Downstream that wants a display name can assert `dialog.meta/name`
+/// on the same `Origin.this`; that attribute composes at query time
+/// without affecting identity.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Origin {
+    /// The origin's entity. Derived from `(profile, subject)`.
+    pub this: Entity,
+    /// Reference to the repository this origin is a view of.
+    pub subject: origin::Subject,
+    /// Reference to the profile that owns this origin.
+    pub profile: origin::Profile,
+}
+
+impl Origin {
+    /// Build an origin concept from a profile DID and a subject DID.
+    pub fn new(profile: Did, subject: Did) -> Self {
+        Self {
+            this: Entity::of(&OriginHash::Origin {
+                subject: &subject,
+                profile: &profile,
+            }),
+            subject: origin::Subject(subject.this()),
+            profile: origin::Profile(profile.this()),
+        }
+    }
+}
+
+impl AsRef<Entity> for Origin {
+    fn as_ref(&self) -> &Entity {
+        &self.this
+    }
+}
+
+/// A branch within an origin.
+///
+/// `this` is content-derived from `(origin, name)`. Devices sharing
+/// a profile converge on the same `Origin.this`, and therefore the
+/// same `Branch.this` — so the schema concept naturally describes
+/// "the same branch" across devices.
+///
+/// # Coexistence with `crate::Branch`
+///
+/// Coexists with [`crate::Branch`] (the persistent handle). Both
+/// describe "the branch named X on this origin" but the schema
+/// concept is a *fact set* synthesized at query time, while the
+/// handle is the imperative API. Always disambiguate via
+/// `crate::schema::Branch` in code that uses both.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Branch {
+    /// The branch's entity. Derived from `(origin, name)`.
+    pub this: Entity,
+    /// The branch's name on this origin.
+    pub name: branch::Name,
+    /// The origin this branch lives on.
+    pub origin: branch::Origin,
+}
+
+impl Branch {
+    /// Build a branch concept from an owning entity and a name.
+    ///
+    /// `origin` is anything that views as an [`Entity`] — typically
+    /// an [`Origin`] via its `AsRef<Entity>` impl. Derives `this`
+    /// from `(origin, name)` and stores `origin` as an attribute so
+    /// every field is consistent with the entity hash.
+    pub fn new(origin: impl AsRef<Entity>, name: impl Into<branch::Name>) -> Self {
+        let origin = origin.as_ref();
+        let name = name.into();
+        Self {
+            this: Entity::of(&BranchHash::Branch {
+                origin,
+                name: &name.0,
+            }),
+            origin: branch::Origin::from(origin.clone()),
+            name,
+        }
+    }
+}
+
+impl AsRef<Entity> for Branch {
+    fn as_ref(&self) -> &Entity {
+        &self.this
+    }
+}
+
+/// The current revision of a branch.
+///
+/// Attached to the same entity as [`Branch`] (`this == Branch.this`)
+/// — a separate concept rather than fields on `Branch` because a
+/// freshly-opened branch with no commits has no revision yet, and
+/// dialog concepts require every field to be present. The
+/// optionality falls out of presence/absence of the fact: if a
+/// `BranchRevision` is asserted, the branch is at that revision; if
+/// not, it's empty.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BranchRevision {
+    /// The branch entity (same as [`Branch::this`]).
+    pub this: Entity,
+    /// Tree hash of the current revision, base58-encoded.
+    pub tree: branch::Tree,
+    /// Logical-clock period component.
+    pub period: branch::Period,
+    /// Logical-clock moment component.
+    pub moment: branch::Moment,
+}
+
+/// What this query session is reading from.
+///
+/// Asserted on the fixed `db:session` entity by the auto-injection
+/// path before every query. Carries the profile and operator DIDs
+/// (as Entities) so a query can ask "who am I, and which operator
+/// session am I in?" without reaching for env-specific accessors.
+///
+/// `Session` is cardinality-one on its three fields. The per-branch
+/// listing — which branches are in this session's scope — lives on
+/// the same entity as a cardinality-many [`session::Branch`]
+/// attribute, queried separately when you need it.
+///
+/// Across multiple branches in one session you can still have only
+/// one profile and one operator, so those go in the concept. Origin
+/// is per-branch (different branches may live on different repos), so
+/// it doesn't belong here — query the per-branch
+/// [`Branch.origin`](Branch) instead.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Session {
+    /// The fixed session entity: `db:session`.
+    pub this: Entity,
+    /// The profile DID, as Entity. From `Identify` on the operator.
+    pub profile: session::Profile,
+    /// The operator DID, as Entity. From `Identify` on the operator.
+    pub operator: session::Operator,
+}
+
+impl Session {
+    /// The conventional entity URI for the session concept.
+    /// Always `db:session` — sessions don't get distinct identities;
+    /// there's exactly one per query.
+    pub fn entity() -> Entity {
+        "db:session"
+            .parse()
+            .expect("db:session is a valid entity URI")
+    }
+}
+
+/// One `(session, branch)` membership fact — the cardinality-many
+/// counterpart to [`Session`].
+///
+/// [`Session`] holds the cardinality-one identity (`profile`,
+/// `operator`); the set of branches in scope is cardinality-many, so
+/// it can't be a `Session` field. `SessionBranch` carries one branch
+/// entity per instance, all sharing `this == Session::entity()`.
+/// Asserting N of them records N branches; a `Query<SessionBranch>`
+/// yields one row per branch.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SessionBranch {
+    /// The session entity — always `db:session`, same as
+    /// [`Session::this`].
+    pub this: Entity,
+    /// One branch in the session's scope.
+    pub branch: session::Branch,
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_varsig::did;
+
+    #[dialog_common::test]
+    fn it_derives_same_entity_for_same_value() {
+        assert_eq!(Entity::of(&"hello"), Entity::of(&"hello"));
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_entities_for_different_values() {
+        assert_ne!(Entity::of(&"alice"), Entity::of(&"bob"));
+    }
+
+    #[dialog_common::test]
+    fn it_produces_did_key_uris() {
+        let e = Entity::of(&"anything");
+        assert!(e.to_string().starts_with("did:key:z6Mk"));
+    }
+
+    #[dialog_common::test]
+    fn it_preserves_uri_through_did_this() {
+        let d = did!("key:z6MkTestEntity");
+        assert_eq!(d.this().to_string(), d.as_str());
+    }
+
+    #[dialog_common::test]
+    fn it_derives_same_origin_for_same_profile_and_subject() {
+        let a = Origin::new(did!("test:p"), did!("test:r"));
+        let b = Origin::new(did!("test:p"), did!("test:r"));
+        assert_eq!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_origins_for_different_profiles() {
+        let a = Origin::new(did!("test:p1"), did!("test:r"));
+        let b = Origin::new(did!("test:p2"), did!("test:r"));
+        assert_ne!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_origins_for_different_subjects() {
+        let a = Origin::new(did!("test:p"), did!("test:r1"));
+        let b = Origin::new(did!("test:p"), did!("test:r2"));
+        assert_ne!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_reflects_subject_and_profile_on_origin_attributes() {
+        let profile = did!("test:profile-x");
+        let subject = did!("test:repo-y");
+        let origin = Origin::new(profile.clone(), subject.clone());
+        assert_eq!(origin.profile.0.to_string(), profile.as_str());
+        assert_eq!(origin.subject.0.to_string(), subject.as_str());
+    }
+
+    #[dialog_common::test]
+    fn it_derives_same_branch_for_same_origin_and_name() {
+        let o = Origin::new(did!("test:p"), did!("test:r"));
+        let a = Branch::new(&o, "main");
+        let b = Branch::new(&o, "main");
+        assert_eq!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_branches_for_different_names() {
+        let o = Origin::new(did!("test:p"), did!("test:r"));
+        let a = Branch::new(&o, "main");
+        let b = Branch::new(&o, "meta");
+        assert_ne!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_branches_for_different_origins() {
+        let o1 = Origin::new(did!("test:p1"), did!("test:r"));
+        let o2 = Origin::new(did!("test:p2"), did!("test:r"));
+        let a = Branch::new(&o1, "main");
+        let b = Branch::new(&o2, "main");
+        assert_ne!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_branches_for_different_repos() {
+        let o1 = Origin::new(did!("test:p"), did!("test:r1"));
+        let o2 = Origin::new(did!("test:p"), did!("test:r2"));
+        let a = Branch::new(&o1, "main");
+        let b = Branch::new(&o2, "main");
+        assert_ne!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_reflects_origin_on_branch_attribute() {
+        let o = Origin::new(did!("test:p"), did!("test:r"));
+        let b = Branch::new(&o, "main");
+        assert_eq!(b.origin.0, o.this);
+    }
+
+    #[dialog_common::test]
+    fn it_attaches_branch_revision_to_branch_entity() {
+        let o = Origin::new(did!("test:p"), did!("test:r"));
+        let b = Branch::new(&o, "main");
+        let rev = BranchRevision {
+            this: b.this.clone(),
+            tree: branch::Tree("zSomeHash".into()),
+            period: branch::Period(1),
+            moment: branch::Moment(42),
+        };
+        assert_eq!(rev.this, b.this);
+    }
+}

--- a/rust/dialog-repository/src/transaction_query.rs
+++ b/rust/dialog-repository/src/transaction_query.rs
@@ -319,4 +319,86 @@ mod tests {
         assert_eq!(names, vec!["Alice".to_string()]);
         Ok(())
     }
+
+    /// `Transaction::integrate` replays an external `Changes` batch into
+    /// a running transaction. After integrating, `tx.query()` must see
+    /// the integrated asserts and respect the integrated retracts the
+    /// same way it does for asserts and retracts added directly.
+    #[dialog_common::test]
+    async fn it_integrates_external_changes_into_branch_transaction() -> anyhow::Result<()> {
+        use dialog_artifacts::Changes;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice: Entity = "id:alice".parse()?;
+        let bob: Entity = "id:bob".parse()?;
+
+        // Seed the branch with Alice; Bob will be added via integrate.
+        branch
+            .transaction()
+            .assert(Person {
+                this: alice.clone(),
+                name: people::Name("Alice".into()),
+            })
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // Build an external Changes that adds Bob and retracts Alice's
+        // name. This batch could have come from any source — a separate
+        // builder, a reactor accumulator, etc.
+        let mut external = Changes::new();
+        external.assert(Person {
+            this: bob.clone(),
+            name: people::Name("Bob".into()),
+        });
+        external.retract(the!("test/name").of(alice.clone()).is("Alice".to_string()));
+
+        // Integrate into a transaction and observe through tx.query().
+        let tx = branch.transaction().integrate(external);
+
+        let mut names: Vec<String> = tx
+            .query()
+            .select(Query::<Person> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .map(|p| p.name.0)
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["Bob".to_string()],
+            "integrated changes must surface Bob (assert) and tombstone \
+             Alice (retract); got {names:?}"
+        );
+
+        // The branch itself remains untouched until commit.
+        let mut committed: Vec<String> = branch
+            .query()
+            .select(Query::<Person> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .map(|p| p.name.0)
+            .collect();
+        committed.sort();
+        assert_eq!(
+            committed,
+            vec!["Alice".to_string()],
+            "integrate must not mutate the branch before commit"
+        );
+
+        Ok(())
+    }
 }

--- a/rust/dialog-repository/src/transaction_query.rs
+++ b/rust/dialog-repository/src/transaction_query.rs
@@ -1,0 +1,322 @@
+//! Querying a transaction's uncommitted writes.
+//!
+//! [`Transaction::query`](crate::repository::branch::Transaction::query)
+//! returns a [`TransactionQuery`] that surfaces the transaction's
+//! pending writes against the underlying branch — "as-if committed"
+//! semantics so a caller can run normal queries mid-transaction.
+//!
+//! # Pending asserts and retracts
+//!
+//! The transaction's pending [`Changes`] flow directly into the query
+//! engine through `Provider<Select> for Changes` — no in-memory tree
+//! materialization. Asserts/Replaces surface as positive facts unioned
+//! with the branch's stream; Retracts lift into tombstones (via
+//! [`tombstones_from`]) that filter matching branch facts via
+//! [`filter_tombstones`] before the merge, so a `tx.retract(x)` shadows
+//! `x` in the underlying branch view without modifying the branch's
+//! persistent tree.
+//!
+//! # Tombstone scope: source-only
+//!
+//! Tombstones suppress facts only in the branch source, not the
+//! pending Changes overlay. So `tx.retract(X).assert(X)` correctly
+//! shows `X`: the pending Changes surface `X` via Provider<Select>;
+//! the branch's `X`, if any, is tombstoned but the overlay's `X`
+//! passes through unmodified.
+//!
+//! # Non-composable
+//!
+//! [`TransactionQuery`] intentionally has no `.with(...)` chain — a
+//! transaction's view is the branch plus its own pending changes,
+//! not a session you can layer more sources onto. To compose more
+//! sources, commit the transaction first and use
+//! [`Branch::query`](crate::Branch::query) (which gives full
+//! `.with(...)` / `.join(...)` composition on the session).
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use dialog_artifacts::selector::Constrained;
+use dialog_artifacts::{
+    ArtifactSelector, ArtifactStream, Changes, DialogArtifactsError, Select, SortKey,
+};
+use dialog_capability::{Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::memory::Resolve;
+use dialog_query::concept::descriptor::ConceptDescriptor;
+use dialog_query::concept::query::ConceptRules;
+use dialog_query::error::EvaluationError;
+use dialog_query::query::{Application, Output};
+use dialog_query::source::SelectRules;
+
+use crate::Branch;
+use crate::RemoteSite;
+use crate::layer::{filter_tombstones, merge_grouped, tombstones_from};
+use crate::repository::branch::select_from_branch;
+
+/// A non-composable query handle returned by
+/// [`Transaction::query`](crate::repository::branch::Transaction::query).
+///
+/// Holds an immutable snapshot of the transaction's pending changes
+/// plus a reference to the branch. The transaction itself remains
+/// open and committable.
+///
+/// See module docs for tombstone semantics.
+pub struct TransactionQuery<'a> {
+    branch: &'a Branch,
+    changes: Changes,
+    tombstones: HashSet<SortKey>,
+}
+
+impl<'a> TransactionQuery<'a> {
+    pub(crate) fn new(branch: &'a Branch, changes: &Changes) -> Self {
+        Self {
+            branch,
+            changes: changes.clone(),
+            tombstones: tombstones_from(changes),
+        }
+    }
+
+    /// Stage a query against this transaction's view. Call
+    /// [`perform`](TransactionSelectQuery::perform) to execute.
+    pub fn select<Q: Application>(self, query: Q) -> TransactionSelectQuery<'a, Q> {
+        TransactionSelectQuery {
+            branch: self.branch,
+            changes: self.changes,
+            tombstones: self.tombstones,
+            query,
+        }
+    }
+}
+
+/// A staged query on a [`TransactionQuery`].
+pub struct TransactionSelectQuery<'a, Q> {
+    branch: &'a Branch,
+    changes: Changes,
+    tombstones: HashSet<SortKey>,
+    query: Q,
+}
+
+impl<'a, Q: Application> TransactionSelectQuery<'a, Q> {
+    /// Execute the query against an env that unions the branch
+    /// (tombstone-filtered) with the transaction's pending changes.
+    pub fn perform<Env>(self, env: &'a Env) -> impl Output<Q::Conclusion> + 'a
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let TransactionSelectQuery {
+            branch,
+            changes,
+            tombstones,
+            query,
+        } = self;
+        async_stream::try_stream! {
+            let trans_env = TransactionEnv {
+                branch,
+                changes,
+                tombstones,
+                env,
+            };
+            let results = Box::pin(query.perform(&trans_env));
+            for await result in results {
+                yield result?;
+            }
+        }
+    }
+}
+
+/// The runtime env serving a [`TransactionSelectQuery`].
+///
+/// Unions the (tombstone-filtered) branch stream with the pending
+/// [`Changes`] overlay via `Provider<Select> for Changes`. Built per
+/// `.perform(env)` so the env reference is never captured on the
+/// outer [`TransactionQuery`].
+pub(crate) struct TransactionEnv<'a, Env> {
+    branch: &'a Branch,
+    changes: Changes,
+    tombstones: HashSet<SortKey>,
+    env: &'a Env,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<'a, Env> Provider<Select<'a>> for TransactionEnv<'a, Env>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    async fn execute(
+        &self,
+        input: ArtifactSelector<Constrained>,
+    ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
+        // Branch stream — filtered by tombstones from the pending
+        // retracts. Tombstones touch only the branch source; the
+        // overlay's facts (below) pass through unfiltered so a
+        // `retract(x).assert(x)` pattern surfaces `x` correctly.
+        let raw = select_from_branch(self.branch, self.env, input.clone()).await?;
+        let filtered_branch = filter_tombstones(raw, self.tombstones.clone());
+
+        // Pending changes overlay — Changes itself is a Provider<Select>.
+        let overlay = Provider::<Select<'a>>::execute(&self.changes, input).await?;
+
+        Ok(merge_grouped(vec![filtered_branch, overlay]))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env: ConditionalSync> Provider<SelectRules> for TransactionEnv<'_, Env> {
+    async fn execute(&self, input: ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
+        // Surfaces only the implicit per-descriptor rule each
+        // `ConceptDescriptor` carries.
+        Ok(ConceptRules::new(&input))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use dialog_artifacts::Entity;
+    use dialog_query::query::Output;
+    use dialog_query::{Concept, Query, Term, the};
+
+    mod people {
+        /// `test/name` attribute used by the Person concept tests.
+        #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("test")]
+        pub struct Name(
+            /// The person's name string.
+            pub String,
+        );
+    }
+
+    /// A simple concept used to exercise transaction-query semantics.
+    #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Person {
+        /// The person entity.
+        pub this: Entity,
+        /// Their `test/name` attribute.
+        pub name: people::Name,
+    }
+
+    #[dialog_common::test]
+    async fn it_surfaces_pending_asserts_through_transaction_query() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice: Entity = "id:alice".parse()?;
+        let tx = branch.transaction().assert(Person {
+            this: alice.clone(),
+            name: people::Name("Alice".into()),
+        });
+
+        let results: Vec<Person> = tx
+            .query()
+            .select(Query::<Person> {
+                this: alice.clone().into(),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].this, alice);
+        assert_eq!(results[0].name.0, "Alice");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_tombstones_pending_retracts_through_transaction_query() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice: Entity = "id:alice".parse()?;
+        let bob: Entity = "id:bob".parse()?;
+        branch
+            .transaction()
+            .assert(Person {
+                this: alice.clone(),
+                name: people::Name("Alice".into()),
+            })
+            .assert(Person {
+                this: bob.clone(),
+                name: people::Name("Bob".into()),
+            })
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let tx = branch
+            .transaction()
+            .retract(the!("test/name").of(alice.clone()).is("Alice".to_string()));
+
+        let names: Vec<String> = tx
+            .query()
+            .select(Query::<Person> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .map(|p| p.name.0)
+            .collect();
+        assert_eq!(names, vec!["Bob".to_string()]);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_value_when_retract_is_followed_by_assert() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice: Entity = "id:alice".parse()?;
+        branch
+            .transaction()
+            .assert(Person {
+                this: alice.clone(),
+                name: people::Name("Alice".into()),
+            })
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let stmt = the!("test/name").of(alice.clone()).is("Alice".to_string());
+        let tx = branch.transaction().retract(stmt.clone()).assert(stmt);
+
+        let names: Vec<String> = tx
+            .query()
+            .select(Query::<Person> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .map(|p| p.name.0)
+            .collect();
+        assert_eq!(names, vec!["Alice".to_string()]);
+        Ok(())
+    }
+}

--- a/rust/dialog-storage/src/storage/backend/fs.rs
+++ b/rust/dialog-storage/src/storage/backend/fs.rs
@@ -373,7 +373,7 @@ where
             });
         }
 
-        try_join_all(writes.into_iter()).await?;
+        try_join_all(writes).await?;
 
         Ok(())
     }

--- a/rust/dialog-ucan-core/src/invocation.rs
+++ b/rust/dialog-ucan-core/src/invocation.rs
@@ -2007,8 +2007,6 @@ mod tests {
         Ok(())
     }
 
-    // --- Time bounds tests ---
-
     #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), tokio::test)]
     #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     async fn chain_check_returns_unbounded_range_for_self_issued() -> TestResult {


### PR DESCRIPTION
Implements `.with` method similar to `d/with` in datomic, but instead of just taking facts it takes more general `QueryLayer` implementation which can be another branch or in-memory search-tree. 

This allows you to query multiple branches as if they were merged or branch with some local facts as if they were merged.

In addition Transaction now also gained .query method just like Branch allowing you to query with pending changes if they were already applied.