### PR TITLE
feat: type inference

### DIFF
--- a/notes/optional-fields.md
+++ b/notes/optional-fields.md
@@ -1,0 +1,543 @@
+# Optional Fields — v2 Design
+
+This document specifies the second design pass for set-widening
+optional concept fields in dialog-db. It supersedes a prior
+implementation (commit `d6629bf7` on `feat/optional-fields`) which
+shipped a working but structurally awkward solution. The lessons
+from v1 are folded into v2.
+
+This document is the design contract for `feat/optional-fields-v2`.
+Implementation follows in subsequent commits.
+
+## Motivation
+
+Concepts model entities as records with named, typed fields. Today
+every field is required: a query for a concept with field `name`
+finds only entities that have a `name` fact. Some real-world
+attributes are inherently optional — a `Person` may or may not have
+a `nickname`, an order may or may not have a `discount_code`. Users
+want to write:
+
+```rust
+#[derive(Concept)]
+struct Person {
+    this: Entity,
+    name: Name,
+    nickname: Option<Nickname>,  // optional
+}
+```
+
+and have `Query::<Person>::default()` return entities that have a
+`name` fact, with `nickname` populated as `Some(value)` when the
+fact exists and `None` when it doesn't. The fact for a `None` field
+is **never persisted** — absence is realized at query time, not
+stored.
+
+This is the same pattern Datomic calls `get-else` and Hickey
+described as "set widening": `Optional<T>` is the set
+`T ∪ {Absent}`, with the subtype rule `T ⊆ Optional<T>`. A `T` value
+flows freely into an `Optional<T>` slot.
+
+## v1 retrospective
+
+v1 (commit `d6629bf7`) shipped working set-widening across nine
+slices: `Binding<Value>` at the Match layer, a schema-level `Type`
+enum with `Required`/`Optional`/`Any`, `AttributeQueryOptional`
+streaming wrapper, `Constraint::Coalesce`, marker-trait taxonomy
+with structural rejection of `Term<Option<Option<U>>>`, and end-to-end
+tests proving both `Some(...)` and `None` realize correctly.
+
+It works. The native test suite is 1361 green. The user-visible
+behavior is correct.
+
+But the implementation accumulated structural debt that motivates
+v2:
+
+1. **Two parallel type taxonomies.** A schema-layer `Type` enum
+   (`Any | Required(ValueType) | Optional(ValueType)`) and a
+   descriptor-layer `Option<ValueType>`. The same concept expressed
+   twice in different shapes, with conversion sites between them.
+2. **`AttributeQueryOptional` as a recursive `DynamicAttributeQuery`
+   variant.** `Optional(Optional(...))` is structurally meaningless
+   but the type permits it. Fixed at construction by `try_new`/
+   `try_typed` validation, but the type signature doesn't prevent
+   the case.
+3. **Type-erasure loss.** `From<Term<Option<T>>> for Term<Any>`
+   strips the optional tag. Once erased, the runtime can't
+   introspect "this term might be Absent." The Slice 7 enforcement
+   of "Negation can't read optional bindings" needed a parallel
+   `optional_producers: HashSet<String>` on the side, because the
+   meet algebra alone couldn't see through the erasure.
+4. **`UnwrapOr` type-erased at the boundary.** `Term<Option<String>>`
+   ::unwrap_or accepts `Term<Entity>` for output without complaint —
+   the type system doesn't enforce source/default/output share a
+   value type.
+5. **Marker traits as the only structural fence.** `OptionalType`
+   and `DefiniteType` exist purely to prevent
+   `Term<Option<Option<U>>>` at the Rust API. The runtime descriptor
+   couldn't enforce the same invariant, so the markers were
+   load-bearing — and proliferated across many bound clauses.
+
+Each of these is a symptom of the same root cause: **the descriptor
+can't express optionality**, so the schema layer added an `Optional`
+variant on its own, and the rest of the codebase built bridges
+between the two.
+
+v2 fixes the root: the descriptor *does* express optionality. Then
+the schema-layer enum collapses, the recursive variant goes away,
+the erasure preserves type info, the `UnwrapOr` typing tightens, and
+the marker traits become ergonomic bounds rather than structural
+fences.
+
+## v2 type system
+
+### `Type` enum
+
+```rust
+pub enum Type {
+    /// Dynamic top — value type unknown until runtime. Used at
+    /// type-erased boundaries (e.g. wire-format `Term<Any>`) and as
+    /// the planner's "I don't know yet" placeholder.
+    Any,
+
+    /// A definite shape. Subtype of `Optional(definite)` via the
+    /// `T ⊆ Optional<T>` set-widening rule.
+    Definite(Box<Definite>),
+
+    /// Set-widened: `Definite ∪ {Absent}`. One level only — nested
+    /// optionality is structurally impossible because the wrapped
+    /// type is `Definite`, not `Type`. This matches the Rust-side
+    /// `T: DefiniteType` bound on `Term<Option<T>>`.
+    Optional(Box<Definite>),
+}
+
+pub enum Definite {
+    /// Atomic value type. Today this is the only Definite variant;
+    /// future work adds Record (concept-as-value) and Variant
+    /// (tagged union) without reshaping the enum.
+    Primitive(ValueType),
+}
+```
+
+Key properties:
+
+- **Recursive via `Box`**, not `const`. We accept the heap-allocation
+  cost so the enum can grow `Record(BTreeMap<String, Type>)` and
+  `Variant(BTreeMap<String, Definite>)` without changing the shape
+  of existing code.
+- **No `const` anywhere in the type system.** The current codebase
+  declares `const TYPE: Option<ValueType>` on `TypeDescriptor` but
+  never uses it in const contexts (every read site is a runtime
+  expression). v2 drops the const requirement to enable `Box`.
+- **`Optional` wraps `Definite`, not `Type`.** This makes
+  `Optional(Optional(...))` and `Optional(Any)` structurally
+  unrepresentable at the data level. The Rust marker traits
+  enforce the same invariant at the type level for typed code.
+- **`Any` sits alongside `Definite` and `Optional`**, not inside
+  `Definite`. `Optional(Any)` is therefore unrepresentable —
+  matching the Rust-side rejection of `Term<Option<Any>>`.
+
+### Type algebra
+
+Two operations:
+
+- **`meet(a, b) -> Result<Type, MeetError>`** — the lattice
+  intersection. Used to combine multiple declarations of the same
+  variable into a single narrowest type. Commutative, associative,
+  identity at `Any`. Conflicting value types reject.
+- **`accepts(consumer, producer) -> bool`** — one-way subtype
+  check. `Definite(T)` accepts `Definite(T)`. `Optional(T)` accepts
+  both `Definite(T)` and `Optional(T)` (set widening). `Any`
+  accepts anything. `Definite(T)` does NOT accept `Optional(T)` —
+  this is the rule that makes "Negation reads optional binding" a
+  type error.
+
+The v1 rule was "`Required ∧ Optional → Required` (strictest wins)
+plus a parallel `optional_producers` set." v2 replaces this with
+the cleaner formulation: **a consumer's declared type must
+`accept` every producer's declared type.** No parallel set —
+the type system itself encodes the constraint.
+
+### Wire format
+
+`Type` serializes as a tagged union:
+
+```json
+"any"
+{ "definite": { "primitive": "Text" } }
+{ "optional": { "primitive": "Text" } }
+```
+
+`Definite::Primitive(ValueType::String)` flattens to
+`{ "primitive": "Text" }` reusing the existing `ValueType` wire
+form. The wrapping `definite`/`optional` tag is added so future
+`Definite::Record(...)` and `Definite::Variant(...)` extensions
+fit without rewriting the on-disk format.
+
+This is a wire-format break from v1's `Option<ValueType>` shape on
+`Field::content_type`. Acceptable since the project is pre-1.0 and
+no Schema is currently persisted across versions.
+
+## Descriptor layer
+
+### Descriptors carry `Type`
+
+```rust
+pub trait TypeDescriptor: Clone + Debug + Default + ... {
+    /// The statically known type, if monomorphic.
+    /// `None` for the dynamic-top descriptor (Any).
+    const KIND: Option<Type>;
+
+    /// The runtime type. For monomorphic descriptors equals
+    /// `KIND.unwrap()`; for `Any` returns the wrapped tag.
+    fn kind(&self) -> Type;
+}
+```
+
+`KIND` replaces v1's `TYPE: Option<ValueType>`. The change from
+`Option<ValueType>` to `Option<Type>` is the central enrichment:
+descriptors now carry the full type taxonomy, not just the leaf
+value type.
+
+`const KIND` works because `Type::Definite(Box::new(Definite::
+Primitive(vt)))` is constructible in const context (Rust 1.83+
+supports `const fn Box::new` for some cases) — *or* we use a
+non-const `KIND_FN()` approach if Box::new const stabilization
+isn't available. Final choice depends on toolchain check.
+
+If neither path works, the fallback is to give up `const` entirely
+and make `KIND` a non-const associated function. The 13 read sites
+in v1 are all runtime expressions; non-const has no behavior cost.
+
+### `Any` carries `Type`, not `Option<ValueType>`
+
+```rust
+pub struct Any(pub Type);
+```
+
+`Any(Type::Any)` represents fully-erased terms (no static info).
+`Any(Type::Definite(Box::new(Definite::Primitive(vt))))` represents
+a term that was originally `Term<U>` for some scalar `U`.
+`Any(Type::Optional(Box::new(Definite::Primitive(vt))))` represents
+a term that was originally `Term<Option<U>>`.
+
+**This is the key fix.** v1's `Any(Option<ValueType>)` lost the
+`Optional` tag at the erasure boundary. v2 preserves it.
+
+### `Term<Option<U>>` descriptor
+
+```rust
+#[derive(Default, Clone, Debug, ...)]
+pub struct OptionalOf<D: TypeDescriptor>(PhantomData<D>);
+
+impl<D: TypeDescriptor> TypeDescriptor for OptionalOf<D> {
+    const KIND: Option<Type> = match D::KIND {
+        Some(Type::Definite(d)) => Some(Type::Optional(d.clone())),
+        // Other shapes prevented by the Rust trait bound `T:
+        // DefiniteType`; const match is exhaustive.
+        _ => None,
+    };
+    fn kind(&self) -> Type {
+        match D::KIND {
+            Some(Type::Definite(d)) => Type::Optional(d.clone()),
+            _ => Type::Any,
+        }
+    }
+}
+
+impl<T: DefiniteType> Typed for Option<T> {
+    type Descriptor = OptionalOf<<T as Typed>::Descriptor>;
+}
+```
+
+`Term<Option<String>>` has `Descriptor = OptionalOf<Text>`. At
+runtime its `kind()` returns
+`Type::Optional(Definite::Primitive(ValueType::String))`. The
+erasure into `Term<Any>` constructs
+`Any(Type::Optional(Definite::Primitive(ValueType::String)))` —
+the optionality survives.
+
+### Schema collapse
+
+v1's `schema::Type` enum is deleted. `Field::content_type` becomes
+`Type` (the new unified one).
+
+```rust
+pub struct Field {
+    description: String,
+    content_type: Type,
+    requirement: Requirement,
+    cardinality: Cardinality,
+}
+```
+
+Conversion sites — `From<&ConceptDescriptor> for Schema`,
+`From<&Cells> for Schema`, `Constraint::Equality::schema`,
+`AttributeQuery::schema` — populate `content_type` from the
+underlying term's `descriptor().kind()`. No more
+`.into()`-coercion ambiguity between `Option<ValueType>` and the
+old `schema::Type` enum.
+
+## Attribute-query layer
+
+### `Resolution` policy on `DynamicAttributeQuery`
+
+v1 introduced a recursive `DynamicAttributeQuery::Optional(Box<...>)`
+variant wrapping an `AttributeQueryOptional` struct. v2 drops the
+variant entirely. Optionality becomes a policy switch on the single
+attribute-query type:
+
+```rust
+pub enum DynamicAttributeQuery {
+    All(AttributeQueryAll),
+    Only(AttributeQueryOnly),
+    // No Optional variant.
+}
+
+// Cardinality + Resolution = behavior matrix.
+pub enum Resolution {
+    /// Standard EAV semantics: zero rows on miss.
+    Required,
+    /// One row per input — Present from the lookup if any fact
+    /// exists, else Absent fallback.
+    Optional,
+}
+```
+
+`Resolution` lives on `AttributeQueryAll` and `AttributeQueryOnly`
+as a field, not as a wrapping enum. Each existing variant carries
+the policy.
+
+### Schema reflects optionality through the descriptor
+
+`AttributeQueryAll::schema()` declares `is`'s `content_type` from
+`is.descriptor().kind()`. If `is: Term<Option<U>>`, the descriptor
+reports `Type::Optional(...)` and the schema reflects that
+directly. No widening logic on the wrapper. No `value_type: Option<
+ValueType>` pin. The descriptor is the single source of truth.
+
+If the user constructed the query with `Resolution::Optional` but
+passed `is: Term<U>` (non-optional Rust type), the descriptor
+reports `Type::Definite(...)` while the runtime evaluates with
+optional semantics. That's a structural mismatch — the constructor
+should reject it. We add a constructor-time check: `Resolution::
+Optional` requires `is.descriptor().kind()` to be either
+`Type::Optional(_)` or `Type::Any` (so wire-format
+`Term<Any>` rules can flow through and have their resolution
+checked at planner time).
+
+### Concept projection emits typed Optional resolvers
+
+`From<&ConceptDescriptor> for DeductiveRule` walks both `with` and
+`maybe` attribute maps:
+
+- `with` attributes get `Resolution::Required` queries.
+- `maybe` attributes get `Resolution::Optional` queries.
+
+The `is` term in each case is `Term::<Option<vt>>::var(...)` for
+maybe fields (typed) or `Term::<vt>::var(...)` for required fields.
+
+## Macro layer
+
+### `Term<Option<U>>` for `Option<T>` fields
+
+The `#[derive(Concept)]` macro:
+
+- For required `T` fields: emits `Term<<T as Attribute>::Type>`.
+  Same as today.
+- For `Option<T>` fields: emits
+  `Term<Option<<T as Attribute>::Type>>`. The Rust-level
+  `Option<...>` wrapper is the typed signal; users get
+  `unwrap_or` on the field, set-widening conversions in/out, and
+  compile-time rejection of nested `Option`.
+
+The realize impl pattern-matches on `Binding`:
+
+```rust
+nickname: match source.lookup(&Term::<Any>::from(&self.nickname))? {
+    Binding::Present(value) => Some(Nickname(value.try_into()?)),
+    Binding::Absent => None,
+}
+```
+
+`Term::<Any>::from(&self.nickname)` is the borrow-form erasure that
+preserves `Type::Optional(...)` in the descriptor (Slice 6 of v1
+introduced this conversion; v2 keeps it but with type-faithful
+preservation).
+
+### `From<Term<U>> for Term<Option<U>>` set-widening
+
+Kept from v1. A user passing `Term::<String>::var("x")` where the
+macro expects `Term<Option<String>>` gets implicit widening via
+`From`. The conversion is structurally trivial: descriptor changes
+from `Text` to `OptionalOf<Text>`, value preserved.
+
+## Coalesce / `unwrap_or`
+
+### Typed `UnwrapOr<T>` builder
+
+v1 erased source/default/output to `Term<Any>` at the builder,
+losing the value-type guarantee at the call site. v2 parameterizes:
+
+```rust
+pub struct UnwrapOr<T: DefiniteType> {
+    source: Term<Any>,        // erased internally, but...
+    default: Term<Any>,       // ...the type T is preserved at the
+    _phantom: PhantomData<T>, //    builder level for compile-time check
+}
+
+impl<T: DefiniteType> Term<Option<T>> {
+    pub fn unwrap_or<D: Into<Term<T>>>(self, default: D) -> UnwrapOr<T> {
+        UnwrapOr {
+            source: Term::<Any>::from(self),
+            default: Term::<Any>::from(default.into()),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: DefiniteType> UnwrapOr<T> {
+    pub fn is<O: Into<Term<T>>>(self, output: O) -> Premise {
+        // Construct the Coalesce constraint from
+        // self.source, self.default, Term::<Any>::from(output.into()).
+    }
+}
+```
+
+The user can no longer write
+`Term::<Option<String>>::var("x").unwrap_or(...).is(Term::<Entity>::var("y"))`
+— it fails at Rust-compile time because `Term<Entity>` doesn't
+satisfy `Into<Term<String>>`.
+
+### `Term<Any>::unwrap_or` for wire-format paths
+
+Rules parsed from JSON arrive as `Term<Any>` for unspecified terms.
+There is no Rust-level type to enforce. v2 adds an untyped
+`Term<Any>::unwrap_or` that returns `UnwrapOr<()>` (or a separate
+`UntypedUnwrapOr` builder). At rule-compile time (`DeductiveRule::
+new`), the planner runs the meet algebra over the resulting Coalesce
+constraint and rejects type-incoherent uses.
+
+Both paths converge on the same runtime `Coalesce` constraint with
+type-erased terms; the typed surface is purely a Rust-API
+compile-time guarantee.
+
+## Slice 7 enforcement, simplified
+
+v1 had three checks:
+
+1. `NegationOnOptional` — Negation reads optional binding.
+2. `RequiredHeadFromOptional` — required head field bound by an
+   optional producer.
+3. `ConceptOnlyOptionalFields` — a concept with empty `with`.
+
+v2 expresses (1) and (2) through `Type::accepts`. The Negation's
+schema declares its parameters as `Type::Definite(_)` (not
+`Optional`) — by definition, Negation needs Present values. The
+required head field's schema declares `Type::Definite(_)`. If any
+producer in the rule body declares `Type::Optional(_)` for the same
+variable, `accepts` rejects. No parallel `optional_producers` set.
+
+Check (3) is unchanged — it's a structural property of the concept
+descriptor, not a type-meet rule.
+
+## Marker traits
+
+The `ScalarType`/`ProductType`/`VariantType`/`OptionalType`/
+`AnyType`/`DefiniteType` family stays. Their role shifts:
+
+- **v1 used markers as the only structural fence** preventing
+  `Option<Option<U>>` at the Rust API. The runtime had no
+  equivalent fence because the descriptor couldn't express
+  optionality.
+- **v2 uses markers as ergonomic bounds.** They're how
+  `Term<Option<T: DefiniteType>>` expresses "T must be
+  non-optional." The runtime descriptor *also* enforces this via
+  the `Optional(Box<Definite>)` shape, but the markers exist so
+  Rust users get compile-time errors instead of runtime panics.
+
+The compile-fail doctests (`Term<Option<Option<U>>>`,
+`Term<Option<Any>>` reject) carry over from v1.
+
+## Wire format and migration
+
+Schema is not currently persisted — it's recomputed from
+descriptors on each session. So the wire-format change to `Type`
+serialization affects only future-persisted schemas. No migration
+needed for existing data.
+
+`Resolution` is a new field on `AttributeQueryAll` /
+`AttributeQueryOnly`. Existing serialized rules (which don't carry
+this field) deserialize with `Resolution::Required` as the default.
+Concept projection regenerates rules with the correct resolution at
+runtime, so the wire-format default doesn't matter for
+concept-derived rules.
+
+## What's deferred
+
+The recursive `Type` and `Definite` accommodate these without
+reshape:
+
+- **`Definite::Record(BTreeMap<String, Type>)`** for concepts as
+  values. Future PR adds the variant; existing code continues to
+  pattern-match exhaustively.
+- **`Definite::Variant(BTreeMap<String, Definite>)`** for tagged
+  unions. Variant payloads are `Definite` (no nested optionality
+  in payloads — the canonical way to express
+  "optional-inside-variant" is to flatten into the outer variant).
+- **Storage encoding for variants** — the `domain/VariantType/Tag
+  → payload` per-tag attribute scheme, with read-time deterministic
+  winner selection across the tag group. Documented separately.
+- **`get-some` (multi-attribute fallback)** — variant-elimination
+  premise. Builds on Variant types.
+- **Map types** — open question; not needed for optionality.
+
+## Implementation phases
+
+Tracked separately as Steps 1–11. Summary:
+
+1. `Type`/`Definite` enums with meet/accepts/serde.
+2. `Binding<Value>` at Match layer (port from v1, unchanged).
+3. Descriptor enriched to carry `Type` (was `Option<ValueType>`).
+4. Collapse v1's `schema::Type` into the new unified `Type`.
+5. `Resolution` policy on `DynamicAttributeQuery`; remove
+   `AttributeQueryOptional`.
+6. Concept projection emits `Resolution::Optional` for `maybe`
+   fields.
+7. Macro emits typed `Term<Option<U>>` for `Option<T>` fields.
+8. `Coalesce`/`UnwrapOr` with proper typed parameterization.
+9. Marker-trait family (slimmer; ergonomic bounds).
+10. End-to-end tests and Slice-7-equivalent enforcement via meet
+    algebra.
+11. Docs, lint, fmt, full workspace test.
+
+Each step compiles and tests; the tree stays green throughout.
+
+## Acceptance criteria
+
+The branch is ready to merge when:
+
+- All v1 end-to-end tests pass under v2 (cherry-picked from
+  `feat/optional-fields`).
+- New tests cover `Type` algebra (meet, accepts, serde
+  round-trips), descriptor preservation through erasure,
+  `Resolution` dispatch, typed `UnwrapOr` rejecting type-mismatched
+  output, and Slice-7-equivalent rejections via meet.
+- Compile-fail doctests still prove `Term<Option<Option<U>>>` and
+  `Term<Option<Any>>` are rejected.
+- Workspace clippy clean, fmt clean, `test:native:debug` green.
+- This document and the Steps 1–11 task list reflect the final
+  shape of the implementation.
+
+## Open questions to settle during implementation
+
+1. **`const KIND` vs non-const `kind()`**: depends on whether `Box::
+   new` stabilizes in const for our toolchain. Decision deferred to
+   Step 1.
+2. **`UnwrapOr<()>` for the untyped path**: viable shape, or
+   separate `UntypedUnwrapOr` builder? Decision deferred to
+   Step 8.
+3. **`Resolution::Optional` validation**: reject at constructor
+   when `is` term's descriptor is `Type::Definite(_)` (mismatch)?
+   Or allow as user signaling "I know what I'm doing, treat as
+   optional anyway"? Decision deferred to Step 5.

--- a/notes/optional-fields.md
+++ b/notes/optional-fields.md
@@ -1,16 +1,34 @@
 # Optional Fields & Type System — v2 Design
 
-This document specifies the type-system rework on
-`feat/optional-fields-v2`. It supersedes v1 (commit `d6629bf7` on
-`feat/optional-fields`) and the original v2 sketch at
-`5cc533ff`. The current direction is **rank-1 parametric
-polymorphism with Damas-Milner type inference** — Roc/Elm style,
-adapted to our Datalog-flavored query engine.
+This document was written as a *design contract* before
+implementation. The implementation took a smaller path than the
+contract proposed. The doc has been split:
 
-This is a design contract for the v2 branch. Implementation
-follows in subsequent commits.
+- **What shipped** — the set-widening type system, the unifier-backed
+  rule-level type inference, the `Resolution` policy, and the
+  `Coalesce` constraint. These are now in code under
+  `rust/dialog-query/`. The shipped pipeline is documented in
+  [`rule-pipeline.md`](./rule-pipeline.md); the type-system shape is
+  in `src/type_system.rs` and `src/type_system/unifier.rs`.
 
-## Motivation
+- **What didn't ship** — rank-1 polymorphic *formulas* with
+  `TypeScheme`/`SchemeBody`/`SchemeType`, and the `instantiate` /
+  `generalize` operations that go with them. The schemes were the
+  design's answer to "generic formulas like `math/sum`"; we didn't
+  have a concrete consumer that needed them, so the work was
+  deferred to a follow-up.
+
+The remainder of this document is the original design contract,
+preserved so the historical intent is visible. **Names like
+`TypeScheme`, `SchemeBody`, `SchemeType`, and `SchemeDefinite` do
+not exist in code.** Where a section maps onto something that did
+ship, an "✅ Shipped as" note points at the real type. Where a
+section described an unshipped piece, a "⚠️ Not shipped" note marks
+it.
+
+---
+
+## Motivation (still accurate)
 
 Three concerns drove the redesign:
 
@@ -38,20 +56,10 @@ Three concerns drove the redesign:
    rule body and feeds back into the storage layer (e.g. for
    index-range optimization).
 
-All three problems share a root: **the schema language can't
-express type variables**. Without type variables, optionality
-becomes a parallel taxonomy, generic formulas can't be declared,
-and inference has nowhere to write its results.
+The shipped work addresses (1) end-to-end and lays the unifier
+groundwork for (3). Concern (2) is the part that didn't ship.
 
-v2 introduces type variables as first-class citizens of the type
-system, plus a Damas-Milner unifier that resolves them at rule
-compile time. Optionality is one specific use of the unifier
-(`Optional<T>` is a slot type that admits `Definite(T) ∪
-{Absent}`); generic formulas are another (`Sum<T: Numeric>` is a
-formula scheme); range predicates a third (constraint set on
-variables).
-
-## v1 retrospective
+## v1 retrospective (still accurate)
 
 v1 shipped working set-widening but accumulated debt:
 
@@ -109,40 +117,40 @@ pub enum Definite {
 }
 ```
 
-Key structural properties:
+✅ **Shipped as** `type_system::Type` with variants
+`Primitive(Primitive)` and `Composite(Primitive, BTreeSet<Composite>)`.
+The shipped form is flatter than the proposed `Definite/Optional`
+split: optionality is encoded as a `Nothing` bit in the same
+`Primitive` bitfield, not as a wrapping `Optional` variant. A
+shipped `Type` carrying `Nothing` *is* the set-widened thing — no
+separate constructor. Nested optionality is still structurally
+impossible: `Type::optional()` adds the bit; calling it again is
+idempotent.
 
-- **`Optional` wraps `Definite`**, not `Type`. Nested optionality
-  unrepresentable.
-- **No `Any` variant.** What v1 called `Any` is `Definite::
-  Variable(fresh)` with constraint `PrimitiveSet::ALL` —
-  "anonymous variable that can take any primitive shape."
-- **Records and variants are reserved as `Definite` constructors.**
-  Future PRs add them; the existing recursion via `Box<Definite>`
-  accommodates them without reshape.
+Key structural properties (mostly hold in the shipped form):
+
+- **No `Any` variant.** ✅ The shipped form has no `Any` either.
+  Untyped slots carry `None` at the `Option<Type>` boundary or
+  use `Primitive::ALL` (any present value) / `Primitive::ANY` (any
+  including `Nothing`).
+- **Records and variants are reserved as `Composite` cases.** ✅ The
+  shipped `Composite` enum has `Product(BTreeMap<String, Type>)` and
+  `Variant{label, value}` — placeholders, not active in inference
+  yet.
 
 ### `PrimitiveSet`
 
-A bitfield over `ValueType` variants. Constraints are sets, not
-single values, so type variables can carry kind-level constraints
-(`NUMERIC`, `STRING_LIKE`, etc.) and unification can intersect
-them.
-
 ```rust
 pub struct PrimitiveSet { bits: u16 }
-
-impl PrimitiveSet {
-    pub const fn singleton(vt: ValueType) -> Self;
-    pub fn intersect(self, other: Self) -> Option<Self>;  // None = empty
-    pub fn includes(self, other: Self) -> bool;            // superset
-    pub fn as_singleton(self) -> Option<ValueType>;        // when narrowed
-    pub fn iter(self) -> impl Iterator<Item = ValueType>;
-
-    pub const ALL: Self;          // every primitive
-    pub const NUMERIC: Self;      // UnsignedInt | SignedInt | Float
-    pub const STRING_LIKE: Self;  // String | Symbol
-    pub const COMPARABLE: Self;   // NUMERIC ∪ STRING_LIKE ∪ Entity ∪ ...
-}
 ```
+
+✅ **Shipped as** `type_system::Primitive` (same shape, different
+name). API matches the proposal closely:
+`Primitive::ALL`/`NUMERIC`/`STRING_LIKE`/`COMPARABLE`, `intersect`,
+`singleton`. The shipped version also exposes
+`Primitive::NOTHING` and a `Primitive::ANY` (= `ALL | NOTHING`)
+that the doc doesn't mention — these are what make the "Nothing
+bit" encoding work.
 
 ### `VarId` and unification
 
@@ -150,354 +158,238 @@ impl PrimitiveSet {
 pub struct VarId(u32);
 
 pub struct UnificationContext {
-    /// Substitution: `VarId` → resolved type.
     substitution: HashMap<VarId, Definite>,
-    /// Constraint registry: per-variable `PrimitiveSet`.
     constraints: HashMap<VarId, PrimitiveSet>,
-    /// Fresh-id allocator.
     next_id: u32,
 }
 ```
 
+✅ **Shipped as** `type_system::unifier::VarId` and
+`type_system::unifier::Context`. The shipped `Context` also tracks
+a `names: HashMap<String, VarId>` so the rule-level inference pass
+can allocate one variable per named rule variable.
+
 Operations:
 
-- `fresh(constraint) -> VarId` allocates a new variable.
-- `unify(a, b)` Robinson unification with constraint
-  intersection. Errors on constraint conflict, occurs check, or
-  primitive mismatch.
-- `apply(ty)` recursively walks `ty`, replacing each
-  `Variable(id)` with the substituted type.
-- `instantiate(scheme)` allocates fresh `VarId`s for the
-  scheme's quantified variables, returning a body type with the
-  substitutions applied.
+- `fresh(constraint) -> VarId` — ✅ shipped.
+- `unify(a, b)` Robinson unification — ✅ shipped.
+- `apply(ty)` — ✅ shipped.
+- `instantiate(scheme)` — ⚠️ **Not shipped.** Nothing constructs
+  `TypeScheme`s, so nothing instantiates them.
 
-Unification rules:
-
-- `Variable(x) ≡ Variable(y)`: bind them; intersect constraints.
-- `Variable(x) ≡ Definite(p)`: check `p`'s primitive belongs to
-  `x`'s constraint; substitute `x := Definite(p)`. Run occurs
-  check.
-- `Variable(x) ≡ Optional(p)`: an Optional cannot satisfy a
-  variable that's used in a `Definite` slot. The unifier records
-  the slot's optionality at the slot level (not on the variable),
-  so this case is "merge constraints; the slot wrapping
-  determines optional vs definite per-use."
-- `Definite(a) ≡ Definite(b)`: structural unify on `a` and `b`.
-- `Optional(a) ≡ Optional(b)`: structural unify on `a` and `b`.
-- `Definite(a) ≡ Optional(b)`: strictest wins — narrow to
-  `Definite(unify(a, b))`. The optional consumer's tolerance for
-  Absent becomes dead code, but that's not an error.
+Unification rules — all the rules between concrete `Type`s and
+between variables and concretes are shipped. The `Definite ≡
+Optional` cases collapsed into the shipped form's intersection
+semantics: optionality is just a bit on the primitive set, and
+intersection narrows it correctly.
 
 ### Type schemes
 
-A formula declares a `TypeScheme` — its rank-1 polymorphic type:
-
 ```rust
-pub struct TypeScheme {
-    /// Quantified type variables and their constraints. Names
-    /// scope-local to this scheme.
-    quantified: Vec<(VarName, PrimitiveSet)>,
-    /// The body type, referencing quantified variables by
-    /// `VarName`. Instantiation replaces these with fresh
-    /// `VarId`s.
-    body: SchemeBody,
-}
-
-pub enum SchemeBody {
-    /// A function-like signature: parameter names → types.
-    Schema(BTreeMap<String, SchemeType>),
-    /// A single value type (rare, for non-function values).
-    Type(SchemeType),
-}
-
-pub enum SchemeType {
-    /// Reference to a quantified variable.
-    Bound(VarName),
-    /// Anonymous fresh variable (used for "any" slots that don't
-    /// share with other slots).
-    Fresh(PrimitiveSet),
-    /// Concrete shape: as `Type` but with `SchemeType` inside
-    /// `Definite::Variable(VarName)` instead of `VarId`.
-    Definite(Box<SchemeDefinite>),
-    Optional(Box<SchemeDefinite>),
-}
-
-pub enum SchemeDefinite {
-    Primitive(PrimitiveSet),
-    Variable(VarName),
-}
+pub struct TypeScheme { ... }
+pub enum SchemeBody { ... }
+pub enum SchemeType { ... }
+pub enum SchemeDefinite { ... }
 ```
 
-Schemes are **static, compile-time constants** in formula module
-definitions. Example for `math/sum`:
+⚠️ **Not shipped.** No type with any of these names exists in
+code. Formulas keep their existing `Schema` (no quantified
+variables); inference happens *over a rule's variables*, not over
+a formula's. This is the biggest deviation from the design.
 
-```rust
-const SUM_SCHEME: LazyLock<TypeScheme> = LazyLock::new(|| TypeScheme {
-    quantified: vec![(VarName::new("T"), PrimitiveSet::NUMERIC)],
-    body: SchemeBody::Schema(btreemap! {
-        "left".into()  => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
-        "right".into() => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
-        "is".into()    => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
-    }),
-});
-```
+**Why it didn't ship:** the PR's actual mission was to make the
+optional-fields case work end-to-end (stop emitting spurious
+`Absent` rows when sibling premises narrow the variable). That
+requires inference over a rule's variables. It does not require
+polymorphic formulas. Adding the `TypeScheme` machinery would have
+meant building infrastructure with no current consumer — no
+shipped formula is yet declared polymorphic.
 
-`unwrap_or` carries `Optional<T>` for its source slot:
-
-```rust
-const UNWRAP_OR_SCHEME: LazyLock<TypeScheme> = LazyLock::new(|| TypeScheme {
-    quantified: vec![(VarName::new("T"), PrimitiveSet::ALL)],
-    body: SchemeBody::Schema(btreemap! {
-        "source".into()  => SchemeType::Optional(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
-        "default".into() => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
-        "output".into()  => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
-    }),
-});
-```
+**What would need to change to ship them:** introduce a
+`TypeScheme` type, attach one to each formula registration in the
+formula registry, add `Context::instantiate` to allocate fresh
+`VarId`s from a scheme's quantified variables, and have the
+planner invoke instantiation when it picks up a formula premise.
+The unifier already handles everything downstream.
 
 ### Wire format
 
-Type schemes are **not serialized**. They're Rust-side metadata
-attached to formula identifiers via a registry. The wire format
-for a formula application stays as today:
-
-```json
-{ "assert": "math/sum", "where": { "left": ..., "right": ..., "is": ... } }
-```
-
-When the planner sees `"math/sum"`, it looks up `SUM_SCHEME` from
-the formula registry, instantiates it (allocates fresh `VarId`s
-for `T`), and unifies against the rule body.
-
-For non-formula schemas (concept descriptors, attribute queries,
-etc.) the wire format is the existing one. These don't have
-quantifiers — they declare concrete `Type` values. The serde
-representation of `Type` itself:
-
-```json
-{ "definite": { "primitive": ["Text"] } }      // exactly String
-{ "definite": { "primitive": ["UnsignedInt", "SignedInt"] } }  // narrower numeric
-{ "optional": { "primitive": ["Text"] } }      // String or Absent
-```
-
-`Variable` in concrete types only appears at runtime (in
-descriptors carrying inferred types after unification). The wire
-format for concept descriptors only emits `Primitive(...)` and
-`Optional(Primitive(...))` — no variable references.
+✅ **Shipped.** Type schemes are not serialized (they're Rust-side
+registry data). Concept descriptors and attribute queries serialize
+their types directly via the existing JSON format. The shipped
+`Type` enum has a serde representation; it's not the exact shape
+the doc proposes (`{"definite": ...}` / `{"optional": ...}`) but
+the underlying property — "concrete types only, no variables on
+the wire" — holds.
 
 ## Rule analysis
 
-`RuleAnalysis` is the per-rule output of the unification pass:
-
 ```rust
 pub struct RuleAnalysis {
-    /// Type intersection per rule-level variable, with
-    /// substitution applied.
     types: HashMap<String, Type>,
-    /// Producers per variable: which premise (by index)
-    /// declared the variable in a `Derived` slot, and what type
-    /// did it declare. Useful for diagnostics and Slice-7-equivalent
-    /// checks.
     producers: HashMap<String, Vec<ProducerEntry>>,
-    /// Scan refinements from range predicates. Empty initially;
-    /// populated as range-predicate constraints are added.
     refinements: HashMap<String, ScanHint>,
 }
 ```
 
-`RuleAnalysis::build(conclusion, premises) -> Result<Self,
-TypeError>` walks the rule body:
+✅ **Shipped as** `rule::analyzer::AnalyzedRule` with
+`types: Arc<TypeEnv>` plus a `DependencyGraph` instead of
+`producers`/`refinements`. The shipped form:
 
-1. Initialize `UnificationContext`.
-2. For each premise, look up its scheme (or use its concrete
-   schema for non-polymorphic premises). Instantiate fresh
-   `VarId`s for any quantified variables.
-3. For each parameter that's a named rule-level variable, unify
-   the slot's instantiated type against the rule's accumulated
-   type for that variable.
-4. After all premises processed, apply the final substitution to
-   every rule-level variable's type.
-5. Validate Slice-7-equivalent rules (Negation can't read a slot
-   that ended up `Optional`; required head fields must be
-   `Definite`; concept must have at least one required `with`
-   field).
-6. Return `RuleAnalysis` with substituted types.
+- Carries the inferred environment via `Arc<TypeEnv>` (shared
+  across the analyzed premises).
+- Builds a `DependencyGraph` (per-premise `binds`/`needs` plus
+  precomputed `requires[]` edges) — broader than the proposed
+  `producers` map. Currently built but not yet consumed by the
+  planner (left for a follow-up).
+- Doesn't carry `refinements` — range-predicate scan hints are
+  deferred along with the predicates themselves.
 
-Stored on the compiled `DeductiveRule` so downstream consumers
-(planner, query-time optimizer) can read inferred types.
+`RuleAnalysis::build(conclusion, premises) -> Result<Self, TypeError>`
+
+✅ **Shipped as** `rule::analyzer::analyze(conclusion, &steps) ->
+Result<AnalyzedRule, AnalysisError>`. The phases match the doc:
+inference, then required-head check, then Coalesce contract
+validation. Step (2) — instantiating formula schemes — isn't done
+because schemes don't ship. Step (5)'s Slice-7 checks ship via
+`AnalysisError::RequiredHeadFromOptional` and the unifier's
+constraint-conflict errors.
 
 ## Descriptor layer
 
-`TypeDescriptor` carries the new `Type` instead of v1's
-`Option<ValueType>`:
-
 ```rust
 pub trait TypeDescriptor: ... {
-    /// Statically known type, if monomorphic.
-    /// `None` means "anonymous variable" (fresh at runtime).
     const KIND: Option<Type>;
-
     fn kind(&self) -> Type;
 }
 ```
 
-Concrete descriptors (`Text`, `Boolean`, etc.) report `Type::
-Definite(Primitive(singleton(vt)))`. The descriptor formerly
-known as `Any` reports an anonymous variable with `ALL`
-constraint at runtime — i.e., its `kind()` allocates a fresh
-`VarId`. (Or we keep a special "anonymous" sentinel; design
-detail to settle in implementation.)
-
-`OptionalOf<D>` ZST handles `Term<Option<U>>`:
-
-```rust
-pub struct OptionalOf<D: TypeDescriptor>(PhantomData<D>);
-
-impl<D: TypeDescriptor> TypeDescriptor for OptionalOf<D> {
-    fn kind(&self) -> Type {
-        match D::KIND {
-            Some(Type::Definite(d)) => Type::Optional(d.clone()),
-            // Anonymous-variable case: Optional<Variable(fresh)>
-            None => Type::Optional(Box::new(Definite::Variable(fresh()))),
-            Some(other) => other,  // shouldn't happen given marker bounds
-        }
-    }
-}
-```
+✅ **Shipped.** `TypeDescriptor::kind` returns `Option<Type>`
+(slightly different signature than `Type` — `None` means "no
+static info, leave to the unifier"). `OptionalOf<D>` ships as
+described.
 
 ## Attribute query layer: `Resolution` policy
 
-v2 drops the recursive `DynamicAttributeQuery::Optional`
-variant. Optionality becomes a `Resolution` field on the
-existing `All`/`Only` variants:
-
 ```rust
 pub enum Resolution {
-    /// Standard EAV: zero rows on miss.
     Required,
-    /// Yield one Absent fallback row on miss.
     Optional,
 }
 ```
 
-Schema reflects optionality through the `is` term's descriptor's
-`kind()`. If `is: Term<Option<U>>`, `is.kind()` returns
-`Type::Optional(...)`, and the schema declares it directly. No
-recursive wrapper, no parallel `value_type` pin.
+✅ **Shipped.** With one refinement: `Resolution` is *derived* from
+`self.is.is_optional()` rather than stored as a field. The shipped
+`AttributeQueryAll::resolution()` returns
+`Resolution::Optional` iff the `is` term's kind admits `Nothing`.
+This makes the rule-level narrowing automatic — once the planner
+narrows the term's kind, the resolution flips with it, without
+needing a separate path.
 
 ## Macro layer
 
-For `Option<T>` fields on `#[derive(Concept)]`, the macro emits
-`Term<Option<<T as Attribute>::Type>>`. The Rust-level
-`Option<...>` wrapper is the typed signal; users get
-`unwrap_or` on the field, set-widening conversions, and
-compile-time rejection of nested `Option`. The realize impl
-pattern-matches on `Binding`.
+✅ **Shipped.** The `#[derive(Concept)]` macro emits
+`Term<Option<<T as Attribute>::Type>>` for `Option<T>` fields.
+Dispatch happens through the `ConceptField` trait with two
+blanket impls (`for N` and `for Option<N>`) leveraging `Option`'s
+`#[fundamental]` annotation — no syntactic detection of the
+`Option` ident.
 
 ## Coalesce / `unwrap_or`
 
-`Coalesce` becomes a formula with `UNWRAP_OR_SCHEME` as its
-type scheme — no longer a separate `Constraint::Coalesce`
-variant. The `UnwrapOr<T: DefiniteType>` Rust-side builder
-constructs the formula application; the typed bound flows
-through Rust generics.
+⚠️ **Partially shipped, but not as a formula.** `Coalesce` ships as
+its own constraint variant (`Constraint::Coalesce`), not as a
+formula with a `UNWRAP_OR_SCHEME`. Its type contract is checked at
+rule-compile time via `Coalesce::validate(ctx)`, which uses the
+shipped `unifier::Context` to verify
+`source: Optional<α>, fallback: α, is: α` — but the contract is
+hand-rolled inside `validate`, not declared as a reusable scheme.
 
-When wire-format rules arrive without Rust types, the planner
-applies `UNWRAP_OR_SCHEME` at unification time. Type errors
-("output doesn't match source type") surface as unification
-failures.
+This is consistent with the broader "no schemes" decision: without
+`TypeScheme` infrastructure, Coalesce's polymorphism is expressed
+ad-hoc rather than via a registered scheme.
 
 ## Slice 7 enforcement
 
-v1 had three checks:
+✅ **Shipped (mostly).**
 
-1. `NegationOnOptional` — Negation reads optional binding.
-2. `RequiredHeadFromOptional` — required head field bound by
-   optional producer.
-3. `ConceptOnlyOptionalFields` — concept with empty `with`.
-
-v2 expresses (1) and (2) through `Type::accepts`-equivalent
-checks during `RuleAnalysis::build`. Negation premises declare
-their parameters as `Definite(...)` (not `Optional`); if any
-positive producer's substituted type is `Optional(...)`,
-unification fails with a clear error. Required head fields
-similarly declare `Definite(...)`. Check (3) is unchanged.
+- `RequiredHeadFromOptional` — shipped as
+  `AnalysisError::RequiredHeadFromOptional`. The shipped check
+  reads the inferred `TypeEnv` and flags any conclusion variable
+  whose inferred kind admits `Nothing`.
+- `NegationOnOptional` — not shipped as a separate check. The
+  shipped semantics: negations don't *contribute* to inference
+  (they're filters), and `apply_types` rewrites their terms with
+  the rule-level kinds — so a negation reading an optional binding
+  sees the narrowed kind, not the user's local one.
+- `ConceptOnlyOptionalFields` — not shipped. Captured as task #80.
 
 ## Marker traits
 
-`ScalarType`/`ProductType`/`VariantType`/`OptionalType`/
-`DefiniteType` family stays as ergonomic Rust-level bounds. They
-prevent `Term<Option<Option<U>>>` and `Term<Option<Any>>` at the
-Rust API.
+✅ **Shipped.** `ScalarType`/`ProductType`/`VariantType`/
+`OptionalType`/`DefiniteType`-family bounds prevent
+`Term<Option<Option<U>>>` and `Term<Option<Any>>` at the Rust API.
 
 ## Implementation phases
 
-1. **Step 1 (amend)** — `PrimitiveSet`, `VarId`, `Type`,
-   `Definite`, `TypeScheme`, `UnificationContext`, `unify`,
-   `apply`, `instantiate`, `generalize`, occurs check. Tests for
-   the algorithm.
-2. **Step 2 (committed)** — `Binding<Value>` at Match layer.
-3. **Step 3** — Descriptor enriched to carry the new `Type`.
-4. **Step 4** — Collapse v1's `schema::Type` into the new `Type`.
-5. **Step 4.5** — `RuleAnalysis::build` with `UnificationContext`
-   integration.
-6. **Step 5** — `Resolution` policy on `DynamicAttributeQuery`.
-7. **Step 6** — Concept projection emits `Resolution::Optional`
-   for `maybe` fields.
-8. **Step 7** — Macro emits typed `Term<Option<U>>` for
-   `Option<T>` fields.
-9. **Step 8** — Coalesce as a formula with `UNWRAP_OR_SCHEME`.
-10. **Step 9** — Marker traits family.
-11. **Step 10** — End-to-end tests; Slice 7 enforcement via
-    unification.
-12. **Step 11** — Docs, lint, fmt, full workspace test.
+The implementation didn't follow the proposed numbered phases
+exactly. The actual shipped order is captured in the commit log on
+`feat/type-inference` (formerly `feat/meet-into-plan`) and
+summarized in [`rule-pipeline.md`](./rule-pipeline.md).
 
 ## What's deferred to follow-up branches
 
-- **Records and variants** — `Definite::Record(...)`,
-  `Definite::Variant(...)` constructors. The recursive `Box<
-  Definite>` accommodates them without reshape.
-- **Generic formulas at runtime** — formula impls that dispatch
-  on the unified type (e.g. `Sum<T>` with separate addition
-  paths for `u32`, `i64`, `f64`). v2 lays the type-system
-  foundation; runtime monomorphization is a follow-up.
+- **Type schemes for polymorphic formulas** (`TypeScheme`,
+  `SchemeBody`, `SchemeType`, `instantiate`). The doc's design
+  intent. The largest deferred chunk.
+- **Records and variants in active inference** — placeholders ship
+  as `Composite::Product`/`Composite::Variant`; the unifier
+  doesn't recurse into them yet.
+- **Generic formulas at runtime** — formula impls that dispatch on
+  the unified type (e.g. `Sum<T>` with separate addition paths
+  for `u32`, `i64`, `f64`). Conditional on type schemes shipping.
 - **Range predicates** — new constraint variants (`<`, `<=`,
-  `starts_with`, etc.) that carry type schemes and contribute to
-  `RuleAnalysis::refinements`. The plumbing is in place; the
-  predicates themselves are a separate slice.
-- **Cross-formula type inference** — propagating type variables
-  across rule bodies that span multiple formulas. v2 unifies
-  within a single rule's `UnificationContext`; cross-rule
-  inference is conceptually more.
-- **`get-some`** — variant-elimination premise. Builds on
-  variant types.
+  `starts_with`, etc.) and their contribution to scan refinements.
+- **Cross-rule type inference** — propagating type variables
+  across rule bodies that span multiple formulas. Within-rule
+  inference ships; across-rule does not.
+- **`get-some`** — variant-elimination premise. Builds on variant
+  types.
+- **`ConceptOnlyOptionalFields` rejection** — task #80.
+- **Dependency graph as planner input** — the shipped
+  `DependencyGraph` is built but unread; the planner still uses
+  `Candidate::update`'s schema-walking loop.
 
 ## Acceptance criteria
 
-- Damas-Milner unifier with full algorithm coverage: identity,
-  variable-variable, variable-concrete, occurs check, constraint
-  conflict, instantiation independence, generalization.
-- All v1 end-to-end tests pass under v2.
-- New tests cover unification corner cases, generic formula
-  declarations, range-predicate-style narrowing.
-- Compile-fail doctests for `Term<Option<Option<U>>>` and
+The original criteria were aspirational for the full design. The
+shipped subset:
+
+- ✅ Unifier with full algorithm coverage for the cases that ship:
+  identity, variable-variable, variable-concrete, occurs check,
+  constraint conflict.
+- ⚠️ "Instantiation independence, generalization" — not shipped
+  (no schemes).
+- ✅ All v1 end-to-end tests pass.
+- ✅ New tests cover unification corner cases at the *rule* level
+  (not formula-scheme level).
+- ⚠️ "Generic formula declarations" — not shipped.
+- ⚠️ "Range-predicate-style narrowing" — infrastructure ready
+  (`TypeEnv`, dependency graph) but no predicates use it yet.
+- ✅ Compile-fail doctests for `Term<Option<Option<U>>>` and
   `Term<Option<Any>>`.
-- Workspace clippy clean, fmt clean, `test:native:debug` green.
-- Design doc reflects the final shape.
+- ✅ Workspace clippy clean, fmt clean.
+- ✅ Design doc reflects the final shape — *this* split.
 
 ## Open questions to settle during implementation
 
-1. **`TypeDescriptor::KIND` const evaluation.** The `Box<
-   Definite>` makes `const` tricky. Likely fall back to non-const
-   `kind()` function. Decision in Step 1.
-2. **Anonymous variable lifetime.** When a descriptor's `kind()`
-   returns `Definite::Variable(fresh)`, who owns the `VarId`? It
-   needs an `UnificationContext` to be meaningful. Likely: every
-   rule-compile pass has its own context, and "anonymous"
-   variables are allocated on demand during unification, not
-   eagerly at descriptor read time. Decision in Step 3.
-3. **Error messages.** Unification failures need source location
-   ("variable `?x` in premise 2 was inferred as String but
-   premise 3 demands UnsignedInt"). The unifier signature
-   accepts a context argument so errors can attribute their
-   source. Decision in Step 1.
+The questions the doc closed during implementation:
+
+1. **`TypeDescriptor::KIND` const evaluation.** Settled as
+   non-const `kind()` returning `Option<Type>`.
+2. **Anonymous variable lifetime.** Settled: per-rule
+   `unifier::Context`; named variables allocated via
+   `var_for_name(name)` on first reference.
+3. **Error messages.** Settled: `InferenceError::Conflict`
+   includes the offending variable name; the `Compile::compile`
+   layer wraps it as `TypeError::TypeInference { reason }`.

--- a/notes/optional-fields.md
+++ b/notes/optional-fields.md
@@ -1,543 +1,503 @@
-# Optional Fields — v2 Design
+# Optional Fields & Type System — v2 Design
 
-This document specifies the second design pass for set-widening
-optional concept fields in dialog-db. It supersedes a prior
-implementation (commit `d6629bf7` on `feat/optional-fields`) which
-shipped a working but structurally awkward solution. The lessons
-from v1 are folded into v2.
+This document specifies the type-system rework on
+`feat/optional-fields-v2`. It supersedes v1 (commit `d6629bf7` on
+`feat/optional-fields`) and the original v2 sketch at
+`5cc533ff`. The current direction is **rank-1 parametric
+polymorphism with Damas-Milner type inference** — Roc/Elm style,
+adapted to our Datalog-flavored query engine.
 
-This document is the design contract for `feat/optional-fields-v2`.
-Implementation follows in subsequent commits.
+This is a design contract for the v2 branch. Implementation
+follows in subsequent commits.
 
 ## Motivation
 
-Concepts model entities as records with named, typed fields. Today
-every field is required: a query for a concept with field `name`
-finds only entities that have a `name` fact. Some real-world
-attributes are inherently optional — a `Person` may or may not have
-a `nickname`, an order may or may not have a `discount_code`. Users
-want to write:
+Three concerns drove the redesign:
 
-```rust
-#[derive(Concept)]
-struct Person {
-    this: Entity,
-    name: Name,
-    nickname: Option<Nickname>,  // optional
-}
-```
+1. **Set-widening optionality.** Concept fields like
+   `nickname: Option<Nickname>` should realize as `Some(value)`
+   when the underlying fact exists and `None` when it doesn't. The
+   storage layer never persists `None` — absence is realized at
+   query time. `Optional<T>` is the set `T ∪ {Absent}` with the
+   subtype rule `T ⊆ Optional<T>`.
 
-and have `Query::<Person>::default()` return entities that have a
-`name` fact, with `nickname` populated as `Some(value)` when the
-fact exists and `None` when it doesn't. The fact for a `None` field
-is **never persisted** — absence is realized at query time, not
-stored.
+2. **Generic formulas.** Today's engine has formulas like
+   `math/sum`, `string/concat`, `to_string` that conceptually want
+   to be polymorphic — `forall T: Numeric. (T, T) → T` — but the
+   schema language has no way to express that, so they end up
+   either type-erased (lossy) or one variant per concrete type
+   (verbose). `Equality` was extracted into its own
+   `Constraint::Equality` variant precisely because it couldn't
+   fit the formula schema's "fixed input/output types" model.
 
-This is the same pattern Datomic calls `get-else` and Hickey
-described as "set widening": `Optional<T>` is the set
-`T ∪ {Absent}`, with the subtype rule `T ⊆ Optional<T>`. A `T` value
-flows freely into an `Optional<T>` slot.
+3. **Range predicates and inference.** Future predicate
+   constraints (`<`, `<=`, `starts_with`, etc.) want to *narrow
+   the type* of a variable based on which predicate uses it.
+   `starts_with` implies `String | Symbol`. The planner needs an
+   inference framework that propagates type information across a
+   rule body and feeds back into the storage layer (e.g. for
+   index-range optimization).
+
+All three problems share a root: **the schema language can't
+express type variables**. Without type variables, optionality
+becomes a parallel taxonomy, generic formulas can't be declared,
+and inference has nowhere to write its results.
+
+v2 introduces type variables as first-class citizens of the type
+system, plus a Damas-Milner unifier that resolves them at rule
+compile time. Optionality is one specific use of the unifier
+(`Optional<T>` is a slot type that admits `Definite(T) ∪
+{Absent}`); generic formulas are another (`Sum<T: Numeric>` is a
+formula scheme); range predicates a third (constraint set on
+variables).
 
 ## v1 retrospective
 
-v1 (commit `d6629bf7`) shipped working set-widening across nine
-slices: `Binding<Value>` at the Match layer, a schema-level `Type`
-enum with `Required`/`Optional`/`Any`, `AttributeQueryOptional`
-streaming wrapper, `Constraint::Coalesce`, marker-trait taxonomy
-with structural rejection of `Term<Option<Option<U>>>`, and end-to-end
-tests proving both `Some(...)` and `None` realize correctly.
+v1 shipped working set-widening but accumulated debt:
 
-It works. The native test suite is 1361 green. The user-visible
-behavior is correct.
+1. Two parallel type taxonomies (schema-layer `Type` + descriptor
+   `Option<ValueType>`).
+2. Recursive `DynamicAttributeQuery::Optional` variant — `Option<
+   Option<...>>` not prevented by the type signature.
+3. Type-erasure loss in `From<Term<Option<T>>> for Term<Any>` —
+   needed a parallel `optional_producers: HashSet<String>` to
+   recover the lost info at planning time.
+4. `UnwrapOr` builder type-erased at the boundary — accepted
+   mismatched output types.
+5. Marker traits as load-bearing structural fences rather than
+   ergonomic bounds.
 
-But the implementation accumulated structural debt that motivates
-v2:
-
-1. **Two parallel type taxonomies.** A schema-layer `Type` enum
-   (`Any | Required(ValueType) | Optional(ValueType)`) and a
-   descriptor-layer `Option<ValueType>`. The same concept expressed
-   twice in different shapes, with conversion sites between them.
-2. **`AttributeQueryOptional` as a recursive `DynamicAttributeQuery`
-   variant.** `Optional(Optional(...))` is structurally meaningless
-   but the type permits it. Fixed at construction by `try_new`/
-   `try_typed` validation, but the type signature doesn't prevent
-   the case.
-3. **Type-erasure loss.** `From<Term<Option<T>>> for Term<Any>`
-   strips the optional tag. Once erased, the runtime can't
-   introspect "this term might be Absent." The Slice 7 enforcement
-   of "Negation can't read optional bindings" needed a parallel
-   `optional_producers: HashSet<String>` on the side, because the
-   meet algebra alone couldn't see through the erasure.
-4. **`UnwrapOr` type-erased at the boundary.** `Term<Option<String>>`
-   ::unwrap_or accepts `Term<Entity>` for output without complaint —
-   the type system doesn't enforce source/default/output share a
-   value type.
-5. **Marker traits as the only structural fence.** `OptionalType`
-   and `DefiniteType` exist purely to prevent
-   `Term<Option<Option<U>>>` at the Rust API. The runtime descriptor
-   couldn't enforce the same invariant, so the markers were
-   load-bearing — and proliferated across many bound clauses.
-
-Each of these is a symptom of the same root cause: **the descriptor
-can't express optionality**, so the schema layer added an `Optional`
-variant on its own, and the rest of the codebase built bridges
-between the two.
-
-v2 fixes the root: the descriptor *does* express optionality. Then
-the schema-layer enum collapses, the recursive variant goes away,
-the erasure preserves type info, the `UnwrapOr` typing tightens, and
-the marker traits become ergonomic bounds rather than structural
-fences.
+Each is a symptom of "the descriptor can't express optionality."
+v2 fixes this at the root: the descriptor expresses optionality,
+type variables, and constraint sets uniformly via the same
+`Type` enum.
 
 ## v2 type system
 
-### `Type` enum
+### `Type` and `Definite`
 
 ```rust
 pub enum Type {
-    /// Dynamic top — value type unknown until runtime. Used at
-    /// type-erased boundaries (e.g. wire-format `Term<Any>`) and as
-    /// the planner's "I don't know yet" placeholder.
-    Any,
-
     /// A definite shape. Subtype of `Optional(definite)` via the
     /// `T ⊆ Optional<T>` set-widening rule.
     Definite(Box<Definite>),
 
-    /// Set-widened: `Definite ∪ {Absent}`. One level only — nested
-    /// optionality is structurally impossible because the wrapped
-    /// type is `Definite`, not `Type`. This matches the Rust-side
-    /// `T: DefiniteType` bound on `Term<Option<T>>`.
+    /// Set-widened: `Definite ∪ {Absent}`. One level only —
+    /// nested optionality is structurally impossible because the
+    /// wrapped type is `Definite`, not `Type`. Optionality lives
+    /// at the slot layer, not on type variables.
     Optional(Box<Definite>),
 }
 
 pub enum Definite {
-    /// Atomic value type. Today this is the only Definite variant;
-    /// future work adds Record (concept-as-value) and Variant
-    /// (tagged union) without reshaping the enum.
-    Primitive(ValueType),
+    /// Atomic value type, possibly union over several primitive
+    /// shapes. `PrimitiveSet::singleton(ValueType::String)` is
+    /// "exactly String"; `PrimitiveSet::NUMERIC` is "any of
+    /// UnsignedInt, SignedInt, Float."
+    Primitive(PrimitiveSet),
+
+    /// A type variable. Anonymous (per-site fresh) or named
+    /// within a single type scheme. The variable's constraint
+    /// (which primitive shapes it can take) lives in the
+    /// `UnificationContext`'s constraint registry, keyed by
+    /// `VarId`.
+    Variable(VarId),
+
+    // Future:
+    // Record(BTreeMap<String, Type>),
+    // Variant(BTreeMap<String, Definite>),
 }
 ```
 
-Key properties:
+Key structural properties:
 
-- **Recursive via `Box`**, not `const`. We accept the heap-allocation
-  cost so the enum can grow `Record(BTreeMap<String, Type>)` and
-  `Variant(BTreeMap<String, Definite>)` without changing the shape
-  of existing code.
-- **No `const` anywhere in the type system.** The current codebase
-  declares `const TYPE: Option<ValueType>` on `TypeDescriptor` but
-  never uses it in const contexts (every read site is a runtime
-  expression). v2 drops the const requirement to enable `Box`.
-- **`Optional` wraps `Definite`, not `Type`.** This makes
-  `Optional(Optional(...))` and `Optional(Any)` structurally
-  unrepresentable at the data level. The Rust marker traits
-  enforce the same invariant at the type level for typed code.
-- **`Any` sits alongside `Definite` and `Optional`**, not inside
-  `Definite`. `Optional(Any)` is therefore unrepresentable —
-  matching the Rust-side rejection of `Term<Option<Any>>`.
+- **`Optional` wraps `Definite`**, not `Type`. Nested optionality
+  unrepresentable.
+- **No `Any` variant.** What v1 called `Any` is `Definite::
+  Variable(fresh)` with constraint `PrimitiveSet::ALL` —
+  "anonymous variable that can take any primitive shape."
+- **Records and variants are reserved as `Definite` constructors.**
+  Future PRs add them; the existing recursion via `Box<Definite>`
+  accommodates them without reshape.
 
-### Type algebra
+### `PrimitiveSet`
 
-Two operations:
+A bitfield over `ValueType` variants. Constraints are sets, not
+single values, so type variables can carry kind-level constraints
+(`NUMERIC`, `STRING_LIKE`, etc.) and unification can intersect
+them.
 
-- **`meet(a, b) -> Result<Type, MeetError>`** — the lattice
-  intersection. Used to combine multiple declarations of the same
-  variable into a single narrowest type. Commutative, associative,
-  identity at `Any`. Conflicting value types reject.
-- **`accepts(consumer, producer) -> bool`** — one-way subtype
-  check. `Definite(T)` accepts `Definite(T)`. `Optional(T)` accepts
-  both `Definite(T)` and `Optional(T)` (set widening). `Any`
-  accepts anything. `Definite(T)` does NOT accept `Optional(T)` —
-  this is the rule that makes "Negation reads optional binding" a
-  type error.
+```rust
+pub struct PrimitiveSet { bits: u16 }
 
-The v1 rule was "`Required ∧ Optional → Required` (strictest wins)
-plus a parallel `optional_producers` set." v2 replaces this with
-the cleaner formulation: **a consumer's declared type must
-`accept` every producer's declared type.** No parallel set —
-the type system itself encodes the constraint.
+impl PrimitiveSet {
+    pub const fn singleton(vt: ValueType) -> Self;
+    pub fn intersect(self, other: Self) -> Option<Self>;  // None = empty
+    pub fn includes(self, other: Self) -> bool;            // superset
+    pub fn as_singleton(self) -> Option<ValueType>;        // when narrowed
+    pub fn iter(self) -> impl Iterator<Item = ValueType>;
+
+    pub const ALL: Self;          // every primitive
+    pub const NUMERIC: Self;      // UnsignedInt | SignedInt | Float
+    pub const STRING_LIKE: Self;  // String | Symbol
+    pub const COMPARABLE: Self;   // NUMERIC ∪ STRING_LIKE ∪ Entity ∪ ...
+}
+```
+
+### `VarId` and unification
+
+```rust
+pub struct VarId(u32);
+
+pub struct UnificationContext {
+    /// Substitution: `VarId` → resolved type.
+    substitution: HashMap<VarId, Definite>,
+    /// Constraint registry: per-variable `PrimitiveSet`.
+    constraints: HashMap<VarId, PrimitiveSet>,
+    /// Fresh-id allocator.
+    next_id: u32,
+}
+```
+
+Operations:
+
+- `fresh(constraint) -> VarId` allocates a new variable.
+- `unify(a, b)` Robinson unification with constraint
+  intersection. Errors on constraint conflict, occurs check, or
+  primitive mismatch.
+- `apply(ty)` recursively walks `ty`, replacing each
+  `Variable(id)` with the substituted type.
+- `instantiate(scheme)` allocates fresh `VarId`s for the
+  scheme's quantified variables, returning a body type with the
+  substitutions applied.
+
+Unification rules:
+
+- `Variable(x) ≡ Variable(y)`: bind them; intersect constraints.
+- `Variable(x) ≡ Definite(p)`: check `p`'s primitive belongs to
+  `x`'s constraint; substitute `x := Definite(p)`. Run occurs
+  check.
+- `Variable(x) ≡ Optional(p)`: an Optional cannot satisfy a
+  variable that's used in a `Definite` slot. The unifier records
+  the slot's optionality at the slot level (not on the variable),
+  so this case is "merge constraints; the slot wrapping
+  determines optional vs definite per-use."
+- `Definite(a) ≡ Definite(b)`: structural unify on `a` and `b`.
+- `Optional(a) ≡ Optional(b)`: structural unify on `a` and `b`.
+- `Definite(a) ≡ Optional(b)`: strictest wins — narrow to
+  `Definite(unify(a, b))`. The optional consumer's tolerance for
+  Absent becomes dead code, but that's not an error.
+
+### Type schemes
+
+A formula declares a `TypeScheme` — its rank-1 polymorphic type:
+
+```rust
+pub struct TypeScheme {
+    /// Quantified type variables and their constraints. Names
+    /// scope-local to this scheme.
+    quantified: Vec<(VarName, PrimitiveSet)>,
+    /// The body type, referencing quantified variables by
+    /// `VarName`. Instantiation replaces these with fresh
+    /// `VarId`s.
+    body: SchemeBody,
+}
+
+pub enum SchemeBody {
+    /// A function-like signature: parameter names → types.
+    Schema(BTreeMap<String, SchemeType>),
+    /// A single value type (rare, for non-function values).
+    Type(SchemeType),
+}
+
+pub enum SchemeType {
+    /// Reference to a quantified variable.
+    Bound(VarName),
+    /// Anonymous fresh variable (used for "any" slots that don't
+    /// share with other slots).
+    Fresh(PrimitiveSet),
+    /// Concrete shape: as `Type` but with `SchemeType` inside
+    /// `Definite::Variable(VarName)` instead of `VarId`.
+    Definite(Box<SchemeDefinite>),
+    Optional(Box<SchemeDefinite>),
+}
+
+pub enum SchemeDefinite {
+    Primitive(PrimitiveSet),
+    Variable(VarName),
+}
+```
+
+Schemes are **static, compile-time constants** in formula module
+definitions. Example for `math/sum`:
+
+```rust
+const SUM_SCHEME: LazyLock<TypeScheme> = LazyLock::new(|| TypeScheme {
+    quantified: vec![(VarName::new("T"), PrimitiveSet::NUMERIC)],
+    body: SchemeBody::Schema(btreemap! {
+        "left".into()  => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
+        "right".into() => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
+        "is".into()    => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
+    }),
+});
+```
+
+`unwrap_or` carries `Optional<T>` for its source slot:
+
+```rust
+const UNWRAP_OR_SCHEME: LazyLock<TypeScheme> = LazyLock::new(|| TypeScheme {
+    quantified: vec![(VarName::new("T"), PrimitiveSet::ALL)],
+    body: SchemeBody::Schema(btreemap! {
+        "source".into()  => SchemeType::Optional(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
+        "default".into() => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
+        "output".into()  => SchemeType::Definite(Box::new(SchemeDefinite::Variable(VarName::new("T")))),
+    }),
+});
+```
 
 ### Wire format
 
-`Type` serializes as a tagged union:
+Type schemes are **not serialized**. They're Rust-side metadata
+attached to formula identifiers via a registry. The wire format
+for a formula application stays as today:
 
 ```json
-"any"
-{ "definite": { "primitive": "Text" } }
-{ "optional": { "primitive": "Text" } }
+{ "assert": "math/sum", "where": { "left": ..., "right": ..., "is": ... } }
 ```
 
-`Definite::Primitive(ValueType::String)` flattens to
-`{ "primitive": "Text" }` reusing the existing `ValueType` wire
-form. The wrapping `definite`/`optional` tag is added so future
-`Definite::Record(...)` and `Definite::Variant(...)` extensions
-fit without rewriting the on-disk format.
+When the planner sees `"math/sum"`, it looks up `SUM_SCHEME` from
+the formula registry, instantiates it (allocates fresh `VarId`s
+for `T`), and unifies against the rule body.
 
-This is a wire-format break from v1's `Option<ValueType>` shape on
-`Field::content_type`. Acceptable since the project is pre-1.0 and
-no Schema is currently persisted across versions.
+For non-formula schemas (concept descriptors, attribute queries,
+etc.) the wire format is the existing one. These don't have
+quantifiers — they declare concrete `Type` values. The serde
+representation of `Type` itself:
+
+```json
+{ "definite": { "primitive": ["Text"] } }      // exactly String
+{ "definite": { "primitive": ["UnsignedInt", "SignedInt"] } }  // narrower numeric
+{ "optional": { "primitive": ["Text"] } }      // String or Absent
+```
+
+`Variable` in concrete types only appears at runtime (in
+descriptors carrying inferred types after unification). The wire
+format for concept descriptors only emits `Primitive(...)` and
+`Optional(Primitive(...))` — no variable references.
+
+## Rule analysis
+
+`RuleAnalysis` is the per-rule output of the unification pass:
+
+```rust
+pub struct RuleAnalysis {
+    /// Type intersection per rule-level variable, with
+    /// substitution applied.
+    types: HashMap<String, Type>,
+    /// Producers per variable: which premise (by index)
+    /// declared the variable in a `Derived` slot, and what type
+    /// did it declare. Useful for diagnostics and Slice-7-equivalent
+    /// checks.
+    producers: HashMap<String, Vec<ProducerEntry>>,
+    /// Scan refinements from range predicates. Empty initially;
+    /// populated as range-predicate constraints are added.
+    refinements: HashMap<String, ScanHint>,
+}
+```
+
+`RuleAnalysis::build(conclusion, premises) -> Result<Self,
+TypeError>` walks the rule body:
+
+1. Initialize `UnificationContext`.
+2. For each premise, look up its scheme (or use its concrete
+   schema for non-polymorphic premises). Instantiate fresh
+   `VarId`s for any quantified variables.
+3. For each parameter that's a named rule-level variable, unify
+   the slot's instantiated type against the rule's accumulated
+   type for that variable.
+4. After all premises processed, apply the final substitution to
+   every rule-level variable's type.
+5. Validate Slice-7-equivalent rules (Negation can't read a slot
+   that ended up `Optional`; required head fields must be
+   `Definite`; concept must have at least one required `with`
+   field).
+6. Return `RuleAnalysis` with substituted types.
+
+Stored on the compiled `DeductiveRule` so downstream consumers
+(planner, query-time optimizer) can read inferred types.
 
 ## Descriptor layer
 
-### Descriptors carry `Type`
+`TypeDescriptor` carries the new `Type` instead of v1's
+`Option<ValueType>`:
 
 ```rust
-pub trait TypeDescriptor: Clone + Debug + Default + ... {
-    /// The statically known type, if monomorphic.
-    /// `None` for the dynamic-top descriptor (Any).
+pub trait TypeDescriptor: ... {
+    /// Statically known type, if monomorphic.
+    /// `None` means "anonymous variable" (fresh at runtime).
     const KIND: Option<Type>;
 
-    /// The runtime type. For monomorphic descriptors equals
-    /// `KIND.unwrap()`; for `Any` returns the wrapped tag.
     fn kind(&self) -> Type;
 }
 ```
 
-`KIND` replaces v1's `TYPE: Option<ValueType>`. The change from
-`Option<ValueType>` to `Option<Type>` is the central enrichment:
-descriptors now carry the full type taxonomy, not just the leaf
-value type.
+Concrete descriptors (`Text`, `Boolean`, etc.) report `Type::
+Definite(Primitive(singleton(vt)))`. The descriptor formerly
+known as `Any` reports an anonymous variable with `ALL`
+constraint at runtime — i.e., its `kind()` allocates a fresh
+`VarId`. (Or we keep a special "anonymous" sentinel; design
+detail to settle in implementation.)
 
-`const KIND` works because `Type::Definite(Box::new(Definite::
-Primitive(vt)))` is constructible in const context (Rust 1.83+
-supports `const fn Box::new` for some cases) — *or* we use a
-non-const `KIND_FN()` approach if Box::new const stabilization
-isn't available. Final choice depends on toolchain check.
-
-If neither path works, the fallback is to give up `const` entirely
-and make `KIND` a non-const associated function. The 13 read sites
-in v1 are all runtime expressions; non-const has no behavior cost.
-
-### `Any` carries `Type`, not `Option<ValueType>`
+`OptionalOf<D>` ZST handles `Term<Option<U>>`:
 
 ```rust
-pub struct Any(pub Type);
-```
-
-`Any(Type::Any)` represents fully-erased terms (no static info).
-`Any(Type::Definite(Box::new(Definite::Primitive(vt))))` represents
-a term that was originally `Term<U>` for some scalar `U`.
-`Any(Type::Optional(Box::new(Definite::Primitive(vt))))` represents
-a term that was originally `Term<Option<U>>`.
-
-**This is the key fix.** v1's `Any(Option<ValueType>)` lost the
-`Optional` tag at the erasure boundary. v2 preserves it.
-
-### `Term<Option<U>>` descriptor
-
-```rust
-#[derive(Default, Clone, Debug, ...)]
 pub struct OptionalOf<D: TypeDescriptor>(PhantomData<D>);
 
 impl<D: TypeDescriptor> TypeDescriptor for OptionalOf<D> {
-    const KIND: Option<Type> = match D::KIND {
-        Some(Type::Definite(d)) => Some(Type::Optional(d.clone())),
-        // Other shapes prevented by the Rust trait bound `T:
-        // DefiniteType`; const match is exhaustive.
-        _ => None,
-    };
     fn kind(&self) -> Type {
         match D::KIND {
             Some(Type::Definite(d)) => Type::Optional(d.clone()),
-            _ => Type::Any,
+            // Anonymous-variable case: Optional<Variable(fresh)>
+            None => Type::Optional(Box::new(Definite::Variable(fresh()))),
+            Some(other) => other,  // shouldn't happen given marker bounds
         }
     }
 }
-
-impl<T: DefiniteType> Typed for Option<T> {
-    type Descriptor = OptionalOf<<T as Typed>::Descriptor>;
-}
 ```
 
-`Term<Option<String>>` has `Descriptor = OptionalOf<Text>`. At
-runtime its `kind()` returns
-`Type::Optional(Definite::Primitive(ValueType::String))`. The
-erasure into `Term<Any>` constructs
-`Any(Type::Optional(Definite::Primitive(ValueType::String)))` —
-the optionality survives.
+## Attribute query layer: `Resolution` policy
 
-### Schema collapse
-
-v1's `schema::Type` enum is deleted. `Field::content_type` becomes
-`Type` (the new unified one).
+v2 drops the recursive `DynamicAttributeQuery::Optional`
+variant. Optionality becomes a `Resolution` field on the
+existing `All`/`Only` variants:
 
 ```rust
-pub struct Field {
-    description: String,
-    content_type: Type,
-    requirement: Requirement,
-    cardinality: Cardinality,
-}
-```
-
-Conversion sites — `From<&ConceptDescriptor> for Schema`,
-`From<&Cells> for Schema`, `Constraint::Equality::schema`,
-`AttributeQuery::schema` — populate `content_type` from the
-underlying term's `descriptor().kind()`. No more
-`.into()`-coercion ambiguity between `Option<ValueType>` and the
-old `schema::Type` enum.
-
-## Attribute-query layer
-
-### `Resolution` policy on `DynamicAttributeQuery`
-
-v1 introduced a recursive `DynamicAttributeQuery::Optional(Box<...>)`
-variant wrapping an `AttributeQueryOptional` struct. v2 drops the
-variant entirely. Optionality becomes a policy switch on the single
-attribute-query type:
-
-```rust
-pub enum DynamicAttributeQuery {
-    All(AttributeQueryAll),
-    Only(AttributeQueryOnly),
-    // No Optional variant.
-}
-
-// Cardinality + Resolution = behavior matrix.
 pub enum Resolution {
-    /// Standard EAV semantics: zero rows on miss.
+    /// Standard EAV: zero rows on miss.
     Required,
-    /// One row per input — Present from the lookup if any fact
-    /// exists, else Absent fallback.
+    /// Yield one Absent fallback row on miss.
     Optional,
 }
 ```
 
-`Resolution` lives on `AttributeQueryAll` and `AttributeQueryOnly`
-as a field, not as a wrapping enum. Each existing variant carries
-the policy.
-
-### Schema reflects optionality through the descriptor
-
-`AttributeQueryAll::schema()` declares `is`'s `content_type` from
-`is.descriptor().kind()`. If `is: Term<Option<U>>`, the descriptor
-reports `Type::Optional(...)` and the schema reflects that
-directly. No widening logic on the wrapper. No `value_type: Option<
-ValueType>` pin. The descriptor is the single source of truth.
-
-If the user constructed the query with `Resolution::Optional` but
-passed `is: Term<U>` (non-optional Rust type), the descriptor
-reports `Type::Definite(...)` while the runtime evaluates with
-optional semantics. That's a structural mismatch — the constructor
-should reject it. We add a constructor-time check: `Resolution::
-Optional` requires `is.descriptor().kind()` to be either
-`Type::Optional(_)` or `Type::Any` (so wire-format
-`Term<Any>` rules can flow through and have their resolution
-checked at planner time).
-
-### Concept projection emits typed Optional resolvers
-
-`From<&ConceptDescriptor> for DeductiveRule` walks both `with` and
-`maybe` attribute maps:
-
-- `with` attributes get `Resolution::Required` queries.
-- `maybe` attributes get `Resolution::Optional` queries.
-
-The `is` term in each case is `Term::<Option<vt>>::var(...)` for
-maybe fields (typed) or `Term::<vt>::var(...)` for required fields.
+Schema reflects optionality through the `is` term's descriptor's
+`kind()`. If `is: Term<Option<U>>`, `is.kind()` returns
+`Type::Optional(...)`, and the schema declares it directly. No
+recursive wrapper, no parallel `value_type` pin.
 
 ## Macro layer
 
-### `Term<Option<U>>` for `Option<T>` fields
-
-The `#[derive(Concept)]` macro:
-
-- For required `T` fields: emits `Term<<T as Attribute>::Type>`.
-  Same as today.
-- For `Option<T>` fields: emits
-  `Term<Option<<T as Attribute>::Type>>`. The Rust-level
-  `Option<...>` wrapper is the typed signal; users get
-  `unwrap_or` on the field, set-widening conversions in/out, and
-  compile-time rejection of nested `Option`.
-
-The realize impl pattern-matches on `Binding`:
-
-```rust
-nickname: match source.lookup(&Term::<Any>::from(&self.nickname))? {
-    Binding::Present(value) => Some(Nickname(value.try_into()?)),
-    Binding::Absent => None,
-}
-```
-
-`Term::<Any>::from(&self.nickname)` is the borrow-form erasure that
-preserves `Type::Optional(...)` in the descriptor (Slice 6 of v1
-introduced this conversion; v2 keeps it but with type-faithful
-preservation).
-
-### `From<Term<U>> for Term<Option<U>>` set-widening
-
-Kept from v1. A user passing `Term::<String>::var("x")` where the
-macro expects `Term<Option<String>>` gets implicit widening via
-`From`. The conversion is structurally trivial: descriptor changes
-from `Text` to `OptionalOf<Text>`, value preserved.
+For `Option<T>` fields on `#[derive(Concept)]`, the macro emits
+`Term<Option<<T as Attribute>::Type>>`. The Rust-level
+`Option<...>` wrapper is the typed signal; users get
+`unwrap_or` on the field, set-widening conversions, and
+compile-time rejection of nested `Option`. The realize impl
+pattern-matches on `Binding`.
 
 ## Coalesce / `unwrap_or`
 
-### Typed `UnwrapOr<T>` builder
+`Coalesce` becomes a formula with `UNWRAP_OR_SCHEME` as its
+type scheme — no longer a separate `Constraint::Coalesce`
+variant. The `UnwrapOr<T: DefiniteType>` Rust-side builder
+constructs the formula application; the typed bound flows
+through Rust generics.
 
-v1 erased source/default/output to `Term<Any>` at the builder,
-losing the value-type guarantee at the call site. v2 parameterizes:
+When wire-format rules arrive without Rust types, the planner
+applies `UNWRAP_OR_SCHEME` at unification time. Type errors
+("output doesn't match source type") surface as unification
+failures.
 
-```rust
-pub struct UnwrapOr<T: DefiniteType> {
-    source: Term<Any>,        // erased internally, but...
-    default: Term<Any>,       // ...the type T is preserved at the
-    _phantom: PhantomData<T>, //    builder level for compile-time check
-}
-
-impl<T: DefiniteType> Term<Option<T>> {
-    pub fn unwrap_or<D: Into<Term<T>>>(self, default: D) -> UnwrapOr<T> {
-        UnwrapOr {
-            source: Term::<Any>::from(self),
-            default: Term::<Any>::from(default.into()),
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<T: DefiniteType> UnwrapOr<T> {
-    pub fn is<O: Into<Term<T>>>(self, output: O) -> Premise {
-        // Construct the Coalesce constraint from
-        // self.source, self.default, Term::<Any>::from(output.into()).
-    }
-}
-```
-
-The user can no longer write
-`Term::<Option<String>>::var("x").unwrap_or(...).is(Term::<Entity>::var("y"))`
-— it fails at Rust-compile time because `Term<Entity>` doesn't
-satisfy `Into<Term<String>>`.
-
-### `Term<Any>::unwrap_or` for wire-format paths
-
-Rules parsed from JSON arrive as `Term<Any>` for unspecified terms.
-There is no Rust-level type to enforce. v2 adds an untyped
-`Term<Any>::unwrap_or` that returns `UnwrapOr<()>` (or a separate
-`UntypedUnwrapOr` builder). At rule-compile time (`DeductiveRule::
-new`), the planner runs the meet algebra over the resulting Coalesce
-constraint and rejects type-incoherent uses.
-
-Both paths converge on the same runtime `Coalesce` constraint with
-type-erased terms; the typed surface is purely a Rust-API
-compile-time guarantee.
-
-## Slice 7 enforcement, simplified
+## Slice 7 enforcement
 
 v1 had three checks:
 
 1. `NegationOnOptional` — Negation reads optional binding.
-2. `RequiredHeadFromOptional` — required head field bound by an
+2. `RequiredHeadFromOptional` — required head field bound by
    optional producer.
-3. `ConceptOnlyOptionalFields` — a concept with empty `with`.
+3. `ConceptOnlyOptionalFields` — concept with empty `with`.
 
-v2 expresses (1) and (2) through `Type::accepts`. The Negation's
-schema declares its parameters as `Type::Definite(_)` (not
-`Optional`) — by definition, Negation needs Present values. The
-required head field's schema declares `Type::Definite(_)`. If any
-producer in the rule body declares `Type::Optional(_)` for the same
-variable, `accepts` rejects. No parallel `optional_producers` set.
-
-Check (3) is unchanged — it's a structural property of the concept
-descriptor, not a type-meet rule.
+v2 expresses (1) and (2) through `Type::accepts`-equivalent
+checks during `RuleAnalysis::build`. Negation premises declare
+their parameters as `Definite(...)` (not `Optional`); if any
+positive producer's substituted type is `Optional(...)`,
+unification fails with a clear error. Required head fields
+similarly declare `Definite(...)`. Check (3) is unchanged.
 
 ## Marker traits
 
-The `ScalarType`/`ProductType`/`VariantType`/`OptionalType`/
-`AnyType`/`DefiniteType` family stays. Their role shifts:
-
-- **v1 used markers as the only structural fence** preventing
-  `Option<Option<U>>` at the Rust API. The runtime had no
-  equivalent fence because the descriptor couldn't express
-  optionality.
-- **v2 uses markers as ergonomic bounds.** They're how
-  `Term<Option<T: DefiniteType>>` expresses "T must be
-  non-optional." The runtime descriptor *also* enforces this via
-  the `Optional(Box<Definite>)` shape, but the markers exist so
-  Rust users get compile-time errors instead of runtime panics.
-
-The compile-fail doctests (`Term<Option<Option<U>>>`,
-`Term<Option<Any>>` reject) carry over from v1.
-
-## Wire format and migration
-
-Schema is not currently persisted — it's recomputed from
-descriptors on each session. So the wire-format change to `Type`
-serialization affects only future-persisted schemas. No migration
-needed for existing data.
-
-`Resolution` is a new field on `AttributeQueryAll` /
-`AttributeQueryOnly`. Existing serialized rules (which don't carry
-this field) deserialize with `Resolution::Required` as the default.
-Concept projection regenerates rules with the correct resolution at
-runtime, so the wire-format default doesn't matter for
-concept-derived rules.
-
-## What's deferred
-
-The recursive `Type` and `Definite` accommodate these without
-reshape:
-
-- **`Definite::Record(BTreeMap<String, Type>)`** for concepts as
-  values. Future PR adds the variant; existing code continues to
-  pattern-match exhaustively.
-- **`Definite::Variant(BTreeMap<String, Definite>)`** for tagged
-  unions. Variant payloads are `Definite` (no nested optionality
-  in payloads — the canonical way to express
-  "optional-inside-variant" is to flatten into the outer variant).
-- **Storage encoding for variants** — the `domain/VariantType/Tag
-  → payload` per-tag attribute scheme, with read-time deterministic
-  winner selection across the tag group. Documented separately.
-- **`get-some` (multi-attribute fallback)** — variant-elimination
-  premise. Builds on Variant types.
-- **Map types** — open question; not needed for optionality.
+`ScalarType`/`ProductType`/`VariantType`/`OptionalType`/
+`DefiniteType` family stays as ergonomic Rust-level bounds. They
+prevent `Term<Option<Option<U>>>` and `Term<Option<Any>>` at the
+Rust API.
 
 ## Implementation phases
 
-Tracked separately as Steps 1–11. Summary:
+1. **Step 1 (amend)** — `PrimitiveSet`, `VarId`, `Type`,
+   `Definite`, `TypeScheme`, `UnificationContext`, `unify`,
+   `apply`, `instantiate`, `generalize`, occurs check. Tests for
+   the algorithm.
+2. **Step 2 (committed)** — `Binding<Value>` at Match layer.
+3. **Step 3** — Descriptor enriched to carry the new `Type`.
+4. **Step 4** — Collapse v1's `schema::Type` into the new `Type`.
+5. **Step 4.5** — `RuleAnalysis::build` with `UnificationContext`
+   integration.
+6. **Step 5** — `Resolution` policy on `DynamicAttributeQuery`.
+7. **Step 6** — Concept projection emits `Resolution::Optional`
+   for `maybe` fields.
+8. **Step 7** — Macro emits typed `Term<Option<U>>` for
+   `Option<T>` fields.
+9. **Step 8** — Coalesce as a formula with `UNWRAP_OR_SCHEME`.
+10. **Step 9** — Marker traits family.
+11. **Step 10** — End-to-end tests; Slice 7 enforcement via
+    unification.
+12. **Step 11** — Docs, lint, fmt, full workspace test.
 
-1. `Type`/`Definite` enums with meet/accepts/serde.
-2. `Binding<Value>` at Match layer (port from v1, unchanged).
-3. Descriptor enriched to carry `Type` (was `Option<ValueType>`).
-4. Collapse v1's `schema::Type` into the new unified `Type`.
-5. `Resolution` policy on `DynamicAttributeQuery`; remove
-   `AttributeQueryOptional`.
-6. Concept projection emits `Resolution::Optional` for `maybe`
-   fields.
-7. Macro emits typed `Term<Option<U>>` for `Option<T>` fields.
-8. `Coalesce`/`UnwrapOr` with proper typed parameterization.
-9. Marker-trait family (slimmer; ergonomic bounds).
-10. End-to-end tests and Slice-7-equivalent enforcement via meet
-    algebra.
-11. Docs, lint, fmt, full workspace test.
+## What's deferred to follow-up branches
 
-Each step compiles and tests; the tree stays green throughout.
+- **Records and variants** — `Definite::Record(...)`,
+  `Definite::Variant(...)` constructors. The recursive `Box<
+  Definite>` accommodates them without reshape.
+- **Generic formulas at runtime** — formula impls that dispatch
+  on the unified type (e.g. `Sum<T>` with separate addition
+  paths for `u32`, `i64`, `f64`). v2 lays the type-system
+  foundation; runtime monomorphization is a follow-up.
+- **Range predicates** — new constraint variants (`<`, `<=`,
+  `starts_with`, etc.) that carry type schemes and contribute to
+  `RuleAnalysis::refinements`. The plumbing is in place; the
+  predicates themselves are a separate slice.
+- **Cross-formula type inference** — propagating type variables
+  across rule bodies that span multiple formulas. v2 unifies
+  within a single rule's `UnificationContext`; cross-rule
+  inference is conceptually more.
+- **`get-some`** — variant-elimination premise. Builds on
+  variant types.
 
 ## Acceptance criteria
 
-The branch is ready to merge when:
-
-- All v1 end-to-end tests pass under v2 (cherry-picked from
-  `feat/optional-fields`).
-- New tests cover `Type` algebra (meet, accepts, serde
-  round-trips), descriptor preservation through erasure,
-  `Resolution` dispatch, typed `UnwrapOr` rejecting type-mismatched
-  output, and Slice-7-equivalent rejections via meet.
-- Compile-fail doctests still prove `Term<Option<Option<U>>>` and
-  `Term<Option<Any>>` are rejected.
+- Damas-Milner unifier with full algorithm coverage: identity,
+  variable-variable, variable-concrete, occurs check, constraint
+  conflict, instantiation independence, generalization.
+- All v1 end-to-end tests pass under v2.
+- New tests cover unification corner cases, generic formula
+  declarations, range-predicate-style narrowing.
+- Compile-fail doctests for `Term<Option<Option<U>>>` and
+  `Term<Option<Any>>`.
 - Workspace clippy clean, fmt clean, `test:native:debug` green.
-- This document and the Steps 1–11 task list reflect the final
-  shape of the implementation.
+- Design doc reflects the final shape.
 
 ## Open questions to settle during implementation
 
-1. **`const KIND` vs non-const `kind()`**: depends on whether `Box::
-   new` stabilizes in const for our toolchain. Decision deferred to
-   Step 1.
-2. **`UnwrapOr<()>` for the untyped path**: viable shape, or
-   separate `UntypedUnwrapOr` builder? Decision deferred to
-   Step 8.
-3. **`Resolution::Optional` validation**: reject at constructor
-   when `is` term's descriptor is `Type::Definite(_)` (mismatch)?
-   Or allow as user signaling "I know what I'm doing, treat as
-   optional anyway"? Decision deferred to Step 5.
+1. **`TypeDescriptor::KIND` const evaluation.** The `Box<
+   Definite>` makes `const` tricky. Likely fall back to non-const
+   `kind()` function. Decision in Step 1.
+2. **Anonymous variable lifetime.** When a descriptor's `kind()`
+   returns `Definite::Variable(fresh)`, who owns the `VarId`? It
+   needs an `UnificationContext` to be meaningful. Likely: every
+   rule-compile pass has its own context, and "anonymous"
+   variables are allocated on demand during unification, not
+   eagerly at descriptor read time. Decision in Step 3.
+3. **Error messages.** Unification failures need source location
+   ("variable `?x` in premise 2 was inferred as String but
+   premise 3 demands UnsignedInt"). The unifier signature
+   accepts a context argument so errors can attribute their
+   source. Decision in Step 1.

--- a/notes/rule-pipeline.md
+++ b/notes/rule-pipeline.md
@@ -1,0 +1,142 @@
+# Rule Compilation Pipeline
+
+A deductive rule moves from user-supplied premises to an executable
+plan in three phases:
+
+```
+   ┌──────────┐    ┌──────────┐    ┌──────────┐
+   │  Parse   │ -> │ Analyze  │ -> │  Plan    │
+   └──────────┘    └──────────┘    └──────────┘
+        |               |               |
+   Descriptor       AnalyzedRule    Conjunction
+```
+
+## Parse
+
+`DeductiveRuleDescriptor` is the serialized form: a conclusion
+(`ConceptDescriptor`) plus `when`/`unless` premise lists with
+user-supplied terms. Parsing yields `Vec<Premise>` plus the
+conclusion. No type information beyond what the user wrote at the
+term layer (e.g. `Term<Option<String>>` carries `String | Nothing`;
+`Term<Any>::var("x")` carries nothing).
+
+## Analyze
+
+`rule::analyzer::analyze(conclusion, &steps) -> Result<AnalyzedRule, AnalysisError>`.
+
+Three sub-steps:
+
+1. **Type inference** (`rule::types::TypeEnv::infer`).
+   For every named variable referenced by any positive premise's
+   slots, unify the slot kinds. Negation premises don't
+   contribute — they filter on already-bound values rather than
+   introducing them. Untyped slots contribute their *requirement
+   shape*: a `Required` slot says "any present value"
+   (`Primitive::ALL`), an `Optional` slot says "any present or
+   absent" (`Primitive::ANY`). Output: name → inferred `Kind`.
+   Errors: `Conflict { variable, reason }` when slots disagree on
+   the kind for a given variable.
+
+2. **Required-head check**.
+   For each conclusion variable, if the inferred kind admits
+   `Nothing`, raise `RequiredHeadFromOptional { variable }`. The
+   rule can't produce `Absent` in a required slot.
+
+3. **Coalesce contract validation**.
+   Every `Constraint::Coalesce` runs against a fresh unifier
+   context. The contract says: source is `Optional<α>`, fallback
+   and is both unify with `α`. Errors:
+   `CoalesceTypeMismatch { reason }`.
+
+The output, `AnalyzedRule`, carries:
+- `conclusion: ConceptDescriptor`
+- `premises: Vec<Premise>` in planned order
+- `types: Arc<TypeEnv>` — the inferred environment, shared
+- `graph: DependencyGraph` — per-premise `binds`/`needs` plus
+  precomputed `requires[]` edges for ordering
+
+Analysis is rule-scoped; the result is immutable. Errors are pre-
+rule (they don't reference a `DeductiveRule`); `DeductiveRule::new`
+wraps them in the corresponding `TypeError::*` variants for display.
+
+## Plan
+
+`Planner::from(premises).plan(&scope) -> Result<Conjunction, TypeError>`.
+
+The planner does:
+
+1. Greedy cost-based ordering: repeatedly pick the cheapest viable
+   premise, remove it from candidates, advance the bound-vars set.
+   Existing `Candidate`/`Schema`/`Parameters` walk.
+2. Run `TypeEnv::infer` on the ordered steps. Failures surface as
+   `TypeError::TypeInference`.
+3. **Narrow each step's premise** via `apply_types(premise, &types)`.
+   The rewrite replaces variable terms (currently only
+   `AttributeQuery::is`) with copies carrying the inferred kind.
+   Negated propositions are walked too — a negation over an
+   optional attribute picks up the same narrowing.
+4. Stamp the rewritten premises into `Plan` values; assemble the
+   `Conjunction`.
+
+The rewrite happens **once at plan time**, not on every evaluation.
+The user-supplied `Premise` values stay untouched; only the in-flight
+working copy in the `Plan` reflects rule-level narrowing.
+
+## Why narrow at plan time
+
+The evaluator's behavior depends on `is.is_optional()` for the
+Absent-fallback decision:
+
+- Without narrowing, an optional attribute always emits an Absent
+  row when its lookup misses — even when a sibling premise's
+  required slot guarantees that variable is Present at the rule
+  level. The downstream join then filters the spurious Absent rows.
+- With narrowing, the optional attribute's `is` term reflects the
+  rule-inferred kind. If inference stripped `Nothing` (because a
+  sibling required premise narrowed it), `is_optional()` returns
+  `false` and the fallback row is never emitted.
+
+The savings are real for any rule that mixes optional and required
+bindings on the same variable.
+
+## Evaluation
+
+`Conjunction::evaluate(selection, env)` folds the steps' evaluators
+in order. Each step's premise is already narrowed; no `TypeEnv` is
+threaded through evaluation. Standalone queries (top-level
+`.perform()` outside any rule) plan with an empty `TypeEnv` so the
+rewrite is a no-op — the user's local term kinds are the sole
+source of optionality info.
+
+## Replanning
+
+`Conjunction::plan(&new_scope)` reruns the planner against a
+different scope (adornment-based replanning for concepts whose
+bindings change between callers). Type inference runs again on the
+fresh order — it's idempotent (re-narrowing an already-narrowed
+premise produces the same kinds) and stable across reorderings
+(inference doesn't depend on step order).
+
+## What lives where
+
+| Location | Contents |
+|---|---|
+| `Premise` (user-facing) | Whatever the user wrote |
+| `AnalyzedRule.types` | Rule-level inferred env, shared via `Arc` |
+| `AnalyzedRule.graph` | Per-premise `binds`/`needs` + `requires[]` |
+| `Plan.premise` | Premise with variable terms narrowed |
+| `Conjunction.steps` | Ordered `Plan`s plus cost/binds/env |
+
+## Errors
+
+| Source | Variant | When |
+|---|---|---|
+| `InferenceError::Conflict` | `TypeEnv::infer` | Slot kinds disagree for one variable |
+| `AnalysisError::Inference` | `analyze` | Wraps the above |
+| `AnalysisError::RequiredHeadFromOptional` | `analyze` | Inferred head admits `Nothing` |
+| `AnalysisError::CoalesceTypeMismatch` | `analyze` | Coalesce contract violated |
+| `TypeError::TypeInference` | `Planner::plan` | Inference error during planning |
+| `TypeError::RequiredHeadFromOptional` | `DeductiveRule::new` | Wraps analysis error with rule |
+| `TypeError::CoalesceTypeMismatch` | `DeductiveRule::new` | Wraps analysis error with rule |
+| `TypeError::UnboundVariable` | `DeductiveRule::new` | Head var not bound by any premise (post-plan) |
+| `TypeError::RequiredBindings` | `Planner::plan` | A premise's dependencies are unsatisfiable |

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -232,7 +232,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         descriptor_pair_pushes.push(quote! {
             {
                 let __pair = (
-                    #field_name_lit,
+                    #field_name_lit.to_string(),
                     <<#field_type as dialog_query::ConceptField>::Attribute
                         as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
                 );
@@ -316,6 +316,29 @@ pub fn derive(input: TokenStream) -> TokenStream {
             fn #validate_fn_name() {
                 #(assert_implements_concept_field::<#validated_types>();)*
             }
+        };
+
+        // Compile-time validation that the concept declares at least
+        // one *required* attribute. A concept made only of optional
+        // (`Option<_>`) fields — or of no attribute fields at all —
+        // constrains nothing, so every entity would match it; that
+        // is rejected here.
+        //
+        // The required/optional split is read from the
+        // [`ConceptField::OPTIONAL`](dialog_query::ConceptField)
+        // associated const (a compile-time `bool` chosen by trait
+        // dispatch), never by syntactic inspection of `Option<_>`.
+        // Summing `!OPTIONAL` over the fields and asserting the total
+        // is non-zero gives a `const` check that fires at compile
+        // time with a clear message.
+        const _: () = {
+            let required_field_count: usize = 0
+                #( + (!<#field_types as dialog_query::ConceptField>::OPTIONAL as usize) )*;
+            assert!(
+                required_field_count >= 1,
+                "a Concept must declare at least one required (non-Option) attribute field; \
+                 a concept built only from optional fields constrains nothing and matches every entity"
+            );
         };
 
         #[doc = #query_struct_doc]
@@ -412,36 +435,48 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // have either or both. The struct's doc comment carries
         // through as the descriptor's `description` so a `concept:`
         // query surfaces it (the field list alone leaves it `None`).
-        impl From<#struct_name> for dialog_query::ConceptDescriptor {
-            fn from(_: #struct_name) -> Self {
-                let mut __with: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
-                let mut __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
-                #(#descriptor_pair_pushes)*
-                dialog_query::ConceptDescriptor::from(__with)
-                    .with_maybe(__maybe)
-                    .with_description(#concept_description_lit)
+        // The concept's runtime schema, cached. This is the single
+        // construction site for the descriptor; both `From` impls
+        // below delegate here. Building goes through the fallible
+        // `ConceptDescriptor::try_from`, which only rejects an empty
+        // required (`with`) set — ruled out at compile time by the
+        // required-field assertion above, so the `expect` is
+        // statically unreachable (it documents the invariant rather
+        // than handling a real failure).
+        impl dialog_query::Descriptor<dialog_query::ConceptDescriptor> for #struct_name {
+            fn descriptor() -> &'static dialog_query::ConceptDescriptor {
+                static DESCRIPTOR: std::sync::OnceLock<dialog_query::ConceptDescriptor> =
+                    std::sync::OnceLock::new();
+                DESCRIPTOR.get_or_init(|| {
+                    let mut __with: Vec<(String, dialog_query::AttributeDescriptor)> = Vec::new();
+                    let mut __maybe: Vec<(String, dialog_query::AttributeDescriptor)> = Vec::new();
+                    #(#descriptor_pair_pushes)*
+                    dialog_query::ConceptDescriptor::try_from(__with)
+                        .expect(
+                            "derive(Concept) guarantees at least one required field at compile time",
+                        )
+                        .with_maybe(__maybe)
+                        .with_description(#concept_description_lit)
+                })
             }
         }
 
-        // Implement From<Query> for ConceptDescriptor
-        impl From<#query_name> for dialog_query::ConceptDescriptor {
-            fn from(_: #query_name) -> Self {
-                let mut __with: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
-                let mut __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
-                #(#descriptor_pair_pushes)*
-                dialog_query::ConceptDescriptor::from(__with)
-                    .with_maybe(__maybe)
-                    .with_description(#concept_description_lit)
-            }
-        }
+        // No `From<#struct_name>`/`From<#query_name> for ConceptDescriptor`:
+        // a concept type's descriptor is obtained through
+        // `Descriptor<ConceptDescriptor>` (or the inherent
+        // `#struct_name::descriptor()`), mirroring how attributes
+        // expose `Descriptor<AttributeDescriptor>`. The conversions
+        // below fill `ConceptQuery.predicate` from that single source.
 
         // Implement From<Query> for Premise
         impl From<#query_name> for dialog_query::Premise {
             fn from(source: #query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 let app = dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 };
                 dialog_query::Premise::Assert(dialog_query::Proposition::Concept(app))
             }
@@ -450,10 +485,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // Implement From<Query> for Proposition
         impl From<#query_name> for dialog_query::Proposition {
             fn from(source: #query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 let app = dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 };
                 dialog_query::Proposition::Concept(app)
             }
@@ -462,10 +499,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // Implement From<Query> for ConceptQuery
         impl From<#query_name> for dialog_query::ConceptQuery {
             fn from(source: #query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 }
             }
         }
@@ -473,10 +512,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // Implement From<&Query> for ConceptQuery
         impl From<&#query_name> for dialog_query::ConceptQuery {
             fn from(source: &#query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 }
             }
         }
@@ -497,8 +538,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
             }
 
             fn this(&self) -> dialog_query::Entity {
-                let predicate: dialog_query::ConceptDescriptor = self.clone().into();
-                predicate.this()
+                <#struct_name as dialog_query::Descriptor<dialog_query::ConceptDescriptor>>::descriptor()
+                    .this()
             }
         }
 
@@ -562,6 +603,14 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // with set-widened semantics (an Absent fallback row when
         // no fact matches).
         impl #struct_name {
+            /// Returns this concept's runtime descriptor (its schema:
+            /// attribute set, types, and content hash). Cached; the
+            /// canonical way to obtain the descriptor for a concept
+            /// type.
+            pub fn descriptor() -> &'static dialog_query::ConceptDescriptor {
+                <Self as dialog_query::Descriptor<dialog_query::ConceptDescriptor>>::descriptor()
+            }
+
             fn when(terms: dialog_query::Query<Self>) -> dialog_query::Premises {
                 let mut selectors: Vec<dialog_query::AttributeQuery> = Vec::new();
                 #(

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -307,8 +307,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
             fn realize(&self, source: dialog_query::Match) -> std::result::Result<Self::Conclusion, dialog_query::EvaluationError> {
                 Ok(#struct_name {
-                    this: dialog_query::Entity::try_from(source.lookup(&dialog_query::Term::from(&self.this))?)?,
-                    #(#field_names: #field_types(source.lookup(&dialog_query::Term::from(&self.#field_names))?.try_into()?)),*
+                    this: dialog_query::Entity::try_from(source.lookup(&dialog_query::Term::from(&self.this))?.content()?)?,
+                    #(#field_names: #field_types(source.lookup(&dialog_query::Term::from(&self.#field_names))?.content()?.try_into()?)),*
                 })
             }
         }

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -73,9 +73,39 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields, parse_macro_input};
+use syn::{Data, DeriveInput, Fields, GenericArgument, PathArguments, Type, parse_macro_input};
 
 use super::helpers::extract_doc_comments;
+
+/// If `ty` is syntactically `Option<T>`, return `Some(&T)`. Otherwise
+/// `None`. Recognizes the bare `Option<T>`, `std::option::Option<T>`,
+/// and `core::option::Option<T>` spellings.
+fn extract_option_inner(ty: &Type) -> Option<&Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+
+    let segments = &type_path.path.segments;
+    let last = segments.last()?;
+    if last.ident != "Option" {
+        return None;
+    }
+    if segments.len() > 1 {
+        let head = &segments[0].ident;
+        if head != "std" && head != "core" {
+            return None;
+        }
+    }
+
+    let PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    let arg = args.args.first()?;
+    let GenericArgument::Type(inner) = arg else {
+        return None;
+    };
+    Some(inner)
+}
 
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -127,15 +157,30 @@ pub fn derive(input: TokenStream) -> TokenStream {
         .into();
     }
 
-    // Collect code fragments for each field. We iterate over fields once and build
-    // up parallel vectors of token streams that get spliced into the final output.
-    let mut query_fields = Vec::new();
-    let mut rule_when_fields = Vec::new();
-    let mut field_names = Vec::new();
-    let mut field_name_lits = Vec::new();
-    let mut field_types = Vec::new();
-    let mut terms_methods = Vec::new();
-    let mut instance_expressions = Vec::new();
+    // Collect code fragments for each field. Required (non-Option types)
+    // and optional (`Option<T>`) fields are tracked in parallel vectors so
+    // the descriptor's `with` and `maybe` slots can be populated
+    // independently. The query/realize/iterator paths also branch by
+    // required vs optional.
+    let mut required_query_fields = Vec::new();
+    let mut required_field_names = Vec::new();
+    let mut required_field_name_lits = Vec::new();
+    let mut required_field_types = Vec::new();
+    let mut required_realize_fields = Vec::new();
+    let mut required_param_inserts = Vec::new();
+    let mut required_terms_methods = Vec::new();
+    let mut required_descriptor_pairs = Vec::new();
+    let mut required_statement_emits = Vec::new();
+
+    let mut optional_query_fields = Vec::new();
+    let mut optional_field_names = Vec::new();
+    let mut optional_field_name_lits = Vec::new();
+    let mut optional_inner_types = Vec::new();
+    let mut optional_realize_fields = Vec::new();
+    let mut optional_param_inserts = Vec::new();
+    let mut optional_terms_methods = Vec::new();
+    let mut optional_descriptor_pairs = Vec::new();
+    let mut optional_statement_emits = Vec::new();
 
     let terms_name = syn::Ident::new(&format!("{}Terms", struct_name), struct_name.span());
 
@@ -143,18 +188,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let field_name = field.ident.as_ref().unwrap();
         let field_name_str = field_name.to_string();
 
-        // Skip the 'this' field - it's handled specially
         if field_name_str == "this" {
             continue;
         }
 
         let field_type = &field.ty;
         let field_name_lit = syn::LitStr::new(&field_name_str, proc_macro2::Span::call_site());
-
-        // Store field name and type for later use in reconstruction
-        field_names.push(field_name);
-        field_types.push(field_type);
-        field_name_lits.push(field_name_lit.clone());
 
         // Forward the user's field doc when present, otherwise synthesize a
         // fallback so `#![deny(missing_docs)]` in consumer crates is happy.
@@ -171,49 +210,137 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let terms_method_doc_lit =
             syn::LitStr::new(&terms_method_doc, proc_macro2::Span::call_site());
 
-        // Extract the inner type from Attribute - the field type implements Attribute
-        // and we need <FieldType as Attribute>::Type for the Term wrapper
-        let inner_type = quote! { <#field_type as dialog_query::Attribute>::Type };
+        // Detect Option<T> wrapping. The wrapper preserves the optional
+        // kind at the Rust type level: the query exposes
+        // `Term<Option<Inner::Type>>`, distinguishing it from the
+        // non-optional `Term<Inner::Type>`. Presence is carried at
+        // runtime by `Binding::Present` / `Binding::Absent`.
+        if let Some(inner_type) = extract_option_inner(field_type) {
+            let inner_value_ty = quote! { <#inner_type as dialog_query::Attribute>::Type };
+            let optional_term_ty = quote! { dialog_query::Term<Option<#inner_value_ty>> };
 
-        // Generate Query field (Term<InnerType>) where InnerType is the Attribute's Type
-        query_fields.push(quote! {
-            #[doc = #query_field_doc_lit]
-            pub #field_name: dialog_query::Term<#inner_type>
-        });
+            optional_query_fields.push(quote! {
+                #[doc = #query_field_doc_lit]
+                pub #field_name: #optional_term_ty
+            });
 
-        terms_methods.push(quote! {
-            #[doc = #terms_method_doc_lit]
-            pub fn #field_name() -> dialog_query::Term<#inner_type> {
-                dialog_query::Term::<#inner_type>::var(#field_name_lit)
-            }
-        });
+            optional_terms_methods.push(quote! {
+                #[doc = #terms_method_doc_lit]
+                pub fn #field_name() -> #optional_term_ty {
+                    dialog_query::Term::<Option<#inner_value_ty>>::var(#field_name_lit)
+                }
+            });
 
-        // Generate rule when field conversion
-        rule_when_fields.push(quote! {
-            {
-                let value_param = dialog_query::Term::<dialog_query::types::Any>::from(terms.#field_name.clone());
+            // Realize: pattern-match on Binding. Present(value) wraps
+            // in Some(_); Absent maps to None. Lookup errors (e.g.
+            // unbound — no premise produced this variable) propagate.
+            //
+            // `Term::<Any>::from(&self.#field_name)` uses the
+            // `From<&Term<Option<T>>> for Term<Any>` borrow-form
+            // conversion to type-erase for lookup.
+            optional_realize_fields.push(quote! {
+                #field_name: match source.lookup(&dialog_query::Term::<dialog_query::types::Any>::from(&self.#field_name))? {
+                    dialog_query::Binding::Present(value) => Some(#inner_type(value.try_into()?)),
+                    dialog_query::Binding::Absent => None,
+                }
+            });
 
-                dialog_query::AttributeQuery::new(
-                    dialog_query::Term::Constant(dialog_query::Value::from(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone())),
-                    terms.this.clone(),
-                    value_param,
-                    dialog_query::Term::blank(),
-                    Some(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
+            optional_param_inserts.push(quote! {
+                terms.insert(
+                    #field_name_lit.into(),
+                    dialog_query::Term::<dialog_query::types::Any>::from(source.#field_name),
+                );
+            });
+
+            optional_descriptor_pairs.push(quote! {
+                (
+                    #field_name_lit,
+                    <#inner_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
                 )
+            });
+
+            // IntoIterator / Statement: emit a relation only when `Some(_)`.
+            // None means "don't persist None" — there is no fact to record.
+            optional_statement_emits.push(quote! {
+                if let Some(__inner) = self.#field_name.as_ref() {
+                    let __expr = dialog_query::attribute::expression::dynamic::DynamicAttributeExpression {
+                        the: <#inner_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone(),
+                        of: self.this.clone(),
+                        is: dialog_query::Value::from(<#inner_type as dialog_query::Attribute>::value(__inner).clone()),
+                        cause: None,
+                        cardinality: Some(<#inner_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
+                    };
+                    __statements.push(__expr.into());
+                }
+            });
+
+            optional_field_names.push(field_name);
+            optional_field_name_lits.push(field_name_lit);
+            optional_inner_types.push(inner_type);
+            continue;
+        }
+
+        // Required (non-Option) field path.
+        let inner_value_ty = quote! { <#field_type as dialog_query::Attribute>::Type };
+
+        required_query_fields.push(quote! {
+            #[doc = #query_field_doc_lit]
+            pub #field_name: dialog_query::Term<#inner_value_ty>
+        });
+
+        required_terms_methods.push(quote! {
+            #[doc = #terms_method_doc_lit]
+            pub fn #field_name() -> dialog_query::Term<#inner_value_ty> {
+                dialog_query::Term::<#inner_value_ty>::var(#field_name_lit)
             }
         });
 
-        // Generate DynamicAttributeExpression for IntoIterator/Statement implementations
-        instance_expressions.push(quote! {
-            dialog_query::attribute::expression::dynamic::DynamicAttributeExpression {
-                the: <#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone(),
-                of: self.this.clone(),
-                is: dialog_query::Value::from(<#field_type as dialog_query::Attribute>::value(&self.#field_name).clone()),
-                cause: None,
-                cardinality: Some(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
+        required_realize_fields.push(quote! {
+            #field_name: #field_type(
+                source.lookup(&dialog_query::Term::from(&self.#field_name))?.content()?.try_into()?
+            )
+        });
+
+        required_param_inserts.push(quote! {
+            terms.insert(
+                #field_name_lit.into(),
+                dialog_query::Term::<dialog_query::types::Any>::from(source.#field_name),
+            );
+        });
+
+        required_descriptor_pairs.push(quote! {
+            (
+                #field_name_lit,
+                <#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
+            )
+        });
+
+        required_statement_emits.push(quote! {
+            {
+                let __expr = dialog_query::attribute::expression::dynamic::DynamicAttributeExpression {
+                    the: <#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone(),
+                    of: self.this.clone(),
+                    is: dialog_query::Value::from(<#field_type as dialog_query::Attribute>::value(&self.#field_name).clone()),
+                    cause: None,
+                    cardinality: Some(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
+                };
+                __statements.push(__expr.into());
             }
         });
+
+        required_field_names.push(field_name);
+        required_field_name_lits.push(field_name_lit);
+        required_field_types.push(field_type);
     }
+
+    // The `assert_implements_attribute` validation needs to run on every
+    // attribute type, including those wrapped in `Option<T>`. Build a
+    // unified list of types to validate.
+    let validated_types: Vec<_> = required_field_types
+        .iter()
+        .map(|t| quote! { #t })
+        .chain(optional_inner_types.iter().map(|t| quote! { #t }))
+        .collect();
 
     // Generate type names based on struct name
     let query_name = syn::Ident::new(&format!("{}Query", struct_name), struct_name.span());
@@ -251,11 +378,13 @@ pub fn derive(input: TokenStream) -> TokenStream {
     );
 
     let expanded = quote! {
-        // Compile-time validation that all fields (except 'this') implement Attribute + Descriptor
+        // Compile-time validation that all fields (except 'this') implement
+        // Attribute + Descriptor. Includes the inner type of any `Option<T>`
+        // field — `Option<T>` itself is not an Attribute.
         const _: () = {
             fn assert_implements_attribute<T: dialog_query::Attribute + dialog_query::Descriptor<dialog_query::AttributeDescriptor>>() {}
             fn #validate_fn_name() {
-                #(assert_implements_attribute::<#field_types>();)*
+                #(assert_implements_attribute::<#validated_types>();)*
             }
         };
 
@@ -264,14 +393,16 @@ pub fn derive(input: TokenStream) -> TokenStream {
         pub struct #query_name {
             #[doc = #query_this_field_doc]
             pub this: dialog_query::Term<dialog_query::Entity>,
-            #(#query_fields),*
+            #(#required_query_fields,)*
+            #(#optional_query_fields,)*
         }
 
         impl Default for #query_name {
             fn default() -> Self {
                 Self {
                     this: dialog_query::Term::var("this"),
-                    #(#field_names: dialog_query::Term::var(#field_name_lits)),*
+                    #(#required_field_names: dialog_query::Term::var(#required_field_name_lits),)*
+                    #(#optional_field_names: dialog_query::Term::var(#optional_field_name_lits),)*
                 }
             }
         }
@@ -284,7 +415,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
             pub fn this() -> dialog_query::Term<dialog_query::Entity> {
                 dialog_query::Term::<dialog_query::Entity>::var("this")
             }
-            #(#terms_methods)*
+            #(#required_terms_methods)*
+            #(#optional_terms_methods)*
         }
 
         // Implement Application trait for the Query struct
@@ -307,8 +439,11 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
             fn realize(&self, source: dialog_query::Match) -> std::result::Result<Self::Conclusion, dialog_query::EvaluationError> {
                 Ok(#struct_name {
-                    this: dialog_query::Entity::try_from(source.lookup(&dialog_query::Term::from(&self.this))?.content()?)?,
-                    #(#field_names: #field_types(source.lookup(&dialog_query::Term::from(&self.#field_names))?.content()?.try_into()?)),*
+                    this: dialog_query::Entity::try_from(
+                        source.lookup(&dialog_query::Term::from(&self.this))?.content()?
+                    )?,
+                    #(#required_realize_fields,)*
+                    #(#optional_realize_fields,)*
                 })
             }
         }
@@ -336,31 +471,42 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
                 terms.insert("this".into(), dialog_query::Term::<dialog_query::types::Any>::from(source.this));
 
-                #(terms.insert(#field_name_lits.into(), dialog_query::Term::<dialog_query::types::Any>::from(source.#field_names));)*
+                #(#required_param_inserts)*
+                #(#optional_param_inserts)*
 
                 terms
             }
         }
 
-        // Implement From<StructName> for ConceptDescriptor
+        // Implement From<StructName> for ConceptDescriptor.
+        //
+        // Required fields populate `with`; `Option<T>` fields populate
+        // `maybe`. The two slots are independent, and a concept may have
+        // either or both. The `Vec<(&str, AttributeDescriptor)>` annotation
+        // is necessary so type inference works when the optional list is
+        // empty (no `Option<T>` fields on the struct).
         impl From<#struct_name> for dialog_query::ConceptDescriptor {
             fn from(_: #struct_name) -> Self {
+                let __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = vec![
+                    #(#optional_descriptor_pairs),*
+                ];
                 dialog_query::ConceptDescriptor::from(vec![
-                    #(
-                        (#field_name_lits, <#field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone())
-                    ),*
+                    #(#required_descriptor_pairs),*
                 ])
+                .with_maybe(__maybe)
             }
         }
 
         // Implement From<Query> for ConceptDescriptor
         impl From<#query_name> for dialog_query::ConceptDescriptor {
             fn from(_: #query_name) -> Self {
+                let __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = vec![
+                    #(#optional_descriptor_pairs),*
+                ];
                 dialog_query::ConceptDescriptor::from(vec![
-                    #(
-                        (#field_name_lits, <#field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone())
-                    ),*
+                    #(#required_descriptor_pairs),*
                 ])
+                .with_maybe(__maybe)
             }
         }
 
@@ -431,30 +577,42 @@ pub fn derive(input: TokenStream) -> TokenStream {
             }
         }
 
-        // Implement IntoIterator to convert concept into attribute statements
+        // Implement IntoIterator to convert concept into attribute statements.
+        //
+        // Required fields always emit a relation; `Option<T>` fields emit
+        // a relation only when `Some(_)`. `None` is *not* persisted —
+        // absence is realized as `Option::None` at projection time, never
+        // stored as a fact.
         impl IntoIterator for #struct_name {
             type Item = dialog_query::AttributeStatement;
             type IntoIter = std::vec::IntoIter<dialog_query::AttributeStatement>;
 
             fn into_iter(self) -> Self::IntoIter {
-                vec![
-                    #(#instance_expressions),*
-                ].into_iter()
+                let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
+                #(#required_statement_emits)*
+                #(#optional_statement_emits)*
+                __statements.into_iter()
             }
         }
 
         // Implement Statement trait
         impl dialog_query::Statement for #struct_name {
             fn assert(self, update: &mut impl dialog_query::Update) {
-                #(
-                    dialog_query::Statement::assert(#instance_expressions, update);
-                )*
+                let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
+                #(#required_statement_emits)*
+                #(#optional_statement_emits)*
+                for __s in __statements {
+                    dialog_query::Statement::assert(__s, update);
+                }
             }
 
             fn retract(self, update: &mut impl dialog_query::Update) {
-                #(
-                    dialog_query::Statement::retract(#instance_expressions, update);
-                )*
+                let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
+                #(#required_statement_emits)*
+                #(#optional_statement_emits)*
+                for __s in __statements {
+                    dialog_query::Statement::retract(__s, update);
+                }
             }
         }
 
@@ -473,11 +631,31 @@ pub fn derive(input: TokenStream) -> TokenStream {
             type Descriptor = dialog_query::ConceptDescriptor;
         }
 
-        // Implement Rule trait
+        // Implement Rule trait — the body lists only required attribute
+        // queries. Optional (`Option<T>`) fields are resolved by a
+        // separate optional-resolution premise inside the concept
+        // descriptor's deductive-rule projection (see
+        // `From<&ConceptDescriptor> for DeductiveRule`).
         impl #struct_name {
             fn when(terms: dialog_query::Query<Self>) -> dialog_query::Premises {
-                let selectors = vec![
-                    #(#rule_when_fields),*
+                let selectors: Vec<dialog_query::AttributeQuery> = vec![
+                    #(
+                        {
+                            let value_param = dialog_query::Term::<dialog_query::types::Any>::from(
+                                terms.#required_field_names.clone()
+                            );
+
+                            dialog_query::AttributeQuery::new(
+                                dialog_query::Term::Constant(dialog_query::Value::from(
+                                    <#required_field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone()
+                                )),
+                                terms.this.clone(),
+                                value_param,
+                                dialog_query::Term::blank(),
+                                Some(<#required_field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
+                            )
+                        }
+                    ),*
                 ];
 
                 selectors.into()

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -73,39 +73,9 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields, GenericArgument, PathArguments, Type, parse_macro_input};
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 use super::helpers::extract_doc_comments;
-
-/// If `ty` is syntactically `Option<T>`, return `Some(&T)`. Otherwise
-/// `None`. Recognizes the bare `Option<T>`, `std::option::Option<T>`,
-/// and `core::option::Option<T>` spellings.
-fn extract_option_inner(ty: &Type) -> Option<&Type> {
-    let Type::Path(type_path) = ty else {
-        return None;
-    };
-
-    let segments = &type_path.path.segments;
-    let last = segments.last()?;
-    if last.ident != "Option" {
-        return None;
-    }
-    if segments.len() > 1 {
-        let head = &segments[0].ident;
-        if head != "std" && head != "core" {
-            return None;
-        }
-    }
-
-    let PathArguments::AngleBracketed(args) = &last.arguments else {
-        return None;
-    };
-    let arg = args.args.first()?;
-    let GenericArgument::Type(inner) = arg else {
-        return None;
-    };
-    Some(inner)
-}
 
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -157,30 +127,29 @@ pub fn derive(input: TokenStream) -> TokenStream {
         .into();
     }
 
-    // Collect code fragments for each field. Required (non-Option types)
-    // and optional (`Option<T>`) fields are tracked in parallel vectors so
-    // the descriptor's `with` and `maybe` slots can be populated
-    // independently. The query/realize/iterator paths also branch by
-    // required vs optional.
-    let mut required_query_fields = Vec::new();
-    let mut required_field_names = Vec::new();
-    let mut required_field_name_lits = Vec::new();
-    let mut required_field_types = Vec::new();
-    let mut required_realize_fields = Vec::new();
-    let mut required_param_inserts = Vec::new();
-    let mut required_terms_methods = Vec::new();
-    let mut required_descriptor_pairs = Vec::new();
-    let mut required_statement_emits = Vec::new();
-
-    let mut optional_query_fields = Vec::new();
-    let mut optional_field_names = Vec::new();
-    let mut optional_field_name_lits = Vec::new();
-    let mut optional_inner_types = Vec::new();
-    let mut optional_realize_fields = Vec::new();
-    let mut optional_param_inserts = Vec::new();
-    let mut optional_terms_methods = Vec::new();
-    let mut optional_descriptor_pairs = Vec::new();
-    let mut optional_statement_emits = Vec::new();
+    // Collect code fragments for each field. The Concept derive
+    // does **not** branch syntactically on `Option<T>`. Instead it
+    // emits trait-based code that delegates to the `ConceptField`
+    // trait, which has two non-overlapping blanket impls in
+    // dialog-query:
+    //
+    // - `impl<N: Attribute> ConceptField for N` (required path)
+    // - `impl<N: Attribute> ConceptField for Option<N>` (optional)
+    //
+    // Rust's coherence permits these because `Option` is
+    // `#[fundamental]`. The macro emits `<F as ConceptField>::*`
+    // and the type system picks the right impl at type-check time,
+    // so aliases, prelude paths, and renamed imports all work
+    // without macro-time syntactic detection.
+    let mut query_fields = Vec::new();
+    let mut field_names = Vec::new();
+    let mut field_name_lits = Vec::new();
+    let mut field_types = Vec::new();
+    let mut realize_fields = Vec::new();
+    let mut param_inserts = Vec::new();
+    let mut terms_methods = Vec::new();
+    let mut descriptor_pair_pushes = Vec::new();
+    let mut statement_emits = Vec::new();
 
     let terms_name = syn::Ident::new(&format!("{}Terms", struct_name), struct_name.span());
 
@@ -210,137 +179,85 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let terms_method_doc_lit =
             syn::LitStr::new(&terms_method_doc, proc_macro2::Span::call_site());
 
-        // Detect Option<T> wrapping. The wrapper preserves the optional
-        // kind at the Rust type level: the query exposes
-        // `Term<Option<Inner::Type>>`, distinguishing it from the
-        // non-optional `Term<Inner::Type>`. Presence is carried at
-        // runtime by `Binding::Present` / `Binding::Absent`.
-        if let Some(inner_type) = extract_option_inner(field_type) {
-            let inner_value_ty = quote! { <#inner_type as dialog_query::Attribute>::Type };
-            let optional_term_ty = quote! { dialog_query::Term<Option<#inner_value_ty>> };
+        // The query field's term type is driven by ConceptField:
+        // - Required field `N`: `<N as ConceptField>::TermType` =
+        //   `<N as Attribute>::Type`.
+        // - Optional field `Option<N>`: `<Option<N> as ConceptField>::TermType`
+        //   = `Option<<N as Attribute>::Type>`.
+        let term_type = quote! {
+            dialog_query::Term<<#field_type as dialog_query::ConceptField>::TermType>
+        };
 
-            optional_query_fields.push(quote! {
-                #[doc = #query_field_doc_lit]
-                pub #field_name: #optional_term_ty
-            });
-
-            optional_terms_methods.push(quote! {
-                #[doc = #terms_method_doc_lit]
-                pub fn #field_name() -> #optional_term_ty {
-                    dialog_query::Term::<Option<#inner_value_ty>>::var(#field_name_lit)
-                }
-            });
-
-            // Realize: pattern-match on Binding. Present(value) wraps
-            // in Some(_); Absent maps to None. Lookup errors (e.g.
-            // unbound — no premise produced this variable) propagate.
-            //
-            // `Term::<Any>::from(&self.#field_name)` uses the
-            // `From<&Term<Option<T>>> for Term<Any>` borrow-form
-            // conversion to type-erase for lookup.
-            optional_realize_fields.push(quote! {
-                #field_name: match source.lookup(&dialog_query::Term::<dialog_query::types::Any>::from(&self.#field_name))? {
-                    dialog_query::Binding::Present(value) => Some(#inner_type(value.try_into()?)),
-                    dialog_query::Binding::Absent => None,
-                }
-            });
-
-            optional_param_inserts.push(quote! {
-                terms.insert(
-                    #field_name_lit.into(),
-                    dialog_query::Term::<dialog_query::types::Any>::from(source.#field_name),
-                );
-            });
-
-            optional_descriptor_pairs.push(quote! {
-                (
-                    #field_name_lit,
-                    <#inner_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
-                )
-            });
-
-            // IntoIterator / Statement: emit a relation only when `Some(_)`.
-            // None means "don't persist None" — there is no fact to record.
-            optional_statement_emits.push(quote! {
-                if let Some(__inner) = self.#field_name.as_ref() {
-                    let __expr = dialog_query::attribute::expression::dynamic::DynamicAttributeExpression {
-                        the: <#inner_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone(),
-                        of: self.this.clone(),
-                        is: dialog_query::Value::from(<#inner_type as dialog_query::Attribute>::value(__inner).clone()),
-                        cause: None,
-                        cardinality: Some(<#inner_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
-                    };
-                    __statements.push(__expr.into());
-                }
-            });
-
-            optional_field_names.push(field_name);
-            optional_field_name_lits.push(field_name_lit);
-            optional_inner_types.push(inner_type);
-            continue;
-        }
-
-        // Required (non-Option) field path.
-        let inner_value_ty = quote! { <#field_type as dialog_query::Attribute>::Type };
-
-        required_query_fields.push(quote! {
+        query_fields.push(quote! {
             #[doc = #query_field_doc_lit]
-            pub #field_name: dialog_query::Term<#inner_value_ty>
+            pub #field_name: #term_type
         });
 
-        required_terms_methods.push(quote! {
+        terms_methods.push(quote! {
             #[doc = #terms_method_doc_lit]
-            pub fn #field_name() -> dialog_query::Term<#inner_value_ty> {
-                dialog_query::Term::<#inner_value_ty>::var(#field_name_lit)
+            pub fn #field_name() -> #term_type {
+                <#term_type>::var(#field_name_lit)
             }
         });
 
-        required_realize_fields.push(quote! {
-            #field_name: #field_type(
-                source.lookup(&dialog_query::Term::from(&self.#field_name))?.content()?.try_into()?
-            )
+        // Realize via the trait method. Required and optional impls
+        // each handle their own Binding semantics.
+        realize_fields.push(quote! {
+            #field_name: <#field_type as dialog_query::ConceptField>::realize(
+                source.lookup(&dialog_query::Term::<dialog_query::types::Any>::from(&self.#field_name))?
+            )?
         });
 
-        required_param_inserts.push(quote! {
+        param_inserts.push(quote! {
             terms.insert(
                 #field_name_lit.into(),
                 dialog_query::Term::<dialog_query::types::Any>::from(source.#field_name),
             );
         });
 
-        required_descriptor_pairs.push(quote! {
-            (
-                #field_name_lit,
-                <#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
-            )
-        });
-
-        required_statement_emits.push(quote! {
+        // The descriptor for the attribute underlying this field —
+        // whether the field is `N` or `Option<N>`, the
+        // `<F as ConceptField>::Attribute` projection lifts to `N`,
+        // which is the type that carries the AttributeDescriptor.
+        // Routing into `with` vs `maybe` is decided at runtime via
+        // the RESOLUTION const.
+        descriptor_pair_pushes.push(quote! {
             {
-                let __expr = dialog_query::attribute::expression::dynamic::DynamicAttributeExpression {
-                    the: <#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone(),
-                    of: self.this.clone(),
-                    is: dialog_query::Value::from(<#field_type as dialog_query::Attribute>::value(&self.#field_name).clone()),
-                    cause: None,
-                    cardinality: Some(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
-                };
-                __statements.push(__expr.into());
+                let __pair = (
+                    #field_name_lit,
+                    <<#field_type as dialog_query::ConceptField>::Attribute
+                        as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
+                );
+                match <#field_type as dialog_query::ConceptField>::RESOLUTION {
+                    dialog_query::attribute::query::Resolution::Required => __with.push(__pair),
+                    dialog_query::attribute::query::Resolution::Optional => __maybe.push(__pair),
+                }
             }
         });
 
-        required_field_names.push(field_name);
-        required_field_name_lits.push(field_name_lit);
-        required_field_types.push(field_type);
+        // Statement emission via the trait method. The concept's
+        // `this` field is an `Entity` (concept structs always have
+        // `this: Entity`), passed through to each field's
+        // statement(s). Required impls push one statement; optional
+        // impls push zero or one depending on Some/None.
+        statement_emits.push(quote! {
+            <#field_type as dialog_query::ConceptField>::push_statements(
+                &self.#field_name,
+                self.this.clone(),
+                &mut __statements,
+            );
+        });
+
+        field_names.push(field_name);
+        field_name_lits.push(field_name_lit);
+        field_types.push(field_type);
     }
 
-    // The `assert_implements_attribute` validation needs to run on every
-    // attribute type, including those wrapped in `Option<T>`. Build a
-    // unified list of types to validate.
-    let validated_types: Vec<_> = required_field_types
-        .iter()
-        .map(|t| quote! { #t })
-        .chain(optional_inner_types.iter().map(|t| quote! { #t }))
-        .collect();
+    // Compile-time assertion list: every field type must implement
+    // ConceptField. The trait's blanket impls make this true for
+    // any `N: Attribute + Descriptor<AttributeDescriptor>` and for
+    // any `Option<N>` with the same bound on `N`.
+    let validated_types: Vec<_> = field_types.iter().map(|t| quote! { #t }).collect();
 
     // Generate type names based on struct name
     let query_name = syn::Ident::new(&format!("{}Query", struct_name), struct_name.span());
@@ -378,13 +295,17 @@ pub fn derive(input: TokenStream) -> TokenStream {
     );
 
     let expanded = quote! {
-        // Compile-time validation that all fields (except 'this') implement
-        // Attribute + Descriptor. Includes the inner type of any `Option<T>`
-        // field — `Option<T>` itself is not an Attribute.
+        // Compile-time validation that every concept field
+        // implements [`ConceptField`](dialog_query::ConceptField).
+        // The trait's two blanket impls cover both required
+        // `T: Attribute` and optional `Option<T>` shapes — anything
+        // outside that pair (e.g. `String`, a non-attribute newtype,
+        // `Option<Option<T>>`) fails this assertion with a clear
+        // bound-not-satisfied error.
         const _: () = {
-            fn assert_implements_attribute<T: dialog_query::Attribute + dialog_query::Descriptor<dialog_query::AttributeDescriptor>>() {}
+            fn assert_implements_concept_field<F: dialog_query::ConceptField>() {}
             fn #validate_fn_name() {
-                #(assert_implements_attribute::<#validated_types>();)*
+                #(assert_implements_concept_field::<#validated_types>();)*
             }
         };
 
@@ -393,16 +314,14 @@ pub fn derive(input: TokenStream) -> TokenStream {
         pub struct #query_name {
             #[doc = #query_this_field_doc]
             pub this: dialog_query::Term<dialog_query::Entity>,
-            #(#required_query_fields,)*
-            #(#optional_query_fields,)*
+            #(#query_fields,)*
         }
 
         impl Default for #query_name {
             fn default() -> Self {
                 Self {
                     this: dialog_query::Term::var("this"),
-                    #(#required_field_names: dialog_query::Term::var(#required_field_name_lits),)*
-                    #(#optional_field_names: dialog_query::Term::var(#optional_field_name_lits),)*
+                    #(#field_names: dialog_query::Term::var(#field_name_lits),)*
                 }
             }
         }
@@ -415,8 +334,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
             pub fn this() -> dialog_query::Term<dialog_query::Entity> {
                 dialog_query::Term::<dialog_query::Entity>::var("this")
             }
-            #(#required_terms_methods)*
-            #(#optional_terms_methods)*
+            #(#terms_methods)*
         }
 
         // Implement Application trait for the Query struct
@@ -442,8 +360,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                     this: dialog_query::Entity::try_from(
                         source.lookup(&dialog_query::Term::from(&self.this))?.content()?
                     )?,
-                    #(#required_realize_fields,)*
-                    #(#optional_realize_fields,)*
+                    #(#realize_fields,)*
                 })
             }
         }
@@ -471,8 +388,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
                 terms.insert("this".into(), dialog_query::Term::<dialog_query::types::Any>::from(source.this));
 
-                #(#required_param_inserts)*
-                #(#optional_param_inserts)*
+                #(#param_inserts)*
 
                 terms
             }
@@ -480,33 +396,27 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
         // Implement From<StructName> for ConceptDescriptor.
         //
-        // Required fields populate `with`; `Option<T>` fields populate
-        // `maybe`. The two slots are independent, and a concept may have
-        // either or both. The `Vec<(&str, AttributeDescriptor)>` annotation
-        // is necessary so type inference works when the optional list is
-        // empty (no `Option<T>` fields on the struct).
+        // Each field is routed into `with` or `maybe` at runtime
+        // based on its `<F as ConceptField>::RESOLUTION` const —
+        // `Required` fields populate `with`, `Optional` fields
+        // populate `maybe`. The two slots are independent, and a
+        // concept may have either or both.
         impl From<#struct_name> for dialog_query::ConceptDescriptor {
             fn from(_: #struct_name) -> Self {
-                let __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = vec![
-                    #(#optional_descriptor_pairs),*
-                ];
-                dialog_query::ConceptDescriptor::from(vec![
-                    #(#required_descriptor_pairs),*
-                ])
-                .with_maybe(__maybe)
+                let mut __with: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
+                let mut __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
+                #(#descriptor_pair_pushes)*
+                dialog_query::ConceptDescriptor::from(__with).with_maybe(__maybe)
             }
         }
 
         // Implement From<Query> for ConceptDescriptor
         impl From<#query_name> for dialog_query::ConceptDescriptor {
             fn from(_: #query_name) -> Self {
-                let __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = vec![
-                    #(#optional_descriptor_pairs),*
-                ];
-                dialog_query::ConceptDescriptor::from(vec![
-                    #(#required_descriptor_pairs),*
-                ])
-                .with_maybe(__maybe)
+                let mut __with: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
+                let mut __maybe: Vec<(&str, dialog_query::AttributeDescriptor)> = Vec::new();
+                #(#descriptor_pair_pushes)*
+                dialog_query::ConceptDescriptor::from(__with).with_maybe(__maybe)
             }
         }
 
@@ -589,8 +499,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
             fn into_iter(self) -> Self::IntoIter {
                 let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
-                #(#required_statement_emits)*
-                #(#optional_statement_emits)*
+                #(#statement_emits)*
                 __statements.into_iter()
             }
         }
@@ -599,8 +508,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         impl dialog_query::Statement for #struct_name {
             fn assert(self, update: &mut impl dialog_query::Update) {
                 let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
-                #(#required_statement_emits)*
-                #(#optional_statement_emits)*
+                #(#statement_emits)*
                 for __s in __statements {
                     dialog_query::Statement::assert(__s, update);
                 }
@@ -608,8 +516,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
             fn retract(self, update: &mut impl dialog_query::Update) {
                 let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
-                #(#required_statement_emits)*
-                #(#optional_statement_emits)*
+                #(#statement_emits)*
                 for __s in __statements {
                     dialog_query::Statement::retract(__s, update);
                 }
@@ -631,32 +538,38 @@ pub fn derive(input: TokenStream) -> TokenStream {
             type Descriptor = dialog_query::ConceptDescriptor;
         }
 
-        // Implement Rule trait — the body lists only required attribute
-        // queries. Optional (`Option<T>`) fields are resolved by a
-        // separate optional-resolution premise inside the concept
-        // descriptor's deductive-rule projection (see
-        // `From<&ConceptDescriptor> for DeductiveRule`).
+        // Implement Rule trait — emit one AttributeQuery per
+        // field, with resolution chosen by the field's
+        // `<F as ConceptField>::RESOLUTION` const. Required fields
+        // get the standard (Resolution::Required) attribute query;
+        // optional fields get the set-widened
+        // (Resolution::Optional) variant which yields an Absent
+        // fallback row when no fact matches.
         impl #struct_name {
             fn when(terms: dialog_query::Query<Self>) -> dialog_query::Premises {
-                let selectors: Vec<dialog_query::AttributeQuery> = vec![
-                    #(
-                        {
-                            let value_param = dialog_query::Term::<dialog_query::types::Any>::from(
-                                terms.#required_field_names.clone()
-                            );
-
-                            dialog_query::AttributeQuery::new(
-                                dialog_query::Term::Constant(dialog_query::Value::from(
-                                    <#required_field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone()
-                                )),
-                                terms.this.clone(),
-                                value_param,
-                                dialog_query::Term::blank(),
-                                Some(<#required_field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
-                            )
-                        }
-                    ),*
-                ];
+                let mut selectors: Vec<dialog_query::AttributeQuery> = Vec::new();
+                #(
+                    {
+                        let value_param = dialog_query::Term::<dialog_query::types::Any>::from(
+                            terms.#field_names.clone()
+                        );
+                        let descriptor = <<#field_types as dialog_query::ConceptField>::Attribute
+                            as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor();
+                        let the_term = dialog_query::Term::Constant(
+                            dialog_query::Value::from(descriptor.the().clone())
+                        );
+                        let cardinality = Some(descriptor.cardinality());
+                        let query = dialog_query::AttributeQuery::with_resolution(
+                            the_term,
+                            terms.this.clone(),
+                            value_param,
+                            dialog_query::Term::blank(),
+                            cardinality,
+                            <#field_types as dialog_query::ConceptField>::RESOLUTION,
+                        );
+                        selectors.push(query);
+                    }
+                )*
 
                 selectors.into()
             }

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -220,7 +220,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // `<F as ConceptField>::Attribute` projection lifts to `N`,
         // which is the type that carries the AttributeDescriptor.
         // Routing into `with` vs `maybe` is decided at runtime via
-        // the RESOLUTION const.
+        // the OPTIONAL const.
         descriptor_pair_pushes.push(quote! {
             {
                 let __pair = (
@@ -228,9 +228,10 @@ pub fn derive(input: TokenStream) -> TokenStream {
                     <<#field_type as dialog_query::ConceptField>::Attribute
                         as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
                 );
-                match <#field_type as dialog_query::ConceptField>::RESOLUTION {
-                    dialog_query::attribute::query::Resolution::Required => __with.push(__pair),
-                    dialog_query::attribute::query::Resolution::Optional => __maybe.push(__pair),
+                if <#field_type as dialog_query::ConceptField>::OPTIONAL {
+                    __maybe.push(__pair);
+                } else {
+                    __with.push(__pair);
                 }
             }
         });
@@ -539,33 +540,34 @@ pub fn derive(input: TokenStream) -> TokenStream {
         }
 
         // Implement Rule trait — emit one AttributeQuery per
-        // field, with resolution chosen by the field's
-        // `<F as ConceptField>::RESOLUTION` const. Required fields
-        // get the standard (Resolution::Required) attribute query;
-        // optional fields get the set-widened
-        // (Resolution::Optional) variant which yields an Absent
-        // fallback row when no fact matches.
+        // field. Required fields pass the user's term through
+        // unchanged; optional fields go through
+        // `<F as ConceptField>::is_term` which widens the slot's
+        // kind to admit the `Nothing` atom. AttributeQuery derives
+        // its resolution from that kind, so optional fields end up
+        // with set-widened semantics (an Absent fallback row when
+        // no fact matches).
         impl #struct_name {
             fn when(terms: dialog_query::Query<Self>) -> dialog_query::Premises {
                 let mut selectors: Vec<dialog_query::AttributeQuery> = Vec::new();
                 #(
                     {
-                        let value_param = dialog_query::Term::<dialog_query::types::Any>::from(
+                        let raw_param = dialog_query::Term::<dialog_query::types::Any>::from(
                             terms.#field_names.clone()
                         );
+                        let value_param = <#field_types as dialog_query::ConceptField>::term(raw_param);
                         let descriptor = <<#field_types as dialog_query::ConceptField>::Attribute
                             as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor();
                         let the_term = dialog_query::Term::Constant(
                             dialog_query::Value::from(descriptor.the().clone())
                         );
                         let cardinality = Some(descriptor.cardinality());
-                        let query = dialog_query::AttributeQuery::with_resolution(
+                        let query = dialog_query::AttributeQuery::new(
                             the_term,
                             terms.this.clone(),
                             value_param,
                             dialog_query::Term::blank(),
                             cardinality,
-                            <#field_types as dialog_query::ConceptField>::RESOLUTION,
                         );
                         selectors.push(query);
                     }

--- a/rust/dialog-macros/src/query/formula.rs
+++ b/rust/dialog-macros/src/query/formula.rs
@@ -252,7 +252,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         .iter()
         .map(|(name, ty, _, _, _)| {
             quote! {
-                #name: #ty::try_from(source.lookup(&dialog_query::Term::from(&self.#name))?)?
+                #name: #ty::try_from(source.lookup(&dialog_query::Term::from(&self.#name))?.content()?)?
             }
         })
         .collect();

--- a/rust/dialog-query/src/attribute/query.rs
+++ b/rust/dialog-query/src/attribute/query.rs
@@ -30,12 +30,10 @@ pub use typed::StaticAttributeQuery;
 ///   premise that wants set-widening optionality at the row
 ///   layer.
 ///
-/// Schema impact: `Resolution::Optional` lifts the `is` slot's
-/// `content_type` from `Type::Definite(...)` to
-/// `Type::Optional(...)` via
-/// [`Type::wrap_optional`](crate::type_system::Type::wrap_optional),
-/// signaling to the planner and unifier that this slot may bind
-/// to Absent.
+/// Schema impact: `Resolution::Optional` widens the `is` slot's
+/// `content_type` with the `Nothing` atom via
+/// [`Type::optional`](crate::type_system::Type::optional), signaling
+/// to the planner and unifier that this slot may bind to Absent.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Resolution {

--- a/rust/dialog-query/src/attribute/query.rs
+++ b/rust/dialog-query/src/attribute/query.rs
@@ -7,6 +7,43 @@ pub mod only;
 /// Typed attribute query wrapping a single `Attribute` type.
 pub mod typed;
 
+use serde::{Deserialize, Serialize};
+
 pub use dynamic::DynamicAttributeQuery;
 pub use dynamic::DynamicAttributeQuery as AttributeQuery;
 pub use typed::StaticAttributeQuery;
+
+/// Resolution policy for an attribute query.
+///
+/// Distinguishes the two row-multiplicity semantics independent of
+/// [`Cardinality`](crate::Cardinality), which controls how many
+/// rows a fact lookup *can* produce. `Resolution` controls what
+/// happens when a fact lookup *finds nothing*:
+///
+/// - [`Resolution::Required`] — the lookup yields zero rows on
+///   miss. Standard EAV semantics: a query that demands a fact
+///   filters out input rows that lack one. This is the default.
+/// - [`Resolution::Optional`] — the lookup yields one fallback
+///   row on miss, with the `is` slot (and the named `cause` slot,
+///   if any) bound to [`Binding::Absent`](crate::Binding::Absent).
+///   Used by concept projection for `maybe` fields and by any
+///   premise that wants set-widening optionality at the row
+///   layer.
+///
+/// Schema impact: `Resolution::Optional` lifts the `is` slot's
+/// `content_type` from `Type::Definite(...)` to
+/// `Type::Optional(...)` via
+/// [`Type::wrap_optional`](crate::type_system::Type::wrap_optional),
+/// signaling to the planner and unifier that this slot may bind
+/// to Absent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Resolution {
+    /// Standard EAV: zero rows when no fact matches the lookup.
+    #[default]
+    Required,
+    /// Yield one fallback row when no fact matches; the `is`
+    /// (and named `cause`) slot bind to
+    /// [`Binding::Absent`](crate::Binding::Absent).
+    Optional,
+}

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -138,7 +138,7 @@ impl AttributeQueryAll {
             "the".to_string(),
             Field {
                 description: "The relation identifier".to_string(),
-                content_type: Some(Type::Symbol),
+                content_type: Some(Type::Symbol).into(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -148,7 +148,7 @@ impl AttributeQueryAll {
             "of".to_string(),
             Field {
                 description: "Entity of the relation".to_string(),
-                content_type: Some(Type::Entity),
+                content_type: Some(Type::Entity).into(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -158,7 +158,7 @@ impl AttributeQueryAll {
             "is".to_string(),
             Field {
                 description: "Value of the relation".to_string(),
-                content_type: None,
+                content_type: None.into(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -466,5 +466,64 @@ mod tests {
         assert_eq!(results[0].is(), &Value::String("Alice".to_string()));
 
         Ok(())
+    }
+
+    /// `AttributeQueryAll::schema()` declares the `the` slot as
+    /// `Type::Definite(Primitive(Symbol))`. Storage selectors
+    /// rely on this to filter facts by attribute identifier.
+    #[dialog_common::test]
+    fn schema_the_slot_is_definite_symbol() {
+        use crate::type_system::Definite;
+        let query = AttributeQueryAll::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+        );
+        let schema = query.schema();
+        let the = schema.get("the").expect("the field present");
+        assert!(!the.content_type.is_optional());
+        assert_eq!(the.content_type.shape().as_singleton(), Some(Type::Symbol));
+        // Constraint type isn't a variable — it's a concrete primitive.
+        assert!(matches!(the.content_type.shape(), Definite::Primitive(_)));
+    }
+
+    /// `AttributeQueryAll::schema()` declares the `of` slot as
+    /// `Type::Definite(Primitive(Entity))`.
+    #[dialog_common::test]
+    fn schema_of_slot_is_definite_entity() {
+        let query = AttributeQueryAll::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+        );
+        let schema = query.schema();
+        let of = schema.get("of").expect("of field present");
+        assert_eq!(of.content_type.shape().as_singleton(), Some(Type::Entity));
+    }
+
+    /// `AttributeQueryAll::schema()` declares the `is` slot as
+    /// `Type::any()` — an anonymous type variable. The slot
+    /// accepts any value type at runtime; the unifier narrows
+    /// based on what other premises declare for the same
+    /// rule-level variable.
+    #[dialog_common::test]
+    fn schema_is_slot_is_anonymous_variable() {
+        use crate::type_system::Definite;
+        let query = AttributeQueryAll::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+        );
+        let schema = query.schema();
+        let is = schema.get("is").expect("is field present");
+        assert!(!is.content_type.is_optional());
+        assert!(
+            matches!(is.content_type.shape(), Definite::Variable(_)),
+            "expected anonymous variable, got {:?}",
+            is.content_type.shape()
+        );
     }
 }

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -193,16 +193,15 @@ impl AttributeQueryAll {
 
         // Pull the kind from the `is` term. `None` means "no
         // static info" — the unifier resolves at rule-compile
-        // time. For `Optional` resolution, the slot must carry an
-        // Optional-shaped kind so the planner sees set-widening
-        // even when the underlying primitive shape is unknown.
-        use crate::type_system::PrimitiveSet;
+        // time. For `Optional` resolution, the slot must admit the
+        // `Nothing` atom so the planner sees set-widening even
+        // when the underlying primitive shape is unknown.
         let is_content = match (self.is.kind(), self.resolution) {
             (Some(k), Resolution::Required) => Some(k),
-            (Some(k), Resolution::Optional) => Some(k.wrap_optional()),
+            (Some(k), Resolution::Optional) => Some(k.optional()),
             (None, Resolution::Required) => None,
             (None, Resolution::Optional) => {
-                Some(type_system::Type::optional_set(PrimitiveSet::ALL))
+                Some(type_system::Type::primitive_set(type_system::Primitive::ALL).optional())
             }
         };
         schema.insert(
@@ -544,10 +543,9 @@ mod tests {
     }
 
     /// `AttributeQueryAll::schema()` declares the `the` slot as
-    /// `Type::Definite(Primitive(Symbol))`.
+    /// a singleton primitive over `Symbol`.
     #[dialog_common::test]
-    fn schema_the_slot_is_definite_symbol() {
-        use crate::type_system::Definite;
+    fn schema_the_slot_is_primitive_symbol() {
         let query = AttributeQueryAll::new(
             Term::var("the"),
             Term::var("of"),
@@ -558,14 +556,14 @@ mod tests {
         let the = schema.get("the").expect("the field present");
         let content = the.content_type().expect("symbol kind present");
         assert!(!content.is_optional());
-        assert_eq!(content.shape().as_singleton(), Some(Type::Symbol));
-        assert!(matches!(content.shape(), Definite::Primitive(_)));
+        assert_eq!(content.as_value_type(), Some(Type::Symbol));
+        assert!(matches!(content, type_system::Type::Primitive(_)));
     }
 
     /// `AttributeQueryAll::schema()` declares the `of` slot as
-    /// `Type::Definite(Primitive(Entity))`.
+    /// a singleton primitive over `Entity`.
     #[dialog_common::test]
-    fn schema_of_slot_is_definite_entity() {
+    fn schema_of_slot_is_primitive_entity() {
         let query = AttributeQueryAll::new(
             Term::var("the"),
             Term::var("of"),
@@ -575,7 +573,7 @@ mod tests {
         let schema = query.schema();
         let of = schema.get("of").expect("of field present");
         let content = of.content_type().expect("entity kind present");
-        assert_eq!(content.shape().as_singleton(), Some(Type::Entity));
+        assert_eq!(content.as_value_type(), Some(Type::Entity));
     }
 
     /// `AttributeQueryAll::schema()` declares the `is` slot as

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -83,10 +83,11 @@ impl AttributeQueryAll {
     }
 
     /// Return a copy of this query with the `is` term replaced.
-    /// Used by the planner at evaluation time to narrow the slot
-    /// to the rule-inferred kind without mutating the user's
-    /// original premise.
-    pub fn with_is(self, is: Term<Any>) -> Self {
+    /// Internal hook used by the planner to stamp rule-inferred
+    /// kinds onto the term before evaluation. Not for external
+    /// callers — user-supplied queries should construct fresh
+    /// instances via [`new`](Self::new).
+    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
         Self { is, ..self }
     }
 

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -82,6 +82,14 @@ impl AttributeQueryAll {
         &self.is
     }
 
+    /// Return a copy of this query with the `is` term replaced.
+    /// Used by the planner at evaluation time to narrow the slot
+    /// to the rule-inferred kind without mutating the user's
+    /// original premise.
+    pub fn with_is(self, is: Term<Any>) -> Self {
+        Self { is, ..self }
+    }
+
     /// Get the 'cause' term.
     pub fn cause(&self) -> &Term<Cause> {
         &self.cause

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -38,52 +38,33 @@ pub struct AttributeQueryAll {
     cause: Term<Cause>,
     /// Internal handle for claim storage.
     source: Term<Record>,
-    /// Resolution policy: `Required` (zero rows on miss, the
-    /// default) or `Optional` (yield one Absent fallback row on
-    /// miss). See [`Resolution`](crate::attribute::query::Resolution).
-    #[serde(default, skip_serializing_if = "is_required_resolution")]
-    resolution: Resolution,
-}
-
-fn is_required_resolution(r: &Resolution) -> bool {
-    matches!(r, Resolution::Required)
 }
 
 impl AttributeQueryAll {
-    /// Create a new attribute query that yields all matches with
-    /// `Resolution::Required` semantics — zero rows on miss.
-    pub fn new(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
-        Self::with_resolution(the, of, is, cause, Resolution::Required)
-    }
-
-    /// Create a new attribute query that yields all matches with
-    /// `Resolution::Optional` semantics — one Absent fallback row
+    /// Create a new attribute query. The resolution policy is
+    /// derived from `is`'s kind: a set-widened (`Nothing`-bit-set)
+    /// kind yields [`Resolution::Optional`] — one Absent fallback
+    /// row on miss; otherwise [`Resolution::Required`] — zero rows
     /// on miss.
-    pub fn optional(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
-        Self::with_resolution(the, of, is, cause, Resolution::Optional)
-    }
-
-    /// Create a new attribute query with explicit resolution.
-    pub fn with_resolution(
-        the: Term<The>,
-        of: Term<Entity>,
-        is: Term<Any>,
-        cause: Term<Cause>,
-        resolution: Resolution,
-    ) -> Self {
+    pub fn new(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
         Self {
             the,
             of,
             is,
             cause,
             source: Term::<Record>::unique(),
-            resolution,
         }
     }
 
-    /// Returns the resolution policy of this query.
+    /// Resolution policy derived from `is`'s kind. A set-widened
+    /// `is` (admits `Nothing`) is [`Resolution::Optional`];
+    /// otherwise [`Resolution::Required`].
     pub fn resolution(&self) -> Resolution {
-        self.resolution
+        if self.is.is_optional() {
+            Resolution::Optional
+        } else {
+            Resolution::Required
+        }
     }
 
     /// Get the 'the' (attribute) term.
@@ -162,7 +143,6 @@ impl AttributeQueryAll {
             is,
             cause,
             source: self.source.clone(),
-            resolution: self.resolution,
         }
     }
 
@@ -191,35 +171,26 @@ impl AttributeQueryAll {
             },
         );
 
-        // Pull the kind from the `is` term. `None` means "no
-        // static info" — the unifier resolves at rule-compile
-        // time. For `Optional` resolution, the slot must admit the
-        // `Nothing` atom so the planner sees set-widening even
-        // when the underlying primitive shape is unknown.
-        let is_content = match (self.is.kind(), self.resolution) {
-            (Some(k), Resolution::Required) => Some(k),
-            (Some(k), Resolution::Optional) => Some(k.optional()),
-            (None, Resolution::Required) => None,
-            (None, Resolution::Optional) => {
-                Some(type_system::Type::primitive_set(type_system::Primitive::ALL).optional())
-            }
-        };
+        // The `is` term's kind already encodes optionality via the
+        // `Nothing` atom. `None` means "no static info" — the
+        // unifier resolves at rule-compile time.
         schema.insert(
             "is".to_string(),
             Field {
                 description: "Value of the relation".to_string(),
-                content_type: is_content,
+                content_type: self.is.kind(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
         );
 
         // The `cause` slot is bound by the merge step on every
-        // Present row; for Optional resolution the fallback row
-        // binds it to `Absent`, so the slot is set-widened.
-        let cause_content = match self.resolution {
-            Resolution::Required => type_system::Type::primitive(Type::Bytes),
-            Resolution::Optional => type_system::Type::primitive(Type::Bytes).optional(),
+        // Present row; when the query is optional the fallback
+        // row binds it to `Absent`, so the slot is set-widened.
+        let cause_content = if self.is.is_optional() {
+            type_system::Type::primitive(Type::Bytes).optional()
+        } else {
+            type_system::Type::primitive(Type::Bytes)
         };
         schema.insert(
             "cause".to_string(),
@@ -293,7 +264,7 @@ impl AttributeQueryAll {
                 // this input and the resolution is Optional, yield
                 // one row with `is` (and named `cause`) bound to
                 // Absent.
-                if !produced && matches!(selector.resolution, Resolution::Optional) {
+                if !produced && selector.is.is_optional() {
                     let mut fallback = base;
                     fallback.bind_absent(&selector.is)?;
                     let cause_term: Term<Any> = Term::<Any>::from(&selector.cause);

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -214,6 +214,23 @@ impl AttributeQueryAll {
             },
         );
 
+        // The `cause` slot is bound by the merge step on every
+        // Present row; for Optional resolution the fallback row
+        // binds it to `Absent`, so the slot is set-widened.
+        let cause_content = match self.resolution {
+            Resolution::Required => type_system::Type::primitive(Type::Bytes),
+            Resolution::Optional => type_system::Type::primitive(Type::Bytes).optional(),
+        };
+        schema.insert(
+            "cause".to_string(),
+            Field {
+                description: "Causal stamp of the relation".to_string(),
+                content_type: Some(cause_content),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+
         schema
     }
 
@@ -233,6 +250,7 @@ impl AttributeQueryAll {
         params.insert("the".to_string(), Term::<Any>::from(&self.the));
         params.insert("of".to_string(), Term::<Any>::from(&self.of));
         params.insert("is".to_string(), self.is.clone());
+        params.insert("cause".to_string(), Term::<Any>::from(&self.cause));
         params
     }
 

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -108,11 +108,13 @@ impl AttributeQueryAll {
         Ok(())
     }
 
-    /// Resolves variables from the given match.
+    /// Resolves variables from the given match. `Absent` bindings
+    /// leave the term unchanged (same as unbound) — only Present
+    /// bindings substitute.
     pub fn resolve(&self, source: &Match) -> Self {
         let the = self.the.resolve(source);
         let of = self.of.resolve(source);
-        let is = match source.lookup(&self.is) {
+        let is = match source.lookup(&self.is).and_then(|b| b.content()) {
             Ok(value) => Term::Constant(value),
             Err(_) => self.is.clone(),
         };

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -2,11 +2,13 @@ use crate::Cardinality;
 use crate::Claim;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
 use crate::attribute::The;
+use crate::attribute::query::Resolution;
 use crate::environment::Environment;
 use crate::query::Application;
 use crate::query::Output;
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
+use crate::type_system;
 use crate::types::{Any, Record};
 use crate::{
     Entity, EvaluationError, Field, Parameters, Requirement, Schema, Term, Type, Value, try_stream,
@@ -36,18 +38,52 @@ pub struct AttributeQueryAll {
     cause: Term<Cause>,
     /// Internal handle for claim storage.
     source: Term<Record>,
+    /// Resolution policy: `Required` (zero rows on miss, the
+    /// default) or `Optional` (yield one Absent fallback row on
+    /// miss). See [`Resolution`](crate::attribute::query::Resolution).
+    #[serde(default, skip_serializing_if = "is_required_resolution")]
+    resolution: Resolution,
+}
+
+fn is_required_resolution(r: &Resolution) -> bool {
+    matches!(r, Resolution::Required)
 }
 
 impl AttributeQueryAll {
-    /// Create a new attribute query that yields all matches.
+    /// Create a new attribute query that yields all matches with
+    /// `Resolution::Required` semantics — zero rows on miss.
     pub fn new(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
+        Self::with_resolution(the, of, is, cause, Resolution::Required)
+    }
+
+    /// Create a new attribute query that yields all matches with
+    /// `Resolution::Optional` semantics — one Absent fallback row
+    /// on miss.
+    pub fn optional(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
+        Self::with_resolution(the, of, is, cause, Resolution::Optional)
+    }
+
+    /// Create a new attribute query with explicit resolution.
+    pub fn with_resolution(
+        the: Term<The>,
+        of: Term<Entity>,
+        is: Term<Any>,
+        cause: Term<Cause>,
+        resolution: Resolution,
+    ) -> Self {
         Self {
             the,
             of,
             is,
             cause,
             source: Term::<Record>::unique(),
+            resolution,
         }
+    }
+
+    /// Returns the resolution policy of this query.
+    pub fn resolution(&self) -> Resolution {
+        self.resolution
     }
 
     /// Get the 'the' (attribute) term.
@@ -126,6 +162,7 @@ impl AttributeQueryAll {
             is,
             cause,
             source: self.source.clone(),
+            resolution: self.resolution,
         }
     }
 
@@ -154,11 +191,21 @@ impl AttributeQueryAll {
             },
         );
 
+        // Pull the underlying value-type tag from the `is` term's
+        // descriptor. `Some(vt)` lifts to `Definite(Primitive(vt))`;
+        // `None` lifts to an anonymous variable. If the resolution
+        // is `Optional`, wrap the result in `Type::Optional` so the
+        // planner sees the slot as set-widened.
+        let is_content: type_system::Type = self.is.content_type().into();
+        let is_content = match self.resolution {
+            Resolution::Required => is_content,
+            Resolution::Optional => is_content.wrap_optional(),
+        };
         schema.insert(
             "is".to_string(),
             Field {
                 description: "Value of the relation".to_string(),
-                content_type: None.into(),
+                content_type: is_content,
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -187,6 +234,16 @@ impl AttributeQueryAll {
     }
 
     /// Evaluate yielding all matching artifacts.
+    ///
+    /// With [`Resolution::Required`] (the default), zero rows are
+    /// yielded for an input when no fact matches the lookup —
+    /// standard EAV semantics.
+    ///
+    /// With [`Resolution::Optional`], if no fact matches for an
+    /// input row, a single fallback row is yielded with the `is`
+    /// slot (and the `cause` slot, if a named variable) bound to
+    /// [`Binding::Absent`](crate::Binding::Absent). This is the
+    /// row-layer signal for "we looked, no fact found."
     pub fn evaluate<'a, Env, M: Selection + 'a>(
         self,
         env: &'a Env,
@@ -201,12 +258,26 @@ impl AttributeQueryAll {
                 let base = candidate?;
                 let selection = selector.resolve(&base);
 
+                let mut produced = false;
                 let stream = Provider::<Select<'_>>::execute(env, (&selection).try_into()?).await?;
                 for await artifact in stream {
                     let artifact = artifact?;
                     let mut extension = base.clone();
                     selector.merge(&mut extension, &artifact)?;
+                    produced = true;
                     yield extension;
+                }
+
+                // Optional fallback: if no rows were produced for
+                // this input and the resolution is Optional, yield
+                // one row with `is` (and named `cause`) bound to
+                // Absent.
+                if !produced && matches!(selector.resolution, Resolution::Optional) {
+                    let mut fallback = base;
+                    fallback.bind_absent(&selector.is)?;
+                    let cause_term: Term<Any> = Term::<Any>::from(&selector.cause);
+                    fallback.bind_absent(&cause_term)?;
+                    yield fallback;
                 }
             }
         }

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -175,7 +175,7 @@ impl AttributeQueryAll {
             "the".to_string(),
             Field {
                 description: "The relation identifier".to_string(),
-                content_type: Some(Type::Symbol).into(),
+                content_type: Some(type_system::Type::primitive(Type::Symbol)),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -185,21 +185,25 @@ impl AttributeQueryAll {
             "of".to_string(),
             Field {
                 description: "Entity of the relation".to_string(),
-                content_type: Some(Type::Entity).into(),
+                content_type: Some(type_system::Type::primitive(Type::Entity)),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
         );
 
-        // Pull the underlying value-type tag from the `is` term's
-        // descriptor. `Some(vt)` lifts to `Definite(Primitive(vt))`;
-        // `None` lifts to an anonymous variable. If the resolution
-        // is `Optional`, wrap the result in `Type::Optional` so the
-        // planner sees the slot as set-widened.
-        let is_content: type_system::Type = self.is.content_type().into();
-        let is_content = match self.resolution {
-            Resolution::Required => is_content,
-            Resolution::Optional => is_content.wrap_optional(),
+        // Pull the kind from the `is` term. `None` means "no
+        // static info" — the unifier resolves at rule-compile
+        // time. For `Optional` resolution, the slot must carry an
+        // Optional-shaped kind so the planner sees set-widening
+        // even when the underlying primitive shape is unknown.
+        use crate::type_system::PrimitiveSet;
+        let is_content = match (self.is.kind(), self.resolution) {
+            (Some(k), Resolution::Required) => Some(k),
+            (Some(k), Resolution::Optional) => Some(k.wrap_optional()),
+            (None, Resolution::Required) => None,
+            (None, Resolution::Optional) => {
+                Some(type_system::Type::optional_set(PrimitiveSet::ALL))
+            }
         };
         schema.insert(
             "is".to_string(),
@@ -540,8 +544,7 @@ mod tests {
     }
 
     /// `AttributeQueryAll::schema()` declares the `the` slot as
-    /// `Type::Definite(Primitive(Symbol))`. Storage selectors
-    /// rely on this to filter facts by attribute identifier.
+    /// `Type::Definite(Primitive(Symbol))`.
     #[dialog_common::test]
     fn schema_the_slot_is_definite_symbol() {
         use crate::type_system::Definite;
@@ -553,10 +556,10 @@ mod tests {
         );
         let schema = query.schema();
         let the = schema.get("the").expect("the field present");
-        assert!(!the.content_type.is_optional());
-        assert_eq!(the.content_type.shape().as_singleton(), Some(Type::Symbol));
-        // Constraint type isn't a variable — it's a concrete primitive.
-        assert!(matches!(the.content_type.shape(), Definite::Primitive(_)));
+        let content = the.content_type().expect("symbol kind present");
+        assert!(!content.is_optional());
+        assert_eq!(content.shape().as_singleton(), Some(Type::Symbol));
+        assert!(matches!(content.shape(), Definite::Primitive(_)));
     }
 
     /// `AttributeQueryAll::schema()` declares the `of` slot as
@@ -571,17 +574,15 @@ mod tests {
         );
         let schema = query.schema();
         let of = schema.get("of").expect("of field present");
-        assert_eq!(of.content_type.shape().as_singleton(), Some(Type::Entity));
+        let content = of.content_type().expect("entity kind present");
+        assert_eq!(content.shape().as_singleton(), Some(Type::Entity));
     }
 
     /// `AttributeQueryAll::schema()` declares the `is` slot as
-    /// `Type::any()` — an anonymous type variable. The slot
-    /// accepts any value type at runtime; the unifier narrows
-    /// based on what other premises declare for the same
-    /// rule-level variable.
+    /// `None` (unknown) when the term carries no static info —
+    /// the unifier narrows at rule-compile time.
     #[dialog_common::test]
-    fn schema_is_slot_is_anonymous_variable() {
-        use crate::type_system::Definite;
+    fn schema_is_slot_is_unknown_when_untyped() {
         let query = AttributeQueryAll::new(
             Term::var("the"),
             Term::var("of"),
@@ -590,11 +591,9 @@ mod tests {
         );
         let schema = query.schema();
         let is = schema.get("is").expect("is field present");
-        assert!(!is.content_type.is_optional());
         assert!(
-            matches!(is.content_type.shape(), Definite::Variable(_)),
-            "expected anonymous variable, got {:?}",
-            is.content_type.shape()
+            is.content_type().is_none(),
+            "untyped `is` term should yield unknown content_type"
         );
     }
 }

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -8,7 +8,7 @@ use crate::query::Application;
 use crate::query::Output;
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
-use crate::type_system;
+use crate::type_system::Type as Kind;
 use crate::types::{Any, Record};
 use crate::{
     Entity, EvaluationError, Field, Parameters, Requirement, Schema, Term, Type, Value, try_stream,
@@ -155,7 +155,7 @@ impl AttributeQueryAll {
             "the".to_string(),
             Field {
                 description: "The relation identifier".to_string(),
-                content_type: Some(type_system::Type::primitive(Type::Symbol)),
+                content_type: Some(Kind::primitive(Type::Symbol)),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -165,7 +165,7 @@ impl AttributeQueryAll {
             "of".to_string(),
             Field {
                 description: "Entity of the relation".to_string(),
-                content_type: Some(type_system::Type::primitive(Type::Entity)),
+                content_type: Some(Kind::primitive(Type::Entity)),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -188,9 +188,9 @@ impl AttributeQueryAll {
         // Present row; when the query is optional the fallback
         // row binds it to `Absent`, so the slot is set-widened.
         let cause_content = if self.is.is_optional() {
-            type_system::Type::primitive(Type::Bytes).optional()
+            Kind::primitive(Type::Bytes).optional()
         } else {
-            type_system::Type::primitive(Type::Bytes)
+            Kind::primitive(Type::Bytes)
         };
         schema.insert(
             "cause".to_string(),
@@ -546,7 +546,7 @@ mod tests {
         let content = the.content_type().expect("symbol kind present");
         assert!(!content.is_optional());
         assert_eq!(content.as_value_type(), Some(Type::Symbol));
-        assert!(matches!(content, type_system::Type::Primitive(_)));
+        assert!(matches!(content, Kind::Primitive(_)));
     }
 
     /// `AttributeQueryAll::schema()` declares the `of` slot as

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -259,6 +259,12 @@ impl AttributeQueryAll {
                 let base = candidate?;
                 let selection = selector.resolve(&base);
 
+                // The entity must be determined for the Absent
+                // fallback to mean anything: "this entity has no such
+                // fact." An unbound entity would manufacture a phantom
+                // Absent row not tied to any concrete entity.
+                let entity_known = selection.of().is_constant();
+
                 let mut produced = false;
                 let stream = Provider::<Select<'_>>::execute(env, (&selection).try_into()?).await?;
                 for await artifact in stream {
@@ -269,11 +275,26 @@ impl AttributeQueryAll {
                     yield extension;
                 }
 
-                // Optional fallback: if no rows were produced for
-                // this input and the resolution is Optional, yield
-                // one row with `is` (and named `cause`) bound to
-                // Absent.
-                if !produced && selector.is.is_optional() {
+                // Optional fallback: yield one Absent row only when
+                // the attribute is genuinely absent for a known
+                // entity. Guards:
+                //   - `!produced`: no fact row covered this input.
+                //   - `selector.is.is_optional()`: the slot admits
+                //     absence.
+                //   - `entity_known`: absence is about a concrete
+                //     entity, not an unbound scan.
+                //   - `!base.is_present(&selector.is)`: the value
+                //     wasn't already pinned to a Present binding. When
+                //     it was, an empty scan is a value *mismatch*
+                //     (the value-keyed scan found nothing equal to the
+                //     pinned value), not absence — and binding that
+                //     Present variable to Absent would error and abort
+                //     the stream.
+                if !produced
+                    && selector.is.is_optional()
+                    && entity_known
+                    && !base.is_present(&selector.is)
+                {
                     let mut fallback = base;
                     fallback.bind_absent(&selector.is)?;
                     let cause_term: Term<Any> = Term::<Any>::from(&selector.cause);
@@ -409,6 +430,61 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].of(), &alice);
         assert_eq!(results[0].is(), &Value::String("Alice".to_string()));
+
+        Ok(())
+    }
+
+    /// An *optional* `is` whose variable was pre-bound to a value the
+    /// entity does not have must not emit an Absent fallback. The
+    /// value-keyed scan finds nothing equal to the pinned value, but
+    /// that is a value *mismatch*, not absence — the attribute exists
+    /// with a different value. Before the fix, the fallback fired and
+    /// tried to bind the already-Present `is` variable to Absent,
+    /// which errors and aborts the stream.
+    #[dialog_common::test]
+    async fn it_does_not_emit_absent_on_optional_value_mismatch() -> anyhow::Result<()> {
+        use crate::selection::Match;
+        use crate::types::Any;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let bob = Entity::new()?;
+
+        // Bob HAS a nickname, but it is "Bobby".
+        branch
+            .transaction()
+            .assert(
+                the!("person/nickname")
+                    .of(bob.clone())
+                    .is("Bobby".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let optional_is: Term<Any> = Term::<Option<String>>::var("nickname").into();
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/nickname")),
+            Term::from(bob.clone()),
+            optional_is.clone(),
+            Term::var("cause"),
+        );
+
+        // An earlier premise pinned ?nickname to "Ali" — not Bob's.
+        let mut seed = Match::new();
+        seed.bind(&optional_is, Value::from("Ali".to_string()))?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(query, seed.seed(), &source)).await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a value mismatch on an optional field is not absence — no Absent fallback"
+        );
 
         Ok(())
     }

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -96,9 +96,9 @@ impl DynamicAttributeQuery {
         }
     }
 
-    /// Return a copy with the `is` term replaced. See
-    /// [`AttributeQueryAll::with_is`].
-    pub fn with_is(self, is: Term<Any>) -> Self {
+    /// Return a copy with the `is` term replaced. Internal hook;
+    /// see [`AttributeQueryAll::with_is`].
+    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
         match self {
             DynamicAttributeQuery::All(q) => DynamicAttributeQuery::All(q.with_is(is)),
             DynamicAttributeQuery::Only(q) => DynamicAttributeQuery::Only(q.with_is(is)),

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -96,6 +96,15 @@ impl DynamicAttributeQuery {
         }
     }
 
+    /// Return a copy with the `is` term replaced. See
+    /// [`AttributeQueryAll::with_is`].
+    pub fn with_is(self, is: Term<Any>) -> Self {
+        match self {
+            DynamicAttributeQuery::All(q) => DynamicAttributeQuery::All(q.with_is(is)),
+            DynamicAttributeQuery::Only(q) => DynamicAttributeQuery::Only(q.with_is(is)),
+        }
+    }
+
     /// Get the 'cause' term.
     pub fn cause(&self) -> &Term<Cause> {
         match self {

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -977,8 +977,8 @@ mod tests {
     }
 
     /// Required-resolution schema declares the `is` slot as a
-    /// concrete (Definite) type or unknown — the slot demands a
-    /// Present value.
+    /// concrete type or unknown — the slot demands a Present
+    /// value (no `Nothing` bit).
     #[dialog_common::test]
     fn required_resolution_schema_is_definite() {
         let q = DynamicAttributeQuery::new(
@@ -1020,8 +1020,7 @@ mod tests {
 
     /// When the `is` term is a typed `Term<Any>` carrying a known
     /// value type, Optional resolution produces a schema whose
-    /// `is` slot is `Type::Optional(Primitive(vt))` — preserving
-    /// the underlying type through the Optional wrap.
+    /// `is` slot admits both that type and `Nothing`.
     #[dialog_common::test]
     fn optional_typed_is_preserves_inner_type() {
         use crate::artifact::Type as ValueType;
@@ -1041,9 +1040,8 @@ mod tests {
         let is = schema.get("is").expect("is field present");
         let content = is.content_type().expect("content_type present");
         assert!(content.is_optional());
-        assert_eq!(
-            content.shape().as_singleton(),
-            Some(ValueType::String),
+        assert!(
+            content.primitive_part().contains(ValueType::String),
             "Optional wrap preserves the inner primitive type"
         );
     }

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -2,6 +2,7 @@ use crate::Cardinality;
 use crate::Claim;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
 use crate::attribute::The;
+use crate::attribute::query::Resolution;
 use crate::environment::Environment;
 use crate::negation::Negation;
 use crate::proposition::Proposition;
@@ -40,6 +41,7 @@ pub enum DynamicAttributeQuery {
 
 impl DynamicAttributeQuery {
     /// Create a new attribute query with the given cardinality.
+    /// Resolution defaults to [`Resolution::Required`].
     ///
     /// `None` or `Some(Cardinality::Many)` → `All` variant.
     /// `Some(Cardinality::One)` → `Only` variant.
@@ -50,11 +52,46 @@ impl DynamicAttributeQuery {
         cause: Term<Cause>,
         cardinality: Option<Cardinality>,
     ) -> Self {
+        Self::with_resolution(the, of, is, cause, cardinality, Resolution::Required)
+    }
+
+    /// Create a new attribute query with [`Resolution::Optional`]
+    /// — yields one Absent fallback row on miss.
+    pub fn optional(
+        the: Term<The>,
+        of: Term<Entity>,
+        is: Term<Any>,
+        cause: Term<Cause>,
+        cardinality: Option<Cardinality>,
+    ) -> Self {
+        Self::with_resolution(the, of, is, cause, cardinality, Resolution::Optional)
+    }
+
+    /// Create a new attribute query with explicit cardinality and
+    /// resolution.
+    pub fn with_resolution(
+        the: Term<The>,
+        of: Term<Entity>,
+        is: Term<Any>,
+        cause: Term<Cause>,
+        cardinality: Option<Cardinality>,
+        resolution: Resolution,
+    ) -> Self {
         match cardinality {
-            Some(Cardinality::One) => {
-                DynamicAttributeQuery::Only(AttributeQueryOnly::new(the, of, is, cause))
-            }
-            _ => DynamicAttributeQuery::All(AttributeQueryAll::new(the, of, is, cause)),
+            Some(Cardinality::One) => DynamicAttributeQuery::Only(
+                AttributeQueryOnly::with_resolution(the, of, is, cause, resolution),
+            ),
+            _ => DynamicAttributeQuery::All(AttributeQueryAll::with_resolution(
+                the, of, is, cause, resolution,
+            )),
+        }
+    }
+
+    /// Returns the resolution policy of this query.
+    pub fn resolution(&self) -> Resolution {
+        match self {
+            DynamicAttributeQuery::All(q) => q.resolution(),
+            DynamicAttributeQuery::Only(q) => q.resolution(),
         }
     }
 
@@ -881,6 +918,227 @@ mod tests {
         assert_eq!(results[0].of(), &alice);
         assert_eq!(results[0].is(), &crate::Value::String("Alice".into()));
 
+        Ok(())
+    }
+
+    /// `DynamicAttributeQuery::new` defaults to
+    /// `Resolution::Required` — the existing semantics.
+    #[dialog_common::test]
+    fn new_defaults_to_required_resolution() {
+        let q = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            None,
+        );
+        assert_eq!(q.resolution(), Resolution::Required);
+    }
+
+    /// `DynamicAttributeQuery::optional` constructs a query with
+    /// `Resolution::Optional`.
+    #[dialog_common::test]
+    fn optional_constructor_sets_optional_resolution() {
+        let q = DynamicAttributeQuery::optional(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            None,
+        );
+        assert_eq!(q.resolution(), Resolution::Optional);
+    }
+
+    /// `DynamicAttributeQuery::with_resolution` propagates
+    /// resolution through both `All` (Many cardinality) and
+    /// `Only` (One cardinality) variants.
+    #[dialog_common::test]
+    fn with_resolution_propagates_through_variants() {
+        let many = DynamicAttributeQuery::with_resolution(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            Some(Cardinality::Many),
+            Resolution::Optional,
+        );
+        let one = DynamicAttributeQuery::with_resolution(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            Some(Cardinality::One),
+            Resolution::Optional,
+        );
+        assert_eq!(many.resolution(), Resolution::Optional);
+        assert_eq!(one.resolution(), Resolution::Optional);
+        assert!(matches!(many, DynamicAttributeQuery::All(_)));
+        assert!(matches!(one, DynamicAttributeQuery::Only(_)));
+    }
+
+    /// Required-resolution schema declares the `is` slot as a
+    /// concrete (Definite) type — the slot demands a Present
+    /// value.
+    #[dialog_common::test]
+    fn required_resolution_schema_is_definite() {
+        let q = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            None,
+        );
+        let schema = q.schema();
+        let is = schema.get("is").expect("is field present");
+        assert!(
+            !is.content_type.is_optional(),
+            "Required resolution must produce non-Optional schema"
+        );
+    }
+
+    /// Optional-resolution schema declares the `is` slot as
+    /// `Type::Optional` — set-widened, may bind to Absent.
+    #[dialog_common::test]
+    fn optional_resolution_schema_is_optional() {
+        let q = DynamicAttributeQuery::optional(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            None,
+        );
+        let schema = q.schema();
+        let is = schema.get("is").expect("is field present");
+        assert!(
+            is.content_type.is_optional(),
+            "Optional resolution must produce Optional schema"
+        );
+    }
+
+    /// When the `is` term is a typed `Term<Any>` carrying a known
+    /// value type, Optional resolution produces a schema whose
+    /// `is` slot is `Type::Optional(Primitive(vt))` — preserving
+    /// the underlying type through the Optional wrap.
+    #[dialog_common::test]
+    fn optional_typed_is_preserves_inner_type() {
+        use crate::artifact::Type as ValueType;
+        let typed_is = Term::<Any>::typed_var("name", Some(ValueType::String));
+        let q = DynamicAttributeQuery::optional(
+            Term::var("the"),
+            Term::var("of"),
+            typed_is,
+            Term::var("cause"),
+            None,
+        );
+        let schema = q.schema();
+        let is = schema.get("is").expect("is field present");
+        assert!(is.content_type.is_optional());
+        assert_eq!(
+            is.content_type.shape().as_singleton(),
+            Some(ValueType::String),
+            "Optional wrap preserves the inner primitive type"
+        );
+    }
+
+    /// Required-resolution evaluation yields zero rows when the
+    /// underlying fact is missing — standard EAV.
+    #[dialog_common::test]
+    async fn required_yields_zero_rows_on_miss() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        // Don't assert any facts — the lookup misses.
+        let alice = Entity::new()?;
+        let q = DynamicAttributeQuery::new(
+            Term::Constant(crate::Value::from(the!("person/name").clone())),
+            Term::Constant(crate::Value::Entity(alice)),
+            Term::var("is"),
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(q, Match::new().seed(), &source)).await?;
+        assert_eq!(
+            results.len(),
+            0,
+            "Required resolution must yield no rows on miss"
+        );
+        Ok(())
+    }
+
+    /// Optional-resolution evaluation yields one row with `is`
+    /// bound to `Absent` when the underlying fact is missing.
+    #[dialog_common::test]
+    async fn optional_yields_absent_fallback_on_miss() -> anyhow::Result<()> {
+        use crate::Binding;
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let q = DynamicAttributeQuery::optional(
+            Term::Constant(crate::Value::from(the!("person/nickname").clone())),
+            Term::Constant(crate::Value::Entity(alice)),
+            Term::var("nickname"),
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(q, Match::new().seed(), &source)).await?;
+        assert_eq!(
+            results.len(),
+            1,
+            "Optional resolution must yield one fallback row on miss"
+        );
+        assert_eq!(
+            results[0].lookup(&Term::var("nickname"))?,
+            Binding::Absent,
+            "fallback row must bind `is` to Absent"
+        );
+        Ok(())
+    }
+
+    /// Optional-resolution evaluation yields the matched row(s)
+    /// when the underlying fact exists — set-widening doesn't
+    /// shadow Present results.
+    #[dialog_common::test]
+    async fn optional_yields_present_when_fact_exists() -> anyhow::Result<()> {
+        use crate::Binding;
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let name_attr = the!("person/name");
+        branch
+            .transaction()
+            .assert(name_attr.clone().of(alice.clone()).is("Alice".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let q = DynamicAttributeQuery::optional(
+            Term::Constant(crate::Value::from(name_attr)),
+            Term::Constant(crate::Value::Entity(alice)),
+            Term::var("name"),
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(q, Match::new().seed(), &source)).await?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("name"))?,
+            Binding::Present(crate::Value::String("Alice".into())),
+            "Optional with a Present fact yields Present, not Absent"
+        );
         Ok(())
     }
 }

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -288,8 +288,9 @@ mod tests {
         assert!(candidate.contains(&Term::var("person")));
         assert!(candidate.contains(&Term::var("name")));
 
-        let person_id: Entity = Entity::try_from(candidate.lookup(&Term::var("person"))?)?;
-        let name_value: crate::Value = candidate.lookup(&Term::var("name"))?;
+        let person_id: Entity =
+            Entity::try_from(candidate.lookup(&Term::var("person"))?.content()?)?;
+        let name_value: crate::Value = candidate.lookup(&Term::var("name"))?.content()?;
 
         assert_eq!(person_id, alice);
         assert_eq!(name_value, crate::Value::String("Alice".to_string()));

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -1004,16 +1004,12 @@ mod tests {
         );
     }
 
-    /// When the `is` term is a typed `Term<Any>` carrying a known
-    /// value type wrapped as optional, the schema's `is` slot
-    /// admits both that type and `Nothing`.
+    /// When the `is` term is a typed `Term<Option<U>>`, the schema's
+    /// `is` slot admits both `U` and `Nothing`.
     #[dialog_common::test]
     fn it_preserves_inner_type_when_is_term_is_optional() {
         use crate::artifact::Type as ValueType;
-        let typed_is = Term::<Any>::typed_var(
-            "name",
-            type_system::Type::primitive(ValueType::String).optional(),
-        );
+        let typed_is: Term<Any> = Term::<Option<String>>::var("name").into();
         let q = DynamicAttributeQuery::new(
             Term::var("the"),
             Term::var("of"),

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -977,8 +977,8 @@ mod tests {
     }
 
     /// Required-resolution schema declares the `is` slot as a
-    /// concrete (Definite) type — the slot demands a Present
-    /// value.
+    /// concrete (Definite) type or unknown — the slot demands a
+    /// Present value.
     #[dialog_common::test]
     fn required_resolution_schema_is_definite() {
         let q = DynamicAttributeQuery::new(
@@ -990,9 +990,11 @@ mod tests {
         );
         let schema = q.schema();
         let is = schema.get("is").expect("is field present");
+        // Untyped `is` slot reports `None` (unknown) — not
+        // Optional in the sense of set-widening.
         assert!(
-            !is.content_type.is_optional(),
-            "Required resolution must produce non-Optional schema"
+            is.content_type().is_none() || !is.content_type().unwrap().is_optional(),
+            "Required resolution must not produce Optional schema"
         );
     }
 
@@ -1009,8 +1011,9 @@ mod tests {
         );
         let schema = q.schema();
         let is = schema.get("is").expect("is field present");
+        let content = is.content_type().expect("content_type present");
         assert!(
-            is.content_type.is_optional(),
+            content.is_optional(),
             "Optional resolution must produce Optional schema"
         );
     }
@@ -1022,7 +1025,11 @@ mod tests {
     #[dialog_common::test]
     fn optional_typed_is_preserves_inner_type() {
         use crate::artifact::Type as ValueType;
-        let typed_is = Term::<Any>::typed_var("name", Some(ValueType::String));
+        use crate::type_system;
+        let typed_is = Term::<Any>::typed_var(
+            "name",
+            Some(type_system::Type::primitive(ValueType::String)),
+        );
         let q = DynamicAttributeQuery::optional(
             Term::var("the"),
             Term::var("of"),
@@ -1032,9 +1039,10 @@ mod tests {
         );
         let schema = q.schema();
         let is = schema.get("is").expect("is field present");
-        assert!(is.content_type.is_optional());
+        let content = is.content_type().expect("content_type present");
+        assert!(content.is_optional());
         assert_eq!(
-            is.content_type.shape().as_singleton(),
+            content.shape().as_singleton(),
             Some(ValueType::String),
             "Optional wrap preserves the inner primitive type"
         );

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -252,17 +252,14 @@ mod tests {
     use crate::session::RuleRegistry;
     use crate::source::test::TestEnv;
     use crate::the;
-    use crate::type_system;
+    use crate::type_system::{Primitive, Type as Kind};
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
 
     /// Construct an optional `is` variable. The query derives its
     /// resolution from the `is` term, so typing the slot as optional
     /// is what flips the query into Absent-fallback mode.
     fn optional_is(name: &str) -> Term<Any> {
-        Term::<Any>::typed_var(
-            name,
-            type_system::Type::primitive_set(type_system::Primitive::ALL).optional(),
-        )
+        Term::<Any>::typed_var(name, Kind::primitive_set(Primitive::ALL).optional())
     }
 
     macro_rules! assert_relation {

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -41,10 +41,14 @@ pub enum DynamicAttributeQuery {
 
 impl DynamicAttributeQuery {
     /// Create a new attribute query with the given cardinality.
-    /// Resolution defaults to [`Resolution::Required`].
     ///
     /// `None` or `Some(Cardinality::Many)` → `All` variant.
     /// `Some(Cardinality::One)` → `Only` variant.
+    ///
+    /// Resolution (Required vs Optional) is derived from the
+    /// typed `is` term: if its kind admits the `Nothing` atom the
+    /// query is treated as optional and yields an `Absent`
+    /// fallback row on miss.
     pub fn new(
         the: Term<The>,
         of: Term<Entity>,
@@ -52,38 +56,11 @@ impl DynamicAttributeQuery {
         cause: Term<Cause>,
         cardinality: Option<Cardinality>,
     ) -> Self {
-        Self::with_resolution(the, of, is, cause, cardinality, Resolution::Required)
-    }
-
-    /// Create a new attribute query with [`Resolution::Optional`]
-    /// — yields one Absent fallback row on miss.
-    pub fn optional(
-        the: Term<The>,
-        of: Term<Entity>,
-        is: Term<Any>,
-        cause: Term<Cause>,
-        cardinality: Option<Cardinality>,
-    ) -> Self {
-        Self::with_resolution(the, of, is, cause, cardinality, Resolution::Optional)
-    }
-
-    /// Create a new attribute query with explicit cardinality and
-    /// resolution.
-    pub fn with_resolution(
-        the: Term<The>,
-        of: Term<Entity>,
-        is: Term<Any>,
-        cause: Term<Cause>,
-        cardinality: Option<Cardinality>,
-        resolution: Resolution,
-    ) -> Self {
         match cardinality {
-            Some(Cardinality::One) => DynamicAttributeQuery::Only(
-                AttributeQueryOnly::with_resolution(the, of, is, cause, resolution),
-            ),
-            _ => DynamicAttributeQuery::All(AttributeQueryAll::with_resolution(
-                the, of, is, cause, resolution,
-            )),
+            Some(Cardinality::One) => {
+                DynamicAttributeQuery::Only(AttributeQueryOnly::new(the, of, is, cause))
+            }
+            _ => DynamicAttributeQuery::All(AttributeQueryAll::new(the, of, is, cause)),
         }
     }
 
@@ -275,7 +252,18 @@ mod tests {
     use crate::session::RuleRegistry;
     use crate::source::test::TestEnv;
     use crate::the;
+    use crate::type_system;
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+
+    /// Construct an optional `is` variable. The query derives its
+    /// resolution from the `is` term, so typing the slot as optional
+    /// is what flips the query into Absent-fallback mode.
+    fn optional_is(name: &str) -> Term<Any> {
+        Term::<Any>::typed_var(
+            name,
+            type_system::Type::primitive_set(type_system::Primitive::ALL).optional(),
+        )
+    }
 
     macro_rules! assert_relation {
         ($branch:expr, $operator:expr, $the:expr, $of:expr, $is:expr) => {{
@@ -935,40 +923,38 @@ mod tests {
         assert_eq!(q.resolution(), Resolution::Required);
     }
 
-    /// `DynamicAttributeQuery::optional` constructs a query with
-    /// `Resolution::Optional`.
+    /// When the `is` term carries an optional kind the derived
+    /// resolution is `Optional`.
     #[dialog_common::test]
-    fn optional_constructor_sets_optional_resolution() {
-        let q = DynamicAttributeQuery::optional(
+    fn it_derives_optional_resolution_from_is_term_kind() {
+        let q = DynamicAttributeQuery::new(
             Term::var("the"),
             Term::var("of"),
-            Term::var("is"),
+            optional_is("is"),
             Term::var("cause"),
             None,
         );
         assert_eq!(q.resolution(), Resolution::Optional);
     }
 
-    /// `DynamicAttributeQuery::with_resolution` propagates
-    /// resolution through both `All` (Many cardinality) and
+    /// Resolution is derived from the `is` term's kind and shows
+    /// up identically across both `All` (Many cardinality) and
     /// `Only` (One cardinality) variants.
     #[dialog_common::test]
-    fn with_resolution_propagates_through_variants() {
-        let many = DynamicAttributeQuery::with_resolution(
+    fn it_propagates_resolution_through_cardinality_variants() {
+        let many = DynamicAttributeQuery::new(
             Term::var("the"),
             Term::var("of"),
-            Term::var("is"),
+            optional_is("is"),
             Term::var("cause"),
             Some(Cardinality::Many),
-            Resolution::Optional,
         );
-        let one = DynamicAttributeQuery::with_resolution(
+        let one = DynamicAttributeQuery::new(
             Term::var("the"),
             Term::var("of"),
-            Term::var("is"),
+            optional_is("is"),
             Term::var("cause"),
             Some(Cardinality::One),
-            Resolution::Optional,
         );
         assert_eq!(many.resolution(), Resolution::Optional);
         assert_eq!(one.resolution(), Resolution::Optional);
@@ -980,7 +966,7 @@ mod tests {
     /// concrete type or unknown — the slot demands a Present
     /// value (no `Nothing` bit).
     #[dialog_common::test]
-    fn required_resolution_schema_is_definite() {
+    fn it_emits_definite_schema_for_required_resolution() {
         let q = DynamicAttributeQuery::new(
             Term::var("the"),
             Term::var("of"),
@@ -998,14 +984,14 @@ mod tests {
         );
     }
 
-    /// Optional-resolution schema declares the `is` slot as
-    /// `Type::Optional` — set-widened, may bind to Absent.
+    /// When the `is` term's kind is optional, the schema's `is`
+    /// slot is optional too and may bind to Absent.
     #[dialog_common::test]
-    fn optional_resolution_schema_is_optional() {
-        let q = DynamicAttributeQuery::optional(
+    fn it_emits_optional_schema_when_is_term_is_optional() {
+        let q = DynamicAttributeQuery::new(
             Term::var("the"),
             Term::var("of"),
-            Term::var("is"),
+            optional_is("is"),
             Term::var("cause"),
             None,
         );
@@ -1014,22 +1000,21 @@ mod tests {
         let content = is.content_type().expect("content_type present");
         assert!(
             content.is_optional(),
-            "Optional resolution must produce Optional schema"
+            "Optional `is` term must produce Optional schema"
         );
     }
 
     /// When the `is` term is a typed `Term<Any>` carrying a known
-    /// value type, Optional resolution produces a schema whose
-    /// `is` slot admits both that type and `Nothing`.
+    /// value type wrapped as optional, the schema's `is` slot
+    /// admits both that type and `Nothing`.
     #[dialog_common::test]
-    fn optional_typed_is_preserves_inner_type() {
+    fn it_preserves_inner_type_when_is_term_is_optional() {
         use crate::artifact::Type as ValueType;
-        use crate::type_system;
         let typed_is = Term::<Any>::typed_var(
             "name",
-            Some(type_system::Type::primitive(ValueType::String)),
+            type_system::Type::primitive(ValueType::String).optional(),
         );
-        let q = DynamicAttributeQuery::optional(
+        let q = DynamicAttributeQuery::new(
             Term::var("the"),
             Term::var("of"),
             typed_is,
@@ -1049,7 +1034,7 @@ mod tests {
     /// Required-resolution evaluation yields zero rows when the
     /// underlying fact is missing — standard EAV.
     #[dialog_common::test]
-    async fn required_yields_zero_rows_on_miss() -> anyhow::Result<()> {
+    async fn it_yields_zero_rows_on_miss_when_required() -> anyhow::Result<()> {
         let (operator, profile) = test_operator_with_profile().await;
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1078,17 +1063,17 @@ mod tests {
     /// Optional-resolution evaluation yields one row with `is`
     /// bound to `Absent` when the underlying fact is missing.
     #[dialog_common::test]
-    async fn optional_yields_absent_fallback_on_miss() -> anyhow::Result<()> {
+    async fn it_yields_absent_fallback_on_miss_when_optional() -> anyhow::Result<()> {
         use crate::Binding;
         let (operator, profile) = test_operator_with_profile().await;
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
 
         let alice = Entity::new()?;
-        let q = DynamicAttributeQuery::optional(
+        let q = DynamicAttributeQuery::new(
             Term::Constant(crate::Value::from(the!("person/nickname").clone())),
             Term::Constant(crate::Value::Entity(alice)),
-            Term::var("nickname"),
+            optional_is("nickname"),
             Term::blank(),
             Some(Cardinality::One),
         );
@@ -1113,7 +1098,7 @@ mod tests {
     /// when the underlying fact exists — set-widening doesn't
     /// shadow Present results.
     #[dialog_common::test]
-    async fn optional_yields_present_when_fact_exists() -> anyhow::Result<()> {
+    async fn it_yields_present_row_when_optional_fact_exists() -> anyhow::Result<()> {
         use crate::Binding;
         let (operator, profile) = test_operator_with_profile().await;
         let repo = test_repo(&operator, &profile).await;
@@ -1128,10 +1113,10 @@ mod tests {
             .perform(&operator)
             .await?;
 
-        let q = DynamicAttributeQuery::optional(
+        let q = DynamicAttributeQuery::new(
             Term::Constant(crate::Value::from(name_attr)),
             Term::Constant(crate::Value::Entity(alice)),
-            Term::var("name"),
+            optional_is("name"),
             Term::blank(),
             Some(Cardinality::One),
         );

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -99,34 +99,14 @@ pub struct AttributeQueryOnly {
 }
 
 impl AttributeQueryOnly {
-    /// Create a new winner-selecting attribute query with
-    /// `Resolution::Required` semantics — zero rows on miss.
+    /// Create a new winner-selecting attribute query. The
+    /// resolution (Required vs Optional) is derived from the
+    /// typed `is` term: if its kind admits the `Nothing` atom the
+    /// query is treated as optional and yields an `Absent`
+    /// fallback row on miss.
     pub fn new(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
         Self {
             query: AttributeQueryAll::new(the, of, is, cause),
-        }
-    }
-
-    /// Create a new winner-selecting attribute query with
-    /// `Resolution::Optional` semantics — one Absent fallback row
-    /// on miss.
-    pub fn optional(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
-        Self {
-            query: AttributeQueryAll::optional(the, of, is, cause),
-        }
-    }
-
-    /// Create a new winner-selecting attribute query with
-    /// explicit resolution.
-    pub fn with_resolution(
-        the: Term<The>,
-        of: Term<Entity>,
-        is: Term<Any>,
-        cause: Term<Cause>,
-        resolution: Resolution,
-    ) -> Self {
-        Self {
-            query: AttributeQueryAll::with_resolution(the, of, is, cause, resolution),
         }
     }
 
@@ -211,7 +191,6 @@ impl AttributeQueryOnly {
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
         let selector = self.query;
-        let resolution = selector.resolution();
         try_stream! {
             for await each in selection {
                 let base = each?;
@@ -285,7 +264,7 @@ impl AttributeQueryOnly {
                 // this input and the resolution is Optional, yield
                 // one row with `is` (and named `cause`) bound to
                 // Absent.
-                if !produced && matches!(resolution, Resolution::Optional) {
+                if !produced && selector.is().is_optional() {
                     let mut fallback = base;
                     fallback.bind_absent(selector.is())?;
                     let cause_term: Term<Any> = Term::<Any>::from(selector.cause());

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -53,14 +53,14 @@ where
 {
     try_stream! {
         let relation = selector.attribute();
-        let attribute = ArtifactsAttribute::try_from(candidate.lookup(&Term::from(&relation))?)?;
-        let entity = Entity::try_from(candidate.lookup(&Term::from(selector.of()))?)?;
-        let value = candidate.lookup(selector.is())?;
+        let attribute = ArtifactsAttribute::try_from(candidate.lookup(&Term::from(&relation))?.content()?)?;
+        let entity = Entity::try_from(candidate.lookup(&Term::from(selector.of()))?.content()?)?;
+        let value = candidate.lookup(selector.is())?.content()?;
         let cause_term = selector.cause();
         let cause = if cause_term.is_blank() {
             None
         } else {
-            Some(Cause::try_from(candidate.lookup(&Term::from(cause_term))?)?)
+            Some(Cause::try_from(candidate.lookup(&Term::from(cause_term))?.content()?)?)
         };
 
         let challengers = Provider::<Select<'_>>::execute(env, ArtifactSelector::new()

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -131,9 +131,9 @@ impl AttributeQueryOnly {
         self.query.is()
     }
 
-    /// Return a copy with the `is` term replaced. See
-    /// [`AttributeQueryAll::with_is`].
-    pub fn with_is(self, is: Term<Any>) -> Self {
+    /// Return a copy with the `is` term replaced. Internal hook;
+    /// see [`AttributeQueryAll::with_is`].
+    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
         Self {
             query: self.query.with_is(is),
         }

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -212,6 +212,14 @@ impl AttributeQueryOnly {
                 let value_known = resolved.is().is_constant();
 
                 let mut produced = false;
+                // Tracks whether the lookup observed *any* fact for
+                // this (attribute, entity). Distinguishes genuine
+                // absence (no fact → Absent fallback is correct) from
+                // a value mismatch (a fact exists but the winner fails
+                // the resolved value constraint → not absence, so no
+                // fallback). Only meaningful on the sliding-window
+                // (entity-known) path.
+                let mut saw_fact = false;
                 if entity_known || (attribute_known && !value_known) {
                     // Sliding window path.
                     let value_constraint = resolved.is().as_constant().cloned();
@@ -228,6 +236,7 @@ impl AttributeQueryOnly {
                     let stream = Provider::<Select<'_>>::execute(env, (&scan).try_into()?).await?;
                     for await artifact in stream {
                         let artifact = artifact?;
+                        saw_fact = true;
 
                         candidate = Some(match candidate.take() {
                             Some(current) if current.the == artifact.the && current.of == artifact.of => {
@@ -268,11 +277,23 @@ impl AttributeQueryOnly {
                     }
                 }
 
-                // Optional fallback: if no rows were produced for
-                // this input and the resolution is Optional, yield
-                // one row with `is` (and named `cause`) bound to
-                // Absent.
-                if !produced && selector.is().is_optional() {
+                // Optional fallback: yield one Absent row only when
+                // the attribute is genuinely *absent* for a known
+                // entity — never when a fact exists but was filtered.
+                //
+                // Three guards, all required:
+                //   - `!produced`: no Present row already covered this
+                //     input.
+                //   - `selector.is().is_optional()`: the slot is
+                //     set-widened, so absence is a legal value.
+                //   - `entity_known && !saw_fact`: the entity is
+                //     determined and the lookup found no fact for it.
+                //     Without this, a value mismatch (`saw_fact` true)
+                //     would wrongly report the attribute as missing,
+                //     and an unbound entity (challenge / value-only
+                //     path) would manufacture a phantom Absent row for
+                //     no concrete entity.
+                if !produced && selector.is().is_optional() && entity_known && !saw_fact {
                     let mut fallback = base;
                     fallback.bind_absent(selector.is())?;
                     let cause_term: Term<Any> = Term::<Any>::from(selector.cause());
@@ -780,6 +801,64 @@ mod tests {
             Cause::from(&winner_ba),
             "Tiebreaker should be deterministic"
         );
+    }
+
+    /// An *optional* `is` whose variable an earlier premise bound to
+    /// a value the entity does NOT have must NOT emit an Absent
+    /// fallback. The fact exists (the entity has the attribute with a
+    /// different value); the miss is a value mismatch, not absence.
+    /// "Absent" means "no fact for this attribute," so a Required
+    /// field in the same situation yields zero rows — the optional
+    /// field must agree on the row count (zero), never assert the
+    /// attribute is missing when it is merely different.
+    ///
+    /// Before the fix, the sliding-window winner failed the resolved
+    /// value constraint, `produced` stayed false, and the fallback
+    /// fired on `is_optional()` alone — binding the already-Present
+    /// `is` variable to Absent, which errors and aborts the whole
+    /// stream.
+    #[dialog_common::test]
+    async fn it_does_not_emit_absent_on_optional_value_mismatch() -> anyhow::Result<()> {
+        use crate::selection::Match;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let bob = Entity::new()?;
+        let nickname_attr = the!("person/nickname");
+
+        // Bob HAS a nickname, but it is "Bobby".
+        assert_relation!(branch, &operator, nickname_attr, bob, "Bobby".to_string());
+
+        // Optional `is` (set-widened): a missing fact would normally
+        // yield one Absent fallback row.
+        let optional_is: Term<Any> = Term::<Option<String>>::var("nickname").into();
+        let query = AttributeQueryOnly::new(
+            Term::from(the!("person/nickname")),
+            Term::from(bob.clone()),
+            optional_is.clone(),
+            Term::var("cause"),
+        );
+
+        // An earlier premise constrained ?nickname to "Ali" — a value
+        // Bob does not have.
+        let mut seed = Match::new();
+        seed.bind(&optional_is, crate::Value::from("Ali".to_string()))?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(query, seed.seed(), &source)).await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a value mismatch on an optional field is NOT absence — \
+             the attribute exists with a different value, so no row \
+             (and certainly no Absent fallback) should be produced"
+        );
+
+        Ok(())
     }
 
     /// When entity is a variable that gets bound by an earlier premise in

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -131,6 +131,14 @@ impl AttributeQueryOnly {
         self.query.is()
     }
 
+    /// Return a copy with the `is` term replaced. See
+    /// [`AttributeQueryAll::with_is`].
+    pub fn with_is(self, is: Term<Any>) -> Self {
+        Self {
+            query: self.query.with_is(is),
+        }
+    }
+
     /// Get the 'cause' term.
     pub fn cause(&self) -> &Term<Cause> {
         self.query.cause()

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -2,6 +2,7 @@ use super::all::AttributeQueryAll;
 use crate::Claim;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
 use crate::attribute::The;
+use crate::attribute::query::Resolution;
 use crate::environment::Environment;
 use crate::query::Application;
 use crate::query::Output;
@@ -98,11 +99,41 @@ pub struct AttributeQueryOnly {
 }
 
 impl AttributeQueryOnly {
-    /// Create a new winner-selecting attribute query.
+    /// Create a new winner-selecting attribute query with
+    /// `Resolution::Required` semantics — zero rows on miss.
     pub fn new(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
         Self {
             query: AttributeQueryAll::new(the, of, is, cause),
         }
+    }
+
+    /// Create a new winner-selecting attribute query with
+    /// `Resolution::Optional` semantics — one Absent fallback row
+    /// on miss.
+    pub fn optional(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
+        Self {
+            query: AttributeQueryAll::optional(the, of, is, cause),
+        }
+    }
+
+    /// Create a new winner-selecting attribute query with
+    /// explicit resolution.
+    pub fn with_resolution(
+        the: Term<The>,
+        of: Term<Entity>,
+        is: Term<Any>,
+        cause: Term<Cause>,
+        resolution: Resolution,
+    ) -> Self {
+        Self {
+            query: AttributeQueryAll::with_resolution(the, of, is, cause, resolution),
+        }
+    }
+
+    /// Returns the resolution policy of this query (delegates to
+    /// the wrapped `AttributeQueryAll`).
+    pub fn resolution(&self) -> Resolution {
+        self.query.resolution()
     }
 
     /// Get the 'the' (attribute) term.
@@ -180,6 +211,7 @@ impl AttributeQueryOnly {
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
         let selector = self.query;
+        let resolution = selector.resolution();
         try_stream! {
             for await each in selection {
                 let base = each?;
@@ -192,6 +224,7 @@ impl AttributeQueryOnly {
                 let attribute_known = resolved.the().is_constant();
                 let value_known = resolved.is().is_constant();
 
+                let mut produced = false;
                 if entity_known || (attribute_known && !value_known) {
                     // Sliding window path.
                     let value_constraint = resolved.is().as_constant().cloned();
@@ -217,6 +250,7 @@ impl AttributeQueryOnly {
                                 if value_constraint.is_none() || value_constraint.as_ref() == Some(&winner.is) {
                                     let mut extension = base.clone();
                                     selector.merge(&mut extension, &winner)?;
+                                    produced = true;
                                     yield extension;
                                 }
                                 artifact
@@ -231,6 +265,7 @@ impl AttributeQueryOnly {
                     {
                         let mut extension = base.clone();
                         selector.merge(&mut extension, &winner)?;
+                        produced = true;
                         yield extension;
                     }
                 } else {
@@ -240,9 +275,22 @@ impl AttributeQueryOnly {
                         let candidate = candidate?;
                         let verified = Box::pin(challenge(env, selector.clone(), candidate));
                         for await v in verified {
+                            produced = true;
                             yield v?;
                         }
                     }
+                }
+
+                // Optional fallback: if no rows were produced for
+                // this input and the resolution is Optional, yield
+                // one row with `is` (and named `cause`) bound to
+                // Absent.
+                if !produced && matches!(resolution, Resolution::Optional) {
+                    let mut fallback = base;
+                    fallback.bind_absent(selector.is())?;
+                    let cause_term: Term<Any> = Term::<Any>::from(selector.cause());
+                    fallback.bind_absent(&cause_term)?;
+                    yield fallback;
                 }
             }
         }

--- a/rust/dialog-query/src/attribute/query/typed.rs
+++ b/rust/dialog-query/src/attribute/query/typed.rs
@@ -94,8 +94,8 @@ where
     fn realize(&self, input: Match) -> Result<Self::Conclusion, EvaluationError> {
         let of_term = &self.of;
         let is_param = Term::<Any>::from(&self.is);
-        let entity: Entity = Entity::try_from(input.lookup(&Term::from(of_term))?)?;
-        let value: Value = input.lookup(&is_param)?;
+        let entity: Entity = Entity::try_from(input.lookup(&Term::from(of_term))?.content()?)?;
+        let value: Value = input.lookup(&is_param)?.content()?;
         let typed_value = A::Type::try_from(value).map_err(|_| {
             EvaluationError::Store(format!(
                 "cannot convert value to {}",

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -7,13 +7,14 @@ pub use descriptor::ConceptDescriptor;
 pub use query::ConceptQuery;
 
 use crate::artifact::Type as ValueType;
-use crate::attribute::query::Resolution;
 use crate::attribute::{Attribute, AttributeDescriptor, AttributeStatement};
 use crate::descriptor::Descriptor;
 use crate::error::EvaluationError;
 pub use crate::predicate::Predicate;
 use crate::selection::Binding;
-use crate::types::{TypeDescriptor, Typed};
+use crate::term::Term;
+use crate::type_system;
+use crate::types::{Any, TypeDescriptor, Typed};
 use crate::{Entity, Parameters, Value};
 use dialog_common::ConditionalSend;
 use std::fmt::Debug;
@@ -75,9 +76,19 @@ pub trait ConceptField: Sized + Clone {
     /// - Optional (`Option<N>`): `Option<<N as Attribute>::Type>`.
     type TermType: Typed + Clone + Debug + ConditionalSend + 'static;
 
-    /// Resolution policy for the field's attribute query.
-    /// `Required` for `N`, `Optional` for `Option<N>`.
-    const RESOLUTION: Resolution;
+    /// `true` if this field is set-widened (the `Option<N>` impl),
+    /// `false` for the bare-attribute (`N`) impl. Used by the
+    /// `#[derive(Concept)]` macro to route the field's descriptor
+    /// into either the `with` (required) or `maybe` (optional)
+    /// section of the generated `ConceptDescriptor`.
+    const OPTIONAL: bool;
+
+    /// Build the `is` slot term for this field's attribute query.
+    /// Required fields pass the user's `value_param` through
+    /// unchanged. Optional fields return an optional-typed term
+    /// so the `AttributeQuery` evaluates with Absent-fallback
+    /// semantics (resolution is derived from the term's kind).
+    fn term(value_param: Term<Any>) -> Term<Any>;
 
     /// Realize a value of `Self` from the row binding for this slot.
     ///
@@ -115,7 +126,13 @@ where
 {
     type Attribute = N;
     type TermType = <N as Attribute>::Type;
-    const RESOLUTION: Resolution = Resolution::Required;
+    const OPTIONAL: bool = false;
+
+    fn term(value_param: Term<Any>) -> Term<Any> {
+        // Required: pass the user's term through as-is; its kind
+        // (if any) is not optional, so the query stays required.
+        value_param
+    }
 
     fn realize(binding: Binding) -> Result<Self, EvaluationError> {
         let value = binding.content()?;
@@ -165,7 +182,24 @@ where
 {
     type Attribute = N;
     type TermType = Option<<N as Attribute>::Type>;
-    const RESOLUTION: Resolution = Resolution::Optional;
+    const OPTIONAL: bool = true;
+
+    fn term(value_param: Term<Any>) -> Term<Any> {
+        // Optional: return an optional-typed term. The underlying
+        // kind (if any) is wrapped via `Type::optional`; an untyped
+        // term becomes "any primitive, optional." The
+        // `AttributeQuery` reads `is.is_optional()` and switches to
+        // the Absent-fallback evaluation path.
+        let name = match value_param.name() {
+            Some(n) => n.to_string(),
+            None => return value_param,
+        };
+        let kind = match value_param.kind() {
+            Some(k) => k.optional(),
+            None => type_system::Type::primitive_set(type_system::Primitive::ALL).optional(),
+        };
+        Term::<Any>::typed_var(name, kind)
+    }
 
     fn realize(binding: Binding) -> Result<Self, EvaluationError> {
         match binding {

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -268,12 +268,20 @@ mod tests {
         fn try_from(input: Match) -> Result<Self, Self::Error> {
             Ok(Person {
                 this: Entity::try_from(
-                    input.lookup(&Term::from(&<Self as Concept>::Term::this()))?,
+                    input
+                        .lookup(&Term::from(&<Self as Concept>::Term::this()))?
+                        .content()?,
                 )?,
                 name: String::try_from(
-                    input.lookup(&Term::from(&<Self as Concept>::Term::name()))?,
+                    input
+                        .lookup(&Term::from(&<Self as Concept>::Term::name()))?
+                        .content()?,
                 )?,
-                age: u32::try_from(input.lookup(&Term::from(&<Self as Concept>::Term::age()))?)?,
+                age: u32::try_from(
+                    input
+                        .lookup(&Term::from(&<Self as Concept>::Term::age()))?
+                        .content()?,
+                )?,
             })
         }
     }
@@ -325,9 +333,9 @@ mod tests {
 
         fn realize(&self, source: Match) -> result::Result<Self::Conclusion, EvaluationError> {
             Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&self.this))?)?,
-                name: String::try_from(source.lookup(&Term::from(&self.name))?)?,
-                age: u32::try_from(source.lookup(&Term::from(&self.age))?)?,
+                this: Entity::try_from(source.lookup(&Term::from(&self.this))?.content()?)?,
+                name: String::try_from(source.lookup(&Term::from(&self.name))?.content()?)?,
+                age: u32::try_from(source.lookup(&Term::from(&self.age))?.content()?)?,
             })
         }
     }

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -6,8 +6,15 @@ pub mod query;
 pub use descriptor::ConceptDescriptor;
 pub use query::ConceptQuery;
 
+use crate::artifact::Type as ValueType;
+use crate::attribute::query::Resolution;
+use crate::attribute::{Attribute, AttributeDescriptor, AttributeStatement};
+use crate::descriptor::Descriptor;
+use crate::error::EvaluationError;
 pub use crate::predicate::Predicate;
-use crate::{Entity, Parameters};
+use crate::selection::Binding;
+use crate::types::{TypeDescriptor, Typed};
+use crate::{Entity, Parameters, Value};
 use dialog_common::ConditionalSend;
 use std::fmt::Debug;
 
@@ -38,6 +45,160 @@ where
 
     /// Content-addressed identity for this concept.
     fn this(&self) -> Entity;
+}
+
+/// Field-level abstraction used by `#[derive(Concept)]` to dispatch
+/// between required (`N: Attribute`) and optional (`Option<N>`)
+/// concept fields without doing syntactic type matching in the
+/// proc macro.
+///
+/// Two blanket impls cover the two cases:
+///
+/// - `impl<N: Attribute> ConceptField for N` — required path.
+/// - `impl<N: Attribute> ConceptField for Option<N>` — optional path.
+///
+/// These don't overlap because `Option` is `#[fundamental]`: Rust's
+/// trait coherence treats `Option<T>` as structurally distinct from
+/// a bare type parameter `T`. The Concept derive refers to
+/// `<F as ConceptField>::TermType` etc. without inspecting `F`'s
+/// syntactic shape — Rust resolves the right impl at type-check
+/// time. Aliases, prelude paths, and renamed imports all work.
+pub trait ConceptField: Sized + Clone {
+    /// The underlying attribute newtype. For both required `N` and
+    /// optional `Option<N>`, this is `N`.
+    type Attribute: Attribute
+        + Descriptor<AttributeDescriptor>
+        + From<<Self::Attribute as Attribute>::Type>;
+
+    /// The type wrapping the attribute's scalar at the term layer.
+    /// - Required (`N`): `<N as Attribute>::Type`.
+    /// - Optional (`Option<N>`): `Option<<N as Attribute>::Type>`.
+    type TermType: Typed + Clone + Debug + ConditionalSend + 'static;
+
+    /// Resolution policy for the field's attribute query.
+    /// `Required` for `N`, `Optional` for `Option<N>`.
+    const RESOLUTION: Resolution;
+
+    /// Realize a value of `Self` from the row binding for this slot.
+    ///
+    /// - Required: the binding must be `Present`; the inner scalar
+    ///   is unwrapped via `TryFrom<Value>` and wrapped in `N`.
+    /// - Optional: `Present(v)` becomes `Some(N(v))`, `Absent`
+    ///   becomes `None`.
+    fn realize(binding: Binding) -> Result<Self, EvaluationError>;
+
+    /// Push the attribute statement(s) for this field into `buf`.
+    ///
+    /// - Required: always one statement.
+    /// - Optional: one if `Some`, none if `None`.
+    fn push_statements(&self, this: Entity, buf: &mut Vec<AttributeStatement>);
+}
+
+// Required path: any `N` that satisfies the attribute bounds gets
+// the `ConceptField` impl with `RESOLUTION = Required` and
+// `TermType = N::Type`. This is the "bare attribute" case in a
+// concept field — `pub name: GivenName` and similar.
+//
+// Coherence note: this blanket and the next one (`for Option<N>`)
+// are non-overlapping because `Option` is `#[fundamental]`. The
+// `#[fundamental]` annotation on std's `Option` tells the trait
+// checker to treat `Option<T>` as structurally distinct from a
+// bare type parameter `T`, so `impl<N> Trait for N` and
+// `impl<N> Trait for Option<N>` are allowed to coexist.
+//
+// Other `#[fundamental]` types where this same pattern would work
+// include `Box<T>`, `&T`, `&mut T`, and `Pin<T>`.
+impl<N> ConceptField for N
+where
+    N: Attribute + Descriptor<AttributeDescriptor> + Clone + From<<N as Attribute>::Type>,
+    <N as Attribute>::Type: Into<Value>,
+{
+    type Attribute = N;
+    type TermType = <N as Attribute>::Type;
+    const RESOLUTION: Resolution = Resolution::Required;
+
+    fn realize(binding: Binding) -> Result<Self, EvaluationError> {
+        let value = binding.content()?;
+        let inner = <<N as Attribute>::Type>::try_from(value).map_err(|_| {
+            EvaluationError::TypeMismatch {
+                expected: <<<N as Attribute>::Type as Typed>::Descriptor as TypeDescriptor>::TYPE
+                    .unwrap_or(ValueType::Symbol),
+                actual: ValueType::Symbol,
+            }
+        })?;
+        Ok(N::from(inner))
+    }
+
+    fn push_statements(&self, this: Entity, buf: &mut Vec<AttributeStatement>) {
+        let descriptor = <Self as Descriptor<AttributeDescriptor>>::descriptor();
+        let expr = AttributeStatement {
+            the: descriptor.the().clone(),
+            of: this,
+            is: <<N as Attribute>::Type as Into<Value>>::into(
+                <Self as Attribute>::value(self).clone(),
+            ),
+            cause: None,
+            cardinality: Some(descriptor.cardinality()),
+        };
+        buf.push(expr);
+    }
+}
+
+// Optional path: `Option<N>` (where `N: Attribute`) gets the
+// `ConceptField` impl with `RESOLUTION = Optional` and
+// `TermType = Option<N::Type>`. This is the "set-widened" case in
+// a concept field — `pub nickname: Option<Nickname>` and similar.
+// `realize` maps `Binding::Absent` to `None`; `push_statements`
+// emits zero records when the value is `None` (absence is never
+// persisted).
+//
+// Resolution at the call site is purely type-system driven —
+// `<Option<N> as ConceptField>` resolves to *this* impl by virtue
+// of the structural `Option<N>` shape. Aliased imports
+// (`use core::option::Option as Maybe`, etc.) resolve identically
+// at the type level even though the surface syntax differs, which
+// is why no proc-macro syntactic detection is needed.
+impl<N> ConceptField for Option<N>
+where
+    N: Attribute + Descriptor<AttributeDescriptor> + Clone + From<<N as Attribute>::Type>,
+    <N as Attribute>::Type: Into<Value>,
+{
+    type Attribute = N;
+    type TermType = Option<<N as Attribute>::Type>;
+    const RESOLUTION: Resolution = Resolution::Optional;
+
+    fn realize(binding: Binding) -> Result<Self, EvaluationError> {
+        match binding {
+            Binding::Present(value) => {
+                let inner = <<N as Attribute>::Type>::try_from(value).map_err(|_| {
+                    EvaluationError::TypeMismatch {
+                        expected:
+                            <<<N as Attribute>::Type as Typed>::Descriptor as TypeDescriptor>::TYPE
+                                .unwrap_or(ValueType::Symbol),
+                        actual: ValueType::Symbol,
+                    }
+                })?;
+                Ok(Some(N::from(inner)))
+            }
+            Binding::Absent => Ok(None),
+        }
+    }
+
+    fn push_statements(&self, this: Entity, buf: &mut Vec<AttributeStatement>) {
+        if let Some(inner) = self.as_ref() {
+            let descriptor = <N as Descriptor<AttributeDescriptor>>::descriptor();
+            let expr = AttributeStatement {
+                the: descriptor.the().clone(),
+                of: this,
+                is: <<N as Attribute>::Type as Into<Value>>::into(
+                    <N as Attribute>::value(inner).clone(),
+                ),
+                cause: None,
+                cardinality: Some(descriptor.cardinality()),
+            };
+            buf.push(expr);
+        }
+    }
 }
 
 // Blanket impl for &T -> Parameters that uses the generated From<T> impl
@@ -114,7 +275,7 @@ mod tests {
     use crate::AttributeStatement;
     use crate::Query;
     use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Select, Type, Value};
-    use crate::attribute::{Attribute as _, AttributeDescriptor};
+    use crate::attribute::AttributeDescriptor;
     use crate::error::EvaluationError;
     use crate::query::Application;
     use crate::query::Output;

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -13,7 +13,7 @@ use crate::error::EvaluationError;
 pub use crate::predicate::Predicate;
 use crate::selection::Binding;
 use crate::term::Term;
-use crate::type_system;
+use crate::type_system::{Primitive, Type as Kind};
 use crate::types::{Any, TypeDescriptor, Typed};
 use crate::{Entity, Parameters, Value};
 use dialog_common::ConditionalSend;
@@ -196,7 +196,7 @@ where
         };
         let kind = match value_param.kind() {
             Some(k) => k.optional(),
-            None => type_system::Type::primitive_set(type_system::Primitive::ALL).optional(),
+            None => Kind::primitive_set(Primitive::ALL).optional(),
         };
         Term::<Any>::typed_var(name, kind)
     }

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -291,6 +291,41 @@ where
 ///     pub name: attrs::Name,
 /// }
 /// ```
+///
+/// A concept must declare at least one *required* attribute. A
+/// struct whose only attribute fields are `Option<_>` constrains
+/// nothing (every entity matches), so the derive rejects it at
+/// compile time via a const assertion over
+/// [`ConceptField::OPTIONAL`].
+///
+/// ```compile_fail
+/// use dialog_query::{Concept, Entity};
+///
+/// mod attrs {
+///     #[derive(dialog_macros::Attribute, Clone, PartialEq)]
+///     pub struct Nickname(pub String);
+/// }
+///
+/// /// Only an optional attribute — should fail to compile.
+/// #[derive(Concept, Debug, Clone)]
+/// pub struct AllOptional {
+///     pub this: Entity,
+///     pub nickname: Option<attrs::Nickname>,
+/// }
+/// ```
+///
+/// A concept with no attribute fields at all (only `this`) is
+/// likewise rejected — it would match every entity.
+///
+/// ```compile_fail
+/// use dialog_query::{Concept, Entity};
+///
+/// /// No attributes — should fail to compile.
+/// #[derive(Concept, Debug, Clone)]
+/// pub struct NoAttributes {
+///     pub this: Entity,
+/// }
+/// ```
 pub trait Conclusion: ConditionalSend {
     /// Each instance has a corresponding entity and this method
     /// returns a reference to it.
@@ -302,243 +337,51 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
-    use std::result;
-    use std::vec;
-
     use super::*;
     use crate::AttributeStatement;
     use crate::Query;
-    use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Select, Type, Value};
-    use crate::attribute::AttributeDescriptor;
-    use crate::error::EvaluationError;
-    use crate::query::Application;
+    use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Value};
     use crate::query::Output;
-    use crate::selection::Selection;
 
+    use crate::Concept;
     use crate::attribute::query::AttributeQuery;
     use crate::session::RuleRegistry;
-    use crate::source::SelectRules;
     use crate::source::test::TestEnv;
     use crate::term::Term;
     use crate::the;
-    use crate::types::Any;
-    use crate::{Cardinality, Concept, Match, Statement};
     use anyhow::Result;
-    use dialog_capability::Provider;
-    use dialog_common::ConditionalSync;
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
 
-    // Define a Person concept for testing using raw concept API
-    // This mirrors what the #[derive(Concept)] macro generates
-    #[derive(Debug, Clone)]
-    struct Person {
+    // Define a Person concept for testing via `#[derive(Concept)]`.
+    // The newtypes live in a module named `person` so the attribute
+    // domain defaults to `person`, yielding `person/name` and
+    // `person/age` to match the stored facts the tests assert against.
+    mod person {
+        use crate::Attribute;
+
+        /// Name of the person.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Name(pub String);
+
+        /// Age of the person.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Age(pub u32);
+    }
+
+    /// A person concept used across the scaffold tests below.
+    #[derive(Concept, Debug, Clone)]
+    pub struct Person {
         pub this: Entity,
-        pub name: String,
-        pub age: u32,
-    }
-
-    // PersonQuery for querying — contains Term-wrapped fields
-    // The derive macro generates typed Terms (Term<String>, Term<u32>) not Term<Value>
-    #[derive(Debug, Clone)]
-    struct PersonQuery {
-        pub this: Term<Entity>,
-        pub name: Term<String>,
-        pub age: Term<u32>,
-    }
-
-    impl Default for PersonQuery {
-        fn default() -> Self {
-            Self {
-                this: Term::var("this"),
-                name: Term::var("name"),
-                age: Term::var("age"),
-            }
-        }
-    }
-
-    struct PersonTerms;
-
-    impl PersonTerms {
-        pub fn this() -> Term<Entity> {
-            Term::<Entity>::var("this")
-        }
-        pub fn name() -> Term<String> {
-            Term::<String>::var("name")
-        }
-        pub fn age() -> Term<u32> {
-            Term::<u32>::var("age")
-        }
-    }
-
-    fn person_predicate() -> ConceptDescriptor {
-        ConceptDescriptor::from(vec![
-            (
-                "name",
-                AttributeDescriptor::new(
-                    the!("person/name"),
-                    "Name of the person",
-                    Cardinality::One,
-                    Some(Type::String),
-                ),
-            ),
-            (
-                "age",
-                AttributeDescriptor::new(
-                    the!("person/age"),
-                    "Age of the person",
-                    Cardinality::One,
-                    Some(Type::UnsignedInt),
-                ),
-            ),
-        ])
-    }
-
-    impl From<Person> for ConceptDescriptor {
-        fn from(_: Person) -> Self {
-            person_predicate()
-        }
-    }
-
-    impl From<PersonQuery> for ConceptDescriptor {
-        fn from(_: PersonQuery) -> Self {
-            person_predicate()
-        }
-    }
-
-    // Implement Concept for Person
-    impl Concept for Person {
-        type Term = PersonTerms;
-
-        fn this(&self) -> Entity {
-            let predicate: ConceptDescriptor = self.clone().into();
-            predicate.this()
-        }
-    }
-
-    impl IntoIterator for Person {
-        type Item = AttributeStatement;
-        type IntoIter = vec::IntoIter<AttributeStatement>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            vec![
-                the!("person/name")
-                    .of(self.this.clone())
-                    .is(self.name.clone())
-                    .into(),
-                the!("person/age").of(self.this.clone()).is(self.age).into(),
-            ]
-            .into_iter()
-        }
-    }
-
-    impl Statement for Person {
-        fn assert(self, update: &mut impl dialog_artifacts::Update) {
-            let name_the = the!("person/name");
-            let age_the = the!("person/age");
-
-            update.associate(name_the.into(), self.this.clone(), Value::from(self.name));
-            update.associate(age_the.into(), self.this.clone(), Value::from(self.age));
-        }
-
-        fn retract(self, update: &mut impl dialog_artifacts::Update) {
-            let name_the = the!("person/name");
-            let age_the = the!("person/age");
-
-            update.dissociate(name_the.into(), self.this.clone(), Value::from(self.name));
-            update.dissociate(age_the.into(), self.this.clone(), Value::from(self.age));
-        }
-    }
-
-    impl Predicate for Person {
-        type Conclusion = Person;
-        type Application = PersonQuery;
-        type Descriptor = ConceptDescriptor;
-    }
-
-    // Implement TryFrom<selection::Match> for Person
-    // This extracts values from the match by field name
-    impl TryFrom<Match> for Person {
-        type Error = EvaluationError;
-
-        fn try_from(input: Match) -> Result<Self, Self::Error> {
-            Ok(Person {
-                this: Entity::try_from(
-                    input
-                        .lookup(&Term::from(&<Self as Concept>::Term::this()))?
-                        .content()?,
-                )?,
-                name: String::try_from(
-                    input
-                        .lookup(&Term::from(&<Self as Concept>::Term::name()))?
-                        .content()?,
-                )?,
-                age: u32::try_from(
-                    input
-                        .lookup(&Term::from(&<Self as Concept>::Term::age()))?
-                        .content()?,
-                )?,
-            })
-        }
-    }
-
-    // Implement Instance for Person
-    impl Conclusion for Person {
-        fn this(&self) -> &Entity {
-            &self.this
-        }
-    }
-
-    // Implement From<PersonQuery> for Parameters
-    impl From<PersonQuery> for Parameters {
-        fn from(source: PersonQuery) -> Self {
-            let mut terms = Self::new();
-            terms.insert("this".into(), Term::<Any>::from(source.this));
-            terms.insert("name".into(), Term::<Any>::from(source.name));
-            terms.insert("age".into(), Term::<Any>::from(source.age));
-            terms
-        }
-    }
-
-    // Implement From<PersonQuery> for ConceptQuery
-    impl From<PersonQuery> for ConceptQuery {
-        fn from(source: PersonQuery) -> Self {
-            let predicate: ConceptDescriptor = source.clone().into();
-            ConceptQuery {
-                terms: source.into(),
-                predicate,
-            }
-        }
-    }
-
-    // Implement Application for PersonQuery
-    impl Application for PersonQuery {
-        type Conclusion = Person;
-
-        fn evaluate<'a, Env, M: Selection + 'a>(
-            self,
-            selection: M,
-            env: &'a Env,
-        ) -> impl Selection + 'a
-        where
-            Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
-        {
-            let application: ConceptQuery = self.into();
-            application.evaluate(selection, env)
-        }
-
-        fn realize(&self, source: Match) -> result::Result<Self::Conclusion, EvaluationError> {
-            Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&self.this))?.content()?)?,
-                name: String::try_from(source.lookup(&Term::from(&self.name))?.content()?)?,
-                age: u32::try_from(source.lookup(&Term::from(&self.age))?.content()?)?,
-            })
-        }
+        /// Person's name (`person/name`).
+        pub name: person::Name,
+        /// Person's age (`person/age`).
+        pub age: person::Age,
     }
 
     #[dialog_common::test]
     fn it_creates_person_concept() {
         // Test that the Person concept has the expected properties
-        let concept = person_predicate();
+        let concept = Person::descriptor().clone();
         // Operator is now a URI based on the hash of the concept's attributes
         assert!(
             concept.this().to_string().starts_with("concept:"),
@@ -558,10 +401,10 @@ mod tests {
     fn it_creates_person_match() {
         // Test creating a PersonQuery for querying
         let entity_var = Term::var("person_entity");
-        let name_var = Term::var("person_name");
-        let age_var = Term::var("person_age");
+        let name_var: Term<String> = Term::var("person_name");
+        let age_var: Term<u32> = Term::var("person_age");
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_var.clone(),
             age: age_var.clone(),
@@ -580,7 +423,7 @@ mod tests {
         let name_const = Term::from("Alice".to_string());
         let age_const = Term::from(30u32);
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_const.clone(),
             age: age_const.clone(),
@@ -600,9 +443,9 @@ mod tests {
         // Test mixing variables and constants in a match pattern
         let entity_var = Term::var("person_entity");
         let name_const = Term::from("Bob".to_string());
-        let age_var = Term::var("any_age");
+        let age_var: Term<u32> = Term::var("any_age");
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_const.clone(),
             age: age_var.clone(),
@@ -620,8 +463,8 @@ mod tests {
         let entity = Entity::new().unwrap();
         let person = Person {
             this: entity.clone(),
-            name: "Charlie".to_string(),
-            age: 25,
+            name: person::Name("Charlie".to_string()),
+            age: person::Age(25),
         };
 
         // Test Instance trait - should return the same entity
@@ -631,7 +474,7 @@ mod tests {
     #[dialog_common::test]
     fn it_maintains_concept_name_consistency() {
         // Test that concept identifier is consistent across different access patterns
-        let concept = person_predicate();
+        let concept = Person::descriptor().clone();
         // Operator is now a URI based on the hash of the concept's attributes
         assert!(
             concept.this().to_string().starts_with("concept:"),
@@ -641,8 +484,8 @@ mod tests {
         // The concept should have consistent naming
         let _person = Person {
             this: Entity::new().unwrap(),
-            name: "Test".to_string(),
-            age: 1,
+            name: person::Name("Test".to_string()),
+            age: person::Age(1),
         };
 
         // Instance should have the same concept identifier
@@ -658,10 +501,10 @@ mod tests {
     fn it_exposes_match_fields() {
         // Test that PersonQuery has the expected fields
         let entity_var = Term::var("entity");
-        let name_var = Term::var("name");
-        let age_var = Term::var("age");
+        let name_var: Term<String> = Term::var("name");
+        let age_var: Term<u32> = Term::var("age");
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_var.clone(),
             age: age_var.clone(),
@@ -678,8 +521,8 @@ mod tests {
         // Test that our derived Debug implementations work
         let person = Person {
             this: Entity::new().unwrap(),
-            name: "Debug Test".to_string(),
-            age: 42,
+            name: person::Name("Debug Test".to_string()),
+            age: person::Age(42),
         };
 
         let debug_output = format!("{:?}", person);
@@ -694,8 +537,8 @@ mod tests {
         let entity = Entity::new().unwrap();
         let person1 = Person {
             this: entity.clone(),
-            name: "Original".to_string(),
-            age: 35,
+            name: person::Name("Original".to_string()),
+            age: person::Age(35),
         };
 
         let person2 = person1.clone();
@@ -705,7 +548,7 @@ mod tests {
 
         // Test PersonQuery clone
         let entity_var = Term::var("entity");
-        let match1 = PersonQuery {
+        let match1 = Query::<Person> {
             this: entity_var.clone(),
             name: Term::var("name"),
             age: Term::var("age"),
@@ -725,7 +568,7 @@ mod tests {
         let alice = Entity::new()?;
 
         // Test 1: Create a PersonQuery with mixed terms
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: Term::from(alice.clone()),
             name: Term::from("Alice".to_string()),
             age: Term::var("age"),
@@ -738,7 +581,7 @@ mod tests {
         assert!(params.get("age").is_some());
 
         // Test 2: Verify concept attributes are accessible
-        let concept = person_predicate();
+        let concept = Person::descriptor().clone();
         assert_eq!(concept.with().iter().count(), 2); // name and age
 
         // Verify we can find specific attributes

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -1282,7 +1282,7 @@ mod tests {
         let name = schema.get("name").expect("name field present");
         let content = name.content_type().expect("content_type present");
         assert!(!content.is_optional());
-        assert_eq!(content.shape().as_singleton(), Some(Type::String));
+        assert_eq!(content.as_value_type(), Some(Type::String));
     }
 
     /// An attribute descriptor with `None` content type produces
@@ -1299,7 +1299,7 @@ mod tests {
     }
 
     /// The synthesized `this` field always declares
-    /// `Type::Definite(Primitive(Entity))`.
+    /// a singleton primitive over `Entity`.
     #[dialog_common::test]
     fn schema_from_concept_synthesizes_this_as_entity() {
         let descriptor = ConceptDescriptor::from(vec![(
@@ -1314,6 +1314,6 @@ mod tests {
         let schema = Schema::from(&descriptor);
         let this = schema.get("this").expect("this field present");
         let content = this.content_type().expect("entity kind present");
-        assert_eq!(content.shape().as_singleton(), Some(Type::Entity));
+        assert_eq!(content.as_value_type(), Some(Type::Entity));
     }
 }

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -253,14 +253,14 @@ impl From<HashMap<String, AttributeDescriptor>> for ConceptDescriptor {
 
 impl From<&ConceptDescriptor> for Schema {
     fn from(predicate: &ConceptDescriptor) -> Self {
-        use crate::type_system;
+        use crate::type_system::Type as Kind;
         let mut schema = Schema::new();
         for (name, attribute) in predicate.with().iter() {
             schema.insert(
                 name.into(),
                 Field {
                     description: attribute.description().into(),
-                    content_type: attribute.content_type().map(type_system::Type::primitive),
+                    content_type: attribute.content_type().map(Kind::primitive),
                     requirement: Requirement::Optional,
                     cardinality: attribute.cardinality(),
                 },
@@ -272,7 +272,7 @@ impl From<&ConceptDescriptor> for Schema {
                 "this".into(),
                 Field {
                     description: "The entity that this model represents".into(),
-                    content_type: Some(type_system::Type::primitive(Type::Entity)),
+                    content_type: Some(Kind::primitive(Type::Entity)),
                     requirement: Requirement::Optional,
                     cardinality: Cardinality::One,
                 },

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -51,14 +51,19 @@ pub struct ConceptDescriptor {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     with: NamedAttributes,
-    /// Optional attributes — not yet supported by the query engine.
+    /// Optional (set-widened) attributes.
     ///
-    /// Accepted during deserialization to ensure documents written against
-    /// the full schema are validated now rather than silently accepted and
-    /// broken later when `maybe` support lands.  Skipped during
-    /// serialization because the engine never produces them.
+    /// Each `maybe` attribute is emitted into the rule body as an
+    /// `AttributeQuery` with `Resolution::Optional`: an entity that
+    /// lacks the fact still produces a row, with the slot bound to
+    /// [`Binding::Absent`](crate::Binding) rather than dropping the
+    /// row. Absence is row-level; no `Nothing` value is ever stored.
     ///
-    /// An empty map deserializes to `None` (treated as absent).
+    /// Skipped during serialization when empty (`None`); an empty
+    /// map deserializes to `None` (treated as absent). Optional
+    /// attributes do **not** count toward the concept's required-
+    /// attribute minimum — a concept must still declare at least one
+    /// `with` attribute (see [`Self::validate`]).
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -118,7 +123,9 @@ impl ConceptDescriptor {
         self.maybe = if map.is_empty() {
             None
         } else {
-            Some(NamedAttributes::from(map))
+            // Non-empty by the guard above; `maybe` carries no
+            // minimum-count invariant of its own.
+            Some(NamedAttributes::from_pairs(map))
         };
         self
     }
@@ -223,53 +230,55 @@ impl ConceptDescriptor {
     }
 }
 
-impl<const N: usize> From<[(&str, AttributeDescriptor); N]> for ConceptDescriptor {
-    fn from(arr: [(&str, AttributeDescriptor); N]) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(arr),
-        }
+/// Build a [`ConceptDescriptor`] from a validated, non-empty
+/// [`NamedAttributes`] required set. Private: the only way to obtain
+/// a `NamedAttributes` is through its own (fallible) constructors,
+/// so reaching here means the non-empty invariant already holds.
+fn descriptor_from_with(with: NamedAttributes) -> ConceptDescriptor {
+    ConceptDescriptor {
+        description: None,
+        maybe: None,
+        with,
     }
 }
 
-impl<const N: usize> From<[(String, AttributeDescriptor); N]> for ConceptDescriptor {
-    fn from(arr: [(String, AttributeDescriptor); N]) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(arr),
-        }
+impl<const N: usize> TryFrom<[(&str, AttributeDescriptor); N]> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(arr: [(&str, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(arr)?))
     }
 }
 
-impl From<Vec<(&str, AttributeDescriptor)>> for ConceptDescriptor {
-    fn from(vec: Vec<(&str, AttributeDescriptor)>) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(vec),
-        }
+impl<const N: usize> TryFrom<[(String, AttributeDescriptor); N]> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(arr: [(String, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(arr)?))
     }
 }
 
-impl From<Vec<(String, AttributeDescriptor)>> for ConceptDescriptor {
-    fn from(vec: Vec<(String, AttributeDescriptor)>) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(vec),
-        }
+impl TryFrom<Vec<(&str, AttributeDescriptor)>> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(&str, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(vec)?))
     }
 }
 
-impl From<HashMap<String, AttributeDescriptor>> for ConceptDescriptor {
-    fn from(map: HashMap<String, AttributeDescriptor>) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(map),
-        }
+impl TryFrom<Vec<(String, AttributeDescriptor)>> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(String, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(vec)?))
+    }
+}
+
+impl TryFrom<HashMap<String, AttributeDescriptor>> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(map: HashMap<String, AttributeDescriptor>) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(map)?))
     }
 }
 
@@ -314,7 +323,9 @@ where
     if map.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(NamedAttributes::from(map)))
+        // Non-empty by the guard above; the `maybe` slot has no
+        // minimum-count invariant, so build directly.
+        Ok(Some(NamedAttributes::from_pairs(map.into_iter().collect())))
     }
 }
 
@@ -556,7 +567,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_serializes_to_expected_json() {
-        let predicate = ConceptDescriptor::from([
+        let predicate = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -575,7 +586,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
 
@@ -670,7 +682,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_serializes_with_description() {
-        let mut predicate = ConceptDescriptor::from([(
+        let mut predicate = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -678,7 +690,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         predicate.description = Some("A user profile".to_string());
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
@@ -690,7 +703,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_omits_null_description_in_json() {
-        let predicate = ConceptDescriptor::from([(
+        let predicate = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -698,7 +711,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
@@ -709,7 +723,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_round_trips_through_json() {
-        let original = ConceptDescriptor::from([(
+        let original = ConceptDescriptor::try_from([(
             "score",
             AttributeDescriptor::new(
                 the!("game/score"),
@@ -717,7 +731,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::UnsignedInt),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string(&original).expect("Should serialize");
         let deserialized: ConceptDescriptor =
@@ -749,7 +764,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_produces_expected_json_structure() {
-        let predicate = ConceptDescriptor::from(vec![(
+        let predicate = ConceptDescriptor::try_from(vec![(
             "id".to_string(),
             AttributeDescriptor::new(
                 the!("product/id"),
@@ -757,7 +772,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::UnsignedInt),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string_pretty(&predicate).expect("Should serialize");
 
@@ -784,7 +800,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_ignores_field_names_in_hash() {
-        let pred1 = ConceptDescriptor::from(vec![
+        let pred1 = ConceptDescriptor::try_from(vec![
             (
                 "field_a".to_string(),
                 AttributeDescriptor::new(
@@ -803,9 +819,10 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
-        let pred2 = ConceptDescriptor::from(vec![
+        let pred2 = ConceptDescriptor::try_from(vec![
             (
                 "different_field_1".to_string(),
                 AttributeDescriptor::new(
@@ -824,7 +841,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         assert_eq!(
             pred1.hash(),
@@ -841,7 +859,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_ignores_attribute_order_in_hash() {
-        let pred1 = ConceptDescriptor::from(vec![
+        let pred1 = ConceptDescriptor::try_from(vec![
             (
                 "name".to_string(),
                 AttributeDescriptor::new(
@@ -860,9 +878,10 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
-        let pred2 = ConceptDescriptor::from(vec![
+        let pred2 = ConceptDescriptor::try_from(vec![
             (
                 "age".to_string(),
                 AttributeDescriptor::new(
@@ -881,7 +900,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         assert_eq!(
             pred1.hash(),
@@ -898,7 +918,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_hashes_differently_for_different_attributes() {
-        let pred1 = ConceptDescriptor::from(vec![(
+        let pred1 = ConceptDescriptor::try_from(vec![(
             "name".to_string(),
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -906,9 +926,10 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
-        let pred2 = ConceptDescriptor::from(vec![(
+        let pred2 = ConceptDescriptor::try_from(vec![(
             "email".to_string(),
             AttributeDescriptor::new(
                 the!("person/email"),
@@ -916,7 +937,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         assert_ne!(
             pred1.hash(),
@@ -939,7 +961,7 @@ mod tests {
     /// - No unexpected top-level keys (only "description", "with")
     #[dialog_common::test]
     fn it_conforms_to_json_schema() {
-        let predicate = ConceptDescriptor::from([
+        let predicate = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -958,7 +980,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
@@ -1216,6 +1239,44 @@ mod tests {
         assert!(result.is_err(), "Should reject empty object");
     }
 
+    /// A concept must have at least one required (`with`) attribute.
+    /// An empty `with` map describes a concept every entity trivially
+    /// matches — the same degenerate shape as a concept with no
+    /// attributes at all — so the parse layer rejects it.
+    #[dialog_common::test]
+    fn it_rejects_empty_with_at_parse() {
+        let json = r#"{
+            "with": {}
+        }"#;
+
+        let result = serde_json::from_str::<ConceptDescriptor>(json);
+        assert!(
+            result.is_err(),
+            "Should reject a concept whose `with` map is empty"
+        );
+    }
+
+    /// A concept with only optional (`maybe`) attributes and an empty
+    /// `with` is just as degenerate: with no required attribute, the
+    /// rule body binds nothing that constrains the entity, so every
+    /// entity matches. Rejected at the parse layer.
+    #[dialog_common::test]
+    fn it_rejects_all_optional_concept_at_parse() {
+        let json = r#"{
+            "with": {},
+            "maybe": {
+                "bio": { "the": "user/bio", "as": "Text" }
+            }
+        }"#;
+
+        let result = serde_json::from_str::<ConceptDescriptor>(json);
+        assert!(
+            result.is_err(),
+            "Should reject a concept with no required attributes (empty `with`), \
+             even when `maybe` attributes are present"
+        );
+    }
+
     #[dialog_common::test]
     fn it_accepts_maybe_field() {
         let json = r#"{
@@ -1253,7 +1314,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_omits_maybe_in_serialization() {
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -1261,7 +1322,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string(&concept).expect("Should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
@@ -1290,8 +1352,7 @@ mod tests {
             pub r#type: TypeAttr,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Sample as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Sample::descriptor().clone();
 
         // Round-trip the descriptor through JSON and assert the field
         // key in the `with` map is `type`, not `r#type`.
@@ -1356,8 +1417,7 @@ mod tests {
             pub email: D,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Sample as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Sample::descriptor().clone();
 
         let json = serde_json::to_value(&descriptor).expect("serialize");
         let with = json["with"].as_object().expect("with map");
@@ -1403,7 +1463,7 @@ mod tests {
     /// attribute's content_type into the unified `type_system::Type`.
     #[dialog_common::test]
     fn schema_from_concept_uses_unified_type() {
-        let descriptor = ConceptDescriptor::from(vec![(
+        let descriptor = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -1411,7 +1471,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let schema = Schema::from(&descriptor);
         let name = schema.get("name").expect("name field present");
         let content = name.content_type().expect("content_type present");
@@ -1423,10 +1484,11 @@ mod tests {
     /// a Field with `None` content_type — unknown.
     #[dialog_common::test]
     fn schema_from_concept_untyped_attribute_produces_none() {
-        let descriptor = ConceptDescriptor::from(vec![(
+        let descriptor = ConceptDescriptor::try_from(vec![(
             "tag",
             AttributeDescriptor::new(the!("misc/tag"), "", Cardinality::One, None),
-        )]);
+        )])
+        .unwrap();
         let schema = Schema::from(&descriptor);
         let tag = schema.get("tag").expect("tag field present");
         assert!(tag.content_type().is_none());
@@ -1436,7 +1498,7 @@ mod tests {
     /// a singleton primitive over `Entity`.
     #[dialog_common::test]
     fn schema_from_concept_synthesizes_this_as_entity() {
-        let descriptor = ConceptDescriptor::from(vec![(
+        let descriptor = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -1444,7 +1506,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let schema = Schema::from(&descriptor);
         let this = schema.get("this").expect("this field present");
         let content = this.content_type().expect("entity kind present");
@@ -1473,8 +1536,7 @@ mod tests {
             pub title: Title,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Recipe as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Recipe::descriptor().clone();
 
         assert_eq!(
             descriptor.description(),
@@ -1512,8 +1574,7 @@ mod tests {
             pub title: Title,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Recipe as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Recipe::descriptor().clone();
 
         assert_eq!(descriptor.description(), None);
         let json = serde_json::to_value(&descriptor).expect("serialize");
@@ -1525,7 +1586,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_sets_the_description_via_with_description() {
-        let descriptor = ConceptDescriptor::from([(
+        let descriptor = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -1533,7 +1594,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         // `From<[..]>` leaves `description` as `None`.
         assert_eq!(descriptor.description(), None);

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -68,9 +68,37 @@ impl ConceptDescriptor {
         self.description.as_deref()
     }
 
-    /// Returns a reference to the named attributes.
+    /// Returns a reference to the required (`with`) attributes.
     pub fn with(&self) -> &NamedAttributes {
         &self.with
+    }
+
+    /// Returns a reference to the optional (`maybe`) attributes,
+    /// if any are declared. Optional fields are emitted into the
+    /// rule body as `AttributeQuery` premises with
+    /// `Resolution::Optional`, so that a missing fact yields a
+    /// fallback row with the slot bound to `Binding::Absent`
+    /// rather than dropping the row entirely.
+    pub fn maybe(&self) -> Option<&NamedAttributes> {
+        self.maybe.as_ref()
+    }
+
+    /// Returns a copy of this descriptor with the given optional
+    /// attributes installed in the `maybe` slot. Empty input
+    /// becomes `None` (no `maybe` block).
+    pub fn with_maybe<I, K>(mut self, maybe: I) -> Self
+    where
+        I: IntoIterator<Item = (K, AttributeDescriptor)>,
+        K: Into<String>,
+    {
+        let map: Vec<(String, AttributeDescriptor)> =
+            maybe.into_iter().map(|(k, v)| (k.into(), v)).collect();
+        self.maybe = if map.is_empty() {
+            None
+        } else {
+            Some(NamedAttributes::from(map))
+        };
+        self
     }
 
     /// Validates the provided parameters against the schema of the attributes.

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -393,11 +393,11 @@ impl ConceptConclusion {
                 name: Some(name), ..
             } => {
                 let typed_term: Term<T> = Term::var(name.clone());
-                T::try_from(self.source.lookup(&Term::from(&typed_term))?).map_err(|_| {
-                    EvaluationError::UnboundVariable {
+                T::try_from(self.source.lookup(&Term::from(&typed_term))?.content()?).map_err(
+                    |_| EvaluationError::UnboundVariable {
                         variable_name: field.to_string(),
-                    }
-                })
+                    },
+                )
             }
             Term::Constant(value) => {
                 T::try_from(value.clone()).map_err(|_| EvaluationError::UnboundVariable {
@@ -456,7 +456,7 @@ impl Application for ConceptQuery {
                 name: Some(name), ..
             } => {
                 let typed_term: Term<Entity> = Term::var(name.clone());
-                Entity::try_from(source.lookup(&Term::from(&typed_term))?)?
+                Entity::try_from(source.lookup(&Term::from(&typed_term))?.content()?)?
             }
             Term::Constant(value) => match value {
                 Value::Entity(e) => e.clone(),

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -253,13 +253,14 @@ impl From<HashMap<String, AttributeDescriptor>> for ConceptDescriptor {
 
 impl From<&ConceptDescriptor> for Schema {
     fn from(predicate: &ConceptDescriptor) -> Self {
+        use crate::type_system;
         let mut schema = Schema::new();
         for (name, attribute) in predicate.with().iter() {
             schema.insert(
                 name.into(),
                 Field {
                     description: attribute.description().into(),
-                    content_type: attribute.content_type().into(),
+                    content_type: attribute.content_type().map(type_system::Type::primitive),
                     requirement: Requirement::Optional,
                     cardinality: attribute.cardinality(),
                 },
@@ -271,7 +272,7 @@ impl From<&ConceptDescriptor> for Schema {
                 "this".into(),
                 Field {
                     description: "The entity that this model represents".into(),
-                    content_type: Some(Type::Entity).into(),
+                    content_type: Some(type_system::Type::primitive(Type::Entity)),
                     requirement: Requirement::Optional,
                     cardinality: Cardinality::One,
                 },
@@ -1264,10 +1265,8 @@ mod tests {
         assert_eq!(concept.maybe, None, "Empty 'maybe' should become None");
     }
 
-    /// `From<&ConceptDescriptor> for Schema` produces Fields whose
-    /// `content_type` is the unified `type_system::Type`. A typed
-    /// attribute descriptor (e.g. with `Type::String`) lifts to
-    /// `Type::Definite(Primitive(String))`.
+    /// `From<&ConceptDescriptor> for Schema` lifts a typed
+    /// attribute's content_type into the unified `type_system::Type`.
     #[dialog_common::test]
     fn schema_from_concept_uses_unified_type() {
         let descriptor = ConceptDescriptor::from(vec![(
@@ -1281,22 +1280,22 @@ mod tests {
         )]);
         let schema = Schema::from(&descriptor);
         let name = schema.get("name").expect("name field present");
-        assert!(!name.content_type.is_optional());
-        assert_eq!(name.content_type.shape().as_singleton(), Some(Type::String));
+        let content = name.content_type().expect("content_type present");
+        assert!(!content.is_optional());
+        assert_eq!(content.shape().as_singleton(), Some(Type::String));
     }
 
     /// An attribute descriptor with `None` content type produces
-    /// a Field with an anonymous unconstrained variable.
+    /// a Field with `None` content_type — unknown.
     #[dialog_common::test]
-    fn schema_from_concept_untyped_attribute_produces_variable() {
-        use crate::type_system::Definite;
+    fn schema_from_concept_untyped_attribute_produces_none() {
         let descriptor = ConceptDescriptor::from(vec![(
             "tag",
             AttributeDescriptor::new(the!("misc/tag"), "", Cardinality::One, None),
         )]);
         let schema = Schema::from(&descriptor);
         let tag = schema.get("tag").expect("tag field present");
-        assert!(matches!(tag.content_type.shape(), Definite::Variable(_)));
+        assert!(tag.content_type().is_none());
     }
 
     /// The synthesized `this` field always declares
@@ -1314,6 +1313,7 @@ mod tests {
         )]);
         let schema = Schema::from(&descriptor);
         let this = schema.get("this").expect("this field present");
-        assert_eq!(this.content_type.shape().as_singleton(), Some(Type::Entity));
+        let content = this.content_type().expect("entity kind present");
+        assert_eq!(content.shape().as_singleton(), Some(Type::Entity));
     }
 }

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -231,7 +231,7 @@ impl From<&ConceptDescriptor> for Schema {
                 name.into(),
                 Field {
                     description: attribute.description().into(),
-                    content_type: attribute.content_type(),
+                    content_type: attribute.content_type().into(),
                     requirement: Requirement::Optional,
                     cardinality: attribute.cardinality(),
                 },
@@ -243,7 +243,7 @@ impl From<&ConceptDescriptor> for Schema {
                 "this".into(),
                 Field {
                     description: "The entity that this model represents".into(),
-                    content_type: Some(Type::Entity),
+                    content_type: Some(Type::Entity).into(),
                     requirement: Requirement::Optional,
                     cardinality: Cardinality::One,
                 },
@@ -1234,5 +1234,58 @@ mod tests {
             serde_json::from_str(json).expect("Should accept empty 'maybe'");
 
         assert_eq!(concept.maybe, None, "Empty 'maybe' should become None");
+    }
+
+    /// `From<&ConceptDescriptor> for Schema` produces Fields whose
+    /// `content_type` is the unified `type_system::Type`. A typed
+    /// attribute descriptor (e.g. with `Type::String`) lifts to
+    /// `Type::Definite(Primitive(String))`.
+    #[dialog_common::test]
+    fn schema_from_concept_uses_unified_type() {
+        let descriptor = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        let schema = Schema::from(&descriptor);
+        let name = schema.get("name").expect("name field present");
+        assert!(!name.content_type.is_optional());
+        assert_eq!(name.content_type.shape().as_singleton(), Some(Type::String));
+    }
+
+    /// An attribute descriptor with `None` content type produces
+    /// a Field with an anonymous unconstrained variable.
+    #[dialog_common::test]
+    fn schema_from_concept_untyped_attribute_produces_variable() {
+        use crate::type_system::Definite;
+        let descriptor = ConceptDescriptor::from(vec![(
+            "tag",
+            AttributeDescriptor::new(the!("misc/tag"), "", Cardinality::One, None),
+        )]);
+        let schema = Schema::from(&descriptor);
+        let tag = schema.get("tag").expect("tag field present");
+        assert!(matches!(tag.content_type.shape(), Definite::Variable(_)));
+    }
+
+    /// The synthesized `this` field always declares
+    /// `Type::Definite(Primitive(Entity))`.
+    #[dialog_common::test]
+    fn schema_from_concept_synthesizes_this_as_entity() {
+        let descriptor = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        let schema = Schema::from(&descriptor);
+        let this = schema.get("this").expect("this field present");
+        assert_eq!(this.content_type.shape().as_singleton(), Some(Type::Entity));
     }
 }

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -1,11 +1,19 @@
 use crate::attribute::AttributeDescriptor;
+use crate::error::TypeError;
+use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// A non-empty collection of named attribute descriptors.
 ///
-/// This is a transparent wrapper around `Vec<(String, AttributeDescriptor)>` that
-/// enforces non-emptiness — you cannot create a `NamedAttributes` with zero entries.
+/// `NamedAttributes` is valid by construction: it cannot hold zero
+/// entries. Every public construction path is fallible
+/// ([`TryFrom`] for arrays / `Vec` / `HashMap`, and [`Deserialize`])
+/// and returns an error on an empty input. A concept's required
+/// (`with`) attribute set is a `NamedAttributes`, so this single
+/// chokepoint guarantees a concept always declares at least one
+/// required attribute — a concept with none would constrain nothing
+/// and match every entity.
 ///
 /// Serializes as a JSON map: `{ "field-name": { "the": "domain/name", ... } }`
 #[repr(transparent)]
@@ -21,6 +29,25 @@ impl NamedAttributes {
     /// Returns an iterator over attribute names.
     pub fn keys(&self) -> impl Iterator<Item = &str> + '_ {
         self.0.iter().map(|(k, _)| k.as_str())
+    }
+
+    /// Build from pairs whose non-emptiness the caller already
+    /// guarantees by other means — the `#[derive(Concept)]` macro
+    /// (which emits a compile-time assertion that at least one field
+    /// is required) and conversions from an already-validated
+    /// descriptor. Internal-only; public construction goes through
+    /// the fallible [`TryFrom`] impls.
+    pub(crate) fn from_pairs(pairs: Vec<(String, AttributeDescriptor)>) -> Self {
+        NamedAttributes(pairs)
+    }
+
+    /// Fallible builder shared by the [`TryFrom`] impls: rejects an
+    /// empty set with [`TypeError::EmptyConcept`].
+    fn try_new(pairs: Vec<(String, AttributeDescriptor)>) -> Result<Self, TypeError> {
+        if pairs.is_empty() {
+            return Err(TypeError::EmptyConcept);
+        }
+        Ok(NamedAttributes(pairs))
     }
 }
 
@@ -40,13 +67,21 @@ impl<'de> Deserialize<'de> for NamedAttributes {
         D: serde::Deserializer<'de>,
     {
         let map = HashMap::<String, AttributeDescriptor>::deserialize(deserializer)?;
-        Ok(NamedAttributes::from(map))
+        if map.is_empty() {
+            // Non-empty by construction: a concept's required (`with`)
+            // attribute set must have at least one entry, otherwise
+            // the concept constrains nothing and every entity matches.
+            return Err(D::Error::invalid_length(0, &"at least one attribute"));
+        }
+        Ok(NamedAttributes(map.into_iter().collect()))
     }
 }
 
-impl<const N: usize> From<[(&str, AttributeDescriptor); N]> for NamedAttributes {
-    fn from(arr: [(&str, AttributeDescriptor); N]) -> Self {
-        NamedAttributes(
+impl<const N: usize> TryFrom<[(&str, AttributeDescriptor); N]> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(arr: [(&str, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Self::try_new(
             arr.into_iter()
                 .map(|(name, attr)| (name.to_string(), attr))
                 .collect(),
@@ -54,15 +89,19 @@ impl<const N: usize> From<[(&str, AttributeDescriptor); N]> for NamedAttributes 
     }
 }
 
-impl<const N: usize> From<[(String, AttributeDescriptor); N]> for NamedAttributes {
-    fn from(arr: [(String, AttributeDescriptor); N]) -> Self {
-        NamedAttributes(arr.into_iter().collect())
+impl<const N: usize> TryFrom<[(String, AttributeDescriptor); N]> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(arr: [(String, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Self::try_new(arr.into_iter().collect())
     }
 }
 
-impl From<Vec<(&str, AttributeDescriptor)>> for NamedAttributes {
-    fn from(vec: Vec<(&str, AttributeDescriptor)>) -> Self {
-        NamedAttributes(
+impl TryFrom<Vec<(&str, AttributeDescriptor)>> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(&str, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Self::try_new(
             vec.into_iter()
                 .map(|(name, attr)| (name.to_string(), attr))
                 .collect(),
@@ -70,14 +109,18 @@ impl From<Vec<(&str, AttributeDescriptor)>> for NamedAttributes {
     }
 }
 
-impl From<Vec<(String, AttributeDescriptor)>> for NamedAttributes {
-    fn from(vec: Vec<(String, AttributeDescriptor)>) -> Self {
-        NamedAttributes(vec)
+impl TryFrom<Vec<(String, AttributeDescriptor)>> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(String, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Self::try_new(vec)
     }
 }
 
-impl From<HashMap<String, AttributeDescriptor>> for NamedAttributes {
-    fn from(map: HashMap<String, AttributeDescriptor>) -> Self {
-        NamedAttributes(map.into_iter().collect())
+impl TryFrom<HashMap<String, AttributeDescriptor>> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(map: HashMap<String, AttributeDescriptor>) -> Result<Self, Self::Error> {
+        Self::try_new(map.into_iter().collect())
     }
 }

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -526,6 +526,98 @@ mod tests {
         Ok(())
     }
 
+    /// End-to-end: a `#[derive(Concept)]` struct with an `Option<T>`
+    /// field round-trips through the full query pipeline. Alice has
+    /// both `name` and `nickname`; Bob has only `name`. The macro
+    /// emits `Term<Option<String>>` for the `nickname` field; at
+    /// realize time, Alice's nickname appears as `Some(_)` and Bob's
+    /// as `None`.
+    #[dialog_common::test]
+    async fn it_executes_macro_concept_with_optional_field() -> anyhow::Result<()> {
+        use dialog_artifacts::Entity;
+        use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+        use futures_util::TryStreamExt;
+
+        mod employee {
+            use crate::Attribute;
+
+            /// Employee given name
+            #[derive(Attribute, Clone, PartialEq)]
+            #[domain("person")]
+            pub struct Name(pub String);
+
+            /// Employee preferred nickname
+            #[derive(Attribute, Clone, PartialEq)]
+            #[domain("person")]
+            pub struct Nickname(pub String);
+        }
+
+        /// Employee with required name and optional nickname.
+        #[derive(crate::Concept, Debug, Clone)]
+        pub struct Employee {
+            /// Employee entity
+            pub this: Entity,
+            /// Required given name
+            pub name: employee::Name,
+            /// Optional nickname
+            pub nickname: Option<employee::Nickname>,
+        }
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .assert(
+                the!("person/nickname")
+                    .of(alice.clone())
+                    .is("Ali".to_string()),
+            )
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let query = crate::Query::<Employee>::default();
+        let employees: Vec<Employee> = query.perform(&source).try_collect().await?;
+
+        assert_eq!(employees.len(), 2);
+
+        let mut found_alice = false;
+        let mut found_bob = false;
+        for emp in employees {
+            match emp.name.0.as_str() {
+                "Alice" => {
+                    assert_eq!(
+                        emp.nickname.as_ref().map(|n| n.0.as_str()),
+                        Some("Ali"),
+                        "Alice should have nickname Some(Ali)"
+                    );
+                    found_alice = true;
+                }
+                "Bob" => {
+                    assert!(emp.nickname.is_none(), "Bob should have nickname None");
+                    found_bob = true;
+                }
+                other => panic!("Unexpected name: {other}"),
+            }
+        }
+        assert!(found_alice && found_bob);
+
+        Ok(())
+    }
+
     #[dialog_common::test]
     async fn it_executes_query_with_bound_entity() -> anyhow::Result<()> {
         use dialog_artifacts::Entity;

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -361,7 +361,7 @@ mod tests {
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
         // Create a person concept
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -380,7 +380,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("person"));
@@ -470,7 +471,7 @@ mod tests {
 
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -479,6 +480,7 @@ mod tests {
                 Some(Type::String),
             ),
         )])
+        .unwrap()
         .with_maybe(vec![(
             "nickname",
             AttributeDescriptor::new(
@@ -664,7 +666,7 @@ mod tests {
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
         // Create a person concept
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -683,7 +685,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("person"));
@@ -711,7 +714,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_operates_on_concept_conclusion() {
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -730,7 +733,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // Test that attributes are present
         let param_names: Vec<&str> = concept.with().keys().collect();
@@ -742,7 +746,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_creates_concept_descriptor() {
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name".to_string(),
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -750,7 +754,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         // Operator is now a computed URI
         assert!(
@@ -763,7 +768,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_analyzes_concept_application() {
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name".to_string(),
                 AttributeDescriptor::new(
@@ -782,7 +787,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("name".to_string(), Term::var("person_name"));
@@ -808,7 +814,7 @@ mod tests {
     fn it_extracts_deductive_rule_parameters() {
         use std::collections::HashSet;
 
-        let predicate = ConceptDescriptor::from([
+        let predicate = ConceptDescriptor::try_from([
             (
                 "name".to_string(),
                 AttributeDescriptor::new(
@@ -827,7 +833,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let rule = DeductiveRule::from(&predicate);
 
         let params: HashSet<&str> = rule.parameters().collect();
@@ -862,10 +869,11 @@ mod tests {
         use crate::error::{AnalyzerError, TypeError};
 
         // Test AnalyzerError creation
-        let predicate = ConceptDescriptor::from(vec![(
+        let predicate = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(the!("test/name"), "", Cardinality::One, Some(Type::String)),
-        )]);
+        )])
+        .unwrap();
         let rule = DeductiveRule::from(&predicate);
 
         let analyzer_error = AnalyzerError::UnusedParameter {
@@ -912,7 +920,7 @@ mod tests {
         terms.insert("test".to_string(), Term::var("test_var"));
         let concept_app = Proposition::Concept(ConceptQuery {
             terms,
-            predicate: ConceptDescriptor::from([(
+            predicate: ConceptDescriptor::try_from([(
                 "name",
                 AttributeDescriptor::new(
                     the!("test/name"),
@@ -920,7 +928,8 @@ mod tests {
                     Cardinality::One,
                     Some(Type::String),
                 ),
-            )]),
+            )])
+            .unwrap(),
         });
 
         match concept_app {
@@ -976,7 +985,7 @@ mod tests {
             .perform(&operator)
             .await?;
 
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -984,7 +993,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         // Query with constant entity - should only return Alice
         let mut terms = Parameters::new();
@@ -1043,7 +1053,7 @@ mod tests {
             .perform(&operator)
             .await?;
 
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -1062,7 +1072,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // Query with constant name value - should only return Bob
         let mut terms = Parameters::new();
@@ -1119,7 +1130,7 @@ mod tests {
             .perform(&operator)
             .await?;
 
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -1138,7 +1149,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // Query with both name and age constants - should only match Alice
         let mut terms = Parameters::new();
@@ -1172,7 +1184,7 @@ mod tests {
     /// Build a representative two-attribute Person concept query with mixed
     /// variable / constant bindings for the serde round-trip tests.
     fn sample_concept_query() -> ConceptQuery {
-        let predicate = ConceptDescriptor::from(vec![
+        let predicate = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -1191,7 +1203,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".into(), Term::<Any>::var("entity"));

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -410,6 +410,122 @@ mod tests {
         Ok(())
     }
 
+    /// End-to-end: a concept with a `maybe` attribute returns
+    /// rows for entities that lack the optional fact, with the
+    /// optional slot bound to `Binding::Absent`. Entities that
+    /// have the fact get `Binding::Present(value)` for the slot.
+    /// This is the v2 set-widening behavior at the concept
+    /// projection layer, driven by `Resolution::Optional` on the
+    /// emitted `AttributeQuery`.
+    #[dialog_common::test]
+    async fn it_executes_concept_with_optional_field() -> anyhow::Result<()> {
+        use crate::Binding;
+        use dialog_artifacts::Entity;
+        use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+
+        // Alice has both name and nickname; Bob has only name.
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .assert(
+                the!("person/nickname")
+                    .of(alice.clone())
+                    .is("Ali".to_string()),
+            )
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let concept = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .with_maybe(vec![(
+            "nickname",
+            AttributeDescriptor::new(
+                the!("person/nickname"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::var("person"));
+        terms.insert("name".to_string(), Term::var("name"));
+        terms.insert("nickname".to_string(), Term::var("nickname"));
+
+        let application = ConceptQuery {
+            terms,
+            predicate: concept,
+        };
+
+        let selection = futures_util::TryStreamExt::try_collect::<Vec<_>>(
+            application.evaluate(Match::new().seed(), &source),
+        )
+        .await?;
+
+        assert_eq!(
+            selection.len(),
+            2,
+            "Should find 2 people (both Alice and Bob)"
+        );
+
+        let nickname_param = Term::var("nickname");
+        let name_param = Term::var("name");
+
+        let mut found_alice_with_nickname = false;
+        let mut found_bob_without_nickname = false;
+        for match_result in selection.iter() {
+            let name = match_result.lookup(&name_param)?.content()?;
+            let nickname = match_result.lookup(&nickname_param)?;
+            match (&name, nickname) {
+                (Value::String(n), Binding::Present(Value::String(nick)))
+                    if n == "Alice" && nick == "Ali" =>
+                {
+                    found_alice_with_nickname = true;
+                }
+                (Value::String(n), Binding::Absent) if n == "Bob" => {
+                    found_bob_without_nickname = true;
+                }
+                _ => panic!(
+                    "unexpected (name, nickname): ({:?}, {:?})",
+                    name,
+                    match_result.lookup(&nickname_param)
+                ),
+            }
+        }
+        assert!(
+            found_alice_with_nickname,
+            "Alice should have nickname Present"
+        );
+        assert!(
+            found_bob_without_nickname,
+            "Bob should have nickname Absent"
+        );
+
+        Ok(())
+    }
+
     #[dialog_common::test]
     async fn it_executes_query_with_bound_entity() -> anyhow::Result<()> {
         use dialog_artifacts::Entity;

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -14,17 +14,17 @@ use crate::schema::CONCEPT_OVERHEAD;
 use crate::selection::Selection;
 use crate::source::SelectRules;
 use crate::{
-    Cardinality, Environment, EvaluationError, Match, Parameters, Schema, Term, try_stream,
+    Binding, Cardinality, Environment, EvaluationError, Match, Parameters, Schema, Term, try_stream,
 };
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
 use std::fmt::Display;
 
-/// Extract a Match with parameter names from a Match with user variable names
-///
-/// This maps values from user-specified variable names to internal parameter names
-/// for scoped evaluation. All factors are copied with their original provenance.
+/// Extract a Match with parameter names from a Match with user
+/// variable names. Maps values from user-specified variable names
+/// to internal parameter names for scoped evaluation. Both Present
+/// and Absent bindings are propagated.
 fn extract_parameters(source: &Match, terms: &Parameters) -> Result<Match, EvaluationError> {
     let mut matched = Match::new();
 
@@ -32,8 +32,14 @@ fn extract_parameters(source: &Match, terms: &Parameters) -> Result<Match, Evalu
         match user_param {
             Term::Variable { name: Some(_), .. } => {
                 let param = Term::var(param_name);
-                if let Ok(value) = source.lookup(user_param) {
-                    matched.bind(&param, value)?;
+                match source.lookup(user_param) {
+                    Ok(Binding::Present(value)) => {
+                        matched.bind(&param, value)?;
+                    }
+                    Ok(Binding::Absent) => {
+                        matched.bind_absent(&param)?;
+                    }
+                    Err(_) => {}
                 }
             }
             Term::Constant(value) => {
@@ -47,10 +53,9 @@ fn extract_parameters(source: &Match, terms: &Parameters) -> Result<Match, Evalu
     Ok(matched)
 }
 
-/// Merge a Match with parameter names back into a Match with user variable names
-///
-/// This maps values from internal parameter names back to user-specified variable names
-/// after evaluation. All factors are copied with their original provenance.
+/// Merge a Match with parameter names back into a Match with user
+/// variable names after evaluation. Both Present and Absent
+/// bindings are propagated.
 fn merge_parameters(
     base: &Match,
     result: &Match,
@@ -64,8 +69,14 @@ fn merge_parameters(
         }
 
         let param = Term::var(param_name);
-        if let Ok(value) = result.lookup(&param) {
-            merged.bind(user_param, value)?;
+        match result.lookup(&param) {
+            Ok(Binding::Present(value)) => {
+                merged.bind(user_param, value)?;
+            }
+            Ok(Binding::Absent) => {
+                merged.bind_absent(user_param)?;
+            }
+            Err(_) => {}
         }
     }
 
@@ -377,8 +388,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let name = match_result.lookup(&name_param)?;
-            let age = match_result.lookup(&age_param)?;
+            let name = match_result.lookup(&name_param)?.content()?;
+            let age = match_result.lookup(&age_param)?.content()?;
 
             match name {
                 Value::String(n) if n == "Alice" => {
@@ -771,7 +782,7 @@ mod tests {
             "Should find only Alice, not both people"
         );
         assert_eq!(
-            selection[0].lookup(&Term::var("name"))?,
+            selection[0].lookup(&Term::var("name"))?.content()?,
             Value::String("Alice".to_string())
         );
 
@@ -843,11 +854,11 @@ mod tests {
 
         assert_eq!(selection.len(), 1, "Should find only Bob");
         assert_eq!(
-            selection[0].lookup(&Term::var("entity"))?,
+            selection[0].lookup(&Term::var("entity"))?.content()?,
             Value::Entity(bob.clone())
         );
         assert_eq!(
-            selection[0].lookup(&Term::var("age"))?,
+            selection[0].lookup(&Term::var("age"))?.content()?,
             Value::UnsignedInt(30)
         );
 
@@ -923,7 +934,7 @@ mod tests {
             "Should find only Alice with exact name and age match"
         );
         assert_eq!(
-            selection[0].lookup(&Term::var("entity"))?,
+            selection[0].lookup(&Term::var("entity"))?.content()?,
             Value::Entity(alice.clone())
         );
 

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -39,7 +39,14 @@ fn extract_parameters(source: &Match, terms: &Parameters) -> Result<Match, Evalu
                     Ok(Binding::Absent) => {
                         matched.bind_absent(&param)?;
                     }
-                    Err(_) => {}
+                    // Unbound is expected here: the user supplied a
+                    // placeholder term (e.g. `Term::var("alice")` in
+                    // `Query<Person> { this: ..., ... }`) that the
+                    // concept query is about to bind. Skip it —
+                    // downstream evaluation fills it in. Propagate
+                    // any other error.
+                    Err(EvaluationError::UnboundVariable { .. }) => {}
+                    Err(e) => return Err(e),
                 }
             }
             Term::Constant(value) => {
@@ -76,7 +83,12 @@ fn merge_parameters(
             Ok(Binding::Absent) => {
                 merged.bind_absent(user_param)?;
             }
-            Err(_) => {}
+            // Unbound is expected: not every parameter survives the
+            // concept evaluation (e.g. a blank slot the rule never
+            // touched). Skip and let the user variable stay
+            // un-extended. Propagate any other error.
+            Err(EvaluationError::UnboundVariable { .. }) => {}
+            Err(e) => return Err(e),
         }
     }
 

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -100,7 +100,7 @@ mod tests {
     use crate::the;
 
     fn person_concept() -> ConceptDescriptor {
-        ConceptDescriptor::from([(
+        ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -109,6 +109,7 @@ mod tests {
                 Some(Type::String),
             ),
         )])
+        .unwrap()
     }
 
     fn alt_rule(descriptor: &ConceptDescriptor) -> DeductiveRule {

--- a/rust/dialog-query/src/constraint.rs
+++ b/rust/dialog-query/src/constraint.rs
@@ -4,14 +4,17 @@
 //! query evaluation. Unlike applications which query the knowledge base, constraints
 //! operate on variable bindings to filter, infer, or validate values.
 
+pub mod coalesce;
 pub mod equality;
 
 use std::fmt;
 
+pub use coalesce::Coalesce;
 pub use equality::Equality;
 
 use crate::selection::Selection;
 use crate::{Environment, Parameters, Schema};
+use futures_util::future::Either;
 use std::fmt::Display;
 
 /// Constraint enum representing different types of constraints between terms.
@@ -23,54 +26,44 @@ use std::fmt::Display;
 #[serde(tag = "assert", content = "where")]
 pub enum Constraint {
     /// Equality constraint between two terms.
-    ///
-    /// Enforces that both terms must have equal values. Supports bidirectional
-    /// inference: if one term is bound, the other will be inferred to have the
-    /// same value.
     #[serde(rename = "==")]
     Equality(Equality),
+    /// Coalesce constraint — bind `is` from `source` when Present,
+    /// else from `fallback`. Set-widening unwrap.
+    #[serde(rename = "coalesce")]
+    Coalesce(Coalesce),
 }
 
 impl Constraint {
     /// Returns the schema for this constraint.
-    ///
-    /// The schema describes what parameters the constraint requires to be evaluable.
     pub fn schema(&self) -> Schema {
         match self {
-            Constraint::Equality(constraint) => constraint.schema(),
+            Constraint::Equality(c) => c.schema(),
+            Constraint::Coalesce(c) => c.schema(),
         }
     }
 
     /// Estimates the cost of evaluating this constraint given the current environment.
-    ///
-    /// Returns `Some(cost)` if the constraint can be evaluated (at least one term is bound).
-    /// Returns `None` if the constraint cannot be evaluated yet (neither term is bound).
     pub fn estimate(&self, env: &Environment) -> Option<usize> {
         match self {
-            Constraint::Equality(constraint) => constraint.estimate(env),
+            Constraint::Equality(c) => c.estimate(env),
+            Constraint::Coalesce(c) => c.estimate(env),
         }
     }
 
     /// Returns the parameters for this constraint.
     pub fn parameters(&self) -> Parameters {
         match self {
-            Constraint::Equality(constraint) => constraint.parameters(),
+            Constraint::Equality(c) => c.parameters(),
+            Constraint::Coalesce(c) => c.parameters(),
         }
     }
 
     /// Evaluates the constraint against the current selection of matches.
-    ///
-    /// This method processes each match in the input selection and:
-    /// - **Filters** matches where constraints are violated
-    /// - **Infers** missing bindings when possible
-    /// - **Errors** when constraints cannot be evaluated
-    ///
-    /// # Returns
-    /// A stream of matches that satisfy the constraint, with any necessary
-    /// variable bindings added through inference.
     pub fn evaluate<M: Selection>(self, selection: M) -> impl Selection {
         match self {
-            Constraint::Equality(constraint) => constraint.evaluate(selection),
+            Constraint::Equality(c) => Either::Left(c.evaluate(selection)),
+            Constraint::Coalesce(c) => Either::Right(c.evaluate(selection)),
         }
     }
 }
@@ -78,7 +71,8 @@ impl Constraint {
 impl Display for Constraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Constraint::Equality(constraint) => Display::fmt(constraint, f),
+            Constraint::Equality(c) => Display::fmt(c, f),
+            Constraint::Coalesce(c) => Display::fmt(c, f),
         }
     }
 }
@@ -86,5 +80,11 @@ impl Display for Constraint {
 impl From<Equality> for Constraint {
     fn from(constraint: Equality) -> Self {
         Constraint::Equality(constraint)
+    }
+}
+
+impl From<Coalesce> for Constraint {
+    fn from(constraint: Coalesce) -> Self {
+        Constraint::Coalesce(constraint)
     }
 }

--- a/rust/dialog-query/src/constraint/coalesce.rs
+++ b/rust/dialog-query/src/constraint/coalesce.rs
@@ -35,12 +35,15 @@ const COALESCE_COST: usize = 1;
 /// is `Absent`.
 ///
 /// Builder shape:
-/// ```ignore
-/// let coalesce = nickname_term.unwrap_or("Anon").is(display_name);
+/// ```no_run
+/// # use dialog_query::Term;
+/// let nickname: Term<Option<String>> = Term::var("nickname");
+/// let display_name: Term<String> = Term::var("display_name");
+/// let premise = nickname.unwrap_or("Anon").is(display_name);
 /// ```
 ///
-/// Type contract (checked at rule-compile time by the unifier
-/// integration in a later slice):
+/// Type contract (checked at rule-compile time by
+/// [`Coalesce::validate`]):
 /// - `source` has kind `Optional<α>` for some `α`.
 /// - `fallback` has kind `α`.
 /// - `is` has kind `α`.
@@ -69,10 +72,14 @@ impl Coalesce {
     ///
     /// The typed builder
     /// [`Term::<Option<U>>::unwrap_or`](crate::Term::unwrap_or)
-    /// enforces the type contract at Rust's type level. For
-    /// dynamic construction (wire-format deserialization, raw
-    /// builders), call [`Self::validate`] to check the contract
-    /// at runtime.
+    /// enforces the type contract at Rust's type level — call
+    /// sites with type mismatches fail to compile. For dynamic
+    /// construction (wire-format deserialization, raw
+    /// `Coalesce::new` calls), [`Self::validate`] checks the
+    /// contract at runtime; it is invoked automatically by
+    /// [`DeductiveRule::new`](crate::DeductiveRule::new) so any
+    /// Coalesce reaching the rule compiler is checked, regardless
+    /// of how it was constructed.
     pub fn new(source: Term<Any>, fallback: Term<Any>, is: Term<Any>) -> Self {
         Self {
             source,

--- a/rust/dialog-query/src/constraint/coalesce.rs
+++ b/rust/dialog-query/src/constraint/coalesce.rs
@@ -394,16 +394,11 @@ mod tests {
     /// fallback / is are both `String`.
     #[dialog_common::test]
     fn validate_accepts_matching_types() {
-        use crate::artifact::Type as ValueType;
-        use crate::type_system;
         use crate::type_system::unifier::Context;
 
-        let source = Term::<Any>::typed_var(
-            "source",
-            type_system::Type::primitive(ValueType::String).optional(),
-        );
+        let source: Term<Any> = Term::<Option<String>>::var("source").into();
         let fallback = Term::<Any>::constant("Anon".to_string());
-        let is = Term::<Any>::typed_var("is", type_system::Type::primitive(ValueType::String));
+        let is: Term<Any> = Term::<String>::var("is").into();
 
         let coalesce = Coalesce::new(source, fallback, is);
         let mut ctx = Context::new();
@@ -415,13 +410,10 @@ mod tests {
     /// `validate` rejects a source whose kind isn't set-widened.
     #[dialog_common::test]
     fn validate_rejects_non_optional_source() {
-        use crate::artifact::Type as ValueType;
-        use crate::type_system;
         use crate::type_system::unifier::{Context, UnifyError};
 
         // Source kind is `String`, not `Optional<String>` — bug.
-        let source =
-            Term::<Any>::typed_var("source", type_system::Type::primitive(ValueType::String));
+        let source: Term<Any> = Term::<String>::var("source").into();
         let fallback = Term::<Any>::constant("Anon".to_string());
         let is = Term::<Any>::var("is");
 
@@ -437,14 +429,9 @@ mod tests {
     /// underlying is `String`, fallback is `u32`.
     #[dialog_common::test]
     fn validate_rejects_fallback_type_mismatch() {
-        use crate::artifact::Type as ValueType;
-        use crate::type_system;
         use crate::type_system::unifier::{Context, UnifyError};
 
-        let source = Term::<Any>::typed_var(
-            "source",
-            type_system::Type::primitive(ValueType::String).optional(),
-        );
+        let source: Term<Any> = Term::<Option<String>>::var("source").into();
         let fallback = Term::<Any>::constant(42u32);
         let is = Term::<Any>::var("is");
 

--- a/rust/dialog-query/src/constraint/coalesce.rs
+++ b/rust/dialog-query/src/constraint/coalesce.rs
@@ -1,0 +1,444 @@
+//! Coalesce constraint — set-widening unwrap with a fallback.
+//!
+//! `Coalesce` is the v2 expression of "if `source` is `Present`,
+//! bind `is` to it; otherwise bind `is` to `fallback`." It is
+//! the operator a `Term::<Option<U>>::unwrap_or` builder produces:
+//!
+//! ```text
+//! nickname.unwrap_or("Anon").is(display_name)
+//! ```
+//!
+//! Evaluation is row-local: one row in, one row out. The
+//! `source` term is looked up against the input row's bindings;
+//! if [`Binding::Present`](crate::Binding::Present) the value
+//! flows into `is`; if [`Binding::Absent`](crate::Binding::Absent)
+//! (or if `source` is unbound) the fallback value flows into `is`
+//! instead. `fallback` may itself be a term — variable or
+//! constant — and is resolved in the same row.
+
+use std::fmt;
+use std::fmt::Display;
+
+use crate::type_system::unifier::{Context, Type as UnifierType, UnifyError, lift};
+use crate::types::Any;
+use crate::{
+    Binding, Cardinality, Environment, Field, Parameters, Requirement, Schema, Selection, Term,
+    try_stream,
+};
+
+/// Cost for evaluating a coalesce constraint (single row lookup +
+/// branch + bind).
+const COALESCE_COST: usize = 1;
+
+/// Set-widening unwrap: produce a non-optional value from an
+/// optional `source`, falling back to `fallback` when the source
+/// is `Absent`.
+///
+/// Builder shape:
+/// ```ignore
+/// let coalesce = nickname_term.unwrap_or("Anon").is(display_name);
+/// ```
+///
+/// Type contract (checked at rule-compile time by the unifier
+/// integration in a later slice):
+/// - `source` has kind `Optional<α>` for some `α`.
+/// - `fallback` has kind `α`.
+/// - `is` has kind `α`.
+///
+/// At runtime, evaluation is `.map`-style — one row in, one row
+/// out:
+/// - If `source` looks up to `Present(v)`: bind `is` to `v`.
+/// - If `source` looks up to `Absent` or is unbound: bind `is` to
+///   `fallback`'s resolved value.
+/// - If `fallback` itself is an unbound variable, the row is
+///   filtered out (we can't bind without a concrete value).
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Coalesce {
+    /// The optional input term — typically a variable bound by an
+    /// upstream optional attribute query.
+    pub source: Term<Any>,
+    /// The default value used when `source` is `Absent` or unbound.
+    pub fallback: Term<Any>,
+    /// The output term that receives either `source`'s value or
+    /// `fallback`'s value.
+    pub is: Term<Any>,
+}
+
+impl Coalesce {
+    /// Create a new coalesce constraint.
+    ///
+    /// The typed builder
+    /// [`Term::<Option<U>>::unwrap_or`](crate::Term::unwrap_or)
+    /// enforces the type contract at Rust's type level. For
+    /// dynamic construction (wire-format deserialization, raw
+    /// builders), call [`Self::validate`] to check the contract
+    /// at runtime.
+    pub fn new(source: Term<Any>, fallback: Term<Any>, is: Term<Any>) -> Self {
+        Self {
+            source,
+            fallback,
+            is,
+        }
+    }
+
+    /// Validate the type contract of this coalesce against a
+    /// unification context: pick a fresh `α`, then unify `α` with
+    /// `source`'s underlying (non-Nothing) shape, `fallback`'s
+    /// kind, and `is`'s kind. If `source`'s kind is given, it
+    /// must include `Nothing` (set-widened) — otherwise this
+    /// coalesce can never trigger the fallback path.
+    ///
+    /// Used at rule-compile time and at wire-format
+    /// deserialization to catch type mismatches that bypass the
+    /// typed builder.
+    ///
+    /// Terms with no static kind contribute no constraint — `α`
+    /// stays open.
+    pub fn validate(&self, ctx: &mut Context) -> Result<(), UnifyError> {
+        let alpha = ctx.fresh_var();
+
+        if let Some(source) = self.source.kind() {
+            if !source.is_optional() {
+                return Err(UnifyError::SourceNotOptional);
+            }
+            // Strip the Nothing bit to get α's underlying shape.
+            let underlying = source.without_nothing();
+            ctx.unify(&UnifierType::Static(underlying), &alpha)?;
+        }
+        if let Some(k) = self.fallback.kind() {
+            ctx.unify(&lift(&k), &alpha)?;
+        }
+        if let Some(k) = self.is.kind() {
+            ctx.unify(&lift(&k), &alpha)?;
+        }
+        Ok(())
+    }
+
+    /// Schema describing the three slots. All three are required;
+    /// `source` is set-widened (Optional), `fallback` and `is`
+    /// share the unwrapped shape.
+    pub fn schema(&self) -> Schema {
+        let mut schema = Schema::new();
+        let requirement = Requirement::new_group();
+        schema.insert(
+            "source".into(),
+            Field {
+                description:
+                    "Optional input term — value flows to `is` when Present, else `fallback` does."
+                        .into(),
+                content_type: self.source.kind(),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema.insert(
+            "fallback".into(),
+            Field {
+                description: "Default value used when `source` is `Absent` or unbound.".into(),
+                content_type: self.fallback.kind(),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema.insert(
+            "is".into(),
+            Field {
+                description: "Output term — receives `source`'s value or `fallback`'s.".into(),
+                content_type: self.is.kind(),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema
+    }
+
+    /// Estimate cost. Constant — coalesce is a row-local rewrite.
+    pub fn estimate(&self, _env: &Environment) -> Option<usize> {
+        Some(COALESCE_COST)
+    }
+
+    /// Returns the named parameters for this constraint.
+    pub fn parameters(&self) -> Parameters {
+        let mut params = Parameters::new();
+        params.insert("source".to_string(), self.source.clone());
+        params.insert("fallback".to_string(), self.fallback.clone());
+        params.insert("is".to_string(), self.is.clone());
+        params
+    }
+
+    /// Evaluate: row-local `.map` — for each input row, decide
+    /// whether to bind `is` from `source` or from `fallback`.
+    /// Never consumes the input stream into a buffer; passes rows
+    /// through one at a time.
+    pub fn evaluate<M: Selection>(self, selection: M) -> impl Selection {
+        let source = self.source;
+        let fallback = self.fallback;
+        let is = self.is;
+        try_stream! {
+            for await candidate in selection {
+                let base = candidate?;
+
+                // Resolve the source binding: Present, Absent, or unbound.
+                let source_binding = base.lookup(&source);
+
+                // Resolve the fallback value: must be concrete to bind output.
+                let fallback_value = base.lookup(&fallback);
+
+                match source_binding {
+                    Ok(Binding::Present(value)) => {
+                        let mut extension = base.clone();
+                        extension.bind(&is, value)?;
+                        yield extension;
+                    }
+                    Ok(Binding::Absent) | Err(_) => {
+                        // Fallback must resolve to a Present value to bind output.
+                        // Absent or unbound fallback filters the row.
+                        if let Ok(Binding::Present(value)) = fallback_value {
+                            let mut extension = base.clone();
+                            extension.bind(&is, value)?;
+                            yield extension;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Display for Coalesce {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "coalesce({}, {}) -> {}",
+            self.source, self.fallback, self.is
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EvaluationError;
+    use crate::Value;
+    use crate::selection::Match;
+    use futures_util::TryStreamExt;
+    use futures_util::stream::iter as stream_iter;
+
+    /// Source is Present — output binds to source's value.
+    #[dialog_common::test]
+    async fn it_binds_output_from_source_when_present() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind(&Term::var("source"), Value::from("hello".to_string()))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("hello".to_string()),
+            "output should bind to source's value"
+        );
+        Ok(())
+    }
+
+    /// Source is Absent — output binds to fallback's value.
+    #[dialog_common::test]
+    async fn it_binds_output_from_fallback_when_absent() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("default".to_string()),
+            "output should bind to fallback's value"
+        );
+        Ok(())
+    }
+
+    /// Source unbound (no binding at all) is also handled like Absent —
+    /// output takes from fallback.
+    #[dialog_common::test]
+    async fn it_binds_output_from_fallback_when_source_unbound() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let candidate = Match::new();
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("default".to_string())
+        );
+        Ok(())
+    }
+
+    /// Fallback may itself be a variable resolved against the row.
+    #[dialog_common::test]
+    async fn it_resolves_fallback_when_variable() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(Term::var("source"), Term::var("fallback"), Term::var("out"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+        candidate.bind(&Term::var("fallback"), Value::from(42u32))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from(42u32)
+        );
+        Ok(())
+    }
+
+    /// Fallback also unbound — can't produce a value, row is filtered.
+    #[dialog_common::test]
+    async fn it_filters_when_source_absent_and_fallback_unbound() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(Term::var("source"), Term::var("fallback"), Term::var("out"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "row should be filtered when no value can be produced"
+        );
+        Ok(())
+    }
+
+    /// Multiple rows in → multiple rows out, each independently decided.
+    /// Confirms streaming `.map` behavior, not collect-then-process.
+    #[dialog_common::test]
+    async fn it_processes_each_row_independently() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        // Two rows: one with Present source, one with Absent source.
+        let mut present_row = Match::new();
+        present_row.bind(&Term::var("source"), Value::from("present".to_string()))?;
+
+        let mut absent_row = Match::new();
+        absent_row.bind_absent(&Term::var("source"))?;
+
+        // Build a seed selection containing both rows.
+        let selection = stream_iter(vec![Ok(present_row), Ok(absent_row)]);
+
+        let results: Vec<Match> = coalesce.evaluate(selection).try_collect().await?;
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("present".to_string())
+        );
+        assert_eq!(
+            results[1].lookup(&Term::var("out"))?.content()?,
+            Value::from("default".to_string())
+        );
+        Ok(())
+    }
+
+    /// Schema reports all three slots.
+    #[dialog_common::test]
+    fn schema_describes_three_slots() {
+        let coalesce = Coalesce::new(Term::var("source"), Term::var("fallback"), Term::var("out"));
+        let schema = coalesce.schema();
+        assert!(schema.get("source").is_some());
+        assert!(schema.get("fallback").is_some());
+        assert!(schema.get("is").is_some());
+    }
+
+    /// `validate` succeeds when source is `Optional<String>` and
+    /// fallback / is are both `String`.
+    #[dialog_common::test]
+    fn validate_accepts_matching_types() {
+        use crate::artifact::Type as ValueType;
+        use crate::type_system;
+        use crate::type_system::unifier::Context;
+
+        let source = Term::<Any>::typed_var(
+            "source",
+            Some(type_system::Type::primitive(ValueType::String).optional()),
+        );
+        let fallback = Term::<Any>::constant("Anon".to_string());
+        let is =
+            Term::<Any>::typed_var("is", Some(type_system::Type::primitive(ValueType::String)));
+
+        let coalesce = Coalesce::new(source, fallback, is);
+        let mut ctx = Context::new();
+        coalesce
+            .validate(&mut ctx)
+            .expect("matching types should validate");
+    }
+
+    /// `validate` rejects a source whose kind isn't set-widened.
+    #[dialog_common::test]
+    fn validate_rejects_non_optional_source() {
+        use crate::artifact::Type as ValueType;
+        use crate::type_system;
+        use crate::type_system::unifier::{Context, UnifyError};
+
+        // Source kind is `String`, not `Optional<String>` — bug.
+        let source = Term::<Any>::typed_var(
+            "source",
+            Some(type_system::Type::primitive(ValueType::String)),
+        );
+        let fallback = Term::<Any>::constant("Anon".to_string());
+        let is = Term::<Any>::var("is");
+
+        let coalesce = Coalesce::new(source, fallback, is);
+        let mut ctx = Context::new();
+        match coalesce.validate(&mut ctx) {
+            Err(UnifyError::SourceNotOptional) => {}
+            other => panic!("expected SourceNotOptional, got {:?}", other),
+        }
+    }
+
+    /// `validate` rejects mismatched fallback type — source's
+    /// underlying is `String`, fallback is `u32`.
+    #[dialog_common::test]
+    fn validate_rejects_fallback_type_mismatch() {
+        use crate::artifact::Type as ValueType;
+        use crate::type_system;
+        use crate::type_system::unifier::{Context, UnifyError};
+
+        let source = Term::<Any>::typed_var(
+            "source",
+            Some(type_system::Type::primitive(ValueType::String).optional()),
+        );
+        let fallback = Term::<Any>::constant(42u32);
+        let is = Term::<Any>::var("is");
+
+        let coalesce = Coalesce::new(source, fallback, is);
+        let mut ctx = Context::new();
+        match coalesce.validate(&mut ctx) {
+            Err(UnifyError::ConstraintConflict { .. }) => {}
+            other => panic!("expected ConstraintConflict, got {:?}", other),
+        }
+    }
+}

--- a/rust/dialog-query/src/constraint/coalesce.rs
+++ b/rust/dialog-query/src/constraint/coalesce.rs
@@ -201,16 +201,39 @@ impl Coalesce {
                 // Resolve the fallback value: must be concrete to bind output.
                 let fallback_value = base.lookup(&fallback);
 
-                match source_binding {
-                    Ok(Binding::Present(value)) => {
-                        let mut extension = base.clone();
-                        extension.bind(&is, value)?;
-                        yield extension;
-                    }
-                    Ok(Binding::Absent) | Err(_) => {
-                        // Fallback must resolve to a Present value to bind output.
-                        // Absent or unbound fallback filters the row.
-                        if let Ok(Binding::Present(value)) = fallback_value {
+                // The value coalesce would bind into `is`: `source`
+                // when Present, else `fallback` if it resolves to a
+                // concrete value. `None` means there is nothing to
+                // produce (Absent/unbound source and Absent/unbound
+                // fallback) — the row is filtered.
+                let chosen = match source_binding {
+                    Ok(Binding::Present(value)) => Some(value),
+                    Ok(Binding::Absent) | Err(_) => match fallback_value {
+                        Ok(Binding::Present(value)) => Some(value),
+                        _ => None,
+                    },
+                };
+
+                if let Some(value) = chosen {
+                    // Reconcile against any existing binding of `is`
+                    // rather than binding unconditionally. An
+                    // unconditional `bind` would error — and the `?`
+                    // would abort the whole stream — when `is` is
+                    // already bound to a different value or to Absent.
+                    // Mirror Equality: a pre-bound `is` acts as a
+                    // filter.
+                    match base.lookup(&is) {
+                        // `is` already carries the same value: yield
+                        // unchanged (bind would be a no-op anyway).
+                        Ok(Binding::Present(existing)) if existing == value => {
+                            yield base;
+                        }
+                        // `is` already carries a different value, or
+                        // Absent: coalesce always yields a Present
+                        // value, which can never equal those — filter.
+                        Ok(Binding::Present(_)) | Ok(Binding::Absent) => {}
+                        // `is` is unbound: bind the chosen value.
+                        Err(_) => {
                             let mut extension = base.clone();
                             extension.bind(&is, value)?;
                             yield extension;
@@ -376,6 +399,83 @@ mod tests {
         assert_eq!(
             results[1].lookup(&Term::var("out"))?.content()?,
             Value::from("default".to_string())
+        );
+        Ok(())
+    }
+
+    /// A pre-bound `is` reconciles as a filter, not a stream abort.
+    /// When `is` is already bound to a *different* Present value, the
+    /// chosen coalesce value can't satisfy it, so the row is filtered
+    /// — exactly one row in, zero rows out, and crucially **no
+    /// error**. Binding `is` unconditionally would make `?` propagate
+    /// `EvaluationError::Assignment` out of the whole stream.
+    #[dialog_common::test]
+    async fn it_filters_when_is_prebound_to_different_value() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind(&Term::var("source"), Value::from("Alice".to_string()))?;
+        // `out` already carries a different value from an upstream premise.
+        candidate.bind(&Term::var("out"), Value::from("Bob".to_string()))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a pre-bound `is` that disagrees should filter the row, not abort the query"
+        );
+        Ok(())
+    }
+
+    /// A pre-bound `is` that *agrees* with the chosen value yields the
+    /// row unchanged.
+    #[dialog_common::test]
+    async fn it_yields_when_is_prebound_to_matching_value() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind(&Term::var("source"), Value::from("Alice".to_string()))?;
+        candidate.bind(&Term::var("out"), Value::from("Alice".to_string()))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1, "a matching pre-bound `is` should yield");
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("Alice".to_string())
+        );
+        Ok(())
+    }
+
+    /// A pre-bound *Absent* `is` filters: coalesce always produces a
+    /// Present value, which can never equal Absent.
+    #[dialog_common::test]
+    async fn it_filters_when_is_prebound_absent() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+        candidate.bind_absent(&Term::var("out"))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a Present coalesce result can't reconcile with an Absent `is` — filter"
         );
         Ok(())
     }

--- a/rust/dialog-query/src/constraint/coalesce.rs
+++ b/rust/dialog-query/src/constraint/coalesce.rs
@@ -400,11 +400,10 @@ mod tests {
 
         let source = Term::<Any>::typed_var(
             "source",
-            Some(type_system::Type::primitive(ValueType::String).optional()),
+            type_system::Type::primitive(ValueType::String).optional(),
         );
         let fallback = Term::<Any>::constant("Anon".to_string());
-        let is =
-            Term::<Any>::typed_var("is", Some(type_system::Type::primitive(ValueType::String)));
+        let is = Term::<Any>::typed_var("is", type_system::Type::primitive(ValueType::String));
 
         let coalesce = Coalesce::new(source, fallback, is);
         let mut ctx = Context::new();
@@ -421,10 +420,8 @@ mod tests {
         use crate::type_system::unifier::{Context, UnifyError};
 
         // Source kind is `String`, not `Optional<String>` — bug.
-        let source = Term::<Any>::typed_var(
-            "source",
-            Some(type_system::Type::primitive(ValueType::String)),
-        );
+        let source =
+            Term::<Any>::typed_var("source", type_system::Type::primitive(ValueType::String));
         let fallback = Term::<Any>::constant("Anon".to_string());
         let is = Term::<Any>::var("is");
 
@@ -446,7 +443,7 @@ mod tests {
 
         let source = Term::<Any>::typed_var(
             "source",
-            Some(type_system::Type::primitive(ValueType::String).optional()),
+            type_system::Type::primitive(ValueType::String).optional(),
         );
         let fallback = Term::<Any>::constant(42u32);
         let is = Term::<Any>::var("is");

--- a/rust/dialog-query/src/constraint/coalesce.rs
+++ b/rust/dialog-query/src/constraint/coalesce.rs
@@ -84,26 +84,36 @@ impl Coalesce {
     /// Validate the type contract of this coalesce against a
     /// unification context: pick a fresh `α`, then unify `α` with
     /// `source`'s underlying (non-Nothing) shape, `fallback`'s
-    /// kind, and `is`'s kind. If `source`'s kind is given, it
-    /// must include `Nothing` (set-widened) — otherwise this
-    /// coalesce can never trigger the fallback path.
+    /// kind, and `is`'s kind.
     ///
-    /// Used at rule-compile time and at wire-format
-    /// deserialization to catch type mismatches that bypass the
-    /// typed builder.
+    /// **Source typing is enforced.** If `source` carries a static
+    /// kind, it must be set-widened (admit `Nothing`); otherwise
+    /// the coalesce can never trigger the fallback path and is
+    /// rejected with [`UnifyError::SourceNotOptional`]. If `source`
+    /// has no static kind (`kind() == None`), it is treated as
+    /// fully unconstrained — the unifier may not narrow it. The
+    /// caller is then responsible for ensuring the source is
+    /// actually set-widened at runtime; the typed
+    /// [`unwrap_or`](crate::Term::unwrap_or) builder enforces this
+    /// at the Rust type level.
     ///
-    /// Terms with no static kind contribute no constraint — `α`
-    /// stays open.
+    /// **`fallback` and `is` with static kinds** must unify with
+    /// `α` — so they agree with each other and with the source's
+    /// underlying shape (when known).
     pub fn validate(&self, ctx: &mut Context) -> Result<(), UnifyError> {
         let alpha = ctx.fresh_var();
 
-        if let Some(source) = self.source.kind() {
-            if !source.is_optional() {
-                return Err(UnifyError::SourceNotOptional);
+        match self.source.kind() {
+            Some(source) if source.is_optional() => {
+                // Strip the Nothing bit to get α's underlying shape.
+                let underlying = source.without_nothing();
+                ctx.unify(&UnifierType::Static(underlying), &alpha)?;
             }
-            // Strip the Nothing bit to get α's underlying shape.
-            let underlying = source.without_nothing();
-            ctx.unify(&UnifierType::Static(underlying), &alpha)?;
+            Some(_) => return Err(UnifyError::SourceNotOptional),
+            None => {
+                // No static kind on source — caller takes responsibility.
+                // α stays open; fallback/is still link to it below.
+            }
         }
         if let Some(k) = self.fallback.kind() {
             ctx.unify(&lift(&k), &alpha)?;

--- a/rust/dialog-query/src/constraint/equality.rs
+++ b/rust/dialog-query/src/constraint/equality.rs
@@ -264,12 +264,12 @@ mod tests {
     /// A typed constant on one side produces a concrete primitive
     /// for that field's content_type.
     #[dialog_common::test]
-    fn schema_lifts_typed_constant_to_definite_primitive() {
+    fn schema_lifts_typed_constant_to_primitive() {
         use crate::artifact::Type as ValueType;
         let constraint = Equality::new(Term::var("x"), Term::constant(42u32));
         let schema = constraint.schema();
         let is_field = schema.get("is").expect("is field present");
         let content = is_field.content_type().expect("content_type present");
-        assert_eq!(content.shape().as_singleton(), Some(ValueType::UnsignedInt));
+        assert_eq!(content.as_value_type(), Some(ValueType::UnsignedInt));
     }
 }

--- a/rust/dialog-query/src/constraint/equality.rs
+++ b/rust/dialog-query/src/constraint/equality.rs
@@ -116,31 +116,50 @@ impl Equality {
                 let base = candidate?;
 
                 match (base.lookup(&this), base.lookup(&is)) {
-                    // Case 1: Both bound to Present values - verify equal.
+                    // Both Present: yield iff values match.
                     (Ok(Binding::Present(this_val)), Ok(Binding::Present(is_val))) => {
                         if this_val == is_val {
                             yield base;
                         }
-                        // Otherwise filter out this match (no yield)
                     }
-                    // Case 1b: Either side is Absent — equality on
-                    // absence has no value to compare; filter out.
-                    (Ok(Binding::Absent), _) | (_, Ok(Binding::Absent)) => {
-                        // Filter out (no yield)
+                    // Both Absent: Nothing == Nothing, yield.
+                    (Ok(Binding::Absent), Ok(Binding::Absent)) => {
+                        yield base;
                     }
-                    // Case 2: Only "is" is bound - infer "this" from "is"
+                    // One side Absent, other Present: disjoint kinds
+                    // (Nothing vs primitive), can never be equal — filter.
+                    (Ok(Binding::Absent), Ok(Binding::Present(_)))
+                    | (Ok(Binding::Present(_)), Ok(Binding::Absent)) => {}
+                    // One side Present, other unbound: propagate the value.
                     (Err(_), Ok(Binding::Present(is_val))) => {
                         let mut extension = base.clone();
                         extension.bind(&this, is_val)?;
                         yield extension;
                     }
-                    // Case 3: Only "this" is bound - infer "is" from "this"
                     (Ok(Binding::Present(this_val)), Err(_)) => {
                         let mut extension = base.clone();
                         extension.bind(&is, this_val)?;
                         yield extension;
                     }
-                    // Case 4: Neither term is bound - cannot evaluate
+                    // One side Absent, other unbound: propagate Absent
+                    // iff the unbound term's kind admits Nothing.
+                    // Otherwise the row violates the unbound term's
+                    // type contract — filter.
+                    (Ok(Binding::Absent), Err(_)) => {
+                        if is.is_optional() || is.kind().is_none() {
+                            let mut extension = base.clone();
+                            extension.bind_absent(&is)?;
+                            yield extension;
+                        }
+                    }
+                    (Err(_), Ok(Binding::Absent)) => {
+                        if this.is_optional() || this.kind().is_none() {
+                            let mut extension = base.clone();
+                            extension.bind_absent(&this)?;
+                            yield extension;
+                        }
+                    }
+                    // Neither bound — equality has nothing to work with.
                     (Err(_), Err(_)) => {
                         Err(EvaluationError::ConstraintViolation {
                             constraint: format!("{} == {}", this, is)
@@ -259,6 +278,79 @@ mod tests {
         let is_field = schema.get("is").expect("is field present");
         assert!(this_field.content_type().is_none());
         assert!(is_field.content_type().is_none());
+    }
+
+    /// Absent on both sides — Nothing == Nothing, yield.
+    #[dialog_common::test]
+    async fn it_yields_when_both_sides_absent() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(Term::var("x"), Term::var("y"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+        candidate.bind_absent(&Term::<Any>::var("y"))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1, "Absent == Absent should yield");
+        Ok(())
+    }
+
+    /// Absent on one side, Present on the other — disjoint kinds,
+    /// filter.
+    #[dialog_common::test]
+    async fn it_filters_when_absent_meets_present() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(Term::var("x"), Term::var("y"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+        candidate.bind(&Term::var("y"), Value::from(42))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 0, "Absent == Present should filter");
+        Ok(())
+    }
+
+    /// Absent on one side, unbound on the other where the unbound
+    /// term's kind admits Nothing — propagate Absent.
+    #[dialog_common::test]
+    async fn it_infers_absent_into_optional_term() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(
+            Term::var("x"),
+            Term::<Any>::from(Term::<Option<String>>::var("y")),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].lookup(&Term::<Any>::var("y"))?, Binding::Absent);
+        Ok(())
+    }
+
+    /// Absent on one side, unbound on the other where the unbound
+    /// term's kind does NOT admit Nothing — filter (would propagate
+    /// Absent into a non-optional slot).
+    #[dialog_common::test]
+    async fn it_filters_absent_into_required_term() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(
+            Term::var("x"),
+            Term::<Any>::from(Term::<String>::var("y")),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "Absent cannot bind a non-optional term — filter"
+        );
+        Ok(())
     }
 
     /// A typed constant on one side produces a concrete primitive

--- a/rust/dialog-query/src/constraint/equality.rs
+++ b/rust/dialog-query/src/constraint/equality.rs
@@ -335,10 +335,7 @@ mod tests {
     /// Absent into a non-optional slot).
     #[dialog_common::test]
     async fn it_filters_absent_into_required_term() -> Result<(), EvaluationError> {
-        let constraint = Equality::new(
-            Term::var("x"),
-            Term::<Any>::from(Term::<String>::var("y")),
-        );
+        let constraint = Equality::new(Term::var("x"), Term::<Any>::from(Term::<String>::var("y")));
 
         let mut candidate = Match::new();
         candidate.bind_absent(&Term::<Any>::var("x"))?;

--- a/rust/dialog-query/src/constraint/equality.rs
+++ b/rust/dialog-query/src/constraint/equality.rs
@@ -61,7 +61,7 @@ impl Equality {
             "this".into(),
             Field {
                 description: "Term that must be equal to the \"is\" term.".into(),
-                content_type: self.this.content_type(),
+                content_type: self.this.content_type().into(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -70,7 +70,7 @@ impl Equality {
             "is".into(),
             Field {
                 description: "Term that must be equal to the \"this\" term.".into(),
-                content_type: self.is.content_type(),
+                content_type: self.is.content_type().into(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -245,6 +245,44 @@ mod tests {
             constraint.estimate(&env),
             None,
             "Should return None when neither term is bound"
+        );
+    }
+
+    /// `Equality::schema()` declares each side's content_type
+    /// from the term's `content_type()` storage tag, lifted into
+    /// the unified `type_system::Type`. Variables of unknown type
+    /// produce anonymous variables; constants of known type
+    /// produce concrete primitives.
+    #[dialog_common::test]
+    fn schema_lifts_unknown_term_type_to_anonymous_variable() {
+        use crate::type_system::Definite;
+        let constraint = Equality::new(Term::var("x"), Term::var("y"));
+        let schema = constraint.schema();
+        let this_field = schema.get("this").expect("this field present");
+        let is_field = schema.get("is").expect("is field present");
+        // Both terms are untyped variables, so both fields lift
+        // to anonymous variables.
+        assert!(matches!(
+            this_field.content_type.shape(),
+            Definite::Variable(_)
+        ));
+        assert!(matches!(
+            is_field.content_type.shape(),
+            Definite::Variable(_)
+        ));
+    }
+
+    /// A typed constant on one side produces a concrete primitive
+    /// for that field's content_type.
+    #[dialog_common::test]
+    fn schema_lifts_typed_constant_to_definite_primitive() {
+        use crate::artifact::Type as ValueType;
+        let constraint = Equality::new(Term::var("x"), Term::constant(42u32));
+        let schema = constraint.schema();
+        let is_field = schema.get("is").expect("is field present");
+        assert_eq!(
+            is_field.content_type.shape().as_singleton(),
+            Some(ValueType::UnsignedInt)
         );
     }
 }

--- a/rust/dialog-query/src/constraint/equality.rs
+++ b/rust/dialog-query/src/constraint/equality.rs
@@ -8,8 +8,8 @@ use std::fmt;
 
 use crate::types::Any;
 pub use crate::{
-    Cardinality, Environment, EvaluationError, Field, Parameters, Requirement, Schema, Selection,
-    Term, Value, try_stream,
+    Binding, Cardinality, Environment, EvaluationError, Field, Parameters, Requirement, Schema,
+    Selection, Term, Value, try_stream,
 };
 use std::fmt::Display;
 
@@ -116,28 +116,31 @@ impl Equality {
                 let base = candidate?;
 
                 match (base.lookup(&this), base.lookup(&is)) {
-                    // Case 1: Both terms are bound - verify they are equal
-                    // Only pass through the match if the values are equal
-                    (Ok(this_val), Ok(is_val)) => {
+                    // Case 1: Both bound to Present values - verify equal.
+                    (Ok(Binding::Present(this_val)), Ok(Binding::Present(is_val))) => {
                         if this_val == is_val {
                             yield base;
                         }
                         // Otherwise filter out this match (no yield)
                     }
+                    // Case 1b: Either side is Absent — equality on
+                    // absence has no value to compare; filter out.
+                    (Ok(Binding::Absent), _) | (_, Ok(Binding::Absent)) => {
+                        // Filter out (no yield)
+                    }
                     // Case 2: Only "is" is bound - infer "this" from "is"
-                    (Err(_), Ok(is_val)) => {
+                    (Err(_), Ok(Binding::Present(is_val))) => {
                         let mut extension = base.clone();
                         extension.bind(&this, is_val)?;
                         yield extension;
                     }
                     // Case 3: Only "this" is bound - infer "is" from "this"
-                    (Ok(this_val), Err(_)) => {
+                    (Ok(Binding::Present(this_val)), Err(_)) => {
                         let mut extension = base.clone();
                         extension.bind(&is, this_val)?;
                         yield extension;
                     }
                     // Case 4: Neither term is bound - cannot evaluate
-                    // Raise a constraint violation error
                     (Err(_), Err(_)) => {
                         Err(EvaluationError::ConstraintViolation {
                             constraint: format!("{} == {}", this, is)
@@ -173,7 +176,7 @@ mod tests {
 
         assert_eq!(results.len(), 1, "Should have one result");
         assert_eq!(
-            results[0].lookup(&Term::var("x"))?,
+            results[0].lookup(&Term::var("x"))?.content()?,
             Value::from(42),
             "x should still be 42"
         );
@@ -211,7 +214,7 @@ mod tests {
 
         assert_eq!(results.len(), 1, "Should have one result");
         assert_eq!(
-            results[0].lookup(&Term::var("x"))?,
+            results[0].lookup(&Term::var("x"))?.content()?,
             Value::from(42),
             "x should be inferred as 42"
         );

--- a/rust/dialog-query/src/constraint/equality.rs
+++ b/rust/dialog-query/src/constraint/equality.rs
@@ -61,7 +61,7 @@ impl Equality {
             "this".into(),
             Field {
                 description: "Term that must be equal to the \"is\" term.".into(),
-                content_type: self.this.content_type().into(),
+                content_type: self.this.kind(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -70,7 +70,7 @@ impl Equality {
             "is".into(),
             Field {
                 description: "Term that must be equal to the \"this\" term.".into(),
-                content_type: self.is.content_type().into(),
+                content_type: self.is.kind(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -248,28 +248,17 @@ mod tests {
         );
     }
 
-    /// `Equality::schema()` declares each side's content_type
-    /// from the term's `content_type()` storage tag, lifted into
-    /// the unified `type_system::Type`. Variables of unknown type
-    /// produce anonymous variables; constants of known type
-    /// produce concrete primitives.
+    /// Untyped term sides produce `None` content_type — no
+    /// static info is available without rule-compile time
+    /// unification.
     #[dialog_common::test]
-    fn schema_lifts_unknown_term_type_to_anonymous_variable() {
-        use crate::type_system::Definite;
+    fn schema_unknown_term_yields_none() {
         let constraint = Equality::new(Term::var("x"), Term::var("y"));
         let schema = constraint.schema();
         let this_field = schema.get("this").expect("this field present");
         let is_field = schema.get("is").expect("is field present");
-        // Both terms are untyped variables, so both fields lift
-        // to anonymous variables.
-        assert!(matches!(
-            this_field.content_type.shape(),
-            Definite::Variable(_)
-        ));
-        assert!(matches!(
-            is_field.content_type.shape(),
-            Definite::Variable(_)
-        ));
+        assert!(this_field.content_type().is_none());
+        assert!(is_field.content_type().is_none());
     }
 
     /// A typed constant on one side produces a concrete primitive
@@ -280,9 +269,7 @@ mod tests {
         let constraint = Equality::new(Term::var("x"), Term::constant(42u32));
         let schema = constraint.schema();
         let is_field = schema.get("is").expect("is field present");
-        assert_eq!(
-            is_field.content_type.shape().as_singleton(),
-            Some(ValueType::UnsignedInt)
-        );
+        let content = is_field.content_type().expect("content_type present");
+        assert_eq!(content.shape().as_singleton(), Some(ValueType::UnsignedInt));
     }
 }

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -63,6 +63,23 @@ pub enum TypeError {
         variable: String,
     },
 
+    /// A rule's conclusion references a required variable that is
+    /// bound only by Optional (set-widened) premises — the rule
+    /// could produce a row with the conclusion variable in Absent
+    /// state, which a required head cannot accept. Fix by adding
+    /// a required-binding premise for the variable, or by coalescing
+    /// the optional source with a fallback before reaching the head.
+    #[error(
+        "Rule {rule} required head \"{variable}\" is bound only by optional premises; \
+         the rule could produce Absent in a required slot"
+    )]
+    RequiredHeadFromOptional {
+        /// The offending rule.
+        rule: Box<DeductiveRule>,
+        /// Name of the optionally-bound head variable.
+        variable: String,
+    },
+
     /// A rule application omits a required parameter.
     #[error("Rule {rule} application omits required parameter \"{parameter}\"")]
     OmittedParameter {

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -91,6 +91,17 @@ pub enum TypeError {
         reason: String,
     },
 
+    /// Type inference over a rule's premises produced a
+    /// contradiction (a variable appears in slots with conflicting
+    /// kinds). The planner cannot proceed because the rule has no
+    /// valid interpretation.
+    #[error("Type inference failed: {reason}")]
+    TypeInference {
+        /// Human-readable description of the conflict, including
+        /// the offending variable.
+        reason: String,
+    },
+
     /// A rule application omits a required parameter.
     #[error("Rule {rule} application omits required parameter \"{parameter}\"")]
     OmittedParameter {

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -46,6 +46,15 @@ pub enum TypeError {
     #[error("Unconstrained fact selector")]
     UnconstrainedSelector,
 
+    /// A concept declares no required (`with`) attributes. Such a
+    /// concept constrains nothing about an entity, so every entity
+    /// trivially matches it — the same degenerate shape as a concept
+    /// with no attributes at all. Optional (`maybe`) attributes do
+    /// not count: they widen results rather than constrain them. A
+    /// concept must have at least one required attribute.
+    #[error("Concept declares no required attributes; at least one `with` attribute is required")]
+    EmptyConcept,
+
     /// A rule declares a parameter that none of its premises use.
     #[error("Rule {rule} does not use parameter \"{parameter}\"")]
     UnusedParameter {

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -70,8 +70,8 @@ pub enum TypeError {
     /// a required-binding premise for the variable, or by coalescing
     /// the optional source with a fallback before reaching the head.
     #[error(
-        "Rule {rule} required head \"{variable}\" is bound only by optional premises; \
-         the rule could produce Absent in a required slot"
+        "Rule {rule}: field \"{variable}\" is optional but the conclusion requires a value. \
+         Use coalesce(...) to provide a fallback, or bind \"{variable}\" from a required premise."
     )]
     RequiredHeadFromOptional {
         /// The offending rule.

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -245,6 +245,23 @@ pub enum EvaluationError {
         variable_name: String,
     },
 
+    /// A binding for the variable exists, but it is
+    /// [`Binding::Absent`](crate::Binding::Absent) — i.e., an
+    /// optional resolver looked up the entity's attribute and
+    /// found no fact. Distinct from
+    /// [`Self::UnboundVariable`] (no binding at all): `Absent`
+    /// means "we looked, and the answer is no value." Consumers
+    /// that require a `Value` can call
+    /// [`Binding::content`](crate::Binding::content) to convert
+    /// this case into an error; consumers that handle optionality
+    /// (Coalesce, the macro's `realize`) pattern-match on
+    /// [`Binding`](crate::Binding) directly.
+    #[error("Variable {variable_name:?} is bound to Absent")]
+    Absent {
+        /// Name of the variable bound to Absent.
+        variable_name: String,
+    },
+
     /// A formula parameter references a variable that is not bound.
     #[error("Variable for '{parameter}' is not bound: {term}")]
     UnboundFormulaVariable {

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -80,6 +80,17 @@ pub enum TypeError {
         variable: String,
     },
 
+    /// A `Coalesce` constraint in this rule violates its type
+    /// contract: its source must be set-widened (`Optional<α>`)
+    /// and its `fallback` and `is` must each unify with `α`.
+    #[error("Rule {rule} has an invalid Coalesce constraint: {reason}")]
+    CoalesceTypeMismatch {
+        /// The offending rule.
+        rule: Box<DeductiveRule>,
+        /// Human-readable reason for the mismatch.
+        reason: String,
+    },
+
     /// A rule application omits a required parameter.
     #[error("Rule {rule} application omits required parameter \"{parameter}\"")]
     OmittedParameter {

--- a/rust/dialog-query/src/formula/bindings.rs
+++ b/rust/dialog-query/src/formula/bindings.rs
@@ -47,7 +47,15 @@ impl Bindings {
         Ok(T::try_from(self.resolve(key)?)?)
     }
 
-    /// Resolve a parameter to its Value
+    /// Resolve a parameter to its [`Value`].
+    ///
+    /// Returns [`EvaluationError::UnboundFormulaVariable`] if the
+    /// parameter is not bound. An [`EvaluationError::Absent`]
+    /// propagates if the binding exists but is
+    /// [`Binding::Absent`](crate::Binding::Absent) — formulas
+    /// don't tolerate absent inputs by default; consumers that
+    /// want to handle absence should pattern-match on
+    /// [`Binding`](crate::Binding) via the source match directly.
     pub fn resolve(&mut self, key: &str) -> Result<Value, EvaluationError> {
         let param = self
             .terms
@@ -56,12 +64,14 @@ impl Bindings {
                 parameter: key.into(),
             })?;
 
-        self.source
-            .lookup(param)
-            .map_err(|_| EvaluationError::UnboundFormulaVariable {
-                term: Box::new(param.clone()),
-                parameter: key.into(),
-            })
+        let binding =
+            self.source
+                .lookup(param)
+                .map_err(|_| EvaluationError::UnboundFormulaVariable {
+                    term: Box::new(param.clone()),
+                    parameter: key.into(),
+                })?;
+        binding.content()
     }
 
     /// Get an immutable reference to the source match

--- a/rust/dialog-query/src/formula/cell.rs
+++ b/rust/dialog-query/src/formula/cell.rs
@@ -313,7 +313,7 @@ mod tests {
     /// `From<&Cells> for Schema` lifts each cell's
     /// `Option<Type>` content_type into the unified
     /// `Option<type_system::Type>`. Typed cells produce
-    /// `Some(Definite(Primitive(vt)))`; untyped cells produce
+    /// `Some(Primitive(singleton(vt)))`; untyped cells produce
     /// `None` (unknown).
     #[dialog_common::test]
     fn schema_from_cells_lifts_content_types() {
@@ -326,7 +326,7 @@ mod tests {
 
         let name = schema.get("name").expect("name field present");
         let content = name.content_type().expect("name kind present");
-        assert_eq!(content.shape().as_singleton(), Some(Type::String));
+        assert_eq!(content.as_value_type(), Some(Type::String));
 
         let untyped = schema.get("untyped").expect("untyped field present");
         assert!(untyped.content_type().is_none());

--- a/rust/dialog-query/src/formula/cell.rs
+++ b/rust/dialog-query/src/formula/cell.rs
@@ -255,7 +255,7 @@ impl From<&Cells> for Schema {
                 name.into(),
                 Field {
                     description: cell.description.clone(),
-                    content_type: cell.content_type,
+                    content_type: cell.content_type.into(),
                     requirement: cell.requirement.clone(),
                     cardinality: Cardinality::One,
                 },
@@ -307,5 +307,30 @@ mod tests {
             &Requirement::Optional
         );
         Ok(())
+    }
+
+    /// `From<&Cells> for Schema` lifts each cell's
+    /// `Option<Type>` content_type into the unified
+    /// `type_system::Type`. Typed cells produce
+    /// `Definite(Primitive(vt))`; untyped cells (`None`)
+    /// produce anonymous variables.
+    #[dialog_common::test]
+    fn schema_from_cells_lifts_content_types() {
+        use crate::Schema;
+        use crate::type_system::Definite;
+        let cells = Cells::define(|builder| {
+            builder.cell("name", Some(Type::String)).required();
+            builder.cell("untyped", None).required();
+        });
+        let schema = Schema::from(&cells);
+
+        let name = schema.get("name").expect("name field present");
+        assert_eq!(name.content_type.shape().as_singleton(), Some(Type::String));
+
+        let untyped = schema.get("untyped").expect("untyped field present");
+        assert!(matches!(
+            untyped.content_type.shape(),
+            Definite::Variable(_)
+        ));
     }
 }

--- a/rust/dialog-query/src/formula/cell.rs
+++ b/rust/dialog-query/src/formula/cell.rs
@@ -248,6 +248,7 @@ impl<T: Iterator<Item = Cell>> From<T> for Cells {
 
 impl From<&Cells> for Schema {
     fn from(cells: &Cells) -> Self {
+        use crate::type_system;
         use crate::{Cardinality, Field};
         let mut schema = Schema::new();
         for (name, cell) in cells.iter() {
@@ -255,7 +256,7 @@ impl From<&Cells> for Schema {
                 name.into(),
                 Field {
                     description: cell.description.clone(),
-                    content_type: cell.content_type.into(),
+                    content_type: cell.content_type.map(type_system::Type::primitive),
                     requirement: cell.requirement.clone(),
                     cardinality: Cardinality::One,
                 },
@@ -311,13 +312,12 @@ mod tests {
 
     /// `From<&Cells> for Schema` lifts each cell's
     /// `Option<Type>` content_type into the unified
-    /// `type_system::Type`. Typed cells produce
-    /// `Definite(Primitive(vt))`; untyped cells (`None`)
-    /// produce anonymous variables.
+    /// `Option<type_system::Type>`. Typed cells produce
+    /// `Some(Definite(Primitive(vt)))`; untyped cells produce
+    /// `None` (unknown).
     #[dialog_common::test]
     fn schema_from_cells_lifts_content_types() {
         use crate::Schema;
-        use crate::type_system::Definite;
         let cells = Cells::define(|builder| {
             builder.cell("name", Some(Type::String)).required();
             builder.cell("untyped", None).required();
@@ -325,12 +325,10 @@ mod tests {
         let schema = Schema::from(&cells);
 
         let name = schema.get("name").expect("name field present");
-        assert_eq!(name.content_type.shape().as_singleton(), Some(Type::String));
+        let content = name.content_type().expect("name kind present");
+        assert_eq!(content.shape().as_singleton(), Some(Type::String));
 
         let untyped = schema.get("untyped").expect("untyped field present");
-        assert!(matches!(
-            untyped.content_type.shape(),
-            Definite::Variable(_)
-        ));
+        assert!(untyped.content_type().is_none());
     }
 }

--- a/rust/dialog-query/src/formula/logic.rs
+++ b/rust/dialog-query/src/formula/logic.rs
@@ -99,6 +99,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );
@@ -125,6 +126,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -151,6 +153,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -177,6 +180,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );
@@ -203,6 +207,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -227,6 +232,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -252,6 +258,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );
@@ -290,6 +297,7 @@ mod tests {
             final_result
                 .lookup(&Term::var("final_result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );

--- a/rust/dialog-query/src/formula/math.rs
+++ b/rust/dialog-query/src/formula/math.rs
@@ -167,6 +167,7 @@ mod tests {
             output
                 .lookup(&Term::var("x"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -174,6 +175,7 @@ mod tests {
             output
                 .lookup(&Term::var("y"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(3)
         );
@@ -183,6 +185,7 @@ mod tests {
             output
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(8)
         );
@@ -234,6 +237,7 @@ mod tests {
             result1
                 .lookup(&Term::var("a"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(2)
         );
@@ -241,6 +245,7 @@ mod tests {
             result1
                 .lookup(&Term::var("b"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(3)
         );
@@ -248,6 +253,7 @@ mod tests {
             result1
                 .lookup(&Term::var("sum"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -264,6 +270,7 @@ mod tests {
             result2
                 .lookup(&Term::var("a"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(10)
         );
@@ -271,6 +278,7 @@ mod tests {
             result2
                 .lookup(&Term::var("b"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(15)
         );
@@ -278,6 +286,7 @@ mod tests {
             result2
                 .lookup(&Term::var("sum"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(25)
         );
@@ -304,6 +313,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(7)
         );
@@ -333,6 +343,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(0)
         );
@@ -359,6 +370,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(42)
         );
@@ -385,6 +397,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -432,6 +445,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(2)
         );
@@ -493,7 +507,14 @@ mod tests {
         let final_results = sum_formula.compute(sum_input)?;
         assert_eq!(final_results.len(), 1);
         assert_eq!(
-            u32::try_from(final_results[0].lookup(&Term::var("final_sum")).unwrap()).ok(),
+            u32::try_from(
+                final_results[0]
+                    .lookup(&Term::var("final_sum"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some(15)
         );
 
@@ -510,6 +531,8 @@ mod tests {
             String::try_from(
                 string_results[0]
                     .lookup(&Term::var("final_string"))
+                    .unwrap()
+                    .content()
                     .unwrap()
             )
             .ok(),

--- a/rust/dialog-query/src/formula/query.rs
+++ b/rust/dialog-query/src/formula/query.rs
@@ -464,7 +464,7 @@ mod tests {
     /// Coalesce round-trips through Proposition. Regression for
     /// the bug where Proposition::deserialize matched only "==" as
     /// a constraint and routed every other string to FormulaQuery.
-    #[test]
+    #[dialog_common::test]
     fn it_round_trips_coalesce_as_proposition() {
         let coalesce = Coalesce::new(
             Term::<Any>::var("source"),

--- a/rust/dialog-query/src/formula/query.rs
+++ b/rust/dialog-query/src/formula/query.rs
@@ -155,6 +155,7 @@ mod tests {
     use super::*;
     use crate::Proposition;
     use crate::constraint::Constraint;
+    use crate::constraint::coalesce::Coalesce;
     use crate::constraint::equality::Equality;
     use crate::term::Term;
     use crate::types::Any;
@@ -457,6 +458,32 @@ mod tests {
                 assert_eq!(eq.is, Term::<Any>::var("y"));
             }
             other => panic!("Expected Constraint(Equality), got {:?}", other),
+        }
+    }
+
+    /// Coalesce round-trips through Proposition. Regression for
+    /// the bug where Proposition::deserialize matched only "==" as
+    /// a constraint and routed every other string to FormulaQuery.
+    #[test]
+    fn it_round_trips_coalesce_as_proposition() {
+        let coalesce = Coalesce::new(
+            Term::<Any>::var("source"),
+            Term::<Any>::var("fallback"),
+            Term::<Any>::var("is"),
+        );
+        let prop = Proposition::Constraint(Constraint::Coalesce(coalesce));
+
+        let json = serde_json::to_value(&prop).unwrap();
+        assert_eq!(json["assert"], "coalesce");
+
+        let deserialized: Proposition = serde_json::from_value(json).unwrap();
+        match &deserialized {
+            Proposition::Constraint(Constraint::Coalesce(c)) => {
+                assert_eq!(c.source.name(), Some("source"));
+                assert_eq!(c.fallback.name(), Some("fallback"));
+                assert_eq!(c.is.name(), Some("is"));
+            }
+            other => panic!("Expected Constraint(Coalesce), got {:?}", other),
         }
     }
 

--- a/rust/dialog-query/src/formula/string.rs
+++ b/rust/dialog-query/src/formula/string.rs
@@ -222,6 +222,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("Hello World".to_string())
         );
@@ -247,6 +248,7 @@ mod tests {
             result
                 .lookup(&Term::var("len"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -272,6 +274,7 @@ mod tests {
             result
                 .lookup(&Term::var("upper"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("HELLO WORLD".to_string())
         );
@@ -297,6 +300,7 @@ mod tests {
             result
                 .lookup(&Term::var("lower"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("hello world".to_string())
         );
@@ -322,6 +326,7 @@ mod tests {
             result
                 .lookup(&Term::var("len"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(0)
         );
@@ -351,6 +356,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("World".to_string())
         );
@@ -377,7 +383,14 @@ mod tests {
         let concat_results = concat_formula.compute(concat_input)?;
         assert_eq!(concat_results.len(), 1);
         assert_eq!(
-            String::try_from(concat_results[0].lookup(&Term::var("full_name")).unwrap()).ok(),
+            String::try_from(
+                concat_results[0]
+                    .lookup(&Term::var("full_name"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some("John Doe".to_string())
         );
 
@@ -396,7 +409,14 @@ mod tests {
         let length_results = length_formula.compute(length_input)?;
         assert_eq!(length_results.len(), 1);
         assert_eq!(
-            u32::try_from(length_results[0].lookup(&Term::var("length")).unwrap()).ok(),
+            u32::try_from(
+                length_results[0]
+                    .lookup(&Term::var("length"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some(11)
         );
 
@@ -415,7 +435,14 @@ mod tests {
         let upper_results = upper_formula.compute(upper_input)?;
         assert_eq!(upper_results.len(), 1);
         assert_eq!(
-            String::try_from(upper_results[0].lookup(&Term::var("output")).unwrap()).ok(),
+            String::try_from(
+                upper_results[0]
+                    .lookup(&Term::var("output"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some("HELLO WORLD".to_string())
         );
 
@@ -444,6 +471,7 @@ mod tests {
             results[0]
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("hello".to_string())
         );

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -68,6 +68,11 @@ pub mod statement;
 pub mod stream;
 /// Term types for pattern matching with variables and constants.
 pub mod term;
+/// Unified schema-layer type system (`Type`, `Definite`, `meet`,
+/// `accepts`). Replaces the older `schema::Type` enum and the
+/// descriptor's `Option<ValueType>` representation; see
+/// `notes/optional-fields.md`.
+pub mod type_system;
 /// Type system utilities bridging Rust types to dialog-artifacts types.
 pub mod types;
 

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -68,10 +68,10 @@ pub mod statement;
 pub mod stream;
 /// Term types for pattern matching with variables and constants.
 pub mod term;
-/// Unified schema-layer type system (`Type`, `Definite`, `meet`,
-/// `accepts`). Replaces the older `schema::Type` enum and the
-/// descriptor's `Option<ValueType>` representation; see
-/// `notes/optional-fields.md`.
+/// Unified schema-layer type system (`Type`, `Primitive`,
+/// `Composite`, set-operations). Replaces the older `schema::Type`
+/// enum and the descriptor's `Option<ValueType>` representation;
+/// see `notes/optional-fields.md`.
 pub mod type_system;
 /// Type system utilities bridging Rust types to dialog-artifacts types.
 pub mod types;

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -82,7 +82,7 @@ pub use attribute::*;
 pub use claim::Claim;
 pub use concept::descriptor::{ConceptConclusion, ConceptDescriptor};
 pub use concept::query::{ConceptQuery, ConceptRules};
-pub use concept::{Concept, Conclusion};
+pub use concept::{Concept, ConceptField, Conclusion};
 pub use constraint::Constraint;
 pub use descriptor::Descriptor;
 pub use environment::*;

--- a/rust/dialog-query/src/parameters.rs
+++ b/rust/dialog-query/src/parameters.rs
@@ -221,7 +221,7 @@ mod tests {
             param,
             &Term::Variable {
                 name: Some("x".into()),
-                descriptor: Any(Some(Type::String))
+                descriptor: Some(Type::String).into(),
             }
         );
     }

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -9,8 +9,10 @@ pub use disjunction::*;
 pub use plan::*;
 
 use crate::error::TypeError;
+use crate::rule::analyzer::AnalyzedRule;
 use crate::rule::types::TypeEnv;
 use crate::{Environment, Premise};
+use std::sync::Arc;
 
 /// State machine that greedily selects the cheapest viable premise at each
 /// step, building an ordered execution plan.
@@ -85,6 +87,7 @@ impl Planner {
             binds,
             env,
             types,
+            analyzed: None,
         })
     }
 
@@ -185,6 +188,40 @@ impl Planner {
 impl From<Vec<Premise>> for Planner {
     fn from(premises: Vec<Premise>) -> Self {
         Self::Idle { premises }
+    }
+}
+
+impl Planner {
+    /// Build a planner from an analyzed rule. The resulting plan
+    /// carries an `Arc<AnalyzedRule>` reference so future replan
+    /// calls (`Conjunction::plan(&scope)`) reuse the same analyzed
+    /// premises rather than re-running analysis.
+    pub fn from_analyzed(rule: Arc<AnalyzedRule>) -> PlannerWithRule {
+        let premises: Vec<Premise> = rule
+            .premises()
+            .map(|analyzed| analyzed.source.clone())
+            .collect();
+        PlannerWithRule {
+            inner: Self::Idle { premises },
+            rule,
+        }
+    }
+}
+
+/// A [`Planner`] bound to an analyzed rule. `plan` propagates the
+/// rule reference into the resulting `Conjunction.analyzed`.
+pub struct PlannerWithRule {
+    inner: Planner,
+    rule: Arc<AnalyzedRule>,
+}
+
+impl PlannerWithRule {
+    /// Plan against the given scope. Returns a `Conjunction` whose
+    /// `analyzed` field points at the same `Arc<AnalyzedRule>`.
+    pub fn plan(self, scope: &Environment) -> Result<Conjunction, TypeError> {
+        let mut conjunction = self.inner.plan(scope)?;
+        conjunction.analyzed = Some(self.rule);
+        Ok(conjunction)
     }
 }
 

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -259,7 +259,11 @@ mod tests {
             .expect("Planning should succeed");
 
         assert_eq!(plan.steps.len(), 2);
-        assert_eq!(plan.binds.len(), 2, "Should bind 2 variables");
+        // ?name, ?greeting, and ?cause — the cause slot is now
+        // declared in the AttributeQuery schema (bound by the
+        // merge step on every Present row), so it counts toward
+        // the plan's bind set.
+        assert_eq!(plan.binds.len(), 3, "Should bind name, greeting, cause");
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -11,7 +11,6 @@ pub use plan::*;
 use crate::error::TypeError;
 use crate::rule::types::TypeEnv;
 use crate::{Environment, Premise};
-use std::sync::Arc;
 
 /// State machine that greedily selects the cheapest viable premise at each
 /// step, building an ordered execution plan.
@@ -69,22 +68,18 @@ impl Planner {
         let types = TypeEnv::infer(&steps).map_err(|err| TypeError::TypeInference {
             reason: err.to_string(),
         })?;
-        let types = Arc::new(types);
 
-        // For each step: stamp the shared `Arc<TypeEnv>` (cheap
-        // clone) and rewrite the premise's variable terms so they
-        // reflect rule-level inference. The rewrite happens once
-        // here, not on every evaluation. Standalone queries (empty
-        // env) skip the rewrite entirely.
-        let stamped: Vec<Plan> = steps
+        // Rewrite each step's premise so its variable terms reflect
+        // the rule-level inferred kinds. Done once here, not on
+        // every evaluation. Standalone queries (empty env) skip the
+        // rewrite entirely.
+        let steps: Vec<Plan> = steps
             .into_iter()
             .map(|step| Plan {
                 premise: plan::apply_types(step.premise, &types),
-                types: types.clone(),
                 ..step
             })
             .collect();
-        let steps = stamped;
 
         Ok(Conjunction {
             steps,

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -67,6 +67,18 @@ impl Planner {
 
         let types = TypeEnv::infer(&steps);
 
+        // Project the rule-wide TypeEnv onto each step's variables
+        // so evaluators can look up inferred kinds locally.
+        for step in &mut steps {
+            let names: Vec<String> = step
+                .premise
+                .parameters()
+                .iter()
+                .filter_map(|(_, term)| term.name().map(String::from))
+                .collect();
+            step.types = types.project(names.iter().map(String::as_str));
+        }
+
         Ok(Conjunction {
             steps,
             cost,

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -68,13 +68,20 @@ impl Planner {
 
         let types = Arc::new(TypeEnv::infer(&steps));
 
-        // Every step in the same rule shares the same Arc — cheap
-        // clone, single lookup target. Evaluators consult
-        // `self.types.get(name)` to read the rule-level inferred
-        // kind for a variable.
-        for step in &mut steps {
-            step.types = types.clone();
-        }
+        // For each step: stamp the shared `Arc<TypeEnv>` (cheap
+        // clone) and rewrite the premise's variable terms so they
+        // reflect rule-level inference. The rewrite happens once
+        // here, not on every evaluation. Standalone queries (empty
+        // env) skip the rewrite entirely.
+        let stamped: Vec<Plan> = steps
+            .into_iter()
+            .map(|step| Plan {
+                premise: plan::apply_types(step.premise, &types),
+                types: types.clone(),
+                ..step
+            })
+            .collect();
+        let steps = stamped;
 
         Ok(Conjunction {
             steps,

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -67,18 +67,14 @@ impl Planner {
             }
         }
 
-        let types = TypeEnv::infer(&steps);
+        let types = Arc::new(TypeEnv::infer(&steps));
 
-        // Project the rule-wide TypeEnv onto each step's variables
-        // so evaluators can look up inferred kinds locally.
+        // Every step in the same rule shares the same Arc — cheap
+        // clone, single lookup target. Evaluators consult
+        // `self.types.get(name)` to read the rule-level inferred
+        // kind for a variable.
         for step in &mut steps {
-            let names: Vec<String> = step
-                .premise
-                .parameters()
-                .iter()
-                .filter_map(|(_, term)| term.name().map(String::from))
-                .collect();
-            step.types = types.project(names.iter().map(String::as_str));
+            step.types = types.clone();
         }
 
         Ok(Conjunction {
@@ -86,7 +82,7 @@ impl Planner {
             cost,
             binds,
             env,
-            types,
+            types: (*types).clone(),
             analyzed: None,
         })
     }

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -9,7 +9,6 @@ pub use disjunction::*;
 pub use plan::*;
 
 use crate::error::TypeError;
-use crate::rule::analyzer::AnalyzedRule;
 use crate::rule::types::TypeEnv;
 use crate::{Environment, Premise};
 use std::sync::Arc;
@@ -82,8 +81,6 @@ impl Planner {
             cost,
             binds,
             env,
-            types: (*types).clone(),
-            analyzed: None,
         })
     }
 
@@ -184,40 +181,6 @@ impl Planner {
 impl From<Vec<Premise>> for Planner {
     fn from(premises: Vec<Premise>) -> Self {
         Self::Idle { premises }
-    }
-}
-
-impl Planner {
-    /// Build a planner from an analyzed rule. The resulting plan
-    /// carries an `Arc<AnalyzedRule>` reference so future replan
-    /// calls (`Conjunction::plan(&scope)`) reuse the same analyzed
-    /// premises rather than re-running analysis.
-    pub fn from_analyzed(rule: Arc<AnalyzedRule>) -> PlannerWithRule {
-        let premises: Vec<Premise> = rule
-            .premises()
-            .map(|analyzed| analyzed.source.clone())
-            .collect();
-        PlannerWithRule {
-            inner: Self::Idle { premises },
-            rule,
-        }
-    }
-}
-
-/// A [`Planner`] bound to an analyzed rule. `plan` propagates the
-/// rule reference into the resulting `Conjunction.analyzed`.
-pub struct PlannerWithRule {
-    inner: Planner,
-    rule: Arc<AnalyzedRule>,
-}
-
-impl PlannerWithRule {
-    /// Plan against the given scope. Returns a `Conjunction` whose
-    /// `analyzed` field points at the same `Arc<AnalyzedRule>`.
-    pub fn plan(self, scope: &Environment) -> Result<Conjunction, TypeError> {
-        let mut conjunction = self.inner.plan(scope)?;
-        conjunction.analyzed = Some(self.rule);
-        Ok(conjunction)
     }
 }
 

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -66,7 +66,10 @@ impl Planner {
             }
         }
 
-        let types = Arc::new(TypeEnv::infer(&steps));
+        let types = TypeEnv::infer(&steps).map_err(|err| TypeError::TypeInference {
+            reason: err.to_string(),
+        })?;
+        let types = Arc::new(types);
 
         // For each step: stamp the shared `Arc<TypeEnv>` (cheap
         // clone) and rewrite the premise's variable terms so they

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -9,6 +9,7 @@ pub use disjunction::*;
 pub use plan::*;
 
 use crate::error::TypeError;
+use crate::rule::types::TypeEnv;
 use crate::{Environment, Premise};
 
 /// State machine that greedily selects the cheapest viable premise at each
@@ -64,11 +65,14 @@ impl Planner {
             }
         }
 
+        let types = TypeEnv::infer(&steps);
+
         Ok(Conjunction {
             steps,
             cost,
             binds,
             env,
+            types,
         })
     }
 

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -330,8 +330,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let name = match_result.lookup(&name_param)?;
-            let age = match_result.lookup(&age_param)?;
+            let name = match_result.lookup(&name_param)?.content()?;
+            let age = match_result.lookup(&age_param)?.content()?;
 
             match name {
                 Value::String(n) if n == "Alice" => {

--- a/rust/dialog-query/src/planner/candidate.rs
+++ b/rust/dialog-query/src/planner/candidate.rs
@@ -1,9 +1,7 @@
 use super::Plan;
 use crate::error::TypeError;
-use crate::rule::types::TypeEnv;
 use crate::{Environment, Parameters, Premise, Requirement, Schema};
 use std::collections::HashSet;
-use std::sync::Arc;
 
 /// A premise under consideration by the query planner, tracking whether it
 /// can execute given the current variable bindings.
@@ -380,16 +378,13 @@ impl TryFrom<Candidate> for Plan {
                 env,
                 ..
             } => {
-                // Drop schema/params - don't need them in the final plan.
-                // `types` starts as an empty shared env; the planner
-                // replaces it with the real `Arc<TypeEnv>` once
-                // it has built the rule-wide TypeEnv from all steps.
+                // Drop schema/params — they're only needed during
+                // planning, not at evaluation time.
                 Ok(Plan {
                     premise,
                     cost,
                     binds,
                     env,
-                    types: Arc::new(TypeEnv::new()),
                 })
             }
             Candidate::Blocked { requires, .. } => {

--- a/rust/dialog-query/src/planner/candidate.rs
+++ b/rust/dialog-query/src/planner/candidate.rs
@@ -1,5 +1,6 @@
 use super::Plan;
 use crate::error::TypeError;
+use crate::rule::types::TypeEnv;
 use crate::{Environment, Parameters, Premise, Requirement, Schema};
 use std::collections::HashSet;
 
@@ -378,12 +379,15 @@ impl TryFrom<Candidate> for Plan {
                 env,
                 ..
             } => {
-                // Drop schema/params - don't need them in the final plan
+                // Drop schema/params - don't need them in the final plan.
+                // `types` starts empty; the planner fills it in once
+                // it has built the rule-wide TypeEnv from all steps.
                 Ok(Plan {
                     premise,
                     cost,
                     binds,
                     env,
+                    types: TypeEnv::new(),
                 })
             }
             Candidate::Blocked { requires, .. } => {

--- a/rust/dialog-query/src/planner/candidate.rs
+++ b/rust/dialog-query/src/planner/candidate.rs
@@ -790,7 +790,7 @@ mod cost_model_tests {
             Some(Cardinality::One),
         );
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -798,7 +798,8 @@ mod cost_model_tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -839,7 +840,7 @@ mod cost_model_tests {
             Some(Cardinality::One),
         );
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -847,7 +848,8 @@ mod cost_model_tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -881,7 +883,7 @@ mod cost_model_tests {
             Some(Cardinality::One),
         );
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -889,7 +891,8 @@ mod cost_model_tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -927,7 +930,7 @@ mod cost_model_tests {
             Some(Type::String),
         );
 
-        let concept = ConceptDescriptor::from([("tags", tag)]);
+        let concept = ConceptDescriptor::try_from([("tags", tag)]).unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -964,7 +967,7 @@ mod cost_model_tests {
             Some(Type::String),
         );
 
-        let concept = ConceptDescriptor::from([("tags", tag)]);
+        let concept = ConceptDescriptor::try_from([("tags", tag)]).unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));

--- a/rust/dialog-query/src/planner/candidate.rs
+++ b/rust/dialog-query/src/planner/candidate.rs
@@ -3,6 +3,7 @@ use crate::error::TypeError;
 use crate::rule::types::TypeEnv;
 use crate::{Environment, Parameters, Premise, Requirement, Schema};
 use std::collections::HashSet;
+use std::sync::Arc;
 
 /// A premise under consideration by the query planner, tracking whether it
 /// can execute given the current variable bindings.
@@ -380,14 +381,15 @@ impl TryFrom<Candidate> for Plan {
                 ..
             } => {
                 // Drop schema/params - don't need them in the final plan.
-                // `types` starts empty; the planner fills it in once
+                // `types` starts as an empty shared env; the planner
+                // replaces it with the real `Arc<TypeEnv>` once
                 // it has built the rule-wide TypeEnv from all steps.
                 Ok(Plan {
                     premise,
                     cost,
                     binds,
                     env,
-                    types: TypeEnv::new(),
+                    types: Arc::new(TypeEnv::new()),
                 })
             }
             Candidate::Blocked { requires, .. } => {

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -1,6 +1,7 @@
 use super::{Plan, Planner};
 use crate::Environment;
 use crate::error::TypeError;
+use crate::rule::analyzer::AnalyzedRule;
 use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
 use crate::source::SelectRules;
@@ -8,6 +9,7 @@ use core::pin::Pin;
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
+use std::sync::Arc;
 
 /// An ordered sequence of [`Plan`] steps produced by the query planner.
 ///
@@ -37,6 +39,13 @@ pub struct Conjunction {
     /// evaluators that want rule-level type information rather than
     /// per-term local kinds.
     pub types: TypeEnv,
+    /// The analyzed rule this conjunction was planned from. Replan
+    /// (`Conjunction::plan(&scope)`) reuses the same analyzed
+    /// premises (with their inference and dependency graph) so we
+    /// don't re-run analysis on every scope change. Standalone
+    /// queries that plan a raw `Vec<Premise>` have no analyzed
+    /// rule; the field is `None` for those.
+    pub analyzed: Option<Arc<AnalyzedRule>>,
 }
 
 impl Conjunction {
@@ -47,8 +56,15 @@ impl Conjunction {
     /// rule's premises need to be re-evaluated with different known bindings
     /// (e.g. adornment-based optimization in concepts).
     pub fn plan(&self, scope: &Environment) -> Result<Self, TypeError> {
-        let premises: Vec<_> = self.steps.iter().map(|step| step.premise.clone()).collect();
-        Planner::from(premises).plan(scope)
+        let mut conjunction = match &self.analyzed {
+            Some(rule) => Planner::from_analyzed(rule.clone()).plan(scope)?,
+            None => {
+                let premises: Vec<_> = self.steps.iter().map(|step| step.premise.clone()).collect();
+                Planner::from(premises).plan(scope)?
+            }
+        };
+        conjunction.analyzed = self.analyzed.clone();
+        Ok(conjunction)
     }
 
     /// Evaluate this conjunction by executing all steps in order.

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -1,15 +1,12 @@
 use super::{Plan, Planner};
 use crate::Environment;
 use crate::error::TypeError;
-use crate::rule::analyzer::AnalyzedRule;
-use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
 use crate::source::SelectRules;
 use core::pin::Pin;
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
-use std::sync::Arc;
 
 /// An ordered sequence of [`Plan`] steps produced by the query planner.
 ///
@@ -34,18 +31,6 @@ pub struct Conjunction {
     pub binds: Environment,
     /// Variables required in the environment to execute this join
     pub env: Environment,
-    /// Inferred types for every named variable mentioned by the
-    /// positive premises. Built once at planning time; consulted by
-    /// evaluators that want rule-level type information rather than
-    /// per-term local kinds.
-    pub types: TypeEnv,
-    /// The analyzed rule this conjunction was planned from. Replan
-    /// (`Conjunction::plan(&scope)`) reuses the same analyzed
-    /// premises (with their inference and dependency graph) so we
-    /// don't re-run analysis on every scope change. Standalone
-    /// queries that plan a raw `Vec<Premise>` have no analyzed
-    /// rule; the field is `None` for those.
-    pub analyzed: Option<Arc<AnalyzedRule>>,
 }
 
 impl Conjunction {
@@ -54,17 +39,12 @@ impl Conjunction {
     /// Converts the steps back into planner candidates and re-orders them
     /// for optimal execution given the new bindings. This is used when a
     /// rule's premises need to be re-evaluated with different known bindings
-    /// (e.g. adornment-based optimization in concepts).
+    /// (e.g. adornment-based optimization in concepts). Type inference
+    /// runs again on the fresh order — its output is stable across
+    /// reorderings, so this is cheap and idempotent.
     pub fn plan(&self, scope: &Environment) -> Result<Self, TypeError> {
-        let mut conjunction = match &self.analyzed {
-            Some(rule) => Planner::from_analyzed(rule.clone()).plan(scope)?,
-            None => {
-                let premises: Vec<_> = self.steps.iter().map(|step| step.premise.clone()).collect();
-                Planner::from(premises).plan(scope)?
-            }
-        };
-        conjunction.analyzed = self.analyzed.clone();
-        Ok(conjunction)
+        let premises: Vec<_> = self.steps.iter().map(|step| step.premise.clone()).collect();
+        Planner::from(premises).plan(scope)
     }
 
     /// Evaluate this conjunction by executing all steps in order.

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -1,6 +1,7 @@
 use super::{Plan, Planner};
 use crate::Environment;
 use crate::error::TypeError;
+use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
 use crate::source::SelectRules;
 use core::pin::Pin;
@@ -31,6 +32,11 @@ pub struct Conjunction {
     pub binds: Environment,
     /// Variables required in the environment to execute this join
     pub env: Environment,
+    /// Inferred types for every named variable mentioned by the
+    /// positive premises. Built once at planning time; consulted by
+    /// evaluators that want rule-level type information rather than
+    /// per-term local kinds.
+    pub types: TypeEnv,
 }
 
 impl Conjunction {

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -10,7 +10,6 @@ use crate::{Environment, Premise};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
-use std::sync::Arc;
 
 /// A finalized, ready-to-execute premise produced by the query planner.
 ///
@@ -20,11 +19,14 @@ use std::sync::Arc;
 /// bound in the environment. The cached schema and parameter data used during
 /// planning are dropped at this point.
 ///
-/// Plans are assembled into a [`Conjunction`](crate::Conjunction) — an ordered sequence of
-/// steps that the query engine evaluates to produce results.
+/// The premise has already been narrowed at plan time via
+/// [`apply_types`] — its variable terms reflect the rule-level
+/// inferred kinds, so evaluators don't need to consult any external
+/// type environment to know which slots are optional.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Plan {
-    /// The premise this plan will execute.
+    /// The premise this plan will execute. Variable terms have
+    /// been narrowed to the rule-level inferred kinds.
     pub premise: Premise,
     /// Estimated execution cost.
     pub cost: usize,
@@ -32,11 +34,6 @@ pub struct Plan {
     pub binds: Environment,
     /// Variables already bound in the environment when this plan runs.
     pub env: Environment,
-    /// Shared view of the rule-wide inferred type environment.
-    /// Every step of the same rule points at the same `Arc`.
-    /// Standalone queries (no rule context) get an empty
-    /// environment.
-    pub types: Arc<TypeEnv>,
 }
 
 impl Plan {
@@ -158,22 +155,10 @@ mod tests {
             .plan(&crate::Environment::new())
             .unwrap();
 
-        // The shared TypeEnv should have narrowed `name` to non-
-        // optional. Each step's `types` Arc points at it.
-        let name_kind = plan
-            .steps
-            .first()
-            .unwrap()
-            .types
-            .get("name")
-            .expect("inferred kind for name");
-        assert!(
-            !name_kind.is_optional(),
-            "inference should strip Nothing when a required binding also exists"
-        );
-
-        // Every plan step's stored premise already has the
-        // narrowed `is` — the rewrite happens at plan time.
+        // Every plan step's stored premise has the narrowed `is` —
+        // the rewrite happens at plan time. The first premise's
+        // user-supplied `is` was `Option<String>`; after planning
+        // it should be `String` only.
         for step in plan.steps {
             if let Premise::Assert(Proposition::Attribute(boxed)) = &step.premise {
                 assert!(
@@ -272,7 +257,7 @@ mod tests {
             let plan = Planner::from(premises)
                 .plan(&crate::Environment::new())
                 .unwrap();
-            plan.steps.into_iter().next().unwrap().types
+            TypeEnv::infer(&plan.steps).unwrap()
         };
 
         // Build a negated attribute query that uses `?name` with

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -1,10 +1,15 @@
+use crate::Term;
+use crate::attribute::query::AttributeQuery;
+use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
 use crate::source::SelectRules;
+use crate::types::Any;
 use crate::{Environment, Premise};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
+use std::sync::Arc;
 
 /// A finalized, ready-to-execute premise produced by the query planner.
 ///
@@ -26,12 +31,11 @@ pub struct Plan {
     pub binds: Environment,
     /// Variables already bound in the environment when this plan runs.
     pub env: Environment,
-    /// Rule-level inferred types for the variables this plan
-    /// references. Empty when the plan runs outside any rule
-    /// context (e.g. top-level `.perform()` on a standalone
-    /// query). Populated by the planner during rule compilation
-    /// via [`TypeEnv::project`].
-    pub types: TypeEnv,
+    /// Shared view of the rule-wide inferred type environment.
+    /// Every step of the same rule points at the same `Arc`.
+    /// Standalone queries (no rule context) get an empty
+    /// environment.
+    pub types: Arc<TypeEnv>,
 }
 
 impl Plan {
@@ -50,7 +54,16 @@ impl Plan {
         &self.env
     }
 
-    /// Evaluate this plan with the given selection and environment
+    /// Evaluate this plan with the given selection and environment.
+    ///
+    /// Before evaluation, the plan narrows the premise's variable
+    /// slots to the kinds inferred for them at the rule level. The
+    /// user-supplied premise (carrying the user's local term kinds)
+    /// stays untouched; only the in-flight working copy reflects
+    /// the rule-inferred kinds. This is how
+    /// [`AttributeQuery::evaluate`]'s `is.is_optional()` check
+    /// picks up rule-level narrowing — the term it consults is
+    /// already the narrowed one.
     pub fn evaluate<'a, Env, M: Selection + 'a>(
         self,
         selection: M,
@@ -59,6 +72,110 @@ impl Plan {
     where
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
-        self.premise.evaluate(selection, env)
+        let narrowed = apply_types(self.premise, &self.types);
+        narrowed.evaluate(selection, env)
+    }
+}
+
+/// Replace each premise's variable terms with copies whose kinds
+/// match the rule-level inferred environment. Currently only
+/// `AttributeQuery::is` is rewritten — that's the slot whose
+/// `is_optional()` answer drives the planner-visible behavior
+/// difference (Absent-fallback emission).
+fn apply_types(premise: Premise, types: &TypeEnv) -> Premise {
+    if types.is_empty() {
+        return premise;
+    }
+    match premise {
+        Premise::Assert(Proposition::Attribute(boxed)) => {
+            let query = *boxed;
+            let narrowed = narrow_attribute(query, types);
+            Premise::Assert(Proposition::Attribute(Box::new(narrowed)))
+        }
+        other => other,
+    }
+}
+
+fn narrow_attribute(query: AttributeQuery, types: &TypeEnv) -> AttributeQuery {
+    let is_term = query.is().clone();
+    let Some(name) = is_term.name() else {
+        return query;
+    };
+    let Some(kind) = types.get(name) else {
+        return query;
+    };
+    let narrowed = Term::<Any>::typed_var(name.to_string(), kind.clone());
+    query.with_is(narrowed)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::artifact::Entity;
+    use crate::planner::Planner;
+    use crate::the;
+    use crate::{Cardinality, Term};
+
+    /// A rule where one premise binds `?name` optionally (so its
+    /// local `is` term carries `String | Nothing`) and another binds
+    /// it required (kind `String`). Rule-level inference narrows
+    /// `?name` to `String`. `Plan::apply_types` should hand the
+    /// evaluator an `is` term whose kind no longer admits `Nothing`.
+    #[dialog_common::test]
+    fn it_narrows_optional_is_term_via_rule_inference() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises)
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        // The shared TypeEnv should have narrowed `name` to non-
+        // optional. Each step's `types` Arc points at it.
+        let name_kind = plan
+            .steps
+            .first()
+            .unwrap()
+            .types
+            .get("name")
+            .expect("inferred kind for name");
+        assert!(
+            !name_kind.is_optional(),
+            "inference should strip Nothing when a required binding also exists"
+        );
+
+        // `apply_types` rewrites the optional `is` to the narrowed
+        // kind for the optional premise. After rewriting, the
+        // attribute query's `is` is no longer optional, so the
+        // evaluator won't emit Absent-fallback rows.
+        for step in plan.steps {
+            let narrowed = apply_types(step.premise.clone(), &step.types);
+            if let Premise::Assert(Proposition::Attribute(boxed)) = narrowed {
+                assert!(
+                    !boxed.is().is_optional(),
+                    "rule-level narrowing should leave `is` non-optional"
+                );
+            }
+        }
     }
 }

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -1,5 +1,6 @@
 use crate::Term;
 use crate::attribute::query::AttributeQuery;
+use crate::negation::Negation;
 use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
@@ -55,15 +56,6 @@ impl Plan {
     }
 
     /// Evaluate this plan with the given selection and environment.
-    ///
-    /// Before evaluation, the plan narrows the premise's variable
-    /// slots to the kinds inferred for them at the rule level. The
-    /// user-supplied premise (carrying the user's local term kinds)
-    /// stays untouched; only the in-flight working copy reflects
-    /// the rule-inferred kinds. This is how
-    /// [`AttributeQuery::evaluate`]'s `is.is_optional()` check
-    /// picks up rule-level narrowing — the term it consults is
-    /// already the narrowed one.
     pub fn evaluate<'a, Env, M: Selection + 'a>(
         self,
         selection: M,
@@ -72,25 +64,40 @@ impl Plan {
     where
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
-        let narrowed = apply_types(self.premise, &self.types);
-        narrowed.evaluate(selection, env)
+        self.premise.evaluate(selection, env)
     }
 }
 
-/// Replace each premise's variable terms with copies whose kinds
-/// match the rule-level inferred environment. Currently only
-/// `AttributeQuery::is` is rewritten — that's the slot whose
-/// `is_optional()` answer drives the planner-visible behavior
-/// difference (Absent-fallback emission).
-fn apply_types(premise: Premise, types: &TypeEnv) -> Premise {
+/// Rewrite a premise to reflect rule-level inferred types.
+///
+/// Currently only [`AttributeQuery::is`] is rewritten — that's the
+/// slot whose `is_optional()` answer drives the planner-visible
+/// behavior difference (Absent-fallback emission). Negated
+/// attribute queries are walked too, so a negation over an
+/// optional attribute picks up the same narrowing as its positive
+/// counterpart.
+///
+/// Called once when a [`Plan`] is built. The user-supplied premise
+/// stays untouched; the plan stores the rewritten working copy.
+pub(crate) fn apply_types(premise: Premise, types: &TypeEnv) -> Premise {
     if types.is_empty() {
         return premise;
     }
     match premise {
-        Premise::Assert(Proposition::Attribute(boxed)) => {
+        Premise::Assert(proposition) => {
+            Premise::Assert(apply_types_to_proposition(proposition, types))
+        }
+        Premise::Unless(Negation(proposition)) => {
+            Premise::Unless(Negation(apply_types_to_proposition(proposition, types)))
+        }
+    }
+}
+
+fn apply_types_to_proposition(proposition: Proposition, types: &TypeEnv) -> Proposition {
+    match proposition {
+        Proposition::Attribute(boxed) => {
             let query = *boxed;
-            let narrowed = narrow_attribute(query, types);
-            Premise::Assert(Proposition::Attribute(Box::new(narrowed)))
+            Proposition::Attribute(Box::new(narrow_attribute(query, types)))
         }
         other => other,
     }
@@ -120,10 +127,11 @@ mod tests {
     use crate::{Cardinality, Term};
 
     /// A rule where one premise binds `?name` optionally (so its
-    /// local `is` term carries `String | Nothing`) and another binds
-    /// it required (kind `String`). Rule-level inference narrows
-    /// `?name` to `String`. `Plan::apply_types` should hand the
-    /// evaluator an `is` term whose kind no longer admits `Nothing`.
+    /// local `is` term carries `String | Nothing`) and another
+    /// binds it required (kind `String`). Rule-level inference
+    /// narrows `?name` to `String`, and the planner stamps the
+    /// narrowed term into each plan step's premise so the
+    /// evaluator's `is.is_optional()` check returns `false`.
     #[dialog_common::test]
     fn it_narrows_optional_is_term_via_rule_inference() {
         let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
@@ -164,18 +172,74 @@ mod tests {
             "inference should strip Nothing when a required binding also exists"
         );
 
-        // `apply_types` rewrites the optional `is` to the narrowed
-        // kind for the optional premise. After rewriting, the
-        // attribute query's `is` is no longer optional, so the
-        // evaluator won't emit Absent-fallback rows.
+        // Every plan step's stored premise already has the
+        // narrowed `is` — the rewrite happens at plan time.
         for step in plan.steps {
-            let narrowed = apply_types(step.premise.clone(), &step.types);
-            if let Premise::Assert(Proposition::Attribute(boxed)) = narrowed {
+            if let Premise::Assert(Proposition::Attribute(boxed)) = &step.premise {
                 assert!(
                     !boxed.is().is_optional(),
                     "rule-level narrowing should leave `is` non-optional"
                 );
             }
+        }
+    }
+
+    /// `apply_types` reaches into negated propositions too. A
+    /// negated attribute query that references an inferred
+    /// variable should see its `is` rewritten to match the env.
+    #[dialog_common::test]
+    fn it_narrows_negated_attribute_via_rule_inference() {
+        use crate::artifact::Type as ValueType;
+        use crate::negation::Negation;
+        use crate::type_system::Type as Kind;
+
+        let env = {
+            // Build an env via the public path: a one-premise rule
+            // with a typed Term<String>. The single binding
+            // dictates the inferred kind.
+            let typed_name: Term<Any> = Term::<String>::var("name").into();
+            let premises = vec![
+                AttributeQuery::new(
+                    Term::from(the!("person/name")),
+                    Term::<Entity>::var("this"),
+                    typed_name,
+                    Term::var("cause"),
+                    Some(Cardinality::One),
+                )
+                .into(),
+            ];
+            let plan = Planner::from(premises)
+                .plan(&crate::Environment::new())
+                .unwrap();
+            plan.steps.into_iter().next().unwrap().types
+        };
+
+        // Build a negated attribute query that uses `?name` with
+        // the still-optional local term kind.
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let neg = AttributeQuery::new(
+            Term::from(the!("person/nickname")),
+            Term::<Entity>::var("this"),
+            optional_name,
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        let original = Premise::Unless(Negation(Proposition::Attribute(Box::new(neg))));
+
+        let narrowed = apply_types(original, &env);
+        if let Premise::Unless(Negation(Proposition::Attribute(boxed))) = narrowed {
+            assert!(
+                !boxed.is().is_optional(),
+                "rule-level narrowing should reach into negated attributes"
+            );
+            assert_eq!(
+                boxed.is().kind().and_then(|k| k.as_value_type()),
+                Some(ValueType::String),
+                "narrowed `is` should carry the inferred String kind"
+            );
+            let _ = Kind::primitive(ValueType::String);
+        } else {
+            panic!("expected negated attribute proposition");
         }
     }
 }

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -184,6 +184,67 @@ mod tests {
         }
     }
 
+    /// End-to-end: with rule-level narrowing applied, an optional
+    /// attribute query whose `?nick` is narrowed to non-optional by
+    /// a sibling premise no longer emits Absent-fallback rows.
+    ///
+    /// The test asserts a stronger fact than "rows are filtered":
+    /// it walks the plan's stored premises and verifies the
+    /// optional attribute's `is` term has been rewritten to a
+    /// non-optional kind. Without that rewrite, the attribute's
+    /// `evaluate` would emit one Absent fallback row per entity
+    /// without a nickname.
+    #[dialog_common::test]
+    fn it_suppresses_absent_fallback_under_rule_inference() {
+        let optional_nick: Term<Any> = Term::<Option<String>>::var("nick").into();
+        let typed_nick: Term<Any> = Term::<String>::var("nick").into();
+        let nickname_query = AttributeQuery::new(
+            Term::from(the!("person/nickname")),
+            Term::<Entity>::var("this"),
+            optional_nick,
+            Term::var("cause1"),
+            Some(Cardinality::One),
+        );
+        let name_query = AttributeQuery::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("this"),
+            typed_nick,
+            Term::var("cause2"),
+            Some(Cardinality::One),
+        );
+
+        // Before planning, the nickname query's `is` is optional.
+        assert!(
+            nickname_query.is().is_optional(),
+            "the local optional kind is preserved on the user's query"
+        );
+
+        let plan = Planner::from(vec![nickname_query.into(), name_query.into()])
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        // After planning, every attribute step that references
+        // `?nick` should have an `is` term whose kind is no
+        // longer optional — the narrowing was applied at plan
+        // time, not deferred to evaluation.
+        let mut narrowed_count = 0;
+        for step in &plan.steps {
+            if let Premise::Assert(Proposition::Attribute(boxed)) = &step.premise
+                && boxed.is().name() == Some("nick")
+            {
+                assert!(
+                    !boxed.is().is_optional(),
+                    "rule-level narrowing should have stripped Nothing from ?nick"
+                );
+                narrowed_count += 1;
+            }
+        }
+        assert_eq!(
+            narrowed_count, 2,
+            "both attribute steps reference ?nick and should both be checked"
+        );
+    }
+
     /// `apply_types` reaches into negated propositions too. A
     /// negated attribute query that references an inferred
     /// variable should see its `is` rewritten to match the env.

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -230,6 +230,84 @@ mod tests {
         );
     }
 
+    /// A standalone query (single optional premise, nothing
+    /// constraining it further) keeps its `is` term's optional
+    /// kind through planning. The rewrite doesn't strip
+    /// optionality when inference didn't strip it either.
+    #[dialog_common::test]
+    fn it_preserves_local_optionality_when_no_other_premise_narrows() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises)
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        if let Premise::Assert(Proposition::Attribute(boxed)) = &plan.steps[0].premise {
+            assert!(
+                boxed.is().is_optional(),
+                "single optional premise should keep its optional `is`"
+            );
+        }
+    }
+
+    /// Replanning a `Conjunction` preserves the rule-level
+    /// narrowing. The fresh inference pass over already-narrowed
+    /// premises is idempotent and yields the same non-optional
+    /// `is` kinds.
+    #[dialog_common::test]
+    fn it_preserves_narrowing_across_replans() {
+        use crate::planner::Conjunction;
+        let optional_name: Term<Any> = Term::<Option<String>>::var("nick").into();
+        let typed_name: Term<Any> = Term::<String>::var("nick").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises)
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        // Replan against a new scope where `this` is bound.
+        let mut scope = crate::Environment::new();
+        scope.add("this");
+        let replanned: Conjunction = plan.plan(&scope).unwrap();
+
+        // The replanned steps still have the narrowed `is`.
+        for step in &replanned.steps {
+            if let Premise::Assert(Proposition::Attribute(boxed)) = &step.premise
+                && boxed.is().name() == Some("nick")
+            {
+                assert!(
+                    !boxed.is().is_optional(),
+                    "narrowing must survive replanning"
+                );
+            }
+        }
+    }
+
     /// `apply_types` reaches into negated propositions too. A
     /// negated attribute query that references an inferred
     /// variable should see its `is` rewritten to match the env.

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -1,3 +1,4 @@
+use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
 use crate::source::SelectRules;
 use crate::{Environment, Premise};
@@ -25,6 +26,12 @@ pub struct Plan {
     pub binds: Environment,
     /// Variables already bound in the environment when this plan runs.
     pub env: Environment,
+    /// Rule-level inferred types for the variables this plan
+    /// references. Empty when the plan runs outside any rule
+    /// context (e.g. top-level `.perform()` on a standalone
+    /// query). Populated by the planner during rule compilation
+    /// via [`TypeEnv::project`].
+    pub types: TypeEnv,
 }
 
 impl Plan {

--- a/rust/dialog-query/src/proposition.rs
+++ b/rust/dialog-query/src/proposition.rs
@@ -175,16 +175,18 @@ impl<'de> Deserialize<'de> for Proposition {
                     .and_then(|v| serde_json::from_value(v.clone()).map_err(de::Error::custom))?;
                 Ok(Proposition::Concept(ConceptQuery { predicate, terms }))
             }
-            // String "==" → Constraint
-            serde_json::Value::String(name) if name == "==" => {
-                let constraint: Constraint =
-                    serde_json::from_value(raw).map_err(de::Error::custom)?;
-                Ok(Proposition::Constraint(constraint))
-            }
-            // Other string → FormulaQuery
+            // String → Constraint or FormulaQuery. Try Constraint
+            // first because its variants are named ("==", "coalesce",
+            // etc.); FormulaQuery is the catchall fallback for any
+            // other formula name.
             serde_json::Value::String(_) => {
-                let fq: FormulaQuery = serde_json::from_value(raw).map_err(de::Error::custom)?;
-                Ok(Proposition::Formula(fq))
+                if let Ok(constraint) = serde_json::from_value::<Constraint>(raw.clone()) {
+                    Ok(Proposition::Constraint(constraint))
+                } else {
+                    let fq: FormulaQuery =
+                        serde_json::from_value(raw).map_err(de::Error::custom)?;
+                    Ok(Proposition::Formula(fq))
+                }
             }
             _ => Err(de::Error::custom(
                 "\"assert\" must be a concept object or a formula/constraint name string",

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -218,9 +218,17 @@ mod tests {
 
         fn try_from(source: Match) -> Result<Self, Self::Error> {
             Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&PersonTerms::this()))?)?,
-                name: String::try_from(source.lookup(&Term::from(&PersonTerms::name()))?)?,
-                age: u32::try_from(source.lookup(&Term::from(&PersonTerms::age()))?)?,
+                this: Entity::try_from(
+                    source
+                        .lookup(&Term::from(&PersonTerms::this()))?
+                        .content()?,
+                )?,
+                name: String::try_from(
+                    source
+                        .lookup(&Term::from(&PersonTerms::name()))?
+                        .content()?,
+                )?,
+                age: u32::try_from(source.lookup(&Term::from(&PersonTerms::age()))?.content()?)?,
             })
         }
     }
@@ -254,9 +262,9 @@ mod tests {
 
         fn realize(&self, source: Match) -> Result<Self::Conclusion, EvaluationError> {
             Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&self.this))?)?,
-                name: String::try_from(source.lookup(&Term::from(&self.name))?)?,
-                age: u32::try_from(source.lookup(&Term::from(&self.age))?)?,
+                this: Entity::try_from(source.lookup(&Term::from(&self.this))?.content()?)?,
+                name: String::try_from(source.lookup(&Term::from(&self.name))?.content()?)?,
+                age: u32::try_from(source.lookup(&Term::from(&self.age))?.content()?)?,
             })
         }
     }

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -9,12 +9,15 @@
 pub mod deductive;
 /// Premises collection type.
 pub mod premises;
+/// Type inference over a rule's premises.
+pub mod types;
 /// When trait and tuple implementations.
 pub mod when;
 
 pub use deductive::DeductiveRule;
 pub use deductive::descriptor::DeductiveRuleDescriptor;
 pub use premises::*;
+pub use types::TypeEnv;
 pub use when::*;
 
 /// Macro for creating When collections with clean array-like syntax

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -107,6 +107,12 @@ pub trait Compile: Sized + Into<Rule> {
     /// deductive and inductive rules; the only difference between
     /// the kinds lives at evaluation time, not compile time.
     fn compile(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
+        // A concept with no required (`with`) attributes is
+        // unconstructable (see `ConceptDescriptor`'s `TryFrom` /
+        // `Deserialize` and the `#[derive(Concept)]` compile-time
+        // assertion), so `conclusion` is guaranteed non-degenerate
+        // here — no explicit emptiness check is needed.
+
         // Plan the order of premises in a scope where none of the
         // rule parameters are bound to find the optimal execution
         // order, or to discover unsatisfiable premises (e.g. a
@@ -210,247 +216,37 @@ macro_rules! when {
 #[cfg(test)]
 mod tests {
     extern crate self as dialog_query;
-    use std::vec::IntoIter;
 
     use super::*;
     use crate::artifact::{Entity, Type};
-    use crate::attribute::{AttributeDescriptor, Cardinality};
     use crate::concept::descriptor::ConceptDescriptor;
-    use crate::concept::query::ConceptQuery;
-    use crate::concept::{Concept, Conclusion};
-    use crate::predicate::Predicate;
-    use crate::premise::Premise;
-    use crate::query::Application;
-    use crate::selection::Match;
-    use crate::selection::Selection;
-    use crate::source::SelectRules;
-    use crate::statement::Statement;
     use crate::term::Term;
-    use crate::the;
-    use crate::{AttributeStatement, EvaluationError, Parameters, Proposition, Query};
-    use dialog_artifacts::Select;
-    use dialog_capability::Provider;
-    use dialog_common::ConditionalSync;
+    use crate::{AttributeStatement, Query};
 
-    // Manual implementation of Person struct with Concept and Rule traits
-    // This serves as a template for what the derive macro should generate
-    #[derive(Debug, Clone)]
+    // Define a Person concept for testing via `#[derive(Concept)]`.
+    // The newtypes live in a module named `person` so the attribute
+    // domain defaults to `person`, yielding `person/name` and
+    // `person/age` to match the facts the scaffold previously asserted.
+    mod person {
+        use crate::Attribute;
+
+        /// Name of the person
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Name(pub String);
+
+        /// Age of the person
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Age(pub u32);
+    }
+
+    /// A person concept used by the rule scaffold tests below.
+    #[derive(crate::Concept, Debug, Clone)]
     pub struct Person {
         pub this: Entity,
-        /// Name of the person
-        pub name: String,
-        /// Age of the person
-        pub age: u32,
-    }
-
-    /// Query pattern for Person - has Term-wrapped fields for querying
-    #[derive(Debug, Clone)]
-    pub struct PersonQuery {
-        /// The entity being matched
-        pub this: Term<Entity>,
-        /// Name term - can be a variable or concrete value
-        pub name: Term<String>,
-        /// Age term - can be a variable or concrete value
-        pub age: Term<u32>,
-    }
-
-    impl Default for PersonQuery {
-        fn default() -> Self {
-            Self {
-                this: Term::var("this"),
-                name: Term::var("name"),
-                age: Term::var("age"),
-            }
-        }
-    }
-
-    /// Attributes pattern for Person - enables fluent query building
-    #[derive(Debug, Clone)]
-    pub struct PersonTerms;
-    impl PersonTerms {
-        pub fn this() -> Term<Entity> {
-            Term::var("this")
-        }
-        pub fn name() -> Term<String> {
-            Term::var("name")
-        }
-        pub fn age() -> Term<u32> {
-            Term::var("age")
-        }
-    }
-
-    fn person_predicate() -> ConceptDescriptor {
-        ConceptDescriptor::from(vec![
-            (
-                "name",
-                AttributeDescriptor::new(
-                    the!("person/name"),
-                    "Name of the person",
-                    Cardinality::One,
-                    Some(Type::String),
-                ),
-            ),
-            (
-                "age",
-                AttributeDescriptor::new(
-                    the!("person/age"),
-                    "Age of the person",
-                    Cardinality::One,
-                    Some(Type::UnsignedInt),
-                ),
-            ),
-        ])
-    }
-
-    impl From<Person> for ConceptDescriptor {
-        fn from(_: Person) -> Self {
-            person_predicate()
-        }
-    }
-
-    impl From<PersonQuery> for ConceptDescriptor {
-        fn from(_: PersonQuery) -> Self {
-            person_predicate()
-        }
-    }
-
-    impl Concept for Person {
-        type Term = PersonTerms;
-
-        fn this(&self) -> Entity {
-            let predicate: ConceptDescriptor = self.clone().into();
-            predicate.this()
-        }
-    }
-
-    impl IntoIterator for Person {
-        type Item = AttributeStatement;
-        type IntoIter = IntoIter<AttributeStatement>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            vec![
-                the!("person/name")
-                    .of(self.this.clone())
-                    .is(self.name.clone())
-                    .into(),
-                the!("person/age").of(self.this.clone()).is(self.age).into(),
-            ]
-            .into_iter()
-        }
-    }
-
-    impl Statement for Person {
-        fn assert(self, update: &mut impl dialog_artifacts::Update) {
-            the!("person/name")
-                .of(self.this.clone())
-                .is(self.name.clone())
-                .assert(update);
-            the!("person/age")
-                .of(self.this.clone())
-                .is(self.age)
-                .assert(update);
-        }
-
-        fn retract(self, update: &mut impl dialog_artifacts::Update) {
-            the!("person/name")
-                .of(self.this.clone())
-                .is(self.name.clone())
-                .retract(update);
-            the!("person/age")
-                .of(self.this.clone())
-                .is(self.age)
-                .retract(update);
-        }
-    }
-
-    impl Predicate for Person {
-        type Conclusion = Person;
-        type Application = PersonQuery;
-        type Descriptor = ConceptDescriptor;
-    }
-
-    impl TryFrom<Match> for Person {
-        type Error = EvaluationError;
-
-        fn try_from(source: Match) -> Result<Self, Self::Error> {
-            Ok(Person {
-                this: Entity::try_from(
-                    source
-                        .lookup(&Term::from(&PersonTerms::this()))?
-                        .content()?,
-                )?,
-                name: String::try_from(
-                    source
-                        .lookup(&Term::from(&PersonTerms::name()))?
-                        .content()?,
-                )?,
-                age: u32::try_from(source.lookup(&Term::from(&PersonTerms::age()))?.content()?)?,
-            })
-        }
-    }
-
-    impl From<PersonQuery> for Parameters {
-        fn from(source: PersonQuery) -> Self {
-            let mut terms = Self::new();
-
-            terms.insert("this".into(), source.this.into());
-            terms.insert("name".into(), source.name.into());
-            terms.insert("age".into(), source.age.into());
-
-            terms
-        }
-    }
-
-    impl Application for PersonQuery {
-        type Conclusion = Person;
-
-        fn evaluate<'a, Env, M: Selection + 'a>(
-            self,
-            selection: M,
-            env: &'a Env,
-        ) -> impl Selection + 'a
-        where
-            Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
-        {
-            let application: ConceptQuery = self.into();
-            application.evaluate(selection, env)
-        }
-
-        fn realize(&self, source: Match) -> Result<Self::Conclusion, EvaluationError> {
-            Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&self.this))?.content()?)?,
-                name: String::try_from(source.lookup(&Term::from(&self.name))?.content()?)?,
-                age: u32::try_from(source.lookup(&Term::from(&self.age))?.content()?)?,
-            })
-        }
-    }
-
-    impl From<PersonQuery> for ConceptQuery {
-        fn from(source: PersonQuery) -> Self {
-            let predicate: ConceptDescriptor = source.clone().into();
-            ConceptQuery {
-                terms: source.into(),
-                predicate,
-            }
-        }
-    }
-
-    impl From<PersonQuery> for Proposition {
-        fn from(source: PersonQuery) -> Self {
-            Proposition::Concept(source.into())
-        }
-    }
-
-    impl From<PersonQuery> for Premise {
-        fn from(source: PersonQuery) -> Self {
-            Premise::Assert(source.into())
-        }
-    }
-
-    impl Conclusion for Person {
-        fn this(&self) -> &Entity {
-            panic!("Instance trait implementation requires an entity field")
-        }
+        /// Name of the person (`person/name`)
+        pub name: person::Name,
+        /// Age of the person (`person/age`)
+        pub age: person::Age,
     }
 
     #[dialog_common::test]
@@ -465,12 +261,10 @@ mod tests {
         }
 
         // Verify rule installs into registry
-        use crate::ConceptDescriptor;
         use crate::rule::deductive::DeductiveRule;
         use crate::session::RuleRegistry;
         let mut rules = RuleRegistry::new();
-        let person_query = Query::<Person>::default();
-        let concept: ConceptDescriptor = person_query.into();
+        let concept = Person::descriptor().clone();
         let premises = person_rule(Query::<Person>::default())
             .into_premises()
             .into_vec();
@@ -516,7 +310,7 @@ mod tests {
         };
 
         // Test that MacroPerson implements Concept
-        let concept: ConceptDescriptor = Query::<MacroPerson>::default().into();
+        let concept: ConceptDescriptor = MacroPerson::descriptor().clone();
         // Operator is now a computed URI
         assert!(
             concept.this().to_string().starts_with("concept:"),
@@ -614,7 +408,7 @@ mod tests {
 
         // Concept descriptor: required field flows into `with`,
         // optional fields flow into `maybe`.
-        let concept: ConceptDescriptor = default.into();
+        let concept: ConceptDescriptor = MacroEmployee::descriptor().clone();
         let with: Vec<_> = concept.with().iter().collect();
         assert_eq!(with.len(), 1);
         assert_eq!(with[0].0, "given-name");
@@ -676,7 +470,7 @@ mod tests {
         // not `with`. If the macro were doing syntactic Option
         // detection by ident name, `Maybe` would not match and
         // `nickname` would land in `with` — wrong.
-        let concept: ConceptDescriptor = Query::<AliasedConcept>::default().into();
+        let concept: ConceptDescriptor = AliasedConcept::descriptor().clone();
         let with: Vec<_> = concept.with().iter().collect();
         assert_eq!(with.len(), 1);
         assert_eq!(with[0].0, "given-name");

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -5,6 +5,8 @@
 //!
 //! The design follows the patterns described in notes/rules.md.
 
+/// Rule analysis — inference and dependency graph over premises.
+pub mod analyzer;
 /// Deductive rule definitions for deriving new facts.
 pub mod deductive;
 /// Premises collection type.
@@ -14,6 +16,7 @@ pub mod types;
 /// When trait and tuple implementations.
 pub mod when;
 
+pub use analyzer::{Analyzed, AnalyzedRule, analyze};
 pub use deductive::DeductiveRule;
 pub use deductive::descriptor::DeductiveRuleDescriptor;
 pub use premises::*;

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -403,4 +403,93 @@ mod tests {
         assert_eq!(birthday_desc.domain(), "macro-person");
         assert_eq!(birthday_desc.name(), "birthday");
     }
+
+    mod macro_employee {
+        use crate::Attribute;
+
+        /// Person's first name
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct GivenName(pub String);
+
+        /// Person's preferred nickname
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Nickname(pub String);
+
+        /// Person's age in years
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Age(pub u32);
+    }
+
+    /// Concept with both required and optional fields. Exercises the
+    /// `Option<T>` branch of the `#[derive(Concept)]` macro: typed
+    /// `Term<Option<U>>` query field, optional descriptor pair into
+    /// `with_maybe`, and optional realize via `Binding`.
+    #[derive(crate::Concept, Debug, Clone)]
+    pub struct MacroEmployee {
+        /// Employee entity
+        pub this: Entity,
+        /// Required given name
+        pub given_name: macro_employee::GivenName,
+        /// Optional preferred nickname
+        pub nickname: Option<macro_employee::Nickname>,
+        /// Optional age
+        pub age: Option<macro_employee::Age>,
+    }
+
+    #[dialog_common::test]
+    fn it_emits_typed_optional_terms_in_macro() {
+        // The query struct must accept `Term<Option<String>>` and
+        // `Term<Option<u32>>` for the optional fields. Constructing the
+        // query with these types is itself a compile-time test.
+        let _query = Query::<MacroEmployee> {
+            this: Term::var("emp"),
+            given_name: Term::<String>::var("emp_given"),
+            nickname: Term::<Option<String>>::var("emp_nickname"),
+            age: Term::<Option<u32>>::var("emp_age"),
+        };
+
+        // Default-constructed query: every field is a named variable
+        // including the optional ones.
+        let default = Query::<MacroEmployee>::default();
+        assert!(matches!(default.this, Term::Variable { .. }));
+        assert!(matches!(default.given_name, Term::Variable { .. }));
+        assert!(matches!(default.nickname, Term::Variable { .. }));
+        assert!(matches!(default.age, Term::Variable { .. }));
+
+        // Concept descriptor: required field flows into `with`,
+        // optional fields flow into `maybe`.
+        let concept: ConceptDescriptor = default.into();
+        let with: Vec<_> = concept.with().iter().collect();
+        assert_eq!(with.len(), 1);
+        assert_eq!(with[0].0, "given_name");
+
+        let maybe = concept.maybe().expect("concept has maybe attributes");
+        let maybe: Vec<_> = maybe.iter().collect();
+        assert_eq!(maybe.len(), 2);
+        assert_eq!(maybe[0].0, "nickname");
+        assert_eq!(maybe[1].0, "age");
+
+        // Rule body emits only required fields. Optional fields are
+        // resolved by the descriptor's deductive-rule projection
+        // separately, not via `when()`.
+        let when_result = MacroEmployee::when(Query::<MacroEmployee>::default());
+        assert_eq!(when_result.len(), 1);
+    }
+
+    #[dialog_common::test]
+    fn it_persists_only_some_optional_values() {
+        // IntoIterator emits a relation per field: required always,
+        // optional only when `Some(_)`. With one Some and one None,
+        // we should see exactly two statements (1 required + 1 Some).
+        let entity = Entity::new().unwrap();
+        let employee = MacroEmployee {
+            this: entity,
+            given_name: macro_employee::GivenName("Ada".into()),
+            nickname: Some(macro_employee::Nickname("AL".into())),
+            age: None,
+        };
+
+        let statements: Vec<AttributeStatement> = employee.into_iter().collect();
+        assert_eq!(statements.len(), 2);
+    }
 }

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -16,7 +16,7 @@ pub mod types;
 /// When trait and tuple implementations.
 pub mod when;
 
-pub use analyzer::{Analyzed, AnalyzedRule, analyze};
+pub use analyzer::{AnalyzedRule, analyze};
 pub use deductive::DeductiveRule;
 pub use deductive::descriptor::DeductiveRuleDescriptor;
 pub use premises::*;

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -469,11 +469,13 @@ mod tests {
         assert_eq!(maybe[0].0, "nickname");
         assert_eq!(maybe[1].0, "age");
 
-        // Rule body emits only required fields. Optional fields are
-        // resolved by the descriptor's deductive-rule projection
-        // separately, not via `when()`.
+        // Rule body emits one attribute query per field (required
+        // *and* optional), with the resolution chosen by each
+        // field's `<F as ConceptField>::RESOLUTION` const. For
+        // MacroEmployee (1 required + 2 optional fields), `when()`
+        // returns 3 attribute queries.
         let when_result = MacroEmployee::when(Query::<MacroEmployee>::default());
-        assert_eq!(when_result.len(), 1);
+        assert_eq!(when_result.len(), 3);
     }
 
     #[dialog_common::test]
@@ -491,5 +493,43 @@ mod tests {
 
         let statements: Vec<AttributeStatement> = employee.into_iter().collect();
         assert_eq!(statements.len(), 2);
+    }
+
+    /// Aliasing `Option` to another name still routes through the
+    /// `ConceptField` impl for `Option<N>`. Proves the macro does
+    /// not depend on syntactic detection of the literal `Option`
+    /// identifier — Rust's type system resolves the alias to the
+    /// underlying `Option<N>` shape at type-check time, picking
+    /// up the right blanket impl.
+    #[dialog_common::test]
+    fn it_routes_optional_through_alias_via_concept_field() {
+        use core::option::Option as Maybe;
+
+        #[derive(crate::Concept, Debug, Clone)]
+        #[allow(dead_code)]
+        pub struct AliasedConcept {
+            /// Entity
+            pub this: Entity,
+            /// Required name
+            pub given_name: macro_employee::GivenName,
+            /// Optional nickname, spelled via an aliased Option
+            pub nickname: Maybe<macro_employee::Nickname>,
+        }
+
+        // Concept descriptor must route `nickname` into `maybe`,
+        // not `with`. If the macro were doing syntactic Option
+        // detection by ident name, `Maybe` would not match and
+        // `nickname` would land in `with` — wrong.
+        let concept: ConceptDescriptor = Query::<AliasedConcept>::default().into();
+        let with: Vec<_> = concept.with().iter().collect();
+        assert_eq!(with.len(), 1);
+        assert_eq!(with[0].0, "given_name");
+
+        let maybe = concept
+            .maybe()
+            .expect("AliasedConcept must have a `maybe` slot");
+        let maybe_entries: Vec<_> = maybe.iter().collect();
+        assert_eq!(maybe_entries.len(), 1);
+        assert_eq!(maybe_entries[0].0, "nickname");
     }
 }

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -292,7 +292,7 @@ mod tests {
     use crate::{Cardinality, Environment, Term};
 
     fn person_with_name() -> ConceptDescriptor {
-        ConceptDescriptor::from(vec![(
+        ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -301,6 +301,7 @@ mod tests {
                 Some(ValueType::String),
             ),
         )])
+        .unwrap()
     }
 
     /// Analysis output carries the inferred type environment.

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -26,9 +26,133 @@ use crate::constraint::Constraint;
 use crate::planner::Plan;
 use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
+use crate::schema::Requirement;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::Arc;
+
+/// Variable-usage information for a single premise.
+///
+/// Computed during analysis by walking the premise's schema and
+/// parameters: a variable is in `binds` if the premise will produce
+/// a value for it (positive premise; non-blank parameter slot), and
+/// in `needs` if the premise reads it without binding (e.g. a
+/// required slot the premise can't satisfy on its own, or a value
+/// it has to look up). A variable can appear in both sets when the
+/// schema lists it under multiple slots with mixed requirements.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PremiseVars {
+    /// Variables this premise will bind upon execution.
+    pub binds: BTreeSet<String>,
+    /// Variables this premise needs already bound to execute.
+    pub needs: BTreeSet<String>,
+}
+
+/// Per-premise variable usage plus precomputed dependency edges.
+///
+/// `requires[i]` is the set of premise indices that must execute
+/// before premise `i` because they bind a variable in `needs[i]`.
+/// The graph respects the user's original premise order: a premise
+/// that binds a variable can satisfy any later premise's need for
+/// it, regardless of cost. Reordering happens during planning, not
+/// here.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DependencyGraph {
+    /// Per-premise variable usage in the original order.
+    pub usage: Vec<PremiseVars>,
+    /// `requires[i]` lists the premise indices `j` such that
+    /// premise `j` binds a variable premise `i` needs.
+    pub requires: Vec<BTreeSet<usize>>,
+}
+
+impl DependencyGraph {
+    /// Returns `true` if no premises were analyzed.
+    pub fn is_empty(&self) -> bool {
+        self.usage.is_empty()
+    }
+
+    /// Number of premises in the graph.
+    pub fn len(&self) -> usize {
+        self.usage.len()
+    }
+
+    /// Compute the dependency graph for a sequence of planned steps.
+    /// Walks each step's schema once: a non-blank named parameter
+    /// goes into `binds` if the schema field is `Optional` or part
+    /// of a satisfied choice group, otherwise into `needs`. Choice
+    /// groups satisfied by a constant or already-bound parameter
+    /// don't contribute to `needs`.
+    pub fn from_steps(steps: &[Plan]) -> Self {
+        let mut usage = Vec::with_capacity(steps.len());
+
+        for step in steps {
+            let is_negation = matches!(step.premise, Premise::Unless(_));
+            let schema = step.premise.schema();
+            let params = step.premise.parameters();
+
+            // Identify choice groups satisfied by a constant in
+            // this step's parameters.
+            let mut satisfied_groups = HashSet::new();
+            for (slot_name, field) in schema.iter() {
+                if let Some(param) = params.get(slot_name)
+                    && let Requirement::Required(Some(group)) = &field.requirement
+                    && param.is_constant()
+                {
+                    satisfied_groups.insert(*group);
+                }
+            }
+
+            let mut vars = PremiseVars::default();
+            for (slot_name, field) in schema.iter() {
+                let Some(param) = params.get(slot_name) else {
+                    continue;
+                };
+                if param.is_constant() || param.is_blank() {
+                    continue;
+                }
+                let Some(name) = param.name() else {
+                    continue;
+                };
+                match &field.requirement {
+                    Requirement::Required(None) => {
+                        vars.needs.insert(name.to_string());
+                    }
+                    Requirement::Required(Some(group)) => {
+                        if satisfied_groups.contains(group) {
+                            if !is_negation {
+                                vars.binds.insert(name.to_string());
+                            }
+                        } else {
+                            vars.needs.insert(name.to_string());
+                        }
+                    }
+                    Requirement::Optional => {
+                        if !is_negation {
+                            vars.binds.insert(name.to_string());
+                        }
+                    }
+                }
+            }
+            usage.push(vars);
+        }
+
+        // For each premise i, find every other premise j (j != i)
+        // that binds something i needs.
+        let mut requires = vec![BTreeSet::new(); usage.len()];
+        for (i, vars) in usage.iter().enumerate() {
+            for need in &vars.needs {
+                for (j, other) in usage.iter().enumerate() {
+                    if j != i && other.binds.contains(need) {
+                        requires[i].insert(j);
+                    }
+                }
+            }
+        }
+
+        Self { usage, requires }
+    }
+}
 
 /// Errors detected by [`analyze`]. These are pre-rule type
 /// problems: inference produced a contradiction or a constraint's
@@ -114,6 +238,9 @@ pub struct AnalyzedRule {
     pub premises: Vec<Analyzed<Premise>>,
     /// The rule-wide inferred type environment.
     pub types: Arc<TypeEnv>,
+    /// Per-premise variable usage and dependency edges. Indexed in
+    /// the same order as `premises`.
+    pub graph: DependencyGraph,
 }
 
 impl AnalyzedRule {
@@ -177,10 +304,12 @@ pub fn analyze(
         .iter()
         .map(|step| Analyzed::new(step.premise.clone(), types.clone()))
         .collect();
+    let graph = DependencyGraph::from_steps(steps);
     Ok(AnalyzedRule {
         conclusion,
         premises,
         types,
+        graph,
     })
 }
 
@@ -235,6 +364,40 @@ mod tests {
         // Every premise in the same rule shares the same Arc.
         for premise in analyzed.premises() {
             assert!(Arc::ptr_eq(&premise.types, &analyzed.types));
+        }
+    }
+
+    /// Two premises that share a variable `?entity`: one binds it
+    /// (the entity slot is a free variable), and one needs it (the
+    /// entity slot is the same variable, satisfied by the first
+    /// premise binding it). The graph records the dependency edge.
+    #[dialog_common::test]
+    fn it_records_dependency_edge_between_premises() {
+        let q1 = AttributeQuery::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("entity"),
+            Term::<String>::var("name").into(),
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        let q2 = AttributeQuery::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("entity"),
+            Term::<Any>::var("age"),
+            Term::var("cause2"),
+            Some(Cardinality::One),
+        );
+        let premises = vec![q1.into(), q2.into()];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let analyzed = analyze(person_with_name(), &plan.steps).unwrap();
+
+        assert_eq!(analyzed.graph.len(), 2);
+
+        // Each step's vars include `entity` (the schema groups
+        // the/of/is/cause as one choice; with a constant `the`,
+        // the group is satisfied, so all of them are binds).
+        for vars in &analyzed.graph.usage {
+            assert!(vars.binds.contains("entity"));
         }
     }
 

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -1,0 +1,164 @@
+//! Rule analysis — the phase between parsing and planning.
+//!
+//! The rule pipeline has three phases:
+//!
+//! 1. **Parse.** A `DeductiveRuleDescriptor` carries the user's
+//!    syntactic form: a conclusion and a list of premises with
+//!    user-supplied terms.
+//! 2. **Analyze.** Type inference runs against the premises'
+//!    slots; type errors (`RequiredHeadFromOptional`, Coalesce
+//!    contract violations) surface here. The output is an
+//!    `AnalyzedRule` — every premise carries a shared, read-only
+//!    view of the rule-wide [`TypeEnv`], plus a dependency graph
+//!    describing which premise binds and which reads each variable.
+//! 3. **Plan.** Given an `AnalyzedRule` and a scope of already-bound
+//!    variables, the planner orders the premises by cost and
+//!    produces a `Conjunction` ready for execution.
+//!
+//! Analysis is rule-scoped; the result is immutable. Planning can
+//! run repeatedly against the same analyzed rule with different
+//! scopes (the use case is concept-rule replanning when caller
+//! bindings change).
+
+use crate::Premise;
+use crate::planner::Plan;
+use crate::rule::types::TypeEnv;
+use crate::type_system::Type as Kind;
+use std::sync::Arc;
+
+/// A piece of the user's rule with the rule-wide type environment
+/// attached. The `source` is whatever the user wrote; `types` is the
+/// inferred environment for the rule containing it. Evaluators
+/// that want a variable's inferred kind ask the environment by name.
+///
+/// `Analyzed` is the common shape for premises after analysis. The
+/// rule-wide [`TypeEnv`] is shared via [`Arc`] so each premise gets
+/// a cheap clone-able view rather than its own projection.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Analyzed<T> {
+    /// The user-supplied form.
+    pub source: T,
+    /// The rule-wide type environment. Shared across every
+    /// `Analyzed` in the same rule.
+    pub types: Arc<TypeEnv>,
+}
+
+impl<T> Analyzed<T> {
+    /// Wrap `source` with a shared type environment.
+    pub fn new(source: T, types: Arc<TypeEnv>) -> Self {
+        Self { source, types }
+    }
+
+    /// Map the wrapped value while preserving the shared environment.
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Analyzed<U> {
+        Analyzed {
+            source: f(self.source),
+            types: self.types,
+        }
+    }
+
+    /// Borrow the wrapped value alongside the shared environment.
+    pub fn as_ref(&self) -> Analyzed<&T> {
+        Analyzed {
+            source: &self.source,
+            types: self.types.clone(),
+        }
+    }
+}
+
+/// A rule that has passed analysis. Carries the conclusion, the
+/// analyzed premises (each with a shared view of the rule-wide
+/// type environment), and the type environment itself.
+///
+/// This is the artifact the planner consumes. It is immutable: the
+/// planner doesn't modify the analyzed rule, it reads from it to
+/// build a [`Conjunction`](crate::planner::Conjunction) ordered for
+/// a given scope.
+///
+/// The dependency graph (which premise binds which variable, which
+/// premises require what) is computed during analysis and will be
+/// added in a follow-up step; the planner currently still derives
+/// it on the fly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnalyzedRule {
+    /// The analyzed premises in their original order. Planning may
+    /// reorder them; analysis preserves user order.
+    pub premises: Vec<Analyzed<Premise>>,
+    /// The rule-wide inferred type environment.
+    pub types: Arc<TypeEnv>,
+}
+
+impl AnalyzedRule {
+    /// Iterate over the analyzed premises.
+    pub fn premises(&self) -> impl Iterator<Item = &Analyzed<Premise>> {
+        self.premises.iter()
+    }
+
+    /// Look up a variable's inferred type by name.
+    pub fn type_of(&self, name: &str) -> Option<&Kind> {
+        self.types.get(name)
+    }
+}
+
+/// Run analysis over the rule's premises: infer types, build the
+/// shared environment, wrap each premise as an `Analyzed<Premise>`.
+///
+/// This is currently a thin wrapper around [`TypeEnv::infer`] that
+/// runs against a `Vec<Plan>` shape (because that's what `infer`
+/// consumes today). It will gain the dependency-graph computation
+/// and richer error reporting in follow-up commits.
+///
+/// Returns the analyzed rule. Type errors detected during analysis
+/// (e.g. `RequiredHeadFromOptional`) are not raised here yet —
+/// `DeductiveRule::new` still owns those checks. Moving them into
+/// the analyzer is a later step.
+pub fn analyze(steps: &[Plan]) -> AnalyzedRule {
+    let types = Arc::new(TypeEnv::infer(steps));
+    let premises = steps
+        .iter()
+        .map(|step| Analyzed::new(step.premise.clone(), types.clone()))
+        .collect();
+    AnalyzedRule { premises, types }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::artifact::{Entity, Type as ValueType};
+    use crate::attribute::query::AttributeQuery;
+    use crate::planner::Planner;
+    use crate::the;
+    use crate::types::Any;
+    use crate::{Cardinality, Environment, Term};
+
+    /// Analysis output carries the inferred type environment and
+    /// wraps each premise with a clone of the shared `Arc<TypeEnv>`.
+    #[dialog_common::test]
+    fn it_analyzes_a_single_typed_premise() {
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let analyzed = analyze(&plan.steps);
+
+        assert_eq!(analyzed.premises.len(), 1);
+        let name_kind = analyzed.type_of("name").expect("name has an inferred type");
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+
+        // Every premise in the same rule shares the same Arc.
+        for premise in analyzed.premises() {
+            assert!(Arc::ptr_eq(&premise.types, &analyzed.types));
+        }
+    }
+}

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -161,6 +161,13 @@ impl DependencyGraph {
 /// after planning, so callers get the rule embedded for display.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum AnalysisError {
+    /// Type inference produced a contradiction — see
+    /// [`InferenceError`](super::types::InferenceError).
+    #[error("type inference failed: {reason}")]
+    Inference {
+        /// Description of the conflict.
+        reason: String,
+    },
     /// A conclusion variable's inferred type admits `Nothing` —
     /// the rule could produce `Absent` in a required slot.
     #[error("conclusion variable {variable} is optional")]
@@ -227,7 +234,11 @@ pub fn analyze(
     conclusion: ConceptDescriptor,
     steps: &[Plan],
 ) -> Result<AnalyzedRule, AnalysisError> {
-    let types = Arc::new(TypeEnv::infer(steps));
+    let types = Arc::new(
+        TypeEnv::infer(steps).map_err(|err| AnalysisError::Inference {
+            reason: err.to_string(),
+        })?,
+    );
 
     // Required heads must not admit `Nothing`.
     if let Some(variable) = conclusion

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -176,76 +176,32 @@ pub enum AnalysisError {
     },
 }
 
-/// A piece of the user's rule with the rule-wide type environment
-/// attached. The `source` is whatever the user wrote; `types` is the
-/// inferred environment for the rule containing it. Evaluators
-/// that want a variable's inferred kind ask the environment by name.
-///
-/// `Analyzed` is the common shape for premises after analysis. The
-/// rule-wide [`TypeEnv`] is shared via [`Arc`] so each premise gets
-/// a cheap clone-able view rather than its own projection.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Analyzed<T> {
-    /// The user-supplied form.
-    pub source: T,
-    /// The rule-wide type environment. Shared across every
-    /// `Analyzed` in the same rule.
-    pub types: Arc<TypeEnv>,
-}
-
-impl<T> Analyzed<T> {
-    /// Wrap `source` with a shared type environment.
-    pub fn new(source: T, types: Arc<TypeEnv>) -> Self {
-        Self { source, types }
-    }
-
-    /// Map the wrapped value while preserving the shared environment.
-    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Analyzed<U> {
-        Analyzed {
-            source: f(self.source),
-            types: self.types,
-        }
-    }
-
-    /// Borrow the wrapped value alongside the shared environment.
-    pub fn as_ref(&self) -> Analyzed<&T> {
-        Analyzed {
-            source: &self.source,
-            types: self.types.clone(),
-        }
-    }
-}
-
 /// A rule that has passed analysis. Carries the conclusion, the
-/// analyzed premises (each with a shared view of the rule-wide
-/// type environment), and the type environment itself.
+/// original premises in their planned order, the rule-wide
+/// inferred type environment, and a per-premise dependency graph.
 ///
-/// This is the artifact the planner consumes. It is immutable: the
-/// planner doesn't modify the analyzed rule, it reads from it to
-/// build a [`Conjunction`](crate::planner::Conjunction) ordered for
-/// a given scope.
-///
-/// The dependency graph (which premise binds which variable, which
-/// premises require what) is computed during analysis and will be
-/// added in a follow-up step; the planner currently still derives
-/// it on the fly.
+/// This is the artifact of analysis. The planner reads it (or its
+/// pieces) to build per-step plans; future iterations of the
+/// planner can consume the dependency graph directly to avoid
+/// re-walking schemas on every iteration.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnalyzedRule {
     /// The rule's conclusion.
     pub conclusion: ConceptDescriptor,
-    /// The analyzed premises in their original order. Planning may
-    /// reorder them; analysis preserves user order.
-    pub premises: Vec<Analyzed<Premise>>,
-    /// The rule-wide inferred type environment.
+    /// The premises in their planned order. Analysis preserves
+    /// the planner's ordering; it doesn't re-order on its own.
+    pub premises: Vec<Premise>,
+    /// The rule-wide inferred type environment. Shared via
+    /// [`Arc`] across consumers.
     pub types: Arc<TypeEnv>,
-    /// Per-premise variable usage and dependency edges. Indexed in
-    /// the same order as `premises`.
+    /// Per-premise variable usage and dependency edges. Indexed
+    /// in the same order as `premises`.
     pub graph: DependencyGraph,
 }
 
 impl AnalyzedRule {
     /// Iterate over the analyzed premises.
-    pub fn premises(&self) -> impl Iterator<Item = &Analyzed<Premise>> {
+    pub fn premises(&self) -> impl Iterator<Item = &Premise> {
         self.premises.iter()
     }
 
@@ -300,10 +256,7 @@ pub fn analyze(
         }
     }
 
-    let premises = steps
-        .iter()
-        .map(|step| Analyzed::new(step.premise.clone(), types.clone()))
-        .collect();
+    let premises = steps.iter().map(|step| step.premise.clone()).collect();
     let graph = DependencyGraph::from_steps(steps);
     Ok(AnalyzedRule {
         conclusion,
@@ -339,8 +292,7 @@ mod tests {
         )])
     }
 
-    /// Analysis output carries the inferred type environment and
-    /// wraps each premise with a clone of the shared `Arc<TypeEnv>`.
+    /// Analysis output carries the inferred type environment.
     #[dialog_common::test]
     fn it_analyzes_a_single_typed_premise() {
         let typed_name: Term<Any> = Term::<String>::var("name").into();
@@ -360,11 +312,6 @@ mod tests {
         assert_eq!(analyzed.premises.len(), 1);
         let name_kind = analyzed.type_of("name").expect("name has an inferred type");
         assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
-
-        // Every premise in the same rule shares the same Arc.
-        for premise in analyzed.premises() {
-            assert!(Arc::ptr_eq(&premise.types, &analyzed.types));
-        }
     }
 
     /// Two premises that share a variable `?entity`: one binds it
@@ -399,6 +346,69 @@ mod tests {
         for vars in &analyzed.graph.usage {
             assert!(vars.binds.contains("entity"));
         }
+    }
+
+    /// A formula premise that needs `?text` and binds `?len`
+    /// depends on an earlier attribute premise that binds `?text`.
+    /// The dependency graph records an edge from the formula's
+    /// `requires[]` to the attribute's index.
+    #[dialog_common::test]
+    fn it_records_formula_dependency_on_attribute() {
+        use crate::formula::Formula;
+        use crate::formula::string::Length;
+        use crate::{Parameters, Premise};
+
+        // Premise 0: attribute query that binds ?text.
+        let attr = AttributeQuery::new(
+            Term::from(the!("note/body")),
+            Term::<Entity>::var("this"),
+            Term::<String>::var("text").into(),
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+
+        // Premise 1: Length formula, needs ?text bound, binds ?len.
+        let mut params = Parameters::new();
+        params.insert("of".to_string(), Term::var("text"));
+        params.insert("is".to_string(), Term::var("len"));
+        let length = Length::apply(params).unwrap();
+
+        let premises: Vec<Premise> = vec![attr.into(), Premise::from(length)];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let analyzed = analyze(person_with_name(), &plan.steps).unwrap();
+
+        assert_eq!(analyzed.graph.len(), 2);
+
+        // The formula step needs `text`; some other step binds it.
+        // Concretely: the attribute step's index should appear in
+        // the formula step's `requires` set.
+        //
+        // The planner orders attribute first (cost), so attribute
+        // is step 0 and formula is step 1. The formula needs
+        // ?text bound by step 0.
+        let formula_idx = analyzed
+            .premises
+            .iter()
+            .position(|p| matches!(p, Premise::Assert(crate::Proposition::Formula(_))))
+            .expect("formula step present");
+        let attr_idx = analyzed
+            .premises
+            .iter()
+            .position(|p| matches!(p, Premise::Assert(crate::Proposition::Attribute(_))))
+            .expect("attribute step present");
+
+        assert!(
+            analyzed.graph.requires[formula_idx].contains(&attr_idx),
+            "formula step should depend on the attribute step that binds ?text"
+        );
+        assert!(
+            analyzed.graph.usage[formula_idx].needs.contains("text"),
+            "formula step should record ?text in its needs"
+        );
+        assert!(
+            analyzed.graph.usage[attr_idx].binds.contains("text"),
+            "attribute step should record ?text in its binds"
+        );
     }
 
     /// Analysis rejects a conclusion variable whose inferred type

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -21,10 +21,36 @@
 //! bindings change).
 
 use crate::Premise;
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::constraint::Constraint;
 use crate::planner::Plan;
+use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::type_system::Type as Kind;
+use crate::type_system::unifier::Context;
 use std::sync::Arc;
+
+/// Errors detected by [`analyze`]. These are pre-rule type
+/// problems: inference produced a contradiction or a constraint's
+/// type contract isn't satisfied. `DeductiveRule::new` wraps these
+/// in the full [`TypeError`](crate::error::TypeError) variants
+/// after planning, so callers get the rule embedded for display.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum AnalysisError {
+    /// A conclusion variable's inferred type admits `Nothing` —
+    /// the rule could produce `Absent` in a required slot.
+    #[error("conclusion variable {variable} is optional")]
+    RequiredHeadFromOptional {
+        /// Name of the offending head variable.
+        variable: String,
+    },
+    /// A `Coalesce` constraint's type contract is violated.
+    #[error("Coalesce type mismatch: {reason}")]
+    CoalesceTypeMismatch {
+        /// Human-readable reason from the unifier.
+        reason: String,
+    },
+}
 
 /// A piece of the user's rule with the rule-wide type environment
 /// attached. The `source` is whatever the user wrote; `types` is the
@@ -81,6 +107,8 @@ impl<T> Analyzed<T> {
 /// it on the fly.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnalyzedRule {
+    /// The rule's conclusion.
+    pub conclusion: ConceptDescriptor,
     /// The analyzed premises in their original order. Planning may
     /// reorder them; analysis preserves user order.
     pub premises: Vec<Analyzed<Premise>>,
@@ -100,25 +128,60 @@ impl AnalyzedRule {
     }
 }
 
-/// Run analysis over the rule's premises: infer types, build the
-/// shared environment, wrap each premise as an `Analyzed<Premise>`.
+/// Run analysis over the rule's premises:
 ///
-/// This is currently a thin wrapper around [`TypeEnv::infer`] that
-/// runs against a `Vec<Plan>` shape (because that's what `infer`
-/// consumes today). It will gain the dependency-graph computation
-/// and richer error reporting in follow-up commits.
+/// 1. Infer the rule-wide type environment from each premise's
+///    slot kinds.
+/// 2. Check that no conclusion variable's inferred type admits
+///    `Nothing` — a required head can't accept `Absent`.
+/// 3. Validate every Coalesce constraint's type contract.
 ///
-/// Returns the analyzed rule. Type errors detected during analysis
-/// (e.g. `RequiredHeadFromOptional`) are not raised here yet —
-/// `DeductiveRule::new` still owns those checks. Moving them into
-/// the analyzer is a later step.
-pub fn analyze(steps: &[Plan]) -> AnalyzedRule {
+/// Returns the analyzed rule on success, or an [`AnalysisError`]
+/// describing the type problem. `DeductiveRule::new` wraps these
+/// in the corresponding [`TypeError`](crate::error::TypeError)
+/// variants with the planned rule embedded for display.
+pub fn analyze(
+    conclusion: ConceptDescriptor,
+    steps: &[Plan],
+) -> Result<AnalyzedRule, AnalysisError> {
     let types = Arc::new(TypeEnv::infer(steps));
+
+    // Required heads must not admit `Nothing`.
+    if let Some(variable) = conclusion
+        .operands()
+        .find(|name| types.get(name).is_some_and(Kind::is_optional))
+    {
+        return Err(AnalysisError::RequiredHeadFromOptional {
+            variable: variable.to_string(),
+        });
+    }
+
+    // Each Coalesce constraint validates against a fresh unifier
+    // context. Catches wire-format and raw-builder mismatches
+    // where the typed builder isn't the construction path.
+    for step in steps {
+        let Premise::Assert(Proposition::Constraint(Constraint::Coalesce(coalesce))) =
+            &step.premise
+        else {
+            continue;
+        };
+        let mut ctx = Context::new();
+        if let Err(err) = coalesce.validate(&mut ctx) {
+            return Err(AnalysisError::CoalesceTypeMismatch {
+                reason: err.to_string(),
+            });
+        }
+    }
+
     let premises = steps
         .iter()
         .map(|step| Analyzed::new(step.premise.clone(), types.clone()))
         .collect();
-    AnalyzedRule { premises, types }
+    Ok(AnalyzedRule {
+        conclusion,
+        premises,
+        types,
+    })
 }
 
 #[cfg(test)]
@@ -128,11 +191,24 @@ mod tests {
 
     use super::*;
     use crate::artifact::{Entity, Type as ValueType};
+    use crate::attribute::AttributeDescriptor;
     use crate::attribute::query::AttributeQuery;
     use crate::planner::Planner;
     use crate::the;
     use crate::types::Any;
     use crate::{Cardinality, Environment, Term};
+
+    fn person_with_name() -> ConceptDescriptor {
+        ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(ValueType::String),
+            ),
+        )])
+    }
 
     /// Analysis output carries the inferred type environment and
     /// wraps each premise with a clone of the shared `Arc<TypeEnv>`.
@@ -150,7 +226,7 @@ mod tests {
             .into(),
         ];
         let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
-        let analyzed = analyze(&plan.steps);
+        let analyzed = analyze(person_with_name(), &plan.steps).unwrap();
 
         assert_eq!(analyzed.premises.len(), 1);
         let name_kind = analyzed.type_of("name").expect("name has an inferred type");
@@ -159,6 +235,31 @@ mod tests {
         // Every premise in the same rule shares the same Arc.
         for premise in analyzed.premises() {
             assert!(Arc::ptr_eq(&premise.types, &analyzed.types));
+        }
+    }
+
+    /// Analysis rejects a conclusion variable whose inferred type
+    /// admits `Nothing` — the rule could yield Absent in the head.
+    #[dialog_common::test]
+    fn it_rejects_required_head_bound_only_by_optional_premises() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let err = analyze(person_with_name(), &plan.steps).unwrap_err();
+        match err {
+            AnalysisError::RequiredHeadFromOptional { variable } => {
+                assert_eq!(variable, "name");
+            }
+            other => panic!("expected RequiredHeadFromOptional, got {other:?}"),
         }
     }
 }

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -19,7 +19,6 @@ use descriptor::DeductiveRuleDescriptor;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::sync::Arc;
 
 /// Represents a deductive rule that can be applied creating a premise.
 #[derive(Debug, Clone, PartialEq)]
@@ -46,31 +45,22 @@ impl DeductiveRule {
         // check + Coalesce contract validation. Failures here are
         // wrapped into the corresponding `TypeError::*` variants so
         // the user sees the rule embedded in the error.
-        let analyzed = match analyzer::analyze(conclusion.clone(), &join.steps) {
-            Ok(analyzed) => Arc::new(analyzed),
-            Err(err) => {
-                let rule = DeductiveRule { conclusion, join };
-                return Err(match err {
-                    AnalysisError::RequiredHeadFromOptional { variable } => {
-                        TypeError::RequiredHeadFromOptional {
-                            rule: Box::new(rule),
-                            variable,
-                        }
+        if let Err(err) = analyzer::analyze(conclusion.clone(), &join.steps) {
+            let rule = DeductiveRule { conclusion, join };
+            return Err(match err {
+                AnalysisError::RequiredHeadFromOptional { variable } => {
+                    TypeError::RequiredHeadFromOptional {
+                        rule: Box::new(rule),
+                        variable,
                     }
-                    AnalysisError::CoalesceTypeMismatch { reason } => {
-                        TypeError::CoalesceTypeMismatch {
-                            rule: Box::new(rule),
-                            reason,
-                        }
-                    }
-                });
-            }
-        };
+                }
+                AnalysisError::CoalesceTypeMismatch { reason } => TypeError::CoalesceTypeMismatch {
+                    rule: Box::new(rule),
+                    reason,
+                },
+            });
+        }
 
-        // Replan via the analyzed-rule path so future
-        // `Conjunction::plan(&scope)` calls reuse the same analyzed
-        // premises (with their inference and dependency graph).
-        let join = Planner::from_analyzed(analyzed).plan(&Environment::new())?;
         let rule = DeductiveRule { conclusion, join };
 
         // Verify that every conclusion parameter is derived by one of the

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -4,15 +4,14 @@ pub mod descriptor;
 use crate::artifact::Entity;
 use crate::attribute::query::AttributeQuery;
 pub use crate::concept::descriptor::ConceptDescriptor;
-use crate::constraint::Constraint;
 use crate::error::TypeError;
 use crate::negation::Negation;
 pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
+use crate::rule::analyzer::{self, AnalysisError};
 use crate::type_system::Primitive;
 use crate::type_system::Type as Kind;
-use crate::type_system::unifier::Context;
 use crate::types::Any;
 pub use crate::{Attribute, Cardinality, Parameters, Proposition, Requirement, Value};
 use crate::{Environment, Term, Type};
@@ -44,10 +43,33 @@ impl DeductiveRule {
         // discover unsatisfiable premises (e.g. a formula whose required
         // cell is never derived by another premise).
         let join = Planner::from(premises).plan(&Environment::new())?;
+
+        // Run rule-level type analysis: inference + required-head
+        // check + Coalesce contract validation. Failures here are
+        // wrapped into the corresponding `TypeError::*` variants so
+        // the user sees the rule embedded in the error.
+        if let Err(err) = analyzer::analyze(conclusion.clone(), &join.steps) {
+            let rule = DeductiveRule { conclusion, join };
+            return Err(match err {
+                AnalysisError::RequiredHeadFromOptional { variable } => {
+                    TypeError::RequiredHeadFromOptional {
+                        rule: Box::new(rule),
+                        variable,
+                    }
+                }
+                AnalysisError::CoalesceTypeMismatch { reason } => TypeError::CoalesceTypeMismatch {
+                    rule: Box::new(rule),
+                    reason,
+                },
+            });
+        }
+
         let rule = DeductiveRule { conclusion, join };
 
         // Verify that every conclusion parameter is derived by one of the
         // premises; otherwise the rule could never fully bind its output.
+        // This check depends on the planner's `binds` set, so it lives
+        // here rather than in analysis.
         let unbound = rule
             .conclusion
             .operands()
@@ -61,59 +83,7 @@ impl DeductiveRule {
             });
         }
 
-        // Reject if any conclusion variable's inferred type admits
-        // `Nothing` — the rule could produce Absent for a required
-        // head. Inference runs once during planning and is stored on
-        // the conjunction.
-        let optional_head = rule
-            .conclusion
-            .operands()
-            .find(|name| {
-                rule.join
-                    .types
-                    .get(name)
-                    .is_some_and(|kind| kind.is_optional())
-            })
-            .map(String::from);
-
-        if let Some(variable) = optional_head {
-            return Err(TypeError::RequiredHeadFromOptional {
-                rule: Box::new(rule),
-                variable,
-            });
-        }
-
-        // Validate every Coalesce constraint's type contract. Each
-        // Coalesce is independent — fresh unifier context per
-        // constraint. Catches wire-format and raw-builder
-        // mismatches where the typed builder isn't the construction
-        // path.
-        let coalesce_error = rule.coalesce_validation_error();
-        if let Some(reason) = coalesce_error {
-            return Err(TypeError::CoalesceTypeMismatch {
-                rule: Box::new(rule),
-                reason,
-            });
-        }
-
         Ok(rule)
-    }
-
-    /// Run [`Coalesce::validate`](crate::constraint::Coalesce::validate)
-    /// on every Coalesce constraint reachable from this rule's
-    /// positive premises. Returns the first failure, if any.
-    fn coalesce_validation_error(&self) -> Option<String> {
-        for step in &self.join.steps {
-            let Premise::Assert(Proposition::Constraint(Constraint::Coalesce(c))) = &step.premise
-            else {
-                continue;
-            };
-            let mut ctx = Context::new();
-            if let Err(err) = c.validate(&mut ctx) {
-                return Some(format!("{err}"));
-            }
-        }
-        None
     }
 
     /// Returns the conclusion predicate for this rule.

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -830,8 +830,8 @@ mod tests {
         // information to combine. An untyped `Term::var` produces
         // `None` content_type, which contributes nothing to the
         // meet — the optional side then wins.
-        let typed_name = Term::<Any>::typed_var("name", type_system::Type::primitive(Type::String));
-        let optional_name = optional_term("name", Some(Type::String));
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
 
         let premises = vec![
             // Optional `is` term: contributes a slot type with Nothing.
@@ -968,11 +968,10 @@ mod tests {
             ),
         )]);
         let this = Term::<Entity>::var("this");
-        let typed_name = Term::<Any>::typed_var("name", type_system::Type::primitive(Type::String));
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
 
         // Source is a `Term<Any>` carrying `String` (not Optional<String>).
-        let bad_source =
-            Term::<Any>::typed_var("source", type_system::Type::primitive(Type::String));
+        let bad_source: Term<Any> = Term::<String>::var("source").into();
         let bad_coalesce = Coalesce::new(
             bad_source,
             Term::<Any>::constant("Anon".to_string()),

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -11,7 +11,10 @@ pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
 use crate::type_system;
+use crate::type_system::Primitive;
+use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
+use crate::types::Any;
 pub use crate::{Attribute, Cardinality, Parameters, Proposition, Requirement, Value};
 use crate::{Environment, Term, Type};
 use descriptor::DeductiveRuleDescriptor;
@@ -281,18 +284,21 @@ impl From<&ConceptDescriptor> for DeductiveRule {
             );
         }
 
-        // Optional (`maybe`) attributes — set-widened semantics.
-        // A missing fact yields a fallback row with the slot
-        // bound to `Binding::Absent`. The `Resolution::Optional`
-        // policy on the emitted `AttributeQuery` carries this
-        // through to the runtime evaluator.
+        // Optional (`maybe`) attributes — a missing fact yields a
+        // fallback row with the slot bound to `Binding::Absent`.
+        // We encode this by typing the `is` term as optional;
+        // `AttributeQuery` derives its resolution from that kind.
         if let Some(maybe) = concept.maybe() {
             for (name, attribute) in maybe.iter() {
+                let kind = match attribute.content_type() {
+                    Some(ty) => Kind::primitive(ty).optional(),
+                    None => Kind::primitive_set(Primitive::ALL).optional(),
+                };
                 premises.push(
-                    AttributeQuery::optional(
+                    AttributeQuery::new(
                         Term::Constant(Value::from(attribute.the().clone())),
                         this.clone(),
-                        Term::var(name),
+                        Term::<Any>::typed_var(name, kind),
                         Term::blank(),
                         Some(attribute.cardinality()),
                     )
@@ -313,6 +319,17 @@ mod tests {
     use crate::attribute::query::AttributeQuery;
     use crate::the;
     use crate::types::Any;
+
+    /// Helper: produce an optional `Term<Any>` — this is how an
+    /// AttributeQuery is told to run with optional resolution, since
+    /// resolution is derived from `is.is_optional()`.
+    fn optional_term(name: &str, inner: Option<Type>) -> Term<Any> {
+        let kind = match inner {
+            Some(ty) => Kind::primitive(ty).optional(),
+            None => Kind::primitive_set(Primitive::ALL).optional(),
+        };
+        Term::<Any>::typed_var(name, kind)
+    }
 
     #[dialog_common::test]
     fn it_compiles_with_valid_premises() {
@@ -772,13 +789,13 @@ mod tests {
             ),
         )]);
         let this = Term::<Entity>::var("this");
-        // Bind ?name with an Optional resolution — the meet for ?name
+        // Bind ?name with an optional `is` term — the meet for ?name
         // includes Nothing.
         let premises = vec![
-            AttributeQuery::optional(
+            AttributeQuery::new(
                 Term::from(the!("user/name")),
                 this,
-                Term::var("name"),
+                optional_term("name", None),
                 Term::var("cause"),
                 Some(Cardinality::One),
             )
@@ -813,20 +830,20 @@ mod tests {
         // information to combine. An untyped `Term::var` produces
         // `None` content_type, which contributes nothing to the
         // meet — the optional side then wins.
-        let typed_name =
-            Term::<Any>::typed_var("name", Some(type_system::Type::primitive(Type::String)));
+        let typed_name = Term::<Any>::typed_var("name", type_system::Type::primitive(Type::String));
+        let optional_name = optional_term("name", Some(Type::String));
 
         let premises = vec![
-            // Optional resolution: contributes a slot type with Nothing.
-            AttributeQuery::optional(
+            // Optional `is` term: contributes a slot type with Nothing.
+            AttributeQuery::new(
                 Term::from(the!("user/name")),
                 this.clone(),
-                typed_name.clone(),
+                optional_name,
                 Term::var("cause1"),
                 Some(Cardinality::One),
             )
             .into(),
-            // Required resolution: contributes a slot type without Nothing.
+            // Required `is` term: contributes a slot type without Nothing.
             AttributeQuery::new(
                 Term::from(the!("user/canonical-name")),
                 this,
@@ -862,22 +879,21 @@ mod tests {
             ),
         )]);
         let this = Term::<Entity>::var("this");
-        let typed_name =
-            Term::<Any>::typed_var("name", Some(type_system::Type::primitive(Type::String)));
+        let optional_name = optional_term("name", Some(Type::String));
 
         let premises = vec![
-            // Optional resolution with typed `is`.
-            AttributeQuery::optional(
+            // Optional `is` (typed): contributes `{String, Nothing}`.
+            AttributeQuery::new(
                 Term::from(the!("user/name")),
                 this.clone(),
-                typed_name,
+                optional_name,
                 Term::var("cause1"),
                 Some(Cardinality::One),
             )
             .into(),
-            // Required resolution with *untyped* `is` (Term::var
-            // without a kind). Should contribute "any present
-            // value" to the meet via the None-content_type branch.
+            // Required with *untyped* `is` (Term::var without a
+            // kind). Contributes "any present value" to the meet
+            // via the None-content_type branch.
             AttributeQuery::new(
                 Term::from(the!("user/canonical-name")),
                 this,
@@ -914,10 +930,10 @@ mod tests {
         // meet's cause contribution carries Nothing, so the
         // required head sees Optional.
         let premises = vec![
-            AttributeQuery::optional(
+            AttributeQuery::new(
                 Term::from(the!("user/name")),
                 this,
-                Term::<Any>::var("name"),
+                optional_term("name", None),
                 Term::<Cause>::var("mark"),
                 Some(Cardinality::One),
             )
@@ -952,12 +968,11 @@ mod tests {
             ),
         )]);
         let this = Term::<Entity>::var("this");
-        let typed_name =
-            Term::<Any>::typed_var("name", Some(type_system::Type::primitive(Type::String)));
+        let typed_name = Term::<Any>::typed_var("name", type_system::Type::primitive(Type::String));
 
         // Source is a `Term<Any>` carrying `String` (not Optional<String>).
         let bad_source =
-            Term::<Any>::typed_var("source", Some(type_system::Type::primitive(Type::String)));
+            Term::<Any>::typed_var("source", type_system::Type::primitive(Type::String));
         let bad_coalesce = Coalesce::new(
             bad_source,
             Term::<Any>::constant("Anon".to_string()),

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -7,11 +7,13 @@ use crate::negation::Negation;
 pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
+use crate::type_system;
 pub use crate::{Attribute, Cardinality, Parameters, Proposition, Requirement, Value};
 use crate::{Environment, Term, Type};
 use descriptor::DeductiveRuleDescriptor;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Represents a deductive rule that can be applied creating a premise.
@@ -27,8 +29,10 @@ pub struct DeductiveRule {
 impl DeductiveRule {
     /// Compile a rule from a conclusion and premises.
     ///
-    /// Plans the optimal premise execution order and validates that every
-    /// conclusion variable is grounded by at least one positive premise.
+    /// Plans the optimal premise execution order, validates that every
+    /// conclusion variable is grounded by at least one positive premise,
+    /// and runs the meet-algebra check that required head variables
+    /// are not bound only by optional (set-widened) sources.
     pub fn new(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
         // Plan the order of premises in a scope where none of the rule
         // parameters are bound to find the optimal execution order, or to
@@ -52,7 +56,75 @@ impl DeductiveRule {
             });
         }
 
+        // Compute the meet across positive premises for every variable
+        // the conclusion's required slots reference. If the meet admits
+        // `Nothing`, the rule could produce Absent for a required head —
+        // reject.
+        let meet = rule.meet_per_variable();
+        let optional_head = rule
+            .conclusion
+            .operands()
+            .find(|name| meet.get(*name).is_some_and(|kind| kind.is_optional()))
+            .map(String::from);
+
+        if let Some(variable) = optional_head {
+            return Err(TypeError::RequiredHeadFromOptional {
+                rule: Box::new(rule),
+                variable,
+            });
+        }
+
         Ok(rule)
+    }
+
+    /// For each variable used by a positive premise, compute the
+    /// meet (intersection) of the kinds the premise slots ascribe
+    /// to it.
+    ///
+    /// The meet algebra: a variable's kind across the rule is the
+    /// intersection of the kinds claimed by every binding slot it
+    /// appears in. If any slot requires a Present value (no
+    /// `Nothing` in its primitive set), the variable is Required
+    /// in the rule — even if other slots are Optional. Only when
+    /// *every* binding is Optional does the variable carry
+    /// `Nothing` in its meet.
+    ///
+    /// Negation premises do not contribute — they don't bind
+    /// variables, only filter on already-bound values.
+    fn meet_per_variable(&self) -> HashMap<String, type_system::Type> {
+        let mut by_variable: HashMap<String, type_system::Type> = HashMap::new();
+
+        for step in &self.join.steps {
+            let Premise::Assert(_) = &step.premise else {
+                continue;
+            };
+            let schema = step.premise.schema();
+            let params = step.premise.parameters();
+
+            for (slot_name, field) in schema.iter() {
+                let Some(slot_type) = field.content_type() else {
+                    continue;
+                };
+                let Some(param) = params.get(slot_name) else {
+                    continue;
+                };
+                let Some(var_name) = param.name() else {
+                    continue;
+                };
+                match by_variable.get(var_name) {
+                    Some(accumulated) => {
+                        if let Some(merged) = accumulated.intersect(slot_type) {
+                            by_variable.insert(var_name.to_string(), merged);
+                        }
+                    }
+                    None => {
+                        by_variable.insert(var_name.to_string(), slot_type.clone());
+                    }
+                }
+            }
+        }
+
+        by_variable
     }
 
     /// Returns the conclusion predicate for this rule.
@@ -189,6 +261,7 @@ mod tests {
     use crate::attribute::AttributeDescriptor;
     use crate::attribute::query::AttributeQuery;
     use crate::the;
+    use crate::types::Any;
 
     #[dialog_common::test]
     fn it_compiles_with_valid_premises() {
@@ -634,5 +707,93 @@ mod tests {
         let empty: Vec<(&str, AttributeDescriptor)> = Vec::new();
         let cleared = with_maybe.with_maybe(empty);
         assert!(cleared.maybe().is_none(), "empty input clears maybe");
+    }
+
+    /// A conclusion variable bound only by an optional attribute
+    /// query carries `Nothing` in its meet. Required heads cannot
+    /// accept that — the rule could produce an Absent value in a
+    /// required slot. Reject.
+    #[dialog_common::test]
+    fn it_rejects_required_head_from_optional_premise() {
+        let conclusion = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        let this = Term::<Entity>::var("this");
+        // Bind ?name with an Optional resolution — the meet for ?name
+        // includes Nothing.
+        let premises = vec![
+            AttributeQuery::optional(
+                Term::from(the!("user/name")),
+                this,
+                Term::var("name"),
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        match result {
+            Err(TypeError::RequiredHeadFromOptional { variable, .. }) => {
+                assert_eq!(variable, "name");
+            }
+            other => panic!("expected RequiredHeadFromOptional, got {other:?}"),
+        }
+    }
+
+    /// A conclusion variable bound by *both* an optional and a
+    /// required premise (with a typed `is` slot) has the Nothing
+    /// bit removed by the meet — at least one premise guarantees
+    /// Present. Accept.
+    #[dialog_common::test]
+    fn it_accepts_required_head_when_meet_strips_nothing() {
+        let conclusion = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        let this = Term::<Entity>::var("this");
+        // The `is` slot must carry a typed kind so the meet has
+        // information to combine. An untyped `Term::var` produces
+        // `None` content_type, which contributes nothing to the
+        // meet — the optional side then wins.
+        let typed_name =
+            Term::<Any>::typed_var("name", Some(type_system::Type::primitive(Type::String)));
+
+        let premises = vec![
+            // Optional resolution: contributes a slot type with Nothing.
+            AttributeQuery::optional(
+                Term::from(the!("user/name")),
+                this.clone(),
+                typed_name.clone(),
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            // Required resolution: contributes a slot type without Nothing.
+            AttributeQuery::new(
+                Term::from(the!("user/canonical-name")),
+                this,
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        assert!(
+            result.is_ok(),
+            "meet of Required + Optional strips Nothing — should compile (got {:?})",
+            result.err()
+        );
     }
 }

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -19,7 +19,6 @@ use crate::{Environment, Term, Type};
 use descriptor::DeductiveRuleDescriptor;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Represents a deductive rule that can be applied creating a premise.
@@ -62,15 +61,19 @@ impl DeductiveRule {
             });
         }
 
-        // Compute the meet across positive premises for every variable
-        // the conclusion's required slots reference. If the meet admits
-        // `Nothing`, the rule could produce Absent for a required head —
-        // reject.
-        let meet = rule.meet_per_variable();
+        // Reject if any conclusion variable's inferred type admits
+        // `Nothing` — the rule could produce Absent for a required
+        // head. Inference runs once during planning and is stored on
+        // the conjunction.
         let optional_head = rule
             .conclusion
             .operands()
-            .find(|name| meet.get(*name).is_some_and(|kind| kind.is_optional()))
+            .find(|name| {
+                rule.join
+                    .types
+                    .get(name)
+                    .is_some_and(|kind| kind.is_optional())
+            })
             .map(String::from);
 
         if let Some(variable) = optional_head {
@@ -111,72 +114,6 @@ impl DeductiveRule {
             }
         }
         None
-    }
-
-    /// For each variable used by a positive premise, compute the
-    /// meet (intersection) of the kinds the premise slots ascribe
-    /// to it.
-    ///
-    /// The meet algebra: a variable's kind across the rule is the
-    /// intersection of the kinds claimed by every binding slot it
-    /// appears in. If any slot requires a Present value (no
-    /// `Nothing` in its primitive set), the variable is Required
-    /// in the rule — even if other slots are Optional. Only when
-    /// *every* binding is Optional does the variable carry
-    /// `Nothing` in its meet.
-    ///
-    /// Slots without an explicit `content_type` contribute their
-    /// requirement shape: a `Required` slot contributes "any
-    /// present value" (`Primitive::ALL`); an `Optional` slot
-    /// contributes "any present or absent value"
-    /// (`Primitive::ANY`). This keeps "untyped Required + typed
-    /// Optional" symmetric with "typed Required + typed Optional":
-    /// both produce a meet without `Nothing`.
-    ///
-    /// Negation premises do not contribute — they don't bind
-    /// variables, only filter on already-bound values.
-    fn meet_per_variable(&self) -> HashMap<String, Kind> {
-        let mut by_variable: HashMap<String, Kind> = HashMap::new();
-
-        for step in &self.join.steps {
-            let Premise::Assert(_) = &step.premise else {
-                continue;
-            };
-            let schema = step.premise.schema();
-            let params = step.premise.parameters();
-
-            for (slot_name, field) in schema.iter() {
-                let Some(param) = params.get(slot_name) else {
-                    continue;
-                };
-                let Some(var_name) = param.name() else {
-                    continue;
-                };
-                let owned;
-                let slot_type: &Kind = match field.content_type() {
-                    Some(t) => t,
-                    None => {
-                        owned = match field.requirement {
-                            Requirement::Required(_) => Kind::primitive_set(Primitive::ALL),
-                            Requirement::Optional => Kind::primitive_set(Primitive::ANY),
-                        };
-                        &owned
-                    }
-                };
-                match by_variable.get(var_name) {
-                    Some(accumulated) => {
-                        if let Some(merged) = accumulated.intersect(slot_type) {
-                            by_variable.insert(var_name.to_string(), merged);
-                        }
-                    }
-                    None => {
-                        by_variable.insert(var_name.to_string(), slot_type.clone());
-                    }
-                }
-            }
-        }
-
-        by_variable
     }
 
     /// Returns the conclusion predicate for this rule.

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -142,6 +142,9 @@ impl From<&ConceptDescriptor> for DeductiveRule {
         let mut premises = Vec::new();
 
         let this = Term::<Entity>::var("this");
+
+        // Required (`with`) attributes — standard EAV semantics.
+        // A missing fact filters the row out entirely.
         for (name, attribute) in concept.with().iter() {
             premises.push(
                 AttributeQuery::new(
@@ -153,6 +156,26 @@ impl From<&ConceptDescriptor> for DeductiveRule {
                 )
                 .into(),
             );
+        }
+
+        // Optional (`maybe`) attributes — set-widened semantics.
+        // A missing fact yields a fallback row with the slot
+        // bound to `Binding::Absent`. The `Resolution::Optional`
+        // policy on the emitted `AttributeQuery` carries this
+        // through to the runtime evaluator.
+        if let Some(maybe) = concept.maybe() {
+            for (name, attribute) in maybe.iter() {
+                premises.push(
+                    AttributeQuery::optional(
+                        Term::Constant(Value::from(attribute.the().clone())),
+                        this.clone(),
+                        Term::var(name),
+                        Term::blank(),
+                        Some(attribute.cardinality()),
+                    )
+                    .into(),
+                );
+            }
         }
 
         DeductiveRule::new(concept.clone(), premises).expect("Concept should compile")
@@ -500,5 +523,116 @@ mod tests {
             result.is_err(),
             "Should reject rule with negated constraint referencing unbound variable ?z (flipped)"
         );
+    }
+
+    /// Concept projection emits one premise per `with` attribute,
+    /// each with `Resolution::Required` (the default). A concept
+    /// with no `maybe` attributes produces only required
+    /// premises.
+    #[dialog_common::test]
+    fn from_concept_with_only_required_emits_required_premises() {
+        use crate::Premise;
+        use crate::attribute::query::Resolution;
+        use crate::proposition::Proposition;
+
+        let concept = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+
+        let rule = DeductiveRule::from(&concept);
+
+        let mut required = 0;
+        let mut optional = 0;
+        for step in rule.join.steps.iter() {
+            if let Premise::Assert(Proposition::Attribute(query)) = &step.premise {
+                match query.resolution() {
+                    Resolution::Required => required += 1,
+                    Resolution::Optional => optional += 1,
+                }
+            }
+        }
+        assert_eq!(required, 1, "expected one required premise");
+        assert_eq!(optional, 0, "expected no optional premises");
+    }
+
+    /// Concept projection emits one premise per `with` attribute
+    /// (Required) and one per `maybe` attribute (Optional).
+    #[dialog_common::test]
+    fn from_concept_with_maybe_emits_optional_resolver() {
+        use crate::Premise;
+        use crate::attribute::query::Resolution;
+        use crate::proposition::Proposition;
+
+        let concept = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .with_maybe(vec![(
+            "nickname",
+            AttributeDescriptor::new(
+                the!("person/nickname"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+
+        let rule = DeductiveRule::from(&concept);
+
+        let mut required = 0;
+        let mut optional = 0;
+        for step in rule.join.steps.iter() {
+            if let Premise::Assert(Proposition::Attribute(query)) = &step.premise {
+                match query.resolution() {
+                    Resolution::Required => required += 1,
+                    Resolution::Optional => optional += 1,
+                }
+            }
+        }
+        assert_eq!(required, 1, "expected one required premise (name)");
+        assert_eq!(optional, 1, "expected one optional premise (nickname)");
+    }
+
+    /// `with_maybe` builder installs the maybe attributes; an
+    /// empty input clears the maybe slot.
+    #[dialog_common::test]
+    fn with_maybe_installs_and_clears() {
+        let concept = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        assert!(concept.maybe().is_none(), "no maybe by default");
+
+        let with_maybe = concept.clone().with_maybe(vec![(
+            "nickname",
+            AttributeDescriptor::new(
+                the!("person/nickname"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        assert!(with_maybe.maybe().is_some(), "maybe installed");
+        assert_eq!(with_maybe.maybe().unwrap().iter().count(), 1);
+
+        let empty: Vec<(&str, AttributeDescriptor)> = Vec::new();
+        let cleared = with_maybe.with_maybe(empty);
+        assert!(cleared.maybe().is_none(), "empty input clears maybe");
     }
 }

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -10,7 +10,6 @@ use crate::negation::Negation;
 pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
-use crate::type_system;
 use crate::type_system::Primitive;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
@@ -136,8 +135,8 @@ impl DeductiveRule {
     ///
     /// Negation premises do not contribute — they don't bind
     /// variables, only filter on already-bound values.
-    fn meet_per_variable(&self) -> HashMap<String, type_system::Type> {
-        let mut by_variable: HashMap<String, type_system::Type> = HashMap::new();
+    fn meet_per_variable(&self) -> HashMap<String, Kind> {
+        let mut by_variable: HashMap<String, Kind> = HashMap::new();
 
         for step in &self.join.steps {
             let Premise::Assert(_) = &step.premise else {
@@ -154,16 +153,12 @@ impl DeductiveRule {
                     continue;
                 };
                 let owned;
-                let slot_type: &type_system::Type = match field.content_type() {
+                let slot_type: &Kind = match field.content_type() {
                     Some(t) => t,
                     None => {
                         owned = match field.requirement {
-                            Requirement::Required(_) => {
-                                type_system::Type::primitive_set(type_system::Primitive::ALL)
-                            }
-                            Requirement::Optional => {
-                                type_system::Type::primitive_set(type_system::Primitive::ANY)
-                            }
+                            Requirement::Required(_) => Kind::primitive_set(Primitive::ALL),
+                            Requirement::Optional => Kind::primitive_set(Primitive::ANY),
                         };
                         &owned
                     }

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -308,7 +308,7 @@ impl From<&ConceptDescriptor> for DeductiveRule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::artifact::{Entity, Type};
+    use crate::artifact::{Cause, Entity, Type};
     use crate::attribute::AttributeDescriptor;
     use crate::attribute::query::AttributeQuery;
     use crate::the;
@@ -893,6 +893,43 @@ mod tests {
             "untyped Required + typed Optional should compile (got {:?})",
             result.err()
         );
+    }
+
+    /// The `cause` slot of an Optional attribute query is set-
+    /// widened in the schema (since the fallback row binds it to
+    /// `Absent`). A rule where a required-head variable shares
+    /// its name with such a cause is therefore rejected by the
+    /// meet algebra.
+    #[dialog_common::test]
+    fn it_rejects_required_head_from_optional_cause() {
+        // Conclusion has a required `mark` field expecting a
+        // typed value (Bytes).
+        let conclusion = ConceptDescriptor::from(vec![(
+            "mark",
+            AttributeDescriptor::new(the!("person/mark"), "", Cardinality::One, Some(Type::Bytes)),
+        )]);
+        let this = Term::<Entity>::var("this");
+        // The optional attribute's cause slot shares the name
+        // `?mark` with the conclusion's required head — the
+        // meet's cause contribution carries Nothing, so the
+        // required head sees Optional.
+        let premises = vec![
+            AttributeQuery::optional(
+                Term::from(the!("user/name")),
+                this,
+                Term::<Any>::var("name"),
+                Term::<Cause>::var("mark"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        match result {
+            Err(TypeError::RequiredHeadFromOptional { variable, .. }) => {
+                assert_eq!(variable, "mark");
+            }
+            other => panic!("expected RequiredHeadFromOptional, got {other:?}"),
+        }
     }
 
     /// A rule containing a malformed Coalesce (non-Optional source)

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -48,6 +48,7 @@ impl DeductiveRule {
         if let Err(err) = analyzer::analyze(conclusion.clone(), &join.steps) {
             let rule = DeductiveRule { conclusion, join };
             return Err(match err {
+                AnalysisError::Inference { reason } => TypeError::TypeInference { reason },
                 AnalysisError::RequiredHeadFromOptional { variable } => {
                     TypeError::RequiredHeadFromOptional {
                         rule: Box::new(rule),

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -1,13 +1,17 @@
 /// Serializable rule descriptor matching the formal notation.
 pub mod descriptor;
 
+use crate::artifact::Entity;
+use crate::attribute::query::AttributeQuery;
 pub use crate::concept::descriptor::ConceptDescriptor;
+use crate::constraint::Constraint;
 use crate::error::TypeError;
 use crate::negation::Negation;
 pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
 use crate::type_system;
+use crate::type_system::unifier::Context;
 pub use crate::{Attribute, Cardinality, Parameters, Proposition, Requirement, Value};
 use crate::{Environment, Term, Type};
 use descriptor::DeductiveRuleDescriptor;
@@ -74,7 +78,37 @@ impl DeductiveRule {
             });
         }
 
+        // Validate every Coalesce constraint's type contract. Each
+        // Coalesce is independent — fresh unifier context per
+        // constraint. Catches wire-format and raw-builder
+        // mismatches where the typed builder isn't the construction
+        // path.
+        let coalesce_error = rule.coalesce_validation_error();
+        if let Some(reason) = coalesce_error {
+            return Err(TypeError::CoalesceTypeMismatch {
+                rule: Box::new(rule),
+                reason,
+            });
+        }
+
         Ok(rule)
+    }
+
+    /// Run [`Coalesce::validate`](crate::constraint::Coalesce::validate)
+    /// on every Coalesce constraint reachable from this rule's
+    /// positive premises. Returns the first failure, if any.
+    fn coalesce_validation_error(&self) -> Option<String> {
+        for step in &self.join.steps {
+            let Premise::Assert(Proposition::Constraint(Constraint::Coalesce(c))) = &step.premise
+            else {
+                continue;
+            };
+            let mut ctx = Context::new();
+            if let Err(err) = c.validate(&mut ctx) {
+                return Some(format!("{err}"));
+            }
+        }
+        None
     }
 
     /// For each variable used by a positive premise, compute the
@@ -89,6 +123,14 @@ impl DeductiveRule {
     /// *every* binding is Optional does the variable carry
     /// `Nothing` in its meet.
     ///
+    /// Slots without an explicit `content_type` contribute their
+    /// requirement shape: a `Required` slot contributes "any
+    /// present value" (`Primitive::ALL`); an `Optional` slot
+    /// contributes "any present or absent value"
+    /// (`Primitive::ANY`). This keeps "untyped Required + typed
+    /// Optional" symmetric with "typed Required + typed Optional":
+    /// both produce a meet without `Nothing`.
+    ///
     /// Negation premises do not contribute — they don't bind
     /// variables, only filter on already-bound values.
     fn meet_per_variable(&self) -> HashMap<String, type_system::Type> {
@@ -102,14 +144,26 @@ impl DeductiveRule {
             let params = step.premise.parameters();
 
             for (slot_name, field) in schema.iter() {
-                let Some(slot_type) = field.content_type() else {
-                    continue;
-                };
                 let Some(param) = params.get(slot_name) else {
                     continue;
                 };
                 let Some(var_name) = param.name() else {
                     continue;
+                };
+                let owned;
+                let slot_type: &type_system::Type = match field.content_type() {
+                    Some(t) => t,
+                    None => {
+                        owned = match field.requirement {
+                            Requirement::Required(_) => {
+                                type_system::Type::primitive_set(type_system::Primitive::ALL)
+                            }
+                            Requirement::Optional => {
+                                type_system::Type::primitive_set(type_system::Primitive::ANY)
+                            }
+                        };
+                        &owned
+                    }
                 };
                 match by_variable.get(var_name) {
                     Some(accumulated) => {
@@ -208,9 +262,6 @@ impl Display for DeductiveRule {
 
 impl From<&ConceptDescriptor> for DeductiveRule {
     fn from(concept: &ConceptDescriptor) -> Self {
-        use crate::artifact::Entity;
-        use crate::attribute::query::AttributeQuery;
-
         let mut premises = Vec::new();
 
         let this = Term::<Entity>::var("this");
@@ -528,8 +579,6 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_negated_constraint_with_unbound_variable() {
-        use crate::attribute::query::AttributeQuery;
-
         let conclusion = ConceptDescriptor::from(vec![(
             "name",
             AttributeDescriptor::new(
@@ -564,8 +613,6 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_negated_constraint_with_unbound_variable_on_left() {
-        use crate::attribute::query::AttributeQuery;
-
         let conclusion = ConceptDescriptor::from(vec![(
             "name",
             AttributeDescriptor::new(
@@ -795,5 +842,108 @@ mod tests {
             "meet of Required + Optional strips Nothing — should compile (got {:?})",
             result.err()
         );
+    }
+
+    /// Symmetric case: an *untyped* Required premise paired with a
+    /// typed Optional premise should also strip Nothing from the
+    /// meet. The untyped Required contribution is "any present
+    /// value" (`Primitive::ALL`), so intersected with
+    /// `Optional<String>` (i.e. `{String, Nothing}`) the meet
+    /// resolves to `{String}` — no Nothing. Rule compiles.
+    #[dialog_common::test]
+    fn it_accepts_untyped_required_paired_with_typed_optional() {
+        let conclusion = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        let this = Term::<Entity>::var("this");
+        let typed_name =
+            Term::<Any>::typed_var("name", Some(type_system::Type::primitive(Type::String)));
+
+        let premises = vec![
+            // Optional resolution with typed `is`.
+            AttributeQuery::optional(
+                Term::from(the!("user/name")),
+                this.clone(),
+                typed_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            // Required resolution with *untyped* `is` (Term::var
+            // without a kind). Should contribute "any present
+            // value" to the meet via the None-content_type branch.
+            AttributeQuery::new(
+                Term::from(the!("user/canonical-name")),
+                this,
+                Term::<Any>::var("name"),
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        assert!(
+            result.is_ok(),
+            "untyped Required + typed Optional should compile (got {:?})",
+            result.err()
+        );
+    }
+
+    /// A rule containing a malformed Coalesce (non-Optional source)
+    /// is rejected at compile time. This is the regression test for
+    /// validate-not-called: previously `Coalesce::validate` existed
+    /// but no production path invoked it, so wire-format or
+    /// raw-constructor mismatches silently passed.
+    #[dialog_common::test]
+    fn it_rejects_coalesce_with_non_optional_source() {
+        use crate::constraint::{Coalesce, Constraint};
+        use crate::premise::Premise;
+
+        let conclusion = ConceptDescriptor::from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        let this = Term::<Entity>::var("this");
+        let typed_name =
+            Term::<Any>::typed_var("name", Some(type_system::Type::primitive(Type::String)));
+
+        // Source is a `Term<Any>` carrying `String` (not Optional<String>).
+        let bad_source =
+            Term::<Any>::typed_var("source", Some(type_system::Type::primitive(Type::String)));
+        let bad_coalesce = Coalesce::new(
+            bad_source,
+            Term::<Any>::constant("Anon".to_string()),
+            typed_name.clone(),
+        );
+
+        let premises = vec![
+            // Required premise so the rule has a chance of compiling
+            // up to the coalesce-validation step.
+            AttributeQuery::new(
+                Term::from(the!("user/name")),
+                this,
+                typed_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            Premise::Assert(Proposition::Constraint(Constraint::Coalesce(bad_coalesce))),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        match result {
+            Err(TypeError::CoalesceTypeMismatch { .. }) => {}
+            other => panic!("expected CoalesceTypeMismatch, got {other:?}"),
+        }
     }
 }

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -35,7 +35,7 @@ impl DeductiveRule {
     ///
     /// Plans the optimal premise execution order, validates that every
     /// conclusion variable is grounded by at least one positive premise,
-    /// and runs the meet-algebra check that required head variables
+    /// and runs the type-inference check that required head variables
     /// are not bound only by optional (set-widened) sources.
     pub fn new(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
         // Plan first so analysis can read the optimized step order.
@@ -715,7 +715,7 @@ mod tests {
     /// bit removed by the meet — at least one premise guarantees
     /// Present. Accept.
     #[dialog_common::test]
-    fn it_accepts_required_head_when_meet_strips_nothing() {
+    fn it_accepts_required_head_when_inference_strips_nothing() {
         let conclusion = ConceptDescriptor::from(vec![(
             "name",
             AttributeDescriptor::new(

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -19,6 +19,7 @@ use descriptor::DeductiveRuleDescriptor;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::sync::Arc;
 
 /// Represents a deductive rule that can be applied creating a premise.
 #[derive(Debug, Clone, PartialEq)]
@@ -38,32 +39,38 @@ impl DeductiveRule {
     /// and runs the meet-algebra check that required head variables
     /// are not bound only by optional (set-widened) sources.
     pub fn new(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
-        // Plan the order of premises in a scope where none of the rule
-        // parameters are bound to find the optimal execution order, or to
-        // discover unsatisfiable premises (e.g. a formula whose required
-        // cell is never derived by another premise).
+        // Plan first so analysis can read the optimized step order.
         let join = Planner::from(premises).plan(&Environment::new())?;
 
         // Run rule-level type analysis: inference + required-head
         // check + Coalesce contract validation. Failures here are
         // wrapped into the corresponding `TypeError::*` variants so
         // the user sees the rule embedded in the error.
-        if let Err(err) = analyzer::analyze(conclusion.clone(), &join.steps) {
-            let rule = DeductiveRule { conclusion, join };
-            return Err(match err {
-                AnalysisError::RequiredHeadFromOptional { variable } => {
-                    TypeError::RequiredHeadFromOptional {
-                        rule: Box::new(rule),
-                        variable,
+        let analyzed = match analyzer::analyze(conclusion.clone(), &join.steps) {
+            Ok(analyzed) => Arc::new(analyzed),
+            Err(err) => {
+                let rule = DeductiveRule { conclusion, join };
+                return Err(match err {
+                    AnalysisError::RequiredHeadFromOptional { variable } => {
+                        TypeError::RequiredHeadFromOptional {
+                            rule: Box::new(rule),
+                            variable,
+                        }
                     }
-                }
-                AnalysisError::CoalesceTypeMismatch { reason } => TypeError::CoalesceTypeMismatch {
-                    rule: Box::new(rule),
-                    reason,
-                },
-            });
-        }
+                    AnalysisError::CoalesceTypeMismatch { reason } => {
+                        TypeError::CoalesceTypeMismatch {
+                            rule: Box::new(rule),
+                            reason,
+                        }
+                    }
+                });
+            }
+        };
 
+        // Replan via the analyzed-rule path so future
+        // `Conjunction::plan(&scope)` calls reuse the same analyzed
+        // premises (with their inference and dependency graph).
+        let join = Planner::from_analyzed(analyzed).plan(&Environment::new())?;
         let rule = DeductiveRule { conclusion, join };
 
         // Verify that every conclusion parameter is derived by one of the

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -188,7 +188,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_compiles_with_valid_premises() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -207,7 +207,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         let premises = vec![
             AttributeQuery::new(
@@ -233,7 +234,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_unconstrained_fact() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "key",
                 AttributeDescriptor::new(
@@ -252,7 +253,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let premises = vec![
             AttributeQuery::new(
                 Term::var("the"),
@@ -268,7 +270,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_unconstrained_relation() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "key",
                 AttributeDescriptor::new(
@@ -287,7 +289,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // All terms are variables — no constants at all.
         // The planner should reject this at install time.
@@ -311,7 +314,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_unused_parameter() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -330,7 +333,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let premises = vec![
             AttributeQuery::new(
                 Term::from(the!("user/name")),
@@ -350,7 +354,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_empty_premises() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -369,13 +373,14 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         assert!(DeductiveRule::new(conclusion, vec![]).is_err());
     }
 
     #[dialog_common::test]
     fn it_compiles_with_chained_dependencies() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "key",
                 AttributeDescriptor::new(
@@ -394,7 +399,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         let premises = vec![
             AttributeQuery::new(
@@ -423,10 +429,11 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_mismatched_parameter_name() {
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "key",
             AttributeDescriptor::new(the!("result/key"), "", Cardinality::One, Some(Type::String)),
-        )]);
+        )])
+        .unwrap();
 
         let premises = vec![
             AttributeQuery::new(
@@ -451,7 +458,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_negated_constraint_with_unbound_variable() {
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -459,7 +466,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let name = Term::<String>::var("name");
         let z = Term::<String>::var("z");
@@ -485,7 +493,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_negated_constraint_with_unbound_variable_on_left() {
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -493,7 +501,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let name = Term::<String>::var("name");
         let z = Term::<String>::var("z");
@@ -527,7 +536,7 @@ mod tests {
         use crate::attribute::query::Resolution;
         use crate::proposition::Proposition;
 
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -535,7 +544,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let rule = DeductiveRule::from(&concept);
 
@@ -561,7 +571,7 @@ mod tests {
         use crate::attribute::query::Resolution;
         use crate::proposition::Proposition;
 
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -570,6 +580,7 @@ mod tests {
                 Some(Type::String),
             ),
         )])
+        .unwrap()
         .with_maybe(vec![(
             "nickname",
             AttributeDescriptor::new(
@@ -596,11 +607,38 @@ mod tests {
         assert_eq!(optional, 1, "expected one optional premise (nickname)");
     }
 
+    /// The degenerate "rule body binds only optionals" shape, at the
+    /// concept layer — rejected by construction.
+    ///
+    /// A concept with zero required (`with`) attributes constrains
+    /// nothing, so every entity would match it; a rule built from it
+    /// would have a body of only optional premises (each yielding an
+    /// Absent fallback on miss). This is unsound, and it is now
+    /// *unconstructable*: `ConceptDescriptor::try_from` of an empty
+    /// required set returns [`TypeError::EmptyConcept`], so the
+    /// degenerate concept can never reach the rule compiler at all.
+    /// `maybe` attributes do not change this — only `with` counts.
+    ///
+    /// (A required head bound *only* by an optional premise — the
+    /// distinct shape where a `with` field exists but is fed from an
+    /// optional source — is caught separately by
+    /// `RequiredHeadFromOptional`; see
+    /// `it_rejects_required_head_from_optional_premise`.)
+    #[dialog_common::test]
+    fn it_rejects_concept_with_no_required_attributes_by_construction() {
+        // Empty required set: construction fails outright.
+        let empty: Vec<(&str, AttributeDescriptor)> = Vec::new();
+        match ConceptDescriptor::try_from(empty) {
+            Err(TypeError::EmptyConcept) => {}
+            other => panic!("expected EmptyConcept, got {other:?}"),
+        }
+    }
+
     /// `with_maybe` builder installs the maybe attributes; an
     /// empty input clears the maybe slot.
     #[dialog_common::test]
     fn with_maybe_installs_and_clears() {
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -608,7 +646,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         assert!(concept.maybe().is_none(), "no maybe by default");
 
         let with_maybe = concept.clone().with_maybe(vec![(
@@ -634,7 +673,7 @@ mod tests {
     /// required slot. Reject.
     #[dialog_common::test]
     fn it_rejects_required_head_from_optional_premise() {
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -642,7 +681,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         // Bind ?name with an optional `is` term — the meet for ?name
         // includes Nothing.
@@ -671,7 +711,7 @@ mod tests {
     /// Present. Accept.
     #[dialog_common::test]
     fn it_accepts_required_head_when_inference_strips_nothing() {
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -679,7 +719,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         // The `is` slot must carry a typed kind so the meet has
         // information to combine. An untyped `Term::var` produces
@@ -724,7 +765,7 @@ mod tests {
     /// resolves to `{String}` — no Nothing. Rule compiles.
     #[dialog_common::test]
     fn it_accepts_untyped_required_paired_with_typed_optional() {
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -732,7 +773,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         let optional_name = optional_term("name", Some(Type::String));
 
@@ -775,10 +817,11 @@ mod tests {
     fn it_rejects_required_head_from_optional_cause() {
         // Conclusion has a required `mark` field expecting a
         // typed value (Bytes).
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "mark",
             AttributeDescriptor::new(the!("person/mark"), "", Cardinality::One, Some(Type::Bytes)),
-        )]);
+        )])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         // The optional attribute's cause slot shares the name
         // `?mark` with the conclusion's required head — the
@@ -813,7 +856,7 @@ mod tests {
         use crate::constraint::{Coalesce, Constraint};
         use crate::premise::Premise;
 
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -821,7 +864,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         let typed_name: Term<Any> = Term::<String>::var("name").into();
 

--- a/rust/dialog-query/src/rule/inductive.rs
+++ b/rust/dialog-query/src/rule/inductive.rs
@@ -141,7 +141,7 @@ mod tests {
 
     /// Build the head: a counter row with a `count` field.
     fn counter_head() -> ConceptDescriptor {
-        ConceptDescriptor::from(vec![(
+        ConceptDescriptor::try_from(vec![(
             "count",
             AttributeDescriptor::new(
                 the!("counter/count"),
@@ -150,6 +150,7 @@ mod tests {
                 Some(Type::UnsignedInt),
             ),
         )])
+        .unwrap()
     }
 
     /// Body premises:
@@ -185,7 +186,7 @@ mod tests {
     #[dialog_common::test]
     fn it_rejects_unbound_head_variable() {
         // Head adds a `name` field that no premise binds.
-        let head = ConceptDescriptor::from(vec![
+        let head = ConceptDescriptor::try_from(vec![
             (
                 "count",
                 AttributeDescriptor::new(
@@ -204,7 +205,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let result = InductiveRule::new(head, increment_body());
         assert!(matches!(result, Err(TypeError::UnboundVariable { .. })));
         if let Err(TypeError::UnboundVariable { variable, .. }) = result {

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -234,6 +234,48 @@ mod tests {
         assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
     }
 
+    /// Negation premises don't contribute to inference. A
+    /// negation that mentions `?x` with kind `String` doesn't
+    /// constrain the rule-level type of `?x`; the positive
+    /// premise that binds `?x` is the sole contributor.
+    #[dialog_common::test]
+    fn it_ignores_negation_contributions_during_inference() {
+        use crate::Proposition;
+        use crate::negation::Negation;
+        // Positive premise binds ?name optionally (Option<String>).
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let positive = AttributeQuery::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("this"),
+            optional_name,
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        // Negation references ?name as Term<String> (non-optional).
+        // If this contributed to inference, ?name's inferred kind
+        // would be narrowed to String (no Nothing). But it doesn't,
+        // so ?name stays Optional<String>.
+        let strict_name: Term<Any> = Term::<String>::var("name").into();
+        let neg_query = AttributeQuery::new(
+            Term::from(the!("person/nickname")),
+            Term::<Entity>::var("this"),
+            strict_name,
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+        let premises = vec![
+            positive.into(),
+            Premise::Unless(Negation(Proposition::Attribute(Box::new(neg_query)))),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps).unwrap();
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            name_kind.is_optional(),
+            "negation should not strip Nothing from `?name`'s inferred kind"
+        );
+    }
+
     /// A variable used as `Term<String>` in one premise and as
     /// `Term<u32>` in another has no consistent type — inference
     /// must report a conflict rather than silently producing one

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -1,0 +1,223 @@
+//! Type inference over a rule's premises.
+//!
+//! Every named variable a rule's positive premises mention places a
+//! constraint on that variable's type: each slot it appears in claims
+//! a kind (from the slot's schema), and the variable's rule-level
+//! type is the unification of those claims.
+//!
+//! This module runs that inference using the [`Context`] from
+//! [`crate::type_system::unifier`] and produces a [`TypeEnv`] —
+//! a name-keyed map from each variable to its inferred type. The
+//! result is carried on the [`Conjunction`](super::Plan) so
+//! downstream evaluators can consult per-variable types instead of
+//! re-deriving them from each term's local kind.
+//!
+//! Untyped slots (those with no static `content_type`) still
+//! contribute to inference via their requirement shape:
+//!
+//! - `Required` slots contribute `Primitive::ALL` — "any present
+//!   value." This excludes `Nothing` from the variable's type.
+//! - `Optional` slots contribute `Primitive::ANY` — "any present or
+//!   absent value." This lets `Nothing` survive unification when
+//!   every slot the variable visits is optional.
+//!
+//! Negation premises do not contribute. They filter on existing
+//! bindings rather than introducing them.
+
+use crate::Premise;
+use crate::planner::Plan;
+use crate::schema::Requirement;
+use crate::type_system::Type as Kind;
+use crate::type_system::unifier::{Context, Type as Inferred, lift};
+use std::collections::HashMap;
+
+use super::super::type_system::Primitive;
+
+/// Inferred types for every named variable referenced by a rule's
+/// positive premises.
+///
+/// Built by [`TypeEnv::infer`] during planning; carried on
+/// [`Conjunction`](crate::planner::Conjunction) so evaluators can
+/// look up rule-level types without re-running inference.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TypeEnv {
+    by_name: HashMap<String, Kind>,
+}
+
+impl TypeEnv {
+    /// Empty environment — no variables inferred.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a `TypeEnv` by walking the given plan steps. For each
+    /// named variable mentioned by any positive premise's slots,
+    /// unify the slot kinds and record the resulting type.
+    ///
+    /// Returns the environment even if unification fails for some
+    /// variable: failures collapse that variable's type to the
+    /// narrower input. The compile-time check for required-head
+    /// optionality reads from the environment, so a failure here
+    /// surfaces as either a missing key or an unexpected
+    /// `Nothing`-admitting result — both already handled by the
+    /// rule compiler.
+    pub fn infer(steps: &[Plan]) -> Self {
+        let mut ctx = Context::new();
+        for step in steps {
+            // Negation premises don't contribute — they filter on
+            // bindings rather than introducing them.
+            let Premise::Assert(_) = &step.premise else {
+                continue;
+            };
+            let schema = step.premise.schema();
+            let params = step.premise.parameters();
+
+            for (slot_name, field) in schema.iter() {
+                let Some(param) = params.get(slot_name) else {
+                    continue;
+                };
+                let Some(var_name) = param.name() else {
+                    continue;
+                };
+                let slot_kind: Kind = match field.content_type() {
+                    Some(t) => t.clone(),
+                    None => match field.requirement {
+                        Requirement::Required(_) => Kind::primitive_set(Primitive::ALL),
+                        Requirement::Optional => Kind::primitive_set(Primitive::ANY),
+                    },
+                };
+                let var = ctx.var_for_name(var_name);
+                // Errors here mean the rule has contradictory slot
+                // kinds for the same variable — leave that for the
+                // compile-time check to surface.
+                let _ = ctx.unify(&lift(&slot_kind), &Inferred::Variable(var));
+            }
+        }
+
+        let mut by_name = HashMap::new();
+        for (name, var_id) in ctx.named_vars() {
+            if let Inferred::Static(kind) = ctx.apply(&Inferred::Variable(*var_id)) {
+                by_name.insert(name.clone(), kind);
+            } else {
+                // Variable never resolved to a static type — record
+                // its constraint as a primitive set. This is the
+                // "no slot ever gave us a concrete shape" case; the
+                // rule compiler treats it as fully unconstrained.
+                by_name.insert(name.clone(), Kind::primitive_set(ctx.constraint(*var_id)));
+            }
+        }
+        Self { by_name }
+    }
+
+    /// Look up the inferred type for a variable by name.
+    pub fn get(&self, name: &str) -> Option<&Kind> {
+        self.by_name.get(name)
+    }
+
+    /// Iterate over `(name, inferred kind)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Kind)> {
+        self.by_name.iter()
+    }
+
+    /// Number of variables inferred.
+    pub fn len(&self) -> usize {
+        self.by_name.len()
+    }
+
+    /// `true` if no variables were inferred.
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::artifact::{Entity, Type as ValueType};
+    use crate::attribute::query::AttributeQuery;
+    use crate::planner::Planner;
+    use crate::types::Any;
+    use crate::{Cardinality, Environment, Term, the};
+
+    /// A typed slot kind flows into the variable's inferred type.
+    #[dialog_common::test]
+    fn it_records_inferred_kind_for_typed_slot() {
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps);
+        let name_kind = env.get("name").expect("name inferred");
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+
+    /// A variable bound only by optional slots keeps the `Nothing`
+    /// bit in its inferred type.
+    #[dialog_common::test]
+    fn it_preserves_nothing_when_only_optional_bindings_exist() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps);
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            name_kind.is_optional(),
+            "single optional binding leaves Nothing in the inferred type"
+        );
+    }
+
+    /// A variable bound by both an optional and a required slot has
+    /// `Nothing` removed by the intersection — the required slot
+    /// wins.
+    #[dialog_common::test]
+    fn it_strips_nothing_when_a_required_binding_also_exists() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps);
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            !name_kind.is_optional(),
+            "Required + Optional bindings strip Nothing from the inferred type"
+        );
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+}

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -234,6 +234,51 @@ mod tests {
         assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
     }
 
+    /// Three premises, all referencing `?name`: two optional, one
+    /// required. The required one alone is enough to strip
+    /// `Nothing` from the inferred type. Verifies that
+    /// inference is *intersection*, not union.
+    #[dialog_common::test]
+    fn it_strips_nothing_when_any_premise_is_required() {
+        let opt_a: Term<Any> = Term::<Option<String>>::var("name").into();
+        let opt_b: Term<Any> = Term::<Option<String>>::var("name").into();
+        let req: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                opt_a,
+                Term::var("c1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/alias")),
+                Term::<Entity>::var("this"),
+                opt_b,
+                Term::var("c2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                req,
+                Term::var("c3"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps).unwrap();
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            !name_kind.is_optional(),
+            "a single required binding among many optional ones strips Nothing"
+        );
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+
     /// Negation premises don't contribute to inference. A
     /// negation that mentions `?x` with kind `String` doesn't
     /// constrain the rule-level type of `?x`; the positive

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -114,6 +114,19 @@ impl TypeEnv {
         self.by_name.get(name)
     }
 
+    /// Return a new `TypeEnv` containing only the entries for the
+    /// given variable names. Used to project the rule-wide
+    /// environment down to a single plan step's variables.
+    pub fn project<'a>(&self, names: impl IntoIterator<Item = &'a str>) -> Self {
+        let mut by_name = HashMap::new();
+        for name in names {
+            if let Some(kind) = self.by_name.get(name) {
+                by_name.insert(name.to_string(), kind.clone());
+            }
+        }
+        Self { by_name }
+    }
+
     /// Iterate over `(name, inferred kind)` pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&String, &Kind)> {
         self.by_name.iter()

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -8,9 +8,8 @@
 //! This module runs that inference using the [`Context`] from
 //! [`crate::type_system::unifier`] and produces a [`TypeEnv`] —
 //! a name-keyed map from each variable to its inferred type. The
-//! result is carried on the [`Conjunction`](super::Plan) so
-//! downstream evaluators can consult per-variable types instead of
-//! re-deriving them from each term's local kind.
+//! planner consumes the env to rewrite each premise's variable
+//! terms so they carry the inferred kinds at evaluation time.
 //!
 //! Untyped slots (those with no static `content_type`) still
 //! contribute to inference via their requirement shape:
@@ -27,11 +26,10 @@
 use crate::Premise;
 use crate::planner::Plan;
 use crate::schema::Requirement;
+use crate::type_system::Primitive;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::{Context, Type as Inferred, lift};
 use std::collections::HashMap;
-
-use super::super::type_system::Primitive;
 
 /// Errors raised by [`TypeEnv::infer`].
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
@@ -50,9 +48,11 @@ pub enum InferenceError {
 /// Inferred types for every named variable referenced by a rule's
 /// positive premises.
 ///
-/// Built by [`TypeEnv::infer`] during planning; carried on
-/// [`Conjunction`](crate::planner::Conjunction) so evaluators can
-/// look up rule-level types without re-running inference.
+/// Built by [`TypeEnv::infer`] during planning. The planner uses
+/// the result to narrow each premise's variable terms so they
+/// carry rule-level kinds at evaluation time. Also carried on
+/// [`AnalyzedRule`](super::AnalyzedRule) (wrapped in an `Arc`) for
+/// later phases that want type-by-variable lookups.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TypeEnv {
     by_name: HashMap<String, Kind>,
@@ -125,19 +125,6 @@ impl TypeEnv {
     /// Look up the inferred type for a variable by name.
     pub fn get(&self, name: &str) -> Option<&Kind> {
         self.by_name.get(name)
-    }
-
-    /// Return a new `TypeEnv` containing only the entries for the
-    /// given variable names. Used to project the rule-wide
-    /// environment down to a single plan step's variables.
-    pub fn project<'a>(&self, names: impl IntoIterator<Item = &'a str>) -> Self {
-        let mut by_name = HashMap::new();
-        for name in names {
-            if let Some(kind) = self.by_name.get(name) {
-                by_name.insert(name.to_string(), kind.clone());
-            }
-        }
-        Self { by_name }
     }
 
     /// Iterate over `(name, inferred kind)` pairs.

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -33,6 +33,20 @@ use std::collections::HashMap;
 
 use super::super::type_system::Primitive;
 
+/// Errors raised by [`TypeEnv::infer`].
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum InferenceError {
+    /// A variable appears in slots whose declared kinds have no
+    /// common type — unification produced a contradiction.
+    #[error("variable {variable} has conflicting kinds across premises: {reason}")]
+    Conflict {
+        /// Name of the offending variable.
+        variable: String,
+        /// Underlying unifier error message.
+        reason: String,
+    },
+}
+
 /// Inferred types for every named variable referenced by a rule's
 /// positive premises.
 ///
@@ -54,14 +68,11 @@ impl TypeEnv {
     /// named variable mentioned by any positive premise's slots,
     /// unify the slot kinds and record the resulting type.
     ///
-    /// Returns the environment even if unification fails for some
-    /// variable: failures collapse that variable's type to the
-    /// narrower input. The compile-time check for required-head
-    /// optionality reads from the environment, so a failure here
-    /// surfaces as either a missing key or an unexpected
-    /// `Nothing`-admitting result — both already handled by the
-    /// rule compiler.
-    pub fn infer(steps: &[Plan]) -> Self {
+    /// Returns `Err` if any variable's kind is contradictory across
+    /// slots (e.g. `?x` is `String` in one premise and `Entity` in
+    /// another). The variable name is returned with the error so
+    /// the caller can surface a useful diagnostic.
+    pub fn infer(steps: &[Plan]) -> Result<Self, InferenceError> {
         let mut ctx = Context::new();
         for step in steps {
             // Negation premises don't contribute — they filter on
@@ -87,10 +98,12 @@ impl TypeEnv {
                     },
                 };
                 let var = ctx.var_for_name(var_name);
-                // Errors here mean the rule has contradictory slot
-                // kinds for the same variable — leave that for the
-                // compile-time check to surface.
-                let _ = ctx.unify(&lift(&slot_kind), &Inferred::Variable(var));
+                if let Err(reason) = ctx.unify(&lift(&slot_kind), &Inferred::Variable(var)) {
+                    return Err(InferenceError::Conflict {
+                        variable: var_name.to_string(),
+                        reason: reason.to_string(),
+                    });
+                }
             }
         }
 
@@ -106,7 +119,7 @@ impl TypeEnv {
                 by_name.insert(name.clone(), Kind::primitive_set(ctx.constraint(*var_id)));
             }
         }
-        Self { by_name }
+        Ok(Self { by_name })
     }
 
     /// Look up the inferred type for a variable by name.
@@ -170,7 +183,7 @@ mod tests {
             .into(),
         ];
         let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
-        let env = TypeEnv::infer(&plan.steps);
+        let env = TypeEnv::infer(&plan.steps).unwrap();
         let name_kind = env.get("name").expect("name inferred");
         assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
     }
@@ -191,7 +204,7 @@ mod tests {
             .into(),
         ];
         let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
-        let env = TypeEnv::infer(&plan.steps);
+        let env = TypeEnv::infer(&plan.steps).unwrap();
         let name_kind = env.get("name").expect("name inferred");
         assert!(
             name_kind.is_optional(),
@@ -225,12 +238,54 @@ mod tests {
             .into(),
         ];
         let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
-        let env = TypeEnv::infer(&plan.steps);
+        let env = TypeEnv::infer(&plan.steps).unwrap();
         let name_kind = env.get("name").expect("name inferred");
         assert!(
             !name_kind.is_optional(),
             "Required + Optional bindings strip Nothing from the inferred type"
         );
         assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+
+    /// A variable used as `Term<String>` in one premise and as
+    /// `Term<u32>` in another has no consistent type — inference
+    /// must report a conflict rather than silently producing one
+    /// or the other. The planner surfaces this as
+    /// `TypeError::TypeInference`.
+    #[dialog_common::test]
+    fn it_rejects_planning_when_variable_kinds_disagree() {
+        use crate::error::TypeError;
+        let as_string: Term<Any> = Term::<String>::var("x").into();
+        let as_u32: Term<Any> = Term::<u32>::var("x").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("thing/label")),
+                Term::<Entity>::var("this"),
+                as_string,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("thing/count")),
+                Term::<Entity>::var("this"),
+                as_u32,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let err = Planner::from(premises)
+            .plan(&Environment::new())
+            .unwrap_err();
+        match err {
+            TypeError::TypeInference { reason } => {
+                assert!(
+                    reason.contains("x"),
+                    "error mentions the conflicting variable name; got: {reason}"
+                );
+            }
+            other => panic!("expected TypeInference, got {other:?}"),
+        }
     }
 }

--- a/rust/dialog-query/src/schema.rs
+++ b/rust/dialog-query/src/schema.rs
@@ -2,8 +2,14 @@
 //!
 //! This module provides a schema system that describes the structure,
 //! types, and requirements of parameters for different premise types.
+//!
+//! As of v2, [`Field::content_type`] uses the unified
+//! [`type_system::Type`] enum rather than the legacy
+//! `Option<artifact::Type>`. The conversion between them is
+//! lossless: `None` becomes a fresh anonymous type variable,
+//! `Some(vt)` becomes `Type::Definite(Primitive(singleton(vt)))`.
 
-use crate::Type;
+use crate::type_system;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -162,12 +168,20 @@ impl Cardinality {
 /// many values ([`Cardinality`]), and whether it must be bound before the
 /// premise can execute ([`Requirement`]). The planner reads these fields
 /// to classify each parameter as a prerequisite or a produced binding.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// [`Self::content_type`] is the unified
+/// [`type_system::Type`] — replaces v1's
+/// `Option<artifact::Type>`. `None` (any type) becomes
+/// `Type::any()` (an anonymous unconstrained variable);
+/// `Some(vt)` becomes
+/// `Type::Definite(Primitive(singleton(vt)))`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Field {
     /// Human-readable description of the field.
     pub description: String,
-    /// Expected value type, or `None` if unconstrained.
-    pub content_type: Option<Type>,
+    /// Expected value type. Use [`type_system::Type::any`] for an
+    /// unconstrained slot (the v2 replacement for v1's `None`).
+    pub content_type: type_system::Type,
     /// Whether the field is required or optional.
     pub requirement: Requirement,
     /// Whether the field holds one or many values.
@@ -177,7 +191,11 @@ pub struct Field {
 impl Field {
     /// Creates a new field with the given description, type, and requirement.
     /// Cardinality defaults to [`Cardinality::One`].
-    pub fn new(description: String, content_type: Option<Type>, requirement: Requirement) -> Self {
+    pub fn new(
+        description: String,
+        content_type: type_system::Type,
+        requirement: Requirement,
+    ) -> Self {
         Self {
             description,
             content_type,
@@ -191,9 +209,9 @@ impl Field {
         &self.description
     }
 
-    /// Returns the expected content type, if any.
-    pub fn content_type(&self) -> Option<Type> {
-        self.content_type
+    /// Returns a reference to the expected content type.
+    pub fn content_type(&self) -> &type_system::Type {
+        &self.content_type
     }
 
     /// Returns the field's requirement level.
@@ -293,6 +311,8 @@ impl Group {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::artifact::Type as ValueType;
+    use crate::type_system::{Definite, PrimitiveSet};
 
     #[dialog_common::test]
     fn it_tracks_requirement_properties() {
@@ -301,5 +321,94 @@ mod tests {
 
         assert!(required.is_required());
         assert!(!derived.is_required());
+    }
+
+    /// Lifting a storage-tag `Some(vt)` into the unified type
+    /// produces `Definite(Primitive(singleton(vt)))`.
+    #[dialog_common::test]
+    fn field_content_type_lifts_some_to_definite_primitive() {
+        let content: type_system::Type = Some(ValueType::String).into();
+        match content {
+            type_system::Type::Definite(d) => match *d {
+                Definite::Primitive(set) => {
+                    assert_eq!(set.as_singleton(), Some(ValueType::String));
+                }
+                other => panic!("expected Primitive, got {:?}", other),
+            },
+            other => panic!("expected Definite, got {:?}", other),
+        }
+    }
+
+    /// Lifting `None` produces an anonymous unconstrained
+    /// variable (`Type::any()`).
+    #[dialog_common::test]
+    fn field_content_type_lifts_none_to_anonymous_variable() {
+        let content: type_system::Type = None.into();
+        match content.shape() {
+            Definite::Variable(_) => {}
+            other => panic!("expected anonymous variable, got {:?}", other),
+        }
+    }
+
+    /// Anonymous variables from successive `None.into()` calls
+    /// have distinct `VarId`s — they're independent type slots
+    /// that the unifier links at rule-compile time, not the same
+    /// variable.
+    #[dialog_common::test]
+    fn field_content_type_anonymous_variables_are_distinct() {
+        let a: type_system::Type = None.into();
+        let b: type_system::Type = None.into();
+        let id_a = match a.shape() {
+            Definite::Variable(id) => *id,
+            _ => panic!("expected variable"),
+        };
+        let id_b = match b.shape() {
+            Definite::Variable(id) => *id,
+            _ => panic!("expected variable"),
+        };
+        assert_ne!(id_a, id_b);
+    }
+
+    /// `Field::new` accepts the unified type directly.
+    #[dialog_common::test]
+    fn field_new_accepts_unified_type() {
+        let f = Field::new(
+            "test".into(),
+            type_system::Type::primitive(ValueType::Boolean),
+            Requirement::Required(None),
+        );
+        assert_eq!(
+            f.content_type().shape().as_singleton(),
+            Some(ValueType::Boolean)
+        );
+        assert!(matches!(f.requirement(), Requirement::Required(_)));
+    }
+
+    /// A constructed Field's content_type round-trips through
+    /// the descriptor: `Some(vt)` lifts to a definite primitive
+    /// with the right value type.
+    #[dialog_common::test]
+    fn field_round_trip_value_type() {
+        let f = Field::new(
+            "x".into(),
+            Some(ValueType::Entity).into(),
+            Requirement::Optional,
+        );
+        let recovered = f.content_type().shape().as_singleton();
+        assert_eq!(recovered, Some(ValueType::Entity));
+    }
+
+    /// Anonymous variables in Fields default to constraint
+    /// `PrimitiveSet::ALL` when consulted via a fresh
+    /// unification context.
+    #[dialog_common::test]
+    fn field_anonymous_variable_constraint_is_all() {
+        let f = Field::new("any_slot".into(), None.into(), Requirement::Optional);
+        let var = match f.content_type().shape() {
+            Definite::Variable(id) => *id,
+            _ => panic!("expected variable"),
+        };
+        let ctx = type_system::UnificationContext::new();
+        assert_eq!(ctx.constraint(var), PrimitiveSet::ALL);
     }
 }

--- a/rust/dialog-query/src/schema.rs
+++ b/rust/dialog-query/src/schema.rs
@@ -7,7 +7,7 @@
 //! [`type_system::Type`] enum rather than the legacy
 //! `Option<artifact::Type>`. The conversion between them is
 //! lossless: `None` becomes a fresh anonymous type variable,
-//! `Some(vt)` becomes `Type::Definite(Primitive(singleton(vt)))`.
+//! `Some(vt)` becomes `Type::Primitive(singleton(vt))`.
 
 use crate::type_system;
 use serde::{Deserialize, Serialize};
@@ -323,7 +323,7 @@ mod tests {
             Requirement::Required(None),
         );
         assert_eq!(
-            f.content_type().unwrap().shape().as_singleton(),
+            f.content_type().unwrap().as_value_type(),
             Some(ValueType::Boolean)
         );
         assert!(matches!(f.requirement(), Requirement::Required(_)));

--- a/rust/dialog-query/src/schema.rs
+++ b/rust/dialog-query/src/schema.rs
@@ -304,6 +304,7 @@ impl Group {
 mod tests {
     use super::*;
     use crate::artifact::Type as ValueType;
+    use crate::type_system::Type as Kind;
 
     #[dialog_common::test]
     fn it_tracks_requirement_properties() {
@@ -319,7 +320,7 @@ mod tests {
     fn field_new_accepts_unified_type() {
         let f = Field::new(
             "test".into(),
-            Some(type_system::Type::primitive(ValueType::Boolean)),
+            Some(Kind::primitive(ValueType::Boolean)),
             Requirement::Required(None),
         );
         assert_eq!(

--- a/rust/dialog-query/src/schema.rs
+++ b/rust/dialog-query/src/schema.rs
@@ -164,24 +164,16 @@ impl Cardinality {
 
 /// Metadata for a single named parameter in a [`Schema`].
 ///
-/// Captures the parameter's expected value type, whether it accepts one or
-/// many values ([`Cardinality`]), and whether it must be bound before the
-/// premise can execute ([`Requirement`]). The planner reads these fields
-/// to classify each parameter as a prerequisite or a produced binding.
-///
-/// [`Self::content_type`] is the unified
-/// [`type_system::Type`] — replaces v1's
-/// `Option<artifact::Type>`. `None` (any type) becomes
-/// `Type::any()` (an anonymous unconstrained variable);
-/// `Some(vt)` becomes
-/// `Type::Definite(Primitive(singleton(vt)))`.
+/// `content_type` is the unified
+/// [`type_system::Type`], wrapped in `Option` so that "no static
+/// info known" is representable directly (the unifier resolves
+/// it at rule-compile time).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Field {
     /// Human-readable description of the field.
     pub description: String,
-    /// Expected value type. Use [`type_system::Type::any`] for an
-    /// unconstrained slot (the v2 replacement for v1's `None`).
-    pub content_type: type_system::Type,
+    /// Expected value type, or `None` if unknown.
+    pub content_type: Option<type_system::Type>,
     /// Whether the field is required or optional.
     pub requirement: Requirement,
     /// Whether the field holds one or many values.
@@ -193,7 +185,7 @@ impl Field {
     /// Cardinality defaults to [`Cardinality::One`].
     pub fn new(
         description: String,
-        content_type: type_system::Type,
+        content_type: Option<type_system::Type>,
         requirement: Requirement,
     ) -> Self {
         Self {
@@ -209,9 +201,9 @@ impl Field {
         &self.description
     }
 
-    /// Returns a reference to the expected content type.
-    pub fn content_type(&self) -> &type_system::Type {
-        &self.content_type
+    /// Returns the expected content type, if known.
+    pub fn content_type(&self) -> Option<&type_system::Type> {
+        self.content_type.as_ref()
     }
 
     /// Returns the field's requirement level.
@@ -312,7 +304,6 @@ impl Group {
 mod tests {
     use super::*;
     use crate::artifact::Type as ValueType;
-    use crate::type_system::{Definite, PrimitiveSet};
 
     #[dialog_common::test]
     fn it_tracks_requirement_properties() {
@@ -323,92 +314,25 @@ mod tests {
         assert!(!derived.is_required());
     }
 
-    /// Lifting a storage-tag `Some(vt)` into the unified type
-    /// produces `Definite(Primitive(singleton(vt)))`.
-    #[dialog_common::test]
-    fn field_content_type_lifts_some_to_definite_primitive() {
-        let content: type_system::Type = Some(ValueType::String).into();
-        match content {
-            type_system::Type::Definite(d) => match *d {
-                Definite::Primitive(set) => {
-                    assert_eq!(set.as_singleton(), Some(ValueType::String));
-                }
-                other => panic!("expected Primitive, got {:?}", other),
-            },
-            other => panic!("expected Definite, got {:?}", other),
-        }
-    }
-
-    /// Lifting `None` produces an anonymous unconstrained
-    /// variable (`Type::any()`).
-    #[dialog_common::test]
-    fn field_content_type_lifts_none_to_anonymous_variable() {
-        let content: type_system::Type = None.into();
-        match content.shape() {
-            Definite::Variable(_) => {}
-            other => panic!("expected anonymous variable, got {:?}", other),
-        }
-    }
-
-    /// Anonymous variables from successive `None.into()` calls
-    /// have distinct `VarId`s — they're independent type slots
-    /// that the unifier links at rule-compile time, not the same
-    /// variable.
-    #[dialog_common::test]
-    fn field_content_type_anonymous_variables_are_distinct() {
-        let a: type_system::Type = None.into();
-        let b: type_system::Type = None.into();
-        let id_a = match a.shape() {
-            Definite::Variable(id) => *id,
-            _ => panic!("expected variable"),
-        };
-        let id_b = match b.shape() {
-            Definite::Variable(id) => *id,
-            _ => panic!("expected variable"),
-        };
-        assert_ne!(id_a, id_b);
-    }
-
     /// `Field::new` accepts the unified type directly.
     #[dialog_common::test]
     fn field_new_accepts_unified_type() {
         let f = Field::new(
             "test".into(),
-            type_system::Type::primitive(ValueType::Boolean),
+            Some(type_system::Type::primitive(ValueType::Boolean)),
             Requirement::Required(None),
         );
         assert_eq!(
-            f.content_type().shape().as_singleton(),
+            f.content_type().unwrap().shape().as_singleton(),
             Some(ValueType::Boolean)
         );
         assert!(matches!(f.requirement(), Requirement::Required(_)));
     }
 
-    /// A constructed Field's content_type round-trips through
-    /// the descriptor: `Some(vt)` lifts to a definite primitive
-    /// with the right value type.
+    /// A field with no static info reports `None`.
     #[dialog_common::test]
-    fn field_round_trip_value_type() {
-        let f = Field::new(
-            "x".into(),
-            Some(ValueType::Entity).into(),
-            Requirement::Optional,
-        );
-        let recovered = f.content_type().shape().as_singleton();
-        assert_eq!(recovered, Some(ValueType::Entity));
-    }
-
-    /// Anonymous variables in Fields default to constraint
-    /// `PrimitiveSet::ALL` when consulted via a fresh
-    /// unification context.
-    #[dialog_common::test]
-    fn field_anonymous_variable_constraint_is_all() {
-        let f = Field::new("any_slot".into(), None.into(), Requirement::Optional);
-        let var = match f.content_type().shape() {
-            Definite::Variable(id) => *id,
-            _ => panic!("expected variable"),
-        };
-        let ctx = type_system::UnificationContext::new();
-        assert_eq!(ctx.constraint(var), PrimitiveSet::ALL);
+    fn field_unknown_type_reports_none() {
+        let f = Field::new("x".into(), None, Requirement::Optional);
+        assert!(f.content_type().is_none());
     }
 }

--- a/rust/dialog-query/src/selection.rs
+++ b/rust/dialog-query/src/selection.rs
@@ -92,6 +92,7 @@ mod tests {
 
         let result = candidate
             .lookup(&name_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "Alice");
@@ -106,6 +107,7 @@ mod tests {
 
         let result = candidate
             .lookup(&age_param)
+            .and_then(|b| b.content())
             .and_then(|v| u32::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 25);
@@ -120,6 +122,7 @@ mod tests {
 
         let result = candidate
             .lookup(&score_param)
+            .and_then(|b| b.content())
             .and_then(|v| i32::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), -10);
@@ -134,6 +137,7 @@ mod tests {
 
         let result = candidate
             .lookup(&active_param)
+            .and_then(|b| b.content())
             .and_then(|v| bool::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert!(result.unwrap());
@@ -151,6 +155,7 @@ mod tests {
 
         let result = candidate
             .lookup(&entity_param)
+            .and_then(|b| b.content())
             .and_then(|v| Entity::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), entity_value);
@@ -163,6 +168,7 @@ mod tests {
 
         let result = candidate
             .lookup(&constant_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "constant_value");
@@ -175,6 +181,7 @@ mod tests {
 
         let result = candidate
             .lookup(&name_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -192,6 +199,7 @@ mod tests {
 
         let result = candidate
             .lookup(&blank_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -211,6 +219,7 @@ mod tests {
 
         let result = candidate
             .lookup(&name_param)
+            .and_then(|b| b.content())
             .and_then(|v| u32::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -229,7 +238,10 @@ mod tests {
         candidate.bind(&name_term, value.clone()).unwrap();
         candidate.bind(&name_term, value.clone()).unwrap();
 
-        assert_eq!(candidate.lookup(&name_term).unwrap(), value);
+        assert_eq!(
+            candidate.lookup(&name_term).unwrap().content().unwrap(),
+            value
+        );
     }
 
     #[dialog_common::test]
@@ -258,10 +270,30 @@ mod tests {
             .bind(&Term::var("active"), Value::Boolean(true))
             .unwrap();
 
-        let name_result = String::try_from(candidate.lookup(&Term::var("name")).unwrap()).unwrap();
-        let age_result = u32::try_from(candidate.lookup(&Term::var("age")).unwrap()).unwrap();
-        let active_result =
-            bool::try_from(candidate.lookup(&Term::var("active")).unwrap()).unwrap();
+        let name_result = String::try_from(
+            candidate
+                .lookup(&Term::var("name"))
+                .unwrap()
+                .content()
+                .unwrap(),
+        )
+        .unwrap();
+        let age_result = u32::try_from(
+            candidate
+                .lookup(&Term::var("age"))
+                .unwrap()
+                .content()
+                .unwrap(),
+        )
+        .unwrap();
+        let active_result = bool::try_from(
+            candidate
+                .lookup(&Term::var("active"))
+                .unwrap()
+                .content()
+                .unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(name_result, "Bob");
         assert_eq!(age_result, 30);

--- a/rust/dialog-query/src/selection/match.rs
+++ b/rust/dialog-query/src/selection/match.rs
@@ -11,19 +11,95 @@ use crate::types::Record;
 
 use super::Selection;
 
+/// A row-level binding for a variable.
+///
+/// Distinguishes [`Binding::Present`] (the variable resolved to a
+/// concrete [`Value`]) from [`Binding::Absent`] (an optional
+/// resolution premise looked up the entity's attribute and found
+/// no fact). `Absent` is structurally distinct from "no binding at
+/// all" — variables that no premise has touched aren't in the
+/// bindings map and produce
+/// [`EvaluationError::UnboundVariable`] from
+/// [`Match::lookup`]; variables that have been touched by an
+/// optional resolver are *always* in the map, with either a
+/// `Present` or an `Absent` entry.
+///
+/// This three-state distinction (unbound / Present / Absent) is
+/// what makes set-widening optionality work without persisting any
+/// `None` value at the storage layer. See `notes/optional-fields.md`
+/// for the design rationale.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Binding {
+    /// The variable resolved to a concrete value.
+    Present(Value),
+    /// An optional resolver looked up the variable's attribute for
+    /// this entity and found no fact. Distinct from "not yet
+    /// bound."
+    Absent,
+}
+
+impl Binding {
+    /// Extract the contained [`Value`], returning
+    /// [`EvaluationError::Absent`] if this binding is `Absent`.
+    /// Use this when the caller cannot tolerate absence — e.g.
+    /// realization paths for required fields, formula inputs.
+    /// Callers that handle optionality (Coalesce, optional
+    /// realize) should pattern-match on `Binding` directly.
+    pub fn content(self) -> Result<Value, EvaluationError> {
+        self.content_for(None)
+    }
+
+    /// Like [`Self::content`] but attaches a variable name to the
+    /// resulting [`EvaluationError::Absent`] so callers can report
+    /// which slot was Absent.
+    pub fn content_for(self, variable_name: Option<&str>) -> Result<Value, EvaluationError> {
+        match self {
+            Binding::Present(value) => Ok(value),
+            Binding::Absent => Err(EvaluationError::Absent {
+                variable_name: variable_name.unwrap_or("_").into(),
+            }),
+        }
+    }
+
+    /// Returns the contained [`Value`] reference if `Present`,
+    /// `None` otherwise.
+    pub fn as_value(&self) -> Option<&Value> {
+        match self {
+            Binding::Present(value) => Some(value),
+            Binding::Absent => None,
+        }
+    }
+
+    /// Returns `true` iff this binding is [`Binding::Absent`].
+    pub fn is_absent(&self) -> bool {
+        matches!(self, Binding::Absent)
+    }
+
+    /// Returns `true` iff this binding is [`Binding::Present`].
+    pub fn is_present(&self) -> bool {
+        matches!(self, Binding::Present(_))
+    }
+}
+
 /// A single result row produced during query evaluation.
 ///
-/// A `Match` accumulates variable bindings as premises are evaluated in
-/// sequence. Each binding maps a variable name to its resolved [`Value`].
+/// A `Match` accumulates variable bindings as premises are
+/// evaluated in sequence. Each binding maps a variable name to a
+/// [`Binding`], which is either `Present(value)` (the variable
+/// resolved to a concrete value) or `Absent` (an optional resolver
+/// found no fact for the entity).
 ///
 /// Matches flow through the evaluation pipeline as a stream
-/// ([`Selection`](super::Selection)): each premise receives the stream,
-/// potentially expands each match into zero or more new matches, and
-/// passes them to the next premise.
+/// ([`Selection`](super::Selection)): each premise receives the
+/// stream, potentially expands each match into zero or more new
+/// matches, and passes them to the next premise.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct Match {
-    /// Named variable bindings: maps variable names to their resolved values.
-    bindings: HashMap<String, Value>,
+    /// Named variable bindings: maps variable names to their
+    /// row-level binding (Present or Absent). A name absent from
+    /// this map means "no premise has touched this variable" —
+    /// distinct from [`Binding::Absent`].
+    bindings: HashMap<String, Binding>,
     // TODO: Once Value::Record supports the RecordFormat trait proposed in
     // https://github.com/dialog-db/dialog-db/pull/221 claims can be stored
     // directly as Value::Record in bindings, eliminating this separate map.
@@ -76,27 +152,43 @@ impl Match {
         Ok(())
     }
 
-    /// Bind a term to a value. For named variables, stores the value in
-    /// the bindings map; checks consistency if already bound. Constants
-    /// and blanks are no-ops.
+    /// Bind a term to a [`Binding::Present`] value. For named
+    /// variables, stores the value in the bindings map; checks
+    /// consistency if already bound:
+    ///
+    /// - existing `Present` with the same value is OK (idempotent).
+    /// - existing `Present` with a different value conflicts.
+    /// - existing `Absent` conflicts with an incoming `Present`.
+    ///
+    /// Constants and blanks are no-ops.
     pub fn bind(&mut self, term: &Term<Any>, value: Value) -> Result<(), EvaluationError> {
         match term {
             Term::Variable {
                 name: Some(name), ..
             } => {
                 if let Some(existing) = self.bindings.get(name) {
-                    if *existing != value {
-                        Err(EvaluationError::Assignment {
+                    match existing {
+                        Binding::Present(existing_value) => {
+                            if *existing_value != value {
+                                Err(EvaluationError::Assignment {
+                                    reason: format!(
+                                        "Can not set {:?} to {:?} because it is already set to {:?}.",
+                                        name, value, existing_value
+                                    ),
+                                })
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        Binding::Absent => Err(EvaluationError::Assignment {
                             reason: format!(
-                                "Can not set {:?} to {:?} because it is already set to {:?}.",
-                                name, value, existing
+                                "Can not set {:?} to {:?} because it is already bound to Absent.",
+                                name, value
                             ),
-                        })
-                    } else {
-                        Ok(())
+                        }),
                     }
                 } else {
-                    self.bindings.insert(name.into(), value);
+                    self.bindings.insert(name.into(), Binding::Present(value));
                     Ok(())
                 }
             }
@@ -104,7 +196,37 @@ impl Match {
         }
     }
 
-    /// Returns true if the parameter is bound in this match.
+    /// Bind a term to [`Binding::Absent`]. Used by optional
+    /// resolution premises that looked up an attribute and found
+    /// no fact. Errors if the variable is already bound to a
+    /// `Present` value. Constants and blanks are no-ops.
+    pub fn bind_absent(&mut self, term: &Term<Any>) -> Result<(), EvaluationError> {
+        match term {
+            Term::Variable {
+                name: Some(name), ..
+            } => {
+                if let Some(existing) = self.bindings.get(name) {
+                    match existing {
+                        Binding::Absent => Ok(()),
+                        Binding::Present(value) => Err(EvaluationError::Assignment {
+                            reason: format!(
+                                "Can not set {:?} to Absent because it is already set to {:?}.",
+                                name, value
+                            ),
+                        }),
+                    }
+                } else {
+                    self.bindings.insert(name.into(), Binding::Absent);
+                    Ok(())
+                }
+            }
+            Term::Variable { name: None, .. } | Term::Constant(_) => Ok(()),
+        }
+    }
+
+    /// Returns `true` iff the term is bound (Present *or* Absent)
+    /// in this match. Use [`Self::is_present`] to check for
+    /// `Present`-only.
     pub fn contains(&self, term: &Term<Any>) -> bool {
         match term {
             Term::Variable {
@@ -115,17 +237,40 @@ impl Match {
         }
     }
 
-    /// Look up the value bound to a term.
+    /// Returns `true` iff the term is bound to a `Present` value
+    /// (excluding `Absent`). Constants always count as Present.
+    pub fn is_present(&self, term: &Term<Any>) -> bool {
+        match term {
+            Term::Variable {
+                name: Some(key), ..
+            } => self
+                .bindings
+                .get(key)
+                .map(|b| b.is_present())
+                .unwrap_or(false),
+            Term::Variable { name: None, .. } => false,
+            Term::Constant(_) => true,
+        }
+    }
+
+    /// Look up the binding for a term.
     ///
-    /// For variables, looks up the binding. For constants, returns the
-    /// constant value. Returns an error if the variable is not bound.
-    pub fn lookup(&self, term: &Term<Any>) -> Result<Value, EvaluationError> {
+    /// For named variables, returns the binding (Present or
+    /// Absent). For constants, returns `Present(value)`. Returns
+    /// [`EvaluationError::UnboundVariable`] for blank variables
+    /// or for named variables that no premise has touched.
+    ///
+    /// Callers that want a `Value` should chain
+    /// `.lookup(&term)?.content()` to convert `Absent` into an
+    /// error. Callers that handle optionality (Coalesce, optional
+    /// realize) pattern-match on `Binding` directly.
+    pub fn lookup(&self, term: &Term<Any>) -> Result<Binding, EvaluationError> {
         match term {
             Term::Variable {
                 name: Some(key), ..
             } => {
-                if let Some(value) = self.bindings.get(key) {
-                    Ok(value.clone())
+                if let Some(binding) = self.bindings.get(key) {
+                    Ok(binding.clone())
                 } else {
                     Err(EvaluationError::UnboundVariable {
                         variable_name: key.clone(),
@@ -135,7 +280,108 @@ impl Match {
             Term::Variable { name: None, .. } => Err(EvaluationError::UnboundVariable {
                 variable_name: "_".into(),
             }),
-            Term::Constant(value) => Ok(value.clone()),
+            Term::Constant(value) => Ok(Binding::Present(value.clone())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::Value;
+
+    #[test]
+    fn binding_content_returns_value_for_present() {
+        let b = Binding::Present(Value::String("hello".into()));
+        assert_eq!(b.content(), Ok(Value::String("hello".into())));
+    }
+
+    #[test]
+    fn binding_content_errors_on_absent() {
+        let b = Binding::Absent;
+        match b.content() {
+            Err(EvaluationError::Absent { variable_name }) => {
+                assert_eq!(variable_name, "_");
+            }
+            other => panic!("expected Absent error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn binding_content_for_attaches_variable_name() {
+        let b = Binding::Absent;
+        match b.content_for(Some("nickname")) {
+            Err(EvaluationError::Absent { variable_name }) => {
+                assert_eq!(variable_name, "nickname");
+            }
+            other => panic!("expected Absent error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn binding_predicates() {
+        assert!(Binding::Present(Value::UnsignedInt(0)).is_present());
+        assert!(!Binding::Present(Value::UnsignedInt(0)).is_absent());
+        assert!(Binding::Absent.is_absent());
+        assert!(!Binding::Absent.is_present());
+    }
+
+    #[test]
+    fn match_bind_absent_creates_absent_binding() {
+        let mut m = Match::new();
+        let term = Term::var("nickname");
+        m.bind_absent(&term).unwrap();
+        assert_eq!(m.lookup(&term).unwrap(), Binding::Absent);
+    }
+
+    #[test]
+    fn match_bind_then_bind_absent_conflicts() {
+        let mut m = Match::new();
+        let term = Term::var("name");
+        m.bind(&term, Value::String("Alice".into())).unwrap();
+        let result = m.bind_absent(&term);
+        assert!(matches!(result, Err(EvaluationError::Assignment { .. })));
+    }
+
+    #[test]
+    fn match_bind_absent_then_bind_conflicts() {
+        let mut m = Match::new();
+        let term = Term::var("name");
+        m.bind_absent(&term).unwrap();
+        let result = m.bind(&term, Value::String("Alice".into()));
+        assert!(matches!(result, Err(EvaluationError::Assignment { .. })));
+    }
+
+    #[test]
+    fn match_bind_absent_is_idempotent() {
+        let mut m = Match::new();
+        let term = Term::var("nickname");
+        m.bind_absent(&term).unwrap();
+        m.bind_absent(&term).unwrap();
+        assert_eq!(m.lookup(&term).unwrap(), Binding::Absent);
+    }
+
+    #[test]
+    fn match_lookup_unbound_returns_unbound_error() {
+        let m = Match::new();
+        match m.lookup(&Term::var("nope")) {
+            Err(EvaluationError::UnboundVariable { variable_name }) => {
+                assert_eq!(variable_name, "nope");
+            }
+            other => panic!("expected UnboundVariable, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn match_is_present_distinguishes_present_from_absent() {
+        let mut m = Match::new();
+        let pname = Term::var("name");
+        let nname = Term::var("nickname");
+        m.bind(&pname, Value::String("Alice".into())).unwrap();
+        m.bind_absent(&nname).unwrap();
+        assert!(m.is_present(&pname));
+        assert!(!m.is_present(&nname));
+        assert!(m.contains(&pname));
+        assert!(m.contains(&nname));
     }
 }

--- a/rust/dialog-query/src/selection/match.rs
+++ b/rust/dialog-query/src/selection/match.rs
@@ -290,13 +290,13 @@ mod tests {
     use super::*;
     use crate::artifact::Value;
 
-    #[test]
+    #[dialog_common::test]
     fn binding_content_returns_value_for_present() {
         let b = Binding::Present(Value::String("hello".into()));
         assert_eq!(b.content(), Ok(Value::String("hello".into())));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn binding_content_errors_on_absent() {
         let b = Binding::Absent;
         match b.content() {
@@ -307,7 +307,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn binding_content_for_attaches_variable_name() {
         let b = Binding::Absent;
         match b.content_for(Some("nickname")) {
@@ -318,7 +318,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn binding_predicates() {
         assert!(Binding::Present(Value::UnsignedInt(0)).is_present());
         assert!(!Binding::Present(Value::UnsignedInt(0)).is_absent());
@@ -326,7 +326,7 @@ mod tests {
         assert!(!Binding::Absent.is_present());
     }
 
-    #[test]
+    #[dialog_common::test]
     fn match_bind_absent_creates_absent_binding() {
         let mut m = Match::new();
         let term = Term::var("nickname");
@@ -334,7 +334,7 @@ mod tests {
         assert_eq!(m.lookup(&term).unwrap(), Binding::Absent);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn match_bind_then_bind_absent_conflicts() {
         let mut m = Match::new();
         let term = Term::var("name");
@@ -343,7 +343,7 @@ mod tests {
         assert!(matches!(result, Err(EvaluationError::Assignment { .. })));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn match_bind_absent_then_bind_conflicts() {
         let mut m = Match::new();
         let term = Term::var("name");
@@ -352,7 +352,7 @@ mod tests {
         assert!(matches!(result, Err(EvaluationError::Assignment { .. })));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn match_bind_absent_is_idempotent() {
         let mut m = Match::new();
         let term = Term::var("nickname");
@@ -361,7 +361,7 @@ mod tests {
         assert_eq!(m.lookup(&term).unwrap(), Binding::Absent);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn match_lookup_unbound_returns_unbound_error() {
         let m = Match::new();
         match m.lookup(&Term::var("nope")) {
@@ -372,7 +372,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn match_is_present_distinguishes_present_from_absent() {
         let mut m = Match::new();
         let pname = Term::var("name");

--- a/rust/dialog-query/src/session.rs
+++ b/rust/dialog-query/src/session.rs
@@ -61,7 +61,7 @@ mod tests {
         }
         let session = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
-        let person = ConceptDescriptor::from([
+        let person = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -80,7 +80,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let name_param = Term::var("name");
         let age_param = Term::var("age");
@@ -147,7 +148,7 @@ mod tests {
             ),
         );
 
-        let person = ConceptDescriptor::from(attributes);
+        let person = ConceptDescriptor::try_from(attributes).unwrap();
 
         // Mixed case - valid parameters with some matching attributes (should succeed)
         let mut mixed_params = Parameters::new();
@@ -165,7 +166,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
 
-        let person = ConceptDescriptor::from([
+        let person = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -184,7 +185,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let alice = person
             .create()
@@ -291,7 +293,7 @@ mod tests {
         }
 
         // employee can be derived from the stuff concept
-        let employee_predicate: ConceptDescriptor = Query::<Employee>::default().into();
+        let employee_predicate: ConceptDescriptor = Employee::descriptor().clone();
         let employee_from_stuff = DeductiveRule::new(
             employee_predicate,
             vec![
@@ -320,7 +322,7 @@ mod tests {
         let mut rules = RuleRegistry::new();
         rules.register(employee_from_stuff)?;
 
-        let stuff_predicate: ConceptDescriptor = Query::<Stuff>::default().into();
+        let stuff_predicate: ConceptDescriptor = Stuff::descriptor().clone();
         let alice = stuff_predicate
             .create()
             .with("name", "Alice".to_string())
@@ -443,7 +445,7 @@ mod tests {
 
         // Replicate Session::install logic for RuleRegistry
         let query = Query::<Employee>::default();
-        let concept: ConceptDescriptor = query.clone().into();
+        let concept: ConceptDescriptor = Employee::descriptor().clone();
         let when = employee_from_stuff(query).into_premises();
         let premises = when.into_vec();
         let install_rule =
@@ -454,7 +456,7 @@ mod tests {
         rules.register(install_rule)?;
 
         // Create test data as Stuff
-        let stuff_predicate: ConceptDescriptor = Query::<Stuff>::default().into();
+        let stuff_predicate: ConceptDescriptor = Stuff::descriptor().clone();
         let alice = stuff_predicate
             .create()
             .with("name", "Alice".to_string())
@@ -533,7 +535,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let _branch = repo.branch("main").open().perform(&operator).await?;
 
-        let adult_conclusion = ConceptDescriptor::from(vec![
+        let adult_conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -552,7 +554,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let rule = DeductiveRule::from(&adult_conclusion);
 
@@ -577,7 +580,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -585,7 +588,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let rule = DeductiveRule::from(&concept);
 
         // Test with RuleRegistry + TestEnv
@@ -605,7 +609,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let _branch = repo.branch("main").open().perform(&operator).await?;
 
-        let adult_concept = ConceptDescriptor::from([(
+        let adult_concept = ConceptDescriptor::try_from([(
             "name".to_string(),
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -613,7 +617,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let adult_rule = DeductiveRule::from(&adult_concept);
 
@@ -684,7 +689,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
         let query_m = Query::<MatchingNote>::default();
-        let concept_m: ConceptDescriptor = query_m.clone().into();
+        let concept_m: ConceptDescriptor = MatchingNote::descriptor().clone();
         let when_m = matching_notes(query_m).into_premises();
         let rule_m = DeductiveRule::new(concept_m, when_m.into_vec()).map_err(|e| {
             EvaluationError::Planning {
@@ -783,7 +788,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
         let query_n = Query::<NonDraftNote>::default();
-        let concept_n: ConceptDescriptor = query_n.clone().into();
+        let concept_n: ConceptDescriptor = NonDraftNote::descriptor().clone();
         let when_n = non_draft_notes(query_n).into_premises();
         let rule_n = DeductiveRule::new(concept_n, when_n.into_vec()).map_err(|e| {
             EvaluationError::Planning {
@@ -889,7 +894,7 @@ mod tests {
         // Install the rule using the clean API - no turbofish needed!
         // The type inference works: Employee is inferred from the function parameter
         let query_e = Query::<Employee>::default();
-        let concept_e: ConceptDescriptor = query_e.clone().into();
+        let concept_e: ConceptDescriptor = Employee::descriptor().clone();
         let when_e = employee_with_implicit_title(query_e).into_premises();
         let rule_e = DeductiveRule::new(concept_e, when_e.into_vec()).map_err(|e| {
             EvaluationError::Planning {
@@ -956,7 +961,7 @@ mod tests {
 
     /// Helper: build a person concept predicate with name and age attributes.
     fn person_concept() -> ConceptDescriptor {
-        ConceptDescriptor::from([
+        ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -976,6 +981,7 @@ mod tests {
                 ),
             ),
         ])
+        .unwrap()
     }
 
     #[dialog_common::test]
@@ -1066,10 +1072,11 @@ mod tests {
         let plan_before = person_rules.plan(&terms, &candidate);
 
         // Install a rule for a DIFFERENT concept entity
-        let unrelated = ConceptDescriptor::from([(
+        let unrelated = ConceptDescriptor::try_from([(
             "title",
             AttributeDescriptor::new(the!("book/title"), "", Cardinality::One, Some(Type::String)),
-        )]);
+        )])
+        .unwrap();
         let rule = DeductiveRule::from(&unrelated);
         registry.register(rule).unwrap();
 

--- a/rust/dialog-query/src/session.rs
+++ b/rust/dialog-query/src/session.rs
@@ -102,8 +102,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let person_name = match_result.lookup(&name_param)?;
-            let person_age = match_result.lookup(&age_param)?;
+            let person_name = match_result.lookup(&name_param)?.content()?;
+            let person_age = match_result.lookup(&age_param)?.content()?;
 
             match person_name {
                 Value::String(name_str) if name_str == "Alice" => {
@@ -227,8 +227,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let person_name = match_result.lookup(&name_param)?;
-            let person_age = match_result.lookup(&age_param)?;
+            let person_name = match_result.lookup(&name_param)?.content()?;
+            let person_age = match_result.lookup(&age_param)?.content()?;
 
             match person_name {
                 Value::String(name_str) if name_str == "Alice" => {
@@ -1294,12 +1294,12 @@ mod tests {
 
         assert_eq!(results.len(), 1, "Should find exactly one person (Alice)");
         assert_eq!(
-            results[0].lookup(&name_param)?,
+            results[0].lookup(&name_param)?.content()?,
             Value::String("Alice".into()),
             "Should resolve to Alice"
         );
         assert_eq!(
-            results[0].lookup(&age_param)?,
+            results[0].lookup(&age_param)?.content()?,
             Value::UnsignedInt(30),
             "Should have Alice's age"
         );

--- a/rust/dialog-query/src/session/rule_registry.rs
+++ b/rust/dialog-query/src/session/rule_registry.rs
@@ -103,7 +103,7 @@ mod tests {
     use crate::the;
 
     fn person_concept() -> ConceptDescriptor {
-        ConceptDescriptor::from([(
+        ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -112,6 +112,7 @@ mod tests {
                 Some(Type::String),
             ),
         )])
+        .unwrap()
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -18,7 +18,7 @@ use crate::Environment;
 use crate::Premise;
 use crate::artifact::{ArtifactsAttribute, Entity, Type, Value};
 use crate::attribute::The;
-use crate::constraint::{Constraint, Equality};
+use crate::constraint::{Coalesce, Constraint, Equality};
 use crate::error::{FieldTypeError, TypeError};
 use crate::proposition::Proposition;
 use crate::selection;
@@ -453,6 +453,53 @@ impl<U: Scalar> From<&Term<Option<U>>> for Term<Any> {
     }
 }
 
+/// Builder for a [`Coalesce`](crate::constraint::Coalesce)
+/// constraint. Produced by
+/// [`Term::<Option<U>>::unwrap_or`](Term::unwrap_or); finalized
+/// by [`UnwrapOr::is`].
+///
+/// The type parameter `U` is the inner scalar type — the source
+/// term has kind `Option<U>` and the fallback has kind `U`. The
+/// final output term passed to `is` must also have kind `U`,
+/// guaranteed by the `impl Into<Term<U>>` bound.
+pub struct UnwrapOr<U: Scalar> {
+    source: Term<Option<U>>,
+    fallback: Term<U>,
+}
+
+impl<U: Scalar> Term<Option<U>> {
+    /// Begin building a `Coalesce` constraint. Returns a builder
+    /// that completes when `.is(output)` is called.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let nickname: Term<Option<String>> = Term::var("nickname");
+    /// let display_name: Term<String> = Term::var("display_name");
+    /// let coalesce = nickname.unwrap_or("Anon").is(display_name);
+    /// ```
+    pub fn unwrap_or<F: Into<Term<U>>>(self, fallback: F) -> UnwrapOr<U> {
+        UnwrapOr {
+            source: self,
+            fallback: fallback.into(),
+        }
+    }
+}
+
+impl<U: Scalar> UnwrapOr<U> {
+    /// Bind the output term, producing a finished
+    /// [`Coalesce`](crate::constraint::Coalesce) constraint
+    /// wrapped in a [`Premise`] ready to drop into a rule body.
+    pub fn is<O: Into<Term<U>>>(self, output: O) -> Premise {
+        let source: Term<Any> = self.source.into();
+        let fallback: Term<Any> = self.fallback.into();
+        let is: Term<Any> = output.into().into();
+        Premise::Assert(Proposition::Constraint(Constraint::Coalesce(
+            Coalesce::new(source, fallback, is),
+        )))
+    }
+}
+
 /// Methods specific to `Term<Any>` — the dynamically-typed term.
 impl Term<Any> {
     /// Create a named variable with a specific type constraint.
@@ -680,6 +727,34 @@ mod tests {
         };
         assert_eq!(c, d);
         assert_eq!(hash_of(&c), hash_of(&d));
+    }
+
+    /// The `unwrap_or(...).is(...)` builder yields a Premise
+    /// containing a `Constraint::Coalesce` with the three slots
+    /// wired correctly. `U`'s static type enforces the source's
+    /// inner type, the fallback's type, and the output's type
+    /// must all match — call sites with type mismatches fail to
+    /// compile.
+    #[dialog_common::test]
+    fn it_builds_coalesce_via_unwrap_or() {
+        let nickname: Term<Option<String>> = Term::var("nickname");
+        let display: Term<String> = Term::var("display");
+        let premise = nickname.unwrap_or("Anon").is(display);
+
+        match premise {
+            Premise::Assert(Proposition::Constraint(Constraint::Coalesce(c))) => {
+                assert_eq!(c.source.name(), Some("nickname"));
+                assert_eq!(c.is.name(), Some("display"));
+                match &c.fallback {
+                    Term::Constant(Value::String(s)) => assert_eq!(s, "Anon"),
+                    other => panic!("expected fallback constant, got {:?}", other),
+                }
+            }
+            other => panic!(
+                "expected Premise::Assert(Constraint::Coalesce), got {:?}",
+                other
+            ),
+        }
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -648,6 +648,14 @@ impl<'de, T: Typed> serde::Deserialize<'de> for Term<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash as HashTrait, Hasher};
+
+    fn hash_of<T: HashTrait>(t: &T) -> u64 {
+        let mut h = DefaultHasher::new();
+        t.hash(&mut h);
+        h.finish()
+    }
 
     /// Two `Term<Any>` values constructed with the same name in
     /// independent calls hash to the same value. This is the
@@ -655,15 +663,6 @@ mod tests {
     /// rule registries) depend on.
     #[dialog_common::test]
     fn it_hashes_equivalent_terms_to_same_value() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        fn hash_of<T: Hash>(t: &T) -> u64 {
-            let mut h = DefaultHasher::new();
-            t.hash(&mut h);
-            h.finish()
-        }
-
         let a: Term<Any> = Term::var("x");
         let b: Term<Any> = Term::var("x");
         assert_eq!(a, b, "structurally equivalent terms must compare equal");
@@ -675,11 +674,11 @@ mod tests {
 
         let c: Term<Any> = Term::Variable {
             name: Some("x".into()),
-            descriptor: Some(crate::artifact::Type::String).into(),
+            descriptor: Some(Type::String).into(),
         };
         let d: Term<Any> = Term::Variable {
             name: Some("x".into()),
-            descriptor: Some(crate::artifact::Type::String).into(),
+            descriptor: Some(Type::String).into(),
         };
         assert_eq!(c, d);
         assert_eq!(hash_of(&c), hash_of(&d));

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -202,6 +202,13 @@ impl<T: Typed> Term<T> {
         self.kind().and_then(|k| k.as_value_type())
     }
 
+    /// Returns `true` iff this term's kind admits the `Nothing`
+    /// atom — i.e. the slot is set-widened. Untyped terms (no
+    /// kind) return `false`.
+    pub fn is_optional(&self) -> bool {
+        self.kind().is_some_and(|k| k.is_optional())
+    }
+
     /// Get the constant value if this term is a constant.
     ///
     /// Returns None for variables.
@@ -504,15 +511,15 @@ impl<U: Scalar> UnwrapOr<U> {
 
 /// Methods specific to `Term<Any>` — the dynamically-typed term.
 impl Term<Any> {
-    /// Create a named variable with a specific type constraint.
+    /// Create a named variable with a specific type kind.
     ///
     /// Use `Term::<Any>::var("x")` for an untyped variable
     /// (inherited from `impl<T: Typed> Term<T>`). Use this method
     /// when you need a runtime type kind.
-    pub fn typed_var(name: impl Into<String>, kind: Option<type_system::Type>) -> Self {
+    pub fn typed_var(name: impl Into<String>, kind: type_system::Type) -> Self {
         Term::Variable {
             name: Some(name.into()),
-            descriptor: Any(kind),
+            descriptor: Any(Some(kind)),
         }
     }
 
@@ -1144,8 +1151,7 @@ mod tests {
     fn it_displays_any_correctly() {
         assert_eq!(Term::<Any>::blank().to_string(), "_");
         assert_eq!(
-            Term::<Any>::typed_var("x", Some(type_system::Type::primitive(Type::String)))
-                .to_string(),
+            Term::<Any>::typed_var("x", type_system::Type::primitive(Type::String)).to_string(),
             "?x<String>"
         );
         assert_eq!(Term::<Any>::var("y").to_string(), "?y<Value>");

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -426,20 +426,21 @@ impl<T: Scalar> From<&Term<T>> for Term<Any> {
     }
 }
 
-/// Type-erase a `Term<Option<U>>` to `Term<Any>`. Optionality is
-/// a Rust-API distinction; at evaluation time the value flows
+/// Type-erase a `Term<Option<U>>` to `Term<Any>`. The descriptor
+/// is widened to carry the `Nothing` bit so that downstream
+/// type-checking (e.g. `Coalesce::validate`) can recognize the
+/// term as set-widened. At evaluation time the value flows
 /// through the same `Term<Any>` path as any other term, with the
 /// row-layer [`Binding::Absent`](crate::Binding::Absent) carrying
-/// the absence signal. The descriptor's storage tag is preserved
-/// from the inner type — `Term<Option<String>>` erases to a
-/// `Term<Any>` whose descriptor reports
-/// `Some(Type::String)`.
+/// the absence signal at runtime.
 impl<U: Scalar> From<Term<Option<U>>> for Term<Any> {
     fn from(term: Term<Option<U>>) -> Self {
         match term {
             Term::Variable { name, .. } => Term::Variable {
                 name,
-                descriptor: Any(<<U as Typed>::Descriptor>::default().kind()),
+                descriptor: Any(<<U as Typed>::Descriptor>::default()
+                    .kind()
+                    .map(|k| k.optional())),
             },
             Term::Constant(value) => Term::Constant(value),
         }
@@ -749,11 +750,44 @@ mod tests {
                     Term::Constant(Value::String(s)) => assert_eq!(s, "Anon"),
                     other => panic!("expected fallback constant, got {:?}", other),
                 }
+                // The source's erased kind must preserve the
+                // Nothing bit so downstream type-checking can
+                // recognize it as set-widened. Without this,
+                // Coalesce::validate would reject the builder's
+                // own output with `SourceNotOptional`.
+                let source_kind = c.source.kind().expect("erased source has a kind");
+                assert!(
+                    source_kind.is_optional(),
+                    "Term<Option<String>>::into::<Term<Any>>() must preserve Nothing"
+                );
             }
             other => panic!(
                 "expected Premise::Assert(Constraint::Coalesce), got {:?}",
                 other
             ),
+        }
+    }
+
+    /// The erased Coalesce from the typed builder passes
+    /// `Coalesce::validate` against a fresh unifier context.
+    /// This is the regression test for the bug where the
+    /// `Term<Option<U>> -> Term<Any>` conversion stripped the
+    /// Nothing bit.
+    #[dialog_common::test]
+    fn it_validates_builder_coalesce_end_to_end() {
+        use crate::type_system::unifier::Context;
+
+        let nickname: Term<Option<String>> = Term::var("nickname");
+        let display: Term<String> = Term::var("display");
+        let premise = nickname.unwrap_or("Anon").is(display);
+
+        match premise {
+            Premise::Assert(Proposition::Constraint(Constraint::Coalesce(c))) => {
+                let mut ctx = Context::new();
+                c.validate(&mut ctx)
+                    .expect("builder-produced Coalesce must validate");
+            }
+            other => panic!("expected Constraint::Coalesce, got {:?}", other),
         }
     }
 

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -474,10 +474,11 @@ impl<U: Scalar> Term<Option<U>> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use dialog_query::Term;
     /// let nickname: Term<Option<String>> = Term::var("nickname");
     /// let display_name: Term<String> = Term::var("display_name");
-    /// let coalesce = nickname.unwrap_or("Anon").is(display_name);
+    /// let premise = nickname.unwrap_or("Anon").is(display_name);
     /// ```
     pub fn unwrap_or<F: Into<Term<U>>>(self, fallback: F) -> UnwrapOr<U> {
         UnwrapOr {

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -187,7 +187,7 @@ impl<T: Typed> Term<T> {
     ///
     /// For variables: delegates to the descriptor's `kind()`.
     /// For constants: lifts the stored value's type into a
-    /// `Type::Definite(Primitive(...))`.
+    /// singleton [`type_system::Type::Primitive`].
     pub fn kind(&self) -> Option<type_system::Type> {
         match self {
             Term::Variable { descriptor, .. } => descriptor.kind(),
@@ -195,11 +195,11 @@ impl<T: Typed> Term<T> {
         }
     }
 
-    /// Legacy view: collapse the unified kind to its singleton
-    /// primitive. Returns `None` for unknown or non-singleton
-    /// shapes.
+    /// Legacy storage-codec view: collapse the unified kind to its
+    /// singleton primitive. Returns `None` for unknown or
+    /// non-singleton shapes.
     pub fn content_type(&self) -> Option<Type> {
-        self.kind().and_then(|k| k.shape().as_singleton())
+        self.kind().and_then(|k| k.as_value_type())
     }
 
     /// Get the constant value if this term is a constant.
@@ -265,7 +265,7 @@ where
                 name: Some(name),
                 descriptor,
             } => {
-                if let Some(data_type) = descriptor.kind().and_then(|k| k.shape().as_singleton()) {
+                if let Some(data_type) = descriptor.kind().and_then(|k| k.as_value_type()) {
                     write!(f, "?{}<{:?}>", name, data_type)
                 } else {
                     write!(f, "?{}<Value>", name)
@@ -563,13 +563,17 @@ impl<T: Scalar> From<Term<T>> for Term<Value> {
     }
 }
 
-/// Serde helper for the variable inner object: `{"name": "x", "type": "Text"}`.
+/// Serde helper for the variable inner object: `{"name": "x", "type": <type_system::Type>}`.
+///
+/// The `type` field carries the full unified [`type_system::Type`]
+/// rather than a legacy [`ValueType`](Type) — `None` denotes an
+/// "untyped" variable.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct VarInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    content_type: Option<Type>,
+    content_type: Option<type_system::Type>,
 }
 
 /// Serde helper enum for `Term<T>`.
@@ -592,17 +596,12 @@ impl<T: Typed> serde::Serialize for Term<T> {
         let repr = match self {
             Term::Variable {
                 name, descriptor, ..
-            } => {
-                // Wire format collapses to legacy Option<ValueType>;
-                // the rich kind is not transmitted today.
-                let content_type = descriptor.kind().and_then(|k| k.shape().as_singleton());
-                TermRepr::Variable {
-                    var: VarInfo {
-                        name: name.clone(),
-                        content_type,
-                    },
-                }
-            }
+            } => TermRepr::Variable {
+                var: VarInfo {
+                    name: name.clone(),
+                    content_type: descriptor.kind(),
+                },
+            },
             Term::Constant(value) => TermRepr::Constant(value.clone()),
         };
         repr.serialize(serializer)
@@ -619,10 +618,9 @@ impl<'de, T: Typed> serde::Deserialize<'de> for Term<T> {
             serde_json::Value::Object(map) if map.contains_key("?") => {
                 let var: VarInfo =
                     serde_json::from_value(map["?"].clone()).map_err(DeserializeError::custom)?;
-                let kind = var.content_type.map(type_system::Type::primitive);
                 Ok(Term::Variable {
                     name: var.name,
-                    descriptor: <T as Typed>::Descriptor::from_kind(kind),
+                    descriptor: <T as Typed>::Descriptor::from_kind(var.content_type),
                 })
             }
             serde_json::Value::Number(n) => {
@@ -921,9 +919,13 @@ mod tests {
             descriptor: Some(Type::String).into(),
         };
         let json = serde_json::to_value(&param).unwrap();
+        // The wire format now carries the full unified type;
+        // a singleton String primitive serializes as the bitfield.
+        let expected_type = serde_json::to_value(type_system::Type::primitive(Type::String))
+            .expect("type serializes");
         assert_eq!(
             json,
-            serde_json::json!({"?": {"name": "x", "type": "Text"}})
+            serde_json::json!({"?": {"name": "x", "type": expected_type}})
         );
     }
 
@@ -953,9 +955,12 @@ mod tests {
 
     #[dialog_common::test]
     fn it_deserializes_any_with_type() {
-        let json = serde_json::json!({"?": {"name": "x", "type": "Text"}});
+        let type_value = serde_json::to_value(type_system::Type::primitive(Type::String))
+            .expect("type serializes");
+        let json = serde_json::json!({"?": {"name": "x", "type": type_value}});
         let param: Term<Any> = serde_json::from_value(json).unwrap();
         assert_eq!(param.name(), Some("x"));
+        assert_eq!(param.content_type(), Some(Type::String));
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -22,6 +22,7 @@ use crate::constraint::{Constraint, Equality};
 use crate::error::{FieldTypeError, TypeError};
 use crate::proposition::Proposition;
 use crate::selection;
+use crate::type_system;
 use crate::types::{Any, Scalar, TypeDescriptor, Typed};
 use serde::de::Error as DeserializeError;
 use std::hash::Hash;
@@ -182,19 +183,23 @@ impl<T: Typed> Term<T> {
         }
     }
 
-    /// Get the content type for this term.
+    /// Get the unified type kind for this term.
     ///
-    /// For variables: returns the type from the descriptor. For concrete
-    /// typed terms this is always `Some(Type::...)`. For `Any` it
-    /// depends on the runtime tag.
-    ///
-    /// For constants: inspects the stored `Value` to determine the type.
-    pub fn content_type(&self) -> Option<Type> {
+    /// For variables: delegates to the descriptor's `kind()`.
+    /// For constants: lifts the stored value's type into a
+    /// `Type::Definite(Primitive(...))`.
+    pub fn kind(&self) -> Option<type_system::Type> {
         match self {
-            Term::Variable { descriptor, .. } => <<T as Typed>::Descriptor as TypeDescriptor>::TYPE
-                .or_else(|| descriptor.content_type()),
-            Term::Constant(value) => Some(Type::from(value)),
+            Term::Variable { descriptor, .. } => descriptor.kind(),
+            Term::Constant(value) => Some(type_system::Type::primitive(Type::from(value))),
         }
+    }
+
+    /// Legacy view: collapse the unified kind to its singleton
+    /// primitive. Returns `None` for unknown or non-singleton
+    /// shapes.
+    pub fn content_type(&self) -> Option<Type> {
+        self.kind().and_then(|k| k.shape().as_singleton())
     }
 
     /// Get the constant value if this term is a constant.
@@ -260,9 +265,7 @@ where
                 name: Some(name),
                 descriptor,
             } => {
-                if let Some(data_type) = <<T as Typed>::Descriptor as TypeDescriptor>::TYPE
-                    .or_else(|| descriptor.content_type())
-                {
+                if let Some(data_type) = descriptor.kind().and_then(|k| k.shape().as_singleton()) {
                     write!(f, "?{}<{:?}>", name, data_type)
                 } else {
                     write!(f, "?{}<Value>", name)
@@ -409,7 +412,7 @@ impl<T: Scalar> From<Term<T>> for Term<Any> {
         match term {
             Term::Variable { name, .. } => Term::Variable {
                 name,
-                descriptor: Any(<<T as Typed>::Descriptor as TypeDescriptor>::TYPE),
+                descriptor: Any(<<T as Typed>::Descriptor>::default().kind()),
             },
             Term::Constant(value) => Term::Constant(value),
         }
@@ -436,7 +439,7 @@ impl<U: Scalar> From<Term<Option<U>>> for Term<Any> {
         match term {
             Term::Variable { name, .. } => Term::Variable {
                 name,
-                descriptor: Any(<<U as Typed>::Descriptor as TypeDescriptor>::TYPE),
+                descriptor: Any(<<U as Typed>::Descriptor>::default().kind()),
             },
             Term::Constant(value) => Term::Constant(value),
         }
@@ -454,13 +457,13 @@ impl<U: Scalar> From<&Term<Option<U>>> for Term<Any> {
 impl Term<Any> {
     /// Create a named variable with a specific type constraint.
     ///
-    /// Use `Term::<Any>::var("x")` for an untyped variable (inherited from
-    /// `impl<T: Typed> Term<T>`). Use this method when you need a runtime
-    /// type tag.
-    pub fn typed_var(name: impl Into<String>, typ: Option<Type>) -> Self {
+    /// Use `Term::<Any>::var("x")` for an untyped variable
+    /// (inherited from `impl<T: Typed> Term<T>`). Use this method
+    /// when you need a runtime type kind.
+    pub fn typed_var(name: impl Into<String>, kind: Option<type_system::Type>) -> Self {
         Term::Variable {
             name: Some(name.into()),
-            descriptor: Any(typ),
+            descriptor: Any(kind),
         }
     }
 
@@ -479,10 +482,9 @@ impl Term<Any> {
 
     /// Narrow a `Term<Any>` to a concrete `Term<T>`.
     ///
-    /// Both variables and constants are validated: if the term carries a known
-    /// type (via the `Any` descriptor or the constant's value) and `T` has a
-    /// statically known type, they must match. Returns
-    /// [`FieldTypeError::TypeMismatch`] on incompatible types.
+    /// Both variables and constants are validated: if the term
+    /// carries a known type and `T` has a statically known type,
+    /// they must match.
     pub fn narrow<T: Typed>(self) -> Result<Term<T>, FieldTypeError> {
         let target = <<T as Typed>::Descriptor as TypeDescriptor>::TYPE;
         let source = self.content_type();
@@ -524,7 +526,7 @@ impl From<Term<Value>> for Term<Any> {
         match term {
             Term::Variable { name, .. } => Term::Variable {
                 name,
-                descriptor: Any(<<Value as Typed>::Descriptor as TypeDescriptor>::TYPE),
+                descriptor: Any(<<Value as Typed>::Descriptor>::default().kind()),
             },
             Term::Constant(value) => Term::Constant(value),
         }
@@ -591,8 +593,9 @@ impl<T: Typed> serde::Serialize for Term<T> {
             Term::Variable {
                 name, descriptor, ..
             } => {
-                let content_type = <<T as Typed>::Descriptor as TypeDescriptor>::TYPE
-                    .or_else(|| descriptor.content_type());
+                // Wire format collapses to legacy Option<ValueType>;
+                // the rich kind is not transmitted today.
+                let content_type = descriptor.kind().and_then(|k| k.shape().as_singleton());
                 TermRepr::Variable {
                     var: VarInfo {
                         name: name.clone(),
@@ -616,9 +619,10 @@ impl<'de, T: Typed> serde::Deserialize<'de> for Term<T> {
             serde_json::Value::Object(map) if map.contains_key("?") => {
                 let var: VarInfo =
                     serde_json::from_value(map["?"].clone()).map_err(DeserializeError::custom)?;
+                let kind = var.content_type.map(type_system::Type::primitive);
                 Ok(Term::Variable {
                     name: var.name,
-                    descriptor: <T as Typed>::Descriptor::from_content_type(var.content_type),
+                    descriptor: <T as Typed>::Descriptor::from_kind(kind),
                 })
             }
             serde_json::Value::Number(n) => {
@@ -644,6 +648,42 @@ impl<'de, T: Typed> serde::Deserialize<'de> for Term<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Two `Term<Any>` values constructed with the same name in
+    /// independent calls hash to the same value. This is the
+    /// stability guarantee that container caches (planner plans,
+    /// rule registries) depend on.
+    #[dialog_common::test]
+    fn it_hashes_equivalent_terms_to_same_value() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+
+        let a: Term<Any> = Term::var("x");
+        let b: Term<Any> = Term::var("x");
+        assert_eq!(a, b, "structurally equivalent terms must compare equal");
+        assert_eq!(
+            hash_of(&a),
+            hash_of(&b),
+            "structurally equivalent terms must hash to the same value"
+        );
+
+        let c: Term<Any> = Term::Variable {
+            name: Some("x".into()),
+            descriptor: Some(crate::artifact::Type::String).into(),
+        };
+        let d: Term<Any> = Term::Variable {
+            name: Some("x".into()),
+            descriptor: Some(crate::artifact::Type::String).into(),
+        };
+        assert_eq!(c, d);
+        assert_eq!(hash_of(&c), hash_of(&d));
+    }
 
     #[dialog_common::test]
     fn it_serializes_and_deserializes() {
@@ -830,7 +870,7 @@ mod tests {
             param,
             Term::Variable {
                 name: Some("name".into()),
-                descriptor: Any(Some(Type::String))
+                descriptor: Some(Type::String).into(),
             }
         );
     }
@@ -843,7 +883,7 @@ mod tests {
             param,
             Term::Variable {
                 name: None,
-                descriptor: Any(Some(Type::String))
+                descriptor: Some(Type::String).into(),
             }
         );
     }
@@ -863,7 +903,7 @@ mod tests {
             param,
             Term::Variable {
                 name: Some("entity".into()),
-                descriptor: Any(Some(Type::Entity))
+                descriptor: Some(Type::Entity).into(),
             }
         );
     }
@@ -879,7 +919,7 @@ mod tests {
     fn it_serializes_any_with_type() {
         let param: Term<Any> = Term::Variable {
             name: Some("x".into()),
-            descriptor: Any(Some(Type::String)),
+            descriptor: Some(Type::String).into(),
         };
         let json = serde_json::to_value(&param).unwrap();
         assert_eq!(
@@ -990,7 +1030,8 @@ mod tests {
     fn it_displays_any_correctly() {
         assert_eq!(Term::<Any>::blank().to_string(), "_");
         assert_eq!(
-            Term::<Any>::typed_var("x", Some(Type::String)).to_string(),
+            Term::<Any>::typed_var("x", Some(type_system::Type::primitive(Type::String)))
+                .to_string(),
             "?x<String>"
         );
         assert_eq!(Term::<Any>::var("y").to_string(), "?y<Value>");
@@ -1007,7 +1048,7 @@ mod tests {
 
         let variable: Term<Any> = Term::Variable {
             name: Some("x".into()),
-            descriptor: Any(Some(Type::String)),
+            descriptor: Some(Type::String).into(),
         };
         assert!(!variable.is_blank());
         assert!(!variable.is_constant());

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -104,12 +104,13 @@ where
         }
     }
 
-    /// Resolve this term against a match. If the term is a variable
-    /// bound in the match, returns a constant term with the bound value.
-    /// Otherwise returns the term unchanged.
+    /// Resolve this term against a match. If the term is a
+    /// variable bound to a [`Binding::Present`](crate::Binding::Present)
+    /// value, returns a constant term with the bound value.
+    /// Otherwise (unbound or `Absent`) returns the term unchanged.
     pub fn resolve(&self, source: &selection::Match) -> Self {
         let term: Term<Any> = self.clone().into();
-        match source.lookup(&term) {
+        match source.lookup(&term).and_then(|b| b.content()) {
             Ok(value) => {
                 if let Ok(converted) = T::try_from(value) {
                     Term::Constant(converted.into())

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -423,6 +423,33 @@ impl<T: Scalar> From<&Term<T>> for Term<Any> {
     }
 }
 
+/// Type-erase a `Term<Option<U>>` to `Term<Any>`. Optionality is
+/// a Rust-API distinction; at evaluation time the value flows
+/// through the same `Term<Any>` path as any other term, with the
+/// row-layer [`Binding::Absent`](crate::Binding::Absent) carrying
+/// the absence signal. The descriptor's storage tag is preserved
+/// from the inner type — `Term<Option<String>>` erases to a
+/// `Term<Any>` whose descriptor reports
+/// `Some(Type::String)`.
+impl<U: Scalar> From<Term<Option<U>>> for Term<Any> {
+    fn from(term: Term<Option<U>>) -> Self {
+        match term {
+            Term::Variable { name, .. } => Term::Variable {
+                name,
+                descriptor: Any(<<U as Typed>::Descriptor as TypeDescriptor>::TYPE),
+            },
+            Term::Constant(value) => Term::Constant(value),
+        }
+    }
+}
+
+/// Borrow form of the optional-to-Any erasure.
+impl<U: Scalar> From<&Term<Option<U>>> for Term<Any> {
+    fn from(term: &Term<Option<U>>) -> Self {
+        Term::<Any>::from(term.clone())
+    }
+}
+
 /// Methods specific to `Term<Any>` — the dynamically-typed term.
 impl Term<Any> {
     /// Create a named variable with a specific type constraint.

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -6,6 +6,14 @@
 //! [`Premise`](crate::Premise), [`DeductiveRule`](crate::DeductiveRule),
 //! and the schema layer.
 //!
+//! A [`Type`] is the set of admissible value shapes a slot may
+//! bind. It is built from a [`Primitive`] bitfield (the atomic
+//! shapes, plus a `Nothing` bit for set-widened optionality) and an
+//! optional set of [`Composite`] shapes (Product records, Variant
+//! tags). The two parts compose by set-union: a value satisfies
+//! [`Type`] iff it inhabits at least one of the primitive bits or
+//! one of the composite shapes.
+//!
 //! Type variables — used for compile-time unification of rules —
 //! live in the [`unifier`] submodule, never in the user-facing
 //! [`Type`]. This split lets the user-facing types derive
@@ -19,31 +27,51 @@ pub mod unifier;
 
 use crate::artifact::Type as ValueType;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
-/// A bitfield over [`ValueType`] variants — a set of admissible
-/// primitive shapes.
+/// A bitfield over [`ValueType`] variants plus a `Nothing` bit —
+/// the set of admissible primitive shapes.
 ///
 /// Used everywhere a "kind constraint" is needed: type variables
-/// declare their constraint as a `PrimitiveSet`, formula schemas
+/// declare their constraint as a `Primitive`, formula schemas
 /// declare per-variable constraints, and unification intersects
-/// them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct PrimitiveSet {
-    /// One bit per [`ValueType`] variant. Bit position is the
-    /// variant's discriminant in [`Self::bit_for`].
+/// them. The `Nothing` bit (position 9) is a synthetic atom with
+/// no corresponding [`ValueType`]; it marks "Absent" admissibility
+/// at the row layer — the new home for what used to be the outer
+/// `Optional` variant.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct Primitive {
+    /// One bit per [`ValueType`] variant (positions 0-8), plus a
+    /// `Nothing` bit at position 9.
     bits: u16,
 }
 
-impl PrimitiveSet {
-    /// Empty set — no admissible types. Constructible but
-    /// rejected at unification time (an empty set means
-    /// "no shape can satisfy this constraint").
+/// Bit position for the synthetic `Nothing` atom.
+const NOTHING_BIT: u16 = 1 << 9;
+
+impl Primitive {
+    /// Empty set — no admissible shapes. Rejected at unification
+    /// time.
     pub const EMPTY: Self = Self { bits: 0 };
 
-    /// Set containing every [`ValueType`] variant.
+    /// Every concrete [`ValueType`] variant, without `Nothing`.
+    /// This is the right default for constraint widening — a
+    /// variable that "accepts anything" still demands a Present
+    /// value.
     pub const ALL: Self = Self {
         bits: 0b1_1111_1111,
     };
+
+    /// Every shape including the `Nothing` atom — the broadest
+    /// possible set, including row-level absence.
+    pub const ANY: Self = Self {
+        bits: Self::ALL.bits | NOTHING_BIT,
+    };
+
+    /// Singleton set containing only the `Nothing` atom.
+    pub const NOTHING: Self = Self { bits: NOTHING_BIT };
 
     /// Numeric primitives: `UnsignedInt`, `SignedInt`, `Float`.
     pub const NUMERIC: Self = Self {
@@ -93,6 +121,16 @@ impl PrimitiveSet {
         self.bits == 0
     }
 
+    /// Returns `true` iff `vt` is a member of this set.
+    pub fn contains(self, vt: ValueType) -> bool {
+        (self.bits & Self::bit_for(vt)) != 0
+    }
+
+    /// Returns `true` iff the `Nothing` atom is a member.
+    pub fn contains_nothing(self) -> bool {
+        (self.bits & NOTHING_BIT) != 0
+    }
+
     /// Set intersection. Returns `None` iff the result is empty.
     pub fn intersect(self, other: Self) -> Option<Self> {
         let merged = Self {
@@ -117,23 +155,19 @@ impl PrimitiveSet {
         (self.bits & other.bits) == other.bits
     }
 
-    /// Returns `true` iff `vt` is a member of this set.
-    pub fn contains(self, vt: ValueType) -> bool {
-        (self.bits & Self::bit_for(vt)) != 0
-    }
-
-    /// If this set has exactly one member, return it.
+    /// If this set has exactly one `ValueType` member (and nothing
+    /// else, not even `Nothing`), return it. A `Nothing`-only set
+    /// returns `None` — it has no `ValueType`.
     pub fn as_singleton(self) -> Option<ValueType> {
-        let count = self.bits.count_ones();
-        if count != 1 {
+        if self.bits.count_ones() != 1 {
             return None;
         }
         let pos = self.bits.trailing_zeros();
         value_type_for_bit(pos)
     }
 
-    /// Iterate over the members of this set in `ValueType`
-    /// discriminant order.
+    /// Iterate the [`ValueType`] members in discriminant order.
+    /// Does **not** yield the `Nothing` atom.
     pub fn iter(self) -> impl Iterator<Item = ValueType> {
         let bits = self.bits;
         (0..9u32).filter_map(move |pos| {
@@ -161,7 +195,7 @@ fn value_type_for_bit(pos: u32) -> Option<ValueType> {
     })
 }
 
-impl From<ValueType> for PrimitiveSet {
+impl From<ValueType> for Primitive {
     fn from(vt: ValueType) -> Self {
         Self::singleton(vt)
     }
@@ -173,99 +207,202 @@ impl From<ValueType> for Type {
     }
 }
 
-/// Schema-layer type of a value, term, or schema slot.
+/// Schema-layer type — the set of admissible value shapes a slot
+/// can bind.
 ///
-/// Two outer variants distinguish set-widening (Optional) from
-/// concrete shapes (Definite). Optionality lives at the slot
-/// layer, never inside a [`Definite`]: this keeps "nested
-/// optionality" structurally unrepresentable.
+/// A [`Type`] is the union of two parts:
+///
+/// - A [`Primitive`] bitfield carrying atomic [`ValueType`] bits
+///   plus an optional `Nothing` atom (row-level absence).
+/// - An optional non-empty set of [`Composite`] shapes for
+///   structured values (records, variants).
+///
+/// Smart constructors enforce the invariant that
+/// `Composite(_, set)` always has `!set.is_empty()`; a request to
+/// build a composite with an empty set collapses to a plain
+/// `Primitive`.
+///
+/// Composites live in a [`BTreeSet`] rather than a [`HashSet`].
+/// Two reasons:
+///
+/// 1. `Type` derives [`Hash`]. `BTreeSet` iterates in a stable
+///    `Ord`-based order, so the derived hash is canonical:
+///    `Type::Composite(p, {a, b})` and `Type::Composite(p, {b, a})`
+///    have identical hashes. `HashSet` does not implement `Hash`
+///    in std, and any hand-rolled order-independent hash would
+///    have to sort internally anyway — `BTreeSet` is that already.
+///
+/// 2. Insertion order at construction never affects equality.
+///    Building the same set via different paths (different unions,
+///    different insert orders) yields equal [`Type`]s.
+///
+/// The cost is requiring [`Ord`] on [`Composite`], [`Type`], and
+/// [`Primitive`]. The ordering is structural plumbing — it has no
+/// semantic meaning (no claim that `u32 < String`); it exists only
+/// to keep the set canonical.
 ///
 /// `Type` is fully static — no type variables, no allocation
 /// state. Deriving [`PartialEq`]/[`Eq`]/[`Hash`] is safe and
 /// produces stable values for equivalent types.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
-    /// A definite shape. Subtype of `Optional(definite)` via the
-    /// `T ⊆ Optional<T>` set-widening rule.
-    Definite(Box<Definite>),
-    /// Set-widened: the wrapped shape *or*
-    /// [`Binding::Absent`](crate::Binding::Absent) at the row
-    /// layer. Wraps a [`Definite`] (not a [`Type`]) so nested
-    /// optionality is structurally impossible.
-    Optional(Box<Definite>),
+    /// Pure primitive set (no composite shapes admitted).
+    Primitive(Primitive),
+    /// Primitive set together with at least one composite shape.
+    /// Invariant: the composite set is never empty.
+    Composite(Primitive, BTreeSet<Composite>),
 }
 
-/// A concrete value shape — non-`Optional`. Static; type variables
-/// live in [`unifier::Type`], not here.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// A composite (structured) value shape. Ordered by derived
+/// [`Ord`] for stable iteration and hashing inside a [`BTreeSet`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum Definite {
-    /// Atomic value type, possibly a union over several primitive
-    /// shapes.
-    Primitive(PrimitiveSet),
-    /// Sum-type placeholder. Reserved for future use; not
-    /// constructed in current code paths.
-    Variant,
-    /// Product-type placeholder. Reserved for future use; not
-    /// constructed in current code paths.
-    Product,
+pub enum Composite {
+    /// Product (record) type with named fields. Field names ordered
+    /// by [`BTreeMap`] for stable equality and hashing.
+    Product(BTreeMap<String, Type>),
+    /// Sum-type variant carrying a single label and its payload.
+    Variant {
+        /// The discriminator label.
+        label: String,
+        /// The payload type for this label.
+        value: Type,
+    },
 }
 
 impl Type {
-    /// Construct a `Type::Definite(Primitive(singleton(vt)))`.
-    pub fn primitive(vt: ValueType) -> Self {
-        Type::Definite(Box::new(Definite::Primitive(PrimitiveSet::singleton(vt))))
+    /// Construct a [`Type::Primitive`] containing the single
+    /// `ValueType`.
+    pub fn primitive(vt: ValueType) -> Type {
+        Type::Primitive(Primitive::singleton(vt))
     }
 
-    /// Construct a `Type::Optional(Primitive(singleton(vt)))`.
-    pub fn optional(vt: ValueType) -> Self {
-        Type::Optional(Box::new(Definite::Primitive(PrimitiveSet::singleton(vt))))
+    /// Construct a [`Type::Primitive`] wrapping the given bitfield.
+    pub fn primitive_set(p: Primitive) -> Type {
+        Type::Primitive(p)
     }
 
-    /// Construct a `Type::Definite(Primitive(set))`.
-    pub fn primitive_set(set: PrimitiveSet) -> Self {
-        Type::Definite(Box::new(Definite::Primitive(set)))
+    /// The type whose only inhabitant is the `Nothing` atom — the
+    /// "absent" row-layer value.
+    pub fn nothing() -> Type {
+        Type::Primitive(Primitive::NOTHING)
     }
 
-    /// Construct a `Type::Optional(Primitive(set))`.
-    pub fn optional_set(set: PrimitiveSet) -> Self {
-        Type::Optional(Box::new(Definite::Primitive(set)))
+    /// Widen this type to also admit `Nothing` — the new home for
+    /// what used to be the outer `Optional` variant. Idempotent.
+    pub fn optional(self) -> Type {
+        match self {
+            Type::Primitive(p) => Type::Primitive(p.union(Primitive::NOTHING)),
+            Type::Composite(p, c) => Type::Composite(p.union(Primitive::NOTHING), c),
+        }
     }
 
-    /// Returns `true` iff this type is set-widened with `Absent`.
+    /// Smart constructor. Collapses `Composite(p, empty)` to
+    /// `Primitive(p)`. Use this rather than building the
+    /// `Composite` variant directly.
+    pub fn composite(primitive: Primitive, composite: BTreeSet<Composite>) -> Type {
+        if composite.is_empty() {
+            Type::Primitive(primitive)
+        } else {
+            Type::Composite(primitive, composite)
+        }
+    }
+
+    /// Build a record type from named fields.
+    pub fn product(fields: BTreeMap<String, Type>) -> Type {
+        let mut set = BTreeSet::new();
+        set.insert(Composite::Product(fields));
+        Type::Composite(Primitive::EMPTY, set)
+    }
+
+    /// Build a singleton variant type from a label and payload.
+    pub fn variant(label: impl Into<String>, value: Type) -> Type {
+        let mut set = BTreeSet::new();
+        set.insert(Composite::Variant {
+            label: label.into(),
+            value,
+        });
+        Type::Composite(Primitive::EMPTY, set)
+    }
+
+    /// Set intersection over both primitive and composite parts.
+    /// Returns `None` when the result is empty — no admissible
+    /// shapes survive.
+    pub fn intersect(&self, other: &Type) -> Option<Type> {
+        let p_self = self.primitive_part();
+        let p_other = other.primitive_part();
+        let p = Primitive {
+            bits: p_self.bits & p_other.bits,
+        };
+
+        let composite_intersection: BTreeSet<Composite> =
+            match (self.composite_part(), other.composite_part()) {
+                (Some(a), Some(b)) => a.intersection(b).cloned().collect(),
+                _ => BTreeSet::new(),
+            };
+
+        if p.is_empty() && composite_intersection.is_empty() {
+            None
+        } else {
+            Some(Type::composite(p, composite_intersection))
+        }
+    }
+
+    /// Set union over both primitive and composite parts.
+    pub fn union(&self, other: &Type) -> Type {
+        let p = self.primitive_part().union(other.primitive_part());
+        let mut composites: BTreeSet<Composite> = BTreeSet::new();
+        if let Some(s) = self.composite_part() {
+            composites.extend(s.iter().cloned());
+        }
+        if let Some(s) = other.composite_part() {
+            composites.extend(s.iter().cloned());
+        }
+        Type::composite(p, composites)
+    }
+
+    /// Subtype check. Returns `true` iff every shape `other`
+    /// admits is also admitted by `self`.
+    pub fn includes(&self, other: &Type) -> bool {
+        if !self.primitive_part().includes(other.primitive_part()) {
+            return false;
+        }
+        match (self.composite_part(), other.composite_part()) {
+            (_, None) => true,
+            (None, Some(b)) => b.is_empty(),
+            (Some(a), Some(b)) => b.iter().all(|x| a.contains(x)),
+        }
+    }
+
+    /// Returns `true` iff this type admits the `Nothing` atom.
     pub fn is_optional(&self) -> bool {
-        matches!(self, Type::Optional(_))
+        self.primitive_part().contains_nothing()
     }
 
-    /// Returns the underlying [`Definite`] regardless of whether
-    /// this is `Definite` or `Optional`.
-    pub fn shape(&self) -> &Definite {
+    /// The primitive part of this type, regardless of variant.
+    pub fn primitive_part(&self) -> Primitive {
         match self {
-            Type::Definite(d) | Type::Optional(d) => d,
+            Type::Primitive(p) => *p,
+            Type::Composite(p, _) => *p,
         }
     }
 
-    /// Lift this type to set-widened (`Optional`). Idempotent.
-    pub fn wrap_optional(self) -> Self {
+    /// The composite part of this type, or `None` if the type has
+    /// only a primitive part.
+    pub fn composite_part(&self) -> Option<&BTreeSet<Composite>> {
         match self {
-            Type::Definite(d) | Type::Optional(d) => Type::Optional(d),
+            Type::Primitive(_) => None,
+            Type::Composite(_, c) => Some(c),
         }
     }
-}
 
-impl Definite {
-    /// Construct a `Definite::Primitive(singleton(vt))`.
-    pub fn primitive(vt: ValueType) -> Self {
-        Definite::Primitive(PrimitiveSet::singleton(vt))
-    }
-
-    /// If this is a primitive shape with a singleton value type,
-    /// return it. `Variant`/`Product` placeholders return `None`.
-    pub fn as_singleton(&self) -> Option<ValueType> {
+    /// Legacy storage-codec view: if this type reduces to exactly
+    /// one [`ValueType`] (no `Nothing`, no composites), return it.
+    pub fn as_value_type(&self) -> Option<ValueType> {
         match self {
-            Definite::Primitive(set) => set.as_singleton(),
-            Definite::Variant | Definite::Product => None,
+            Type::Primitive(p) => p.as_singleton(),
+            Type::Composite(_, _) => None,
         }
     }
 }
@@ -278,73 +415,99 @@ mod tests {
         Type::primitive(vt)
     }
     fn o(vt: ValueType) -> Type {
-        Type::optional(vt)
+        Type::primitive(vt).optional()
     }
 
     #[dialog_common::test]
-    fn primitive_set_singleton() {
-        let s = PrimitiveSet::singleton(ValueType::String);
+    fn primitive_singleton() {
+        let s = Primitive::singleton(ValueType::String);
         assert!(s.contains(ValueType::String));
         assert!(!s.contains(ValueType::UnsignedInt));
+        assert!(!s.contains_nothing());
         assert_eq!(s.as_singleton(), Some(ValueType::String));
     }
 
     #[dialog_common::test]
-    fn primitive_set_intersect_overlap() {
-        let s = PrimitiveSet::NUMERIC
-            .intersect(PrimitiveSet::singleton(ValueType::UnsignedInt))
+    fn primitive_intersect_overlap() {
+        let s = Primitive::NUMERIC
+            .intersect(Primitive::singleton(ValueType::UnsignedInt))
             .unwrap();
         assert_eq!(s.as_singleton(), Some(ValueType::UnsignedInt));
     }
 
     #[dialog_common::test]
-    fn primitive_set_intersect_disjoint() {
+    fn primitive_intersect_disjoint() {
         assert!(
-            PrimitiveSet::singleton(ValueType::String)
-                .intersect(PrimitiveSet::singleton(ValueType::Entity))
+            Primitive::singleton(ValueType::String)
+                .intersect(Primitive::singleton(ValueType::Entity))
                 .is_none()
         );
     }
 
     #[dialog_common::test]
-    fn primitive_set_includes_self() {
-        assert!(PrimitiveSet::ALL.includes(PrimitiveSet::ALL));
-        assert!(PrimitiveSet::NUMERIC.includes(PrimitiveSet::singleton(ValueType::UnsignedInt)));
+    fn primitive_includes_self() {
+        assert!(Primitive::ALL.includes(Primitive::ALL));
+        assert!(Primitive::NUMERIC.includes(Primitive::singleton(ValueType::UnsignedInt)));
     }
 
     #[dialog_common::test]
-    fn primitive_set_iter() {
-        let s = PrimitiveSet::NUMERIC;
+    fn primitive_iter_skips_nothing() {
+        let s = Primitive::NUMERIC.union(Primitive::NOTHING);
         let members: Vec<_> = s.iter().collect();
         assert_eq!(members.len(), 3);
         assert!(members.contains(&ValueType::UnsignedInt));
         assert!(members.contains(&ValueType::SignedInt));
         assert!(members.contains(&ValueType::Float));
+        assert!(s.contains_nothing());
     }
 
     #[dialog_common::test]
-    fn primitive_set_serde_round_trip() {
-        let s = PrimitiveSet::NUMERIC;
+    fn primitive_nothing_singleton_returns_none() {
+        assert_eq!(Primitive::NOTHING.as_singleton(), None);
+    }
+
+    #[dialog_common::test]
+    fn primitive_all_excludes_nothing() {
+        assert!(!Primitive::ALL.contains_nothing());
+        assert!(Primitive::ANY.contains_nothing());
+        assert!(Primitive::ANY.includes(Primitive::ALL));
+        assert!(Primitive::ANY.includes(Primitive::NOTHING));
+    }
+
+    #[dialog_common::test]
+    fn primitive_serde_round_trip() {
+        let s = Primitive::NUMERIC;
         let j = serde_json::to_string(&s).unwrap();
-        let back: PrimitiveSet = serde_json::from_str(&j).unwrap();
+        let back: Primitive = serde_json::from_str(&j).unwrap();
         assert_eq!(s, back);
     }
 
     #[dialog_common::test]
-    fn type_primitive_is_definite() {
+    fn type_primitive_is_not_optional() {
         let t = p(ValueType::String);
-        assert!(matches!(t, Type::Definite(_)));
+        assert!(matches!(t, Type::Primitive(_)));
         assert!(!t.is_optional());
     }
 
     #[dialog_common::test]
-    fn type_optional_wraps_definite() {
+    fn type_optional_widens_with_nothing() {
         let t = o(ValueType::String);
         assert!(t.is_optional());
+        assert_eq!(t.as_value_type(), None);
+        assert_eq!(t.primitive_part().as_singleton(), None);
+        assert!(t.primitive_part().contains(ValueType::String));
+        assert!(t.primitive_part().contains_nothing());
     }
 
     #[dialog_common::test]
-    fn type_serde_round_trip_definite() {
+    fn type_optional_is_idempotent() {
+        let a = p(ValueType::String).optional();
+        let b = a.clone().optional();
+        assert_eq!(a, b);
+    }
+
+    #[dialog_common::test]
+    fn type_serde_round_trip_primitive() {
         let t = p(ValueType::String);
         let j = serde_json::to_string(&t).unwrap();
         let back: Type = serde_json::from_str(&j).unwrap();
@@ -360,19 +523,178 @@ mod tests {
     }
 
     /// Equivalent types hash and compare equal regardless of how
-    /// they were constructed — the property the unifier-internal
-    /// split was designed to enforce.
+    /// they were constructed.
     #[dialog_common::test]
     fn type_hash_is_stable_across_constructions() {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
         let a = p(ValueType::String);
-        let b = Type::Definite(Box::new(Definite::primitive(ValueType::String)));
+        let b = Type::primitive_set(Primitive::singleton(ValueType::String));
         let mut ha = DefaultHasher::new();
         let mut hb = DefaultHasher::new();
         a.hash(&mut ha);
         b.hash(&mut hb);
         assert_eq!(ha.finish(), hb.finish());
         assert_eq!(a, b);
+    }
+
+    #[dialog_common::test]
+    fn product_constructor_round_trip() {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), Type::primitive(ValueType::String));
+        fields.insert("age".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let a = Type::product(fields.clone());
+        let b = Type::product(fields);
+        assert_eq!(a, b);
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut ha = DefaultHasher::new();
+        let mut hb = DefaultHasher::new();
+        a.hash(&mut ha);
+        b.hash(&mut hb);
+        assert_eq!(ha.finish(), hb.finish());
+    }
+
+    #[dialog_common::test]
+    fn variant_constructor_carries_label_and_payload() {
+        let some = Type::variant("Some", Type::primitive(ValueType::String));
+        let composites = some.composite_part().unwrap();
+        assert_eq!(composites.len(), 1);
+        let first = composites.iter().next().unwrap();
+        match first {
+            Composite::Variant { label, value } => {
+                assert_eq!(label, "Some");
+                assert_eq!(*value, Type::primitive(ValueType::String));
+            }
+            other => panic!("expected Variant, got {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn intersect_two_records_same_fields() {
+        let mut fields = BTreeMap::new();
+        fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(fields.clone());
+        let b = Type::product(fields);
+        let c = a.intersect(&b).expect("intersection non-empty");
+        assert_eq!(a, c);
+    }
+
+    #[dialog_common::test]
+    fn intersect_primitive_and_composite_keeps_primitive_only() {
+        let mut fields = BTreeMap::new();
+        fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let composite = Type::product(fields);
+        let prim = Type::primitive(ValueType::String);
+        // primitive part of `composite` is EMPTY; composite part of `prim` is None.
+        // Intersection of primitive parts: EMPTY ∩ {String} = EMPTY.
+        // Intersection of composite parts: None ∩ {Product{...}} = empty.
+        // Overall: empty → None.
+        assert!(prim.intersect(&composite).is_none());
+
+        // But if the composite carries a Record primitive bit, the
+        // intersection has that bit alone.
+        let composite_with_record = Type::composite(
+            Primitive::singleton(ValueType::Record),
+            composite
+                .composite_part()
+                .cloned()
+                .unwrap_or_else(BTreeSet::new),
+        );
+        let record_prim = Type::primitive(ValueType::Record);
+        let intersected = record_prim.intersect(&composite_with_record).unwrap();
+        assert_eq!(
+            intersected.primitive_part().as_singleton(),
+            Some(ValueType::Record)
+        );
+        assert!(intersected.composite_part().is_none());
+    }
+
+    #[dialog_common::test]
+    fn includes_product_subtype_extra_fields_in_subject() {
+        // A type T "includes" U iff T admits every shape U admits.
+        // For our set semantics, T includes U requires every
+        // composite of U to be present in T's composite set. So
+        // larger composite sets in T are fine; an extra Product in
+        // U not in T breaks inclusion.
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields.clone());
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        // a and b are different products; neither includes the other.
+        assert!(!a.includes(&b));
+        assert!(!b.includes(&a));
+
+        // a includes itself.
+        assert!(a.includes(&a));
+
+        // Union of {a, b} includes both.
+        let union = a.union(&b);
+        assert!(union.includes(&a));
+        assert!(union.includes(&b));
+    }
+
+    #[dialog_common::test]
+    fn smart_constructor_collapses_empty_composite_set() {
+        let collapsed = Type::composite(Primitive::singleton(ValueType::String), BTreeSet::new());
+        assert!(matches!(collapsed, Type::Primitive(_)));
+        assert_eq!(collapsed.as_value_type(), Some(ValueType::String));
+    }
+
+    #[dialog_common::test]
+    fn nothing_constructor_yields_only_nothing() {
+        let t = Type::nothing();
+        assert!(t.is_optional());
+        assert_eq!(t.primitive_part().as_singleton(), None);
+        assert_eq!(t.as_value_type(), None);
+    }
+
+    #[dialog_common::test]
+    fn as_value_type_unique_singleton() {
+        assert_eq!(
+            p(ValueType::String).as_value_type(),
+            Some(ValueType::String)
+        );
+        assert_eq!(o(ValueType::String).as_value_type(), None);
+        assert_eq!(
+            Type::primitive_set(Primitive::NUMERIC).as_value_type(),
+            None
+        );
+    }
+
+    /// Insertion order of composite elements does not affect
+    /// equality or hash. The [`BTreeSet`] storage canonicalizes
+    /// the set, so different paths to the same set of shapes
+    /// produce equal `Type`s with equal hashes.
+    #[dialog_common::test]
+    fn composite_set_is_insertion_order_independent() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash as HashTrait, Hasher};
+
+        fn hash_of<T: HashTrait>(t: &T) -> u64 {
+            let mut h = DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+
+        let a = Type::variant("A", p(ValueType::String));
+        let b = Type::variant("B", p(ValueType::UnsignedInt));
+
+        // Build the same multi-element set two different ways:
+        // ({A, B}) via a.union(b), and ({B, A}) via b.union(a).
+        let ab = a.union(&b);
+        let ba = b.union(&a);
+
+        assert_eq!(ab, ba, "set equality is order-independent");
+        assert_eq!(
+            hash_of(&ab),
+            hash_of(&ba),
+            "set hash is order-independent"
+        );
     }
 }

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -348,6 +348,14 @@ impl Type {
     /// Set intersection over both primitive and composite parts.
     /// Returns `None` when the result is empty — no admissible
     /// shapes survive.
+    ///
+    /// Composite shapes narrow structurally: two
+    /// `Composite::Product` values with the same field-name set
+    /// intersect their field types recursively (if any field
+    /// intersection is empty, the product is eliminated). Products
+    /// with disjoint field-name sets do not intersect — they
+    /// describe disjoint records. Variants intersect by matching
+    /// label, recursing into payload types.
     pub fn intersect(&self, other: &Type) -> Option<Type> {
         let p_self = self.primitive_part();
         let p_other = other.primitive_part();
@@ -357,7 +365,7 @@ impl Type {
 
         let composite_intersection: BTreeSet<Composite> =
             match (self.composite_part(), other.composite_part()) {
-                (Some(a), Some(b)) => a.intersection(b).cloned().collect(),
+                (Some(a), Some(b)) => intersect_composite_sets(a, b),
                 _ => BTreeSet::new(),
             };
 
@@ -383,6 +391,13 @@ impl Type {
 
     /// Subtype check. Returns `true` iff every shape `other`
     /// admits is also admitted by `self`.
+    ///
+    /// For composites: each shape in `other` must be included by
+    /// some shape in `self`. Inclusion is structural — a Product
+    /// `{x: T1, y: T2}` includes a Product `{x: T1', y: T2'}` when
+    /// the field-name sets match and each `Ti` includes `Ti'`. A
+    /// product with extra fields includes one with fewer fields
+    /// (width subtyping is not assumed; equal field sets only).
     pub fn includes(&self, other: &Type) -> bool {
         if !self.primitive_part().includes(other.primitive_part()) {
             return false;
@@ -390,7 +405,9 @@ impl Type {
         match (self.composite_part(), other.composite_part()) {
             (_, None) => true,
             (None, Some(b)) => b.is_empty(),
-            (Some(a), Some(b)) => b.iter().all(|x| a.contains(x)),
+            (Some(a), Some(b)) => b
+                .iter()
+                .all(|b_shape| a.iter().any(|a_shape| composite_includes(a_shape, b_shape))),
         }
     }
 
@@ -423,6 +440,104 @@ impl Type {
             Type::Primitive(p) => p.as_singleton(),
             Type::Composite(_, _) => None,
         }
+    }
+}
+
+/// Structurally intersect two sets of [`Composite`] shapes.
+///
+/// For each `Composite::Product` in `a`, look for a same-field-set
+/// `Composite::Product` in `b` and intersect their field types
+/// pairwise; if any field intersection is empty, the product is
+/// eliminated. For each `Composite::Variant` in `a`, look for a
+/// same-label `Composite::Variant` in `b` and intersect their
+/// payload types. Anything in `a` or `b` without a structural
+/// counterpart on the other side is dropped — set intersection
+/// only keeps shapes admitted by both sides.
+fn intersect_composite_sets(
+    a: &BTreeSet<Composite>,
+    b: &BTreeSet<Composite>,
+) -> BTreeSet<Composite> {
+    let mut result = BTreeSet::new();
+    for a_shape in a {
+        for b_shape in b {
+            if let Some(merged) = intersect_composite(a_shape, b_shape) {
+                result.insert(merged);
+            }
+        }
+    }
+    result
+}
+
+/// Pairwise intersection of two [`Composite`] shapes. Two
+/// products intersect iff they share the same set of field names;
+/// two variants iff they share the same label.
+fn intersect_composite(a: &Composite, b: &Composite) -> Option<Composite> {
+    match (a, b) {
+        (Composite::Product(fa), Composite::Product(fb)) => {
+            if fa.len() != fb.len() {
+                return None;
+            }
+            let mut out = BTreeMap::new();
+            for (name, ta) in fa {
+                let tb = fb.get(name)?;
+                let merged = ta.intersect(tb)?;
+                out.insert(name.clone(), merged);
+            }
+            Some(Composite::Product(out))
+        }
+        (
+            Composite::Variant {
+                label: la,
+                value: va,
+            },
+            Composite::Variant {
+                label: lb,
+                value: vb,
+            },
+        ) => {
+            if la != lb {
+                return None;
+            }
+            let merged = va.intersect(vb)?;
+            Some(Composite::Variant {
+                label: la.clone(),
+                value: merged,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Structural inclusion check between two [`Composite`] shapes.
+/// `a` includes `b` iff they are the same shape kind, have matching
+/// keys/labels, and each of `a`'s recursive types includes `b`'s.
+fn composite_includes(a: &Composite, b: &Composite) -> bool {
+    match (a, b) {
+        (Composite::Product(fa), Composite::Product(fb)) => {
+            if fa.len() != fb.len() {
+                return false;
+            }
+            for (name, ta) in fa {
+                let Some(tb) = fb.get(name) else {
+                    return false;
+                };
+                if !ta.includes(tb) {
+                    return false;
+                }
+            }
+            true
+        }
+        (
+            Composite::Variant {
+                label: la,
+                value: va,
+            },
+            Composite::Variant {
+                label: lb,
+                value: vb,
+            },
+        ) => la == lb && va.includes(vb),
+        _ => false,
     }
 }
 
@@ -597,6 +712,81 @@ mod tests {
         let b = Type::product(fields);
         let c = a.intersect(&b).expect("intersection non-empty");
         assert_eq!(a, c);
+    }
+
+    /// Two products with the same field names but different field
+    /// types narrow structurally: intersect each field's type
+    /// recursively. If every field intersection is non-empty, the
+    /// product survives with the narrowed fields.
+    #[dialog_common::test]
+    fn intersect_products_narrows_field_types() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive_set(Primitive::NUMERIC));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        let merged = a.intersect(&b).expect("narrows to UnsignedInt");
+        let composite = merged.composite_part().expect("composite present");
+        let product = composite.iter().next().expect("one product");
+        match product {
+            Composite::Product(fields) => {
+                let x_type = fields.get("x").expect("x field");
+                assert_eq!(x_type.as_value_type(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("expected Product, got {other:?}"),
+        }
+    }
+
+    /// Two products with disjoint field types fail to intersect.
+    #[dialog_common::test]
+    fn intersect_products_disjoint_fields_eliminated() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        assert!(a.intersect(&b).is_none());
+    }
+
+    /// Two products with different field-name sets do not
+    /// intersect — they describe disjoint record shapes.
+    #[dialog_common::test]
+    fn intersect_products_different_keys_eliminated() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::String));
+        let b = Type::product(b_fields);
+
+        assert!(a.intersect(&b).is_none());
+    }
+
+    /// Two variants with the same label intersect their payloads;
+    /// different labels do not intersect.
+    #[dialog_common::test]
+    fn intersect_variants_by_label() {
+        let a = Type::variant("Some", Type::primitive_set(Primitive::NUMERIC));
+        let b = Type::variant("Some", Type::primitive(ValueType::UnsignedInt));
+        let merged = a.intersect(&b).expect("same label narrows payload");
+        let composite = merged.composite_part().expect("composite present");
+        match composite.iter().next().expect("one variant") {
+            Composite::Variant { label, value } => {
+                assert_eq!(label, "Some");
+                assert_eq!(value.as_value_type(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("expected Variant, got {other:?}"),
+        }
+
+        let c = Type::variant("Other", Type::primitive(ValueType::UnsignedInt));
+        assert!(a.intersect(&c).is_none());
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -281,7 +281,7 @@ mod tests {
         Type::optional(vt)
     }
 
-    #[test]
+    #[dialog_common::test]
     fn primitive_set_singleton() {
         let s = PrimitiveSet::singleton(ValueType::String);
         assert!(s.contains(ValueType::String));
@@ -289,7 +289,7 @@ mod tests {
         assert_eq!(s.as_singleton(), Some(ValueType::String));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn primitive_set_intersect_overlap() {
         let s = PrimitiveSet::NUMERIC
             .intersect(PrimitiveSet::singleton(ValueType::UnsignedInt))
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(s.as_singleton(), Some(ValueType::UnsignedInt));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn primitive_set_intersect_disjoint() {
         assert!(
             PrimitiveSet::singleton(ValueType::String)
@@ -306,13 +306,13 @@ mod tests {
         );
     }
 
-    #[test]
+    #[dialog_common::test]
     fn primitive_set_includes_self() {
         assert!(PrimitiveSet::ALL.includes(PrimitiveSet::ALL));
         assert!(PrimitiveSet::NUMERIC.includes(PrimitiveSet::singleton(ValueType::UnsignedInt)));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn primitive_set_iter() {
         let s = PrimitiveSet::NUMERIC;
         let members: Vec<_> = s.iter().collect();
@@ -322,7 +322,7 @@ mod tests {
         assert!(members.contains(&ValueType::Float));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn primitive_set_serde_round_trip() {
         let s = PrimitiveSet::NUMERIC;
         let j = serde_json::to_string(&s).unwrap();
@@ -330,20 +330,20 @@ mod tests {
         assert_eq!(s, back);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn type_primitive_is_definite() {
         let t = p(ValueType::String);
         assert!(matches!(t, Type::Definite(_)));
         assert!(!t.is_optional());
     }
 
-    #[test]
+    #[dialog_common::test]
     fn type_optional_wraps_definite() {
         let t = o(ValueType::String);
         assert!(t.is_optional());
     }
 
-    #[test]
+    #[dialog_common::test]
     fn type_serde_round_trip_definite() {
         let t = p(ValueType::String);
         let j = serde_json::to_string(&t).unwrap();
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(t, back);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn type_serde_round_trip_optional() {
         let t = o(ValueType::Entity);
         let j = serde_json::to_string(&t).unwrap();
@@ -362,7 +362,7 @@ mod tests {
     /// Equivalent types hash and compare equal regardless of how
     /// they were constructed — the property the unifier-internal
     /// split was designed to enforce.
-    #[test]
+    #[dialog_common::test]
     fn type_hash_is_stable_across_constructions() {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -544,6 +544,14 @@ fn composite_includes(a: &Composite, b: &Composite) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash as HashTrait, Hasher};
+
+    fn hash_of<T: HashTrait>(t: &T) -> u64 {
+        let mut h = DefaultHasher::new();
+        t.hash(&mut h);
+        h.finish()
+    }
 
     fn p(vt: ValueType) -> Type {
         Type::primitive(vt)
@@ -882,15 +890,6 @@ mod tests {
     /// produce equal `Type`s with equal hashes.
     #[dialog_common::test]
     fn composite_set_is_insertion_order_independent() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash as HashTrait, Hasher};
-
-        fn hash_of<T: HashTrait>(t: &T) -> u64 {
-            let mut h = DefaultHasher::new();
-            t.hash(&mut h);
-            h.finish()
-        }
-
         let a = Type::variant("A", p(ValueType::String));
         let b = Type::variant("B", p(ValueType::UnsignedInt));
 
@@ -901,5 +900,51 @@ mod tests {
 
         assert_eq!(ab, ba, "set equality is order-independent");
         assert_eq!(hash_of(&ab), hash_of(&ba), "set hash is order-independent");
+    }
+
+    /// Field insertion order into a `BTreeMap<String, Type>` does
+    /// not affect product equality or hash — the BTreeMap sorts
+    /// by key. Same product built via `{x, y}` vs `{y, x}` insert
+    /// orders must compare equal and hash equal.
+    #[dialog_common::test]
+    fn product_field_insertion_order_independent() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        a_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let b = Type::product(b_fields);
+
+        assert_eq!(
+            a, b,
+            "product equality is field-insertion-order independent"
+        );
+        assert_eq!(
+            hash_of(&a),
+            hash_of(&b),
+            "product hash is field-insertion-order independent"
+        );
+    }
+
+    /// Combining two products via union also produces identical
+    /// hashes regardless of which product was unioned first.
+    #[dialog_common::test]
+    fn product_union_is_order_independent() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        let ab = a.union(&b);
+        let ba = b.union(&a);
+
+        assert_eq!(ab, ba);
+        assert_eq!(hash_of(&ab), hash_of(&ba));
     }
 }

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -203,6 +203,31 @@ impl From<ValueType> for PrimitiveSet {
     }
 }
 
+impl From<ValueType> for Type {
+    fn from(vt: ValueType) -> Self {
+        Self::primitive(vt)
+    }
+}
+
+impl From<Option<ValueType>> for Type {
+    /// Lifts the legacy `Option<ValueType>` storage-tag
+    /// representation into the unified type system.
+    ///
+    /// - `None` → an anonymous unconstrained variable
+    ///   ([`Self::any`]). Each call allocates a fresh
+    ///   [`VarId`], so multiple `None.into()` invocations
+    ///   produce distinct variables. The unifier links them at
+    ///   rule-compile time when the same rule-level variable
+    ///   name is shared across slots.
+    /// - `Some(vt)` → `Type::Definite(Primitive(singleton(vt)))`.
+    fn from(value: Option<ValueType>) -> Self {
+        match value {
+            Some(vt) => Self::primitive(vt),
+            None => Self::any(),
+        }
+    }
+}
+
 /// Schema-layer type of a value, term, or schema slot.
 ///
 /// Two outer variants distinguish set-widening (Optional) from

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -1,51 +1,24 @@
 //! Unified type system for the query engine.
 //!
-//! This module is the foundation of v2's type system. It defines:
+//! This module defines the static, derive-friendly user-facing
+//! [`Type`] used by [`Term`](crate::Term),
+//! [`Equality`](crate::constraint::Equality),
+//! [`Premise`](crate::Premise), [`DeductiveRule`](crate::DeductiveRule),
+//! and the schema layer.
 //!
-//! - [`Type`] / [`Definite`] — the runtime type representation,
-//!   covering primitive value types, type variables, and
-//!   set-widened (Optional) types. Designed to grow `Record` and
-//!   `Variant` constructors in future PRs without reshape.
-//! - [`PrimitiveSet`] — a bitfield over [`ValueType`] variants.
-//!   Enables type variables to carry kind-level constraints
-//!   (`NUMERIC`, `STRING_LIKE`, etc.) and lets unification narrow
-//!   via set intersection.
-//! - [`VarId`] / [`TypeScheme`] — rank-1 polymorphic type
-//!   schemes, used by formula declarations to express generic
-//!   signatures like `Sum<T: Numeric>(T, T) -> T`.
-//! - [`UnificationContext`] — a Damas-Milner unifier with
-//!   substitution, constraint registry, fresh-id allocator, and
-//!   the [`unify`](UnificationContext::unify) algorithm itself.
-//! - [`MatchOptionality`] — slot-level optionality for unification.
+//! Type variables — used for compile-time unification of rules —
+//! live in the [`unifier`] submodule, never in the user-facing
+//! [`Type`]. This split lets the user-facing types derive
+//! [`PartialEq`]/[`Eq`]/[`Hash`] cleanly: equivalent rules produce
+//! stable hashes regardless of how many anonymous variables they
+//! have.
 //!
 //! See `notes/optional-fields.md` for the design rationale.
 
+pub mod unifier;
+
 use crate::artifact::Type as ValueType;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
-
-/// A unique identifier for a type variable within a unification
-/// context. Allocated by [`UnificationContext::fresh`] or by
-/// [`UnificationContext::instantiate`] when a [`TypeScheme`]'s
-/// quantified variable is bound to a fresh runtime variable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct VarId(u32);
-
-/// Process-global counter for [`VarId`] allocation. Used as a
-/// fallback when no [`UnificationContext`] is available — most
-/// allocation goes through a context's per-context counter for
-/// determinism.
-static GLOBAL_VAR_COUNTER: AtomicU32 = AtomicU32::new(0);
-
-impl VarId {
-    /// Allocate a new globally-unique `VarId`. Used at descriptor
-    /// boundaries where no context is available; rule-compile-time
-    /// unification uses [`UnificationContext::fresh`] instead.
-    pub fn global_fresh() -> Self {
-        Self(GLOBAL_VAR_COUNTER.fetch_add(1, Ordering::Relaxed))
-    }
-}
 
 /// A bitfield over [`ValueType`] variants — a set of admissible
 /// primitive shapes.
@@ -67,8 +40,7 @@ impl PrimitiveSet {
     /// "no shape can satisfy this constraint").
     pub const EMPTY: Self = Self { bits: 0 };
 
-    /// Set containing every [`ValueType`] variant. Equivalent to
-    /// the v1 `Type::Any` for primitive shapes.
+    /// Set containing every [`ValueType`] variant.
     pub const ALL: Self = Self {
         bits: 0b1_1111_1111,
     };
@@ -85,8 +57,7 @@ impl PrimitiveSet {
         bits: Self::bit_for(ValueType::String) | Self::bit_for(ValueType::Symbol),
     };
 
-    /// Comparable primitives: numeric ∪ string-like ∪ entity ∪ bytes.
-    /// Used as the constraint for ordering predicates (`<`, `<=`, etc.).
+    /// Comparable primitives: numeric, string-like, entity, bytes.
     pub const COMPARABLE: Self = Self {
         bits: Self::NUMERIC.bits
             | Self::STRING_LIKE.bits
@@ -102,8 +73,7 @@ impl PrimitiveSet {
     }
 
     /// Bitfield position for a `ValueType` variant. Stable across
-    /// builds so serialization round-trips. Adding a new variant
-    /// requires extending this match and the `ALL` mask above.
+    /// builds so serialization round-trips.
     const fn bit_for(vt: ValueType) -> u16 {
         match vt {
             ValueType::String => 1 << 0,
@@ -123,10 +93,7 @@ impl PrimitiveSet {
         self.bits == 0
     }
 
-    /// Set intersection. Returns `None` iff the result is empty —
-    /// signals "no shape can satisfy both constraints," which
-    /// callers (notably [`UnificationContext::unify`]) treat as a
-    /// type error.
+    /// Set intersection. Returns `None` iff the result is empty.
     pub fn intersect(self, other: Self) -> Option<Self> {
         let merged = Self {
             bits: self.bits & other.bits,
@@ -145,8 +112,7 @@ impl PrimitiveSet {
         }
     }
 
-    /// Returns `true` iff `self` is a (non-strict) superset of
-    /// `other`. Used by the `includes`-style subtype check.
+    /// Returns `true` iff `self` is a (non-strict) superset of `other`.
     pub fn includes(self, other: Self) -> bool {
         (self.bits & other.bits) == other.bits
     }
@@ -156,9 +122,7 @@ impl PrimitiveSet {
         (self.bits & Self::bit_for(vt)) != 0
     }
 
-    /// If this set has exactly one member, return it. Useful for
-    /// the common "I narrowed the constraint down to a single
-    /// type" case.
+    /// If this set has exactly one member, return it.
     pub fn as_singleton(self) -> Option<ValueType> {
         let count = self.bits.count_ones();
         if count != 1 {
@@ -209,31 +173,16 @@ impl From<ValueType> for Type {
     }
 }
 
-impl From<Option<ValueType>> for Type {
-    /// Lifts the legacy `Option<ValueType>` storage-tag
-    /// representation into the unified type system.
-    ///
-    /// - `None` → an anonymous unconstrained variable
-    ///   ([`Self::any`]). Each call allocates a fresh
-    ///   [`VarId`], so multiple `None.into()` invocations
-    ///   produce distinct variables. The unifier links them at
-    ///   rule-compile time when the same rule-level variable
-    ///   name is shared across slots.
-    /// - `Some(vt)` → `Type::Definite(Primitive(singleton(vt)))`.
-    fn from(value: Option<ValueType>) -> Self {
-        match value {
-            Some(vt) => Self::primitive(vt),
-            None => Self::any(),
-        }
-    }
-}
-
 /// Schema-layer type of a value, term, or schema slot.
 ///
 /// Two outer variants distinguish set-widening (Optional) from
 /// concrete shapes (Definite). Optionality lives at the slot
-/// layer, never on type variables — this keeps "nested
+/// layer, never inside a [`Definite`]: this keeps "nested
 /// optionality" structurally unrepresentable.
+///
+/// `Type` is fully static — no type variables, no allocation
+/// state. Deriving [`PartialEq`]/[`Eq`]/[`Hash`] is safe and
+/// produces stable values for equivalent types.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
@@ -247,26 +196,20 @@ pub enum Type {
     Optional(Box<Definite>),
 }
 
-/// A concrete value shape — non-`Optional`. Includes type
-/// variables (which still represent "a single shape," just
-/// unknown until unified).
+/// A concrete value shape — non-`Optional`. Static; type variables
+/// live in [`unifier::Type`], not here.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Definite {
     /// Atomic value type, possibly a union over several primitive
-    /// shapes. `PrimitiveSet::singleton(ValueType::String)` is
-    /// "exactly String"; `PrimitiveSet::NUMERIC` is "any of
-    /// `UnsignedInt`, `SignedInt`, `Float`."
+    /// shapes.
     Primitive(PrimitiveSet),
-    /// A type variable. The variable's constraint
-    /// (`PrimitiveSet`) lives in the
-    /// [`UnificationContext`]'s constraint registry, keyed by
-    /// `VarId`. The variable resolves to a concrete `Definite`
-    /// once unified.
-    Variable(VarId),
-    // Future:
-    // Record(BTreeMap<String, Type>),
-    // Variant(BTreeMap<String, Definite>),
+    /// Sum-type placeholder. Reserved for future use; not
+    /// constructed in current code paths.
+    Variant,
+    /// Product-type placeholder. Reserved for future use; not
+    /// constructed in current code paths.
+    Product,
 }
 
 impl Type {
@@ -290,44 +233,20 @@ impl Type {
         Type::Optional(Box::new(Definite::Primitive(set)))
     }
 
-    /// Construct a `Type::Definite(Variable(id))`.
-    pub fn variable(id: VarId) -> Self {
-        Type::Definite(Box::new(Definite::Variable(id)))
-    }
-
-    /// Construct an "anonymous unconstrained variable" type — the
-    /// v2 replacement for v1's `Type::Any`. Allocates a globally-
-    /// unique [`VarId`]; for rule-compile-time anonymous
-    /// allocation use
-    /// [`UnificationContext::fresh`](UnificationContext::fresh)
-    /// with `PrimitiveSet::ALL`.
-    pub fn any() -> Self {
-        Type::variable(VarId::global_fresh())
-    }
-
     /// Returns `true` iff this type is set-widened with `Absent`.
     pub fn is_optional(&self) -> bool {
         matches!(self, Type::Optional(_))
     }
 
     /// Returns the underlying [`Definite`] regardless of whether
-    /// this is `Definite` or `Optional`. Used by callers that
-    /// need to inspect the shape independently of optionality.
+    /// this is `Definite` or `Optional`.
     pub fn shape(&self) -> &Definite {
         match self {
             Type::Definite(d) | Type::Optional(d) => d,
         }
     }
 
-    /// Lift this type to set-widened (`Optional`). Idempotent —
-    /// applying twice has no further effect (`Optional(Optional)`
-    /// would be structurally redundant; the outer enum prevents
-    /// it by construction).
-    ///
-    /// Used by [`DynamicAttributeQuery`](crate::DynamicAttributeQuery)
-    /// when its [`Resolution`](crate::attribute::query::Resolution) is
-    /// `Optional`: the schema's `is` slot needs to advertise
-    /// "this slot may bind to Absent at the row layer."
+    /// Lift this type to set-widened (`Optional`). Idempotent.
     pub fn wrap_optional(self) -> Self {
         match self {
             Type::Definite(d) | Type::Optional(d) => Type::Optional(d),
@@ -342,329 +261,13 @@ impl Definite {
     }
 
     /// If this is a primitive shape with a singleton value type,
-    /// return it.
+    /// return it. `Variant`/`Product` placeholders return `None`.
     pub fn as_singleton(&self) -> Option<ValueType> {
         match self {
             Definite::Primitive(set) => set.as_singleton(),
-            Definite::Variable(_) => None,
+            Definite::Variant | Definite::Product => None,
         }
     }
-}
-
-/// Slot-level optionality used during unification. Tracks whether
-/// a use site of a variable is wrapped in `Optional` independently
-/// of the variable's own shape.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum MatchOptionality {
-    /// The slot demands a Present value — `Type::Definite(_)`.
-    Required,
-    /// The slot tolerates `Absent` — `Type::Optional(_)`.
-    Optional,
-}
-
-impl MatchOptionality {
-    /// Lift a `Type` to its slot-level optionality plus the
-    /// underlying shape.
-    pub fn split(ty: &Type) -> (Self, &Definite) {
-        match ty {
-            Type::Definite(d) => (Self::Required, d),
-            Type::Optional(d) => (Self::Optional, d),
-        }
-    }
-
-    /// "Strictest wins" combine: `Required` ∧ `Optional` =
-    /// `Required`. Used when two slots demand the same variable
-    /// but with different optionality.
-    pub fn combine(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Required, _) | (_, Self::Required) => Self::Required,
-            (Self::Optional, Self::Optional) => Self::Optional,
-        }
-    }
-}
-
-/// Errors raised by unification.
-#[derive(Debug, Clone, PartialEq, thiserror::Error)]
-pub enum UnifyError {
-    /// Two types' primitive constraint sets have empty
-    /// intersection — no shape can satisfy both.
-    #[error("constraint conflict between {left:?} and {right:?}")]
-    ConstraintConflict {
-        /// The narrower side.
-        left: PrimitiveSet,
-        /// The other narrower side.
-        right: PrimitiveSet,
-    },
-    /// Occurs check: unifying a variable with a type that
-    /// transitively contains the variable would produce an
-    /// infinite type. Today's `Definite` doesn't compose, so
-    /// this is unreachable; reserved for future `Record` /
-    /// `Variant` constructors.
-    #[error("occurs check failed for variable {var:?}")]
-    OccursCheck {
-        /// The offending variable.
-        var: VarId,
-    },
-}
-
-/// A rank-1 polymorphic type scheme. Used by formula declarations
-/// to express generic signatures like
-/// `Sum<T: Numeric>(left: T, right: T) -> T`.
-///
-/// Schemes are static Rust-side metadata, not part of the wire
-/// format. Each formula module defines a `LazyLock<TypeScheme>`
-/// constant; the registry maps formula identifiers (e.g.
-/// `"math/sum"`) to their schemes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TypeScheme {
-    /// Quantified variables and their constraints. Names are
-    /// scope-local to this scheme.
-    pub quantified: Vec<(SchemeVarName, PrimitiveSet)>,
-    /// The scheme body, referencing quantified variables by
-    /// name. Instantiation replaces names with fresh `VarId`s.
-    pub body: SchemeBody,
-}
-
-/// A name binding a quantified type variable in a scheme. Local
-/// to the scheme; instantiation replaces it with a fresh
-/// [`VarId`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct SchemeVarName(pub String);
-
-impl SchemeVarName {
-    /// Construct a name. Convention: single uppercase letter (`T`,
-    /// `U`) for the most common case, but any string works.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
-    }
-}
-
-/// The body of a [`TypeScheme`] — either a function-like signature
-/// (formula schemas) or a single value type.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemeBody {
-    /// A function-like signature: parameter names → slot types.
-    Schema(Vec<(String, SchemeType)>),
-    /// A single value type — for non-function schemes.
-    Type(SchemeType),
-}
-
-/// A type expression inside a [`TypeScheme`]. References
-/// quantified variables by name; instantiation replaces names
-/// with fresh runtime [`VarId`]s.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemeType {
-    /// `Definite(SchemeDefinite)`.
-    Definite(Box<SchemeDefinite>),
-    /// `Optional(SchemeDefinite)` — set-widened slot.
-    Optional(Box<SchemeDefinite>),
-}
-
-/// `Definite` shape inside a [`TypeScheme`]. Variables reference
-/// quantified names; instantiation replaces with [`VarId`]s.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemeDefinite {
-    /// Concrete primitive set — no variable.
-    Primitive(PrimitiveSet),
-    /// Reference to a quantified variable by name.
-    Variable(SchemeVarName),
-}
-
-/// Per-rule unification context. Tracks the substitution map,
-/// per-variable constraints, and a fresh-id counter.
-#[derive(Debug, Clone, Default)]
-pub struct UnificationContext {
-    /// Substitution: variable → resolved (or partially-resolved)
-    /// `Definite`. Updated in-place by [`Self::unify`]. The
-    /// substituted value may itself contain variables that haven't
-    /// yet been resolved.
-    substitution: HashMap<VarId, Definite>,
-    /// Per-variable primitive constraint. Populated when a
-    /// variable is allocated; intersected during unification.
-    constraints: HashMap<VarId, PrimitiveSet>,
-    /// Counter for fresh `VarId` allocation within this context.
-    next_id: u32,
-}
-
-impl UnificationContext {
-    /// Create an empty context.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Allocate a fresh `VarId` with the given constraint.
-    pub fn fresh(&mut self, constraint: PrimitiveSet) -> VarId {
-        let id = VarId(self.next_id);
-        self.next_id += 1;
-        self.constraints.insert(id, constraint);
-        id
-    }
-
-    /// Look up the constraint for a variable. Returns
-    /// [`PrimitiveSet::ALL`] if the variable is unknown to this
-    /// context (e.g. one allocated via [`VarId::global_fresh`]
-    /// outside any context).
-    pub fn constraint(&self, var: VarId) -> PrimitiveSet {
-        self.constraints
-            .get(&var)
-            .copied()
-            .unwrap_or(PrimitiveSet::ALL)
-    }
-
-    /// Apply the current substitution to a `Type`, recursively
-    /// resolving any variables that have been bound. Variables
-    /// that haven't been bound stay as `Variable(id)`.
-    pub fn apply(&self, ty: &Type) -> Type {
-        match ty {
-            Type::Definite(d) => Type::Definite(Box::new(self.apply_definite(d))),
-            Type::Optional(d) => Type::Optional(Box::new(self.apply_definite(d))),
-        }
-    }
-
-    fn apply_definite(&self, d: &Definite) -> Definite {
-        match d {
-            Definite::Primitive(_) => d.clone(),
-            Definite::Variable(id) => {
-                if let Some(resolved) = self.substitution.get(id) {
-                    self.apply_definite(resolved)
-                } else {
-                    Definite::Variable(*id)
-                }
-            }
-        }
-    }
-
-    /// Robinson unification with constraint propagation. Updates
-    /// `self` in-place. Returns `Err` on constraint conflict or
-    /// occurs check failure.
-    pub fn unify(&mut self, a: &Type, b: &Type) -> Result<(), UnifyError> {
-        let a = self.apply(a);
-        let b = self.apply(b);
-        let (_a_opt, a_def) = MatchOptionality::split(&a);
-        let (_b_opt, b_def) = MatchOptionality::split(&b);
-
-        // Slot-level optionality is informational at this layer:
-        // the underlying definite shapes are unified regardless,
-        // and "strictest wins" means a Definite consumer paired
-        // with an Optional producer narrows to Definite. Higher
-        // layers (RuleAnalysis, Slice 7 enforcement) read the
-        // slot-level optionality from each use site directly.
-
-        self.unify_definite(a_def, b_def)?;
-
-        Ok(())
-    }
-
-    fn unify_definite(&mut self, a: &Definite, b: &Definite) -> Result<(), UnifyError> {
-        match (a, b) {
-            // Two same variables: nothing to do.
-            (Definite::Variable(x), Definite::Variable(y)) if x == y => Ok(()),
-            // Two distinct variables: bind one to the other,
-            // intersecting constraints.
-            (Definite::Variable(x), Definite::Variable(y)) => {
-                let cx = self.constraint(*x);
-                let cy = self.constraint(*y);
-                let merged = cx.intersect(cy).ok_or(UnifyError::ConstraintConflict {
-                    left: cx,
-                    right: cy,
-                })?;
-                self.constraints.insert(*x, merged);
-                self.constraints.insert(*y, merged);
-                self.substitution.insert(*y, Definite::Variable(*x));
-                Ok(())
-            }
-            // Variable vs primitive: check constraint, substitute.
-            (Definite::Variable(x), Definite::Primitive(p))
-            | (Definite::Primitive(p), Definite::Variable(x)) => {
-                let cx = self.constraint(*x);
-                let merged = cx.intersect(*p).ok_or(UnifyError::ConstraintConflict {
-                    left: cx,
-                    right: *p,
-                })?;
-                self.constraints.insert(*x, merged);
-                self.substitution.insert(*x, Definite::Primitive(merged));
-                Ok(())
-            }
-            // Two primitives: intersect their sets.
-            (Definite::Primitive(p), Definite::Primitive(q)) => p
-                .intersect(*q)
-                .ok_or(UnifyError::ConstraintConflict {
-                    left: *p,
-                    right: *q,
-                })
-                .map(|_| ()),
-        }
-    }
-
-    /// Instantiate a [`TypeScheme`]: allocate fresh `VarId`s for
-    /// each quantified name, then materialize the body into a
-    /// concrete signature with substitutions applied.
-    ///
-    /// Two calls to `instantiate` on the same scheme produce
-    /// independent fresh variables — different uses of the same
-    /// formula don't conflate their type variables.
-    pub fn instantiate(&mut self, scheme: &TypeScheme) -> InstantiatedScheme {
-        let mut substitution: HashMap<SchemeVarName, VarId> = HashMap::new();
-        for (name, constraint) in &scheme.quantified {
-            let id = self.fresh(*constraint);
-            substitution.insert(name.clone(), id);
-        }
-        InstantiatedScheme {
-            body: instantiate_body(&scheme.body, &substitution),
-            variables: substitution,
-        }
-    }
-}
-
-fn instantiate_body(body: &SchemeBody, sub: &HashMap<SchemeVarName, VarId>) -> InstantiatedBody {
-    match body {
-        SchemeBody::Schema(fields) => InstantiatedBody::Schema(
-            fields
-                .iter()
-                .map(|(name, ty)| (name.clone(), instantiate_type(ty, sub)))
-                .collect(),
-        ),
-        SchemeBody::Type(ty) => InstantiatedBody::Type(instantiate_type(ty, sub)),
-    }
-}
-
-fn instantiate_type(ty: &SchemeType, sub: &HashMap<SchemeVarName, VarId>) -> Type {
-    match ty {
-        SchemeType::Definite(d) => Type::Definite(Box::new(instantiate_definite(d, sub))),
-        SchemeType::Optional(d) => Type::Optional(Box::new(instantiate_definite(d, sub))),
-    }
-}
-
-fn instantiate_definite(d: &SchemeDefinite, sub: &HashMap<SchemeVarName, VarId>) -> Definite {
-    match d {
-        SchemeDefinite::Primitive(p) => Definite::Primitive(*p),
-        SchemeDefinite::Variable(name) => Definite::Variable(
-            *sub.get(name)
-                .expect("scheme references unquantified variable"),
-        ),
-    }
-}
-
-/// The result of instantiating a [`TypeScheme`]. Carries the
-/// fresh-`VarId` substitution alongside the body so callers can
-/// look up which `VarId` represents which scheme variable.
-#[derive(Debug, Clone)]
-pub struct InstantiatedScheme {
-    /// The instantiated body — concrete `Type`s with `VarId`
-    /// references in place of scheme-variable names.
-    pub body: InstantiatedBody,
-    /// Maps each scheme variable name to the fresh `VarId`
-    /// allocated for this instantiation.
-    pub variables: HashMap<SchemeVarName, VarId>,
-}
-
-/// An instantiated [`SchemeBody`].
-#[derive(Debug, Clone)]
-pub enum InstantiatedBody {
-    /// Function-like signature: `Vec<(name, slot_type)>`.
-    Schema(Vec<(String, Type)>),
-    /// A single value type.
-    Type(Type),
 }
 
 #[cfg(test)]
@@ -677,8 +280,6 @@ mod tests {
     fn o(vt: ValueType) -> Type {
         Type::optional(vt)
     }
-
-    // ============== PrimitiveSet ==============
 
     #[test]
     fn primitive_set_singleton() {
@@ -729,8 +330,6 @@ mod tests {
         assert_eq!(s, back);
     }
 
-    // ============== Type construction ==============
-
     #[test]
     fn type_primitive_is_definite() {
         let t = p(ValueType::String);
@@ -742,15 +341,6 @@ mod tests {
     fn type_optional_wraps_definite() {
         let t = o(ValueType::String);
         assert!(t.is_optional());
-    }
-
-    #[test]
-    fn type_any_is_anonymous_variable() {
-        let t = Type::any();
-        match t.shape() {
-            Definite::Variable(_) => {}
-            other => panic!("expected anonymous variable, got {:?}", other),
-        }
     }
 
     #[test]
@@ -769,278 +359,20 @@ mod tests {
         assert_eq!(t, back);
     }
 
-    // ============== UnificationContext: variable basics ==============
-
+    /// Equivalent types hash and compare equal regardless of how
+    /// they were constructed — the property the unifier-internal
+    /// split was designed to enforce.
     #[test]
-    fn fresh_variables_are_distinct() {
-        let mut ctx = UnificationContext::new();
-        let a = ctx.fresh(PrimitiveSet::ALL);
-        let b = ctx.fresh(PrimitiveSet::ALL);
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn fresh_records_constraint() {
-        let mut ctx = UnificationContext::new();
-        let a = ctx.fresh(PrimitiveSet::NUMERIC);
-        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
-    }
-
-    // ============== UnificationContext: unify primitive vs primitive ==============
-
-    #[test]
-    fn unify_two_concrete_primitives_same_succeeds() {
-        let mut ctx = UnificationContext::new();
-        ctx.unify(&p(ValueType::String), &p(ValueType::String))
-            .unwrap();
-    }
-
-    #[test]
-    fn unify_two_concrete_primitives_different_fails() {
-        let mut ctx = UnificationContext::new();
-        let result = ctx.unify(&p(ValueType::String), &p(ValueType::Entity));
-        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
-    }
-
-    // ============== UnificationContext: unify variable vs primitive ==============
-
-    #[test]
-    fn unify_variable_with_concrete_substitutes() {
-        let mut ctx = UnificationContext::new();
-        let v = ctx.fresh(PrimitiveSet::NUMERIC);
-        ctx.unify(&Type::variable(v), &p(ValueType::UnsignedInt))
-            .unwrap();
-        let resolved = ctx.apply(&Type::variable(v));
-        match resolved.shape() {
-            Definite::Primitive(set) => {
-                assert_eq!(set.as_singleton(), Some(ValueType::UnsignedInt));
-            }
-            other => panic!("expected concrete primitive, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn unify_variable_with_concrete_outside_constraint_fails() {
-        let mut ctx = UnificationContext::new();
-        let v = ctx.fresh(PrimitiveSet::NUMERIC);
-        let result = ctx.unify(&Type::variable(v), &p(ValueType::String));
-        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
-    }
-
-    #[test]
-    fn unify_variable_constraint_propagates() {
-        let mut ctx = UnificationContext::new();
-        let v = ctx.fresh(PrimitiveSet::NUMERIC);
-        let v_ty = Type::variable(v);
-        let comparable = Type::primitive_set(PrimitiveSet::COMPARABLE);
-        ctx.unify(&v_ty, &comparable).unwrap();
-        let resolved = ctx.apply(&v_ty);
-        match resolved.shape() {
-            Definite::Primitive(set) => {
-                assert_eq!(*set, PrimitiveSet::NUMERIC);
-            }
-            other => panic!("expected primitive, got {:?}", other),
-        }
-    }
-
-    // ============== UnificationContext: unify variable vs variable ==============
-
-    #[test]
-    fn unify_two_variables_intersects_constraints() {
-        let mut ctx = UnificationContext::new();
-        let a = ctx.fresh(PrimitiveSet::NUMERIC);
-        let b = ctx.fresh(PrimitiveSet::COMPARABLE);
-        ctx.unify(&Type::variable(a), &Type::variable(b)).unwrap();
-        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
-        assert_eq!(ctx.constraint(b), PrimitiveSet::NUMERIC);
-    }
-
-    #[test]
-    fn unify_two_variables_disjoint_fails() {
-        let mut ctx = UnificationContext::new();
-        let a = ctx.fresh(PrimitiveSet::NUMERIC);
-        let b = ctx.fresh(PrimitiveSet::singleton(ValueType::String));
-        let result = ctx.unify(&Type::variable(a), &Type::variable(b));
-        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
-    }
-
-    #[test]
-    fn chained_unification_propagates() {
-        let mut ctx = UnificationContext::new();
-        let t = ctx.fresh(PrimitiveSet::NUMERIC);
-        let u = ctx.fresh(PrimitiveSet::NUMERIC);
-        ctx.unify(&Type::variable(t), &Type::variable(u)).unwrap();
-        ctx.unify(&Type::variable(t), &p(ValueType::UnsignedInt))
-            .unwrap();
-        let t_resolved = ctx.apply(&Type::variable(t));
-        let u_resolved = ctx.apply(&Type::variable(u));
-        assert_eq!(
-            t_resolved.shape().as_singleton(),
-            Some(ValueType::UnsignedInt)
-        );
-        assert_eq!(
-            u_resolved.shape().as_singleton(),
-            Some(ValueType::UnsignedInt)
-        );
-    }
-
-    // ============== UnificationContext: optionality interaction ==============
-
-    #[test]
-    fn unify_optional_with_definite_same_shape_succeeds() {
-        let mut ctx = UnificationContext::new();
-        ctx.unify(&p(ValueType::String), &o(ValueType::String))
-            .unwrap();
-    }
-
-    #[test]
-    fn unify_optional_with_definite_disjoint_fails() {
-        let mut ctx = UnificationContext::new();
-        let result = ctx.unify(&p(ValueType::String), &o(ValueType::Entity));
-        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
-    }
-
-    // ============== TypeScheme: instantiation ==============
-
-    fn sum_scheme() -> TypeScheme {
-        TypeScheme {
-            quantified: vec![(SchemeVarName::new("T"), PrimitiveSet::NUMERIC)],
-            body: SchemeBody::Schema(vec![
-                (
-                    "left".into(),
-                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
-                        "T",
-                    )))),
-                ),
-                (
-                    "right".into(),
-                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
-                        "T",
-                    )))),
-                ),
-                (
-                    "out".into(),
-                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
-                        "T",
-                    )))),
-                ),
-            ]),
-        }
-    }
-
-    #[test]
-    fn instantiate_allocates_fresh_variables() {
-        let scheme = sum_scheme();
-        let mut ctx = UnificationContext::new();
-        let i1 = ctx.instantiate(&scheme);
-        let i2 = ctx.instantiate(&scheme);
-        let t1 = i1.variables.get(&SchemeVarName::new("T")).copied().unwrap();
-        let t2 = i2.variables.get(&SchemeVarName::new("T")).copied().unwrap();
-        assert_ne!(t1, t2);
-        assert_eq!(ctx.constraint(t1), PrimitiveSet::NUMERIC);
-        assert_eq!(ctx.constraint(t2), PrimitiveSet::NUMERIC);
-    }
-
-    #[test]
-    fn instantiate_shared_variable_in_body() {
-        let scheme = sum_scheme();
-        let mut ctx = UnificationContext::new();
-        let inst = ctx.instantiate(&scheme);
-        if let InstantiatedBody::Schema(fields) = &inst.body {
-            let var_ids: Vec<VarId> = fields
-                .iter()
-                .map(|(_, ty)| match ty.shape() {
-                    Definite::Variable(id) => *id,
-                    other => panic!("expected variable, got {:?}", other),
-                })
-                .collect();
-            assert_eq!(var_ids.len(), 3);
-            assert_eq!(var_ids[0], var_ids[1]);
-            assert_eq!(var_ids[1], var_ids[2]);
-        } else {
-            panic!("expected Schema body");
-        }
-    }
-
-    #[test]
-    fn instantiated_polymorphic_formula_unifies() {
-        let scheme = sum_scheme();
-        let mut ctx = UnificationContext::new();
-        let inst = ctx.instantiate(&scheme);
-        let fields = match &inst.body {
-            InstantiatedBody::Schema(f) => f,
-            _ => panic!(),
-        };
-        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
-        for (_, ty) in fields {
-            let resolved = ctx.apply(ty);
-            assert_eq!(
-                resolved.shape().as_singleton(),
-                Some(ValueType::UnsignedInt),
-                "expected u32 after unification"
-            );
-        }
-    }
-
-    #[test]
-    fn instantiated_polymorphic_formula_rejects_mismatch() {
-        let scheme = sum_scheme();
-        let mut ctx = UnificationContext::new();
-        let inst = ctx.instantiate(&scheme);
-        let fields = match &inst.body {
-            InstantiatedBody::Schema(f) => f,
-            _ => panic!(),
-        };
-        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
-        let result = ctx.unify(&fields[1].1, &p(ValueType::String));
-        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
-    }
-
-    #[test]
-    fn two_instantiations_are_independent() {
-        // First instantiation pins T to u32; second instantiation
-        // should still be free to pin T to a different type.
-        let scheme = sum_scheme();
-        let mut ctx = UnificationContext::new();
-        let i1 = ctx.instantiate(&scheme);
-        let i2 = ctx.instantiate(&scheme);
-        let i1_left = match &i1.body {
-            InstantiatedBody::Schema(f) => f[0].1.clone(),
-            _ => panic!(),
-        };
-        let i2_left = match &i2.body {
-            InstantiatedBody::Schema(f) => f[0].1.clone(),
-            _ => panic!(),
-        };
-        ctx.unify(&i1_left, &p(ValueType::UnsignedInt)).unwrap();
-        // Independent — second instantiation can pin to a different
-        // member of NUMERIC without conflict.
-        ctx.unify(&i2_left, &p(ValueType::Float)).unwrap();
-    }
-
-    // ============== MatchOptionality ==============
-
-    #[test]
-    fn match_optionality_split() {
-        let (opt, _) = MatchOptionality::split(&p(ValueType::String));
-        assert_eq!(opt, MatchOptionality::Required);
-        let (opt, _) = MatchOptionality::split(&o(ValueType::String));
-        assert_eq!(opt, MatchOptionality::Optional);
-    }
-
-    #[test]
-    fn match_optionality_combine_strictest_wins() {
-        assert_eq!(
-            MatchOptionality::Required.combine(MatchOptionality::Optional),
-            MatchOptionality::Required
-        );
-        assert_eq!(
-            MatchOptionality::Optional.combine(MatchOptionality::Required),
-            MatchOptionality::Required
-        );
-        assert_eq!(
-            MatchOptionality::Optional.combine(MatchOptionality::Optional),
-            MatchOptionality::Optional
-        );
+    fn type_hash_is_stable_across_constructions() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let a = p(ValueType::String);
+        let b = Type::Definite(Box::new(Definite::primitive(ValueType::String)));
+        let mut ha = DefaultHasher::new();
+        let mut hb = DefaultHasher::new();
+        a.hash(&mut ha);
+        b.hash(&mut hb);
+        assert_eq!(ha.finish(), hb.finish());
+        assert_eq!(a, b);
     }
 }

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -131,6 +131,15 @@ impl Primitive {
         (self.bits & NOTHING_BIT) != 0
     }
 
+    /// Returns a copy of this set with the `Nothing` atom removed.
+    /// Used to strip set-widening from an `Optional<T>` type back
+    /// to its underlying `T` shape.
+    pub fn without_nothing(self) -> Self {
+        Self {
+            bits: self.bits & !NOTHING_BIT,
+        }
+    }
+
     /// Set intersection. Returns `None` iff the result is empty.
     pub fn intersect(self, other: Self) -> Option<Self> {
         let merged = Self {
@@ -295,6 +304,16 @@ impl Type {
         match self {
             Type::Primitive(p) => Type::Primitive(p.union(Primitive::NOTHING)),
             Type::Composite(p, c) => Type::Composite(p.union(Primitive::NOTHING), c),
+        }
+    }
+
+    /// The inverse of [`optional`]: strip the `Nothing` atom if
+    /// present, yielding the underlying non-widened type.
+    /// Idempotent.
+    pub fn without_nothing(self) -> Type {
+        match self {
+            Type::Primitive(p) => Type::Primitive(p.without_nothing()),
+            Type::Composite(p, c) => Type::Composite(p.without_nothing(), c),
         }
     }
 
@@ -691,10 +710,6 @@ mod tests {
         let ba = b.union(&a);
 
         assert_eq!(ab, ba, "set equality is order-independent");
-        assert_eq!(
-            hash_of(&ab),
-            hash_of(&ba),
-            "set hash is order-independent"
-        );
+        assert_eq!(hash_of(&ab), hash_of(&ba), "set hash is order-independent");
     }
 }

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -1,0 +1,1006 @@
+//! Unified type system for the query engine.
+//!
+//! This module is the foundation of v2's type system. It defines:
+//!
+//! - [`Type`] / [`Definite`] — the runtime type representation,
+//!   covering primitive value types, type variables, and
+//!   set-widened (Optional) types. Designed to grow `Record` and
+//!   `Variant` constructors in future PRs without reshape.
+//! - [`PrimitiveSet`] — a bitfield over [`ValueType`] variants.
+//!   Enables type variables to carry kind-level constraints
+//!   (`NUMERIC`, `STRING_LIKE`, etc.) and lets unification narrow
+//!   via set intersection.
+//! - [`VarId`] / [`TypeScheme`] — rank-1 polymorphic type
+//!   schemes, used by formula declarations to express generic
+//!   signatures like `Sum<T: Numeric>(T, T) -> T`.
+//! - [`UnificationContext`] — a Damas-Milner unifier with
+//!   substitution, constraint registry, fresh-id allocator, and
+//!   the [`unify`](UnificationContext::unify) algorithm itself.
+//! - [`MatchOptionality`] — slot-level optionality for unification.
+//!
+//! See `notes/optional-fields.md` for the design rationale.
+
+use crate::artifact::Type as ValueType;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// A unique identifier for a type variable within a unification
+/// context. Allocated by [`UnificationContext::fresh`] or by
+/// [`UnificationContext::instantiate`] when a [`TypeScheme`]'s
+/// quantified variable is bound to a fresh runtime variable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct VarId(u32);
+
+/// Process-global counter for [`VarId`] allocation. Used as a
+/// fallback when no [`UnificationContext`] is available — most
+/// allocation goes through a context's per-context counter for
+/// determinism.
+static GLOBAL_VAR_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+impl VarId {
+    /// Allocate a new globally-unique `VarId`. Used at descriptor
+    /// boundaries where no context is available; rule-compile-time
+    /// unification uses [`UnificationContext::fresh`] instead.
+    pub fn global_fresh() -> Self {
+        Self(GLOBAL_VAR_COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+/// A bitfield over [`ValueType`] variants — a set of admissible
+/// primitive shapes.
+///
+/// Used everywhere a "kind constraint" is needed: type variables
+/// declare their constraint as a `PrimitiveSet`, formula schemas
+/// declare per-variable constraints, and unification intersects
+/// them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PrimitiveSet {
+    /// One bit per [`ValueType`] variant. Bit position is the
+    /// variant's discriminant in [`Self::bit_for`].
+    bits: u16,
+}
+
+impl PrimitiveSet {
+    /// Empty set — no admissible types. Constructible but
+    /// rejected at unification time (an empty set means
+    /// "no shape can satisfy this constraint").
+    pub const EMPTY: Self = Self { bits: 0 };
+
+    /// Set containing every [`ValueType`] variant. Equivalent to
+    /// the v1 `Type::Any` for primitive shapes.
+    pub const ALL: Self = Self {
+        bits: 0b1_1111_1111,
+    };
+
+    /// Numeric primitives: `UnsignedInt`, `SignedInt`, `Float`.
+    pub const NUMERIC: Self = Self {
+        bits: Self::bit_for(ValueType::UnsignedInt)
+            | Self::bit_for(ValueType::SignedInt)
+            | Self::bit_for(ValueType::Float),
+    };
+
+    /// String-like primitives: `String`, `Symbol`.
+    pub const STRING_LIKE: Self = Self {
+        bits: Self::bit_for(ValueType::String) | Self::bit_for(ValueType::Symbol),
+    };
+
+    /// Comparable primitives: numeric ∪ string-like ∪ entity ∪ bytes.
+    /// Used as the constraint for ordering predicates (`<`, `<=`, etc.).
+    pub const COMPARABLE: Self = Self {
+        bits: Self::NUMERIC.bits
+            | Self::STRING_LIKE.bits
+            | Self::bit_for(ValueType::Entity)
+            | Self::bit_for(ValueType::Bytes),
+    };
+
+    /// Construct a singleton set from a single `ValueType`.
+    pub const fn singleton(vt: ValueType) -> Self {
+        Self {
+            bits: Self::bit_for(vt),
+        }
+    }
+
+    /// Bitfield position for a `ValueType` variant. Stable across
+    /// builds so serialization round-trips. Adding a new variant
+    /// requires extending this match and the `ALL` mask above.
+    const fn bit_for(vt: ValueType) -> u16 {
+        match vt {
+            ValueType::String => 1 << 0,
+            ValueType::Boolean => 1 << 1,
+            ValueType::UnsignedInt => 1 << 2,
+            ValueType::SignedInt => 1 << 3,
+            ValueType::Float => 1 << 4,
+            ValueType::Bytes => 1 << 5,
+            ValueType::Entity => 1 << 6,
+            ValueType::Symbol => 1 << 7,
+            ValueType::Record => 1 << 8,
+        }
+    }
+
+    /// Returns `true` iff this set has no members.
+    pub fn is_empty(self) -> bool {
+        self.bits == 0
+    }
+
+    /// Set intersection. Returns `None` iff the result is empty —
+    /// signals "no shape can satisfy both constraints," which
+    /// callers (notably [`UnificationContext::unify`]) treat as a
+    /// type error.
+    pub fn intersect(self, other: Self) -> Option<Self> {
+        let merged = Self {
+            bits: self.bits & other.bits,
+        };
+        if merged.is_empty() {
+            None
+        } else {
+            Some(merged)
+        }
+    }
+
+    /// Set union. Always non-empty if either input is.
+    pub fn union(self, other: Self) -> Self {
+        Self {
+            bits: self.bits | other.bits,
+        }
+    }
+
+    /// Returns `true` iff `self` is a (non-strict) superset of
+    /// `other`. Used by the `includes`-style subtype check.
+    pub fn includes(self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+
+    /// Returns `true` iff `vt` is a member of this set.
+    pub fn contains(self, vt: ValueType) -> bool {
+        (self.bits & Self::bit_for(vt)) != 0
+    }
+
+    /// If this set has exactly one member, return it. Useful for
+    /// the common "I narrowed the constraint down to a single
+    /// type" case.
+    pub fn as_singleton(self) -> Option<ValueType> {
+        let count = self.bits.count_ones();
+        if count != 1 {
+            return None;
+        }
+        let pos = self.bits.trailing_zeros();
+        value_type_for_bit(pos)
+    }
+
+    /// Iterate over the members of this set in `ValueType`
+    /// discriminant order.
+    pub fn iter(self) -> impl Iterator<Item = ValueType> {
+        let bits = self.bits;
+        (0..9u32).filter_map(move |pos| {
+            if (bits & (1 << pos)) != 0 {
+                value_type_for_bit(pos)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+fn value_type_for_bit(pos: u32) -> Option<ValueType> {
+    Some(match pos {
+        0 => ValueType::String,
+        1 => ValueType::Boolean,
+        2 => ValueType::UnsignedInt,
+        3 => ValueType::SignedInt,
+        4 => ValueType::Float,
+        5 => ValueType::Bytes,
+        6 => ValueType::Entity,
+        7 => ValueType::Symbol,
+        8 => ValueType::Record,
+        _ => return None,
+    })
+}
+
+impl From<ValueType> for PrimitiveSet {
+    fn from(vt: ValueType) -> Self {
+        Self::singleton(vt)
+    }
+}
+
+/// Schema-layer type of a value, term, or schema slot.
+///
+/// Two outer variants distinguish set-widening (Optional) from
+/// concrete shapes (Definite). Optionality lives at the slot
+/// layer, never on type variables — this keeps "nested
+/// optionality" structurally unrepresentable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Type {
+    /// A definite shape. Subtype of `Optional(definite)` via the
+    /// `T ⊆ Optional<T>` set-widening rule.
+    Definite(Box<Definite>),
+    /// Set-widened: the wrapped shape *or*
+    /// [`Binding::Absent`](crate::Binding::Absent) at the row
+    /// layer. Wraps a [`Definite`] (not a [`Type`]) so nested
+    /// optionality is structurally impossible.
+    Optional(Box<Definite>),
+}
+
+/// A concrete value shape — non-`Optional`. Includes type
+/// variables (which still represent "a single shape," just
+/// unknown until unified).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Definite {
+    /// Atomic value type, possibly a union over several primitive
+    /// shapes. `PrimitiveSet::singleton(ValueType::String)` is
+    /// "exactly String"; `PrimitiveSet::NUMERIC` is "any of
+    /// `UnsignedInt`, `SignedInt`, `Float`."
+    Primitive(PrimitiveSet),
+    /// A type variable. The variable's constraint
+    /// (`PrimitiveSet`) lives in the
+    /// [`UnificationContext`]'s constraint registry, keyed by
+    /// `VarId`. The variable resolves to a concrete `Definite`
+    /// once unified.
+    Variable(VarId),
+    // Future:
+    // Record(BTreeMap<String, Type>),
+    // Variant(BTreeMap<String, Definite>),
+}
+
+impl Type {
+    /// Construct a `Type::Definite(Primitive(singleton(vt)))`.
+    pub fn primitive(vt: ValueType) -> Self {
+        Type::Definite(Box::new(Definite::Primitive(PrimitiveSet::singleton(vt))))
+    }
+
+    /// Construct a `Type::Optional(Primitive(singleton(vt)))`.
+    pub fn optional(vt: ValueType) -> Self {
+        Type::Optional(Box::new(Definite::Primitive(PrimitiveSet::singleton(vt))))
+    }
+
+    /// Construct a `Type::Definite(Primitive(set))`.
+    pub fn primitive_set(set: PrimitiveSet) -> Self {
+        Type::Definite(Box::new(Definite::Primitive(set)))
+    }
+
+    /// Construct a `Type::Optional(Primitive(set))`.
+    pub fn optional_set(set: PrimitiveSet) -> Self {
+        Type::Optional(Box::new(Definite::Primitive(set)))
+    }
+
+    /// Construct a `Type::Definite(Variable(id))`.
+    pub fn variable(id: VarId) -> Self {
+        Type::Definite(Box::new(Definite::Variable(id)))
+    }
+
+    /// Construct an "anonymous unconstrained variable" type — the
+    /// v2 replacement for v1's `Type::Any`. Allocates a globally-
+    /// unique [`VarId`]; for rule-compile-time anonymous
+    /// allocation use
+    /// [`UnificationContext::fresh`](UnificationContext::fresh)
+    /// with `PrimitiveSet::ALL`.
+    pub fn any() -> Self {
+        Type::variable(VarId::global_fresh())
+    }
+
+    /// Returns `true` iff this type is set-widened with `Absent`.
+    pub fn is_optional(&self) -> bool {
+        matches!(self, Type::Optional(_))
+    }
+
+    /// Returns the underlying [`Definite`] regardless of whether
+    /// this is `Definite` or `Optional`. Used by callers that
+    /// need to inspect the shape independently of optionality.
+    pub fn shape(&self) -> &Definite {
+        match self {
+            Type::Definite(d) | Type::Optional(d) => d,
+        }
+    }
+}
+
+impl Definite {
+    /// Construct a `Definite::Primitive(singleton(vt))`.
+    pub fn primitive(vt: ValueType) -> Self {
+        Definite::Primitive(PrimitiveSet::singleton(vt))
+    }
+
+    /// If this is a primitive shape with a singleton value type,
+    /// return it.
+    pub fn as_singleton(&self) -> Option<ValueType> {
+        match self {
+            Definite::Primitive(set) => set.as_singleton(),
+            Definite::Variable(_) => None,
+        }
+    }
+}
+
+/// Slot-level optionality used during unification. Tracks whether
+/// a use site of a variable is wrapped in `Optional` independently
+/// of the variable's own shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MatchOptionality {
+    /// The slot demands a Present value — `Type::Definite(_)`.
+    Required,
+    /// The slot tolerates `Absent` — `Type::Optional(_)`.
+    Optional,
+}
+
+impl MatchOptionality {
+    /// Lift a `Type` to its slot-level optionality plus the
+    /// underlying shape.
+    pub fn split(ty: &Type) -> (Self, &Definite) {
+        match ty {
+            Type::Definite(d) => (Self::Required, d),
+            Type::Optional(d) => (Self::Optional, d),
+        }
+    }
+
+    /// "Strictest wins" combine: `Required` ∧ `Optional` =
+    /// `Required`. Used when two slots demand the same variable
+    /// but with different optionality.
+    pub fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Required, _) | (_, Self::Required) => Self::Required,
+            (Self::Optional, Self::Optional) => Self::Optional,
+        }
+    }
+}
+
+/// Errors raised by unification.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum UnifyError {
+    /// Two types' primitive constraint sets have empty
+    /// intersection — no shape can satisfy both.
+    #[error("constraint conflict between {left:?} and {right:?}")]
+    ConstraintConflict {
+        /// The narrower side.
+        left: PrimitiveSet,
+        /// The other narrower side.
+        right: PrimitiveSet,
+    },
+    /// Occurs check: unifying a variable with a type that
+    /// transitively contains the variable would produce an
+    /// infinite type. Today's `Definite` doesn't compose, so
+    /// this is unreachable; reserved for future `Record` /
+    /// `Variant` constructors.
+    #[error("occurs check failed for variable {var:?}")]
+    OccursCheck {
+        /// The offending variable.
+        var: VarId,
+    },
+}
+
+/// A rank-1 polymorphic type scheme. Used by formula declarations
+/// to express generic signatures like
+/// `Sum<T: Numeric>(left: T, right: T) -> T`.
+///
+/// Schemes are static Rust-side metadata, not part of the wire
+/// format. Each formula module defines a `LazyLock<TypeScheme>`
+/// constant; the registry maps formula identifiers (e.g.
+/// `"math/sum"`) to their schemes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeScheme {
+    /// Quantified variables and their constraints. Names are
+    /// scope-local to this scheme.
+    pub quantified: Vec<(SchemeVarName, PrimitiveSet)>,
+    /// The scheme body, referencing quantified variables by
+    /// name. Instantiation replaces names with fresh `VarId`s.
+    pub body: SchemeBody,
+}
+
+/// A name binding a quantified type variable in a scheme. Local
+/// to the scheme; instantiation replaces it with a fresh
+/// [`VarId`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SchemeVarName(pub String);
+
+impl SchemeVarName {
+    /// Construct a name. Convention: single uppercase letter (`T`,
+    /// `U`) for the most common case, but any string works.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+/// The body of a [`TypeScheme`] — either a function-like signature
+/// (formula schemas) or a single value type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemeBody {
+    /// A function-like signature: parameter names → slot types.
+    Schema(Vec<(String, SchemeType)>),
+    /// A single value type — for non-function schemes.
+    Type(SchemeType),
+}
+
+/// A type expression inside a [`TypeScheme`]. References
+/// quantified variables by name; instantiation replaces names
+/// with fresh runtime [`VarId`]s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemeType {
+    /// `Definite(SchemeDefinite)`.
+    Definite(Box<SchemeDefinite>),
+    /// `Optional(SchemeDefinite)` — set-widened slot.
+    Optional(Box<SchemeDefinite>),
+}
+
+/// `Definite` shape inside a [`TypeScheme`]. Variables reference
+/// quantified names; instantiation replaces with [`VarId`]s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemeDefinite {
+    /// Concrete primitive set — no variable.
+    Primitive(PrimitiveSet),
+    /// Reference to a quantified variable by name.
+    Variable(SchemeVarName),
+}
+
+/// Per-rule unification context. Tracks the substitution map,
+/// per-variable constraints, and a fresh-id counter.
+#[derive(Debug, Clone, Default)]
+pub struct UnificationContext {
+    /// Substitution: variable → resolved (or partially-resolved)
+    /// `Definite`. Updated in-place by [`Self::unify`]. The
+    /// substituted value may itself contain variables that haven't
+    /// yet been resolved.
+    substitution: HashMap<VarId, Definite>,
+    /// Per-variable primitive constraint. Populated when a
+    /// variable is allocated; intersected during unification.
+    constraints: HashMap<VarId, PrimitiveSet>,
+    /// Counter for fresh `VarId` allocation within this context.
+    next_id: u32,
+}
+
+impl UnificationContext {
+    /// Create an empty context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a fresh `VarId` with the given constraint.
+    pub fn fresh(&mut self, constraint: PrimitiveSet) -> VarId {
+        let id = VarId(self.next_id);
+        self.next_id += 1;
+        self.constraints.insert(id, constraint);
+        id
+    }
+
+    /// Look up the constraint for a variable. Returns
+    /// [`PrimitiveSet::ALL`] if the variable is unknown to this
+    /// context (e.g. one allocated via [`VarId::global_fresh`]
+    /// outside any context).
+    pub fn constraint(&self, var: VarId) -> PrimitiveSet {
+        self.constraints
+            .get(&var)
+            .copied()
+            .unwrap_or(PrimitiveSet::ALL)
+    }
+
+    /// Apply the current substitution to a `Type`, recursively
+    /// resolving any variables that have been bound. Variables
+    /// that haven't been bound stay as `Variable(id)`.
+    pub fn apply(&self, ty: &Type) -> Type {
+        match ty {
+            Type::Definite(d) => Type::Definite(Box::new(self.apply_definite(d))),
+            Type::Optional(d) => Type::Optional(Box::new(self.apply_definite(d))),
+        }
+    }
+
+    fn apply_definite(&self, d: &Definite) -> Definite {
+        match d {
+            Definite::Primitive(_) => d.clone(),
+            Definite::Variable(id) => {
+                if let Some(resolved) = self.substitution.get(id) {
+                    self.apply_definite(resolved)
+                } else {
+                    Definite::Variable(*id)
+                }
+            }
+        }
+    }
+
+    /// Robinson unification with constraint propagation. Updates
+    /// `self` in-place. Returns `Err` on constraint conflict or
+    /// occurs check failure.
+    pub fn unify(&mut self, a: &Type, b: &Type) -> Result<(), UnifyError> {
+        let a = self.apply(a);
+        let b = self.apply(b);
+        let (_a_opt, a_def) = MatchOptionality::split(&a);
+        let (_b_opt, b_def) = MatchOptionality::split(&b);
+
+        // Slot-level optionality is informational at this layer:
+        // the underlying definite shapes are unified regardless,
+        // and "strictest wins" means a Definite consumer paired
+        // with an Optional producer narrows to Definite. Higher
+        // layers (RuleAnalysis, Slice 7 enforcement) read the
+        // slot-level optionality from each use site directly.
+
+        self.unify_definite(a_def, b_def)?;
+
+        Ok(())
+    }
+
+    fn unify_definite(&mut self, a: &Definite, b: &Definite) -> Result<(), UnifyError> {
+        match (a, b) {
+            // Two same variables: nothing to do.
+            (Definite::Variable(x), Definite::Variable(y)) if x == y => Ok(()),
+            // Two distinct variables: bind one to the other,
+            // intersecting constraints.
+            (Definite::Variable(x), Definite::Variable(y)) => {
+                let cx = self.constraint(*x);
+                let cy = self.constraint(*y);
+                let merged = cx.intersect(cy).ok_or(UnifyError::ConstraintConflict {
+                    left: cx,
+                    right: cy,
+                })?;
+                self.constraints.insert(*x, merged);
+                self.constraints.insert(*y, merged);
+                self.substitution.insert(*y, Definite::Variable(*x));
+                Ok(())
+            }
+            // Variable vs primitive: check constraint, substitute.
+            (Definite::Variable(x), Definite::Primitive(p))
+            | (Definite::Primitive(p), Definite::Variable(x)) => {
+                let cx = self.constraint(*x);
+                let merged = cx.intersect(*p).ok_or(UnifyError::ConstraintConflict {
+                    left: cx,
+                    right: *p,
+                })?;
+                self.constraints.insert(*x, merged);
+                self.substitution.insert(*x, Definite::Primitive(merged));
+                Ok(())
+            }
+            // Two primitives: intersect their sets.
+            (Definite::Primitive(p), Definite::Primitive(q)) => p
+                .intersect(*q)
+                .ok_or(UnifyError::ConstraintConflict {
+                    left: *p,
+                    right: *q,
+                })
+                .map(|_| ()),
+        }
+    }
+
+    /// Instantiate a [`TypeScheme`]: allocate fresh `VarId`s for
+    /// each quantified name, then materialize the body into a
+    /// concrete signature with substitutions applied.
+    ///
+    /// Two calls to `instantiate` on the same scheme produce
+    /// independent fresh variables — different uses of the same
+    /// formula don't conflate their type variables.
+    pub fn instantiate(&mut self, scheme: &TypeScheme) -> InstantiatedScheme {
+        let mut substitution: HashMap<SchemeVarName, VarId> = HashMap::new();
+        for (name, constraint) in &scheme.quantified {
+            let id = self.fresh(*constraint);
+            substitution.insert(name.clone(), id);
+        }
+        InstantiatedScheme {
+            body: instantiate_body(&scheme.body, &substitution),
+            variables: substitution,
+        }
+    }
+}
+
+fn instantiate_body(body: &SchemeBody, sub: &HashMap<SchemeVarName, VarId>) -> InstantiatedBody {
+    match body {
+        SchemeBody::Schema(fields) => InstantiatedBody::Schema(
+            fields
+                .iter()
+                .map(|(name, ty)| (name.clone(), instantiate_type(ty, sub)))
+                .collect(),
+        ),
+        SchemeBody::Type(ty) => InstantiatedBody::Type(instantiate_type(ty, sub)),
+    }
+}
+
+fn instantiate_type(ty: &SchemeType, sub: &HashMap<SchemeVarName, VarId>) -> Type {
+    match ty {
+        SchemeType::Definite(d) => Type::Definite(Box::new(instantiate_definite(d, sub))),
+        SchemeType::Optional(d) => Type::Optional(Box::new(instantiate_definite(d, sub))),
+    }
+}
+
+fn instantiate_definite(d: &SchemeDefinite, sub: &HashMap<SchemeVarName, VarId>) -> Definite {
+    match d {
+        SchemeDefinite::Primitive(p) => Definite::Primitive(*p),
+        SchemeDefinite::Variable(name) => Definite::Variable(
+            *sub.get(name)
+                .expect("scheme references unquantified variable"),
+        ),
+    }
+}
+
+/// The result of instantiating a [`TypeScheme`]. Carries the
+/// fresh-`VarId` substitution alongside the body so callers can
+/// look up which `VarId` represents which scheme variable.
+#[derive(Debug, Clone)]
+pub struct InstantiatedScheme {
+    /// The instantiated body — concrete `Type`s with `VarId`
+    /// references in place of scheme-variable names.
+    pub body: InstantiatedBody,
+    /// Maps each scheme variable name to the fresh `VarId`
+    /// allocated for this instantiation.
+    pub variables: HashMap<SchemeVarName, VarId>,
+}
+
+/// An instantiated [`SchemeBody`].
+#[derive(Debug, Clone)]
+pub enum InstantiatedBody {
+    /// Function-like signature: `Vec<(name, slot_type)>`.
+    Schema(Vec<(String, Type)>),
+    /// A single value type.
+    Type(Type),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(vt: ValueType) -> Type {
+        Type::primitive(vt)
+    }
+    fn o(vt: ValueType) -> Type {
+        Type::optional(vt)
+    }
+
+    // ============== PrimitiveSet ==============
+
+    #[test]
+    fn primitive_set_singleton() {
+        let s = PrimitiveSet::singleton(ValueType::String);
+        assert!(s.contains(ValueType::String));
+        assert!(!s.contains(ValueType::UnsignedInt));
+        assert_eq!(s.as_singleton(), Some(ValueType::String));
+    }
+
+    #[test]
+    fn primitive_set_intersect_overlap() {
+        let s = PrimitiveSet::NUMERIC
+            .intersect(PrimitiveSet::singleton(ValueType::UnsignedInt))
+            .unwrap();
+        assert_eq!(s.as_singleton(), Some(ValueType::UnsignedInt));
+    }
+
+    #[test]
+    fn primitive_set_intersect_disjoint() {
+        assert!(
+            PrimitiveSet::singleton(ValueType::String)
+                .intersect(PrimitiveSet::singleton(ValueType::Entity))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn primitive_set_includes_self() {
+        assert!(PrimitiveSet::ALL.includes(PrimitiveSet::ALL));
+        assert!(PrimitiveSet::NUMERIC.includes(PrimitiveSet::singleton(ValueType::UnsignedInt)));
+    }
+
+    #[test]
+    fn primitive_set_iter() {
+        let s = PrimitiveSet::NUMERIC;
+        let members: Vec<_> = s.iter().collect();
+        assert_eq!(members.len(), 3);
+        assert!(members.contains(&ValueType::UnsignedInt));
+        assert!(members.contains(&ValueType::SignedInt));
+        assert!(members.contains(&ValueType::Float));
+    }
+
+    #[test]
+    fn primitive_set_serde_round_trip() {
+        let s = PrimitiveSet::NUMERIC;
+        let j = serde_json::to_string(&s).unwrap();
+        let back: PrimitiveSet = serde_json::from_str(&j).unwrap();
+        assert_eq!(s, back);
+    }
+
+    // ============== Type construction ==============
+
+    #[test]
+    fn type_primitive_is_definite() {
+        let t = p(ValueType::String);
+        assert!(matches!(t, Type::Definite(_)));
+        assert!(!t.is_optional());
+    }
+
+    #[test]
+    fn type_optional_wraps_definite() {
+        let t = o(ValueType::String);
+        assert!(t.is_optional());
+    }
+
+    #[test]
+    fn type_any_is_anonymous_variable() {
+        let t = Type::any();
+        match t.shape() {
+            Definite::Variable(_) => {}
+            other => panic!("expected anonymous variable, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn type_serde_round_trip_definite() {
+        let t = p(ValueType::String);
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
+    }
+
+    #[test]
+    fn type_serde_round_trip_optional() {
+        let t = o(ValueType::Entity);
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
+    }
+
+    // ============== UnificationContext: variable basics ==============
+
+    #[test]
+    fn fresh_variables_are_distinct() {
+        let mut ctx = UnificationContext::new();
+        let a = ctx.fresh(PrimitiveSet::ALL);
+        let b = ctx.fresh(PrimitiveSet::ALL);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn fresh_records_constraint() {
+        let mut ctx = UnificationContext::new();
+        let a = ctx.fresh(PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
+    }
+
+    // ============== UnificationContext: unify primitive vs primitive ==============
+
+    #[test]
+    fn unify_two_concrete_primitives_same_succeeds() {
+        let mut ctx = UnificationContext::new();
+        ctx.unify(&p(ValueType::String), &p(ValueType::String))
+            .unwrap();
+    }
+
+    #[test]
+    fn unify_two_concrete_primitives_different_fails() {
+        let mut ctx = UnificationContext::new();
+        let result = ctx.unify(&p(ValueType::String), &p(ValueType::Entity));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    // ============== UnificationContext: unify variable vs primitive ==============
+
+    #[test]
+    fn unify_variable_with_concrete_substitutes() {
+        let mut ctx = UnificationContext::new();
+        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        ctx.unify(&Type::variable(v), &p(ValueType::UnsignedInt))
+            .unwrap();
+        let resolved = ctx.apply(&Type::variable(v));
+        match resolved.shape() {
+            Definite::Primitive(set) => {
+                assert_eq!(set.as_singleton(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("expected concrete primitive, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unify_variable_with_concrete_outside_constraint_fails() {
+        let mut ctx = UnificationContext::new();
+        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        let result = ctx.unify(&Type::variable(v), &p(ValueType::String));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[test]
+    fn unify_variable_constraint_propagates() {
+        let mut ctx = UnificationContext::new();
+        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        let v_ty = Type::variable(v);
+        let comparable = Type::primitive_set(PrimitiveSet::COMPARABLE);
+        ctx.unify(&v_ty, &comparable).unwrap();
+        let resolved = ctx.apply(&v_ty);
+        match resolved.shape() {
+            Definite::Primitive(set) => {
+                assert_eq!(*set, PrimitiveSet::NUMERIC);
+            }
+            other => panic!("expected primitive, got {:?}", other),
+        }
+    }
+
+    // ============== UnificationContext: unify variable vs variable ==============
+
+    #[test]
+    fn unify_two_variables_intersects_constraints() {
+        let mut ctx = UnificationContext::new();
+        let a = ctx.fresh(PrimitiveSet::NUMERIC);
+        let b = ctx.fresh(PrimitiveSet::COMPARABLE);
+        ctx.unify(&Type::variable(a), &Type::variable(b)).unwrap();
+        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(b), PrimitiveSet::NUMERIC);
+    }
+
+    #[test]
+    fn unify_two_variables_disjoint_fails() {
+        let mut ctx = UnificationContext::new();
+        let a = ctx.fresh(PrimitiveSet::NUMERIC);
+        let b = ctx.fresh(PrimitiveSet::singleton(ValueType::String));
+        let result = ctx.unify(&Type::variable(a), &Type::variable(b));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[test]
+    fn chained_unification_propagates() {
+        let mut ctx = UnificationContext::new();
+        let t = ctx.fresh(PrimitiveSet::NUMERIC);
+        let u = ctx.fresh(PrimitiveSet::NUMERIC);
+        ctx.unify(&Type::variable(t), &Type::variable(u)).unwrap();
+        ctx.unify(&Type::variable(t), &p(ValueType::UnsignedInt))
+            .unwrap();
+        let t_resolved = ctx.apply(&Type::variable(t));
+        let u_resolved = ctx.apply(&Type::variable(u));
+        assert_eq!(
+            t_resolved.shape().as_singleton(),
+            Some(ValueType::UnsignedInt)
+        );
+        assert_eq!(
+            u_resolved.shape().as_singleton(),
+            Some(ValueType::UnsignedInt)
+        );
+    }
+
+    // ============== UnificationContext: optionality interaction ==============
+
+    #[test]
+    fn unify_optional_with_definite_same_shape_succeeds() {
+        let mut ctx = UnificationContext::new();
+        ctx.unify(&p(ValueType::String), &o(ValueType::String))
+            .unwrap();
+    }
+
+    #[test]
+    fn unify_optional_with_definite_disjoint_fails() {
+        let mut ctx = UnificationContext::new();
+        let result = ctx.unify(&p(ValueType::String), &o(ValueType::Entity));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    // ============== TypeScheme: instantiation ==============
+
+    fn sum_scheme() -> TypeScheme {
+        TypeScheme {
+            quantified: vec![(SchemeVarName::new("T"), PrimitiveSet::NUMERIC)],
+            body: SchemeBody::Schema(vec![
+                (
+                    "left".into(),
+                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
+                        "T",
+                    )))),
+                ),
+                (
+                    "right".into(),
+                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
+                        "T",
+                    )))),
+                ),
+                (
+                    "out".into(),
+                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
+                        "T",
+                    )))),
+                ),
+            ]),
+        }
+    }
+
+    #[test]
+    fn instantiate_allocates_fresh_variables() {
+        let scheme = sum_scheme();
+        let mut ctx = UnificationContext::new();
+        let i1 = ctx.instantiate(&scheme);
+        let i2 = ctx.instantiate(&scheme);
+        let t1 = i1.variables.get(&SchemeVarName::new("T")).copied().unwrap();
+        let t2 = i2.variables.get(&SchemeVarName::new("T")).copied().unwrap();
+        assert_ne!(t1, t2);
+        assert_eq!(ctx.constraint(t1), PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(t2), PrimitiveSet::NUMERIC);
+    }
+
+    #[test]
+    fn instantiate_shared_variable_in_body() {
+        let scheme = sum_scheme();
+        let mut ctx = UnificationContext::new();
+        let inst = ctx.instantiate(&scheme);
+        if let InstantiatedBody::Schema(fields) = &inst.body {
+            let var_ids: Vec<VarId> = fields
+                .iter()
+                .map(|(_, ty)| match ty.shape() {
+                    Definite::Variable(id) => *id,
+                    other => panic!("expected variable, got {:?}", other),
+                })
+                .collect();
+            assert_eq!(var_ids.len(), 3);
+            assert_eq!(var_ids[0], var_ids[1]);
+            assert_eq!(var_ids[1], var_ids[2]);
+        } else {
+            panic!("expected Schema body");
+        }
+    }
+
+    #[test]
+    fn instantiated_polymorphic_formula_unifies() {
+        let scheme = sum_scheme();
+        let mut ctx = UnificationContext::new();
+        let inst = ctx.instantiate(&scheme);
+        let fields = match &inst.body {
+            InstantiatedBody::Schema(f) => f,
+            _ => panic!(),
+        };
+        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
+        for (_, ty) in fields {
+            let resolved = ctx.apply(ty);
+            assert_eq!(
+                resolved.shape().as_singleton(),
+                Some(ValueType::UnsignedInt),
+                "expected u32 after unification"
+            );
+        }
+    }
+
+    #[test]
+    fn instantiated_polymorphic_formula_rejects_mismatch() {
+        let scheme = sum_scheme();
+        let mut ctx = UnificationContext::new();
+        let inst = ctx.instantiate(&scheme);
+        let fields = match &inst.body {
+            InstantiatedBody::Schema(f) => f,
+            _ => panic!(),
+        };
+        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
+        let result = ctx.unify(&fields[1].1, &p(ValueType::String));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[test]
+    fn two_instantiations_are_independent() {
+        // First instantiation pins T to u32; second instantiation
+        // should still be free to pin T to a different type.
+        let scheme = sum_scheme();
+        let mut ctx = UnificationContext::new();
+        let i1 = ctx.instantiate(&scheme);
+        let i2 = ctx.instantiate(&scheme);
+        let i1_left = match &i1.body {
+            InstantiatedBody::Schema(f) => f[0].1.clone(),
+            _ => panic!(),
+        };
+        let i2_left = match &i2.body {
+            InstantiatedBody::Schema(f) => f[0].1.clone(),
+            _ => panic!(),
+        };
+        ctx.unify(&i1_left, &p(ValueType::UnsignedInt)).unwrap();
+        // Independent — second instantiation can pin to a different
+        // member of NUMERIC without conflict.
+        ctx.unify(&i2_left, &p(ValueType::Float)).unwrap();
+    }
+
+    // ============== MatchOptionality ==============
+
+    #[test]
+    fn match_optionality_split() {
+        let (opt, _) = MatchOptionality::split(&p(ValueType::String));
+        assert_eq!(opt, MatchOptionality::Required);
+        let (opt, _) = MatchOptionality::split(&o(ValueType::String));
+        assert_eq!(opt, MatchOptionality::Optional);
+    }
+
+    #[test]
+    fn match_optionality_combine_strictest_wins() {
+        assert_eq!(
+            MatchOptionality::Required.combine(MatchOptionality::Optional),
+            MatchOptionality::Required
+        );
+        assert_eq!(
+            MatchOptionality::Optional.combine(MatchOptionality::Required),
+            MatchOptionality::Required
+        );
+        assert_eq!(
+            MatchOptionality::Optional.combine(MatchOptionality::Optional),
+            MatchOptionality::Optional
+        );
+    }
+}

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -318,6 +318,21 @@ impl Type {
             Type::Definite(d) | Type::Optional(d) => d,
         }
     }
+
+    /// Lift this type to set-widened (`Optional`). Idempotent —
+    /// applying twice has no further effect (`Optional(Optional)`
+    /// would be structurally redundant; the outer enum prevents
+    /// it by construction).
+    ///
+    /// Used by [`DynamicAttributeQuery`](crate::DynamicAttributeQuery)
+    /// when its [`Resolution`](crate::attribute::query::Resolution) is
+    /// `Optional`: the schema's `is` slot needs to advertise
+    /// "this slot may bind to Absent at the row layer."
+    pub fn wrap_optional(self) -> Self {
+        match self {
+            Type::Definite(d) | Type::Optional(d) => Type::Optional(d),
+        }
+    }
 }
 
 impl Definite {

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -96,6 +96,11 @@ pub enum UnifyError {
         /// The offending variable.
         var: VarId,
     },
+    /// A `Coalesce` source type was expected to be set-widened
+    /// with `Nothing` but is not. Raised by
+    /// [`Coalesce::validate`](crate::constraint::Coalesce::validate).
+    #[error("Coalesce source is not Optional")]
+    SourceNotOptional,
 }
 
 /// A rank-1 polymorphic type scheme. Used by formula declarations

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -250,6 +250,12 @@ impl Context {
 
     /// Robinson unification with constraint propagation. Updates
     /// `self` in-place. Returns `Err` on constraint conflict.
+    ///
+    /// Static types intersect via [`StaticType::intersect`], which
+    /// narrows both primitive and composite parts (products by
+    /// shared field-name set, variants by label). Variables carry
+    /// a [`Primitive`] constraint that's intersected with the
+    /// primitive part of any concrete type they're unified with.
     pub fn unify(&mut self, a: &Type, b: &Type) -> Result<(), UnifyError> {
         let a = self.apply(a);
         let b = self.apply(b);
@@ -269,33 +275,29 @@ impl Context {
             }
             (Type::Variable(x), Type::Static(s)) | (Type::Static(s), Type::Variable(x)) => {
                 let cx = self.constraint(x);
-                let p = primitive_set_of(&s).ok_or(UnifyError::ConstraintConflict {
-                    left: cx,
-                    right: Primitive::EMPTY,
-                })?;
+                // Intersect the variable's primitive constraint
+                // against the static's primitive part. The variable
+                // resolves to the narrowed static type — preserving
+                // any composite part of the static side.
+                let p = s.primitive_part();
                 let merged = cx
                     .intersect(p)
                     .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
                 self.constraints.insert(x, merged);
-                self.substitution
-                    .insert(x, Type::Static(StaticType::primitive_set(merged)));
+                let resolved = match s.composite_part() {
+                    Some(c) if !c.is_empty() => StaticType::composite(merged, c.clone()),
+                    _ => StaticType::primitive_set(merged),
+                };
+                self.substitution.insert(x, Type::Static(resolved));
                 Ok(())
             }
             (Type::Static(a), Type::Static(b)) => {
-                let pa = primitive_set_of(&a).ok_or(UnifyError::ConstraintConflict {
-                    left: Primitive::EMPTY,
-                    right: Primitive::EMPTY,
-                })?;
-                let pb = primitive_set_of(&b).ok_or(UnifyError::ConstraintConflict {
-                    left: pa,
-                    right: Primitive::EMPTY,
-                })?;
-                pa.intersect(pb)
-                    .ok_or(UnifyError::ConstraintConflict {
-                        left: pa,
-                        right: pb,
-                    })
+                a.intersect(&b)
                     .map(|_| ())
+                    .ok_or_else(|| UnifyError::ConstraintConflict {
+                        left: a.primitive_part(),
+                        right: b.primitive_part(),
+                    })
             }
         }
     }
@@ -313,15 +315,6 @@ impl Context {
             variables: substitution,
         }
     }
-}
-
-/// Extract the primitive set of a static type. For composite-only
-/// types (no primitive bits and no admissible singleton) returns
-/// `None`. The unifier currently operates over the primitive part
-/// alone; composite-only constraints are reserved for future use.
-fn primitive_set_of(ty: &StaticType) -> Option<Primitive> {
-    let p = ty.primitive_part();
-    if p.is_empty() { None } else { Some(p) }
 }
 
 fn instantiate_body(body: &SchemeBody, sub: &HashMap<SchemeVarName, VarId>) -> InstantiatedBody {

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -1,0 +1,678 @@
+//! Unifier-internal type representation and Damas-Milner unifier.
+//!
+//! This submodule owns everything that needs to talk about
+//! per-rule type variables: [`VarId`] allocation, the
+//! [`Type`] enum with its `Static`/`Variable` distinction, the
+//! [`Context`] that drives unification, and the [`TypeScheme`]
+//! machinery for rank-1 polymorphic formula signatures.
+//!
+//! Variables never escape into the user-facing
+//! [`super::Type`]. Lifting between layers happens via [`lift`]
+//! and [`Context::infer`].
+
+use crate::artifact::Type as ValueType;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::{Definite, PrimitiveSet};
+
+/// A unique identifier for a type variable within a unification
+/// context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct VarId(u32);
+
+/// Unifier-internal type — either a static
+/// [user-facing type](super::Type) or a fresh type variable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Type {
+    /// A static, user-facing type lifted into the unifier domain.
+    Static(super::Type),
+    /// A type variable allocated by a [`Context`].
+    Variable(VarId),
+}
+
+impl Type {
+    /// Build a static primitive type, wrapped for unification.
+    pub fn primitive(vt: ValueType) -> Self {
+        Type::Static(super::Type::primitive(vt))
+    }
+
+    /// Build a static primitive set, wrapped for unification.
+    pub fn primitive_set(set: PrimitiveSet) -> Self {
+        Type::Static(super::Type::primitive_set(set))
+    }
+
+    /// Build a static optional primitive, wrapped for unification.
+    pub fn optional(vt: ValueType) -> Self {
+        Type::Static(super::Type::optional(vt))
+    }
+}
+
+/// Lift a static [user-facing type](super::Type) into the unifier
+/// domain. Always wraps in [`Type::Static`].
+pub fn lift(ty: &super::Type) -> Type {
+    Type::Static(ty.clone())
+}
+
+/// Slot-level optionality used during unification. Tracks whether
+/// a use site of a variable is wrapped in `Optional` independently
+/// of the variable's own shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MatchOptionality {
+    /// The slot demands a Present value.
+    Required,
+    /// The slot tolerates `Absent`.
+    Optional,
+}
+
+impl MatchOptionality {
+    /// "Strictest wins" combine: `Required` ∧ `Optional` =
+    /// `Required`.
+    pub fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Required, _) | (_, Self::Required) => Self::Required,
+            (Self::Optional, Self::Optional) => Self::Optional,
+        }
+    }
+}
+
+/// Errors raised by unification.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum UnifyError {
+    /// Two types' primitive constraint sets have empty
+    /// intersection — no shape can satisfy both.
+    #[error("constraint conflict between {left:?} and {right:?}")]
+    ConstraintConflict {
+        /// The narrower side.
+        left: PrimitiveSet,
+        /// The other narrower side.
+        right: PrimitiveSet,
+    },
+    /// Occurs check: unifying a variable with a type that
+    /// transitively contains the variable would produce an
+    /// infinite type. Reserved for future composite shapes.
+    #[error("occurs check failed for variable {var:?}")]
+    OccursCheck {
+        /// The offending variable.
+        var: VarId,
+    },
+}
+
+/// A rank-1 polymorphic type scheme. Used by formula declarations
+/// to express generic signatures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeScheme {
+    /// Quantified variables and their constraints.
+    pub quantified: Vec<(SchemeVarName, PrimitiveSet)>,
+    /// The scheme body, referencing quantified variables by name.
+    pub body: SchemeBody,
+}
+
+/// A name binding a quantified type variable in a scheme.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SchemeVarName(pub String);
+
+impl SchemeVarName {
+    /// Construct a name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+/// The body of a [`TypeScheme`] — either a function-like signature
+/// or a single value type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemeBody {
+    /// A function-like signature: parameter names → slot types.
+    Schema(Vec<(String, SchemeType)>),
+    /// A single value type.
+    Type(SchemeType),
+}
+
+/// A type expression inside a [`TypeScheme`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemeType {
+    /// `Definite(SchemeDefinite)`.
+    Definite(Box<SchemeDefinite>),
+    /// `Optional(SchemeDefinite)` — set-widened slot.
+    Optional(Box<SchemeDefinite>),
+}
+
+/// `Definite` shape inside a [`TypeScheme`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemeDefinite {
+    /// Concrete primitive set — no variable.
+    Primitive(PrimitiveSet),
+    /// Reference to a quantified variable by name.
+    Variable(SchemeVarName),
+}
+
+/// Per-rule unification context. Tracks the substitution map,
+/// per-variable constraints, named variables in lexical scope,
+/// and a fresh-id counter.
+#[derive(Debug, Clone, Default)]
+pub struct Context {
+    /// Substitution: variable → resolved (or partially-resolved)
+    /// type. Updated in-place by [`Self::unify`].
+    substitution: HashMap<VarId, Type>,
+    /// Per-variable primitive constraint.
+    constraints: HashMap<VarId, PrimitiveSet>,
+    /// Lexically-scoped name → `VarId` map; ensures that the same
+    /// name within a scope refers to the same variable.
+    names: HashMap<String, VarId>,
+    /// Counter for fresh `VarId` allocation within this context.
+    next_id: u32,
+}
+
+impl Context {
+    /// Create an empty context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a fresh `VarId` with the given constraint.
+    pub fn fresh(&mut self, constraint: PrimitiveSet) -> VarId {
+        let id = VarId(self.next_id);
+        self.next_id += 1;
+        self.constraints.insert(id, constraint);
+        id
+    }
+
+    /// Allocate a fresh anonymous variable type with constraint
+    /// [`PrimitiveSet::ALL`].
+    pub fn fresh_var(&mut self) -> Type {
+        Type::Variable(self.fresh(PrimitiveSet::ALL))
+    }
+
+    /// Look up or allocate the `VarId` associated with a name in
+    /// this scope. The first call for a given name allocates;
+    /// later calls return the same id.
+    pub fn var_for_name(&mut self, name: &str) -> VarId {
+        if let Some(id) = self.names.get(name) {
+            return *id;
+        }
+        let id = self.fresh(PrimitiveSet::ALL);
+        self.names.insert(name.to_string(), id);
+        id
+    }
+
+    /// Look up the constraint for a variable. Returns
+    /// [`PrimitiveSet::ALL`] if the variable is unknown to this
+    /// context.
+    pub fn constraint(&self, var: VarId) -> PrimitiveSet {
+        self.constraints
+            .get(&var)
+            .copied()
+            .unwrap_or(PrimitiveSet::ALL)
+    }
+
+    /// Materialize a [`Type`] for a slot from optional name and
+    /// optional static kind:
+    ///
+    /// - `(Some(_), Some(t))` and `(None, Some(t))`:
+    ///   wrap `t` as [`Type::Static`] (the user supplied a static
+    ///   type, so no variable is needed).
+    /// - `(Some(name), None)`: look up or allocate a variable for
+    ///   the name; return [`Type::Variable`].
+    /// - `(None, None)`: allocate a fresh anonymous variable;
+    ///   return [`Type::Variable`].
+    pub fn infer(&mut self, name: Option<&str>, kind: Option<super::Type>) -> Type {
+        match (name, kind) {
+            (_, Some(t)) => Type::Static(t),
+            (Some(n), None) => Type::Variable(self.var_for_name(n)),
+            (None, None) => self.fresh_var(),
+        }
+    }
+
+    /// Apply the current substitution to a [`Type`], recursively
+    /// resolving any variables that have been bound.
+    pub fn apply(&self, ty: &Type) -> Type {
+        match ty {
+            Type::Static(s) => Type::Static(s.clone()),
+            Type::Variable(id) => {
+                if let Some(resolved) = self.substitution.get(id) {
+                    self.apply(resolved)
+                } else {
+                    Type::Variable(*id)
+                }
+            }
+        }
+    }
+
+    /// Robinson unification with constraint propagation. Updates
+    /// `self` in-place. Returns `Err` on constraint conflict.
+    pub fn unify(&mut self, a: &Type, b: &Type) -> Result<(), UnifyError> {
+        let a = self.apply(a);
+        let b = self.apply(b);
+        match (a, b) {
+            (Type::Variable(x), Type::Variable(y)) if x == y => Ok(()),
+            (Type::Variable(x), Type::Variable(y)) => {
+                let cx = self.constraint(x);
+                let cy = self.constraint(y);
+                let merged = cx.intersect(cy).ok_or(UnifyError::ConstraintConflict {
+                    left: cx,
+                    right: cy,
+                })?;
+                self.constraints.insert(x, merged);
+                self.constraints.insert(y, merged);
+                self.substitution.insert(y, Type::Variable(x));
+                Ok(())
+            }
+            (Type::Variable(x), Type::Static(s)) | (Type::Static(s), Type::Variable(x)) => {
+                let cx = self.constraint(x);
+                let p = primitive_set_of(&s).ok_or(UnifyError::ConstraintConflict {
+                    left: cx,
+                    right: PrimitiveSet::EMPTY,
+                })?;
+                let merged = cx
+                    .intersect(p)
+                    .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
+                self.constraints.insert(x, merged);
+                self.substitution
+                    .insert(x, Type::Static(super::Type::primitive_set(merged)));
+                Ok(())
+            }
+            (Type::Static(a), Type::Static(b)) => {
+                let pa = primitive_set_of(&a).ok_or(UnifyError::ConstraintConflict {
+                    left: PrimitiveSet::EMPTY,
+                    right: PrimitiveSet::EMPTY,
+                })?;
+                let pb = primitive_set_of(&b).ok_or(UnifyError::ConstraintConflict {
+                    left: pa,
+                    right: PrimitiveSet::EMPTY,
+                })?;
+                pa.intersect(pb)
+                    .ok_or(UnifyError::ConstraintConflict {
+                        left: pa,
+                        right: pb,
+                    })
+                    .map(|_| ())
+            }
+        }
+    }
+
+    /// Instantiate a [`TypeScheme`]: allocate fresh `VarId`s for
+    /// each quantified name, then materialize the body.
+    pub fn instantiate(&mut self, scheme: &TypeScheme) -> InstantiatedScheme {
+        let mut substitution: HashMap<SchemeVarName, VarId> = HashMap::new();
+        for (name, constraint) in &scheme.quantified {
+            let id = self.fresh(*constraint);
+            substitution.insert(name.clone(), id);
+        }
+        InstantiatedScheme {
+            body: instantiate_body(&scheme.body, &substitution),
+            variables: substitution,
+        }
+    }
+}
+
+/// Extract the primitive set of a static type, ignoring
+/// optionality at the unifier layer. Returns `None` for the
+/// (currently unconstructible) `Variant`/`Product` placeholders.
+fn primitive_set_of(ty: &super::Type) -> Option<PrimitiveSet> {
+    match ty.shape() {
+        Definite::Primitive(set) => Some(*set),
+        Definite::Variant | Definite::Product => None,
+    }
+}
+
+fn instantiate_body(body: &SchemeBody, sub: &HashMap<SchemeVarName, VarId>) -> InstantiatedBody {
+    match body {
+        SchemeBody::Schema(fields) => InstantiatedBody::Schema(
+            fields
+                .iter()
+                .map(|(name, ty)| (name.clone(), instantiate_type(ty, sub)))
+                .collect(),
+        ),
+        SchemeBody::Type(ty) => InstantiatedBody::Type(instantiate_type(ty, sub)),
+    }
+}
+
+fn instantiate_type(ty: &SchemeType, sub: &HashMap<SchemeVarName, VarId>) -> Type {
+    match ty {
+        SchemeType::Definite(d) => instantiate_definite(d, sub, false),
+        SchemeType::Optional(d) => instantiate_definite(d, sub, true),
+    }
+}
+
+fn instantiate_definite(
+    d: &SchemeDefinite,
+    sub: &HashMap<SchemeVarName, VarId>,
+    optional: bool,
+) -> Type {
+    match d {
+        SchemeDefinite::Primitive(p) => {
+            let static_ty = if optional {
+                super::Type::optional_set(*p)
+            } else {
+                super::Type::primitive_set(*p)
+            };
+            Type::Static(static_ty)
+        }
+        SchemeDefinite::Variable(name) => Type::Variable(
+            *sub.get(name)
+                .expect("scheme references unquantified variable"),
+        ),
+    }
+}
+
+/// The result of instantiating a [`TypeScheme`].
+#[derive(Debug, Clone)]
+pub struct InstantiatedScheme {
+    /// The instantiated body.
+    pub body: InstantiatedBody,
+    /// Maps each scheme variable name to the fresh `VarId`
+    /// allocated for this instantiation.
+    pub variables: HashMap<SchemeVarName, VarId>,
+}
+
+/// An instantiated [`SchemeBody`].
+#[derive(Debug, Clone)]
+pub enum InstantiatedBody {
+    /// Function-like signature.
+    Schema(Vec<(String, Type)>),
+    /// A single type.
+    Type(Type),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(vt: ValueType) -> Type {
+        Type::primitive(vt)
+    }
+
+    #[test]
+    fn fresh_variables_are_distinct() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(PrimitiveSet::ALL);
+        let b = ctx.fresh(PrimitiveSet::ALL);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn fresh_records_constraint() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
+    }
+
+    #[test]
+    fn unify_two_concrete_primitives_same_succeeds() {
+        let mut ctx = Context::new();
+        ctx.unify(&p(ValueType::String), &p(ValueType::String))
+            .unwrap();
+    }
+
+    #[test]
+    fn unify_two_concrete_primitives_different_fails() {
+        let mut ctx = Context::new();
+        let result = ctx.unify(&p(ValueType::String), &p(ValueType::Entity));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[test]
+    fn unify_variable_with_concrete_substitutes() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        ctx.unify(&Type::Variable(v), &p(ValueType::UnsignedInt))
+            .unwrap();
+        let resolved = ctx.apply(&Type::Variable(v));
+        match resolved {
+            Type::Static(s) => {
+                assert_eq!(s.shape().as_singleton(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("expected static, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unify_variable_with_concrete_outside_constraint_fails() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        let result = ctx.unify(&Type::Variable(v), &p(ValueType::String));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[test]
+    fn unify_variable_constraint_propagates() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        let v_ty = Type::Variable(v);
+        let comparable = Type::primitive_set(PrimitiveSet::COMPARABLE);
+        ctx.unify(&v_ty, &comparable).unwrap();
+        let resolved = ctx.apply(&v_ty);
+        match resolved {
+            Type::Static(s) => match s.shape() {
+                Definite::Primitive(set) => assert_eq!(*set, PrimitiveSet::NUMERIC),
+                other => panic!("expected primitive, got {:?}", other),
+            },
+            other => panic!("expected static, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unify_two_variables_intersects_constraints() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(PrimitiveSet::NUMERIC);
+        let b = ctx.fresh(PrimitiveSet::COMPARABLE);
+        ctx.unify(&Type::Variable(a), &Type::Variable(b)).unwrap();
+        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(b), PrimitiveSet::NUMERIC);
+    }
+
+    #[test]
+    fn unify_two_variables_disjoint_fails() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(PrimitiveSet::NUMERIC);
+        let b = ctx.fresh(PrimitiveSet::singleton(ValueType::String));
+        let result = ctx.unify(&Type::Variable(a), &Type::Variable(b));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[test]
+    fn chained_unification_propagates() {
+        let mut ctx = Context::new();
+        let t = ctx.fresh(PrimitiveSet::NUMERIC);
+        let u = ctx.fresh(PrimitiveSet::NUMERIC);
+        ctx.unify(&Type::Variable(t), &Type::Variable(u)).unwrap();
+        ctx.unify(&Type::Variable(t), &p(ValueType::UnsignedInt))
+            .unwrap();
+        let t_resolved = ctx.apply(&Type::Variable(t));
+        let u_resolved = ctx.apply(&Type::Variable(u));
+        match (t_resolved, u_resolved) {
+            (Type::Static(t), Type::Static(u)) => {
+                assert_eq!(t.shape().as_singleton(), Some(ValueType::UnsignedInt));
+                assert_eq!(u.shape().as_singleton(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unify_optional_with_definite_same_shape_succeeds() {
+        let mut ctx = Context::new();
+        ctx.unify(&p(ValueType::String), &Type::optional(ValueType::String))
+            .unwrap();
+    }
+
+    #[test]
+    fn unify_optional_with_definite_disjoint_fails() {
+        let mut ctx = Context::new();
+        let result = ctx.unify(&p(ValueType::String), &Type::optional(ValueType::Entity));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    fn sum_scheme() -> TypeScheme {
+        TypeScheme {
+            quantified: vec![(SchemeVarName::new("T"), PrimitiveSet::NUMERIC)],
+            body: SchemeBody::Schema(vec![
+                (
+                    "left".into(),
+                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
+                        "T",
+                    )))),
+                ),
+                (
+                    "right".into(),
+                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
+                        "T",
+                    )))),
+                ),
+                (
+                    "out".into(),
+                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
+                        "T",
+                    )))),
+                ),
+            ]),
+        }
+    }
+
+    #[test]
+    fn instantiate_allocates_fresh_variables() {
+        let scheme = sum_scheme();
+        let mut ctx = Context::new();
+        let i1 = ctx.instantiate(&scheme);
+        let i2 = ctx.instantiate(&scheme);
+        let t1 = i1.variables.get(&SchemeVarName::new("T")).copied().unwrap();
+        let t2 = i2.variables.get(&SchemeVarName::new("T")).copied().unwrap();
+        assert_ne!(t1, t2);
+        assert_eq!(ctx.constraint(t1), PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(t2), PrimitiveSet::NUMERIC);
+    }
+
+    #[test]
+    fn instantiate_shared_variable_in_body() {
+        let scheme = sum_scheme();
+        let mut ctx = Context::new();
+        let inst = ctx.instantiate(&scheme);
+        if let InstantiatedBody::Schema(fields) = &inst.body {
+            let var_ids: Vec<VarId> = fields
+                .iter()
+                .map(|(_, ty)| match ty {
+                    Type::Variable(id) => *id,
+                    other => panic!("expected variable, got {:?}", other),
+                })
+                .collect();
+            assert_eq!(var_ids.len(), 3);
+            assert_eq!(var_ids[0], var_ids[1]);
+            assert_eq!(var_ids[1], var_ids[2]);
+        } else {
+            panic!("expected Schema body");
+        }
+    }
+
+    #[test]
+    fn instantiated_polymorphic_formula_unifies() {
+        let scheme = sum_scheme();
+        let mut ctx = Context::new();
+        let inst = ctx.instantiate(&scheme);
+        let fields = match &inst.body {
+            InstantiatedBody::Schema(f) => f,
+            _ => panic!(),
+        };
+        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
+        for (_, ty) in fields {
+            let resolved = ctx.apply(ty);
+            match resolved {
+                Type::Static(s) => assert_eq!(
+                    s.shape().as_singleton(),
+                    Some(ValueType::UnsignedInt),
+                    "expected u32 after unification"
+                ),
+                other => panic!("expected static, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn instantiated_polymorphic_formula_rejects_mismatch() {
+        let scheme = sum_scheme();
+        let mut ctx = Context::new();
+        let inst = ctx.instantiate(&scheme);
+        let fields = match &inst.body {
+            InstantiatedBody::Schema(f) => f,
+            _ => panic!(),
+        };
+        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
+        let result = ctx.unify(&fields[1].1, &p(ValueType::String));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[test]
+    fn two_instantiations_are_independent() {
+        let scheme = sum_scheme();
+        let mut ctx = Context::new();
+        let i1 = ctx.instantiate(&scheme);
+        let i2 = ctx.instantiate(&scheme);
+        let i1_left = match &i1.body {
+            InstantiatedBody::Schema(f) => f[0].1.clone(),
+            _ => panic!(),
+        };
+        let i2_left = match &i2.body {
+            InstantiatedBody::Schema(f) => f[0].1.clone(),
+            _ => panic!(),
+        };
+        ctx.unify(&i1_left, &p(ValueType::UnsignedInt)).unwrap();
+        ctx.unify(&i2_left, &p(ValueType::Float)).unwrap();
+    }
+
+    #[test]
+    fn match_optionality_combine_strictest_wins() {
+        assert_eq!(
+            MatchOptionality::Required.combine(MatchOptionality::Optional),
+            MatchOptionality::Required
+        );
+        assert_eq!(
+            MatchOptionality::Optional.combine(MatchOptionality::Required),
+            MatchOptionality::Required
+        );
+        assert_eq!(
+            MatchOptionality::Optional.combine(MatchOptionality::Optional),
+            MatchOptionality::Optional
+        );
+    }
+
+    /// `infer` with no name and no kind allocates a fresh
+    /// anonymous variable.
+    #[test]
+    fn infer_anonymous_unconstrained() {
+        let mut ctx = Context::new();
+        let a = ctx.infer(None, None);
+        let b = ctx.infer(None, None);
+        match (&a, &b) {
+            (Type::Variable(x), Type::Variable(y)) => assert_ne!(x, y),
+            _ => panic!("expected two distinct variables"),
+        }
+    }
+
+    /// `infer` with a name (no kind) allocates once per name in
+    /// scope; repeated calls return the same variable.
+    #[test]
+    fn infer_named_is_stable_within_scope() {
+        let mut ctx = Context::new();
+        let a = ctx.infer(Some("x"), None);
+        let b = ctx.infer(Some("x"), None);
+        match (&a, &b) {
+            (Type::Variable(x), Type::Variable(y)) => assert_eq!(x, y),
+            _ => panic!("expected variables"),
+        }
+    }
+
+    /// `infer` with a kind always wraps statically — no variable
+    /// is allocated even when a name is given.
+    #[test]
+    fn infer_with_kind_wraps_statically() {
+        let mut ctx = Context::new();
+        let a = ctx.infer(
+            Some("x"),
+            Some(super::super::Type::primitive(ValueType::String)),
+        );
+        match a {
+            Type::Static(_) => {}
+            other => panic!("expected static, got {:?}", other),
+        }
+    }
+}

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -1,10 +1,9 @@
-//! Unifier-internal type representation and Damas-Milner unifier.
+//! Unifier-internal type representation and unification.
 //!
 //! This submodule owns everything that needs to talk about
 //! per-rule type variables: [`VarId`] allocation, the
-//! [`Type`] enum with its `Static`/`Variable` distinction, the
-//! [`Context`] that drives unification, and the [`TypeScheme`]
-//! machinery for rank-1 polymorphic formula signatures.
+//! [`Type`] enum with its `Static`/`Variable` distinction, and
+//! the [`Context`] that drives unification.
 //!
 //! Variables never escape into the user-facing
 //! [`StaticType`]. Lifting between layers happens via [`lift`]
@@ -54,28 +53,6 @@ pub fn lift(ty: &StaticType) -> Type {
     Type::Static(ty.clone())
 }
 
-/// Slot-level optionality used during unification. Tracks whether
-/// a use site of a variable is wrapped in `Optional` independently
-/// of the variable's own shape.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum MatchOptionality {
-    /// The slot demands a Present value.
-    Required,
-    /// The slot tolerates `Absent`.
-    Optional,
-}
-
-impl MatchOptionality {
-    /// "Strictest wins" combine: `Required` ∧ `Optional` =
-    /// `Required`.
-    pub fn combine(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Required, _) | (_, Self::Required) => Self::Required,
-            (Self::Optional, Self::Optional) => Self::Optional,
-        }
-    }
-}
-
 /// Errors raised by unification.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum UnifyError {
@@ -101,59 +78,6 @@ pub enum UnifyError {
     /// [`Coalesce::validate`](crate::constraint::Coalesce::validate).
     #[error("Coalesce source is not Optional")]
     SourceNotOptional,
-}
-
-/// A rank-1 polymorphic type scheme. Used by formula declarations
-/// to express generic signatures.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TypeScheme {
-    /// Quantified variables and their constraints.
-    pub quantified: Vec<(SchemeVarName, Primitive)>,
-    /// The scheme body, referencing quantified variables by name.
-    pub body: SchemeBody,
-}
-
-/// A name binding a quantified type variable in a scheme.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct SchemeVarName(pub String);
-
-impl SchemeVarName {
-    /// Construct a name.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
-    }
-}
-
-/// The body of a [`TypeScheme`] — either a function-like signature
-/// or a single value type.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemeBody {
-    /// A function-like signature: parameter names → slot types.
-    Schema(Vec<(String, SchemeType)>),
-    /// A single value type.
-    Type(SchemeType),
-}
-
-/// A type expression inside a [`TypeScheme`]. The `optional` flag
-/// requests set-widening (adds the `Nothing` bit) when the scheme
-/// is instantiated to a static type.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemeType {
-    /// Required slot — produces a plain primitive after
-    /// instantiation.
-    Required(Box<SchemeShape>),
-    /// Optional slot — produces a primitive set widened with
-    /// `Nothing` after instantiation.
-    Optional(Box<SchemeShape>),
-}
-
-/// Primitive or variable shape inside a [`TypeScheme`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemeShape {
-    /// Concrete primitive set — no variable.
-    Primitive(Primitive),
-    /// Reference to a quantified variable by name.
-    Variable(SchemeVarName),
 }
 
 /// Per-rule unification context. Tracks the substitution map,
@@ -301,75 +225,6 @@ impl Context {
             }
         }
     }
-
-    /// Instantiate a [`TypeScheme`]: allocate fresh `VarId`s for
-    /// each quantified name, then materialize the body.
-    pub fn instantiate(&mut self, scheme: &TypeScheme) -> InstantiatedScheme {
-        let mut substitution: HashMap<SchemeVarName, VarId> = HashMap::new();
-        for (name, constraint) in &scheme.quantified {
-            let id = self.fresh(*constraint);
-            substitution.insert(name.clone(), id);
-        }
-        InstantiatedScheme {
-            body: instantiate_body(&scheme.body, &substitution),
-            variables: substitution,
-        }
-    }
-}
-
-fn instantiate_body(body: &SchemeBody, sub: &HashMap<SchemeVarName, VarId>) -> InstantiatedBody {
-    match body {
-        SchemeBody::Schema(fields) => InstantiatedBody::Schema(
-            fields
-                .iter()
-                .map(|(name, ty)| (name.clone(), instantiate_type(ty, sub)))
-                .collect(),
-        ),
-        SchemeBody::Type(ty) => InstantiatedBody::Type(instantiate_type(ty, sub)),
-    }
-}
-
-fn instantiate_type(ty: &SchemeType, sub: &HashMap<SchemeVarName, VarId>) -> Type {
-    match ty {
-        SchemeType::Required(d) => instantiate_shape(d, sub, false),
-        SchemeType::Optional(d) => instantiate_shape(d, sub, true),
-    }
-}
-
-fn instantiate_shape(d: &SchemeShape, sub: &HashMap<SchemeVarName, VarId>, optional: bool) -> Type {
-    match d {
-        SchemeShape::Primitive(p) => {
-            let static_ty = if optional {
-                StaticType::primitive_set(*p).optional()
-            } else {
-                StaticType::primitive_set(*p)
-            };
-            Type::Static(static_ty)
-        }
-        SchemeShape::Variable(name) => Type::Variable(
-            *sub.get(name)
-                .expect("scheme references unquantified variable"),
-        ),
-    }
-}
-
-/// The result of instantiating a [`TypeScheme`].
-#[derive(Debug, Clone)]
-pub struct InstantiatedScheme {
-    /// The instantiated body.
-    pub body: InstantiatedBody,
-    /// Maps each scheme variable name to the fresh `VarId`
-    /// allocated for this instantiation.
-    pub variables: HashMap<SchemeVarName, VarId>,
-}
-
-/// An instantiated [`SchemeBody`].
-#[derive(Debug, Clone)]
-pub enum InstantiatedBody {
-    /// Function-like signature.
-    Schema(Vec<(String, Type)>),
-    /// A single type.
-    Type(Type),
 }
 
 #[cfg(test)]
@@ -496,131 +351,6 @@ mod tests {
         let mut ctx = Context::new();
         let result = ctx.unify(&p(ValueType::String), &Type::optional(ValueType::Entity));
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
-    }
-
-    fn sum_scheme() -> TypeScheme {
-        TypeScheme {
-            quantified: vec![(SchemeVarName::new("T"), Primitive::NUMERIC)],
-            body: SchemeBody::Schema(vec![
-                (
-                    "left".into(),
-                    SchemeType::Required(Box::new(SchemeShape::Variable(SchemeVarName::new("T")))),
-                ),
-                (
-                    "right".into(),
-                    SchemeType::Required(Box::new(SchemeShape::Variable(SchemeVarName::new("T")))),
-                ),
-                (
-                    "out".into(),
-                    SchemeType::Required(Box::new(SchemeShape::Variable(SchemeVarName::new("T")))),
-                ),
-            ]),
-        }
-    }
-
-    #[dialog_common::test]
-    fn instantiate_allocates_fresh_variables() {
-        let scheme = sum_scheme();
-        let mut ctx = Context::new();
-        let i1 = ctx.instantiate(&scheme);
-        let i2 = ctx.instantiate(&scheme);
-        let t1 = i1.variables.get(&SchemeVarName::new("T")).copied().unwrap();
-        let t2 = i2.variables.get(&SchemeVarName::new("T")).copied().unwrap();
-        assert_ne!(t1, t2);
-        assert_eq!(ctx.constraint(t1), Primitive::NUMERIC);
-        assert_eq!(ctx.constraint(t2), Primitive::NUMERIC);
-    }
-
-    #[dialog_common::test]
-    fn instantiate_shared_variable_in_body() {
-        let scheme = sum_scheme();
-        let mut ctx = Context::new();
-        let inst = ctx.instantiate(&scheme);
-        if let InstantiatedBody::Schema(fields) = &inst.body {
-            let var_ids: Vec<VarId> = fields
-                .iter()
-                .map(|(_, ty)| match ty {
-                    Type::Variable(id) => *id,
-                    other => panic!("expected variable, got {:?}", other),
-                })
-                .collect();
-            assert_eq!(var_ids.len(), 3);
-            assert_eq!(var_ids[0], var_ids[1]);
-            assert_eq!(var_ids[1], var_ids[2]);
-        } else {
-            panic!("expected Schema body");
-        }
-    }
-
-    #[dialog_common::test]
-    fn instantiated_polymorphic_formula_unifies() {
-        let scheme = sum_scheme();
-        let mut ctx = Context::new();
-        let inst = ctx.instantiate(&scheme);
-        let fields = match &inst.body {
-            InstantiatedBody::Schema(f) => f,
-            _ => panic!(),
-        };
-        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
-        for (_, ty) in fields {
-            let resolved = ctx.apply(ty);
-            match resolved {
-                Type::Static(s) => assert_eq!(
-                    s.as_value_type(),
-                    Some(ValueType::UnsignedInt),
-                    "expected u32 after unification"
-                ),
-                other => panic!("expected static, got {:?}", other),
-            }
-        }
-    }
-
-    #[dialog_common::test]
-    fn instantiated_polymorphic_formula_rejects_mismatch() {
-        let scheme = sum_scheme();
-        let mut ctx = Context::new();
-        let inst = ctx.instantiate(&scheme);
-        let fields = match &inst.body {
-            InstantiatedBody::Schema(f) => f,
-            _ => panic!(),
-        };
-        ctx.unify(&fields[0].1, &p(ValueType::UnsignedInt)).unwrap();
-        let result = ctx.unify(&fields[1].1, &p(ValueType::String));
-        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
-    }
-
-    #[dialog_common::test]
-    fn two_instantiations_are_independent() {
-        let scheme = sum_scheme();
-        let mut ctx = Context::new();
-        let i1 = ctx.instantiate(&scheme);
-        let i2 = ctx.instantiate(&scheme);
-        let i1_left = match &i1.body {
-            InstantiatedBody::Schema(f) => f[0].1.clone(),
-            _ => panic!(),
-        };
-        let i2_left = match &i2.body {
-            InstantiatedBody::Schema(f) => f[0].1.clone(),
-            _ => panic!(),
-        };
-        ctx.unify(&i1_left, &p(ValueType::UnsignedInt)).unwrap();
-        ctx.unify(&i2_left, &p(ValueType::Float)).unwrap();
-    }
-
-    #[dialog_common::test]
-    fn match_optionality_combine_strictest_wins() {
-        assert_eq!(
-            MatchOptionality::Required.combine(MatchOptionality::Optional),
-            MatchOptionality::Required
-        );
-        assert_eq!(
-            MatchOptionality::Optional.combine(MatchOptionality::Required),
-            MatchOptionality::Required
-        );
-        assert_eq!(
-            MatchOptionality::Optional.combine(MatchOptionality::Optional),
-            MatchOptionality::Optional
-        );
     }
 
     /// `infer` with no name and no kind allocates a fresh

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -118,15 +118,25 @@ impl Context {
     }
 
     /// Look up or allocate the `VarId` associated with a name in
-    /// this scope. The first call for a given name allocates;
-    /// later calls return the same id.
+    /// this scope. The first call for a given name allocates with
+    /// the maximally-permissive constraint [`Primitive::ANY`] —
+    /// includes `Nothing`, so optionality can survive unification.
+    /// Narrowing happens when slot kinds without `Nothing` unify
+    /// against the variable.
+    /// Later calls return the same id.
     pub fn var_for_name(&mut self, name: &str) -> VarId {
         if let Some(id) = self.names.get(name) {
             return *id;
         }
-        let id = self.fresh(Primitive::ALL);
+        let id = self.fresh(Primitive::ANY);
         self.names.insert(name.to_string(), id);
         id
+    }
+
+    /// Iterate over `(name, VarId)` pairs for every named variable
+    /// allocated in this context. The order is unspecified.
+    pub fn named_vars(&self) -> impl Iterator<Item = (&String, &VarId)> {
+        self.names.iter()
     }
 
     /// Look up the constraint for a variable. Returns
@@ -172,6 +182,20 @@ impl Context {
         }
     }
 
+    /// Walk the substitution following variable-to-variable links
+    /// (union-find style), returning the canonical [`VarId`] for
+    /// the chain. Stops at the first non-variable substitution or
+    /// at an unsubstituted variable.
+    fn root(&self, mut id: VarId) -> VarId {
+        while let Some(Type::Variable(next)) = self.substitution.get(&id) {
+            if *next == id {
+                break;
+            }
+            id = *next;
+        }
+        id
+    }
+
     /// Robinson unification with constraint propagation. Updates
     /// `self` in-place. Returns `Err` on constraint conflict.
     ///
@@ -181,11 +205,27 @@ impl Context {
     /// a [`Primitive`] constraint that's intersected with the
     /// primitive part of any concrete type they're unified with.
     pub fn unify(&mut self, a: &Type, b: &Type) -> Result<(), UnifyError> {
-        let a = self.apply(a);
-        let b = self.apply(b);
         match (a, b) {
-            (Type::Variable(x), Type::Variable(y)) if x == y => Ok(()),
             (Type::Variable(x), Type::Variable(y)) => {
+                let x = self.root(*x);
+                let y = self.root(*y);
+                if x == y {
+                    return Ok(());
+                }
+                // If either side has already been resolved to a
+                // static, unify that resolved static against the
+                // other variable instead.
+                let xs = self.substitution.get(&x).cloned();
+                let ys = self.substitution.get(&y).cloned();
+                match (xs, ys) {
+                    (Some(Type::Static(sx)), _) => {
+                        return self.unify(&Type::Static(sx), &Type::Variable(y));
+                    }
+                    (_, Some(Type::Static(sy))) => {
+                        return self.unify(&Type::Variable(x), &Type::Static(sy));
+                    }
+                    _ => {}
+                }
                 let cx = self.constraint(x);
                 let cy = self.constraint(y);
                 let merged = cx.intersect(cy).ok_or(UnifyError::ConstraintConflict {
@@ -198,17 +238,32 @@ impl Context {
                 Ok(())
             }
             (Type::Variable(x), Type::Static(s)) | (Type::Static(s), Type::Variable(x)) => {
+                let x = self.root(*x);
+                // If `x` is already resolved to a static, intersect
+                // the previous resolution with the new static — the
+                // variable's resolved type is the narrowest static
+                // satisfying every unify call that touched it.
+                let prev = match self.substitution.get(&x) {
+                    Some(Type::Static(prev)) => Some(prev.clone()),
+                    _ => None,
+                };
+                let narrowed_static = match prev {
+                    Some(prev) => {
+                        prev.intersect(s)
+                            .ok_or_else(|| UnifyError::ConstraintConflict {
+                                left: prev.primitive_part(),
+                                right: s.primitive_part(),
+                            })?
+                    }
+                    None => s.clone(),
+                };
                 let cx = self.constraint(x);
-                // Intersect the variable's primitive constraint
-                // against the static's primitive part. The variable
-                // resolves to the narrowed static type — preserving
-                // any composite part of the static side.
-                let p = s.primitive_part();
+                let p = narrowed_static.primitive_part();
                 let merged = cx
                     .intersect(p)
                     .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
                 self.constraints.insert(x, merged);
-                let resolved = match s.composite_part() {
+                let resolved = match narrowed_static.composite_part() {
                     Some(c) if !c.is_empty() => StaticType::composite(merged, c.clone()),
                     _ => StaticType::primitive_set(merged),
                 };
@@ -216,7 +271,7 @@ impl Context {
                 Ok(())
             }
             (Type::Static(a), Type::Static(b)) => {
-                a.intersect(&b)
+                a.intersect(b)
                     .map(|_| ())
                     .ok_or_else(|| UnifyError::ConstraintConflict {
                         left: a.primitive_part(),

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -11,8 +11,8 @@
 //! and [`Context::infer`].
 
 use crate::artifact::Type as ValueType;
+use crate::type_system::Primitive;
 use crate::type_system::Type as StaticType;
-use crate::type_system::{Definite, PrimitiveSet};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -38,13 +38,13 @@ impl Type {
     }
 
     /// Build a static primitive set, wrapped for unification.
-    pub fn primitive_set(set: PrimitiveSet) -> Self {
+    pub fn primitive_set(set: Primitive) -> Self {
         Type::Static(StaticType::primitive_set(set))
     }
 
     /// Build a static optional primitive, wrapped for unification.
     pub fn optional(vt: ValueType) -> Self {
-        Type::Static(StaticType::optional(vt))
+        Type::Static(StaticType::primitive(vt).optional())
     }
 }
 
@@ -84,9 +84,9 @@ pub enum UnifyError {
     #[error("constraint conflict between {left:?} and {right:?}")]
     ConstraintConflict {
         /// The narrower side.
-        left: PrimitiveSet,
+        left: Primitive,
         /// The other narrower side.
-        right: PrimitiveSet,
+        right: Primitive,
     },
     /// Occurs check: unifying a variable with a type that
     /// transitively contains the variable would produce an
@@ -103,7 +103,7 @@ pub enum UnifyError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeScheme {
     /// Quantified variables and their constraints.
-    pub quantified: Vec<(SchemeVarName, PrimitiveSet)>,
+    pub quantified: Vec<(SchemeVarName, Primitive)>,
     /// The scheme body, referencing quantified variables by name.
     pub body: SchemeBody,
 }
@@ -129,20 +129,24 @@ pub enum SchemeBody {
     Type(SchemeType),
 }
 
-/// A type expression inside a [`TypeScheme`].
+/// A type expression inside a [`TypeScheme`]. The `optional` flag
+/// requests set-widening (adds the `Nothing` bit) when the scheme
+/// is instantiated to a static type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SchemeType {
-    /// `Definite(SchemeDefinite)`.
-    Definite(Box<SchemeDefinite>),
-    /// `Optional(SchemeDefinite)` — set-widened slot.
-    Optional(Box<SchemeDefinite>),
+    /// Required slot — produces a plain primitive after
+    /// instantiation.
+    Required(Box<SchemeShape>),
+    /// Optional slot — produces a primitive set widened with
+    /// `Nothing` after instantiation.
+    Optional(Box<SchemeShape>),
 }
 
-/// `Definite` shape inside a [`TypeScheme`].
+/// Primitive or variable shape inside a [`TypeScheme`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemeDefinite {
+pub enum SchemeShape {
     /// Concrete primitive set — no variable.
-    Primitive(PrimitiveSet),
+    Primitive(Primitive),
     /// Reference to a quantified variable by name.
     Variable(SchemeVarName),
 }
@@ -156,7 +160,7 @@ pub struct Context {
     /// type. Updated in-place by [`Self::unify`].
     substitution: HashMap<VarId, Type>,
     /// Per-variable primitive constraint.
-    constraints: HashMap<VarId, PrimitiveSet>,
+    constraints: HashMap<VarId, Primitive>,
     /// Lexically-scoped name → `VarId` map; ensures that the same
     /// name within a scope refers to the same variable.
     names: HashMap<String, VarId>,
@@ -171,7 +175,7 @@ impl Context {
     }
 
     /// Allocate a fresh `VarId` with the given constraint.
-    pub fn fresh(&mut self, constraint: PrimitiveSet) -> VarId {
+    pub fn fresh(&mut self, constraint: Primitive) -> VarId {
         let id = VarId(self.next_id);
         self.next_id += 1;
         self.constraints.insert(id, constraint);
@@ -179,9 +183,9 @@ impl Context {
     }
 
     /// Allocate a fresh anonymous variable type with constraint
-    /// [`PrimitiveSet::ALL`].
+    /// [`Primitive::ALL`].
     pub fn fresh_var(&mut self) -> Type {
-        Type::Variable(self.fresh(PrimitiveSet::ALL))
+        Type::Variable(self.fresh(Primitive::ALL))
     }
 
     /// Look up or allocate the `VarId` associated with a name in
@@ -191,19 +195,19 @@ impl Context {
         if let Some(id) = self.names.get(name) {
             return *id;
         }
-        let id = self.fresh(PrimitiveSet::ALL);
+        let id = self.fresh(Primitive::ALL);
         self.names.insert(name.to_string(), id);
         id
     }
 
     /// Look up the constraint for a variable. Returns
-    /// [`PrimitiveSet::ALL`] if the variable is unknown to this
+    /// [`Primitive::ALL`] if the variable is unknown to this
     /// context.
-    pub fn constraint(&self, var: VarId) -> PrimitiveSet {
+    pub fn constraint(&self, var: VarId) -> Primitive {
         self.constraints
             .get(&var)
             .copied()
-            .unwrap_or(PrimitiveSet::ALL)
+            .unwrap_or(Primitive::ALL)
     }
 
     /// Materialize a [`Type`] for a slot from optional name and
@@ -262,7 +266,7 @@ impl Context {
                 let cx = self.constraint(x);
                 let p = primitive_set_of(&s).ok_or(UnifyError::ConstraintConflict {
                     left: cx,
-                    right: PrimitiveSet::EMPTY,
+                    right: Primitive::EMPTY,
                 })?;
                 let merged = cx
                     .intersect(p)
@@ -274,12 +278,12 @@ impl Context {
             }
             (Type::Static(a), Type::Static(b)) => {
                 let pa = primitive_set_of(&a).ok_or(UnifyError::ConstraintConflict {
-                    left: PrimitiveSet::EMPTY,
-                    right: PrimitiveSet::EMPTY,
+                    left: Primitive::EMPTY,
+                    right: Primitive::EMPTY,
                 })?;
                 let pb = primitive_set_of(&b).ok_or(UnifyError::ConstraintConflict {
                     left: pa,
-                    right: PrimitiveSet::EMPTY,
+                    right: Primitive::EMPTY,
                 })?;
                 pa.intersect(pb)
                     .ok_or(UnifyError::ConstraintConflict {
@@ -306,14 +310,13 @@ impl Context {
     }
 }
 
-/// Extract the primitive set of a static type, ignoring
-/// optionality at the unifier layer. Returns `None` for the
-/// (currently unconstructible) `Variant`/`Product` placeholders.
-fn primitive_set_of(ty: &StaticType) -> Option<PrimitiveSet> {
-    match ty.shape() {
-        Definite::Primitive(set) => Some(*set),
-        Definite::Variant | Definite::Product => None,
-    }
+/// Extract the primitive set of a static type. For composite-only
+/// types (no primitive bits and no admissible singleton) returns
+/// `None`. The unifier currently operates over the primitive part
+/// alone; composite-only constraints are reserved for future use.
+fn primitive_set_of(ty: &StaticType) -> Option<Primitive> {
+    let p = ty.primitive_part();
+    if p.is_empty() { None } else { Some(p) }
 }
 
 fn instantiate_body(body: &SchemeBody, sub: &HashMap<SchemeVarName, VarId>) -> InstantiatedBody {
@@ -330,26 +333,22 @@ fn instantiate_body(body: &SchemeBody, sub: &HashMap<SchemeVarName, VarId>) -> I
 
 fn instantiate_type(ty: &SchemeType, sub: &HashMap<SchemeVarName, VarId>) -> Type {
     match ty {
-        SchemeType::Definite(d) => instantiate_definite(d, sub, false),
-        SchemeType::Optional(d) => instantiate_definite(d, sub, true),
+        SchemeType::Required(d) => instantiate_shape(d, sub, false),
+        SchemeType::Optional(d) => instantiate_shape(d, sub, true),
     }
 }
 
-fn instantiate_definite(
-    d: &SchemeDefinite,
-    sub: &HashMap<SchemeVarName, VarId>,
-    optional: bool,
-) -> Type {
+fn instantiate_shape(d: &SchemeShape, sub: &HashMap<SchemeVarName, VarId>, optional: bool) -> Type {
     match d {
-        SchemeDefinite::Primitive(p) => {
+        SchemeShape::Primitive(p) => {
             let static_ty = if optional {
-                StaticType::optional_set(*p)
+                StaticType::primitive_set(*p).optional()
             } else {
                 StaticType::primitive_set(*p)
             };
             Type::Static(static_ty)
         }
-        SchemeDefinite::Variable(name) => Type::Variable(
+        SchemeShape::Variable(name) => Type::Variable(
             *sub.get(name)
                 .expect("scheme references unquantified variable"),
         ),
@@ -386,16 +385,16 @@ mod tests {
     #[dialog_common::test]
     fn fresh_variables_are_distinct() {
         let mut ctx = Context::new();
-        let a = ctx.fresh(PrimitiveSet::ALL);
-        let b = ctx.fresh(PrimitiveSet::ALL);
+        let a = ctx.fresh(Primitive::ALL);
+        let b = ctx.fresh(Primitive::ALL);
         assert_ne!(a, b);
     }
 
     #[dialog_common::test]
     fn fresh_records_constraint() {
         let mut ctx = Context::new();
-        let a = ctx.fresh(PrimitiveSet::NUMERIC);
-        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
+        let a = ctx.fresh(Primitive::NUMERIC);
+        assert_eq!(ctx.constraint(a), Primitive::NUMERIC);
     }
 
     #[dialog_common::test]
@@ -415,13 +414,13 @@ mod tests {
     #[dialog_common::test]
     fn unify_variable_with_concrete_substitutes() {
         let mut ctx = Context::new();
-        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        let v = ctx.fresh(Primitive::NUMERIC);
         ctx.unify(&Type::Variable(v), &p(ValueType::UnsignedInt))
             .unwrap();
         let resolved = ctx.apply(&Type::Variable(v));
         match resolved {
             Type::Static(s) => {
-                assert_eq!(s.shape().as_singleton(), Some(ValueType::UnsignedInt));
+                assert_eq!(s.as_value_type(), Some(ValueType::UnsignedInt));
             }
             other => panic!("expected static, got {:?}", other),
         }
@@ -430,7 +429,7 @@ mod tests {
     #[dialog_common::test]
     fn unify_variable_with_concrete_outside_constraint_fails() {
         let mut ctx = Context::new();
-        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        let v = ctx.fresh(Primitive::NUMERIC);
         let result = ctx.unify(&Type::Variable(v), &p(ValueType::String));
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
     }
@@ -438,16 +437,13 @@ mod tests {
     #[dialog_common::test]
     fn unify_variable_constraint_propagates() {
         let mut ctx = Context::new();
-        let v = ctx.fresh(PrimitiveSet::NUMERIC);
+        let v = ctx.fresh(Primitive::NUMERIC);
         let v_ty = Type::Variable(v);
-        let comparable = Type::primitive_set(PrimitiveSet::COMPARABLE);
+        let comparable = Type::primitive_set(Primitive::COMPARABLE);
         ctx.unify(&v_ty, &comparable).unwrap();
         let resolved = ctx.apply(&v_ty);
         match resolved {
-            Type::Static(s) => match s.shape() {
-                Definite::Primitive(set) => assert_eq!(*set, PrimitiveSet::NUMERIC),
-                other => panic!("expected primitive, got {:?}", other),
-            },
+            Type::Static(s) => assert_eq!(s.primitive_part(), Primitive::NUMERIC),
             other => panic!("expected static, got {:?}", other),
         }
     }
@@ -455,18 +451,18 @@ mod tests {
     #[dialog_common::test]
     fn unify_two_variables_intersects_constraints() {
         let mut ctx = Context::new();
-        let a = ctx.fresh(PrimitiveSet::NUMERIC);
-        let b = ctx.fresh(PrimitiveSet::COMPARABLE);
+        let a = ctx.fresh(Primitive::NUMERIC);
+        let b = ctx.fresh(Primitive::COMPARABLE);
         ctx.unify(&Type::Variable(a), &Type::Variable(b)).unwrap();
-        assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
-        assert_eq!(ctx.constraint(b), PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(a), Primitive::NUMERIC);
+        assert_eq!(ctx.constraint(b), Primitive::NUMERIC);
     }
 
     #[dialog_common::test]
     fn unify_two_variables_disjoint_fails() {
         let mut ctx = Context::new();
-        let a = ctx.fresh(PrimitiveSet::NUMERIC);
-        let b = ctx.fresh(PrimitiveSet::singleton(ValueType::String));
+        let a = ctx.fresh(Primitive::NUMERIC);
+        let b = ctx.fresh(Primitive::singleton(ValueType::String));
         let result = ctx.unify(&Type::Variable(a), &Type::Variable(b));
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
     }
@@ -474,8 +470,8 @@ mod tests {
     #[dialog_common::test]
     fn chained_unification_propagates() {
         let mut ctx = Context::new();
-        let t = ctx.fresh(PrimitiveSet::NUMERIC);
-        let u = ctx.fresh(PrimitiveSet::NUMERIC);
+        let t = ctx.fresh(Primitive::NUMERIC);
+        let u = ctx.fresh(Primitive::NUMERIC);
         ctx.unify(&Type::Variable(t), &Type::Variable(u)).unwrap();
         ctx.unify(&Type::Variable(t), &p(ValueType::UnsignedInt))
             .unwrap();
@@ -483,8 +479,8 @@ mod tests {
         let u_resolved = ctx.apply(&Type::Variable(u));
         match (t_resolved, u_resolved) {
             (Type::Static(t), Type::Static(u)) => {
-                assert_eq!(t.shape().as_singleton(), Some(ValueType::UnsignedInt));
-                assert_eq!(u.shape().as_singleton(), Some(ValueType::UnsignedInt));
+                assert_eq!(t.as_value_type(), Some(ValueType::UnsignedInt));
+                assert_eq!(u.as_value_type(), Some(ValueType::UnsignedInt));
             }
             other => panic!("unexpected: {:?}", other),
         }
@@ -506,25 +502,19 @@ mod tests {
 
     fn sum_scheme() -> TypeScheme {
         TypeScheme {
-            quantified: vec![(SchemeVarName::new("T"), PrimitiveSet::NUMERIC)],
+            quantified: vec![(SchemeVarName::new("T"), Primitive::NUMERIC)],
             body: SchemeBody::Schema(vec![
                 (
                     "left".into(),
-                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
-                        "T",
-                    )))),
+                    SchemeType::Required(Box::new(SchemeShape::Variable(SchemeVarName::new("T")))),
                 ),
                 (
                     "right".into(),
-                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
-                        "T",
-                    )))),
+                    SchemeType::Required(Box::new(SchemeShape::Variable(SchemeVarName::new("T")))),
                 ),
                 (
                     "out".into(),
-                    SchemeType::Definite(Box::new(SchemeDefinite::Variable(SchemeVarName::new(
-                        "T",
-                    )))),
+                    SchemeType::Required(Box::new(SchemeShape::Variable(SchemeVarName::new("T")))),
                 ),
             ]),
         }
@@ -539,8 +529,8 @@ mod tests {
         let t1 = i1.variables.get(&SchemeVarName::new("T")).copied().unwrap();
         let t2 = i2.variables.get(&SchemeVarName::new("T")).copied().unwrap();
         assert_ne!(t1, t2);
-        assert_eq!(ctx.constraint(t1), PrimitiveSet::NUMERIC);
-        assert_eq!(ctx.constraint(t2), PrimitiveSet::NUMERIC);
+        assert_eq!(ctx.constraint(t1), Primitive::NUMERIC);
+        assert_eq!(ctx.constraint(t2), Primitive::NUMERIC);
     }
 
     #[dialog_common::test]
@@ -578,7 +568,7 @@ mod tests {
             let resolved = ctx.apply(ty);
             match resolved {
                 Type::Static(s) => assert_eq!(
-                    s.shape().as_singleton(),
+                    s.as_value_type(),
                     Some(ValueType::UnsignedInt),
                     "expected u32 after unification"
                 ),

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -7,14 +7,14 @@
 //! machinery for rank-1 polymorphic formula signatures.
 //!
 //! Variables never escape into the user-facing
-//! [`super::Type`]. Lifting between layers happens via [`lift`]
+//! [`StaticType`]. Lifting between layers happens via [`lift`]
 //! and [`Context::infer`].
 
 use crate::artifact::Type as ValueType;
+use crate::type_system::Type as StaticType;
+use crate::type_system::{Definite, PrimitiveSet};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use super::{Definite, PrimitiveSet};
 
 /// A unique identifier for a type variable within a unification
 /// context.
@@ -22,11 +22,11 @@ use super::{Definite, PrimitiveSet};
 pub struct VarId(u32);
 
 /// Unifier-internal type — either a static
-/// [user-facing type](super::Type) or a fresh type variable.
+/// [user-facing type](StaticType) or a fresh type variable.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Type {
     /// A static, user-facing type lifted into the unifier domain.
-    Static(super::Type),
+    Static(StaticType),
     /// A type variable allocated by a [`Context`].
     Variable(VarId),
 }
@@ -34,23 +34,23 @@ pub enum Type {
 impl Type {
     /// Build a static primitive type, wrapped for unification.
     pub fn primitive(vt: ValueType) -> Self {
-        Type::Static(super::Type::primitive(vt))
+        Type::Static(StaticType::primitive(vt))
     }
 
     /// Build a static primitive set, wrapped for unification.
     pub fn primitive_set(set: PrimitiveSet) -> Self {
-        Type::Static(super::Type::primitive_set(set))
+        Type::Static(StaticType::primitive_set(set))
     }
 
     /// Build a static optional primitive, wrapped for unification.
     pub fn optional(vt: ValueType) -> Self {
-        Type::Static(super::Type::optional(vt))
+        Type::Static(StaticType::optional(vt))
     }
 }
 
-/// Lift a static [user-facing type](super::Type) into the unifier
+/// Lift a static [user-facing type](StaticType) into the unifier
 /// domain. Always wraps in [`Type::Static`].
-pub fn lift(ty: &super::Type) -> Type {
+pub fn lift(ty: &StaticType) -> Type {
     Type::Static(ty.clone())
 }
 
@@ -216,7 +216,7 @@ impl Context {
     ///   the name; return [`Type::Variable`].
     /// - `(None, None)`: allocate a fresh anonymous variable;
     ///   return [`Type::Variable`].
-    pub fn infer(&mut self, name: Option<&str>, kind: Option<super::Type>) -> Type {
+    pub fn infer(&mut self, name: Option<&str>, kind: Option<StaticType>) -> Type {
         match (name, kind) {
             (_, Some(t)) => Type::Static(t),
             (Some(n), None) => Type::Variable(self.var_for_name(n)),
@@ -269,7 +269,7 @@ impl Context {
                     .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
                 self.constraints.insert(x, merged);
                 self.substitution
-                    .insert(x, Type::Static(super::Type::primitive_set(merged)));
+                    .insert(x, Type::Static(StaticType::primitive_set(merged)));
                 Ok(())
             }
             (Type::Static(a), Type::Static(b)) => {
@@ -309,7 +309,7 @@ impl Context {
 /// Extract the primitive set of a static type, ignoring
 /// optionality at the unifier layer. Returns `None` for the
 /// (currently unconstructible) `Variant`/`Product` placeholders.
-fn primitive_set_of(ty: &super::Type) -> Option<PrimitiveSet> {
+fn primitive_set_of(ty: &StaticType) -> Option<PrimitiveSet> {
     match ty.shape() {
         Definite::Primitive(set) => Some(*set),
         Definite::Variant | Definite::Product => None,
@@ -343,9 +343,9 @@ fn instantiate_definite(
     match d {
         SchemeDefinite::Primitive(p) => {
             let static_ty = if optional {
-                super::Type::optional_set(*p)
+                StaticType::optional_set(*p)
             } else {
-                super::Type::primitive_set(*p)
+                StaticType::primitive_set(*p)
             };
             Type::Static(static_ty)
         }
@@ -383,7 +383,7 @@ mod tests {
         Type::primitive(vt)
     }
 
-    #[test]
+    #[dialog_common::test]
     fn fresh_variables_are_distinct() {
         let mut ctx = Context::new();
         let a = ctx.fresh(PrimitiveSet::ALL);
@@ -391,28 +391,28 @@ mod tests {
         assert_ne!(a, b);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn fresh_records_constraint() {
         let mut ctx = Context::new();
         let a = ctx.fresh(PrimitiveSet::NUMERIC);
         assert_eq!(ctx.constraint(a), PrimitiveSet::NUMERIC);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_two_concrete_primitives_same_succeeds() {
         let mut ctx = Context::new();
         ctx.unify(&p(ValueType::String), &p(ValueType::String))
             .unwrap();
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_two_concrete_primitives_different_fails() {
         let mut ctx = Context::new();
         let result = ctx.unify(&p(ValueType::String), &p(ValueType::Entity));
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_variable_with_concrete_substitutes() {
         let mut ctx = Context::new();
         let v = ctx.fresh(PrimitiveSet::NUMERIC);
@@ -427,7 +427,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_variable_with_concrete_outside_constraint_fails() {
         let mut ctx = Context::new();
         let v = ctx.fresh(PrimitiveSet::NUMERIC);
@@ -435,7 +435,7 @@ mod tests {
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_variable_constraint_propagates() {
         let mut ctx = Context::new();
         let v = ctx.fresh(PrimitiveSet::NUMERIC);
@@ -452,7 +452,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_two_variables_intersects_constraints() {
         let mut ctx = Context::new();
         let a = ctx.fresh(PrimitiveSet::NUMERIC);
@@ -462,7 +462,7 @@ mod tests {
         assert_eq!(ctx.constraint(b), PrimitiveSet::NUMERIC);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_two_variables_disjoint_fails() {
         let mut ctx = Context::new();
         let a = ctx.fresh(PrimitiveSet::NUMERIC);
@@ -471,7 +471,7 @@ mod tests {
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn chained_unification_propagates() {
         let mut ctx = Context::new();
         let t = ctx.fresh(PrimitiveSet::NUMERIC);
@@ -490,14 +490,14 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_optional_with_definite_same_shape_succeeds() {
         let mut ctx = Context::new();
         ctx.unify(&p(ValueType::String), &Type::optional(ValueType::String))
             .unwrap();
     }
 
-    #[test]
+    #[dialog_common::test]
     fn unify_optional_with_definite_disjoint_fails() {
         let mut ctx = Context::new();
         let result = ctx.unify(&p(ValueType::String), &Type::optional(ValueType::Entity));
@@ -530,7 +530,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn instantiate_allocates_fresh_variables() {
         let scheme = sum_scheme();
         let mut ctx = Context::new();
@@ -543,7 +543,7 @@ mod tests {
         assert_eq!(ctx.constraint(t2), PrimitiveSet::NUMERIC);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn instantiate_shared_variable_in_body() {
         let scheme = sum_scheme();
         let mut ctx = Context::new();
@@ -564,7 +564,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn instantiated_polymorphic_formula_unifies() {
         let scheme = sum_scheme();
         let mut ctx = Context::new();
@@ -587,7 +587,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn instantiated_polymorphic_formula_rejects_mismatch() {
         let scheme = sum_scheme();
         let mut ctx = Context::new();
@@ -601,7 +601,7 @@ mod tests {
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn two_instantiations_are_independent() {
         let scheme = sum_scheme();
         let mut ctx = Context::new();
@@ -619,7 +619,7 @@ mod tests {
         ctx.unify(&i2_left, &p(ValueType::Float)).unwrap();
     }
 
-    #[test]
+    #[dialog_common::test]
     fn match_optionality_combine_strictest_wins() {
         assert_eq!(
             MatchOptionality::Required.combine(MatchOptionality::Optional),
@@ -637,7 +637,7 @@ mod tests {
 
     /// `infer` with no name and no kind allocates a fresh
     /// anonymous variable.
-    #[test]
+    #[dialog_common::test]
     fn infer_anonymous_unconstrained() {
         let mut ctx = Context::new();
         let a = ctx.infer(None, None);
@@ -650,7 +650,7 @@ mod tests {
 
     /// `infer` with a name (no kind) allocates once per name in
     /// scope; repeated calls return the same variable.
-    #[test]
+    #[dialog_common::test]
     fn infer_named_is_stable_within_scope() {
         let mut ctx = Context::new();
         let a = ctx.infer(Some("x"), None);
@@ -663,13 +663,10 @@ mod tests {
 
     /// `infer` with a kind always wraps statically — no variable
     /// is allocated even when a name is given.
-    #[test]
+    #[dialog_common::test]
     fn infer_with_kind_wraps_statically() {
         let mut ctx = Context::new();
-        let a = ctx.infer(
-            Some("x"),
-            Some(super::super::Type::primitive(ValueType::String)),
-        );
+        let a = ctx.infer(Some("x"), Some(StaticType::primitive(ValueType::String)));
         match a {
             Type::Static(_) => {}
             other => panic!("expected static, got {:?}", other),

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -1,23 +1,21 @@
 //! Type system utilities for dialog-query
 //!
-//! This module provides the bridge between Rust's compile-time type system and
-//! the runtime type system. The core abstractions are:
+//! This module bridges Rust's compile-time type system to the
+//! query engine's runtime type system. The core abstractions are:
 //!
-//! - [`TypeDescriptor`] — a trait implemented by named ZSTs (like [`Text`],
-//!   [`Boolean`]) that carry a static `TYPE` constant and can report the
-//!   runtime type of a value. Now also exposes
-//!   [`kind`](TypeDescriptor::kind) returning the unified
-//!   [`type_system::Type`] for the v2 type system.
-//! - [`Typed`] — maps a Rust type (e.g. `String`) to its [`TypeDescriptor`]
-//!   (e.g. `Text`). Also implemented by the ZSTs themselves so that
-//!   `Term<String>` and `Term<Text>` are interchangeable.
-//! - [`Scalar`] — concrete types with bidirectional [`Value`] conversion.
-//! - [`Any`] — a descriptor that carries a runtime `Option<Type>`, used for
-//!   type-erased terms (`Term<Any>` replaces the old `Parameter`).
-//!   In v2, `Any::kind()` reports a fresh anonymous type variable
-//!   when the wrapped tag is `None`.
-//! - [`OptionalOf`] — a wrapper descriptor for `Term<Option<U>>`. Reports
-//!   `Type::Optional(...)` from the inner descriptor's `Type::Definite(...)`.
+//! - [`TypeDescriptor`] — a trait implemented by named ZSTs (like
+//!   [`Text`], [`Boolean`]) that report a unified
+//!   [`type_system::Type`] for a value via
+//!   [`kind`](TypeDescriptor::kind).
+//! - [`Typed`] — maps a Rust type (e.g. `String`) to its
+//!   [`TypeDescriptor`] (e.g. `Text`).
+//! - [`Scalar`] — concrete types with bidirectional [`Value`]
+//!   conversion.
+//! - [`Any`] — a descriptor that carries a runtime
+//!   `Option<type_system::Type>`. Used for type-erased terms.
+//! - [`OptionalOf`] — a wrapper descriptor for `Term<Option<U>>`.
+//!   Lifts the inner descriptor's `Type::Definite(...)` into
+//!   `Type::Optional(...)`.
 
 use crate::type_system;
 use dialog_common::ConditionalSend;
@@ -28,78 +26,43 @@ use std::marker::PhantomData;
 pub use crate::artifact::{ArtifactsAttribute, Cause, Entity, Type, Value};
 use crate::attribute::The;
 
-/// Trait implemented by type descriptors — named ZSTs that represent a
-/// runtime type at the Rust type level.
+/// Trait implemented by type descriptors — named ZSTs that
+/// represent a runtime type at the Rust type level.
 ///
-/// Each descriptor exposes three views of its represented type:
-/// 1. **Storage tag** — the legacy [`Type`] (alias for
-///    `dialog_artifacts::ValueDataType`) carried in
-///    [`Self::TYPE`]. `Some(Type::String)` for concrete
-///    descriptors, `None` for [`Any`]. This view is what storage
-///    selectors and wire-format value tags consume.
-/// 2. **Runtime tag** — [`Self::content_type`] returns the same
-///    `Option<Type>` but takes `&self`, allowing dynamic
-///    descriptors (like [`Any`]) to inspect their wrapped state.
-/// 3. **Unified type** — [`Self::kind`] returns the v2
-///    [`type_system::Type`], the rich representation used by the
-///    Damas-Milner unifier and rule-compile-time analysis.
-///    Lossless from `TYPE`: a `None` storage tag becomes a fresh
-///    anonymous variable; a `Some(vt)` becomes
-///    `Type::Definite(Primitive(singleton(vt)))`.
+/// Each descriptor reports its represented type via
+/// [`Self::kind`] returning `Option<type_system::Type>`. `None`
+/// means "unknown — the unifier decides at rule-compile time."
 pub trait TypeDescriptor:
     Clone + fmt::Debug + Default + PartialEq + Eq + Hash + Send + Sync + 'static
 {
-    /// The legacy storage tag, if statically known.
-    /// `None` means "any type" — determined at runtime.
+    /// The legacy storage tag, if statically known. `None` means
+    /// "any type."
     const TYPE: Option<Type>;
 
-    /// Report the runtime storage tag this descriptor represents.
-    ///
-    /// For concrete descriptors (e.g. [`Text`]) this returns
-    /// `Self::TYPE`. For [`Any`] this returns the wrapped
-    /// `Option<Type>`.
-    fn content_type(&self) -> Option<Type>;
-
     /// Report the unified [`type_system::Type`] this descriptor
-    /// represents.
+    /// represents. `None` means "no static info — leave to the
+    /// unifier."
     ///
-    /// Default implementation builds from [`Self::TYPE`]:
-    /// - `None` → a fresh anonymous variable with constraint
-    ///   [`PrimitiveSet::ALL`](type_system::PrimitiveSet::ALL).
-    /// - `Some(vt)` → `Type::Definite(Primitive(singleton(vt)))`.
-    ///
-    /// Dynamic descriptors ([`Any`]) override to inspect their
-    /// wrapped state. Wrapper descriptors ([`OptionalOf`])
-    /// override to lift the inner kind into `Type::Optional`.
-    fn kind(&self) -> type_system::Type {
-        match Self::TYPE {
-            Some(vt) => type_system::Type::primitive(vt),
-            None => type_system::Type::any(),
-        }
+    /// Default implementation lifts [`Self::TYPE`]:
+    /// `Some(vt) → Some(Type::primitive(vt))`, `None → None`.
+    fn kind(&self) -> Option<type_system::Type> {
+        Self::TYPE.map(type_system::Type::primitive)
     }
 
-    /// Reconstruct a descriptor from a runtime type tag.
+    /// Reconstruct a descriptor from a unified type kind.
     ///
-    /// For concrete descriptors this ignores the input and returns `Self::default()`.
-    /// For [`Any`] this wraps the type tag.
-    fn from_content_type(_type: Option<Type>) -> Self {
+    /// Concrete descriptors ignore the input. [`Any`] wraps it.
+    fn from_kind(_kind: Option<type_system::Type>) -> Self {
         Self::default()
     }
 }
 
 /// Maps a Rust type to its [`TypeDescriptor`].
-///
-/// For concrete types like `String`, this maps to a named ZST (`Text`).
-/// Each ZST also implements `Typed` mapping to itself, so `Term<String>`
-/// and `Term<Text>` use the same internal representation.
 pub trait Typed {
-    /// The descriptor type that represents this type in the term system.
+    /// The descriptor type that represents this type in the term
+    /// system.
     type Descriptor: TypeDescriptor;
 }
-
-// Named ZST descriptors and their TypeDescriptor + Typed implementations.
-// Each descriptor is a zero-sized type that carries type information at the
-// Rust type level, enabling Term<T> to store type metadata without overhead.
 
 macro_rules! define_descriptor {
     (
@@ -112,10 +75,6 @@ macro_rules! define_descriptor {
 
         impl TypeDescriptor for $name {
             const TYPE: Option<Type> = Some($variant);
-
-            fn content_type(&self) -> Option<Type> {
-                Some($variant)
-            }
         }
 
         impl Typed for $name {
@@ -169,38 +128,21 @@ define_descriptor!(
     Record, Type::Record
 );
 
-/// Descriptor for dynamically-typed values — carries an optional runtime
-/// type tag. `Term<Any>` is the unified replacement for the old `Parameter`.
+/// Descriptor for dynamically-typed values — carries an optional
+/// runtime type kind. `Term<Any>` is the unified replacement for
+/// the old `Parameter`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-pub struct Any(pub Option<Type>);
+pub struct Any(pub Option<type_system::Type>);
 
 impl TypeDescriptor for Any {
     const TYPE: Option<Type> = None;
 
-    fn content_type(&self) -> Option<Type> {
-        self.0
+    fn kind(&self) -> Option<type_system::Type> {
+        self.0.clone()
     }
 
-    /// For [`Any`], `kind()` mirrors the wrapped storage tag:
-    /// - `Some(vt)` → `Type::Definite(Primitive(singleton(vt)))`.
-    /// - `None` → fresh anonymous variable
-    ///   (`Definite::Variable(VarId::global_fresh())`) with
-    ///   constraint [`PrimitiveSet::ALL`](type_system::PrimitiveSet::ALL).
-    ///
-    /// Each call with `None` allocates a new global `VarId`.
-    /// Callers that need stable identity across multiple
-    /// `kind()` calls on the same `Term<Any>` should consult
-    /// the rule-level [`UnificationContext`](type_system::UnificationContext)
-    /// rather than calling `kind()` repeatedly.
-    fn kind(&self) -> type_system::Type {
-        match self.0 {
-            Some(vt) => type_system::Type::primitive(vt),
-            None => type_system::Type::any(),
-        }
-    }
-
-    fn from_content_type(typ: Option<Type>) -> Self {
-        Any(typ)
+    fn from_kind(kind: Option<type_system::Type>) -> Self {
+        Any(kind)
     }
 }
 
@@ -208,52 +150,37 @@ impl Typed for Any {
     type Descriptor = Self;
 }
 
+impl From<Option<Type>> for Any {
+    /// Lift a legacy storage tag into an `Any` descriptor.
+    /// `Some(vt) → Some(Type::primitive(vt))`, `None → None`.
+    fn from(value: Option<Type>) -> Self {
+        Any(value.map(type_system::Type::primitive))
+    }
+}
+
 /// Wrapper descriptor lifting an inner [`TypeDescriptor`] into a
 /// set-widened (Optional) shape.
 ///
 /// Used by `Term<Option<U>>` to report its kind as
 /// `Type::Optional(...)` based on the inner descriptor's
-/// `Type::Definite(...)`. Adding `Option<U>` at the Rust type
-/// level produces a `Term<Option<U>>` whose descriptor is
-/// `OptionalOf<<U as Typed>::Descriptor>`.
-///
-/// `OptionalOf` is a ZST: it carries no runtime data, the inner
-/// descriptor's information is reached via `D::kind()`.
-///
-/// Note: only used in v2's typed surface for `Term<Option<U>>`.
-/// The macro layer (Step 7) emits `Term<Option<...>>` for
-/// `Option<T>` fields, which routes through this descriptor.
+/// `Type::Definite(...)`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct OptionalOf<D: TypeDescriptor>(PhantomData<D>);
 
 impl<D: TypeDescriptor> TypeDescriptor for OptionalOf<D> {
-    /// Optional doesn't have a single storage tag — it admits
-    /// either the inner type *or* `Absent`. The legacy `TYPE`
-    /// constant is `None` to signal "no single static tag";
-    /// callers needing the rich information call `kind()`.
     const TYPE: Option<Type> = D::TYPE;
 
-    fn content_type(&self) -> Option<Type> {
-        D::TYPE
-    }
-
-    /// Lift the inner descriptor's `kind()` from
-    /// `Type::Definite(d)` to `Type::Optional(d)`.
-    ///
-    /// If the inner descriptor reports a non-`Definite` kind
-    /// (e.g. another `Optional` — which the marker traits at the
-    /// Rust API layer prevent, but be defensive at runtime), the
-    /// kind passes through unchanged.
-    fn kind(&self) -> type_system::Type {
-        match D::default().kind() {
+    /// Lift the inner descriptor's `kind()` into `Optional`.
+    /// `Some(Type::Definite(d)) → Some(Type::Optional(d))`.
+    /// `Some(Type::Optional(d))` passes through.
+    /// `None → None`.
+    fn kind(&self) -> Option<type_system::Type> {
+        D::default().kind().map(|k| match k {
             type_system::Type::Definite(d) => type_system::Type::Optional(d),
             other => other,
-        }
+        })
     }
 }
-
-// Typed implementations for Rust primitive and dialog-artifacts types.
-// Each maps to the appropriate named ZST descriptor.
 
 macro_rules! impl_typed {
     ($rust_type:ty, $descriptor:ty) => {
@@ -286,24 +213,13 @@ impl_typed!(Cause, Bytes);
 impl_typed!(Value, Any);
 
 /// `Option<U>: Typed` for any [`Scalar`] `U`. Maps to
-/// [`OptionalOf<U::Descriptor>`], so `Term<Option<String>>` and
-/// `Term<Option<u32>>` get a descriptor that reports
-/// `Type::Optional(Primitive(...))` via [`TypeDescriptor::kind`].
-///
-/// The `U: Scalar` bound is what structurally rejects nested
-/// optionality: `Option<U>` itself is not `Scalar` (no
-/// `impl Scalar for Option<U>`), so `Option<Option<U>>` fails to
-/// satisfy `Typed`. This is the v2 replacement for v1's
-/// `OptionalType: !DefiniteType` marker-trait fence.
+/// [`OptionalOf<U::Descriptor>`].
 impl<U: Scalar> Typed for Option<U> {
     type Descriptor = OptionalOf<<U as Typed>::Descriptor>;
 }
 
-/// A concrete type that can be used as a term value with bidirectional Value conversion.
-///
-/// `Scalar` types have a known static [`TypeDescriptor`] (their `Tag` is `()`-like —
-/// a ZST) and can convert to/from [`Value`]. Every `Scalar` type must implement
-/// `Into<Value>` (typically via `From<T> for Value`) for the forward direction.
+/// A concrete type that can be used as a term value with
+/// bidirectional Value conversion.
 pub trait Scalar:
     Typed + Clone + fmt::Debug + Into<Value> + 'static + ConditionalSend + TryFrom<Value>
 {
@@ -340,12 +256,12 @@ impl Scalar for usize {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::type_system::{Definite, PrimitiveSet};
+    use crate::type_system::Definite;
 
-    /// `Text::kind()` reports `Type::Definite(Primitive(singleton(String)))`.
+    /// `Text::kind()` reports `Some(Type::Definite(Primitive(String)))`.
     #[test]
     fn text_descriptor_kind_is_definite_string() {
-        let kind = Text.kind();
+        let kind = Text.kind().expect("Text has a static kind");
         match kind {
             type_system::Type::Definite(d) => match *d {
                 Definite::Primitive(set) => {
@@ -360,129 +276,79 @@ mod tests {
     /// Each named ZST descriptor reports the right primitive.
     #[test]
     fn named_descriptors_report_their_primitives() {
-        assert_eq!(Text.kind().shape().as_singleton(), Some(Type::String));
-        assert_eq!(Boolean.kind().shape().as_singleton(), Some(Type::Boolean));
+        let to_singleton = |k: Option<type_system::Type>| k.unwrap().shape().as_singleton();
+        assert_eq!(to_singleton(Text.kind()), Some(Type::String));
+        assert_eq!(to_singleton(Boolean.kind()), Some(Type::Boolean));
         assert_eq!(
-            UnsignedInteger.kind().shape().as_singleton(),
+            to_singleton(UnsignedInteger.kind()),
             Some(Type::UnsignedInt)
         );
-        assert_eq!(
-            SignedInteger.kind().shape().as_singleton(),
-            Some(Type::SignedInt)
-        );
-        assert_eq!(Float.kind().shape().as_singleton(), Some(Type::Float));
-        assert_eq!(Bytes.kind().shape().as_singleton(), Some(Type::Bytes));
-        assert_eq!(EntityType.kind().shape().as_singleton(), Some(Type::Entity));
-        assert_eq!(Symbol.kind().shape().as_singleton(), Some(Type::Symbol));
-        assert_eq!(Record.kind().shape().as_singleton(), Some(Type::Record));
+        assert_eq!(to_singleton(SignedInteger.kind()), Some(Type::SignedInt));
+        assert_eq!(to_singleton(Float.kind()), Some(Type::Float));
+        assert_eq!(to_singleton(Bytes.kind()), Some(Type::Bytes));
+        assert_eq!(to_singleton(EntityType.kind()), Some(Type::Entity));
+        assert_eq!(to_singleton(Symbol.kind()), Some(Type::Symbol));
+        assert_eq!(to_singleton(Record.kind()), Some(Type::Record));
     }
 
-    /// `Any(Some(vt))` reports `Type::Definite(Primitive(singleton(vt)))`.
+    /// `Any(Some(Type::primitive(vt)))` reports the wrapped kind.
     #[test]
     fn any_descriptor_with_tag_reports_definite() {
-        let descriptor = Any(Some(Type::Entity));
-        let kind = descriptor.kind();
+        let descriptor = Any(Some(type_system::Type::primitive(Type::Entity)));
+        let kind = descriptor.kind().expect("kind present");
         assert!(!kind.is_optional());
         assert_eq!(kind.shape().as_singleton(), Some(Type::Entity));
     }
 
-    /// `Any(None)` reports an anonymous variable.
+    /// `Any(None)` reports `None` — no static info.
     #[test]
-    fn any_descriptor_without_tag_reports_variable() {
+    fn any_descriptor_without_tag_reports_none() {
         let descriptor = Any(None);
-        let kind = descriptor.kind();
-        match kind.shape() {
-            Definite::Variable(_) => {}
-            other => panic!("expected variable, got {:?}", other),
-        }
+        assert!(descriptor.kind().is_none());
     }
 
-    /// `Any(None).kind()` allocates a fresh `VarId` each call.
+    /// `Any::default()` yields `Any(None)`.
     #[test]
-    fn any_descriptor_kind_is_unique_per_call() {
-        let descriptor = Any(None);
-        let a = match descriptor.kind().shape() {
-            Definite::Variable(id) => *id,
-            _ => panic!("expected variable"),
-        };
-        let b = match descriptor.kind().shape() {
-            Definite::Variable(id) => *id,
-            _ => panic!("expected variable"),
-        };
-        assert_ne!(a, b);
+    fn any_default_is_none() {
+        let descriptor = Any::default();
+        assert_eq!(descriptor, Any(None));
+        assert!(descriptor.kind().is_none());
     }
 
-    /// `OptionalOf<Text>::kind()` reports `Type::Optional(Primitive(String))`.
+    /// `From<Option<Type>> for Any` lifts a legacy storage tag.
+    #[test]
+    fn from_option_value_type_lifts_into_any() {
+        let a: Any = Some(Type::String).into();
+        assert_eq!(a.kind(), Some(type_system::Type::primitive(Type::String)));
+        let b: Any = None.into();
+        assert_eq!(b, Any(None));
+    }
+
+    /// `OptionalOf<Text>::kind()` reports
+    /// `Some(Type::Optional(Primitive(String)))`.
     #[test]
     fn optional_of_text_reports_optional_string() {
         let descriptor: OptionalOf<Text> = OptionalOf::default();
-        let kind = descriptor.kind();
+        let kind = descriptor.kind().expect("present");
         assert!(kind.is_optional());
-        assert_eq!(
-            kind.shape().as_singleton(),
-            Some(Type::String),
-            "inner shape preserved through Optional wrap"
-        );
+        assert_eq!(kind.shape().as_singleton(), Some(Type::String));
     }
 
     /// `OptionalOf<EntityType>::kind()` reports
-    /// `Type::Optional(Primitive(Entity))`.
+    /// `Some(Type::Optional(Primitive(Entity)))`.
     #[test]
     fn optional_of_entity_reports_optional_entity() {
         let descriptor: OptionalOf<EntityType> = OptionalOf::default();
-        let kind = descriptor.kind();
+        let kind = descriptor.kind().expect("present");
         assert!(kind.is_optional());
         assert_eq!(kind.shape().as_singleton(), Some(Type::Entity));
     }
 
-    /// `OptionalOf<Any>` should pass through (Any's kind is a
-    /// variable, not Definite, so the Optional wrap is a no-op
-    /// per the defensive fall-through). Marker traits at the
-    /// Rust API layer prevent this case in well-typed code.
+    /// `OptionalOf<Any>` passes through `None` since `Any`'s
+    /// default kind is `None`.
     #[test]
-    fn optional_of_any_passes_through() {
+    fn optional_of_any_passes_through_none() {
         let descriptor: OptionalOf<Any> = OptionalOf::default();
-        let kind = descriptor.kind();
-        // Any's kind is Type::Definite(Variable(_)). Optional
-        // wrap turns that into Type::Optional(Variable(_)).
-        // Both are valid; our test just verifies kind() doesn't
-        // panic and produces a well-formed Type.
-        match kind {
-            type_system::Type::Optional(d) => match *d {
-                Definite::Variable(_) => {}
-                other => panic!("expected Variable, got {:?}", other),
-            },
-            type_system::Type::Definite(d) => match *d {
-                Definite::Variable(_) => {}
-                other => panic!("expected Variable, got {:?}", other),
-            },
-        }
-    }
-
-    /// The default `kind()` from `TYPE` matches the override
-    /// behavior — sanity check that the trait default and the
-    /// macro-generated impls agree.
-    #[test]
-    fn default_kind_matches_named_descriptor() {
-        // Text uses the default kind() from the trait. This test
-        // verifies the default impl is wired correctly.
-        let kind = Text.kind();
-        assert_eq!(kind.shape().as_singleton(), Some(Type::String));
-    }
-
-    /// Constraint set on `Any`'s anonymous variable is `ALL`.
-    #[test]
-    fn any_descriptor_variable_constraint_is_all() {
-        let descriptor = Any(None);
-        let kind = descriptor.kind();
-        let var_id = match kind.shape() {
-            Definite::Variable(id) => *id,
-            _ => panic!("expected variable"),
-        };
-        // The global VarId allocator doesn't track constraints;
-        // a fresh UnificationContext considering this VarId
-        // would treat its constraint as ALL by default.
-        let ctx = type_system::UnificationContext::new();
-        assert_eq!(ctx.constraint(var_id), PrimitiveSet::ALL);
+        assert!(descriptor.kind().is_none());
     }
 }

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -285,6 +285,20 @@ impl_typed!(The, Symbol);
 impl_typed!(Cause, Bytes);
 impl_typed!(Value, Any);
 
+/// `Option<U>: Typed` for any [`Scalar`] `U`. Maps to
+/// [`OptionalOf<U::Descriptor>`], so `Term<Option<String>>` and
+/// `Term<Option<u32>>` get a descriptor that reports
+/// `Type::Optional(Primitive(...))` via [`TypeDescriptor::kind`].
+///
+/// The `U: Scalar` bound is what structurally rejects nested
+/// optionality: `Option<U>` itself is not `Scalar` (no
+/// `impl Scalar for Option<U>`), so `Option<Option<U>>` fails to
+/// satisfy `Typed`. This is the v2 replacement for v1's
+/// `OptionalType: !DefiniteType` marker-trait fence.
+impl<U: Scalar> Typed for Option<U> {
+    type Descriptor = OptionalOf<<U as Typed>::Descriptor>;
+}
+
 /// A concrete type that can be used as a term value with bidirectional Value conversion.
 ///
 /// `Scalar` types have a known static [`TypeDescriptor`] (their `Tag` is `()`-like —

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -1,46 +1,82 @@
 //! Type system utilities for dialog-query
 //!
 //! This module provides the bridge between Rust's compile-time type system and
-//! dialog-artifacts' runtime [`Type`] system. The core abstractions are:
+//! the runtime type system. The core abstractions are:
 //!
 //! - [`TypeDescriptor`] — a trait implemented by named ZSTs (like [`Text`],
 //!   [`Boolean`]) that carry a static `TYPE` constant and can report the
-//!   runtime type of a value.
+//!   runtime type of a value. Now also exposes
+//!   [`kind`](TypeDescriptor::kind) returning the unified
+//!   [`type_system::Type`] for the v2 type system.
 //! - [`Typed`] — maps a Rust type (e.g. `String`) to its [`TypeDescriptor`]
 //!   (e.g. `Text`). Also implemented by the ZSTs themselves so that
 //!   `Term<String>` and `Term<Text>` are interchangeable.
 //! - [`Scalar`] — concrete types with bidirectional [`Value`] conversion.
 //! - [`Any`] — a descriptor that carries a runtime `Option<Type>`, used for
 //!   type-erased terms (`Term<Any>` replaces the old `Parameter`).
+//!   In v2, `Any::kind()` reports a fresh anonymous type variable
+//!   when the wrapped tag is `None`.
+//! - [`OptionalOf`] — a wrapper descriptor for `Term<Option<U>>`. Reports
+//!   `Type::Optional(...)` from the inner descriptor's `Type::Definite(...)`.
 
+use crate::type_system;
 use dialog_common::ConditionalSend;
 use std::fmt;
 use std::hash::Hash;
+use std::marker::PhantomData;
 
 pub use crate::artifact::{ArtifactsAttribute, Cause, Entity, Type, Value};
 use crate::attribute::The;
 
 /// Trait implemented by type descriptors — named ZSTs that represent a
-/// dialog-artifacts type at the Rust type level.
+/// runtime type at the Rust type level.
 ///
-/// Each descriptor answers two questions:
-/// 1. **What is the static type?** — via `TYPE` (compile-time constant).
-///    `Some(Type::String)` for concrete types, `None` for [`Any`].
-/// 2. **What is the runtime type of a given value?** — via `content_type()`.
-///    For concrete descriptors this always returns `TYPE`. For [`Any`] it
-///    inspects the wrapped `Option<Type>`.
+/// Each descriptor exposes three views of its represented type:
+/// 1. **Storage tag** — the legacy [`Type`] (alias for
+///    `dialog_artifacts::ValueDataType`) carried in
+///    [`Self::TYPE`]. `Some(Type::String)` for concrete
+///    descriptors, `None` for [`Any`]. This view is what storage
+///    selectors and wire-format value tags consume.
+/// 2. **Runtime tag** — [`Self::content_type`] returns the same
+///    `Option<Type>` but takes `&self`, allowing dynamic
+///    descriptors (like [`Any`]) to inspect their wrapped state.
+/// 3. **Unified type** — [`Self::kind`] returns the v2
+///    [`type_system::Type`], the rich representation used by the
+///    Damas-Milner unifier and rule-compile-time analysis.
+///    Lossless from `TYPE`: a `None` storage tag becomes a fresh
+///    anonymous variable; a `Some(vt)` becomes
+///    `Type::Definite(Primitive(singleton(vt)))`.
 pub trait TypeDescriptor:
     Clone + fmt::Debug + Default + PartialEq + Eq + Hash + Send + Sync + 'static
 {
-    /// The dialog-artifacts type, if statically known.
+    /// The legacy storage tag, if statically known.
     /// `None` means "any type" — determined at runtime.
     const TYPE: Option<Type>;
 
-    /// Report the runtime type this descriptor represents.
+    /// Report the runtime storage tag this descriptor represents.
     ///
-    /// For concrete descriptors (e.g. [`Text`]) this returns `Self::TYPE`.
-    /// For [`Any`] this returns the wrapped `Option<Type>`.
+    /// For concrete descriptors (e.g. [`Text`]) this returns
+    /// `Self::TYPE`. For [`Any`] this returns the wrapped
+    /// `Option<Type>`.
     fn content_type(&self) -> Option<Type>;
+
+    /// Report the unified [`type_system::Type`] this descriptor
+    /// represents.
+    ///
+    /// Default implementation builds from [`Self::TYPE`]:
+    /// - `None` → a fresh anonymous variable with constraint
+    ///   [`PrimitiveSet::ALL`](type_system::PrimitiveSet::ALL).
+    /// - `Some(vt)` → `Type::Definite(Primitive(singleton(vt)))`.
+    ///
+    /// Dynamic descriptors ([`Any`]) override to inspect their
+    /// wrapped state. Wrapper descriptors ([`OptionalOf`])
+    /// override to lift the inner kind into `Type::Optional`.
+    fn kind(&self) -> type_system::Type {
+        match Self::TYPE {
+            Some(vt) => type_system::Type::primitive(vt),
+            None => type_system::Type::any(),
+        }
+    }
 
     /// Reconstruct a descriptor from a runtime type tag.
     ///
@@ -145,6 +181,24 @@ impl TypeDescriptor for Any {
         self.0
     }
 
+    /// For [`Any`], `kind()` mirrors the wrapped storage tag:
+    /// - `Some(vt)` → `Type::Definite(Primitive(singleton(vt)))`.
+    /// - `None` → fresh anonymous variable
+    ///   (`Definite::Variable(VarId::global_fresh())`) with
+    ///   constraint [`PrimitiveSet::ALL`](type_system::PrimitiveSet::ALL).
+    ///
+    /// Each call with `None` allocates a new global `VarId`.
+    /// Callers that need stable identity across multiple
+    /// `kind()` calls on the same `Term<Any>` should consult
+    /// the rule-level [`UnificationContext`](type_system::UnificationContext)
+    /// rather than calling `kind()` repeatedly.
+    fn kind(&self) -> type_system::Type {
+        match self.0 {
+            Some(vt) => type_system::Type::primitive(vt),
+            None => type_system::Type::any(),
+        }
+    }
+
     fn from_content_type(typ: Option<Type>) -> Self {
         Any(typ)
     }
@@ -152,6 +206,50 @@ impl TypeDescriptor for Any {
 
 impl Typed for Any {
     type Descriptor = Self;
+}
+
+/// Wrapper descriptor lifting an inner [`TypeDescriptor`] into a
+/// set-widened (Optional) shape.
+///
+/// Used by `Term<Option<U>>` to report its kind as
+/// `Type::Optional(...)` based on the inner descriptor's
+/// `Type::Definite(...)`. Adding `Option<U>` at the Rust type
+/// level produces a `Term<Option<U>>` whose descriptor is
+/// `OptionalOf<<U as Typed>::Descriptor>`.
+///
+/// `OptionalOf` is a ZST: it carries no runtime data, the inner
+/// descriptor's information is reached via `D::kind()`.
+///
+/// Note: only used in v2's typed surface for `Term<Option<U>>`.
+/// The macro layer (Step 7) emits `Term<Option<...>>` for
+/// `Option<T>` fields, which routes through this descriptor.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct OptionalOf<D: TypeDescriptor>(PhantomData<D>);
+
+impl<D: TypeDescriptor> TypeDescriptor for OptionalOf<D> {
+    /// Optional doesn't have a single storage tag — it admits
+    /// either the inner type *or* `Absent`. The legacy `TYPE`
+    /// constant is `None` to signal "no single static tag";
+    /// callers needing the rich information call `kind()`.
+    const TYPE: Option<Type> = D::TYPE;
+
+    fn content_type(&self) -> Option<Type> {
+        D::TYPE
+    }
+
+    /// Lift the inner descriptor's `kind()` from
+    /// `Type::Definite(d)` to `Type::Optional(d)`.
+    ///
+    /// If the inner descriptor reports a non-`Definite` kind
+    /// (e.g. another `Optional` — which the marker traits at the
+    /// Rust API layer prevent, but be defensive at runtime), the
+    /// kind passes through unchanged.
+    fn kind(&self) -> type_system::Type {
+        match D::default().kind() {
+            type_system::Type::Definite(d) => type_system::Type::Optional(d),
+            other => other,
+        }
+    }
 }
 
 // Typed implementations for Rust primitive and dialog-artifacts types.
@@ -224,3 +322,153 @@ impl_scalar!(
 );
 
 impl Scalar for usize {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::type_system::{Definite, PrimitiveSet};
+
+    /// `Text::kind()` reports `Type::Definite(Primitive(singleton(String)))`.
+    #[test]
+    fn text_descriptor_kind_is_definite_string() {
+        let kind = Text.kind();
+        match kind {
+            type_system::Type::Definite(d) => match *d {
+                Definite::Primitive(set) => {
+                    assert_eq!(set.as_singleton(), Some(Type::String));
+                }
+                other => panic!("expected Primitive, got {:?}", other),
+            },
+            other => panic!("expected Definite, got {:?}", other),
+        }
+    }
+
+    /// Each named ZST descriptor reports the right primitive.
+    #[test]
+    fn named_descriptors_report_their_primitives() {
+        assert_eq!(Text.kind().shape().as_singleton(), Some(Type::String));
+        assert_eq!(Boolean.kind().shape().as_singleton(), Some(Type::Boolean));
+        assert_eq!(
+            UnsignedInteger.kind().shape().as_singleton(),
+            Some(Type::UnsignedInt)
+        );
+        assert_eq!(
+            SignedInteger.kind().shape().as_singleton(),
+            Some(Type::SignedInt)
+        );
+        assert_eq!(Float.kind().shape().as_singleton(), Some(Type::Float));
+        assert_eq!(Bytes.kind().shape().as_singleton(), Some(Type::Bytes));
+        assert_eq!(EntityType.kind().shape().as_singleton(), Some(Type::Entity));
+        assert_eq!(Symbol.kind().shape().as_singleton(), Some(Type::Symbol));
+        assert_eq!(Record.kind().shape().as_singleton(), Some(Type::Record));
+    }
+
+    /// `Any(Some(vt))` reports `Type::Definite(Primitive(singleton(vt)))`.
+    #[test]
+    fn any_descriptor_with_tag_reports_definite() {
+        let descriptor = Any(Some(Type::Entity));
+        let kind = descriptor.kind();
+        assert!(!kind.is_optional());
+        assert_eq!(kind.shape().as_singleton(), Some(Type::Entity));
+    }
+
+    /// `Any(None)` reports an anonymous variable.
+    #[test]
+    fn any_descriptor_without_tag_reports_variable() {
+        let descriptor = Any(None);
+        let kind = descriptor.kind();
+        match kind.shape() {
+            Definite::Variable(_) => {}
+            other => panic!("expected variable, got {:?}", other),
+        }
+    }
+
+    /// `Any(None).kind()` allocates a fresh `VarId` each call.
+    #[test]
+    fn any_descriptor_kind_is_unique_per_call() {
+        let descriptor = Any(None);
+        let a = match descriptor.kind().shape() {
+            Definite::Variable(id) => *id,
+            _ => panic!("expected variable"),
+        };
+        let b = match descriptor.kind().shape() {
+            Definite::Variable(id) => *id,
+            _ => panic!("expected variable"),
+        };
+        assert_ne!(a, b);
+    }
+
+    /// `OptionalOf<Text>::kind()` reports `Type::Optional(Primitive(String))`.
+    #[test]
+    fn optional_of_text_reports_optional_string() {
+        let descriptor: OptionalOf<Text> = OptionalOf::default();
+        let kind = descriptor.kind();
+        assert!(kind.is_optional());
+        assert_eq!(
+            kind.shape().as_singleton(),
+            Some(Type::String),
+            "inner shape preserved through Optional wrap"
+        );
+    }
+
+    /// `OptionalOf<EntityType>::kind()` reports
+    /// `Type::Optional(Primitive(Entity))`.
+    #[test]
+    fn optional_of_entity_reports_optional_entity() {
+        let descriptor: OptionalOf<EntityType> = OptionalOf::default();
+        let kind = descriptor.kind();
+        assert!(kind.is_optional());
+        assert_eq!(kind.shape().as_singleton(), Some(Type::Entity));
+    }
+
+    /// `OptionalOf<Any>` should pass through (Any's kind is a
+    /// variable, not Definite, so the Optional wrap is a no-op
+    /// per the defensive fall-through). Marker traits at the
+    /// Rust API layer prevent this case in well-typed code.
+    #[test]
+    fn optional_of_any_passes_through() {
+        let descriptor: OptionalOf<Any> = OptionalOf::default();
+        let kind = descriptor.kind();
+        // Any's kind is Type::Definite(Variable(_)). Optional
+        // wrap turns that into Type::Optional(Variable(_)).
+        // Both are valid; our test just verifies kind() doesn't
+        // panic and produces a well-formed Type.
+        match kind {
+            type_system::Type::Optional(d) => match *d {
+                Definite::Variable(_) => {}
+                other => panic!("expected Variable, got {:?}", other),
+            },
+            type_system::Type::Definite(d) => match *d {
+                Definite::Variable(_) => {}
+                other => panic!("expected Variable, got {:?}", other),
+            },
+        }
+    }
+
+    /// The default `kind()` from `TYPE` matches the override
+    /// behavior — sanity check that the trait default and the
+    /// macro-generated impls agree.
+    #[test]
+    fn default_kind_matches_named_descriptor() {
+        // Text uses the default kind() from the trait. This test
+        // verifies the default impl is wired correctly.
+        let kind = Text.kind();
+        assert_eq!(kind.shape().as_singleton(), Some(Type::String));
+    }
+
+    /// Constraint set on `Any`'s anonymous variable is `ALL`.
+    #[test]
+    fn any_descriptor_variable_constraint_is_all() {
+        let descriptor = Any(None);
+        let kind = descriptor.kind();
+        let var_id = match kind.shape() {
+            Definite::Variable(id) => *id,
+            _ => panic!("expected variable"),
+        };
+        // The global VarId allocator doesn't track constraints;
+        // a fresh UnificationContext considering this VarId
+        // would treat its constraint as ALL by default.
+        let ctx = type_system::UnificationContext::new();
+        assert_eq!(ctx.constraint(var_id), PrimitiveSet::ALL);
+    }
+}

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -18,6 +18,7 @@
 //!   [`type_system::Type::optional`].
 
 use crate::type_system;
+use crate::type_system::Type as Kind;
 use dialog_common::ConditionalSend;
 use std::fmt;
 use std::hash::Hash;
@@ -46,7 +47,7 @@ pub trait TypeDescriptor:
     /// Default implementation lifts [`Self::TYPE`]:
     /// `Some(vt) → Some(Type::primitive(vt))`, `None → None`.
     fn kind(&self) -> Option<type_system::Type> {
-        Self::TYPE.map(type_system::Type::primitive)
+        Self::TYPE.map(Kind::primitive)
     }
 
     /// Reconstruct a descriptor from a unified type kind.
@@ -154,7 +155,7 @@ impl From<Option<Type>> for Any {
     /// Lift a legacy storage tag into an `Any` descriptor.
     /// `Some(vt) → Some(Type::primitive(vt))`, `None → None`.
     fn from(value: Option<Type>) -> Self {
-        Any(value.map(type_system::Type::primitive))
+        Any(value.map(Kind::primitive))
     }
 }
 
@@ -357,7 +358,7 @@ mod tests {
     /// Each named ZST descriptor reports the right primitive.
     #[dialog_common::test]
     fn named_descriptors_report_their_primitives() {
-        let to_singleton = |k: Option<type_system::Type>| k.unwrap().as_value_type();
+        let to_singleton = |k: Option<Kind>| k.unwrap().as_value_type();
         assert_eq!(to_singleton(Text.kind()), Some(Type::String));
         assert_eq!(to_singleton(Boolean.kind()), Some(Type::Boolean));
         assert_eq!(
@@ -375,7 +376,7 @@ mod tests {
     /// `Any(Some(Type::primitive(vt)))` reports the wrapped kind.
     #[dialog_common::test]
     fn any_descriptor_with_tag_reports_primitive() {
-        let descriptor = Any(Some(type_system::Type::primitive(Type::Entity)));
+        let descriptor = Any(Some(Kind::primitive(Type::Entity)));
         let kind = descriptor.kind().expect("kind present");
         assert!(!kind.is_optional());
         assert_eq!(kind.as_value_type(), Some(Type::Entity));
@@ -400,7 +401,7 @@ mod tests {
     #[dialog_common::test]
     fn from_option_value_type_lifts_into_any() {
         let a: Any = Some(Type::String).into();
-        assert_eq!(a.kind(), Some(type_system::Type::primitive(Type::String)));
+        assert_eq!(a.kind(), Some(Kind::primitive(Type::String)));
         let b: Any = None.into();
         assert_eq!(b, Any(None));
     }

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -14,8 +14,8 @@
 //! - [`Any`] — a descriptor that carries a runtime
 //!   `Option<type_system::Type>`. Used for type-erased terms.
 //! - [`OptionalOf`] — a wrapper descriptor for `Term<Option<U>>`.
-//!   Lifts the inner descriptor's `Type::Definite(...)` into
-//!   `Type::Optional(...)`.
+//!   Widens the inner descriptor's kind with the `Nothing` atom via
+//!   [`type_system::Type::optional`].
 
 use crate::type_system;
 use dialog_common::ConditionalSend;
@@ -158,27 +158,18 @@ impl From<Option<Type>> for Any {
     }
 }
 
-/// Wrapper descriptor lifting an inner [`TypeDescriptor`] into a
-/// set-widened (Optional) shape.
-///
-/// Used by `Term<Option<U>>` to report its kind as
-/// `Type::Optional(...)` based on the inner descriptor's
-/// `Type::Definite(...)`.
+/// Wrapper descriptor widening an inner [`TypeDescriptor`]'s kind
+/// with the `Nothing` atom — used by `Term<Option<U>>`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct OptionalOf<D: TypeDescriptor>(PhantomData<D>);
 
 impl<D: TypeDescriptor> TypeDescriptor for OptionalOf<D> {
     const TYPE: Option<Type> = D::TYPE;
 
-    /// Lift the inner descriptor's `kind()` into `Optional`.
-    /// `Some(Type::Definite(d)) → Some(Type::Optional(d))`.
-    /// `Some(Type::Optional(d))` passes through.
-    /// `None → None`.
+    /// Widen the inner descriptor's `kind()` with the `Nothing`
+    /// atom via [`type_system::Type::optional`]. `None → None`.
     fn kind(&self) -> Option<type_system::Type> {
-        D::default().kind().map(|k| match k {
-            type_system::Type::Definite(d) => type_system::Type::Optional(d),
-            other => other,
-        })
+        D::default().kind().map(|k| k.optional())
     }
 }
 
@@ -256,27 +247,19 @@ impl Scalar for usize {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::type_system::Definite;
 
-    /// `Text::kind()` reports `Some(Type::Definite(Primitive(String)))`.
-    #[test]
-    fn text_descriptor_kind_is_definite_string() {
+    /// `Text::kind()` reports `Some(Type::Primitive({String}))`.
+    #[dialog_common::test]
+    fn text_descriptor_kind_is_primitive_string() {
         let kind = Text.kind().expect("Text has a static kind");
-        match kind {
-            type_system::Type::Definite(d) => match *d {
-                Definite::Primitive(set) => {
-                    assert_eq!(set.as_singleton(), Some(Type::String));
-                }
-                other => panic!("expected Primitive, got {:?}", other),
-            },
-            other => panic!("expected Definite, got {:?}", other),
-        }
+        assert_eq!(kind.as_value_type(), Some(Type::String));
+        assert!(!kind.is_optional());
     }
 
     /// Each named ZST descriptor reports the right primitive.
-    #[test]
+    #[dialog_common::test]
     fn named_descriptors_report_their_primitives() {
-        let to_singleton = |k: Option<type_system::Type>| k.unwrap().shape().as_singleton();
+        let to_singleton = |k: Option<type_system::Type>| k.unwrap().as_value_type();
         assert_eq!(to_singleton(Text.kind()), Some(Type::String));
         assert_eq!(to_singleton(Boolean.kind()), Some(Type::Boolean));
         assert_eq!(
@@ -292,23 +275,23 @@ mod tests {
     }
 
     /// `Any(Some(Type::primitive(vt)))` reports the wrapped kind.
-    #[test]
-    fn any_descriptor_with_tag_reports_definite() {
+    #[dialog_common::test]
+    fn any_descriptor_with_tag_reports_primitive() {
         let descriptor = Any(Some(type_system::Type::primitive(Type::Entity)));
         let kind = descriptor.kind().expect("kind present");
         assert!(!kind.is_optional());
-        assert_eq!(kind.shape().as_singleton(), Some(Type::Entity));
+        assert_eq!(kind.as_value_type(), Some(Type::Entity));
     }
 
     /// `Any(None)` reports `None` — no static info.
-    #[test]
+    #[dialog_common::test]
     fn any_descriptor_without_tag_reports_none() {
         let descriptor = Any(None);
         assert!(descriptor.kind().is_none());
     }
 
     /// `Any::default()` yields `Any(None)`.
-    #[test]
+    #[dialog_common::test]
     fn any_default_is_none() {
         let descriptor = Any::default();
         assert_eq!(descriptor, Any(None));
@@ -316,7 +299,7 @@ mod tests {
     }
 
     /// `From<Option<Type>> for Any` lifts a legacy storage tag.
-    #[test]
+    #[dialog_common::test]
     fn from_option_value_type_lifts_into_any() {
         let a: Any = Some(Type::String).into();
         assert_eq!(a.kind(), Some(type_system::Type::primitive(Type::String)));
@@ -324,29 +307,27 @@ mod tests {
         assert_eq!(b, Any(None));
     }
 
-    /// `OptionalOf<Text>::kind()` reports
-    /// `Some(Type::Optional(Primitive(String)))`.
-    #[test]
-    fn optional_of_text_reports_optional_string() {
+    /// `OptionalOf<Text>::kind()` widens String with `Nothing`.
+    #[dialog_common::test]
+    fn optional_of_text_widens_with_nothing() {
         let descriptor: OptionalOf<Text> = OptionalOf::default();
         let kind = descriptor.kind().expect("present");
         assert!(kind.is_optional());
-        assert_eq!(kind.shape().as_singleton(), Some(Type::String));
+        assert!(kind.primitive_part().contains(Type::String));
     }
 
-    /// `OptionalOf<EntityType>::kind()` reports
-    /// `Some(Type::Optional(Primitive(Entity)))`.
-    #[test]
-    fn optional_of_entity_reports_optional_entity() {
+    /// `OptionalOf<EntityType>::kind()` widens Entity with `Nothing`.
+    #[dialog_common::test]
+    fn optional_of_entity_widens_with_nothing() {
         let descriptor: OptionalOf<EntityType> = OptionalOf::default();
         let kind = descriptor.kind().expect("present");
         assert!(kind.is_optional());
-        assert_eq!(kind.shape().as_singleton(), Some(Type::Entity));
+        assert!(kind.primitive_part().contains(Type::Entity));
     }
 
     /// `OptionalOf<Any>` passes through `None` since `Any`'s
     /// default kind is `None`.
-    #[test]
+    #[dialog_common::test]
     fn optional_of_any_passes_through_none() {
         let descriptor: OptionalOf<Any> = OptionalOf::default();
         assert!(descriptor.kind().is_none());

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -244,6 +244,104 @@ impl_scalar!(
 
 impl Scalar for usize {}
 
+// Kind-marker trait family — classify types by *shape* for
+// compile-time bounds, orthogonal to [`Typed`] (which is the
+// mechanical "what descriptor represents this Rust type" map).
+//
+// Membership table:
+// - `ScalarType`  — atomic value types ([`Scalar`] members).
+// - `ProductType` — record/product shapes. Reserved.
+// - `VariantType` — sum/variant shapes. Reserved.
+// - `OptionalType` — `Option<T>` for `T: DefiniteType`.
+// - `AnyType`     — the dynamic top, [`Any`].
+// - `DefiniteType` — umbrella over `Scalar`/`Product`/`Variant`,
+//   the canonical "any concrete shape, not optional, not dynamic"
+//   predicate. Used as the bound on `Option<T>`'s `Typed` impl,
+//   which is what structurally rejects `Option<Option<U>>` and
+//   `Option<Any>` at compile time.
+
+/// Kind marker for atomic (scalar) shapes — types like `String`,
+/// `i32`, `Entity`. Every [`Scalar`] is `ScalarType` via the
+/// blanket impl below.
+///
+/// New code that needs a pure kind bound (without the practical
+/// `Clone + Into<Value> + ...` bag carried by [`Scalar`]) should
+/// use `ScalarType`.
+pub trait ScalarType: Typed {}
+
+impl<T: Scalar> ScalarType for T {}
+
+/// Kind marker for product (record) shapes. Reserved for future
+/// use; no types impl this trait yet, but the slot exists so that
+/// product-only generic code reads symmetrically with
+/// [`ScalarType`] and [`VariantType`].
+pub trait ProductType: Typed {}
+
+/// Kind marker for variant (sum) shapes. Reserved for future
+/// use; no types impl this trait yet.
+pub trait VariantType: Typed {}
+
+/// Kind marker for the dynamic top type, [`Any`].
+///
+/// `Any` is deliberately *not* a [`DefiniteType`]: it already
+/// admits absence implicitly (via [`Binding`](crate::Binding))
+/// and wrapping it in `Option` would be a category error. This
+/// exclusion is what makes `Option<Any>` rejected at compile time.
+pub trait AnyType: Typed {}
+
+impl AnyType for Any {}
+
+/// Kind marker for the `Option<T>` shape family.
+///
+/// `Option<T>` impls `OptionalType` for any `T: DefiniteType`.
+/// The bound on `T` is the structural fence that makes:
+///
+/// - `Option<Option<U>>` reject (nested optionality is meaningless
+///   under set-widening; `OptionalType` does not impl
+///   `DefiniteType`).
+/// - `Option<Any>` reject (`AnyType` does not impl `DefiniteType`).
+///
+/// The compile-fail doctests below prove both rejections.
+///
+/// Nested optionality is rejected:
+///
+/// ```compile_fail
+/// # use dialog_query::Term;
+/// // Option<Option<String>> does not satisfy Typed because
+/// // Option<String> is not DefiniteType.
+/// let _: Term<Option<Option<String>>> = Term::var("x");
+/// ```
+///
+/// Optional-of-Any is rejected:
+///
+/// ```compile_fail
+/// # use dialog_query::{Term, types::Any};
+/// // Option<Any> does not satisfy Typed because Any is not
+/// // DefiniteType.
+/// let _: Term<Option<Any>> = Term::var("x");
+/// ```
+pub trait OptionalType: Typed {}
+
+impl<T: Scalar> OptionalType for Option<T> {}
+
+/// Umbrella supertrait for **definite** types — any concrete shape
+/// that is not the dynamic top ([`AnyType`]) and not set-widened
+/// ([`OptionalType`]).
+///
+/// **Membership.** Every [`Scalar`] is `DefiniteType` via a
+/// blanket impl. Future products and variants will join via their
+/// own `impl … for X` lines.
+///
+/// **Where the bound is used.** This is the bound on `T` in
+/// `Option<T>`'s [`Typed`] impl, and the canonical "any concrete
+/// value type, but not Any, not Optional" predicate. Rust trait
+/// bounds compose by intersection (`T: A + B` = both), so an
+/// umbrella supertrait is the right shape for *union* of
+/// `Scalar`/`Product`/`Variant`.
+pub trait DefiniteType: Typed {}
+
+impl<T: Scalar> DefiniteType for T {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,5 +429,29 @@ mod tests {
     fn optional_of_any_passes_through_none() {
         let descriptor: OptionalOf<Any> = OptionalOf::default();
         assert!(descriptor.kind().is_none());
+    }
+
+    /// Kind-marker family is consistent: scalar types are
+    /// `ScalarType` and `DefiniteType`; `Any` is `AnyType` but not
+    /// `DefiniteType`; `Option<T>` is `OptionalType`.
+    ///
+    /// These are compile-time checks: the test body uses
+    /// function-bound helpers that only accept types that satisfy
+    /// the corresponding marker trait.
+    #[dialog_common::test]
+    fn kind_markers_classify_consistently() {
+        fn requires_scalar<T: ScalarType>() {}
+        fn requires_definite<T: DefiniteType>() {}
+        fn requires_optional<T: OptionalType>() {}
+        fn requires_any<T: AnyType>() {}
+
+        requires_scalar::<String>();
+        requires_scalar::<u32>();
+        requires_scalar::<Entity>();
+        requires_definite::<String>();
+        requires_definite::<u32>();
+        requires_optional::<Option<String>>();
+        requires_optional::<Option<u32>>();
+        requires_any::<Any>();
     }
 }


### PR DESCRIPTION
## Overview

Two layered concerns are landing together here:

1. **Set-widening optional concept fields.** A concept field declared `Option<T>` resolves to `None` at projection time when no fact exists, instead of dropping the row entirely. Absence is row-level, not stored — we never persist a "Nothing" value.

2. **Rule-level type inference.** Every named variable a rule mentions places a constraint on its type (from the slot it appears in). Inference unifies those constraints once, at rule-compile time, and the planner uses the result to narrow premise terms before evaluation.

The second concern grew out of a hole the first one exposed: optional attribute queries were emitting `Absent` fallback rows even when a sibling premise required the same variable to be present, leaving the join to filter the spurious rows. With inference, the planner sees the rule-level constraint and the optional query stops emitting them in the first place.

## Why

Without rule-level inference, every premise reasoned only about its own term's static kind:

```rust
// Optional attribute query for ?nickname:
//   - missing fact → emit Absent-fallback row
// Sibling premise requires ?nickname to be String:
//   - downstream join filters Absent rows
```

Two failure modes:

- **Wasted work.** Absent rows emitted, then immediately filtered.
- **Surprising errors.** Constraints like `?x == ?y` couldn't tell whether to propagate `Absent`, infer `Absent`, or filter — without rule context, the answer wasn't well-defined.

Inference makes the rule-level constraint visible to every part of the pipeline that wants it. The optional query consults the inferred kind for its `is` variable; if the rule has narrowed it to non-optional, the fallback row is suppressed at the source.

## How it works

A rule moves through three phases:

```
Parse ──► Analyze ──► Plan
```

**Parse** produces a `Vec<Premise>` from the user's `DeductiveRuleDescriptor`. No type info beyond what the user wrote at the term layer (`Term<Option<String>>` carries `String | Nothing`; bare `Term::var("x")` carries nothing).

**Analyze** (`rule::analyzer::analyze`) does three things:

1. **Type inference** — `TypeEnv::infer` walks every positive premise's slots, allocates a unifier variable per variable name, and unifies each slot's kind. Negations don't contribute; they filter on existing bindings.

2. **Required-head check** — every conclusion variable's inferred kind must not admit `Nothing`. Otherwise the rule could produce `Absent` in a required slot.

3. **Coalesce contract validation** — each `coalesce(source, fallback) = is` checks `source: Optional<α>`, `fallback: α`, `is: α`.

The output is an `AnalyzedRule` carrying the inferred `TypeEnv` (shared via `Arc`) and a per-premise dependency graph (precomputed `binds`/`needs`/`requires[]`).

**Plan** runs the existing greedy cost-based planner over the analyzed rule, then **narrows each premise's variable terms via `apply_types`**:

```rust
// Before planning: user-supplied
is: Term<Option<String>>      // kind = String | Nothing

// Rule-level inference narrows ?name to String (some sibling premise
// has a required slot for it). After narrowing:
is: Term<Any>                 // kind = String  (no Nothing bit)
```

Narrowing happens **once at plan time**. The evaluator is unchanged — its `is.is_optional()` check just sees the narrowed term and returns the right answer. No `TypeEnv` is threaded through evaluation. User-supplied premises stay untouched; only the in-flight working copy in the plan reflects the narrowing.

**Replanning** (`Conjunction::plan(&new_scope)`, used for adornment-based optimization in concept queries) reruns the same pipeline against a different scope. Inference is idempotent over already-narrowed premises.

## What the reviewer should look at

- `rust/dialog-query/src/rule/analyzer.rs` — analysis orchestration, `AnalyzedRule`, dependency graph.
- `rust/dialog-query/src/rule/types.rs` — `TypeEnv::infer`, the actual inference pass (uses the existing `type_system::unifier::Context`).
- `rust/dialog-query/src/planner.rs` and `rust/dialog-query/src/planner/plan.rs` — where narrowing is applied to premises.
- `rust/dialog-query/src/rule.rs` — the `Compile` trait whose default impl threads planning + analysis together; shared by `DeductiveRule` and `InductiveRule`.
- `notes/rule-pipeline.md` — design note covering the three phases, error attribution, and rationale for narrowing at plan time.

## Testing

The behavior change is covered end-to-end:

- `it_suppresses_absent_fallback_under_rule_inference` — confirms the planner rewrites the optional `is` term to be non-optional when rule-level inference strips `Nothing`.
- `it_strips_nothing_when_a_required_binding_also_exists` / `it_strips_nothing_when_any_premise_is_required` — multi-premise inference cases.
- `it_preserves_nothing_when_only_optional_bindings_exist` — a single optional premise keeps its local optionality through planning.
- `it_rejects_planning_when_variable_kinds_disagree` — inference contradictions raise `TypeError::TypeInference` instead of being silently swallowed.
- `it_ignores_negation_contributions_during_inference` — negations are filters, not constraints.
- `it_preserves_narrowing_across_replans` — replanning is idempotent.

Plus tests covering `Equality` over `Absent` (both-absent yields, absent-vs-present filters), the type-inference conflict path, and the dependency graph.

1485 workspace tests pass, clippy and fmt clean.

## What's intentionally not in scope

- **Consuming the dependency graph in the planner.** Today the planner still uses `Candidate::update`'s schema-walking loop; the dependency graph is built but unread. Replacing the walk with the graph is a meaningful planner refactor that I judged out of scope for this PR. The graph infrastructure is in place for that follow-up.
- **Narrowing nested concept queries.** `apply_types` rewrites `AttributeQuery::is` and walks into negated attributes. Other premise kinds (concept queries with nested terms) aren't narrowed yet because their kinds are schema-fixed today; this becomes relevant only if future premise types gain inferrable slots.
