### PR TITLE
feat(dialog-query): rule-level type inference and optional concept fields

### DIFF
--- a/notes/optional-fields.md
+++ b/notes/optional-fields.md
@@ -1,0 +1,395 @@
+# Optional Fields & Type System — v2 Design
+
+This document was written as a *design contract* before
+implementation. The implementation took a smaller path than the
+contract proposed. The doc has been split:
+
+- **What shipped** — the set-widening type system, the unifier-backed
+  rule-level type inference, the `Resolution` policy, and the
+  `Coalesce` constraint. These are now in code under
+  `rust/dialog-query/`. The shipped pipeline is documented in
+  [`rule-pipeline.md`](./rule-pipeline.md); the type-system shape is
+  in `src/type_system.rs` and `src/type_system/unifier.rs`.
+
+- **What didn't ship** — rank-1 polymorphic *formulas* with
+  `TypeScheme`/`SchemeBody`/`SchemeType`, and the `instantiate` /
+  `generalize` operations that go with them. The schemes were the
+  design's answer to "generic formulas like `math/sum`"; we didn't
+  have a concrete consumer that needed them, so the work was
+  deferred to a follow-up.
+
+The remainder of this document is the original design contract,
+preserved so the historical intent is visible. **Names like
+`TypeScheme`, `SchemeBody`, `SchemeType`, and `SchemeDefinite` do
+not exist in code.** Where a section maps onto something that did
+ship, an "✅ Shipped as" note points at the real type. Where a
+section described an unshipped piece, a "⚠️ Not shipped" note marks
+it.
+
+---
+
+## Motivation (still accurate)
+
+Three concerns drove the redesign:
+
+1. **Set-widening optionality.** Concept fields like
+   `nickname: Option<Nickname>` should realize as `Some(value)`
+   when the underlying fact exists and `None` when it doesn't. The
+   storage layer never persists `None` — absence is realized at
+   query time. `Optional<T>` is the set `T ∪ {Absent}` with the
+   subtype rule `T ⊆ Optional<T>`.
+
+2. **Generic formulas.** Today's engine has formulas like
+   `math/sum`, `string/concat`, `to_string` that conceptually want
+   to be polymorphic — `forall T: Numeric. (T, T) → T` — but the
+   schema language has no way to express that, so they end up
+   either type-erased (lossy) or one variant per concrete type
+   (verbose). `Equality` was extracted into its own
+   `Constraint::Equality` variant precisely because it couldn't
+   fit the formula schema's "fixed input/output types" model.
+
+3. **Range predicates and inference.** Future predicate
+   constraints (`<`, `<=`, `starts_with`, etc.) want to *narrow
+   the type* of a variable based on which predicate uses it.
+   `starts_with` implies `String | Symbol`. The planner needs an
+   inference framework that propagates type information across a
+   rule body and feeds back into the storage layer (e.g. for
+   index-range optimization).
+
+The shipped work addresses (1) end-to-end and lays the unifier
+groundwork for (3). Concern (2) is the part that didn't ship.
+
+## v1 retrospective (still accurate)
+
+v1 shipped working set-widening but accumulated debt:
+
+1. Two parallel type taxonomies (schema-layer `Type` + descriptor
+   `Option<ValueType>`).
+2. Recursive `DynamicAttributeQuery::Optional` variant — `Option<
+   Option<...>>` not prevented by the type signature.
+3. Type-erasure loss in `From<Term<Option<T>>> for Term<Any>` —
+   needed a parallel `optional_producers: HashSet<String>` to
+   recover the lost info at planning time.
+4. `UnwrapOr` builder type-erased at the boundary — accepted
+   mismatched output types.
+5. Marker traits as load-bearing structural fences rather than
+   ergonomic bounds.
+
+Each is a symptom of "the descriptor can't express optionality."
+v2 fixes this at the root: the descriptor expresses optionality,
+type variables, and constraint sets uniformly via the same
+`Type` enum.
+
+## v2 type system
+
+### `Type` and `Definite`
+
+```rust
+pub enum Type {
+    /// A definite shape. Subtype of `Optional(definite)` via the
+    /// `T ⊆ Optional<T>` set-widening rule.
+    Definite(Box<Definite>),
+
+    /// Set-widened: `Definite ∪ {Absent}`. One level only —
+    /// nested optionality is structurally impossible because the
+    /// wrapped type is `Definite`, not `Type`. Optionality lives
+    /// at the slot layer, not on type variables.
+    Optional(Box<Definite>),
+}
+
+pub enum Definite {
+    /// Atomic value type, possibly union over several primitive
+    /// shapes. `PrimitiveSet::singleton(ValueType::String)` is
+    /// "exactly String"; `PrimitiveSet::NUMERIC` is "any of
+    /// UnsignedInt, SignedInt, Float."
+    Primitive(PrimitiveSet),
+
+    /// A type variable. Anonymous (per-site fresh) or named
+    /// within a single type scheme. The variable's constraint
+    /// (which primitive shapes it can take) lives in the
+    /// `UnificationContext`'s constraint registry, keyed by
+    /// `VarId`.
+    Variable(VarId),
+
+    // Future:
+    // Record(BTreeMap<String, Type>),
+    // Variant(BTreeMap<String, Definite>),
+}
+```
+
+✅ **Shipped as** `type_system::Type` with variants
+`Primitive(Primitive)` and `Composite(Primitive, BTreeSet<Composite>)`.
+The shipped form is flatter than the proposed `Definite/Optional`
+split: optionality is encoded as a `Nothing` bit in the same
+`Primitive` bitfield, not as a wrapping `Optional` variant. A
+shipped `Type` carrying `Nothing` *is* the set-widened thing — no
+separate constructor. Nested optionality is still structurally
+impossible: `Type::optional()` adds the bit; calling it again is
+idempotent.
+
+Key structural properties (mostly hold in the shipped form):
+
+- **No `Any` variant.** ✅ The shipped form has no `Any` either.
+  Untyped slots carry `None` at the `Option<Type>` boundary or
+  use `Primitive::ALL` (any present value) / `Primitive::ANY` (any
+  including `Nothing`).
+- **Records and variants are reserved as `Composite` cases.** ✅ The
+  shipped `Composite` enum has `Product(BTreeMap<String, Type>)` and
+  `Variant{label, value}` — placeholders, not active in inference
+  yet.
+
+### `PrimitiveSet`
+
+```rust
+pub struct PrimitiveSet { bits: u16 }
+```
+
+✅ **Shipped as** `type_system::Primitive` (same shape, different
+name). API matches the proposal closely:
+`Primitive::ALL`/`NUMERIC`/`STRING_LIKE`/`COMPARABLE`, `intersect`,
+`singleton`. The shipped version also exposes
+`Primitive::NOTHING` and a `Primitive::ANY` (= `ALL | NOTHING`)
+that the doc doesn't mention — these are what make the "Nothing
+bit" encoding work.
+
+### `VarId` and unification
+
+```rust
+pub struct VarId(u32);
+
+pub struct UnificationContext {
+    substitution: HashMap<VarId, Definite>,
+    constraints: HashMap<VarId, PrimitiveSet>,
+    next_id: u32,
+}
+```
+
+✅ **Shipped as** `type_system::unifier::VarId` and
+`type_system::unifier::Context`. The shipped `Context` also tracks
+a `names: HashMap<String, VarId>` so the rule-level inference pass
+can allocate one variable per named rule variable.
+
+Operations:
+
+- `fresh(constraint) -> VarId` — ✅ shipped.
+- `unify(a, b)` Robinson unification — ✅ shipped.
+- `apply(ty)` — ✅ shipped.
+- `instantiate(scheme)` — ⚠️ **Not shipped.** Nothing constructs
+  `TypeScheme`s, so nothing instantiates them.
+
+Unification rules — all the rules between concrete `Type`s and
+between variables and concretes are shipped. The `Definite ≡
+Optional` cases collapsed into the shipped form's intersection
+semantics: optionality is just a bit on the primitive set, and
+intersection narrows it correctly.
+
+### Type schemes
+
+```rust
+pub struct TypeScheme { ... }
+pub enum SchemeBody { ... }
+pub enum SchemeType { ... }
+pub enum SchemeDefinite { ... }
+```
+
+⚠️ **Not shipped.** No type with any of these names exists in
+code. Formulas keep their existing `Schema` (no quantified
+variables); inference happens *over a rule's variables*, not over
+a formula's. This is the biggest deviation from the design.
+
+**Why it didn't ship:** the PR's actual mission was to make the
+optional-fields case work end-to-end (stop emitting spurious
+`Absent` rows when sibling premises narrow the variable). That
+requires inference over a rule's variables. It does not require
+polymorphic formulas. Adding the `TypeScheme` machinery would have
+meant building infrastructure with no current consumer — no
+shipped formula is yet declared polymorphic.
+
+**What would need to change to ship them:** introduce a
+`TypeScheme` type, attach one to each formula registration in the
+formula registry, add `Context::instantiate` to allocate fresh
+`VarId`s from a scheme's quantified variables, and have the
+planner invoke instantiation when it picks up a formula premise.
+The unifier already handles everything downstream.
+
+### Wire format
+
+✅ **Shipped.** Type schemes are not serialized (they're Rust-side
+registry data). Concept descriptors and attribute queries serialize
+their types directly via the existing JSON format. The shipped
+`Type` enum has a serde representation; it's not the exact shape
+the doc proposes (`{"definite": ...}` / `{"optional": ...}`) but
+the underlying property — "concrete types only, no variables on
+the wire" — holds.
+
+## Rule analysis
+
+```rust
+pub struct RuleAnalysis {
+    types: HashMap<String, Type>,
+    producers: HashMap<String, Vec<ProducerEntry>>,
+    refinements: HashMap<String, ScanHint>,
+}
+```
+
+✅ **Shipped as** `rule::analyzer::AnalyzedRule` with
+`types: Arc<TypeEnv>` plus a `DependencyGraph` instead of
+`producers`/`refinements`. The shipped form:
+
+- Carries the inferred environment via `Arc<TypeEnv>` (shared
+  across the analyzed premises).
+- Builds a `DependencyGraph` (per-premise `binds`/`needs` plus
+  precomputed `requires[]` edges) — broader than the proposed
+  `producers` map. Currently built but not yet consumed by the
+  planner (left for a follow-up).
+- Doesn't carry `refinements` — range-predicate scan hints are
+  deferred along with the predicates themselves.
+
+`RuleAnalysis::build(conclusion, premises) -> Result<Self, TypeError>`
+
+✅ **Shipped as** `rule::analyzer::analyze(conclusion, &steps) ->
+Result<AnalyzedRule, AnalysisError>`. The phases match the doc:
+inference, then required-head check, then Coalesce contract
+validation. Step (2) — instantiating formula schemes — isn't done
+because schemes don't ship. Step (5)'s Slice-7 checks ship via
+`AnalysisError::RequiredHeadFromOptional` and the unifier's
+constraint-conflict errors.
+
+## Descriptor layer
+
+```rust
+pub trait TypeDescriptor: ... {
+    const KIND: Option<Type>;
+    fn kind(&self) -> Type;
+}
+```
+
+✅ **Shipped.** `TypeDescriptor::kind` returns `Option<Type>`
+(slightly different signature than `Type` — `None` means "no
+static info, leave to the unifier"). `OptionalOf<D>` ships as
+described.
+
+## Attribute query layer: `Resolution` policy
+
+```rust
+pub enum Resolution {
+    Required,
+    Optional,
+}
+```
+
+✅ **Shipped.** With one refinement: `Resolution` is *derived* from
+`self.is.is_optional()` rather than stored as a field. The shipped
+`AttributeQueryAll::resolution()` returns
+`Resolution::Optional` iff the `is` term's kind admits `Nothing`.
+This makes the rule-level narrowing automatic — once the planner
+narrows the term's kind, the resolution flips with it, without
+needing a separate path.
+
+## Macro layer
+
+✅ **Shipped.** The `#[derive(Concept)]` macro emits
+`Term<Option<<T as Attribute>::Type>>` for `Option<T>` fields.
+Dispatch happens through the `ConceptField` trait with two
+blanket impls (`for N` and `for Option<N>`) leveraging `Option`'s
+`#[fundamental]` annotation — no syntactic detection of the
+`Option` ident.
+
+## Coalesce / `unwrap_or`
+
+⚠️ **Partially shipped, but not as a formula.** `Coalesce` ships as
+its own constraint variant (`Constraint::Coalesce`), not as a
+formula with a `UNWRAP_OR_SCHEME`. Its type contract is checked at
+rule-compile time via `Coalesce::validate(ctx)`, which uses the
+shipped `unifier::Context` to verify
+`source: Optional<α>, fallback: α, is: α` — but the contract is
+hand-rolled inside `validate`, not declared as a reusable scheme.
+
+This is consistent with the broader "no schemes" decision: without
+`TypeScheme` infrastructure, Coalesce's polymorphism is expressed
+ad-hoc rather than via a registered scheme.
+
+## Slice 7 enforcement
+
+✅ **Shipped (mostly).**
+
+- `RequiredHeadFromOptional` — shipped as
+  `AnalysisError::RequiredHeadFromOptional`. The shipped check
+  reads the inferred `TypeEnv` and flags any conclusion variable
+  whose inferred kind admits `Nothing`.
+- `NegationOnOptional` — not shipped as a separate check. The
+  shipped semantics: negations don't *contribute* to inference
+  (they're filters), and `apply_types` rewrites their terms with
+  the rule-level kinds — so a negation reading an optional binding
+  sees the narrowed kind, not the user's local one.
+- `ConceptOnlyOptionalFields` — not shipped. Captured as task #80.
+
+## Marker traits
+
+✅ **Shipped.** `ScalarType`/`ProductType`/`VariantType`/
+`OptionalType`/`DefiniteType`-family bounds prevent
+`Term<Option<Option<U>>>` and `Term<Option<Any>>` at the Rust API.
+
+## Implementation phases
+
+The implementation didn't follow the proposed numbered phases
+exactly. The actual shipped order is captured in the commit log on
+`feat/type-inference` (formerly `feat/meet-into-plan`) and
+summarized in [`rule-pipeline.md`](./rule-pipeline.md).
+
+## What's deferred to follow-up branches
+
+- **Type schemes for polymorphic formulas** (`TypeScheme`,
+  `SchemeBody`, `SchemeType`, `instantiate`). The doc's design
+  intent. The largest deferred chunk.
+- **Records and variants in active inference** — placeholders ship
+  as `Composite::Product`/`Composite::Variant`; the unifier
+  doesn't recurse into them yet.
+- **Generic formulas at runtime** — formula impls that dispatch on
+  the unified type (e.g. `Sum<T>` with separate addition paths
+  for `u32`, `i64`, `f64`). Conditional on type schemes shipping.
+- **Range predicates** — new constraint variants (`<`, `<=`,
+  `starts_with`, etc.) and their contribution to scan refinements.
+- **Cross-rule type inference** — propagating type variables
+  across rule bodies that span multiple formulas. Within-rule
+  inference ships; across-rule does not.
+- **`get-some`** — variant-elimination premise. Builds on variant
+  types.
+- **`ConceptOnlyOptionalFields` rejection** — task #80.
+- **Dependency graph as planner input** — the shipped
+  `DependencyGraph` is built but unread; the planner still uses
+  `Candidate::update`'s schema-walking loop.
+
+## Acceptance criteria
+
+The original criteria were aspirational for the full design. The
+shipped subset:
+
+- ✅ Unifier with full algorithm coverage for the cases that ship:
+  identity, variable-variable, variable-concrete, occurs check,
+  constraint conflict.
+- ⚠️ "Instantiation independence, generalization" — not shipped
+  (no schemes).
+- ✅ All v1 end-to-end tests pass.
+- ✅ New tests cover unification corner cases at the *rule* level
+  (not formula-scheme level).
+- ⚠️ "Generic formula declarations" — not shipped.
+- ⚠️ "Range-predicate-style narrowing" — infrastructure ready
+  (`TypeEnv`, dependency graph) but no predicates use it yet.
+- ✅ Compile-fail doctests for `Term<Option<Option<U>>>` and
+  `Term<Option<Any>>`.
+- ✅ Workspace clippy clean, fmt clean.
+- ✅ Design doc reflects the final shape — *this* split.
+
+## Open questions to settle during implementation
+
+The questions the doc closed during implementation:
+
+1. **`TypeDescriptor::KIND` const evaluation.** Settled as
+   non-const `kind()` returning `Option<Type>`.
+2. **Anonymous variable lifetime.** Settled: per-rule
+   `unifier::Context`; named variables allocated via
+   `var_for_name(name)` on first reference.
+3. **Error messages.** Settled: `InferenceError::Conflict`
+   includes the offending variable name; the `Compile::compile`
+   layer wraps it as `TypeError::TypeInference { reason }`.

--- a/notes/rule-pipeline.md
+++ b/notes/rule-pipeline.md
@@ -1,0 +1,142 @@
+# Rule Compilation Pipeline
+
+A deductive rule moves from user-supplied premises to an executable
+plan in three phases:
+
+```
+   ┌──────────┐    ┌──────────┐    ┌──────────┐
+   │  Parse   │ -> │ Analyze  │ -> │  Plan    │
+   └──────────┘    └──────────┘    └──────────┘
+        |               |               |
+   Descriptor       AnalyzedRule    Conjunction
+```
+
+## Parse
+
+`DeductiveRuleDescriptor` is the serialized form: a conclusion
+(`ConceptDescriptor`) plus `when`/`unless` premise lists with
+user-supplied terms. Parsing yields `Vec<Premise>` plus the
+conclusion. No type information beyond what the user wrote at the
+term layer (e.g. `Term<Option<String>>` carries `String | Nothing`;
+`Term<Any>::var("x")` carries nothing).
+
+## Analyze
+
+`rule::analyzer::analyze(conclusion, &steps) -> Result<AnalyzedRule, AnalysisError>`.
+
+Three sub-steps:
+
+1. **Type inference** (`rule::types::TypeEnv::infer`).
+   For every named variable referenced by any positive premise's
+   slots, unify the slot kinds. Negation premises don't
+   contribute — they filter on already-bound values rather than
+   introducing them. Untyped slots contribute their *requirement
+   shape*: a `Required` slot says "any present value"
+   (`Primitive::ALL`), an `Optional` slot says "any present or
+   absent" (`Primitive::ANY`). Output: name → inferred `Kind`.
+   Errors: `Conflict { variable, reason }` when slots disagree on
+   the kind for a given variable.
+
+2. **Required-head check**.
+   For each conclusion variable, if the inferred kind admits
+   `Nothing`, raise `RequiredHeadFromOptional { variable }`. The
+   rule can't produce `Absent` in a required slot.
+
+3. **Coalesce contract validation**.
+   Every `Constraint::Coalesce` runs against a fresh unifier
+   context. The contract says: source is `Optional<α>`, fallback
+   and is both unify with `α`. Errors:
+   `CoalesceTypeMismatch { reason }`.
+
+The output, `AnalyzedRule`, carries:
+- `conclusion: ConceptDescriptor`
+- `premises: Vec<Premise>` in planned order
+- `types: Arc<TypeEnv>` — the inferred environment, shared
+- `graph: DependencyGraph` — per-premise `binds`/`needs` plus
+  precomputed `requires[]` edges for ordering
+
+Analysis is rule-scoped; the result is immutable. Errors are pre-
+rule (they don't reference a `DeductiveRule`); `DeductiveRule::new`
+wraps them in the corresponding `TypeError::*` variants for display.
+
+## Plan
+
+`Planner::from(premises).plan(&scope) -> Result<Conjunction, TypeError>`.
+
+The planner does:
+
+1. Greedy cost-based ordering: repeatedly pick the cheapest viable
+   premise, remove it from candidates, advance the bound-vars set.
+   Existing `Candidate`/`Schema`/`Parameters` walk.
+2. Run `TypeEnv::infer` on the ordered steps. Failures surface as
+   `TypeError::TypeInference`.
+3. **Narrow each step's premise** via `apply_types(premise, &types)`.
+   The rewrite replaces variable terms (currently only
+   `AttributeQuery::is`) with copies carrying the inferred kind.
+   Negated propositions are walked too — a negation over an
+   optional attribute picks up the same narrowing.
+4. Stamp the rewritten premises into `Plan` values; assemble the
+   `Conjunction`.
+
+The rewrite happens **once at plan time**, not on every evaluation.
+The user-supplied `Premise` values stay untouched; only the in-flight
+working copy in the `Plan` reflects rule-level narrowing.
+
+## Why narrow at plan time
+
+The evaluator's behavior depends on `is.is_optional()` for the
+Absent-fallback decision:
+
+- Without narrowing, an optional attribute always emits an Absent
+  row when its lookup misses — even when a sibling premise's
+  required slot guarantees that variable is Present at the rule
+  level. The downstream join then filters the spurious Absent rows.
+- With narrowing, the optional attribute's `is` term reflects the
+  rule-inferred kind. If inference stripped `Nothing` (because a
+  sibling required premise narrowed it), `is_optional()` returns
+  `false` and the fallback row is never emitted.
+
+The savings are real for any rule that mixes optional and required
+bindings on the same variable.
+
+## Evaluation
+
+`Conjunction::evaluate(selection, env)` folds the steps' evaluators
+in order. Each step's premise is already narrowed; no `TypeEnv` is
+threaded through evaluation. Standalone queries (top-level
+`.perform()` outside any rule) plan with an empty `TypeEnv` so the
+rewrite is a no-op — the user's local term kinds are the sole
+source of optionality info.
+
+## Replanning
+
+`Conjunction::plan(&new_scope)` reruns the planner against a
+different scope (adornment-based replanning for concepts whose
+bindings change between callers). Type inference runs again on the
+fresh order — it's idempotent (re-narrowing an already-narrowed
+premise produces the same kinds) and stable across reorderings
+(inference doesn't depend on step order).
+
+## What lives where
+
+| Location | Contents |
+|---|---|
+| `Premise` (user-facing) | Whatever the user wrote |
+| `AnalyzedRule.types` | Rule-level inferred env, shared via `Arc` |
+| `AnalyzedRule.graph` | Per-premise `binds`/`needs` + `requires[]` |
+| `Plan.premise` | Premise with variable terms narrowed |
+| `Conjunction.steps` | Ordered `Plan`s plus cost/binds/env |
+
+## Errors
+
+| Source | Variant | When |
+|---|---|---|
+| `InferenceError::Conflict` | `TypeEnv::infer` | Slot kinds disagree for one variable |
+| `AnalysisError::Inference` | `analyze` | Wraps the above |
+| `AnalysisError::RequiredHeadFromOptional` | `analyze` | Inferred head admits `Nothing` |
+| `AnalysisError::CoalesceTypeMismatch` | `analyze` | Coalesce contract violated |
+| `TypeError::TypeInference` | `Planner::plan` | Inference error during planning |
+| `TypeError::RequiredHeadFromOptional` | `DeductiveRule::new` | Wraps analysis error with rule |
+| `TypeError::CoalesceTypeMismatch` | `DeductiveRule::new` | Wraps analysis error with rule |
+| `TypeError::UnboundVariable` | `DeductiveRule::new` | Head var not bound by any premise (post-plan) |
+| `TypeError::RequiredBindings` | `Planner::plan` | A premise's dependencies are unsatisfiable |

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -129,15 +129,29 @@ pub fn derive(input: TokenStream) -> TokenStream {
         .into();
     }
 
-    // Collect code fragments for each field. We iterate over fields once and build
-    // up parallel vectors of token streams that get spliced into the final output.
+    // Collect code fragments for each field. The Concept derive
+    // does **not** branch syntactically on `Option<T>`. Instead it
+    // emits trait-based code that delegates to the `ConceptField`
+    // trait, which has two non-overlapping blanket impls in
+    // dialog-query:
+    //
+    // - `impl<N: Attribute> ConceptField for N` (required path)
+    // - `impl<N: Attribute> ConceptField for Option<N>` (optional)
+    //
+    // Rust's coherence permits these because `Option` is
+    // `#[fundamental]`. The macro emits `<F as ConceptField>::*`
+    // and the type system picks the right impl at type-check time,
+    // so aliases, prelude paths, and renamed imports all work
+    // without macro-time syntactic detection.
     let mut query_fields = Vec::new();
-    let mut rule_when_fields = Vec::new();
     let mut field_names = Vec::new();
     let mut field_name_lits = Vec::new();
     let mut field_types = Vec::new();
+    let mut realize_fields = Vec::new();
+    let mut param_inserts = Vec::new();
     let mut terms_methods = Vec::new();
-    let mut instance_expressions = Vec::new();
+    let mut descriptor_pair_pushes = Vec::new();
+    let mut statement_emits = Vec::new();
 
     let terms_name = syn::Ident::new(&format!("{}Terms", struct_name), struct_name.span());
 
@@ -158,11 +172,6 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let field_type = &field.ty;
         let field_name_lit = syn::LitStr::new(&field_name_str, proc_macro2::Span::call_site());
 
-        // Store field name and type for later use in reconstruction
-        field_names.push(field_name);
-        field_types.push(field_type);
-        field_name_lits.push(field_name_lit.clone());
-
         // Forward the user's field doc when present, otherwise synthesize a
         // fallback so `#![deny(missing_docs)]` in consumer crates is happy.
         let user_doc = extract_doc_comments(&field.attrs);
@@ -178,49 +187,86 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let terms_method_doc_lit =
             syn::LitStr::new(&terms_method_doc, proc_macro2::Span::call_site());
 
-        // Extract the inner type from Attribute - the field type implements Attribute
-        // and we need <FieldType as Attribute>::Type for the Term wrapper
-        let inner_type = quote! { <#field_type as dialog_query::Attribute>::Type };
+        // The query field's term type is driven by ConceptField:
+        // - Required field `N`: `<N as ConceptField>::TermType` =
+        //   `<N as Attribute>::Type`.
+        // - Optional field `Option<N>`: `<Option<N> as ConceptField>::TermType`
+        //   = `Option<<N as Attribute>::Type>`.
+        let term_type = quote! {
+            dialog_query::Term<<#field_type as dialog_query::ConceptField>::TermType>
+        };
 
-        // Generate Query field (Term<InnerType>) where InnerType is the Attribute's Type
         query_fields.push(quote! {
             #[doc = #query_field_doc_lit]
-            pub #field_name: dialog_query::Term<#inner_type>
+            pub #field_name: #term_type
         });
 
         terms_methods.push(quote! {
             #[doc = #terms_method_doc_lit]
-            pub fn #field_name() -> dialog_query::Term<#inner_type> {
-                dialog_query::Term::<#inner_type>::var(#field_name_lit)
+            pub fn #field_name() -> #term_type {
+                <#term_type>::var(#field_name_lit)
             }
         });
 
-        // Generate rule when field conversion
-        rule_when_fields.push(quote! {
+        // Realize via the trait method. Required and optional impls
+        // each handle their own Binding semantics.
+        realize_fields.push(quote! {
+            #field_name: <#field_type as dialog_query::ConceptField>::realize(
+                source.lookup(&dialog_query::Term::<dialog_query::types::Any>::from(&self.#field_name))?
+            )?
+        });
+
+        param_inserts.push(quote! {
+            terms.insert(
+                #field_name_lit.into(),
+                dialog_query::Term::<dialog_query::types::Any>::from(source.#field_name),
+            );
+        });
+
+        // The descriptor for the attribute underlying this field —
+        // whether the field is `N` or `Option<N>`, the
+        // `<F as ConceptField>::Attribute` projection lifts to `N`,
+        // which is the type that carries the AttributeDescriptor.
+        // Routing into `with` vs `maybe` is decided at runtime via
+        // the OPTIONAL const.
+        descriptor_pair_pushes.push(quote! {
             {
-                let value_param = dialog_query::Term::<dialog_query::types::Any>::from(terms.#field_name.clone());
-
-                dialog_query::AttributeQuery::new(
-                    dialog_query::Term::Constant(dialog_query::Value::from(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone())),
-                    terms.this.clone(),
-                    value_param,
-                    dialog_query::Term::blank(),
-                    Some(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
-                )
+                let __pair = (
+                    #field_name_lit.to_string(),
+                    <<#field_type as dialog_query::ConceptField>::Attribute
+                        as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
+                );
+                if <#field_type as dialog_query::ConceptField>::OPTIONAL {
+                    __maybe.push(__pair);
+                } else {
+                    __with.push(__pair);
+                }
             }
         });
 
-        // Generate DynamicAttributeExpression for IntoIterator/Statement implementations
-        instance_expressions.push(quote! {
-            dialog_query::attribute::expression::dynamic::DynamicAttributeExpression {
-                the: <#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().the().clone(),
-                of: self.this.clone(),
-                is: dialog_query::Value::from(<#field_type as dialog_query::Attribute>::value(&self.#field_name).clone()),
-                cause: None,
-                cardinality: Some(<#field_type as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().cardinality()),
-            }
+        // Statement emission via the trait method. The concept's
+        // `this` field is an `Entity` (concept structs always have
+        // `this: Entity`), passed through to each field's
+        // statement(s). Required impls push one statement; optional
+        // impls push zero or one depending on Some/None.
+        statement_emits.push(quote! {
+            <#field_type as dialog_query::ConceptField>::push_statements(
+                &self.#field_name,
+                self.this.clone(),
+                &mut __statements,
+            );
         });
+
+        field_names.push(field_name);
+        field_name_lits.push(field_name_lit);
+        field_types.push(field_type);
     }
+
+    // Compile-time assertion list: every field type must implement
+    // ConceptField. The trait's blanket impls make this true for
+    // any `N: Attribute + Descriptor<AttributeDescriptor>` and for
+    // any `Option<N>` with the same bound on `N`.
+    let validated_types: Vec<_> = field_types.iter().map(|t| quote! { #t }).collect();
 
     // Generate type names based on struct name
     let query_name = syn::Ident::new(&format!("{}Query", struct_name), struct_name.span());
@@ -258,12 +304,41 @@ pub fn derive(input: TokenStream) -> TokenStream {
     );
 
     let expanded = quote! {
-        // Compile-time validation that all fields (except 'this') implement Attribute + Descriptor
+        // Compile-time validation that every concept field
+        // implements [`ConceptField`](dialog_query::ConceptField).
+        // The trait's two blanket impls cover both required
+        // `T: Attribute` and optional `Option<T>` shapes — anything
+        // outside that pair (e.g. `String`, a non-attribute newtype,
+        // `Option<Option<T>>`) fails this assertion with a clear
+        // bound-not-satisfied error.
         const _: () = {
-            fn assert_implements_attribute<T: dialog_query::Attribute + dialog_query::Descriptor<dialog_query::AttributeDescriptor>>() {}
+            fn assert_implements_concept_field<F: dialog_query::ConceptField>() {}
             fn #validate_fn_name() {
-                #(assert_implements_attribute::<#field_types>();)*
+                #(assert_implements_concept_field::<#validated_types>();)*
             }
+        };
+
+        // Compile-time validation that the concept declares at least
+        // one *required* attribute. A concept made only of optional
+        // (`Option<_>`) fields — or of no attribute fields at all —
+        // constrains nothing, so every entity would match it; that
+        // is rejected here.
+        //
+        // The required/optional split is read from the
+        // [`ConceptField::OPTIONAL`](dialog_query::ConceptField)
+        // associated const (a compile-time `bool` chosen by trait
+        // dispatch), never by syntactic inspection of `Option<_>`.
+        // Summing `!OPTIONAL` over the fields and asserting the total
+        // is non-zero gives a `const` check that fires at compile
+        // time with a clear message.
+        const _: () = {
+            let required_field_count: usize = 0
+                #( + (!<#field_types as dialog_query::ConceptField>::OPTIONAL as usize) )*;
+            assert!(
+                required_field_count >= 1,
+                "a Concept must declare at least one required (non-Option) attribute field; \
+                 a concept built only from optional fields constrains nothing and matches every entity"
+            );
         };
 
         #[doc = #query_struct_doc]
@@ -271,14 +346,14 @@ pub fn derive(input: TokenStream) -> TokenStream {
         pub struct #query_name {
             #[doc = #query_this_field_doc]
             pub this: dialog_query::Term<dialog_query::Entity>,
-            #(#query_fields),*
+            #(#query_fields,)*
         }
 
         impl Default for #query_name {
             fn default() -> Self {
                 Self {
                     this: dialog_query::Term::var("this"),
-                    #(#field_names: dialog_query::Term::var(#field_name_lits)),*
+                    #(#field_names: dialog_query::Term::var(#field_name_lits),)*
                 }
             }
         }
@@ -314,8 +389,10 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
             fn realize(&self, source: dialog_query::Match) -> std::result::Result<Self::Conclusion, dialog_query::EvaluationError> {
                 Ok(#struct_name {
-                    this: dialog_query::Entity::try_from(source.lookup(&dialog_query::Term::from(&self.this))?)?,
-                    #(#field_names: #field_types(source.lookup(&dialog_query::Term::from(&self.#field_names))?.try_into()?)),*
+                    this: dialog_query::Entity::try_from(
+                        source.lookup(&dialog_query::Term::from(&self.this))?.content()?
+                    )?,
+                    #(#realize_fields,)*
                 })
             }
         }
@@ -343,46 +420,63 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
                 terms.insert("this".into(), dialog_query::Term::<dialog_query::types::Any>::from(source.this));
 
-                #(terms.insert(#field_name_lits.into(), dialog_query::Term::<dialog_query::types::Any>::from(source.#field_names));)*
+                #(#param_inserts)*
 
                 terms
             }
         }
 
         // Implement From<StructName> for ConceptDescriptor.
-        // The struct's doc comment carries through as the
-        // descriptor's `description` so a `concept:` query
-        // surfaces it (the field list alone leaves it `None`).
-        impl From<#struct_name> for dialog_query::ConceptDescriptor {
-            fn from(_: #struct_name) -> Self {
-                dialog_query::ConceptDescriptor::from(vec![
-                    #(
-                        (#field_name_lits, <#field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone())
-                    ),*
-                ])
-                .with_description(#concept_description_lit)
+        //
+        // Each field is routed into `with` or `maybe` at runtime
+        // based on its `<F as ConceptField>::OPTIONAL` const —
+        // required fields populate `with`, optional fields populate
+        // `maybe`. The two slots are independent, and a concept may
+        // have either or both. The struct's doc comment carries
+        // through as the descriptor's `description` so a `concept:`
+        // query surfaces it (the field list alone leaves it `None`).
+        // The concept's runtime schema, cached. This is the single
+        // construction site for the descriptor; both `From` impls
+        // below delegate here. Building goes through the fallible
+        // `ConceptDescriptor::try_from`, which only rejects an empty
+        // required (`with`) set — ruled out at compile time by the
+        // required-field assertion above, so the `expect` is
+        // statically unreachable (it documents the invariant rather
+        // than handling a real failure).
+        impl dialog_query::Descriptor<dialog_query::ConceptDescriptor> for #struct_name {
+            fn descriptor() -> &'static dialog_query::ConceptDescriptor {
+                static DESCRIPTOR: std::sync::OnceLock<dialog_query::ConceptDescriptor> =
+                    std::sync::OnceLock::new();
+                DESCRIPTOR.get_or_init(|| {
+                    let mut __with: Vec<(String, dialog_query::AttributeDescriptor)> = Vec::new();
+                    let mut __maybe: Vec<(String, dialog_query::AttributeDescriptor)> = Vec::new();
+                    #(#descriptor_pair_pushes)*
+                    dialog_query::ConceptDescriptor::try_from(__with)
+                        .expect(
+                            "derive(Concept) guarantees at least one required field at compile time",
+                        )
+                        .with_maybe(__maybe)
+                        .with_description(#concept_description_lit)
+                })
             }
         }
 
-        // Implement From<Query> for ConceptDescriptor
-        impl From<#query_name> for dialog_query::ConceptDescriptor {
-            fn from(_: #query_name) -> Self {
-                dialog_query::ConceptDescriptor::from(vec![
-                    #(
-                        (#field_name_lits, <#field_types as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone())
-                    ),*
-                ])
-                .with_description(#concept_description_lit)
-            }
-        }
+        // No `From<#struct_name>`/`From<#query_name> for ConceptDescriptor`:
+        // a concept type's descriptor is obtained through
+        // `Descriptor<ConceptDescriptor>` (or the inherent
+        // `#struct_name::descriptor()`), mirroring how attributes
+        // expose `Descriptor<AttributeDescriptor>`. The conversions
+        // below fill `ConceptQuery.predicate` from that single source.
 
         // Implement From<Query> for Premise
         impl From<#query_name> for dialog_query::Premise {
             fn from(source: #query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 let app = dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 };
                 dialog_query::Premise::Assert(dialog_query::Proposition::Concept(app))
             }
@@ -391,10 +485,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // Implement From<Query> for Proposition
         impl From<#query_name> for dialog_query::Proposition {
             fn from(source: #query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 let app = dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 };
                 dialog_query::Proposition::Concept(app)
             }
@@ -403,10 +499,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // Implement From<Query> for ConceptQuery
         impl From<#query_name> for dialog_query::ConceptQuery {
             fn from(source: #query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 }
             }
         }
@@ -414,10 +512,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // Implement From<&Query> for ConceptQuery
         impl From<&#query_name> for dialog_query::ConceptQuery {
             fn from(source: &#query_name) -> Self {
-                let predicate: dialog_query::ConceptDescriptor = source.clone().into();
                 dialog_query::ConceptQuery {
                     terms: source.into(),
-                    predicate,
+                    predicate: <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor()
+                    .clone(),
                 }
             }
         }
@@ -438,35 +538,44 @@ pub fn derive(input: TokenStream) -> TokenStream {
             }
 
             fn this(&self) -> dialog_query::Entity {
-                let predicate: dialog_query::ConceptDescriptor = self.clone().into();
-                predicate.this()
+                <#struct_name as dialog_query::Descriptor<dialog_query::ConceptDescriptor>>::descriptor()
+                    .this()
             }
         }
 
-        // Implement IntoIterator to convert concept into attribute statements
+        // Implement IntoIterator to convert concept into attribute statements.
+        //
+        // Required fields always emit a relation; `Option<T>` fields emit
+        // a relation only when `Some(_)`. `None` is *not* persisted —
+        // absence is realized as `Option::None` at projection time, never
+        // stored as a fact.
         impl IntoIterator for #struct_name {
             type Item = dialog_query::AttributeStatement;
             type IntoIter = std::vec::IntoIter<dialog_query::AttributeStatement>;
 
             fn into_iter(self) -> Self::IntoIter {
-                vec![
-                    #(#instance_expressions),*
-                ].into_iter()
+                let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
+                #(#statement_emits)*
+                __statements.into_iter()
             }
         }
 
         // Implement Statement trait
         impl dialog_query::Statement for #struct_name {
             fn assert(self, update: &mut impl dialog_query::Update) {
-                #(
-                    dialog_query::Statement::assert(#instance_expressions, update);
-                )*
+                let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
+                #(#statement_emits)*
+                for __s in __statements {
+                    dialog_query::Statement::assert(__s, update);
+                }
             }
 
             fn retract(self, update: &mut impl dialog_query::Update) {
-                #(
-                    dialog_query::Statement::retract(#instance_expressions, update);
-                )*
+                let mut __statements: Vec<dialog_query::AttributeStatement> = Vec::new();
+                #(#statement_emits)*
+                for __s in __statements {
+                    dialog_query::Statement::retract(__s, update);
+                }
             }
         }
 
@@ -485,12 +594,47 @@ pub fn derive(input: TokenStream) -> TokenStream {
             type Descriptor = dialog_query::ConceptDescriptor;
         }
 
-        // Implement Rule trait
+        // Implement Rule trait — emit one AttributeQuery per
+        // field. Required fields pass the user's term through
+        // unchanged; optional fields go through
+        // `<F as ConceptField>::is_term` which widens the slot's
+        // kind to admit the `Nothing` atom. AttributeQuery derives
+        // its resolution from that kind, so optional fields end up
+        // with set-widened semantics (an Absent fallback row when
+        // no fact matches).
         impl #struct_name {
+            /// Returns this concept's runtime descriptor (its schema:
+            /// attribute set, types, and content hash). Cached; the
+            /// canonical way to obtain the descriptor for a concept
+            /// type.
+            pub fn descriptor() -> &'static dialog_query::ConceptDescriptor {
+                <Self as dialog_query::Descriptor<dialog_query::ConceptDescriptor>>::descriptor()
+            }
+
             fn when(terms: dialog_query::Query<Self>) -> dialog_query::Premises {
-                let selectors = vec![
-                    #(#rule_when_fields),*
-                ];
+                let mut selectors: Vec<dialog_query::AttributeQuery> = Vec::new();
+                #(
+                    {
+                        let raw_param = dialog_query::Term::<dialog_query::types::Any>::from(
+                            terms.#field_names.clone()
+                        );
+                        let value_param = <#field_types as dialog_query::ConceptField>::term(raw_param);
+                        let descriptor = <<#field_types as dialog_query::ConceptField>::Attribute
+                            as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor();
+                        let the_term = dialog_query::Term::Constant(
+                            dialog_query::Value::from(descriptor.the().clone())
+                        );
+                        let cardinality = Some(descriptor.cardinality());
+                        let query = dialog_query::AttributeQuery::new(
+                            the_term,
+                            terms.this.clone(),
+                            value_param,
+                            dialog_query::Term::blank(),
+                            cardinality,
+                        );
+                        selectors.push(query);
+                    }
+                )*
 
                 selectors.into()
             }

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -223,24 +223,16 @@ pub fn derive(input: TokenStream) -> TokenStream {
             );
         });
 
-        // The descriptor for the attribute underlying this field —
-        // whether the field is `N` or `Option<N>`, the
-        // `<F as ConceptField>::Attribute` projection lifts to `N`,
-        // which is the type that carries the AttributeDescriptor.
-        // Each field becomes a `ConceptFieldDescriptor`; optionality
-        // is tagged at runtime from the `OPTIONAL` const (never by
-        // syntactic `Option<_>` inspection).
+        // Each field becomes a `ConceptFieldDescriptor` via
+        // `ConceptField::field_descriptor`, which wraps the
+        // attribute's descriptor with this field's optionality
+        // (tagged from the `OPTIONAL` const, never by syntactic
+        // `Option<_>` inspection).
         descriptor_pair_pushes.push(quote! {
-            {
-                let __descriptor = <<#field_type as dialog_query::ConceptField>::Attribute
-                    as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone();
-                let __field = if <#field_type as dialog_query::ConceptField>::OPTIONAL {
-                    dialog_query::ConceptFieldDescriptor::optional(__descriptor)
-                } else {
-                    dialog_query::ConceptFieldDescriptor::required(__descriptor)
-                };
-                __fields.push((#field_name_lit.to_string(), __field));
-            }
+            __fields.push((
+                #field_name_lit.to_string(),
+                <#field_type as dialog_query::ConceptField>::field_descriptor(),
+            ));
         });
 
         // Statement emission via the trait method. The concept's

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -227,20 +227,19 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // whether the field is `N` or `Option<N>`, the
         // `<F as ConceptField>::Attribute` projection lifts to `N`,
         // which is the type that carries the AttributeDescriptor.
-        // Routing into `with` vs `maybe` is decided at runtime via
-        // the OPTIONAL const.
+        // Each field becomes a `ConceptFieldDescriptor`; optionality
+        // is tagged at runtime from the `OPTIONAL` const (never by
+        // syntactic `Option<_>` inspection).
         descriptor_pair_pushes.push(quote! {
             {
-                let __pair = (
-                    #field_name_lit.to_string(),
-                    <<#field_type as dialog_query::ConceptField>::Attribute
-                        as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone(),
-                );
-                if <#field_type as dialog_query::ConceptField>::OPTIONAL {
-                    __maybe.push(__pair);
+                let __descriptor = <<#field_type as dialog_query::ConceptField>::Attribute
+                    as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor().clone();
+                let __field = if <#field_type as dialog_query::ConceptField>::OPTIONAL {
+                    dialog_query::ConceptFieldDescriptor::optional(__descriptor)
                 } else {
-                    __with.push(__pair);
-                }
+                    dialog_query::ConceptFieldDescriptor::required(__descriptor)
+                };
+                __fields.push((#field_name_lit.to_string(), __field));
             }
         });
 
@@ -448,14 +447,13 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 static DESCRIPTOR: std::sync::OnceLock<dialog_query::ConceptDescriptor> =
                     std::sync::OnceLock::new();
                 DESCRIPTOR.get_or_init(|| {
-                    let mut __with: Vec<(String, dialog_query::AttributeDescriptor)> = Vec::new();
-                    let mut __maybe: Vec<(String, dialog_query::AttributeDescriptor)> = Vec::new();
+                    let mut __fields: Vec<(String, dialog_query::ConceptFieldDescriptor)> =
+                        Vec::new();
                     #(#descriptor_pair_pushes)*
-                    dialog_query::ConceptDescriptor::try_from(__with)
+                    dialog_query::ConceptDescriptor::try_from(__fields)
                         .expect(
                             "derive(Concept) guarantees at least one required field at compile time",
                         )
-                        .with_maybe(__maybe)
                         .with_description(#concept_description_lit)
                 })
             }

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -417,20 +417,21 @@ pub fn derive(input: TokenStream) -> TokenStream {
             }
         }
 
-        // Implement From<StructName> for ConceptDescriptor.
+        // The concept's runtime schema (`ConceptDescriptor`), cached.
+        // This is the single construction site for the descriptor;
+        // the `From<#query_name>` conversions below delegate here.
         //
-        // Each field is routed into `with` or `maybe` at runtime
-        // based on its `<F as ConceptField>::OPTIONAL` const —
-        // required fields populate `with`, optional fields populate
-        // `maybe`. The two slots are independent, and a concept may
-        // have either or both. The struct's doc comment carries
-        // through as the descriptor's `description` so a `concept:`
-        // query surfaces it (the field list alone leaves it `None`).
-        // The concept's runtime schema, cached. This is the single
-        // construction site for the descriptor; both `From` impls
-        // below delegate here. Building goes through the fallible
-        // `ConceptDescriptor::try_from`, which only rejects an empty
-        // required (`with`) set — ruled out at compile time by the
+        // Each field becomes a `ConceptFieldDescriptor` via
+        // `ConceptField::field_descriptor`, which carries the field's
+        // optionality (from the `OPTIONAL` const). All fields live in
+        // the descriptor's single `with` map; optionality is a
+        // per-field flag. The struct's doc comment carries through as
+        // the descriptor's `description` so a `concept:` query
+        // surfaces it (the field list alone leaves it `None`).
+        //
+        // Building goes through the fallible
+        // `ConceptDescriptor::try_from`, which only rejects a set
+        // with no required field — ruled out at compile time by the
         // required-field assertion above, so the `expect` is
         // statically unreachable (it documents the invariant rather
         // than handling a real failure).

--- a/rust/dialog-macros/src/query/formula.rs
+++ b/rust/dialog-macros/src/query/formula.rs
@@ -259,7 +259,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         .iter()
         .map(|(name, ty, _, _, _)| {
             quote! {
-                #name: #ty::try_from(source.lookup(&dialog_query::Term::from(&self.#name))?)?
+                #name: #ty::try_from(source.lookup(&dialog_query::Term::from(&self.#name))?.content()?)?
             }
         })
         .collect();

--- a/rust/dialog-query/src/attribute/query.rs
+++ b/rust/dialog-query/src/attribute/query.rs
@@ -7,6 +7,41 @@ pub mod only;
 /// Typed attribute query wrapping a single `Attribute` type.
 pub mod typed;
 
+use serde::{Deserialize, Serialize};
+
 pub use dynamic::DynamicAttributeQuery;
 pub use dynamic::DynamicAttributeQuery as AttributeQuery;
 pub use typed::StaticAttributeQuery;
+
+/// Resolution policy for an attribute query.
+///
+/// Distinguishes the two row-multiplicity semantics independent of
+/// [`Cardinality`](crate::Cardinality), which controls how many
+/// rows a fact lookup *can* produce. `Resolution` controls what
+/// happens when a fact lookup *finds nothing*:
+///
+/// - [`Resolution::Required`] — the lookup yields zero rows on
+///   miss. Standard EAV semantics: a query that demands a fact
+///   filters out input rows that lack one. This is the default.
+/// - [`Resolution::Optional`] — the lookup yields one fallback
+///   row on miss, with the `is` slot (and the named `cause` slot,
+///   if any) bound to [`Binding::Absent`](crate::Binding::Absent).
+///   Used by concept projection for `maybe` fields and by any
+///   premise that wants set-widening optionality at the row
+///   layer.
+///
+/// Schema impact: `Resolution::Optional` widens the `is` slot's
+/// `content_type` with the `Nothing` atom via
+/// [`Type::optional`](crate::type_system::Type::optional), signaling
+/// to the planner and unifier that this slot may bind to Absent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Resolution {
+    /// Standard EAV: zero rows when no fact matches the lookup.
+    #[default]
+    Required,
+    /// Yield one fallback row when no fact matches; the `is`
+    /// (and named `cause`) slot bind to
+    /// [`Binding::Absent`](crate::Binding::Absent).
+    Optional,
+}

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -2,11 +2,13 @@ use crate::Cardinality;
 use crate::Claim;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
 use crate::attribute::The;
+use crate::attribute::query::Resolution;
 use crate::environment::Environment;
 use crate::query::Application;
 use crate::query::Output;
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
+use crate::type_system::Type as Kind;
 use crate::types::{Any, Record};
 use crate::{
     Entity, EvaluationError, Field, Parameters, Requirement, Schema, Term, Type, Value, try_stream,
@@ -39,7 +41,11 @@ pub struct AttributeQueryAll {
 }
 
 impl AttributeQueryAll {
-    /// Create a new attribute query that yields all matches.
+    /// Create a new attribute query. The resolution policy is
+    /// derived from `is`'s kind: a set-widened (`Nothing`-bit-set)
+    /// kind yields [`Resolution::Optional`] — one Absent fallback
+    /// row on miss; otherwise [`Resolution::Required`] — zero rows
+    /// on miss.
     pub fn new(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
         Self {
             the,
@@ -47,6 +53,17 @@ impl AttributeQueryAll {
             is,
             cause,
             source: Term::<Record>::unique(),
+        }
+    }
+
+    /// Resolution policy derived from `is`'s kind. A set-widened
+    /// `is` (admits `Nothing`) is [`Resolution::Optional`];
+    /// otherwise [`Resolution::Required`].
+    pub fn resolution(&self) -> Resolution {
+        if self.is.is_optional() {
+            Resolution::Optional
+        } else {
+            Resolution::Required
         }
     }
 
@@ -63,6 +80,15 @@ impl AttributeQueryAll {
     /// Get the 'is' (value) parameter.
     pub fn is(&self) -> &Term<Any> {
         &self.is
+    }
+
+    /// Return a copy of this query with the `is` term replaced.
+    /// Internal hook used by the planner to stamp rule-inferred
+    /// kinds onto the term before evaluation. Not for external
+    /// callers — user-supplied queries should construct fresh
+    /// instances via [`new`](Self::new).
+    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
+        Self { is, ..self }
     }
 
     /// Get the 'cause' term.
@@ -108,11 +134,13 @@ impl AttributeQueryAll {
         Ok(())
     }
 
-    /// Resolves variables from the given match.
+    /// Resolves variables from the given match. `Absent` bindings
+    /// leave the term unchanged (same as unbound) — only Present
+    /// bindings substitute.
     pub fn resolve(&self, source: &Match) -> Self {
         let the = self.the.resolve(source);
         let of = self.of.resolve(source);
-        let is = match source.lookup(&self.is) {
+        let is = match source.lookup(&self.is).and_then(|b| b.content()) {
             Ok(value) => Term::Constant(value),
             Err(_) => self.is.clone(),
         };
@@ -136,7 +164,7 @@ impl AttributeQueryAll {
             "the".to_string(),
             Field {
                 description: "The relation identifier".to_string(),
-                content_type: Some(Type::Symbol),
+                content_type: Some(Kind::primitive(Type::Symbol)),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -146,17 +174,38 @@ impl AttributeQueryAll {
             "of".to_string(),
             Field {
                 description: "Entity of the relation".to_string(),
-                content_type: Some(Type::Entity),
+                content_type: Some(Kind::primitive(Type::Entity)),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
         );
 
+        // The `is` term's kind already encodes optionality via the
+        // `Nothing` atom. `None` means "no static info" — the
+        // unifier resolves at rule-compile time.
         schema.insert(
             "is".to_string(),
             Field {
                 description: "Value of the relation".to_string(),
-                content_type: None,
+                content_type: self.is.kind(),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+
+        // The `cause` slot is bound by the merge step on every
+        // Present row; when the query is optional the fallback
+        // row binds it to `Absent`, so the slot is set-widened.
+        let cause_content = if self.is.is_optional() {
+            Kind::primitive(Type::Bytes).optional()
+        } else {
+            Kind::primitive(Type::Bytes)
+        };
+        schema.insert(
+            "cause".to_string(),
+            Field {
+                description: "Causal stamp of the relation".to_string(),
+                content_type: Some(cause_content),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -181,10 +230,21 @@ impl AttributeQueryAll {
         params.insert("the".to_string(), Term::<Any>::from(&self.the));
         params.insert("of".to_string(), Term::<Any>::from(&self.of));
         params.insert("is".to_string(), self.is.clone());
+        params.insert("cause".to_string(), Term::<Any>::from(&self.cause));
         params
     }
 
     /// Evaluate yielding all matching artifacts.
+    ///
+    /// With [`Resolution::Required`] (the default), zero rows are
+    /// yielded for an input when no fact matches the lookup —
+    /// standard EAV semantics.
+    ///
+    /// With [`Resolution::Optional`], if no fact matches for an
+    /// input row, a single fallback row is yielded with the `is`
+    /// slot (and the `cause` slot, if a named variable) bound to
+    /// [`Binding::Absent`](crate::Binding::Absent). This is the
+    /// row-layer signal for "we looked, no fact found."
     pub fn evaluate<'a, Env, M: Selection + 'a>(
         self,
         env: &'a Env,
@@ -199,12 +259,47 @@ impl AttributeQueryAll {
                 let base = candidate?;
                 let selection = selector.resolve(&base);
 
+                // The entity must be determined for the Absent
+                // fallback to mean anything: "this entity has no such
+                // fact." An unbound entity would manufacture a phantom
+                // Absent row not tied to any concrete entity.
+                let entity_known = selection.of().is_constant();
+
+                let mut produced = false;
                 let stream = Provider::<Select<'_>>::execute(env, (&selection).try_into()?).await?;
                 for await artifact in stream {
                     let artifact = artifact?;
                     let mut extension = base.clone();
                     selector.merge(&mut extension, &artifact)?;
+                    produced = true;
                     yield extension;
+                }
+
+                // Optional fallback: yield one Absent row only when
+                // the attribute is genuinely absent for a known
+                // entity. Guards:
+                //   - `!produced`: no fact row covered this input.
+                //   - `selector.is.is_optional()`: the slot admits
+                //     absence.
+                //   - `entity_known`: absence is about a concrete
+                //     entity, not an unbound scan.
+                //   - `!base.is_present(&selector.is)`: the value
+                //     wasn't already pinned to a Present binding. When
+                //     it was, an empty scan is a value *mismatch*
+                //     (the value-keyed scan found nothing equal to the
+                //     pinned value), not absence — and binding that
+                //     Present variable to Absent would error and abort
+                //     the stream.
+                if !produced
+                    && selector.is.is_optional()
+                    && entity_known
+                    && !base.is_present(&selector.is)
+                {
+                    let mut fallback = base;
+                    fallback.bind_absent(&selector.is)?;
+                    let cause_term: Term<Any> = Term::<Any>::from(&selector.cause);
+                    fallback.bind_absent(&cause_term)?;
+                    yield fallback;
                 }
             }
         }
@@ -339,6 +434,61 @@ mod tests {
         Ok(())
     }
 
+    /// An *optional* `is` whose variable was pre-bound to a value the
+    /// entity does not have must not emit an Absent fallback. The
+    /// value-keyed scan finds nothing equal to the pinned value, but
+    /// that is a value *mismatch*, not absence — the attribute exists
+    /// with a different value. Before the fix, the fallback fired and
+    /// tried to bind the already-Present `is` variable to Absent,
+    /// which errors and aborts the stream.
+    #[dialog_common::test]
+    async fn it_does_not_emit_absent_on_optional_value_mismatch() -> anyhow::Result<()> {
+        use crate::selection::Match;
+        use crate::types::Any;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let bob = Entity::new()?;
+
+        // Bob HAS a nickname, but it is "Bobby".
+        branch
+            .transaction()
+            .assert(
+                the!("person/nickname")
+                    .of(bob.clone())
+                    .is("Bobby".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let optional_is: Term<Any> = Term::<Option<String>>::var("nickname").into();
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/nickname")),
+            Term::from(bob.clone()),
+            optional_is.clone(),
+            Term::var("cause"),
+        );
+
+        // An earlier premise pinned ?nickname to "Ali" — not Bob's.
+        let mut seed = Match::new();
+        seed.bind(&optional_is, Value::from("Ali".to_string()))?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(query, seed.seed(), &source)).await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a value mismatch on an optional field is not absence — no Absent fallback"
+        );
+
+        Ok(())
+    }
+
     #[dialog_common::test]
     async fn it_scans_with_constant_entity() -> anyhow::Result<()> {
         let (operator, profile) = test_operator_with_profile().await;
@@ -464,5 +614,58 @@ mod tests {
         assert_eq!(results[0].is(), &Value::String("Alice".to_string()));
 
         Ok(())
+    }
+
+    /// `AttributeQueryAll::schema()` declares the `the` slot as
+    /// a singleton primitive over `Symbol`.
+    #[dialog_common::test]
+    fn schema_the_slot_is_primitive_symbol() {
+        let query = AttributeQueryAll::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+        );
+        let schema = query.schema();
+        let the = schema.get("the").expect("the field present");
+        let content = the.content_type().expect("symbol kind present");
+        assert!(!content.is_optional());
+        assert_eq!(content.as_value_type(), Some(Type::Symbol));
+        assert!(matches!(content, Kind::Primitive(_)));
+    }
+
+    /// `AttributeQueryAll::schema()` declares the `of` slot as
+    /// a singleton primitive over `Entity`.
+    #[dialog_common::test]
+    fn schema_of_slot_is_primitive_entity() {
+        let query = AttributeQueryAll::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+        );
+        let schema = query.schema();
+        let of = schema.get("of").expect("of field present");
+        let content = of.content_type().expect("entity kind present");
+        assert_eq!(content.as_value_type(), Some(Type::Entity));
+    }
+
+    /// `AttributeQueryAll::schema()` declares the `is` slot as
+    /// `None` (unknown) when the term carries no static info —
+    /// the unifier narrows at rule-compile time.
+    #[dialog_common::test]
+    fn schema_is_slot_is_unknown_when_untyped() {
+        let query = AttributeQueryAll::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+        );
+        let schema = query.schema();
+        let is = schema.get("is").expect("is field present");
+        assert!(
+            is.content_type().is_none(),
+            "untyped `is` term should yield unknown content_type"
+        );
     }
 }

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -82,12 +82,16 @@ impl AttributeQueryAll {
         &self.is
     }
 
-    /// Return a copy of this query with the `is` term replaced.
-    /// Internal hook used by the planner to stamp rule-inferred
-    /// kinds onto the term before evaluation. Not for external
-    /// callers — user-supplied queries should construct fresh
-    /// instances via [`new`](Self::new).
-    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
+    /// Return a copy of this query with the `is` term's type
+    /// narrowed to `kind`. The planner uses this to stamp the
+    /// rule-inferred kind onto the value variable before evaluation;
+    /// `the`/`of`/`cause` are fixed. A non-variable `is` (a constant)
+    /// is left unchanged.
+    pub(crate) fn with_type(self, kind: Kind) -> Self {
+        let is = match self.is.name() {
+            Some(name) => Term::<Any>::typed_var(name.to_string(), kind),
+            None => self.is,
+        };
         Self { is, ..self }
     }
 

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -10,6 +10,7 @@ use crate::query::Application;
 use crate::query::Output;
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
+use crate::type_system::Type as Kind;
 use crate::types::{Any, Record};
 use crate::{Entity, EvaluationError, Parameters, Premise, Schema, Term};
 use dialog_artifacts::{Cause, Select};
@@ -96,12 +97,12 @@ impl DynamicAttributeQuery {
         }
     }
 
-    /// Return a copy with the `is` term replaced. Internal hook;
-    /// see [`AttributeQueryAll::with_is`].
-    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
+    /// Return a copy with the `is` term's type narrowed to `kind`.
+    /// See [`AttributeQueryAll::with_type`].
+    pub(crate) fn with_type(self, kind: Kind) -> Self {
         match self {
-            DynamicAttributeQuery::All(q) => DynamicAttributeQuery::All(q.with_is(is)),
-            DynamicAttributeQuery::Only(q) => DynamicAttributeQuery::Only(q.with_is(is)),
+            DynamicAttributeQuery::All(q) => DynamicAttributeQuery::All(q.with_type(kind)),
+            DynamicAttributeQuery::Only(q) => DynamicAttributeQuery::Only(q.with_type(kind)),
         }
     }
 

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -2,6 +2,7 @@ use crate::Cardinality;
 use crate::Claim;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
 use crate::attribute::The;
+use crate::attribute::query::Resolution;
 use crate::environment::Environment;
 use crate::negation::Negation;
 use crate::proposition::Proposition;
@@ -43,6 +44,11 @@ impl DynamicAttributeQuery {
     ///
     /// `None` or `Some(Cardinality::Many)` → `All` variant.
     /// `Some(Cardinality::One)` → `Only` variant.
+    ///
+    /// Resolution (Required vs Optional) is derived from the
+    /// typed `is` term: if its kind admits the `Nothing` atom the
+    /// query is treated as optional and yields an `Absent`
+    /// fallback row on miss.
     pub fn new(
         the: Term<The>,
         of: Term<Entity>,
@@ -55,6 +61,14 @@ impl DynamicAttributeQuery {
                 DynamicAttributeQuery::Only(AttributeQueryOnly::new(the, of, is, cause))
             }
             _ => DynamicAttributeQuery::All(AttributeQueryAll::new(the, of, is, cause)),
+        }
+    }
+
+    /// Returns the resolution policy of this query.
+    pub fn resolution(&self) -> Resolution {
+        match self {
+            DynamicAttributeQuery::All(q) => q.resolution(),
+            DynamicAttributeQuery::Only(q) => q.resolution(),
         }
     }
 
@@ -79,6 +93,15 @@ impl DynamicAttributeQuery {
         match self {
             DynamicAttributeQuery::All(q) => q.is(),
             DynamicAttributeQuery::Only(q) => q.is(),
+        }
+    }
+
+    /// Return a copy with the `is` term replaced. Internal hook;
+    /// see [`AttributeQueryAll::with_is`].
+    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
+        match self {
+            DynamicAttributeQuery::All(q) => DynamicAttributeQuery::All(q.with_is(is)),
+            DynamicAttributeQuery::Only(q) => DynamicAttributeQuery::Only(q.with_is(is)),
         }
     }
 
@@ -238,7 +261,15 @@ mod tests {
     use crate::session::RuleRegistry;
     use crate::source::test::TestEnv;
     use crate::the;
+    use crate::type_system::{Primitive, Type as Kind};
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+
+    /// Construct an optional `is` variable. The query derives its
+    /// resolution from the `is` term, so typing the slot as optional
+    /// is what flips the query into Absent-fallback mode.
+    fn optional_is(name: &str) -> Term<Any> {
+        Term::<Any>::typed_var(name, Kind::primitive_set(Primitive::ALL).optional())
+    }
 
     macro_rules! assert_relation {
         ($branch:expr, $operator:expr, $the:expr, $of:expr, $is:expr) => {{
@@ -288,8 +319,9 @@ mod tests {
         assert!(candidate.contains(&Term::var("person")));
         assert!(candidate.contains(&Term::var("name")));
 
-        let person_id: Entity = Entity::try_from(candidate.lookup(&Term::var("person"))?)?;
-        let name_value: crate::Value = candidate.lookup(&Term::var("name"))?;
+        let person_id: Entity =
+            Entity::try_from(candidate.lookup(&Term::var("person"))?.content()?)?;
+        let name_value: crate::Value = candidate.lookup(&Term::var("name"))?.content()?;
 
         assert_eq!(person_id, alice);
         assert_eq!(name_value, crate::Value::String("Alice".to_string()));
@@ -880,6 +912,226 @@ mod tests {
         assert_eq!(results[0].of(), &alice);
         assert_eq!(results[0].is(), &crate::Value::String("Alice".into()));
 
+        Ok(())
+    }
+
+    /// `DynamicAttributeQuery::new` defaults to
+    /// `Resolution::Required` — the existing semantics.
+    #[dialog_common::test]
+    fn new_defaults_to_required_resolution() {
+        let q = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            None,
+        );
+        assert_eq!(q.resolution(), Resolution::Required);
+    }
+
+    /// When the `is` term carries an optional kind the derived
+    /// resolution is `Optional`.
+    #[dialog_common::test]
+    fn it_derives_optional_resolution_from_is_term_kind() {
+        let q = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            optional_is("is"),
+            Term::var("cause"),
+            None,
+        );
+        assert_eq!(q.resolution(), Resolution::Optional);
+    }
+
+    /// Resolution is derived from the `is` term's kind and shows
+    /// up identically across both `All` (Many cardinality) and
+    /// `Only` (One cardinality) variants.
+    #[dialog_common::test]
+    fn it_propagates_resolution_through_cardinality_variants() {
+        let many = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            optional_is("is"),
+            Term::var("cause"),
+            Some(Cardinality::Many),
+        );
+        let one = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            optional_is("is"),
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        assert_eq!(many.resolution(), Resolution::Optional);
+        assert_eq!(one.resolution(), Resolution::Optional);
+        assert!(matches!(many, DynamicAttributeQuery::All(_)));
+        assert!(matches!(one, DynamicAttributeQuery::Only(_)));
+    }
+
+    /// Required-resolution schema declares the `is` slot as a
+    /// concrete type or unknown — the slot demands a Present
+    /// value (no `Nothing` bit).
+    #[dialog_common::test]
+    fn it_emits_definite_schema_for_required_resolution() {
+        let q = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            Term::var("is"),
+            Term::var("cause"),
+            None,
+        );
+        let schema = q.schema();
+        let is = schema.get("is").expect("is field present");
+        // Untyped `is` slot reports `None` (unknown) — not
+        // Optional in the sense of set-widening.
+        assert!(
+            is.content_type().is_none() || !is.content_type().unwrap().is_optional(),
+            "Required resolution must not produce Optional schema"
+        );
+    }
+
+    /// When the `is` term's kind is optional, the schema's `is`
+    /// slot is optional too and may bind to Absent.
+    #[dialog_common::test]
+    fn it_emits_optional_schema_when_is_term_is_optional() {
+        let q = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            optional_is("is"),
+            Term::var("cause"),
+            None,
+        );
+        let schema = q.schema();
+        let is = schema.get("is").expect("is field present");
+        let content = is.content_type().expect("content_type present");
+        assert!(
+            content.is_optional(),
+            "Optional `is` term must produce Optional schema"
+        );
+    }
+
+    /// When the `is` term is a typed `Term<Option<U>>`, the schema's
+    /// `is` slot admits both `U` and `Nothing`.
+    #[dialog_common::test]
+    fn it_preserves_inner_type_when_is_term_is_optional() {
+        use crate::artifact::Type as ValueType;
+        let typed_is: Term<Any> = Term::<Option<String>>::var("name").into();
+        let q = DynamicAttributeQuery::new(
+            Term::var("the"),
+            Term::var("of"),
+            typed_is,
+            Term::var("cause"),
+            None,
+        );
+        let schema = q.schema();
+        let is = schema.get("is").expect("is field present");
+        let content = is.content_type().expect("content_type present");
+        assert!(content.is_optional());
+        assert!(
+            content.primitive_part().contains(ValueType::String),
+            "Optional wrap preserves the inner primitive type"
+        );
+    }
+
+    /// Required-resolution evaluation yields zero rows when the
+    /// underlying fact is missing — standard EAV.
+    #[dialog_common::test]
+    async fn it_yields_zero_rows_on_miss_when_required() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        // Don't assert any facts — the lookup misses.
+        let alice = Entity::new()?;
+        let q = DynamicAttributeQuery::new(
+            Term::Constant(crate::Value::from(the!("person/name").clone())),
+            Term::Constant(crate::Value::Entity(alice)),
+            Term::var("is"),
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(q, Match::new().seed(), &source)).await?;
+        assert_eq!(
+            results.len(),
+            0,
+            "Required resolution must yield no rows on miss"
+        );
+        Ok(())
+    }
+
+    /// Optional-resolution evaluation yields one row with `is`
+    /// bound to `Absent` when the underlying fact is missing.
+    #[dialog_common::test]
+    async fn it_yields_absent_fallback_on_miss_when_optional() -> anyhow::Result<()> {
+        use crate::Binding;
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let q = DynamicAttributeQuery::new(
+            Term::Constant(crate::Value::from(the!("person/nickname").clone())),
+            Term::Constant(crate::Value::Entity(alice)),
+            optional_is("nickname"),
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(q, Match::new().seed(), &source)).await?;
+        assert_eq!(
+            results.len(),
+            1,
+            "Optional resolution must yield one fallback row on miss"
+        );
+        assert_eq!(
+            results[0].lookup(&Term::var("nickname"))?,
+            Binding::Absent,
+            "fallback row must bind `is` to Absent"
+        );
+        Ok(())
+    }
+
+    /// Optional-resolution evaluation yields the matched row(s)
+    /// when the underlying fact exists — set-widening doesn't
+    /// shadow Present results.
+    #[dialog_common::test]
+    async fn it_yields_present_row_when_optional_fact_exists() -> anyhow::Result<()> {
+        use crate::Binding;
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let name_attr = the!("person/name");
+        branch
+            .transaction()
+            .assert(name_attr.clone().of(alice.clone()).is("Alice".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let q = DynamicAttributeQuery::new(
+            Term::Constant(crate::Value::from(name_attr)),
+            Term::Constant(crate::Value::Entity(alice)),
+            optional_is("name"),
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(q, Match::new().seed(), &source)).await?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("name"))?,
+            Binding::Present(crate::Value::String("Alice".into())),
+            "Optional with a Present fact yields Present, not Absent"
+        );
         Ok(())
     }
 }

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -9,6 +9,7 @@ use crate::query::Output;
 use crate::schema::Cardinality;
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
+use crate::type_system::Type as Kind;
 use crate::types::{Any, Record};
 use crate::{Entity, EvaluationError, Parameters, Schema, Term, try_stream};
 use dialog_artifacts::{Artifact, Cause, Select};
@@ -131,11 +132,11 @@ impl AttributeQueryOnly {
         self.query.is()
     }
 
-    /// Return a copy with the `is` term replaced. Internal hook;
-    /// see [`AttributeQueryAll::with_is`].
-    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
+    /// Return a copy with the `is` term's type narrowed to `kind`.
+    /// See [`AttributeQueryAll::with_type`].
+    pub(crate) fn with_type(self, kind: Kind) -> Self {
         Self {
-            query: self.query.with_is(is),
+            query: self.query.with_type(kind),
         }
     }
 

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -2,6 +2,7 @@ use super::all::AttributeQueryAll;
 use crate::Claim;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
 use crate::attribute::The;
+use crate::attribute::query::Resolution;
 use crate::environment::Environment;
 use crate::query::Application;
 use crate::query::Output;
@@ -53,14 +54,14 @@ where
 {
     try_stream! {
         let relation = selector.attribute();
-        let attribute = ArtifactsAttribute::try_from(candidate.lookup(&Term::from(&relation))?)?;
-        let entity = Entity::try_from(candidate.lookup(&Term::from(selector.of()))?)?;
-        let value = candidate.lookup(selector.is())?;
+        let attribute = ArtifactsAttribute::try_from(candidate.lookup(&Term::from(&relation))?.content()?)?;
+        let entity = Entity::try_from(candidate.lookup(&Term::from(selector.of()))?.content()?)?;
+        let value = candidate.lookup(selector.is())?.content()?;
         let cause_term = selector.cause();
         let cause = if cause_term.is_blank() {
             None
         } else {
-            Some(Cause::try_from(candidate.lookup(&Term::from(cause_term))?)?)
+            Some(Cause::try_from(candidate.lookup(&Term::from(cause_term))?.content()?)?)
         };
 
         let challengers = Provider::<Select<'_>>::execute(env, ArtifactSelector::new()
@@ -98,11 +99,21 @@ pub struct AttributeQueryOnly {
 }
 
 impl AttributeQueryOnly {
-    /// Create a new winner-selecting attribute query.
+    /// Create a new winner-selecting attribute query. The
+    /// resolution (Required vs Optional) is derived from the
+    /// typed `is` term: if its kind admits the `Nothing` atom the
+    /// query is treated as optional and yields an `Absent`
+    /// fallback row on miss.
     pub fn new(the: Term<The>, of: Term<Entity>, is: Term<Any>, cause: Term<Cause>) -> Self {
         Self {
             query: AttributeQueryAll::new(the, of, is, cause),
         }
+    }
+
+    /// Returns the resolution policy of this query (delegates to
+    /// the wrapped `AttributeQueryAll`).
+    pub fn resolution(&self) -> Resolution {
+        self.query.resolution()
     }
 
     /// Get the 'the' (attribute) term.
@@ -118,6 +129,14 @@ impl AttributeQueryOnly {
     /// Get the 'is' (value) parameter.
     pub fn is(&self) -> &Term<Any> {
         self.query.is()
+    }
+
+    /// Return a copy with the `is` term replaced. Internal hook;
+    /// see [`AttributeQueryAll::with_is`].
+    pub(crate) fn with_is(self, is: Term<Any>) -> Self {
+        Self {
+            query: self.query.with_is(is),
+        }
     }
 
     /// Get the 'cause' term.
@@ -192,6 +211,15 @@ impl AttributeQueryOnly {
                 let attribute_known = resolved.the().is_constant();
                 let value_known = resolved.is().is_constant();
 
+                let mut produced = false;
+                // Tracks whether the lookup observed *any* fact for
+                // this (attribute, entity). Distinguishes genuine
+                // absence (no fact → Absent fallback is correct) from
+                // a value mismatch (a fact exists but the winner fails
+                // the resolved value constraint → not absence, so no
+                // fallback). Only meaningful on the sliding-window
+                // (entity-known) path.
+                let mut saw_fact = false;
                 if entity_known || (attribute_known && !value_known) {
                     // Sliding window path.
                     let value_constraint = resolved.is().as_constant().cloned();
@@ -208,6 +236,7 @@ impl AttributeQueryOnly {
                     let stream = Provider::<Select<'_>>::execute(env, (&scan).try_into()?).await?;
                     for await artifact in stream {
                         let artifact = artifact?;
+                        saw_fact = true;
 
                         candidate = Some(match candidate.take() {
                             Some(current) if current.the == artifact.the && current.of == artifact.of => {
@@ -217,6 +246,7 @@ impl AttributeQueryOnly {
                                 if value_constraint.is_none() || value_constraint.as_ref() == Some(&winner.is) {
                                     let mut extension = base.clone();
                                     selector.merge(&mut extension, &winner)?;
+                                    produced = true;
                                     yield extension;
                                 }
                                 artifact
@@ -231,6 +261,7 @@ impl AttributeQueryOnly {
                     {
                         let mut extension = base.clone();
                         selector.merge(&mut extension, &winner)?;
+                        produced = true;
                         yield extension;
                     }
                 } else {
@@ -240,9 +271,34 @@ impl AttributeQueryOnly {
                         let candidate = candidate?;
                         let verified = Box::pin(challenge(env, selector.clone(), candidate));
                         for await v in verified {
+                            produced = true;
                             yield v?;
                         }
                     }
+                }
+
+                // Optional fallback: yield one Absent row only when
+                // the attribute is genuinely *absent* for a known
+                // entity — never when a fact exists but was filtered.
+                //
+                // Three guards, all required:
+                //   - `!produced`: no Present row already covered this
+                //     input.
+                //   - `selector.is().is_optional()`: the slot is
+                //     set-widened, so absence is a legal value.
+                //   - `entity_known && !saw_fact`: the entity is
+                //     determined and the lookup found no fact for it.
+                //     Without this, a value mismatch (`saw_fact` true)
+                //     would wrongly report the attribute as missing,
+                //     and an unbound entity (challenge / value-only
+                //     path) would manufacture a phantom Absent row for
+                //     no concrete entity.
+                if !produced && selector.is().is_optional() && entity_known && !saw_fact {
+                    let mut fallback = base;
+                    fallback.bind_absent(selector.is())?;
+                    let cause_term: Term<Any> = Term::<Any>::from(selector.cause());
+                    fallback.bind_absent(&cause_term)?;
+                    yield fallback;
                 }
             }
         }
@@ -745,6 +801,64 @@ mod tests {
             Cause::from(&winner_ba),
             "Tiebreaker should be deterministic"
         );
+    }
+
+    /// An *optional* `is` whose variable an earlier premise bound to
+    /// a value the entity does NOT have must NOT emit an Absent
+    /// fallback. The fact exists (the entity has the attribute with a
+    /// different value); the miss is a value mismatch, not absence.
+    /// "Absent" means "no fact for this attribute," so a Required
+    /// field in the same situation yields zero rows — the optional
+    /// field must agree on the row count (zero), never assert the
+    /// attribute is missing when it is merely different.
+    ///
+    /// Before the fix, the sliding-window winner failed the resolved
+    /// value constraint, `produced` stayed false, and the fallback
+    /// fired on `is_optional()` alone — binding the already-Present
+    /// `is` variable to Absent, which errors and aborts the whole
+    /// stream.
+    #[dialog_common::test]
+    async fn it_does_not_emit_absent_on_optional_value_mismatch() -> anyhow::Result<()> {
+        use crate::selection::Match;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let bob = Entity::new()?;
+        let nickname_attr = the!("person/nickname");
+
+        // Bob HAS a nickname, but it is "Bobby".
+        assert_relation!(branch, &operator, nickname_attr, bob, "Bobby".to_string());
+
+        // Optional `is` (set-widened): a missing fact would normally
+        // yield one Absent fallback row.
+        let optional_is: Term<Any> = Term::<Option<String>>::var("nickname").into();
+        let query = AttributeQueryOnly::new(
+            Term::from(the!("person/nickname")),
+            Term::from(bob.clone()),
+            optional_is.clone(),
+            Term::var("cause"),
+        );
+
+        // An earlier premise constrained ?nickname to "Ali" — a value
+        // Bob does not have.
+        let mut seed = Match::new();
+        seed.bind(&optional_is, crate::Value::from("Ali".to_string()))?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results =
+            Selection::try_vec(Application::evaluate(query, seed.seed(), &source)).await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a value mismatch on an optional field is NOT absence — \
+             the attribute exists with a different value, so no row \
+             (and certainly no Absent fallback) should be produced"
+        );
+
+        Ok(())
     }
 
     /// When entity is a variable that gets bound by an earlier premise in

--- a/rust/dialog-query/src/attribute/query/typed.rs
+++ b/rust/dialog-query/src/attribute/query/typed.rs
@@ -94,8 +94,8 @@ where
     fn realize(&self, input: Match) -> Result<Self::Conclusion, EvaluationError> {
         let of_term = &self.of;
         let is_param = Term::<Any>::from(&self.is);
-        let entity: Entity = Entity::try_from(input.lookup(&Term::from(of_term))?)?;
-        let value: Value = input.lookup(&is_param)?;
+        let entity: Entity = Entity::try_from(input.lookup(&Term::from(of_term))?.content()?)?;
+        let value: Value = input.lookup(&is_param)?.content()?;
         let typed_value = A::Type::try_from(value).map_err(|_| {
             EvaluationError::Store(format!(
                 "cannot convert value to {}",

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -6,8 +6,16 @@ pub mod query;
 pub use descriptor::ConceptDescriptor;
 pub use query::ConceptQuery;
 
+use crate::artifact::Type as ValueType;
+use crate::attribute::{Attribute, AttributeDescriptor, AttributeStatement};
+use crate::descriptor::Descriptor;
+use crate::error::EvaluationError;
 pub use crate::predicate::Predicate;
-use crate::{Entity, Parameters};
+use crate::selection::Binding;
+use crate::term::Term;
+use crate::type_system::{Primitive, Type as Kind};
+use crate::types::{Any, TypeDescriptor, Typed};
+use crate::{Entity, Parameters, Value};
 use dialog_common::ConditionalSend;
 use std::fmt::Debug;
 
@@ -38,6 +46,193 @@ where
 
     /// Content-addressed identity for this concept.
     fn this(&self) -> Entity;
+}
+
+/// Field-level abstraction used by `#[derive(Concept)]` to dispatch
+/// between required (`N: Attribute`) and optional (`Option<N>`)
+/// concept fields without doing syntactic type matching in the
+/// proc macro.
+///
+/// Two blanket impls cover the two cases:
+///
+/// - `impl<N: Attribute> ConceptField for N` — required path.
+/// - `impl<N: Attribute> ConceptField for Option<N>` — optional path.
+///
+/// These don't overlap because `Option` is `#[fundamental]`: Rust's
+/// trait coherence treats `Option<T>` as structurally distinct from
+/// a bare type parameter `T`. The Concept derive refers to
+/// `<F as ConceptField>::TermType` etc. without inspecting `F`'s
+/// syntactic shape — Rust resolves the right impl at type-check
+/// time. Aliases, prelude paths, and renamed imports all work.
+pub trait ConceptField: Sized + Clone {
+    /// The underlying attribute newtype. For both required `N` and
+    /// optional `Option<N>`, this is `N`.
+    type Attribute: Attribute
+        + Descriptor<AttributeDescriptor>
+        + From<<Self::Attribute as Attribute>::Type>;
+
+    /// The type wrapping the attribute's scalar at the term layer.
+    /// - Required (`N`): `<N as Attribute>::Type`.
+    /// - Optional (`Option<N>`): `Option<<N as Attribute>::Type>`.
+    type TermType: Typed + Clone + Debug + ConditionalSend + 'static;
+
+    /// `true` if this field is set-widened (the `Option<N>` impl),
+    /// `false` for the bare-attribute (`N`) impl. Used by the
+    /// `#[derive(Concept)]` macro to route the field's descriptor
+    /// into either the `with` (required) or `maybe` (optional)
+    /// section of the generated `ConceptDescriptor`.
+    const OPTIONAL: bool;
+
+    /// Build the `is` slot term for this field's attribute query.
+    /// Required fields pass the user's `value_param` through
+    /// unchanged. Optional fields return an optional-typed term
+    /// so the `AttributeQuery` evaluates with Absent-fallback
+    /// semantics (resolution is derived from the term's kind).
+    fn term(value_param: Term<Any>) -> Term<Any>;
+
+    /// Realize a value of `Self` from the row binding for this slot.
+    ///
+    /// - Required: the binding must be `Present`; the inner scalar
+    ///   is unwrapped via `TryFrom<Value>` and wrapped in `N`.
+    /// - Optional: `Present(v)` becomes `Some(N(v))`, `Absent`
+    ///   becomes `None`.
+    fn realize(binding: Binding) -> Result<Self, EvaluationError>;
+
+    /// Push the attribute statement(s) for this field into `buf`.
+    ///
+    /// - Required: always one statement.
+    /// - Optional: one if `Some`, none if `None`.
+    fn push_statements(&self, this: Entity, buf: &mut Vec<AttributeStatement>);
+}
+
+// Required path: any `N` that satisfies the attribute bounds gets
+// the `ConceptField` impl with `RESOLUTION = Required` and
+// `TermType = N::Type`. This is the "bare attribute" case in a
+// concept field — `pub name: GivenName` and similar.
+//
+// Coherence note: this blanket and the next one (`for Option<N>`)
+// are non-overlapping because `Option` is `#[fundamental]`. The
+// `#[fundamental]` annotation on std's `Option` tells the trait
+// checker to treat `Option<T>` as structurally distinct from a
+// bare type parameter `T`, so `impl<N> Trait for N` and
+// `impl<N> Trait for Option<N>` are allowed to coexist.
+//
+// Other `#[fundamental]` types where this same pattern would work
+// include `Box<T>`, `&T`, `&mut T`, and `Pin<T>`.
+impl<N> ConceptField for N
+where
+    N: Attribute + Descriptor<AttributeDescriptor> + Clone + From<<N as Attribute>::Type>,
+    <N as Attribute>::Type: Into<Value>,
+{
+    type Attribute = N;
+    type TermType = <N as Attribute>::Type;
+    const OPTIONAL: bool = false;
+
+    fn term(value_param: Term<Any>) -> Term<Any> {
+        // Required: pass the user's term through as-is; its kind
+        // (if any) is not optional, so the query stays required.
+        value_param
+    }
+
+    fn realize(binding: Binding) -> Result<Self, EvaluationError> {
+        let value = binding.content()?;
+        let inner = <<N as Attribute>::Type>::try_from(value).map_err(|_| {
+            EvaluationError::TypeMismatch {
+                expected: <<<N as Attribute>::Type as Typed>::Descriptor as TypeDescriptor>::TYPE
+                    .unwrap_or(ValueType::Symbol),
+                actual: ValueType::Symbol,
+            }
+        })?;
+        Ok(N::from(inner))
+    }
+
+    fn push_statements(&self, this: Entity, buf: &mut Vec<AttributeStatement>) {
+        let descriptor = <Self as Descriptor<AttributeDescriptor>>::descriptor();
+        let expr = AttributeStatement {
+            the: descriptor.the().clone(),
+            of: this,
+            is: <<N as Attribute>::Type as Into<Value>>::into(
+                <Self as Attribute>::value(self).clone(),
+            ),
+            cause: None,
+            cardinality: Some(descriptor.cardinality()),
+        };
+        buf.push(expr);
+    }
+}
+
+// Optional path: `Option<N>` (where `N: Attribute`) gets the
+// `ConceptField` impl with `RESOLUTION = Optional` and
+// `TermType = Option<N::Type>`. This is the "set-widened" case in
+// a concept field — `pub nickname: Option<Nickname>` and similar.
+// `realize` maps `Binding::Absent` to `None`; `push_statements`
+// emits zero records when the value is `None` (absence is never
+// persisted).
+//
+// Resolution at the call site is purely type-system driven —
+// `<Option<N> as ConceptField>` resolves to *this* impl by virtue
+// of the structural `Option<N>` shape. Aliased imports
+// (`use core::option::Option as Maybe`, etc.) resolve identically
+// at the type level even though the surface syntax differs, which
+// is why no proc-macro syntactic detection is needed.
+impl<N> ConceptField for Option<N>
+where
+    N: Attribute + Descriptor<AttributeDescriptor> + Clone + From<<N as Attribute>::Type>,
+    <N as Attribute>::Type: Into<Value>,
+{
+    type Attribute = N;
+    type TermType = Option<<N as Attribute>::Type>;
+    const OPTIONAL: bool = true;
+
+    fn term(value_param: Term<Any>) -> Term<Any> {
+        // Optional: return an optional-typed term. The underlying
+        // kind (if any) is wrapped via `Type::optional`; an untyped
+        // term becomes "any primitive, optional." The
+        // `AttributeQuery` reads `is.is_optional()` and switches to
+        // the Absent-fallback evaluation path.
+        let name = match value_param.name() {
+            Some(n) => n.to_string(),
+            None => return value_param,
+        };
+        let kind = match value_param.kind() {
+            Some(k) => k.optional(),
+            None => Kind::primitive_set(Primitive::ALL).optional(),
+        };
+        Term::<Any>::typed_var(name, kind)
+    }
+
+    fn realize(binding: Binding) -> Result<Self, EvaluationError> {
+        match binding {
+            Binding::Present(value) => {
+                let inner = <<N as Attribute>::Type>::try_from(value).map_err(|_| {
+                    EvaluationError::TypeMismatch {
+                        expected:
+                            <<<N as Attribute>::Type as Typed>::Descriptor as TypeDescriptor>::TYPE
+                                .unwrap_or(ValueType::Symbol),
+                        actual: ValueType::Symbol,
+                    }
+                })?;
+                Ok(Some(N::from(inner)))
+            }
+            Binding::Absent => Ok(None),
+        }
+    }
+
+    fn push_statements(&self, this: Entity, buf: &mut Vec<AttributeStatement>) {
+        if let Some(inner) = self.as_ref() {
+            let descriptor = <N as Descriptor<AttributeDescriptor>>::descriptor();
+            let expr = AttributeStatement {
+                the: descriptor.the().clone(),
+                of: this,
+                is: <<N as Attribute>::Type as Into<Value>>::into(
+                    <N as Attribute>::value(inner).clone(),
+                ),
+                cause: None,
+                cardinality: Some(descriptor.cardinality()),
+            };
+            buf.push(expr);
+        }
+    }
 }
 
 // Blanket impl for &T -> Parameters that uses the generated From<T> impl
@@ -96,6 +291,41 @@ where
 ///     pub name: attrs::Name,
 /// }
 /// ```
+///
+/// A concept must declare at least one *required* attribute. A
+/// struct whose only attribute fields are `Option<_>` constrains
+/// nothing (every entity matches), so the derive rejects it at
+/// compile time via a const assertion over
+/// [`ConceptField::OPTIONAL`].
+///
+/// ```compile_fail
+/// use dialog_query::{Concept, Entity};
+///
+/// mod attrs {
+///     #[derive(dialog_macros::Attribute, Clone, PartialEq)]
+///     pub struct Nickname(pub String);
+/// }
+///
+/// /// Only an optional attribute — should fail to compile.
+/// #[derive(Concept, Debug, Clone)]
+/// pub struct AllOptional {
+///     pub this: Entity,
+///     pub nickname: Option<attrs::Nickname>,
+/// }
+/// ```
+///
+/// A concept with no attribute fields at all (only `this`) is
+/// likewise rejected — it would match every entity.
+///
+/// ```compile_fail
+/// use dialog_query::{Concept, Entity};
+///
+/// /// No attributes — should fail to compile.
+/// #[derive(Concept, Debug, Clone)]
+/// pub struct NoAttributes {
+///     pub this: Entity,
+/// }
+/// ```
 pub trait Conclusion: ConditionalSend {
     /// Each instance has a corresponding entity and this method
     /// returns a reference to it.
@@ -107,235 +337,51 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
-    use std::result;
-    use std::vec;
-
     use super::*;
     use crate::AttributeStatement;
     use crate::Query;
-    use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Select, Type, Value};
-    use crate::attribute::{Attribute as _, AttributeDescriptor};
-    use crate::error::EvaluationError;
-    use crate::query::Application;
+    use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Value};
     use crate::query::Output;
-    use crate::selection::Selection;
 
+    use crate::Concept;
     use crate::attribute::query::AttributeQuery;
     use crate::session::RuleRegistry;
-    use crate::source::SelectRules;
     use crate::source::test::TestEnv;
     use crate::term::Term;
     use crate::the;
-    use crate::types::Any;
-    use crate::{Cardinality, Concept, Match, Statement};
     use anyhow::Result;
-    use dialog_capability::Provider;
-    use dialog_common::ConditionalSync;
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
 
-    // Define a Person concept for testing using raw concept API
-    // This mirrors what the #[derive(Concept)] macro generates
-    #[derive(Debug, Clone)]
-    struct Person {
+    // Define a Person concept for testing via `#[derive(Concept)]`.
+    // The newtypes live in a module named `person` so the attribute
+    // domain defaults to `person`, yielding `person/name` and
+    // `person/age` to match the stored facts the tests assert against.
+    mod person {
+        use crate::Attribute;
+
+        /// Name of the person.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Name(pub String);
+
+        /// Age of the person.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Age(pub u32);
+    }
+
+    /// A person concept used across the scaffold tests below.
+    #[derive(Concept, Debug, Clone)]
+    pub struct Person {
         pub this: Entity,
-        pub name: String,
-        pub age: u32,
-    }
-
-    // PersonQuery for querying — contains Term-wrapped fields
-    // The derive macro generates typed Terms (Term<String>, Term<u32>) not Term<Value>
-    #[derive(Debug, Clone)]
-    struct PersonQuery {
-        pub this: Term<Entity>,
-        pub name: Term<String>,
-        pub age: Term<u32>,
-    }
-
-    impl Default for PersonQuery {
-        fn default() -> Self {
-            Self {
-                this: Term::var("this"),
-                name: Term::var("name"),
-                age: Term::var("age"),
-            }
-        }
-    }
-
-    struct PersonTerms;
-
-    impl PersonTerms {
-        pub fn this() -> Term<Entity> {
-            Term::<Entity>::var("this")
-        }
-        pub fn name() -> Term<String> {
-            Term::<String>::var("name")
-        }
-        pub fn age() -> Term<u32> {
-            Term::<u32>::var("age")
-        }
-    }
-
-    fn person_predicate() -> ConceptDescriptor {
-        ConceptDescriptor::from(vec![
-            (
-                "name",
-                AttributeDescriptor::new(
-                    the!("person/name"),
-                    "Name of the person",
-                    Cardinality::One,
-                    Some(Type::String),
-                ),
-            ),
-            (
-                "age",
-                AttributeDescriptor::new(
-                    the!("person/age"),
-                    "Age of the person",
-                    Cardinality::One,
-                    Some(Type::UnsignedInt),
-                ),
-            ),
-        ])
-    }
-
-    impl From<Person> for ConceptDescriptor {
-        fn from(_: Person) -> Self {
-            person_predicate()
-        }
-    }
-
-    impl From<PersonQuery> for ConceptDescriptor {
-        fn from(_: PersonQuery) -> Self {
-            person_predicate()
-        }
-    }
-
-    // Implement Concept for Person
-    impl Concept for Person {
-        type Term = PersonTerms;
-
-        fn this(&self) -> Entity {
-            let predicate: ConceptDescriptor = self.clone().into();
-            predicate.this()
-        }
-    }
-
-    impl IntoIterator for Person {
-        type Item = AttributeStatement;
-        type IntoIter = vec::IntoIter<AttributeStatement>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            vec![
-                the!("person/name")
-                    .of(self.this.clone())
-                    .is(self.name.clone())
-                    .into(),
-                the!("person/age").of(self.this.clone()).is(self.age).into(),
-            ]
-            .into_iter()
-        }
-    }
-
-    impl Statement for Person {
-        fn assert(self, update: &mut impl dialog_artifacts::Update) {
-            let name_the = the!("person/name");
-            let age_the = the!("person/age");
-
-            update.associate(name_the.into(), self.this.clone(), Value::from(self.name));
-            update.associate(age_the.into(), self.this.clone(), Value::from(self.age));
-        }
-
-        fn retract(self, update: &mut impl dialog_artifacts::Update) {
-            let name_the = the!("person/name");
-            let age_the = the!("person/age");
-
-            update.dissociate(name_the.into(), self.this.clone(), Value::from(self.name));
-            update.dissociate(age_the.into(), self.this.clone(), Value::from(self.age));
-        }
-    }
-
-    impl Predicate for Person {
-        type Conclusion = Person;
-        type Application = PersonQuery;
-        type Descriptor = ConceptDescriptor;
-    }
-
-    // Implement TryFrom<selection::Match> for Person
-    // This extracts values from the match by field name
-    impl TryFrom<Match> for Person {
-        type Error = EvaluationError;
-
-        fn try_from(input: Match) -> Result<Self, Self::Error> {
-            Ok(Person {
-                this: Entity::try_from(
-                    input.lookup(&Term::from(&<Self as Concept>::Term::this()))?,
-                )?,
-                name: String::try_from(
-                    input.lookup(&Term::from(&<Self as Concept>::Term::name()))?,
-                )?,
-                age: u32::try_from(input.lookup(&Term::from(&<Self as Concept>::Term::age()))?)?,
-            })
-        }
-    }
-
-    // Implement Instance for Person
-    impl Conclusion for Person {
-        fn this(&self) -> &Entity {
-            &self.this
-        }
-    }
-
-    // Implement From<PersonQuery> for Parameters
-    impl From<PersonQuery> for Parameters {
-        fn from(source: PersonQuery) -> Self {
-            let mut terms = Self::new();
-            terms.insert("this".into(), Term::<Any>::from(source.this));
-            terms.insert("name".into(), Term::<Any>::from(source.name));
-            terms.insert("age".into(), Term::<Any>::from(source.age));
-            terms
-        }
-    }
-
-    // Implement From<PersonQuery> for ConceptQuery
-    impl From<PersonQuery> for ConceptQuery {
-        fn from(source: PersonQuery) -> Self {
-            let predicate: ConceptDescriptor = source.clone().into();
-            ConceptQuery {
-                terms: source.into(),
-                predicate,
-            }
-        }
-    }
-
-    // Implement Application for PersonQuery
-    impl Application for PersonQuery {
-        type Conclusion = Person;
-
-        fn evaluate<'a, Env, M: Selection + 'a>(
-            self,
-            selection: M,
-            env: &'a Env,
-        ) -> impl Selection + 'a
-        where
-            Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
-        {
-            let application: ConceptQuery = self.into();
-            application.evaluate(selection, env)
-        }
-
-        fn realize(&self, source: Match) -> result::Result<Self::Conclusion, EvaluationError> {
-            Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&self.this))?)?,
-                name: String::try_from(source.lookup(&Term::from(&self.name))?)?,
-                age: u32::try_from(source.lookup(&Term::from(&self.age))?)?,
-            })
-        }
+        /// Person's name (`person/name`).
+        pub name: person::Name,
+        /// Person's age (`person/age`).
+        pub age: person::Age,
     }
 
     #[dialog_common::test]
     fn it_creates_person_concept() {
         // Test that the Person concept has the expected properties
-        let concept = person_predicate();
+        let concept = Person::descriptor().clone();
         // Operator is now a URI based on the hash of the concept's attributes
         assert!(
             concept.this().to_string().starts_with("concept:"),
@@ -355,10 +401,10 @@ mod tests {
     fn it_creates_person_match() {
         // Test creating a PersonQuery for querying
         let entity_var = Term::var("person_entity");
-        let name_var = Term::var("person_name");
-        let age_var = Term::var("person_age");
+        let name_var: Term<String> = Term::var("person_name");
+        let age_var: Term<u32> = Term::var("person_age");
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_var.clone(),
             age: age_var.clone(),
@@ -377,7 +423,7 @@ mod tests {
         let name_const = Term::from("Alice".to_string());
         let age_const = Term::from(30u32);
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_const.clone(),
             age: age_const.clone(),
@@ -397,9 +443,9 @@ mod tests {
         // Test mixing variables and constants in a match pattern
         let entity_var = Term::var("person_entity");
         let name_const = Term::from("Bob".to_string());
-        let age_var = Term::var("any_age");
+        let age_var: Term<u32> = Term::var("any_age");
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_const.clone(),
             age: age_var.clone(),
@@ -417,8 +463,8 @@ mod tests {
         let entity = Entity::new().unwrap();
         let person = Person {
             this: entity.clone(),
-            name: "Charlie".to_string(),
-            age: 25,
+            name: person::Name("Charlie".to_string()),
+            age: person::Age(25),
         };
 
         // Test Instance trait - should return the same entity
@@ -428,7 +474,7 @@ mod tests {
     #[dialog_common::test]
     fn it_maintains_concept_name_consistency() {
         // Test that concept identifier is consistent across different access patterns
-        let concept = person_predicate();
+        let concept = Person::descriptor().clone();
         // Operator is now a URI based on the hash of the concept's attributes
         assert!(
             concept.this().to_string().starts_with("concept:"),
@@ -438,8 +484,8 @@ mod tests {
         // The concept should have consistent naming
         let _person = Person {
             this: Entity::new().unwrap(),
-            name: "Test".to_string(),
-            age: 1,
+            name: person::Name("Test".to_string()),
+            age: person::Age(1),
         };
 
         // Instance should have the same concept identifier
@@ -455,10 +501,10 @@ mod tests {
     fn it_exposes_match_fields() {
         // Test that PersonQuery has the expected fields
         let entity_var = Term::var("entity");
-        let name_var = Term::var("name");
-        let age_var = Term::var("age");
+        let name_var: Term<String> = Term::var("name");
+        let age_var: Term<u32> = Term::var("age");
 
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: entity_var.clone(),
             name: name_var.clone(),
             age: age_var.clone(),
@@ -475,8 +521,8 @@ mod tests {
         // Test that our derived Debug implementations work
         let person = Person {
             this: Entity::new().unwrap(),
-            name: "Debug Test".to_string(),
-            age: 42,
+            name: person::Name("Debug Test".to_string()),
+            age: person::Age(42),
         };
 
         let debug_output = format!("{:?}", person);
@@ -491,8 +537,8 @@ mod tests {
         let entity = Entity::new().unwrap();
         let person1 = Person {
             this: entity.clone(),
-            name: "Original".to_string(),
-            age: 35,
+            name: person::Name("Original".to_string()),
+            age: person::Age(35),
         };
 
         let person2 = person1.clone();
@@ -502,7 +548,7 @@ mod tests {
 
         // Test PersonQuery clone
         let entity_var = Term::var("entity");
-        let match1 = PersonQuery {
+        let match1 = Query::<Person> {
             this: entity_var.clone(),
             name: Term::var("name"),
             age: Term::var("age"),
@@ -522,7 +568,7 @@ mod tests {
         let alice = Entity::new()?;
 
         // Test 1: Create a PersonQuery with mixed terms
-        let person_match = PersonQuery {
+        let person_match = Query::<Person> {
             this: Term::from(alice.clone()),
             name: Term::from("Alice".to_string()),
             age: Term::var("age"),
@@ -535,7 +581,7 @@ mod tests {
         assert!(params.get("age").is_some());
 
         // Test 2: Verify concept attributes are accessible
-        let concept = person_predicate();
+        let concept = Person::descriptor().clone();
         assert_eq!(concept.with().iter().count(), 2); // name and age
 
         // Verify we can find specific attributes

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -3,7 +3,7 @@ pub mod descriptor;
 /// Concept application for querying entities that match a concept pattern.
 pub mod query;
 
-pub use descriptor::ConceptDescriptor;
+pub use descriptor::{ConceptDescriptor, ConceptFieldDescriptor};
 pub use query::ConceptQuery;
 
 use crate::artifact::Type as ValueType;
@@ -77,11 +77,25 @@ pub trait ConceptField: Sized + Clone {
     type TermType: Typed + Clone + Debug + ConditionalSend + 'static;
 
     /// `true` if this field is set-widened (the `Option<N>` impl),
-    /// `false` for the bare-attribute (`N`) impl. Used by the
-    /// `#[derive(Concept)]` macro to route the field's descriptor
-    /// into either the `with` (required) or `maybe` (optional)
-    /// section of the generated `ConceptDescriptor`.
+    /// `false` for the bare-attribute (`N`) impl. Drives
+    /// [`field_descriptor`](Self::field_descriptor) and the
+    /// `#[derive(Concept)]` compile-time "at least one required
+    /// field" assertion.
     const OPTIONAL: bool;
+
+    /// The [`ConceptFieldDescriptor`] for this field: the underlying
+    /// attribute's descriptor wrapped with this field's optionality.
+    /// Used by `#[derive(Concept)]` to build the concept's attribute
+    /// map without branching on [`OPTIONAL`](Self::OPTIONAL) in the
+    /// generated code.
+    fn field_descriptor() -> ConceptFieldDescriptor {
+        let descriptor = <Self::Attribute as Descriptor<AttributeDescriptor>>::descriptor().clone();
+        if Self::OPTIONAL {
+            ConceptFieldDescriptor::optional(descriptor)
+        } else {
+            ConceptFieldDescriptor::required(descriptor)
+        }
+    }
 
     /// Build the `is` slot term for this field's attribute query.
     /// Required fields pass the user's `value_param` through

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -120,7 +120,7 @@ pub trait ConceptField: Sized + Clone {
 }
 
 // Required path: any `N` that satisfies the attribute bounds gets
-// the `ConceptField` impl with `RESOLUTION = Required` and
+// the `ConceptField` impl with `OPTIONAL = false` and
 // `TermType = N::Type`. This is the "bare attribute" case in a
 // concept field — `pub name: GivenName` and similar.
 //
@@ -176,7 +176,7 @@ where
 }
 
 // Optional path: `Option<N>` (where `N: Attribute`) gets the
-// `ConceptField` impl with `RESOLUTION = Optional` and
+// `ConceptField` impl with `OPTIONAL = true` and
 // `TermType = Option<N::Type>`. This is the "set-widened" case in
 // a concept field — `pub nickname: Option<Nickname>` and similar.
 // `realize` maps `Binding::Absent` to `None`; `push_statements`

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -1,6 +1,6 @@
 /// Named attribute collections for concept descriptors.
 mod named_attributes;
-pub use named_attributes::NamedAttributes;
+pub use named_attributes::{ConceptFieldDescriptor, NamedAttributes};
 
 use std::iter;
 
@@ -50,26 +50,17 @@ use std::ops::Not;
 pub struct ConceptDescriptor {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    with: NamedAttributes,
-    /// Optional (set-widened) attributes.
-    ///
-    /// Each `maybe` attribute is emitted into the rule body as an
-    /// `AttributeQuery` with `Resolution::Optional`: an entity that
-    /// lacks the fact still produces a row, with the slot bound to
+    /// All of the concept's attributes, required and optional alike.
+    /// Optionality is carried per-attribute by
+    /// [`AttributeDescriptor::is_optional`] (serialized as
+    /// `"optional": true` on the wire), so there is no separate
+    /// `maybe` block. An optional attribute is emitted into the rule
+    /// body as a set-widened `AttributeQuery`: a missing fact yields
+    /// a fallback row with the slot bound to
     /// [`Binding::Absent`](crate::Binding) rather than dropping the
-    /// row. Absence is row-level; no `Nothing` value is ever stored.
-    ///
-    /// Skipped during serialization when empty (`None`); an empty
-    /// map deserializes to `None` (treated as absent). Optional
-    /// attributes do **not** count toward the concept's required-
-    /// attribute minimum — a concept must still declare at least one
-    /// `with` attribute (see [`Self::validate`]).
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_maybe"
-    )]
-    maybe: Option<NamedAttributes>,
+    /// row. A concept must still declare at least one *required*
+    /// attribute.
+    with: NamedAttributes,
 }
 
 impl ConceptDescriptor {
@@ -95,45 +86,18 @@ impl ConceptDescriptor {
         self
     }
 
-    /// Returns a reference to the required (`with`) attributes.
+    /// Returns a reference to this concept's attributes (required
+    /// and optional alike). Use [`AttributeDescriptor::is_optional`]
+    /// to tell them apart.
     pub fn with(&self) -> &NamedAttributes {
         &self.with
     }
 
-    /// Returns a reference to the optional (`maybe`) attributes,
-    /// if any are declared. Optional fields are emitted into the
-    /// rule body as `AttributeQuery` premises with
-    /// `Resolution::Optional`, so that a missing fact yields a
-    /// fallback row with the slot bound to `Binding::Absent`
-    /// rather than dropping the row entirely.
-    pub fn maybe(&self) -> Option<&NamedAttributes> {
-        self.maybe.as_ref()
-    }
-
-    /// Returns a copy of this descriptor with the given optional
-    /// attributes installed in the `maybe` slot. Empty input
-    /// becomes `None` (no `maybe` block).
-    pub fn with_maybe<I, K>(mut self, maybe: I) -> Self
-    where
-        I: IntoIterator<Item = (K, AttributeDescriptor)>,
-        K: Into<String>,
-    {
-        let map: Vec<(String, AttributeDescriptor)> =
-            maybe.into_iter().map(|(k, v)| (k.into(), v)).collect();
-        self.maybe = if map.is_empty() {
-            None
-        } else {
-            // Non-empty by the guard above; `maybe` carries no
-            // minimum-count invariant of its own.
-            Some(NamedAttributes::from_pairs(map))
-        };
-        self
-    }
-
     /// Validates the provided parameters against the schema of the attributes.
     pub fn conform(&self, parameters: Parameters) -> Result<Parameters, TypeError> {
-        for (name, attribute) in self.with().iter() {
-            attribute
+        for (name, field) in self.with().iter() {
+            field
+                .descriptor()
                 .conform(parameters.get(name))
                 .map_err(|e| e.at(name.into()))?;
         }
@@ -141,9 +105,21 @@ impl ConceptDescriptor {
         Ok(parameters)
     }
 
-    /// Returns an iterator over operand names, starting with "this" followed by attribute keys.
+    /// Returns an iterator over the concept's *required* operand
+    /// names, starting with `"this"` followed by the required
+    /// attribute keys.
+    ///
+    /// Optional attributes are excluded: they may resolve to
+    /// `Absent`, so they are not subject to the required-head
+    /// grounding check. Use [`Self::with`] to enumerate every
+    /// attribute including optional ones.
     pub fn operands(&self) -> impl Iterator<Item = &str> {
-        iter::once("this").chain(self.with().keys())
+        iter::once("this").chain(
+            self.with()
+                .iter()
+                .filter(|(_, attribute)| !attribute.is_optional())
+                .map(|(name, _)| name),
+        )
     }
 
     /// Derives a `Schema` from this descriptor's attributes.
@@ -153,21 +129,41 @@ impl ConceptDescriptor {
 
     /// Encode this concept as CBOR for hashing.
     ///
-    /// Creates a CBOR-encoded representation as a map where:
-    /// - Keys are attribute URIs (the:{hash}) in sorted order
-    /// - Values are empty objects {}
+    /// Creates a CBOR-encoded map where:
+    /// - Keys are attribute URIs (`the:{hash}`) in sorted order.
+    /// - The value for a **required** attribute is an empty map `{}`.
+    /// - The value for an **optional** attribute is `{ "optional":
+    ///   true }`.
+    ///
+    /// A concept with no optional attributes therefore hashes
+    /// exactly as it did before optionality existed (every value is
+    /// `{}`), so existing concept identities are preserved. Marking
+    /// an attribute optional changes its value object, and thus the
+    /// concept's identity.
     pub fn to_cbor_bytes(&self) -> Vec<u8> {
         use serde::Serialize;
         use std::collections::BTreeMap;
 
+        /// Per-attribute hash value: `{}` for required,
+        /// `{ "optional": true }` for optional. `optional` is omitted
+        /// when false, so a required attribute encodes as an empty
+        /// map — byte-identical to the pre-optionality encoding.
         #[derive(Serialize)]
-        struct EmptyObject {}
+        struct AttributeIdentity {
+            #[serde(skip_serializing_if = "std::ops::Not::not")]
+            optional: bool,
+        }
 
-        let mut attr_map: BTreeMap<String, EmptyObject> = BTreeMap::new();
+        let mut attr_map: BTreeMap<String, AttributeIdentity> = BTreeMap::new();
 
         for (_name, schema) in self.with().iter() {
             let uri = schema.to_uri();
-            attr_map.insert(uri, EmptyObject {});
+            attr_map.insert(
+                uri,
+                AttributeIdentity {
+                    optional: schema.is_optional(),
+                },
+            );
         }
 
         serde_ipld_dagcbor::to_vec(&attr_map).expect("CBOR encoding should not fail")
@@ -201,13 +197,14 @@ impl ConceptDescriptor {
     /// Validates a model against this descriptor's schema and creates an instance.
     fn conform_model(&self, model: Model) -> Result<ConceptStatement, TypeError> {
         let mut relations = vec![];
-        for (name, attribute) in self.with().iter() {
+        for (name, field) in self.with().iter() {
             if let Some(value) = model.attributes.get(name) {
-                let relation = attribute
+                let relation = field
+                    .descriptor()
                     .resolve(value.clone())
                     .map_err(|e| e.at(name.to_string()))?;
                 relations.push(relation);
-            } else {
+            } else if !field.is_optional() {
                 return Err(TypeError::OmittedRequirement {
                     binding: name.into(),
                 });
@@ -230,23 +227,37 @@ impl ConceptDescriptor {
     }
 }
 
-/// Build a [`ConceptDescriptor`] from a validated, non-empty
-/// [`NamedAttributes`] required set. Private: the only way to obtain
-/// a `NamedAttributes` is through its own (fallible) constructors,
-/// so reaching here means the non-empty invariant already holds.
+/// Build a [`ConceptDescriptor`] from a validated [`NamedAttributes`]
+/// set. Private: the only way to obtain a `NamedAttributes` is
+/// through its own (fallible) constructors, which guarantee at least
+/// one required attribute, so reaching here means the invariant
+/// already holds.
 fn descriptor_from_with(with: NamedAttributes) -> ConceptDescriptor {
     ConceptDescriptor {
         description: None,
-        maybe: None,
         with,
     }
+}
+
+/// Wrap a `(name, AttributeDescriptor)` pair as a *required* concept
+/// field. The collection `TryFrom` impls accept bare attribute
+/// descriptors for ergonomics — a hand-written
+/// `ConceptDescriptor::try_from([("name", AttributeDescriptor::new(..))])`
+/// means "this attribute is required." Optional fields are built via
+/// [`ConceptFieldDescriptor::optional`] and the
+/// `ConceptFieldDescriptor`-keyed `TryFrom` impls.
+fn required_field<K: Into<String>>(
+    (name, attr): (K, AttributeDescriptor),
+) -> (String, ConceptFieldDescriptor) {
+    (name.into(), ConceptFieldDescriptor::required(attr))
 }
 
 impl<const N: usize> TryFrom<[(&str, AttributeDescriptor); N]> for ConceptDescriptor {
     type Error = TypeError;
 
     fn try_from(arr: [(&str, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
-        Ok(descriptor_from_with(NamedAttributes::try_from(arr)?))
+        let pairs: Vec<_> = arr.into_iter().map(required_field).collect();
+        Ok(descriptor_from_with(NamedAttributes::try_from(pairs)?))
     }
 }
 
@@ -254,7 +265,8 @@ impl<const N: usize> TryFrom<[(String, AttributeDescriptor); N]> for ConceptDesc
     type Error = TypeError;
 
     fn try_from(arr: [(String, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
-        Ok(descriptor_from_with(NamedAttributes::try_from(arr)?))
+        let pairs: Vec<_> = arr.into_iter().map(required_field).collect();
+        Ok(descriptor_from_with(NamedAttributes::try_from(pairs)?))
     }
 }
 
@@ -262,7 +274,8 @@ impl TryFrom<Vec<(&str, AttributeDescriptor)>> for ConceptDescriptor {
     type Error = TypeError;
 
     fn try_from(vec: Vec<(&str, AttributeDescriptor)>) -> Result<Self, Self::Error> {
-        Ok(descriptor_from_with(NamedAttributes::try_from(vec)?))
+        let pairs: Vec<_> = vec.into_iter().map(required_field).collect();
+        Ok(descriptor_from_with(NamedAttributes::try_from(pairs)?))
     }
 }
 
@@ -270,7 +283,8 @@ impl TryFrom<Vec<(String, AttributeDescriptor)>> for ConceptDescriptor {
     type Error = TypeError;
 
     fn try_from(vec: Vec<(String, AttributeDescriptor)>) -> Result<Self, Self::Error> {
-        Ok(descriptor_from_with(NamedAttributes::try_from(vec)?))
+        let pairs: Vec<_> = vec.into_iter().map(required_field).collect();
+        Ok(descriptor_from_with(NamedAttributes::try_from(pairs)?))
     }
 }
 
@@ -278,7 +292,19 @@ impl TryFrom<HashMap<String, AttributeDescriptor>> for ConceptDescriptor {
     type Error = TypeError;
 
     fn try_from(map: HashMap<String, AttributeDescriptor>) -> Result<Self, Self::Error> {
-        Ok(descriptor_from_with(NamedAttributes::try_from(map)?))
+        let pairs: Vec<_> = map.into_iter().map(required_field).collect();
+        Ok(descriptor_from_with(NamedAttributes::try_from(pairs)?))
+    }
+}
+
+/// Build a descriptor directly from already-wrapped concept fields
+/// (required and/or optional). Used by the `#[derive(Concept)]`
+/// macro path, which tags each field's optionality before building.
+impl TryFrom<Vec<(String, ConceptFieldDescriptor)>> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(fields: Vec<(String, ConceptFieldDescriptor)>) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(fields)?))
     }
 }
 
@@ -286,14 +312,21 @@ impl From<&ConceptDescriptor> for Schema {
     fn from(predicate: &ConceptDescriptor) -> Self {
         use crate::type_system::Type as Kind;
         let mut schema = Schema::new();
-        for (name, attribute) in predicate.with().iter() {
+        for (name, field) in predicate.with().iter() {
             schema.insert(
                 name.into(),
                 Field {
-                    description: attribute.description().into(),
-                    content_type: attribute.content_type().map(Kind::primitive),
+                    description: field.description().into(),
+                    content_type: field.content_type().map(Kind::primitive),
+                    // Every concept slot is `Optional` at the schema
+                    // layer: a `concept:` query *produces* its fields
+                    // rather than requiring the caller to supply them.
+                    // This is orthogonal to a field's `is_optional()`
+                    // (set-widened / Absent-on-miss) concept-membership
+                    // flag, which is carried into the rule body via the
+                    // `is` term's kind, not the schema requirement.
                     requirement: Requirement::Optional,
-                    cardinality: attribute.cardinality(),
+                    cardinality: field.cardinality(),
                 },
             );
         }
@@ -311,21 +344,6 @@ impl From<&ConceptDescriptor> for Schema {
         }
 
         schema
-    }
-}
-
-/// Deserializes an optional `NamedAttributes` map, treating an empty map as `None`.
-fn deserialize_maybe<'de, D>(deserializer: D) -> Result<Option<NamedAttributes>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let map = HashMap::<String, AttributeDescriptor>::deserialize(deserializer)?;
-    if map.is_empty() {
-        Ok(None)
-    } else {
-        // Non-empty by the guard above; the `maybe` slot has no
-        // minimum-count invariant, so build directly.
-        Ok(Some(NamedAttributes::from_pairs(map.into_iter().collect())))
     }
 }
 
@@ -957,7 +975,7 @@ mod tests {
     /// - Top-level object
     /// - "with" key is required, maps field names to Attribute objects
     /// - "description" key is optional string
-    /// - Each Attribute has "the" (required), optional "description", "cardinality", "as"
+    /// - Each Attribute has "the" (required), optional "description", "cardinality", "as", "optional"
     /// - No unexpected top-level keys (only "description", "with")
     #[dialog_common::test]
     fn it_conforms_to_json_schema() {
@@ -987,10 +1005,10 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
         let obj = parsed.as_object().expect("Top-level must be object");
 
-        // Only allowed top-level keys per schema: "description", "with", "maybe"
+        // Only allowed top-level keys per schema: "description", "with"
         for key in obj.keys() {
             assert!(
-                ["description", "with", "maybe"].contains(&key.as_str()),
+                ["description", "with"].contains(&key.as_str()),
                 "Unexpected top-level key: {key}"
             );
         }
@@ -1031,7 +1049,7 @@ mod tests {
             // Only allowed attribute keys per schema
             for key in attr.keys() {
                 assert!(
-                    ["the", "description", "cardinality", "as"].contains(&key.as_str()),
+                    ["the", "description", "cardinality", "as", "optional"].contains(&key.as_str()),
                     "Unexpected key '{key}' in attribute '{field_name}'"
                 );
             }
@@ -1256,64 +1274,78 @@ mod tests {
         );
     }
 
-    /// A concept with only optional (`maybe`) attributes and an empty
-    /// `with` is just as degenerate: with no required attribute, the
-    /// rule body binds nothing that constrains the entity, so every
-    /// entity matches. Rejected at the parse layer.
+    /// A concept whose every attribute is optional is just as
+    /// degenerate: with no required attribute, the rule body binds
+    /// nothing that constrains the entity, so every entity matches.
+    /// Rejected at the parse layer.
     #[dialog_common::test]
     fn it_rejects_all_optional_concept_at_parse() {
         let json = r#"{
-            "with": {},
-            "maybe": {
-                "bio": { "the": "user/bio", "as": "Text" }
+            "with": {
+                "bio": { "the": "user/bio", "as": "Text", "optional": true }
             }
         }"#;
 
         let result = serde_json::from_str::<ConceptDescriptor>(json);
         assert!(
             result.is_err(),
-            "Should reject a concept with no required attributes (empty `with`), \
-             even when `maybe` attributes are present"
+            "Should reject a concept with no required attributes \
+             (every `with` entry flagged optional)"
         );
     }
 
     #[dialog_common::test]
-    fn it_accepts_maybe_field() {
+    fn it_accepts_optional_field() {
         let json = r#"{
             "with": {
-                "name": { "the": "user/name", "as": "Text" }
-            },
-            "maybe": {
-                "bio": { "the": "user/bio", "as": "Text" }
+                "name": { "the": "user/name", "as": "Text" },
+                "bio": { "the": "user/bio", "as": "Text", "optional": true }
             }
         }"#;
 
         let concept: ConceptDescriptor =
-            serde_json::from_str(json).expect("Should accept 'maybe' field");
+            serde_json::from_str(json).expect("Should accept an optional field");
 
-        assert_eq!(concept.with().iter().count(), 1);
+        assert_eq!(concept.with().iter().count(), 2);
+
+        let bio = concept
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "bio")
+            .map(|(_, field)| field)
+            .expect("bio field present");
+        assert!(bio.is_optional(), "bio must be optional");
+
+        let name = concept
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "name")
+            .map(|(_, field)| field)
+            .expect("name field present");
+        assert!(!name.is_optional(), "name must be required");
     }
 
     #[dialog_common::test]
-    fn it_validates_maybe_on_parse() {
+    fn it_validates_optional_field_on_parse() {
         let json = r#"{
             "with": {
-                "name": { "the": "user/name", "as": "Text" }
-            },
-            "maybe": {
-                "bio": { "the": "invalid" }
+                "name": { "the": "user/name", "as": "Text" },
+                "bio": { "the": "invalid", "optional": true }
             }
         }"#;
 
         let result = serde_json::from_str::<ConceptDescriptor>(json);
         assert!(
             result.is_err(),
-            "Should validate 'maybe' attributes even though they are not yet supported"
+            "Should validate optional attributes the same as required ones"
         );
     }
 
+    /// A required-only concept must serialize with no `optional`
+    /// keys anywhere, byte-compatible with the pre-optionality
+    /// encoding. There is no separate top-level `maybe` block either.
     #[dialog_common::test]
-    fn it_omits_maybe_in_serialization() {
+    fn it_omits_optional_flag_for_required_fields() {
         let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
@@ -1330,8 +1362,72 @@ mod tests {
 
         assert!(
             parsed.get("maybe").is_none(),
-            "Should not serialize 'maybe' when absent"
+            "There is no top-level 'maybe' block"
         );
+
+        let with = parsed["with"].as_object().expect("Should have 'with'");
+        for (field_name, attr) in with {
+            assert!(
+                attr.as_object()
+                    .expect("attribute is an object")
+                    .get("optional")
+                    .is_none(),
+                "Required field '{field_name}' must omit the 'optional' key"
+            );
+        }
+    }
+
+    /// An optional field round-trips, carrying `"optional": true` on
+    /// the wire and parsing back as optional.
+    #[dialog_common::test]
+    fn it_round_trips_an_optional_field() {
+        let concept = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("user/name"),
+                    "User's name",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "bio".to_string(),
+                ConceptFieldDescriptor::optional(AttributeDescriptor::new(
+                    the!("user/bio"),
+                    "User's bio",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+        ])
+        .unwrap();
+
+        let json = serde_json::to_string(&concept).expect("Should serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
+
+        let with = parsed["with"].as_object().expect("Should have 'with'");
+        assert_eq!(
+            with["bio"]["optional"],
+            serde_json::json!(true),
+            "Optional field must carry 'optional': true"
+        );
+        assert!(
+            with["name"].as_object().unwrap().get("optional").is_none(),
+            "Required field must omit 'optional'"
+        );
+
+        let round_tripped: ConceptDescriptor =
+            serde_json::from_str(&json).expect("Should deserialize");
+        assert_eq!(round_tripped.this(), concept.this());
+
+        let bio = round_tripped
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "bio")
+            .map(|(_, field)| field)
+            .expect("bio present");
+        assert!(bio.is_optional());
     }
 
     #[dialog_common::test]
@@ -1444,19 +1540,73 @@ mod tests {
         );
     }
 
+    /// Marking a field optional changes the concept's identity, but a
+    /// required-only concept hashes exactly as it would have before
+    /// optionality existed: building the same attribute as required
+    /// yields the same `this`/`hash`, while flipping it to optional
+    /// changes both.
     #[dialog_common::test]
-    fn it_deserializes_empty_maybe_as_none() {
-        let json = r#"{
-            "with": {
-                "name": { "the": "user/name", "as": "Text" }
-            },
-            "maybe": {}
-        }"#;
+    fn it_hashes_optionality_into_identity() {
+        let name_attr = || {
+            AttributeDescriptor::new(
+                the!("user/name"),
+                "User's name",
+                Cardinality::One,
+                Some(Type::String),
+            )
+        };
+        let bio_attr = || {
+            AttributeDescriptor::new(
+                the!("user/bio"),
+                "User's bio",
+                Cardinality::One,
+                Some(Type::String),
+            )
+        };
 
-        let concept: ConceptDescriptor =
-            serde_json::from_str(json).expect("Should accept empty 'maybe'");
+        // Two required-only concepts built from the same attributes
+        // are identical, regardless of construction path.
+        let required_array =
+            ConceptDescriptor::try_from([("name", name_attr()), ("bio", bio_attr())]).unwrap();
+        let required_fields = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(name_attr()),
+            ),
+            (
+                "bio".to_string(),
+                ConceptFieldDescriptor::required(bio_attr()),
+            ),
+        ])
+        .unwrap();
+        assert_eq!(
+            required_array.hash(),
+            required_fields.hash(),
+            "required-only concept identity is independent of construction path"
+        );
 
-        assert_eq!(concept.maybe, None, "Empty 'maybe' should become None");
+        // Flipping `bio` to optional changes the identity.
+        let with_optional = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(name_attr()),
+            ),
+            (
+                "bio".to_string(),
+                ConceptFieldDescriptor::optional(bio_attr()),
+            ),
+        ])
+        .unwrap();
+        assert_ne!(
+            required_array.hash(),
+            with_optional.hash(),
+            "marking a field optional must change the concept's hash"
+        );
+        assert_ne!(
+            required_array.this(),
+            with_optional.this(),
+            "marking a field optional must change the concept's URI"
+        );
     }
 
     /// `From<&ConceptDescriptor> for Schema` lifts a typed

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -51,14 +51,19 @@ pub struct ConceptDescriptor {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     with: NamedAttributes,
-    /// Optional attributes — not yet supported by the query engine.
+    /// Optional (set-widened) attributes.
     ///
-    /// Accepted during deserialization to ensure documents written against
-    /// the full schema are validated now rather than silently accepted and
-    /// broken later when `maybe` support lands.  Skipped during
-    /// serialization because the engine never produces them.
+    /// Each `maybe` attribute is emitted into the rule body as an
+    /// `AttributeQuery` with `Resolution::Optional`: an entity that
+    /// lacks the fact still produces a row, with the slot bound to
+    /// [`Binding::Absent`](crate::Binding) rather than dropping the
+    /// row. Absence is row-level; no `Nothing` value is ever stored.
     ///
-    /// An empty map deserializes to `None` (treated as absent).
+    /// Skipped during serialization when empty (`None`); an empty
+    /// map deserializes to `None` (treated as absent). Optional
+    /// attributes do **not** count toward the concept's required-
+    /// attribute minimum — a concept must still declare at least one
+    /// `with` attribute (see [`Self::validate`]).
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -90,9 +95,39 @@ impl ConceptDescriptor {
         self
     }
 
-    /// Returns a reference to the named attributes.
+    /// Returns a reference to the required (`with`) attributes.
     pub fn with(&self) -> &NamedAttributes {
         &self.with
+    }
+
+    /// Returns a reference to the optional (`maybe`) attributes,
+    /// if any are declared. Optional fields are emitted into the
+    /// rule body as `AttributeQuery` premises with
+    /// `Resolution::Optional`, so that a missing fact yields a
+    /// fallback row with the slot bound to `Binding::Absent`
+    /// rather than dropping the row entirely.
+    pub fn maybe(&self) -> Option<&NamedAttributes> {
+        self.maybe.as_ref()
+    }
+
+    /// Returns a copy of this descriptor with the given optional
+    /// attributes installed in the `maybe` slot. Empty input
+    /// becomes `None` (no `maybe` block).
+    pub fn with_maybe<I, K>(mut self, maybe: I) -> Self
+    where
+        I: IntoIterator<Item = (K, AttributeDescriptor)>,
+        K: Into<String>,
+    {
+        let map: Vec<(String, AttributeDescriptor)> =
+            maybe.into_iter().map(|(k, v)| (k.into(), v)).collect();
+        self.maybe = if map.is_empty() {
+            None
+        } else {
+            // Non-empty by the guard above; `maybe` carries no
+            // minimum-count invariant of its own.
+            Some(NamedAttributes::from_pairs(map))
+        };
+        self
     }
 
     /// Validates the provided parameters against the schema of the attributes.
@@ -195,65 +230,68 @@ impl ConceptDescriptor {
     }
 }
 
-impl<const N: usize> From<[(&str, AttributeDescriptor); N]> for ConceptDescriptor {
-    fn from(arr: [(&str, AttributeDescriptor); N]) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(arr),
-        }
+/// Build a [`ConceptDescriptor`] from a validated, non-empty
+/// [`NamedAttributes`] required set. Private: the only way to obtain
+/// a `NamedAttributes` is through its own (fallible) constructors,
+/// so reaching here means the non-empty invariant already holds.
+fn descriptor_from_with(with: NamedAttributes) -> ConceptDescriptor {
+    ConceptDescriptor {
+        description: None,
+        maybe: None,
+        with,
     }
 }
 
-impl<const N: usize> From<[(String, AttributeDescriptor); N]> for ConceptDescriptor {
-    fn from(arr: [(String, AttributeDescriptor); N]) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(arr),
-        }
+impl<const N: usize> TryFrom<[(&str, AttributeDescriptor); N]> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(arr: [(&str, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(arr)?))
     }
 }
 
-impl From<Vec<(&str, AttributeDescriptor)>> for ConceptDescriptor {
-    fn from(vec: Vec<(&str, AttributeDescriptor)>) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(vec),
-        }
+impl<const N: usize> TryFrom<[(String, AttributeDescriptor); N]> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(arr: [(String, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(arr)?))
     }
 }
 
-impl From<Vec<(String, AttributeDescriptor)>> for ConceptDescriptor {
-    fn from(vec: Vec<(String, AttributeDescriptor)>) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(vec),
-        }
+impl TryFrom<Vec<(&str, AttributeDescriptor)>> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(&str, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(vec)?))
     }
 }
 
-impl From<HashMap<String, AttributeDescriptor>> for ConceptDescriptor {
-    fn from(map: HashMap<String, AttributeDescriptor>) -> Self {
-        ConceptDescriptor {
-            description: None,
-            maybe: None,
-            with: NamedAttributes::from(map),
-        }
+impl TryFrom<Vec<(String, AttributeDescriptor)>> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(String, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(vec)?))
+    }
+}
+
+impl TryFrom<HashMap<String, AttributeDescriptor>> for ConceptDescriptor {
+    type Error = TypeError;
+
+    fn try_from(map: HashMap<String, AttributeDescriptor>) -> Result<Self, Self::Error> {
+        Ok(descriptor_from_with(NamedAttributes::try_from(map)?))
     }
 }
 
 impl From<&ConceptDescriptor> for Schema {
     fn from(predicate: &ConceptDescriptor) -> Self {
+        use crate::type_system::Type as Kind;
         let mut schema = Schema::new();
         for (name, attribute) in predicate.with().iter() {
             schema.insert(
                 name.into(),
                 Field {
                     description: attribute.description().into(),
-                    content_type: attribute.content_type(),
+                    content_type: attribute.content_type().map(Kind::primitive),
                     requirement: Requirement::Optional,
                     cardinality: attribute.cardinality(),
                 },
@@ -265,7 +303,7 @@ impl From<&ConceptDescriptor> for Schema {
                 "this".into(),
                 Field {
                     description: "The entity that this model represents".into(),
-                    content_type: Some(Type::Entity),
+                    content_type: Some(Kind::primitive(Type::Entity)),
                     requirement: Requirement::Optional,
                     cardinality: Cardinality::One,
                 },
@@ -285,7 +323,9 @@ where
     if map.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(NamedAttributes::from(map)))
+        // Non-empty by the guard above; the `maybe` slot has no
+        // minimum-count invariant, so build directly.
+        Ok(Some(NamedAttributes::from_pairs(map.into_iter().collect())))
     }
 }
 
@@ -415,11 +455,11 @@ impl ConceptConclusion {
                 name: Some(name), ..
             } => {
                 let typed_term: Term<T> = Term::var(name.clone());
-                T::try_from(self.source.lookup(&Term::from(&typed_term))?).map_err(|_| {
-                    EvaluationError::UnboundVariable {
+                T::try_from(self.source.lookup(&Term::from(&typed_term))?.content()?).map_err(
+                    |_| EvaluationError::UnboundVariable {
                         variable_name: field.to_string(),
-                    }
-                })
+                    },
+                )
             }
             Term::Constant(value) => {
                 T::try_from(value.clone()).map_err(|_| EvaluationError::UnboundVariable {
@@ -478,7 +518,7 @@ impl Application for ConceptQuery {
                 name: Some(name), ..
             } => {
                 let typed_term: Term<Entity> = Term::var(name.clone());
-                Entity::try_from(source.lookup(&Term::from(&typed_term))?)?
+                Entity::try_from(source.lookup(&Term::from(&typed_term))?.content()?)?
             }
             Term::Constant(value) => match value {
                 Value::Entity(e) => e.clone(),
@@ -527,7 +567,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_serializes_to_expected_json() {
-        let predicate = ConceptDescriptor::from([
+        let predicate = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -546,7 +586,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
 
@@ -641,7 +682,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_serializes_with_description() {
-        let mut predicate = ConceptDescriptor::from([(
+        let mut predicate = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -649,7 +690,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         predicate.description = Some("A user profile".to_string());
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
@@ -661,7 +703,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_omits_null_description_in_json() {
-        let predicate = ConceptDescriptor::from([(
+        let predicate = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -669,7 +711,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
@@ -680,7 +723,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_round_trips_through_json() {
-        let original = ConceptDescriptor::from([(
+        let original = ConceptDescriptor::try_from([(
             "score",
             AttributeDescriptor::new(
                 the!("game/score"),
@@ -688,7 +731,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::UnsignedInt),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string(&original).expect("Should serialize");
         let deserialized: ConceptDescriptor =
@@ -720,7 +764,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_produces_expected_json_structure() {
-        let predicate = ConceptDescriptor::from(vec![(
+        let predicate = ConceptDescriptor::try_from(vec![(
             "id".to_string(),
             AttributeDescriptor::new(
                 the!("product/id"),
@@ -728,7 +772,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::UnsignedInt),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string_pretty(&predicate).expect("Should serialize");
 
@@ -755,7 +800,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_ignores_field_names_in_hash() {
-        let pred1 = ConceptDescriptor::from(vec![
+        let pred1 = ConceptDescriptor::try_from(vec![
             (
                 "field_a".to_string(),
                 AttributeDescriptor::new(
@@ -774,9 +819,10 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
-        let pred2 = ConceptDescriptor::from(vec![
+        let pred2 = ConceptDescriptor::try_from(vec![
             (
                 "different_field_1".to_string(),
                 AttributeDescriptor::new(
@@ -795,7 +841,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         assert_eq!(
             pred1.hash(),
@@ -812,7 +859,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_ignores_attribute_order_in_hash() {
-        let pred1 = ConceptDescriptor::from(vec![
+        let pred1 = ConceptDescriptor::try_from(vec![
             (
                 "name".to_string(),
                 AttributeDescriptor::new(
@@ -831,9 +878,10 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
-        let pred2 = ConceptDescriptor::from(vec![
+        let pred2 = ConceptDescriptor::try_from(vec![
             (
                 "age".to_string(),
                 AttributeDescriptor::new(
@@ -852,7 +900,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         assert_eq!(
             pred1.hash(),
@@ -869,7 +918,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_hashes_differently_for_different_attributes() {
-        let pred1 = ConceptDescriptor::from(vec![(
+        let pred1 = ConceptDescriptor::try_from(vec![(
             "name".to_string(),
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -877,9 +926,10 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
-        let pred2 = ConceptDescriptor::from(vec![(
+        let pred2 = ConceptDescriptor::try_from(vec![(
             "email".to_string(),
             AttributeDescriptor::new(
                 the!("person/email"),
@@ -887,7 +937,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         assert_ne!(
             pred1.hash(),
@@ -910,7 +961,7 @@ mod tests {
     /// - No unexpected top-level keys (only "description", "with")
     #[dialog_common::test]
     fn it_conforms_to_json_schema() {
-        let predicate = ConceptDescriptor::from([
+        let predicate = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -929,7 +980,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let json = serde_json::to_string(&predicate).expect("Should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
@@ -1187,6 +1239,44 @@ mod tests {
         assert!(result.is_err(), "Should reject empty object");
     }
 
+    /// A concept must have at least one required (`with`) attribute.
+    /// An empty `with` map describes a concept every entity trivially
+    /// matches — the same degenerate shape as a concept with no
+    /// attributes at all — so the parse layer rejects it.
+    #[dialog_common::test]
+    fn it_rejects_empty_with_at_parse() {
+        let json = r#"{
+            "with": {}
+        }"#;
+
+        let result = serde_json::from_str::<ConceptDescriptor>(json);
+        assert!(
+            result.is_err(),
+            "Should reject a concept whose `with` map is empty"
+        );
+    }
+
+    /// A concept with only optional (`maybe`) attributes and an empty
+    /// `with` is just as degenerate: with no required attribute, the
+    /// rule body binds nothing that constrains the entity, so every
+    /// entity matches. Rejected at the parse layer.
+    #[dialog_common::test]
+    fn it_rejects_all_optional_concept_at_parse() {
+        let json = r#"{
+            "with": {},
+            "maybe": {
+                "bio": { "the": "user/bio", "as": "Text" }
+            }
+        }"#;
+
+        let result = serde_json::from_str::<ConceptDescriptor>(json);
+        assert!(
+            result.is_err(),
+            "Should reject a concept with no required attributes (empty `with`), \
+             even when `maybe` attributes are present"
+        );
+    }
+
     #[dialog_common::test]
     fn it_accepts_maybe_field() {
         let json = r#"{
@@ -1224,7 +1314,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_omits_maybe_in_serialization() {
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -1232,7 +1322,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let json = serde_json::to_string(&concept).expect("Should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse");
@@ -1261,8 +1352,7 @@ mod tests {
             pub r#type: TypeAttr,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Sample as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Sample::descriptor().clone();
 
         // Round-trip the descriptor through JSON and assert the field
         // key in the `with` map is `type`, not `r#type`.
@@ -1327,8 +1417,7 @@ mod tests {
             pub email: D,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Sample as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Sample::descriptor().clone();
 
         let json = serde_json::to_value(&descriptor).expect("serialize");
         let with = json["with"].as_object().expect("with map");
@@ -1370,6 +1459,61 @@ mod tests {
         assert_eq!(concept.maybe, None, "Empty 'maybe' should become None");
     }
 
+    /// `From<&ConceptDescriptor> for Schema` lifts a typed
+    /// attribute's content_type into the unified `type_system::Type`.
+    #[dialog_common::test]
+    fn schema_from_concept_uses_unified_type() {
+        let descriptor = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let schema = Schema::from(&descriptor);
+        let name = schema.get("name").expect("name field present");
+        let content = name.content_type().expect("content_type present");
+        assert!(!content.is_optional());
+        assert_eq!(content.as_value_type(), Some(Type::String));
+    }
+
+    /// An attribute descriptor with `None` content type produces
+    /// a Field with `None` content_type — unknown.
+    #[dialog_common::test]
+    fn schema_from_concept_untyped_attribute_produces_none() {
+        let descriptor = ConceptDescriptor::try_from(vec![(
+            "tag",
+            AttributeDescriptor::new(the!("misc/tag"), "", Cardinality::One, None),
+        )])
+        .unwrap();
+        let schema = Schema::from(&descriptor);
+        let tag = schema.get("tag").expect("tag field present");
+        assert!(tag.content_type().is_none());
+    }
+
+    /// The synthesized `this` field always declares
+    /// a singleton primitive over `Entity`.
+    #[dialog_common::test]
+    fn schema_from_concept_synthesizes_this_as_entity() {
+        let descriptor = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let schema = Schema::from(&descriptor);
+        let this = schema.get("this").expect("this field present");
+        let content = this.content_type().expect("entity kind present");
+        assert_eq!(content.as_value_type(), Some(Type::Entity));
+    }
+
     #[dialog_common::test]
     fn it_carries_the_concept_doc_comment_into_the_descriptor() {
         use crate::{Attribute, Concept, Entity};
@@ -1392,8 +1536,7 @@ mod tests {
             pub title: Title,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Recipe as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Recipe::descriptor().clone();
 
         assert_eq!(
             descriptor.description(),
@@ -1431,8 +1574,7 @@ mod tests {
             pub title: Title,
         }
 
-        let descriptor: ConceptDescriptor =
-            <Recipe as crate::Predicate>::Application::default().into();
+        let descriptor: ConceptDescriptor = Recipe::descriptor().clone();
 
         assert_eq!(descriptor.description(), None);
         let json = serde_json::to_value(&descriptor).expect("serialize");
@@ -1444,7 +1586,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_sets_the_description_via_with_description() {
-        let descriptor = ConceptDescriptor::from([(
+        let descriptor = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -1452,7 +1594,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         // `From<[..]>` leaves `description` as `None`.
         assert_eq!(descriptor.description(), None);

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -1,53 +1,166 @@
-use crate::attribute::AttributeDescriptor;
+use crate::Cardinality;
+use crate::artifact::Type;
+use crate::attribute::{AttributeDescriptor, The};
 use crate::error::TypeError;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-/// A non-empty collection of named attribute descriptors.
+/// `skip_serializing_if` helper: a required field omits the
+/// `optional` key on the wire, so a required entry serializes
+/// exactly as a bare [`AttributeDescriptor`] did before optionality
+/// existed.
+fn is_not_optional(optional: &bool) -> bool {
+    !*optional
+}
+
+/// A single attribute as it participates in a concept: the
+/// [`AttributeDescriptor`] plus the concept-membership facts about
+/// it (currently just whether it is `optional`).
 ///
-/// `NamedAttributes` is valid by construction: it cannot hold zero
-/// entries. Every public construction path is fallible
-/// ([`TryFrom`] for arrays / `Vec` / `HashMap`, and [`Deserialize`])
-/// and returns an error on an empty input. A concept's required
-/// (`with`) attribute set is a `NamedAttributes`, so this single
-/// chokepoint guarantees a concept always declares at least one
-/// required attribute — a concept with none would constrain nothing
-/// and match every entity.
+/// Attributes themselves are always required — an attribute is an
+/// attribute. Optionality is a property of *how a concept uses* the
+/// attribute (`Option<T>` field in a `#[derive(Concept)]` struct),
+/// so it lives here, at the concept-field layer, not on
+/// [`AttributeDescriptor`].
 ///
-/// Serializes as a JSON map: `{ "field-name": { "the": "domain/name", ... } }`
+/// On the wire the descriptor is flattened, so a field serializes as
+/// a single object carrying the attribute fields plus an optional
+/// `"optional": true`:
+///
+/// ```json
+/// { "the": "person/nickname", "as": "Text", "optional": true }
+/// ```
+///
+/// A required field omits `optional`, so it is byte-identical to the
+/// pre-optionality encoding.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConceptFieldDescriptor {
+    #[serde(flatten)]
+    descriptor: AttributeDescriptor,
+    /// Whether this field is optional (set-widened) within the
+    /// concept: a missing fact yields an `Absent` row instead of
+    /// dropping the row. Required fields (the default) omit this on
+    /// the wire.
+    #[serde(default, skip_serializing_if = "is_not_optional")]
+    optional: bool,
+}
+
+impl ConceptFieldDescriptor {
+    /// A required concept field wrapping the given attribute descriptor.
+    pub fn required(descriptor: AttributeDescriptor) -> Self {
+        Self {
+            descriptor,
+            optional: false,
+        }
+    }
+
+    /// An optional (set-widened) concept field wrapping the given
+    /// attribute descriptor.
+    pub fn optional(descriptor: AttributeDescriptor) -> Self {
+        Self {
+            descriptor,
+            optional: true,
+        }
+    }
+
+    /// The underlying attribute descriptor.
+    pub fn descriptor(&self) -> &AttributeDescriptor {
+        &self.descriptor
+    }
+
+    /// Returns `true` iff this field is optional (set-widened).
+    pub fn is_optional(&self) -> bool {
+        self.optional
+    }
+
+    /// Convenience: the attribute's relation identifier.
+    pub fn the(&self) -> &The {
+        self.descriptor.the()
+    }
+
+    /// Convenience: the attribute's domain.
+    pub fn domain(&self) -> &str {
+        self.descriptor.domain()
+    }
+
+    /// Convenience: the attribute's name.
+    pub fn name(&self) -> &str {
+        self.descriptor.name()
+    }
+
+    /// Convenience: the attribute's content type, if known.
+    pub fn content_type(&self) -> Option<Type> {
+        self.descriptor.content_type()
+    }
+
+    /// Convenience: the attribute's cardinality.
+    pub fn cardinality(&self) -> Cardinality {
+        self.descriptor.cardinality()
+    }
+
+    /// Convenience: the attribute's description.
+    pub fn description(&self) -> &str {
+        self.descriptor.description()
+    }
+
+    /// Convenience: the attribute's content-addressed URI.
+    pub fn to_uri(&self) -> String {
+        self.descriptor.to_uri()
+    }
+
+    /// Convenience: cost estimate for scanning this attribute. See
+    /// [`AttributeDescriptor::estimate`].
+    pub fn estimate(&self, of: bool, is: bool) -> usize {
+        self.descriptor.estimate(of, is)
+    }
+}
+
+impl From<AttributeDescriptor> for ConceptFieldDescriptor {
+    /// A bare attribute descriptor becomes a *required* concept field.
+    fn from(descriptor: AttributeDescriptor) -> Self {
+        Self::required(descriptor)
+    }
+}
+
+/// A non-empty collection of named concept fields.
+///
+/// `NamedAttributes` maps a field name to a [`ConceptFieldDescriptor`]
+/// (an attribute plus its concept-membership facts), stored in a
+/// [`BTreeMap`] so iteration and serialization are deterministic
+/// (sorted by field name) and field names are de-duplicated.
+///
+/// It is valid by construction: it cannot hold zero entries, and at
+/// least one entry must be required. Every public construction path
+/// is fallible ([`TryFrom`] for arrays / `Vec` / `HashMap`, and
+/// [`Deserialize`]) and errors otherwise — a concept with no required
+/// attribute would constrain nothing and match every entity.
+///
+/// Serializes as a JSON map: `{ "field-name": { "the": "domain/name", ... } }`.
 #[repr(transparent)]
 #[derive(Debug, Clone, PartialEq)]
-pub struct NamedAttributes(Vec<(String, AttributeDescriptor)>);
+pub struct NamedAttributes(BTreeMap<String, ConceptFieldDescriptor>);
 
 impl NamedAttributes {
-    /// Returns an iterator over all attributes as (name, descriptor) pairs.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&str, &AttributeDescriptor)> {
+    /// Returns an iterator over all fields as (name, field) pairs,
+    /// sorted by field name.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&str, &ConceptFieldDescriptor)> {
         self.0.iter().map(|(k, v)| (k.as_str(), v))
     }
 
-    /// Returns an iterator over attribute names.
+    /// Returns an iterator over field names, sorted.
     pub fn keys(&self) -> impl Iterator<Item = &str> + '_ {
-        self.0.iter().map(|(k, _)| k.as_str())
-    }
-
-    /// Build from pairs whose non-emptiness the caller already
-    /// guarantees by other means — the `#[derive(Concept)]` macro
-    /// (which emits a compile-time assertion that at least one field
-    /// is required) and conversions from an already-validated
-    /// descriptor. Internal-only; public construction goes through
-    /// the fallible [`TryFrom`] impls.
-    pub(crate) fn from_pairs(pairs: Vec<(String, AttributeDescriptor)>) -> Self {
-        NamedAttributes(pairs)
+        self.0.keys().map(String::as_str)
     }
 
     /// Fallible builder shared by the [`TryFrom`] impls: rejects an
-    /// empty set with [`TypeError::EmptyConcept`].
-    fn try_new(pairs: Vec<(String, AttributeDescriptor)>) -> Result<Self, TypeError> {
-        if pairs.is_empty() {
+    /// empty set, or a set with no required field, with
+    /// [`TypeError::EmptyConcept`].
+    fn try_new(map: BTreeMap<String, ConceptFieldDescriptor>) -> Result<Self, TypeError> {
+        if map.is_empty() || map.values().all(|field| field.is_optional()) {
             return Err(TypeError::EmptyConcept);
         }
-        Ok(NamedAttributes(pairs))
+        Ok(NamedAttributes(map))
     }
 }
 
@@ -56,8 +169,7 @@ impl Serialize for NamedAttributes {
     where
         S: serde::Serializer,
     {
-        let map: HashMap<&str, &AttributeDescriptor> = self.iter().collect();
-        map.serialize(serializer)
+        self.0.serialize(serializer)
     }
 }
 
@@ -66,61 +178,58 @@ impl<'de> Deserialize<'de> for NamedAttributes {
     where
         D: serde::Deserializer<'de>,
     {
-        let map = HashMap::<String, AttributeDescriptor>::deserialize(deserializer)?;
-        if map.is_empty() {
-            // Non-empty by construction: a concept's required (`with`)
-            // attribute set must have at least one entry, otherwise
-            // the concept constrains nothing and every entity matches.
-            return Err(D::Error::invalid_length(0, &"at least one attribute"));
-        }
-        Ok(NamedAttributes(map.into_iter().collect()))
+        let map = BTreeMap::<String, ConceptFieldDescriptor>::deserialize(deserializer)?;
+        // Reuse the same validity check as every other construction
+        // path rather than re-implementing it: at least one entry,
+        // at least one of them required.
+        NamedAttributes::try_from(map).map_err(D::Error::custom)
     }
 }
 
-impl<const N: usize> TryFrom<[(&str, AttributeDescriptor); N]> for NamedAttributes {
+impl<const N: usize> TryFrom<[(&str, ConceptFieldDescriptor); N]> for NamedAttributes {
     type Error = TypeError;
 
-    fn try_from(arr: [(&str, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+    fn try_from(arr: [(&str, ConceptFieldDescriptor); N]) -> Result<Self, Self::Error> {
         Self::try_new(
             arr.into_iter()
-                .map(|(name, attr)| (name.to_string(), attr))
+                .map(|(name, field)| (name.to_string(), field))
                 .collect(),
         )
     }
 }
 
-impl<const N: usize> TryFrom<[(String, AttributeDescriptor); N]> for NamedAttributes {
+impl<const N: usize> TryFrom<[(String, ConceptFieldDescriptor); N]> for NamedAttributes {
     type Error = TypeError;
 
-    fn try_from(arr: [(String, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+    fn try_from(arr: [(String, ConceptFieldDescriptor); N]) -> Result<Self, Self::Error> {
         Self::try_new(arr.into_iter().collect())
     }
 }
 
-impl TryFrom<Vec<(&str, AttributeDescriptor)>> for NamedAttributes {
+impl TryFrom<Vec<(&str, ConceptFieldDescriptor)>> for NamedAttributes {
     type Error = TypeError;
 
-    fn try_from(vec: Vec<(&str, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+    fn try_from(vec: Vec<(&str, ConceptFieldDescriptor)>) -> Result<Self, Self::Error> {
         Self::try_new(
             vec.into_iter()
-                .map(|(name, attr)| (name.to_string(), attr))
+                .map(|(name, field)| (name.to_string(), field))
                 .collect(),
         )
     }
 }
 
-impl TryFrom<Vec<(String, AttributeDescriptor)>> for NamedAttributes {
+impl TryFrom<Vec<(String, ConceptFieldDescriptor)>> for NamedAttributes {
     type Error = TypeError;
 
-    fn try_from(vec: Vec<(String, AttributeDescriptor)>) -> Result<Self, Self::Error> {
-        Self::try_new(vec)
+    fn try_from(vec: Vec<(String, ConceptFieldDescriptor)>) -> Result<Self, Self::Error> {
+        Self::try_new(vec.into_iter().collect())
     }
 }
 
-impl TryFrom<HashMap<String, AttributeDescriptor>> for NamedAttributes {
+impl TryFrom<BTreeMap<String, ConceptFieldDescriptor>> for NamedAttributes {
     type Error = TypeError;
 
-    fn try_from(map: HashMap<String, AttributeDescriptor>) -> Result<Self, Self::Error> {
-        Self::try_new(map.into_iter().collect())
+    fn try_from(map: BTreeMap<String, ConceptFieldDescriptor>) -> Result<Self, Self::Error> {
+        Self::try_new(map)
     }
 }

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -1,11 +1,19 @@
 use crate::attribute::AttributeDescriptor;
+use crate::error::TypeError;
+use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// A non-empty collection of named attribute descriptors.
 ///
-/// This is a transparent wrapper around `Vec<(String, AttributeDescriptor)>` that
-/// enforces non-emptiness — you cannot create a `NamedAttributes` with zero entries.
+/// `NamedAttributes` is valid by construction: it cannot hold zero
+/// entries. Every public construction path is fallible
+/// ([`TryFrom`] for arrays / `Vec` / `HashMap`, and [`Deserialize`])
+/// and returns an error on an empty input. A concept's required
+/// (`with`) attribute set is a `NamedAttributes`, so this single
+/// chokepoint guarantees a concept always declares at least one
+/// required attribute — a concept with none would constrain nothing
+/// and match every entity.
 ///
 /// Serializes as a JSON map: `{ "field-name": { "the": "domain/name", ... } }`
 #[repr(transparent)]
@@ -21,6 +29,25 @@ impl NamedAttributes {
     /// Returns an iterator over attribute names.
     pub fn keys(&self) -> impl Iterator<Item = &str> + '_ {
         self.0.iter().map(|(k, _)| k.as_str())
+    }
+
+    /// Build from pairs whose non-emptiness the caller already
+    /// guarantees by other means — the `#[derive(Concept)]` macro
+    /// (which emits a compile-time assertion that at least one field
+    /// is required) and conversions from an already-validated
+    /// descriptor. Internal-only; public construction goes through
+    /// the fallible [`TryFrom`] impls.
+    pub(crate) fn from_pairs(pairs: Vec<(String, AttributeDescriptor)>) -> Self {
+        NamedAttributes(pairs)
+    }
+
+    /// Fallible builder shared by the [`TryFrom`] impls: rejects an
+    /// empty set with [`TypeError::EmptyConcept`].
+    fn try_new(pairs: Vec<(String, AttributeDescriptor)>) -> Result<Self, TypeError> {
+        if pairs.is_empty() {
+            return Err(TypeError::EmptyConcept);
+        }
+        Ok(NamedAttributes(pairs))
     }
 }
 
@@ -40,13 +67,21 @@ impl<'de> Deserialize<'de> for NamedAttributes {
         D: serde::Deserializer<'de>,
     {
         let map = HashMap::<String, AttributeDescriptor>::deserialize(deserializer)?;
-        Ok(NamedAttributes::from(map))
+        if map.is_empty() {
+            // Non-empty by construction: a concept's required (`with`)
+            // attribute set must have at least one entry, otherwise
+            // the concept constrains nothing and every entity matches.
+            return Err(D::Error::invalid_length(0, &"at least one attribute"));
+        }
+        Ok(NamedAttributes(map.into_iter().collect()))
     }
 }
 
-impl<const N: usize> From<[(&str, AttributeDescriptor); N]> for NamedAttributes {
-    fn from(arr: [(&str, AttributeDescriptor); N]) -> Self {
-        NamedAttributes(
+impl<const N: usize> TryFrom<[(&str, AttributeDescriptor); N]> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(arr: [(&str, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Self::try_new(
             arr.into_iter()
                 .map(|(name, attr)| (name.to_string(), attr))
                 .collect(),
@@ -54,15 +89,19 @@ impl<const N: usize> From<[(&str, AttributeDescriptor); N]> for NamedAttributes 
     }
 }
 
-impl<const N: usize> From<[(String, AttributeDescriptor); N]> for NamedAttributes {
-    fn from(arr: [(String, AttributeDescriptor); N]) -> Self {
-        NamedAttributes(arr.into_iter().collect())
+impl<const N: usize> TryFrom<[(String, AttributeDescriptor); N]> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(arr: [(String, AttributeDescriptor); N]) -> Result<Self, Self::Error> {
+        Self::try_new(arr.into_iter().collect())
     }
 }
 
-impl From<Vec<(&str, AttributeDescriptor)>> for NamedAttributes {
-    fn from(vec: Vec<(&str, AttributeDescriptor)>) -> Self {
-        NamedAttributes(
+impl TryFrom<Vec<(&str, AttributeDescriptor)>> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(&str, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Self::try_new(
             vec.into_iter()
                 .map(|(name, attr)| (name.to_string(), attr))
                 .collect(),
@@ -70,14 +109,18 @@ impl From<Vec<(&str, AttributeDescriptor)>> for NamedAttributes {
     }
 }
 
-impl From<Vec<(String, AttributeDescriptor)>> for NamedAttributes {
-    fn from(vec: Vec<(String, AttributeDescriptor)>) -> Self {
-        NamedAttributes(vec)
+impl TryFrom<Vec<(String, AttributeDescriptor)>> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(vec: Vec<(String, AttributeDescriptor)>) -> Result<Self, Self::Error> {
+        Self::try_new(vec)
     }
 }
 
-impl From<HashMap<String, AttributeDescriptor>> for NamedAttributes {
-    fn from(map: HashMap<String, AttributeDescriptor>) -> Self {
-        NamedAttributes(map.into_iter().collect())
+impl TryFrom<HashMap<String, AttributeDescriptor>> for NamedAttributes {
+    type Error = TypeError;
+
+    fn try_from(map: HashMap<String, AttributeDescriptor>) -> Result<Self, Self::Error> {
+        Self::try_new(map.into_iter().collect())
     }
 }

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -7,8 +7,7 @@ pub use rules::ConceptRules;
 
 use std::fmt;
 
-use crate::attribute::AttributeDescriptor;
-use crate::concept::descriptor::ConceptDescriptor;
+use crate::concept::descriptor::{ConceptDescriptor, ConceptFieldDescriptor};
 use crate::planner::Disjunction;
 use crate::schema::CONCEPT_OVERHEAD;
 use crate::selection::Selection;
@@ -152,10 +151,10 @@ impl ConceptQuery {
             Some(total)
         } else {
             // Entity is not bound - categorize attributes to find best execution strategy
-            let mut bound_one: Option<&AttributeDescriptor> = None;
-            let mut bound_many: Option<&AttributeDescriptor> = None;
-            let mut unbound_one: Option<&AttributeDescriptor> = None;
-            let mut unbound_many: Option<&AttributeDescriptor> = None;
+            let mut bound_one: Option<&ConceptFieldDescriptor> = None;
+            let mut bound_many: Option<&ConceptFieldDescriptor> = None;
+            let mut unbound_one: Option<&ConceptFieldDescriptor> = None;
+            let mut unbound_many: Option<&ConceptFieldDescriptor> = None;
 
             for (name, attribute) in self.predicate.with().iter() {
                 if let Some(param) = self.terms.get(name) {
@@ -471,25 +470,27 @@ mod tests {
 
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
-        let concept = ConceptDescriptor::try_from(vec![(
-            "name",
-            AttributeDescriptor::new(
-                the!("person/name"),
-                "",
-                Cardinality::One,
-                Some(Type::String),
+        let concept = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
             ),
-        )])
-        .unwrap()
-        .with_maybe(vec![(
-            "nickname",
-            AttributeDescriptor::new(
-                the!("person/nickname"),
-                "",
-                Cardinality::One,
-                Some(Type::String),
+            (
+                "nickname".to_string(),
+                ConceptFieldDescriptor::optional(AttributeDescriptor::new(
+                    the!("person/nickname"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
             ),
-        )]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("person"));

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -14,7 +14,7 @@ use crate::schema::CONCEPT_OVERHEAD;
 use crate::selection::Selection;
 use crate::source::SelectRules;
 use crate::{
-    Cardinality, Environment, EvaluationError, Match, Parameters, Schema, Term, try_stream,
+    Binding, Cardinality, Environment, EvaluationError, Match, Parameters, Schema, Term, try_stream,
 };
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
@@ -22,10 +22,10 @@ use dialog_common::ConditionalSync;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-/// Extract a Match with parameter names from a Match with user variable names
-///
-/// This maps values from user-specified variable names to internal parameter names
-/// for scoped evaluation. All factors are copied with their original provenance.
+/// Extract a Match with parameter names from a Match with user
+/// variable names. Maps values from user-specified variable names
+/// to internal parameter names for scoped evaluation. Both Present
+/// and Absent bindings are propagated.
 fn extract_parameters(source: &Match, terms: &Parameters) -> Result<Match, EvaluationError> {
     let mut matched = Match::new();
 
@@ -33,8 +33,21 @@ fn extract_parameters(source: &Match, terms: &Parameters) -> Result<Match, Evalu
         match user_param {
             Term::Variable { name: Some(_), .. } => {
                 let param = Term::var(param_name);
-                if let Ok(value) = source.lookup(user_param) {
-                    matched.bind(&param, value)?;
+                match source.lookup(user_param) {
+                    Ok(Binding::Present(value)) => {
+                        matched.bind(&param, value)?;
+                    }
+                    Ok(Binding::Absent) => {
+                        matched.bind_absent(&param)?;
+                    }
+                    // Unbound is expected here: the user supplied a
+                    // placeholder term (e.g. `Term::var("alice")` in
+                    // `Query<Person> { this: ..., ... }`) that the
+                    // concept query is about to bind. Skip it —
+                    // downstream evaluation fills it in. Propagate
+                    // any other error.
+                    Err(EvaluationError::UnboundVariable { .. }) => {}
+                    Err(e) => return Err(e),
                 }
             }
             Term::Constant(value) => {
@@ -48,10 +61,9 @@ fn extract_parameters(source: &Match, terms: &Parameters) -> Result<Match, Evalu
     Ok(matched)
 }
 
-/// Merge a Match with parameter names back into a Match with user variable names
-///
-/// This maps values from internal parameter names back to user-specified variable names
-/// after evaluation. All factors are copied with their original provenance.
+/// Merge a Match with parameter names back into a Match with user
+/// variable names after evaluation. Both Present and Absent
+/// bindings are propagated.
 fn merge_parameters(
     base: &Match,
     result: &Match,
@@ -65,8 +77,19 @@ fn merge_parameters(
         }
 
         let param = Term::var(param_name);
-        if let Ok(value) = result.lookup(&param) {
-            merged.bind(user_param, value)?;
+        match result.lookup(&param) {
+            Ok(Binding::Present(value)) => {
+                merged.bind(user_param, value)?;
+            }
+            Ok(Binding::Absent) => {
+                merged.bind_absent(user_param)?;
+            }
+            // Unbound is expected: not every parameter survives the
+            // concept evaluation (e.g. a blank slot the rule never
+            // touched). Skip and let the user variable stay
+            // un-extended. Propagate any other error.
+            Err(EvaluationError::UnboundVariable { .. }) => {}
+            Err(e) => return Err(e),
         }
     }
 
@@ -338,7 +361,7 @@ mod tests {
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
         // Create a person concept
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -357,7 +380,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("person"));
@@ -385,8 +409,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let name = match_result.lookup(&name_param)?;
-            let age = match_result.lookup(&age_param)?;
+            let name = match_result.lookup(&name_param)?.content()?;
+            let age = match_result.lookup(&age_param)?.content()?;
 
             match name {
                 Value::String(n) if n == "Alice" => {
@@ -403,6 +427,215 @@ mod tests {
 
         assert!(found_alice, "Should find Alice");
         assert!(found_bob, "Should find Bob");
+
+        Ok(())
+    }
+
+    /// End-to-end: a concept with a `maybe` attribute returns
+    /// rows for entities that lack the optional fact, with the
+    /// optional slot bound to `Binding::Absent`. Entities that
+    /// have the fact get `Binding::Present(value)` for the slot.
+    /// This is the v2 set-widening behavior at the concept
+    /// projection layer, driven by `Resolution::Optional` on the
+    /// emitted `AttributeQuery`.
+    #[dialog_common::test]
+    async fn it_executes_concept_with_optional_field() -> anyhow::Result<()> {
+        use crate::Binding;
+        use dialog_artifacts::Entity;
+        use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+
+        // Alice has both name and nickname; Bob has only name.
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .assert(
+                the!("person/nickname")
+                    .of(alice.clone())
+                    .is("Ali".to_string()),
+            )
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let concept = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap()
+        .with_maybe(vec![(
+            "nickname",
+            AttributeDescriptor::new(
+                the!("person/nickname"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::var("person"));
+        terms.insert("name".to_string(), Term::var("name"));
+        terms.insert("nickname".to_string(), Term::var("nickname"));
+
+        let application = ConceptQuery {
+            terms,
+            predicate: concept,
+        };
+
+        let selection = futures_util::TryStreamExt::try_collect::<Vec<_>>(
+            application.evaluate(Match::new().seed(), &source),
+        )
+        .await?;
+
+        assert_eq!(
+            selection.len(),
+            2,
+            "Should find 2 people (both Alice and Bob)"
+        );
+
+        let nickname_param = Term::var("nickname");
+        let name_param = Term::var("name");
+
+        let mut found_alice_with_nickname = false;
+        let mut found_bob_without_nickname = false;
+        for match_result in selection.iter() {
+            let name = match_result.lookup(&name_param)?.content()?;
+            let nickname = match_result.lookup(&nickname_param)?;
+            match (&name, nickname) {
+                (Value::String(n), Binding::Present(Value::String(nick)))
+                    if n == "Alice" && nick == "Ali" =>
+                {
+                    found_alice_with_nickname = true;
+                }
+                (Value::String(n), Binding::Absent) if n == "Bob" => {
+                    found_bob_without_nickname = true;
+                }
+                _ => panic!(
+                    "unexpected (name, nickname): ({:?}, {:?})",
+                    name,
+                    match_result.lookup(&nickname_param)
+                ),
+            }
+        }
+        assert!(
+            found_alice_with_nickname,
+            "Alice should have nickname Present"
+        );
+        assert!(
+            found_bob_without_nickname,
+            "Bob should have nickname Absent"
+        );
+
+        Ok(())
+    }
+
+    /// End-to-end: a `#[derive(Concept)]` struct with an `Option<T>`
+    /// field round-trips through the full query pipeline. Alice has
+    /// both `name` and `nickname`; Bob has only `name`. The macro
+    /// emits `Term<Option<String>>` for the `nickname` field; at
+    /// realize time, Alice's nickname appears as `Some(_)` and Bob's
+    /// as `None`.
+    #[dialog_common::test]
+    async fn it_executes_macro_concept_with_optional_field() -> anyhow::Result<()> {
+        use dialog_artifacts::Entity;
+        use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+        use futures_util::TryStreamExt;
+
+        mod employee {
+            use crate::Attribute;
+
+            /// Employee given name
+            #[derive(Attribute, Clone, PartialEq)]
+            #[domain("person")]
+            pub struct Name(pub String);
+
+            /// Employee preferred nickname
+            #[derive(Attribute, Clone, PartialEq)]
+            #[domain("person")]
+            pub struct Nickname(pub String);
+        }
+
+        /// Employee with required name and optional nickname.
+        #[derive(crate::Concept, Debug, Clone)]
+        pub struct Employee {
+            /// Employee entity
+            pub this: Entity,
+            /// Required given name
+            pub name: employee::Name,
+            /// Optional nickname
+            pub nickname: Option<employee::Nickname>,
+        }
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .assert(
+                the!("person/nickname")
+                    .of(alice.clone())
+                    .is("Ali".to_string()),
+            )
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let query = crate::Query::<Employee>::default();
+        let employees: Vec<Employee> = query.perform(&source).try_collect().await?;
+
+        assert_eq!(employees.len(), 2);
+
+        let mut found_alice = false;
+        let mut found_bob = false;
+        for emp in employees {
+            match emp.name.0.as_str() {
+                "Alice" => {
+                    assert_eq!(
+                        emp.nickname.as_ref().map(|n| n.0.as_str()),
+                        Some("Ali"),
+                        "Alice should have nickname Some(Ali)"
+                    );
+                    found_alice = true;
+                }
+                "Bob" => {
+                    assert!(emp.nickname.is_none(), "Bob should have nickname None");
+                    found_bob = true;
+                }
+                other => panic!("Unexpected name: {other}"),
+            }
+        }
+        assert!(found_alice && found_bob);
 
         Ok(())
     }
@@ -433,7 +666,7 @@ mod tests {
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
         // Create a person concept
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -452,7 +685,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("person"));
@@ -480,7 +714,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_operates_on_concept_conclusion() {
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -499,7 +733,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // Test that attributes are present
         let param_names: Vec<&str> = concept.with().keys().collect();
@@ -511,7 +746,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_creates_concept_descriptor() {
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name".to_string(),
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -519,7 +754,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         // Operator is now a computed URI
         assert!(
@@ -532,7 +768,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_analyzes_concept_application() {
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name".to_string(),
                 AttributeDescriptor::new(
@@ -551,7 +787,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("name".to_string(), Term::var("person_name"));
@@ -577,7 +814,7 @@ mod tests {
     fn it_extracts_deductive_rule_parameters() {
         use std::collections::HashSet;
 
-        let predicate = ConceptDescriptor::from([
+        let predicate = ConceptDescriptor::try_from([
             (
                 "name".to_string(),
                 AttributeDescriptor::new(
@@ -596,7 +833,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let rule = DeductiveRule::from(&predicate);
 
         let params: HashSet<&str> = rule.parameters().collect();
@@ -631,10 +869,11 @@ mod tests {
         use crate::error::{AnalyzerError, TypeError};
 
         // Test AnalyzerError creation
-        let predicate = ConceptDescriptor::from(vec![(
+        let predicate = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(the!("test/name"), "", Cardinality::One, Some(Type::String)),
-        )]);
+        )])
+        .unwrap();
         let rule = DeductiveRule::from(&predicate);
 
         let analyzer_error = AnalyzerError::UnusedParameter {
@@ -681,7 +920,7 @@ mod tests {
         terms.insert("test".to_string(), Term::var("test_var"));
         let concept_app = Proposition::Concept(ConceptQuery {
             terms,
-            predicate: ConceptDescriptor::from([(
+            predicate: ConceptDescriptor::try_from([(
                 "name",
                 AttributeDescriptor::new(
                     the!("test/name"),
@@ -689,7 +928,8 @@ mod tests {
                     Cardinality::One,
                     Some(Type::String),
                 ),
-            )]),
+            )])
+            .unwrap(),
         });
 
         match concept_app {
@@ -745,7 +985,7 @@ mod tests {
             .perform(&operator)
             .await?;
 
-        let concept = ConceptDescriptor::from(vec![(
+        let concept = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -753,7 +993,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         // Query with constant entity - should only return Alice
         let mut terms = Parameters::new();
@@ -779,7 +1020,7 @@ mod tests {
             "Should find only Alice, not both people"
         );
         assert_eq!(
-            selection[0].lookup(&Term::var("name"))?,
+            selection[0].lookup(&Term::var("name"))?.content()?,
             Value::String("Alice".to_string())
         );
 
@@ -812,7 +1053,7 @@ mod tests {
             .perform(&operator)
             .await?;
 
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -831,7 +1072,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // Query with constant name value - should only return Bob
         let mut terms = Parameters::new();
@@ -851,11 +1093,11 @@ mod tests {
 
         assert_eq!(selection.len(), 1, "Should find only Bob");
         assert_eq!(
-            selection[0].lookup(&Term::var("entity"))?,
+            selection[0].lookup(&Term::var("entity"))?.content()?,
             Value::Entity(bob.clone())
         );
         assert_eq!(
-            selection[0].lookup(&Term::var("age"))?,
+            selection[0].lookup(&Term::var("age"))?.content()?,
             Value::UnsignedInt(30)
         );
 
@@ -888,7 +1130,7 @@ mod tests {
             .perform(&operator)
             .await?;
 
-        let concept = ConceptDescriptor::from(vec![
+        let concept = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -907,7 +1149,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // Query with both name and age constants - should only match Alice
         let mut terms = Parameters::new();
@@ -931,7 +1174,7 @@ mod tests {
             "Should find only Alice with exact name and age match"
         );
         assert_eq!(
-            selection[0].lookup(&Term::var("entity"))?,
+            selection[0].lookup(&Term::var("entity"))?.content()?,
             Value::Entity(alice.clone())
         );
 
@@ -941,7 +1184,7 @@ mod tests {
     /// Build a representative two-attribute Person concept query with mixed
     /// variable / constant bindings for the serde round-trip tests.
     fn sample_concept_query() -> ConceptQuery {
-        let predicate = ConceptDescriptor::from(vec![
+        let predicate = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -960,7 +1203,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".into(), Term::<Any>::var("entity"));

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -100,7 +100,7 @@ mod tests {
     use crate::the;
 
     fn person_concept() -> ConceptDescriptor {
-        ConceptDescriptor::from([(
+        ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -109,6 +109,7 @@ mod tests {
                 Some(Type::String),
             ),
         )])
+        .unwrap()
     }
 
     fn alt_rule(descriptor: &ConceptDescriptor) -> DeductiveRule {

--- a/rust/dialog-query/src/constraint.rs
+++ b/rust/dialog-query/src/constraint.rs
@@ -4,14 +4,17 @@
 //! query evaluation. Unlike applications which query the knowledge base, constraints
 //! operate on variable bindings to filter, infer, or validate values.
 
+pub mod coalesce;
 pub mod equality;
 
 use std::fmt;
 
+pub use coalesce::Coalesce;
 pub use equality::Equality;
 
 use crate::selection::Selection;
 use crate::{Environment, Parameters, Schema};
+use futures_util::future::Either;
 use std::fmt::Display;
 
 /// Constraint enum representing different types of constraints between terms.
@@ -23,54 +26,44 @@ use std::fmt::Display;
 #[serde(tag = "assert", content = "where")]
 pub enum Constraint {
     /// Equality constraint between two terms.
-    ///
-    /// Enforces that both terms must have equal values. Supports bidirectional
-    /// inference: if one term is bound, the other will be inferred to have the
-    /// same value.
     #[serde(rename = "==")]
     Equality(Equality),
+    /// Coalesce constraint — bind `is` from `source` when Present,
+    /// else from `fallback`. Set-widening unwrap.
+    #[serde(rename = "coalesce")]
+    Coalesce(Coalesce),
 }
 
 impl Constraint {
     /// Returns the schema for this constraint.
-    ///
-    /// The schema describes what parameters the constraint requires to be evaluable.
     pub fn schema(&self) -> Schema {
         match self {
-            Constraint::Equality(constraint) => constraint.schema(),
+            Constraint::Equality(c) => c.schema(),
+            Constraint::Coalesce(c) => c.schema(),
         }
     }
 
     /// Estimates the cost of evaluating this constraint given the current environment.
-    ///
-    /// Returns `Some(cost)` if the constraint can be evaluated (at least one term is bound).
-    /// Returns `None` if the constraint cannot be evaluated yet (neither term is bound).
     pub fn estimate(&self, env: &Environment) -> Option<usize> {
         match self {
-            Constraint::Equality(constraint) => constraint.estimate(env),
+            Constraint::Equality(c) => c.estimate(env),
+            Constraint::Coalesce(c) => c.estimate(env),
         }
     }
 
     /// Returns the parameters for this constraint.
     pub fn parameters(&self) -> Parameters {
         match self {
-            Constraint::Equality(constraint) => constraint.parameters(),
+            Constraint::Equality(c) => c.parameters(),
+            Constraint::Coalesce(c) => c.parameters(),
         }
     }
 
     /// Evaluates the constraint against the current selection of matches.
-    ///
-    /// This method processes each match in the input selection and:
-    /// - **Filters** matches where constraints are violated
-    /// - **Infers** missing bindings when possible
-    /// - **Errors** when constraints cannot be evaluated
-    ///
-    /// # Returns
-    /// A stream of matches that satisfy the constraint, with any necessary
-    /// variable bindings added through inference.
     pub fn evaluate<M: Selection>(self, selection: M) -> impl Selection {
         match self {
-            Constraint::Equality(constraint) => constraint.evaluate(selection),
+            Constraint::Equality(c) => Either::Left(c.evaluate(selection)),
+            Constraint::Coalesce(c) => Either::Right(c.evaluate(selection)),
         }
     }
 }
@@ -78,7 +71,8 @@ impl Constraint {
 impl Display for Constraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Constraint::Equality(constraint) => Display::fmt(constraint, f),
+            Constraint::Equality(c) => Display::fmt(c, f),
+            Constraint::Coalesce(c) => Display::fmt(c, f),
         }
     }
 }
@@ -86,5 +80,11 @@ impl Display for Constraint {
 impl From<Equality> for Constraint {
     fn from(constraint: Equality) -> Self {
         Constraint::Equality(constraint)
+    }
+}
+
+impl From<Coalesce> for Constraint {
+    fn from(constraint: Coalesce) -> Self {
+        Constraint::Coalesce(constraint)
     }
 }

--- a/rust/dialog-query/src/constraint/coalesce.rs
+++ b/rust/dialog-query/src/constraint/coalesce.rs
@@ -1,0 +1,545 @@
+//! Coalesce constraint — set-widening unwrap with a fallback.
+//!
+//! `Coalesce` is the v2 expression of "if `source` is `Present`,
+//! bind `is` to it; otherwise bind `is` to `fallback`." It is
+//! the operator a `Term::<Option<U>>::unwrap_or` builder produces:
+//!
+//! ```text
+//! nickname.unwrap_or("Anon").is(display_name)
+//! ```
+//!
+//! Evaluation is row-local: one row in, one row out. The
+//! `source` term is looked up against the input row's bindings;
+//! if [`Binding::Present`](crate::Binding::Present) the value
+//! flows into `is`; if [`Binding::Absent`](crate::Binding::Absent)
+//! (or if `source` is unbound) the fallback value flows into `is`
+//! instead. `fallback` may itself be a term — variable or
+//! constant — and is resolved in the same row.
+
+use std::fmt;
+use std::fmt::Display;
+
+use crate::type_system::unifier::{Context, Type as UnifierType, UnifyError, lift};
+use crate::types::Any;
+use crate::{
+    Binding, Cardinality, Environment, Field, Parameters, Requirement, Schema, Selection, Term,
+    try_stream,
+};
+
+/// Cost for evaluating a coalesce constraint (single row lookup +
+/// branch + bind).
+const COALESCE_COST: usize = 1;
+
+/// Set-widening unwrap: produce a non-optional value from an
+/// optional `source`, falling back to `fallback` when the source
+/// is `Absent`.
+///
+/// Builder shape:
+/// ```no_run
+/// # use dialog_query::Term;
+/// let nickname: Term<Option<String>> = Term::var("nickname");
+/// let display_name: Term<String> = Term::var("display_name");
+/// let premise = nickname.unwrap_or("Anon").is(display_name);
+/// ```
+///
+/// Type contract (checked at rule-compile time by
+/// [`Coalesce::validate`]):
+/// - `source` has kind `Optional<α>` for some `α`.
+/// - `fallback` has kind `α`.
+/// - `is` has kind `α`.
+///
+/// At runtime, evaluation is `.map`-style — one row in, one row
+/// out:
+/// - If `source` looks up to `Present(v)`: bind `is` to `v`.
+/// - If `source` looks up to `Absent` or is unbound: bind `is` to
+///   `fallback`'s resolved value.
+/// - If `fallback` itself is an unbound variable, the row is
+///   filtered out (we can't bind without a concrete value).
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Coalesce {
+    /// The optional input term — typically a variable bound by an
+    /// upstream optional attribute query.
+    pub source: Term<Any>,
+    /// The default value used when `source` is `Absent` or unbound.
+    pub fallback: Term<Any>,
+    /// The output term that receives either `source`'s value or
+    /// `fallback`'s value.
+    pub is: Term<Any>,
+}
+
+impl Coalesce {
+    /// Create a new coalesce constraint.
+    ///
+    /// The typed builder
+    /// [`Term::<Option<U>>::unwrap_or`](crate::Term::unwrap_or)
+    /// enforces the type contract at Rust's type level — call
+    /// sites with type mismatches fail to compile. For dynamic
+    /// construction (wire-format deserialization, raw
+    /// `Coalesce::new` calls), [`Self::validate`] checks the
+    /// contract at runtime; it is invoked automatically by
+    /// [`DeductiveRule::new`](crate::DeductiveRule::new) so any
+    /// Coalesce reaching the rule compiler is checked, regardless
+    /// of how it was constructed.
+    pub fn new(source: Term<Any>, fallback: Term<Any>, is: Term<Any>) -> Self {
+        Self {
+            source,
+            fallback,
+            is,
+        }
+    }
+
+    /// Validate the type contract of this coalesce against a
+    /// unification context: pick a fresh `α`, then unify `α` with
+    /// `source`'s underlying (non-Nothing) shape, `fallback`'s
+    /// kind, and `is`'s kind.
+    ///
+    /// **Source typing is enforced.** If `source` carries a static
+    /// kind, it must be set-widened (admit `Nothing`); otherwise
+    /// the coalesce can never trigger the fallback path and is
+    /// rejected with [`UnifyError::SourceNotOptional`]. If `source`
+    /// has no static kind (`kind() == None`), it is treated as
+    /// fully unconstrained — the unifier may not narrow it. The
+    /// caller is then responsible for ensuring the source is
+    /// actually set-widened at runtime; the typed
+    /// [`unwrap_or`](crate::Term::unwrap_or) builder enforces this
+    /// at the Rust type level.
+    ///
+    /// **`fallback` and `is` with static kinds** must unify with
+    /// `α` — so they agree with each other and with the source's
+    /// underlying shape (when known).
+    pub fn validate(&self, ctx: &mut Context) -> Result<(), UnifyError> {
+        let alpha = ctx.fresh_var();
+
+        match self.source.kind() {
+            Some(source) if source.is_optional() => {
+                // Strip the Nothing bit to get α's underlying shape.
+                let underlying = source.without_nothing();
+                ctx.unify(&UnifierType::Static(underlying), &alpha)?;
+            }
+            Some(_) => return Err(UnifyError::SourceNotOptional),
+            None => {
+                // No static kind on source — caller takes responsibility.
+                // α stays open; fallback/is still link to it below.
+            }
+        }
+        if let Some(k) = self.fallback.kind() {
+            ctx.unify(&lift(&k), &alpha)?;
+        }
+        if let Some(k) = self.is.kind() {
+            ctx.unify(&lift(&k), &alpha)?;
+        }
+        Ok(())
+    }
+
+    /// Schema describing the three slots. All three are required;
+    /// `source` is set-widened (Optional), `fallback` and `is`
+    /// share the unwrapped shape.
+    pub fn schema(&self) -> Schema {
+        let mut schema = Schema::new();
+        let requirement = Requirement::new_group();
+        schema.insert(
+            "source".into(),
+            Field {
+                description:
+                    "Optional input term — value flows to `is` when Present, else `fallback` does."
+                        .into(),
+                content_type: self.source.kind(),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema.insert(
+            "fallback".into(),
+            Field {
+                description: "Default value used when `source` is `Absent` or unbound.".into(),
+                content_type: self.fallback.kind(),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema.insert(
+            "is".into(),
+            Field {
+                description: "Output term — receives `source`'s value or `fallback`'s.".into(),
+                content_type: self.is.kind(),
+                requirement: requirement.required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema
+    }
+
+    /// Estimate cost. Constant — coalesce is a row-local rewrite.
+    pub fn estimate(&self, _env: &Environment) -> Option<usize> {
+        Some(COALESCE_COST)
+    }
+
+    /// Returns the named parameters for this constraint.
+    pub fn parameters(&self) -> Parameters {
+        let mut params = Parameters::new();
+        params.insert("source".to_string(), self.source.clone());
+        params.insert("fallback".to_string(), self.fallback.clone());
+        params.insert("is".to_string(), self.is.clone());
+        params
+    }
+
+    /// Evaluate: row-local `.map` — for each input row, decide
+    /// whether to bind `is` from `source` or from `fallback`.
+    /// Never consumes the input stream into a buffer; passes rows
+    /// through one at a time.
+    pub fn evaluate<M: Selection>(self, selection: M) -> impl Selection {
+        let source = self.source;
+        let fallback = self.fallback;
+        let is = self.is;
+        try_stream! {
+            for await candidate in selection {
+                let base = candidate?;
+
+                // Resolve the source binding: Present, Absent, or unbound.
+                let source_binding = base.lookup(&source);
+
+                // Resolve the fallback value: must be concrete to bind output.
+                let fallback_value = base.lookup(&fallback);
+
+                // The value coalesce would bind into `is`: `source`
+                // when Present, else `fallback` if it resolves to a
+                // concrete value. `None` means there is nothing to
+                // produce (Absent/unbound source and Absent/unbound
+                // fallback) — the row is filtered.
+                let chosen = match source_binding {
+                    Ok(Binding::Present(value)) => Some(value),
+                    Ok(Binding::Absent) | Err(_) => match fallback_value {
+                        Ok(Binding::Present(value)) => Some(value),
+                        _ => None,
+                    },
+                };
+
+                if let Some(value) = chosen {
+                    // Reconcile against any existing binding of `is`
+                    // rather than binding unconditionally. An
+                    // unconditional `bind` would error — and the `?`
+                    // would abort the whole stream — when `is` is
+                    // already bound to a different value or to Absent.
+                    // Mirror Equality: a pre-bound `is` acts as a
+                    // filter.
+                    match base.lookup(&is) {
+                        // `is` already carries the same value: yield
+                        // unchanged (bind would be a no-op anyway).
+                        Ok(Binding::Present(existing)) if existing == value => {
+                            yield base;
+                        }
+                        // `is` already carries a different value, or
+                        // Absent: coalesce always yields a Present
+                        // value, which can never equal those — filter.
+                        Ok(Binding::Present(_)) | Ok(Binding::Absent) => {}
+                        // `is` is unbound: bind the chosen value.
+                        Err(_) => {
+                            let mut extension = base.clone();
+                            extension.bind(&is, value)?;
+                            yield extension;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Display for Coalesce {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "coalesce({}, {}) -> {}",
+            self.source, self.fallback, self.is
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EvaluationError;
+    use crate::Value;
+    use crate::selection::Match;
+    use futures_util::TryStreamExt;
+    use futures_util::stream::iter as stream_iter;
+
+    /// Source is Present — output binds to source's value.
+    #[dialog_common::test]
+    async fn it_binds_output_from_source_when_present() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind(&Term::var("source"), Value::from("hello".to_string()))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("hello".to_string()),
+            "output should bind to source's value"
+        );
+        Ok(())
+    }
+
+    /// Source is Absent — output binds to fallback's value.
+    #[dialog_common::test]
+    async fn it_binds_output_from_fallback_when_absent() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("default".to_string()),
+            "output should bind to fallback's value"
+        );
+        Ok(())
+    }
+
+    /// Source unbound (no binding at all) is also handled like Absent —
+    /// output takes from fallback.
+    #[dialog_common::test]
+    async fn it_binds_output_from_fallback_when_source_unbound() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let candidate = Match::new();
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("default".to_string())
+        );
+        Ok(())
+    }
+
+    /// Fallback may itself be a variable resolved against the row.
+    #[dialog_common::test]
+    async fn it_resolves_fallback_when_variable() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(Term::var("source"), Term::var("fallback"), Term::var("out"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+        candidate.bind(&Term::var("fallback"), Value::from(42u32))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from(42u32)
+        );
+        Ok(())
+    }
+
+    /// Fallback also unbound — can't produce a value, row is filtered.
+    #[dialog_common::test]
+    async fn it_filters_when_source_absent_and_fallback_unbound() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(Term::var("source"), Term::var("fallback"), Term::var("out"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "row should be filtered when no value can be produced"
+        );
+        Ok(())
+    }
+
+    /// Multiple rows in → multiple rows out, each independently decided.
+    /// Confirms streaming `.map` behavior, not collect-then-process.
+    #[dialog_common::test]
+    async fn it_processes_each_row_independently() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        // Two rows: one with Present source, one with Absent source.
+        let mut present_row = Match::new();
+        present_row.bind(&Term::var("source"), Value::from("present".to_string()))?;
+
+        let mut absent_row = Match::new();
+        absent_row.bind_absent(&Term::var("source"))?;
+
+        // Build a seed selection containing both rows.
+        let selection = stream_iter(vec![Ok(present_row), Ok(absent_row)]);
+
+        let results: Vec<Match> = coalesce.evaluate(selection).try_collect().await?;
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("present".to_string())
+        );
+        assert_eq!(
+            results[1].lookup(&Term::var("out"))?.content()?,
+            Value::from("default".to_string())
+        );
+        Ok(())
+    }
+
+    /// A pre-bound `is` reconciles as a filter, not a stream abort.
+    /// When `is` is already bound to a *different* Present value, the
+    /// chosen coalesce value can't satisfy it, so the row is filtered
+    /// — exactly one row in, zero rows out, and crucially **no
+    /// error**. Binding `is` unconditionally would make `?` propagate
+    /// `EvaluationError::Assignment` out of the whole stream.
+    #[dialog_common::test]
+    async fn it_filters_when_is_prebound_to_different_value() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind(&Term::var("source"), Value::from("Alice".to_string()))?;
+        // `out` already carries a different value from an upstream premise.
+        candidate.bind(&Term::var("out"), Value::from("Bob".to_string()))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a pre-bound `is` that disagrees should filter the row, not abort the query"
+        );
+        Ok(())
+    }
+
+    /// A pre-bound `is` that *agrees* with the chosen value yields the
+    /// row unchanged.
+    #[dialog_common::test]
+    async fn it_yields_when_is_prebound_to_matching_value() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind(&Term::var("source"), Value::from("Alice".to_string()))?;
+        candidate.bind(&Term::var("out"), Value::from("Alice".to_string()))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1, "a matching pre-bound `is` should yield");
+        assert_eq!(
+            results[0].lookup(&Term::var("out"))?.content()?,
+            Value::from("Alice".to_string())
+        );
+        Ok(())
+    }
+
+    /// A pre-bound *Absent* `is` filters: coalesce always produces a
+    /// Present value, which can never equal Absent.
+    #[dialog_common::test]
+    async fn it_filters_when_is_prebound_absent() -> Result<(), EvaluationError> {
+        let coalesce = Coalesce::new(
+            Term::var("source"),
+            Term::Constant(Value::from("default".to_string())),
+            Term::var("out"),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::var("source"))?;
+        candidate.bind_absent(&Term::var("out"))?;
+
+        let results: Vec<Match> = coalesce.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "a Present coalesce result can't reconcile with an Absent `is` — filter"
+        );
+        Ok(())
+    }
+
+    /// Schema reports all three slots.
+    #[dialog_common::test]
+    fn schema_describes_three_slots() {
+        let coalesce = Coalesce::new(Term::var("source"), Term::var("fallback"), Term::var("out"));
+        let schema = coalesce.schema();
+        assert!(schema.get("source").is_some());
+        assert!(schema.get("fallback").is_some());
+        assert!(schema.get("is").is_some());
+    }
+
+    /// `validate` succeeds when source is `Optional<String>` and
+    /// fallback / is are both `String`.
+    #[dialog_common::test]
+    fn validate_accepts_matching_types() {
+        use crate::type_system::unifier::Context;
+
+        let source: Term<Any> = Term::<Option<String>>::var("source").into();
+        let fallback = Term::<Any>::constant("Anon".to_string());
+        let is: Term<Any> = Term::<String>::var("is").into();
+
+        let coalesce = Coalesce::new(source, fallback, is);
+        let mut ctx = Context::new();
+        coalesce
+            .validate(&mut ctx)
+            .expect("matching types should validate");
+    }
+
+    /// `validate` rejects a source whose kind isn't set-widened.
+    #[dialog_common::test]
+    fn validate_rejects_non_optional_source() {
+        use crate::type_system::unifier::{Context, UnifyError};
+
+        // Source kind is `String`, not `Optional<String>` — bug.
+        let source: Term<Any> = Term::<String>::var("source").into();
+        let fallback = Term::<Any>::constant("Anon".to_string());
+        let is = Term::<Any>::var("is");
+
+        let coalesce = Coalesce::new(source, fallback, is);
+        let mut ctx = Context::new();
+        match coalesce.validate(&mut ctx) {
+            Err(UnifyError::SourceNotOptional) => {}
+            other => panic!("expected SourceNotOptional, got {:?}", other),
+        }
+    }
+
+    /// `validate` rejects mismatched fallback type — source's
+    /// underlying is `String`, fallback is `u32`.
+    #[dialog_common::test]
+    fn validate_rejects_fallback_type_mismatch() {
+        use crate::type_system::unifier::{Context, UnifyError};
+
+        let source: Term<Any> = Term::<Option<String>>::var("source").into();
+        let fallback = Term::<Any>::constant(42u32);
+        let is = Term::<Any>::var("is");
+
+        let coalesce = Coalesce::new(source, fallback, is);
+        let mut ctx = Context::new();
+        match coalesce.validate(&mut ctx) {
+            Err(UnifyError::ConstraintConflict { .. }) => {}
+            other => panic!("expected ConstraintConflict, got {:?}", other),
+        }
+    }
+}

--- a/rust/dialog-query/src/constraint/equality.rs
+++ b/rust/dialog-query/src/constraint/equality.rs
@@ -8,8 +8,8 @@ use std::fmt;
 
 use crate::types::Any;
 pub use crate::{
-    Cardinality, Environment, EvaluationError, Field, Parameters, Requirement, Schema, Selection,
-    Term, Value, try_stream,
+    Binding, Cardinality, Environment, EvaluationError, Field, Parameters, Requirement, Schema,
+    Selection, Term, Value, try_stream,
 };
 use std::fmt::Display;
 
@@ -61,7 +61,7 @@ impl Equality {
             "this".into(),
             Field {
                 description: "Term that must be equal to the \"is\" term.".into(),
-                content_type: self.this.content_type(),
+                content_type: self.this.kind(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -70,7 +70,7 @@ impl Equality {
             "is".into(),
             Field {
                 description: "Term that must be equal to the \"this\" term.".into(),
-                content_type: self.is.content_type(),
+                content_type: self.is.kind(),
                 requirement: requirement.required(),
                 cardinality: Cardinality::One,
             },
@@ -116,28 +116,50 @@ impl Equality {
                 let base = candidate?;
 
                 match (base.lookup(&this), base.lookup(&is)) {
-                    // Case 1: Both terms are bound - verify they are equal
-                    // Only pass through the match if the values are equal
-                    (Ok(this_val), Ok(is_val)) => {
+                    // Both Present: yield iff values match.
+                    (Ok(Binding::Present(this_val)), Ok(Binding::Present(is_val))) => {
                         if this_val == is_val {
                             yield base;
                         }
-                        // Otherwise filter out this match (no yield)
                     }
-                    // Case 2: Only "is" is bound - infer "this" from "is"
-                    (Err(_), Ok(is_val)) => {
+                    // Both Absent: Nothing == Nothing, yield.
+                    (Ok(Binding::Absent), Ok(Binding::Absent)) => {
+                        yield base;
+                    }
+                    // One side Absent, other Present: disjoint kinds
+                    // (Nothing vs primitive), can never be equal — filter.
+                    (Ok(Binding::Absent), Ok(Binding::Present(_)))
+                    | (Ok(Binding::Present(_)), Ok(Binding::Absent)) => {}
+                    // One side Present, other unbound: propagate the value.
+                    (Err(_), Ok(Binding::Present(is_val))) => {
                         let mut extension = base.clone();
                         extension.bind(&this, is_val)?;
                         yield extension;
                     }
-                    // Case 3: Only "this" is bound - infer "is" from "this"
-                    (Ok(this_val), Err(_)) => {
+                    (Ok(Binding::Present(this_val)), Err(_)) => {
                         let mut extension = base.clone();
                         extension.bind(&is, this_val)?;
                         yield extension;
                     }
-                    // Case 4: Neither term is bound - cannot evaluate
-                    // Raise a constraint violation error
+                    // One side Absent, other unbound: propagate Absent
+                    // iff the unbound term's kind admits Nothing.
+                    // Otherwise the row violates the unbound term's
+                    // type contract — filter.
+                    (Ok(Binding::Absent), Err(_)) => {
+                        if is.is_optional() || is.kind().is_none() {
+                            let mut extension = base.clone();
+                            extension.bind_absent(&is)?;
+                            yield extension;
+                        }
+                    }
+                    (Err(_), Ok(Binding::Absent)) => {
+                        if this.is_optional() || this.kind().is_none() {
+                            let mut extension = base.clone();
+                            extension.bind_absent(&this)?;
+                            yield extension;
+                        }
+                    }
+                    // Neither bound — equality has nothing to work with.
                     (Err(_), Err(_)) => {
                         Err(EvaluationError::ConstraintViolation {
                             constraint: format!("{} == {}", this, is)
@@ -173,7 +195,7 @@ mod tests {
 
         assert_eq!(results.len(), 1, "Should have one result");
         assert_eq!(
-            results[0].lookup(&Term::var("x"))?,
+            results[0].lookup(&Term::var("x"))?.content()?,
             Value::from(42),
             "x should still be 42"
         );
@@ -211,7 +233,7 @@ mod tests {
 
         assert_eq!(results.len(), 1, "Should have one result");
         assert_eq!(
-            results[0].lookup(&Term::var("x"))?,
+            results[0].lookup(&Term::var("x"))?.content()?,
             Value::from(42),
             "x should be inferred as 42"
         );
@@ -243,5 +265,100 @@ mod tests {
             None,
             "Should return None when neither term is bound"
         );
+    }
+
+    /// Untyped term sides produce `None` content_type — no
+    /// static info is available without rule-compile time
+    /// unification.
+    #[dialog_common::test]
+    fn schema_unknown_term_yields_none() {
+        let constraint = Equality::new(Term::var("x"), Term::var("y"));
+        let schema = constraint.schema();
+        let this_field = schema.get("this").expect("this field present");
+        let is_field = schema.get("is").expect("is field present");
+        assert!(this_field.content_type().is_none());
+        assert!(is_field.content_type().is_none());
+    }
+
+    /// Absent on both sides — Nothing == Nothing, yield.
+    #[dialog_common::test]
+    async fn it_yields_when_both_sides_absent() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(Term::var("x"), Term::var("y"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+        candidate.bind_absent(&Term::<Any>::var("y"))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1, "Absent == Absent should yield");
+        Ok(())
+    }
+
+    /// Absent on one side, Present on the other — disjoint kinds,
+    /// filter.
+    #[dialog_common::test]
+    async fn it_filters_when_absent_meets_present() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(Term::var("x"), Term::var("y"));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+        candidate.bind(&Term::var("y"), Value::from(42))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 0, "Absent == Present should filter");
+        Ok(())
+    }
+
+    /// Absent on one side, unbound on the other where the unbound
+    /// term's kind admits Nothing — propagate Absent.
+    #[dialog_common::test]
+    async fn it_infers_absent_into_optional_term() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(
+            Term::var("x"),
+            Term::<Any>::from(Term::<Option<String>>::var("y")),
+        );
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].lookup(&Term::<Any>::var("y"))?, Binding::Absent);
+        Ok(())
+    }
+
+    /// Absent on one side, unbound on the other where the unbound
+    /// term's kind does NOT admit Nothing — filter (would propagate
+    /// Absent into a non-optional slot).
+    #[dialog_common::test]
+    async fn it_filters_absent_into_required_term() -> Result<(), EvaluationError> {
+        let constraint = Equality::new(Term::var("x"), Term::<Any>::from(Term::<String>::var("y")));
+
+        let mut candidate = Match::new();
+        candidate.bind_absent(&Term::<Any>::var("x"))?;
+
+        let results: Vec<Match> = constraint.evaluate(candidate.seed()).try_collect().await?;
+
+        assert_eq!(
+            results.len(),
+            0,
+            "Absent cannot bind a non-optional term — filter"
+        );
+        Ok(())
+    }
+
+    /// A typed constant on one side produces a concrete primitive
+    /// for that field's content_type.
+    #[dialog_common::test]
+    fn schema_lifts_typed_constant_to_primitive() {
+        use crate::artifact::Type as ValueType;
+        let constraint = Equality::new(Term::var("x"), Term::constant(42u32));
+        let schema = constraint.schema();
+        let is_field = schema.get("is").expect("is field present");
+        let content = is_field.content_type().expect("content_type present");
+        assert_eq!(content.as_value_type(), Some(ValueType::UnsignedInt));
     }
 }

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -46,6 +46,15 @@ pub enum TypeError {
     #[error("Unconstrained fact selector")]
     UnconstrainedSelector,
 
+    /// A concept declares no required (`with`) attributes. Such a
+    /// concept constrains nothing about an entity, so every entity
+    /// trivially matches it — the same degenerate shape as a concept
+    /// with no attributes at all. Optional (`maybe`) attributes do
+    /// not count: they widen results rather than constrain them. A
+    /// concept must have at least one required attribute.
+    #[error("Concept declares no required attributes; at least one `with` attribute is required")]
+    EmptyConcept,
+
     /// A rule declares a parameter that none of its premises use.
     #[error("Rule {rule} does not use parameter \"{parameter}\"")]
     UnusedParameter {
@@ -62,6 +71,45 @@ pub enum TypeError {
         rule: Box<Rule>,
         /// Name of the unbound variable.
         variable: String,
+    },
+
+    /// A rule's conclusion references a required variable that is
+    /// bound only by Optional (set-widened) premises — the rule
+    /// could produce a row with the conclusion variable in Absent
+    /// state, which a required head cannot accept. Fix by adding
+    /// a required-binding premise for the variable, or by coalescing
+    /// the optional source with a fallback before reaching the head.
+    #[error(
+        "Rule {rule}: field \"{variable}\" is optional but the conclusion requires a value. \
+         Use coalesce(...) to provide a fallback, or bind \"{variable}\" from a required premise."
+    )]
+    RequiredHeadFromOptional {
+        /// The offending rule.
+        rule: Box<Rule>,
+        /// Name of the optionally-bound head variable.
+        variable: String,
+    },
+
+    /// A `Coalesce` constraint in this rule violates its type
+    /// contract: its source must be set-widened (`Optional<α>`)
+    /// and its `fallback` and `is` must each unify with `α`.
+    #[error("Rule {rule} has an invalid Coalesce constraint: {reason}")]
+    CoalesceTypeMismatch {
+        /// The offending rule.
+        rule: Box<Rule>,
+        /// Human-readable reason for the mismatch.
+        reason: String,
+    },
+
+    /// Type inference over a rule's premises produced a
+    /// contradiction (a variable appears in slots with conflicting
+    /// kinds). The planner cannot proceed because the rule has no
+    /// valid interpretation.
+    #[error("Type inference failed: {reason}")]
+    TypeInference {
+        /// Human-readable description of the conflict, including
+        /// the offending variable.
+        reason: String,
     },
 
     /// A rule application omits a required parameter.
@@ -237,6 +285,23 @@ pub enum EvaluationError {
     #[error("Unbound variable {variable_name:?}")]
     UnboundVariable {
         /// Name of the unbound variable.
+        variable_name: String,
+    },
+
+    /// A binding for the variable exists, but it is
+    /// [`Binding::Absent`](crate::Binding::Absent) — i.e., an
+    /// optional resolver looked up the entity's attribute and
+    /// found no fact. Distinct from
+    /// [`Self::UnboundVariable`] (no binding at all): `Absent`
+    /// means "we looked, and the answer is no value." Consumers
+    /// that require a `Value` can call
+    /// [`Binding::content`](crate::Binding::content) to convert
+    /// this case into an error; consumers that handle optionality
+    /// (Coalesce, the macro's `realize`) pattern-match on
+    /// [`Binding`](crate::Binding) directly.
+    #[error("Variable {variable_name:?} is bound to Absent")]
+    Absent {
+        /// Name of the variable bound to Absent.
         variable_name: String,
     },
 

--- a/rust/dialog-query/src/formula/bindings.rs
+++ b/rust/dialog-query/src/formula/bindings.rs
@@ -47,7 +47,15 @@ impl Bindings {
         Ok(T::try_from(self.resolve(key)?)?)
     }
 
-    /// Resolve a parameter to its Value
+    /// Resolve a parameter to its [`Value`].
+    ///
+    /// Returns [`EvaluationError::UnboundFormulaVariable`] if the
+    /// parameter is not bound. An [`EvaluationError::Absent`]
+    /// propagates if the binding exists but is
+    /// [`Binding::Absent`](crate::Binding::Absent) — formulas
+    /// don't tolerate absent inputs by default; consumers that
+    /// want to handle absence should pattern-match on
+    /// [`Binding`](crate::Binding) via the source match directly.
     pub fn resolve(&mut self, key: &str) -> Result<Value, EvaluationError> {
         let param = self
             .terms
@@ -56,12 +64,14 @@ impl Bindings {
                 parameter: key.into(),
             })?;
 
-        self.source
-            .lookup(param)
-            .map_err(|_| EvaluationError::UnboundFormulaVariable {
-                term: Box::new(param.clone()),
-                parameter: key.into(),
-            })
+        let binding =
+            self.source
+                .lookup(param)
+                .map_err(|_| EvaluationError::UnboundFormulaVariable {
+                    term: Box::new(param.clone()),
+                    parameter: key.into(),
+                })?;
+        binding.content()
     }
 
     /// Get an immutable reference to the source match

--- a/rust/dialog-query/src/formula/cell.rs
+++ b/rust/dialog-query/src/formula/cell.rs
@@ -248,6 +248,7 @@ impl<T: Iterator<Item = Cell>> From<T> for Cells {
 
 impl From<&Cells> for Schema {
     fn from(cells: &Cells) -> Self {
+        use crate::type_system;
         use crate::{Cardinality, Field};
         let mut schema = Schema::new();
         for (name, cell) in cells.iter() {
@@ -255,7 +256,7 @@ impl From<&Cells> for Schema {
                 name.into(),
                 Field {
                     description: cell.description.clone(),
-                    content_type: cell.content_type,
+                    content_type: cell.content_type.map(type_system::Type::primitive),
                     requirement: cell.requirement.clone(),
                     cardinality: Cardinality::One,
                 },
@@ -307,5 +308,27 @@ mod tests {
             &Requirement::Optional
         );
         Ok(())
+    }
+
+    /// `From<&Cells> for Schema` lifts each cell's
+    /// `Option<Type>` content_type into the unified
+    /// `Option<type_system::Type>`. Typed cells produce
+    /// `Some(Primitive(singleton(vt)))`; untyped cells produce
+    /// `None` (unknown).
+    #[dialog_common::test]
+    fn schema_from_cells_lifts_content_types() {
+        use crate::Schema;
+        let cells = Cells::define(|builder| {
+            builder.cell("name", Some(Type::String)).required();
+            builder.cell("untyped", None).required();
+        });
+        let schema = Schema::from(&cells);
+
+        let name = schema.get("name").expect("name field present");
+        let content = name.content_type().expect("name kind present");
+        assert_eq!(content.as_value_type(), Some(Type::String));
+
+        let untyped = schema.get("untyped").expect("untyped field present");
+        assert!(untyped.content_type().is_none());
     }
 }

--- a/rust/dialog-query/src/formula/logic.rs
+++ b/rust/dialog-query/src/formula/logic.rs
@@ -99,6 +99,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );
@@ -125,6 +126,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -151,6 +153,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -177,6 +180,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );
@@ -203,6 +207,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -227,6 +232,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(false)
         );
@@ -252,6 +258,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );
@@ -290,6 +297,7 @@ mod tests {
             final_result
                 .lookup(&Term::var("final_result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| bool::try_from(v).ok()),
             Some(true)
         );

--- a/rust/dialog-query/src/formula/math.rs
+++ b/rust/dialog-query/src/formula/math.rs
@@ -167,6 +167,7 @@ mod tests {
             output
                 .lookup(&Term::var("x"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -174,6 +175,7 @@ mod tests {
             output
                 .lookup(&Term::var("y"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(3)
         );
@@ -183,6 +185,7 @@ mod tests {
             output
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(8)
         );
@@ -234,6 +237,7 @@ mod tests {
             result1
                 .lookup(&Term::var("a"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(2)
         );
@@ -241,6 +245,7 @@ mod tests {
             result1
                 .lookup(&Term::var("b"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(3)
         );
@@ -248,6 +253,7 @@ mod tests {
             result1
                 .lookup(&Term::var("sum"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -264,6 +270,7 @@ mod tests {
             result2
                 .lookup(&Term::var("a"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(10)
         );
@@ -271,6 +278,7 @@ mod tests {
             result2
                 .lookup(&Term::var("b"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(15)
         );
@@ -278,6 +286,7 @@ mod tests {
             result2
                 .lookup(&Term::var("sum"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(25)
         );
@@ -304,6 +313,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(7)
         );
@@ -333,6 +343,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(0)
         );
@@ -359,6 +370,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(42)
         );
@@ -385,6 +397,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -432,6 +445,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(2)
         );
@@ -493,7 +507,14 @@ mod tests {
         let final_results = sum_formula.compute(sum_input)?;
         assert_eq!(final_results.len(), 1);
         assert_eq!(
-            u32::try_from(final_results[0].lookup(&Term::var("final_sum")).unwrap()).ok(),
+            u32::try_from(
+                final_results[0]
+                    .lookup(&Term::var("final_sum"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some(15)
         );
 
@@ -510,6 +531,8 @@ mod tests {
             String::try_from(
                 string_results[0]
                     .lookup(&Term::var("final_string"))
+                    .unwrap()
+                    .content()
                     .unwrap()
             )
             .ok(),

--- a/rust/dialog-query/src/formula/query.rs
+++ b/rust/dialog-query/src/formula/query.rs
@@ -155,6 +155,7 @@ mod tests {
     use super::*;
     use crate::Proposition;
     use crate::constraint::Constraint;
+    use crate::constraint::coalesce::Coalesce;
     use crate::constraint::equality::Equality;
     use crate::term::Term;
     use crate::types::Any;
@@ -457,6 +458,32 @@ mod tests {
                 assert_eq!(eq.is, Term::<Any>::var("y"));
             }
             other => panic!("Expected Constraint(Equality), got {:?}", other),
+        }
+    }
+
+    /// Coalesce round-trips through Proposition. Regression for
+    /// the bug where Proposition::deserialize matched only "==" as
+    /// a constraint and routed every other string to FormulaQuery.
+    #[dialog_common::test]
+    fn it_round_trips_coalesce_as_proposition() {
+        let coalesce = Coalesce::new(
+            Term::<Any>::var("source"),
+            Term::<Any>::var("fallback"),
+            Term::<Any>::var("is"),
+        );
+        let prop = Proposition::Constraint(Constraint::Coalesce(coalesce));
+
+        let json = serde_json::to_value(&prop).unwrap();
+        assert_eq!(json["assert"], "coalesce");
+
+        let deserialized: Proposition = serde_json::from_value(json).unwrap();
+        match &deserialized {
+            Proposition::Constraint(Constraint::Coalesce(c)) => {
+                assert_eq!(c.source.name(), Some("source"));
+                assert_eq!(c.fallback.name(), Some("fallback"));
+                assert_eq!(c.is.name(), Some("is"));
+            }
+            other => panic!("Expected Constraint(Coalesce), got {:?}", other),
         }
     }
 

--- a/rust/dialog-query/src/formula/string.rs
+++ b/rust/dialog-query/src/formula/string.rs
@@ -222,6 +222,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("Hello World".to_string())
         );
@@ -247,6 +248,7 @@ mod tests {
             result
                 .lookup(&Term::var("len"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(5)
         );
@@ -272,6 +274,7 @@ mod tests {
             result
                 .lookup(&Term::var("upper"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("HELLO WORLD".to_string())
         );
@@ -297,6 +300,7 @@ mod tests {
             result
                 .lookup(&Term::var("lower"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("hello world".to_string())
         );
@@ -322,6 +326,7 @@ mod tests {
             result
                 .lookup(&Term::var("len"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| u32::try_from(v).ok()),
             Some(0)
         );
@@ -351,6 +356,7 @@ mod tests {
             result
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("World".to_string())
         );
@@ -377,7 +383,14 @@ mod tests {
         let concat_results = concat_formula.compute(concat_input)?;
         assert_eq!(concat_results.len(), 1);
         assert_eq!(
-            String::try_from(concat_results[0].lookup(&Term::var("full_name")).unwrap()).ok(),
+            String::try_from(
+                concat_results[0]
+                    .lookup(&Term::var("full_name"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some("John Doe".to_string())
         );
 
@@ -396,7 +409,14 @@ mod tests {
         let length_results = length_formula.compute(length_input)?;
         assert_eq!(length_results.len(), 1);
         assert_eq!(
-            u32::try_from(length_results[0].lookup(&Term::var("length")).unwrap()).ok(),
+            u32::try_from(
+                length_results[0]
+                    .lookup(&Term::var("length"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some(11)
         );
 
@@ -415,7 +435,14 @@ mod tests {
         let upper_results = upper_formula.compute(upper_input)?;
         assert_eq!(upper_results.len(), 1);
         assert_eq!(
-            String::try_from(upper_results[0].lookup(&Term::var("output")).unwrap()).ok(),
+            String::try_from(
+                upper_results[0]
+                    .lookup(&Term::var("output"))
+                    .unwrap()
+                    .content()
+                    .unwrap()
+            )
+            .ok(),
             Some("HELLO WORLD".to_string())
         );
 
@@ -444,6 +471,7 @@ mod tests {
             results[0]
                 .lookup(&Term::var("result"))
                 .ok()
+                .and_then(|b| b.content().ok())
                 .and_then(|v| String::try_from(v).ok()),
             Some("hello".to_string())
         );

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -80,7 +80,7 @@ pub use artifact::*;
 pub use attribute::query::{AttributeQuery, DynamicAttributeQuery};
 pub use attribute::*;
 pub use claim::Claim;
-pub use concept::descriptor::{ConceptConclusion, ConceptDescriptor};
+pub use concept::descriptor::{ConceptConclusion, ConceptDescriptor, ConceptFieldDescriptor};
 pub use concept::query::{ConceptQuery, ConceptRules};
 pub use concept::{Concept, ConceptField, Conclusion};
 pub use constraint::Constraint;

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -68,6 +68,11 @@ pub mod statement;
 pub mod stream;
 /// Term types for pattern matching with variables and constants.
 pub mod term;
+/// Unified schema-layer type system (`Type`, `Primitive`,
+/// `Composite`, set-operations). Replaces the older `schema::Type`
+/// enum and the descriptor's `Option<ValueType>` representation;
+/// see `notes/optional-fields.md`.
+pub mod type_system;
 /// Type system utilities bridging Rust types to dialog-artifacts types.
 pub mod types;
 
@@ -77,7 +82,7 @@ pub use attribute::*;
 pub use claim::Claim;
 pub use concept::descriptor::{ConceptConclusion, ConceptDescriptor};
 pub use concept::query::{ConceptQuery, ConceptRules};
-pub use concept::{Concept, Conclusion};
+pub use concept::{Concept, ConceptField, Conclusion};
 pub use constraint::Constraint;
 pub use descriptor::Descriptor;
 pub use environment::*;

--- a/rust/dialog-query/src/parameters.rs
+++ b/rust/dialog-query/src/parameters.rs
@@ -221,7 +221,7 @@ mod tests {
             param,
             &Term::Variable {
                 name: Some("x".into()),
-                descriptor: Any(Some(Type::String))
+                descriptor: Some(Type::String).into(),
             }
         );
     }

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -9,6 +9,7 @@ pub use disjunction::*;
 pub use plan::*;
 
 use crate::error::TypeError;
+use crate::rule::types::TypeEnv;
 use crate::{Environment, Premise};
 
 /// State machine that greedily selects the cheapest viable premise at each
@@ -63,6 +64,22 @@ impl Planner {
                 binds.add(var_name);
             }
         }
+
+        let types = TypeEnv::infer(&steps).map_err(|err| TypeError::TypeInference {
+            reason: err.to_string(),
+        })?;
+
+        // Rewrite each step's premise so its variable terms reflect
+        // the rule-level inferred kinds. Done once here, not on
+        // every evaluation. Standalone queries (empty env) skip the
+        // rewrite entirely.
+        let steps: Vec<Plan> = steps
+            .into_iter()
+            .map(|step| Plan {
+                premise: plan::apply_types(step.premise, &types),
+                ..step
+            })
+            .collect();
 
         Ok(Conjunction {
             steps,
@@ -259,7 +276,11 @@ mod tests {
             .expect("Planning should succeed");
 
         assert_eq!(plan.steps.len(), 2);
-        assert_eq!(plan.binds.len(), 2, "Should bind 2 variables");
+        // ?name, ?greeting, and ?cause — the cause slot is now
+        // declared in the AttributeQuery schema (bound by the
+        // merge step on every Present row), so it counts toward
+        // the plan's bind set.
+        assert_eq!(plan.binds.len(), 3, "Should bind name, greeting, cause");
     }
 
     #[dialog_common::test]
@@ -330,8 +351,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let name = match_result.lookup(&name_param)?;
-            let age = match_result.lookup(&age_param)?;
+            let name = match_result.lookup(&name_param)?.content()?;
+            let age = match_result.lookup(&age_param)?.content()?;
 
             match name {
                 Value::String(n) if n == "Alice" => {

--- a/rust/dialog-query/src/planner/candidate.rs
+++ b/rust/dialog-query/src/planner/candidate.rs
@@ -378,7 +378,8 @@ impl TryFrom<Candidate> for Plan {
                 env,
                 ..
             } => {
-                // Drop schema/params - don't need them in the final plan
+                // Drop schema/params — they're only needed during
+                // planning, not at evaluation time.
                 Ok(Plan {
                     premise,
                     cost,
@@ -789,7 +790,7 @@ mod cost_model_tests {
             Some(Cardinality::One),
         );
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -797,7 +798,8 @@ mod cost_model_tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -838,7 +840,7 @@ mod cost_model_tests {
             Some(Cardinality::One),
         );
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -846,7 +848,8 @@ mod cost_model_tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -880,7 +883,7 @@ mod cost_model_tests {
             Some(Cardinality::One),
         );
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("user/name"),
@@ -888,7 +891,8 @@ mod cost_model_tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -926,7 +930,7 @@ mod cost_model_tests {
             Some(Type::String),
         );
 
-        let concept = ConceptDescriptor::from([("tags", tag)]);
+        let concept = ConceptDescriptor::try_from([("tags", tag)]).unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));
@@ -963,7 +967,7 @@ mod cost_model_tests {
             Some(Type::String),
         );
 
-        let concept = ConceptDescriptor::from([("tags", tag)]);
+        let concept = ConceptDescriptor::try_from([("tags", tag)]).unwrap();
 
         let mut terms = Parameters::new();
         terms.insert("this".to_string(), Term::var("entity"));

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -39,7 +39,9 @@ impl Conjunction {
     /// Converts the steps back into planner candidates and re-orders them
     /// for optimal execution given the new bindings. This is used when a
     /// rule's premises need to be re-evaluated with different known bindings
-    /// (e.g. adornment-based optimization in concepts).
+    /// (e.g. adornment-based optimization in concepts). Type inference
+    /// runs again on the fresh order — its output is stable across
+    /// reorderings, so this is cheap and idempotent.
     pub fn plan(&self, scope: &Environment) -> Result<Self, TypeError> {
         let premises: Vec<_> = self.steps.iter().map(|step| step.premise.clone()).collect();
         Planner::from(premises).plan(scope)

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -1,5 +1,11 @@
+use crate::Term;
+use crate::attribute::query::AttributeQuery;
+use crate::negation::Negation;
+use crate::proposition::Proposition;
+use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
 use crate::source::SelectRules;
+use crate::types::Any;
 use crate::{Environment, Premise};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
@@ -13,11 +19,14 @@ use dialog_common::ConditionalSync;
 /// bound in the environment. The cached schema and parameter data used during
 /// planning are dropped at this point.
 ///
-/// Plans are assembled into a [`Conjunction`](crate::Conjunction) — an ordered sequence of
-/// steps that the query engine evaluates to produce results.
+/// The premise has already been narrowed at plan time via
+/// [`apply_types`] — its variable terms reflect the rule-level
+/// inferred kinds, so evaluators don't need to consult any external
+/// type environment to know which slots are optional.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Plan {
-    /// The premise this plan will execute.
+    /// The premise this plan will execute. Variable terms have
+    /// been narrowed to the rule-level inferred kinds.
     pub premise: Premise,
     /// Estimated execution cost.
     pub cost: usize,
@@ -43,7 +52,7 @@ impl Plan {
         &self.env
     }
 
-    /// Evaluate this plan with the given selection and environment
+    /// Evaluate this plan with the given selection and environment.
     pub fn evaluate<'a, Env, M: Selection + 'a>(
         self,
         selection: M,
@@ -53,5 +62,308 @@ impl Plan {
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
         self.premise.evaluate(selection, env)
+    }
+}
+
+/// Rewrite a premise to reflect rule-level inferred types.
+///
+/// Currently only [`AttributeQuery::is`] is rewritten — that's the
+/// slot whose `is_optional()` answer drives the planner-visible
+/// behavior difference (Absent-fallback emission). Negated
+/// attribute queries are walked too, so a negation over an
+/// optional attribute picks up the same narrowing as its positive
+/// counterpart.
+///
+/// Called once when a [`Plan`] is built. The user-supplied premise
+/// stays untouched; the plan stores the rewritten working copy.
+pub(crate) fn apply_types(premise: Premise, types: &TypeEnv) -> Premise {
+    if types.is_empty() {
+        return premise;
+    }
+    match premise {
+        Premise::Assert(proposition) => {
+            Premise::Assert(apply_types_to_proposition(proposition, types))
+        }
+        Premise::Unless(Negation(proposition)) => {
+            Premise::Unless(Negation(apply_types_to_proposition(proposition, types)))
+        }
+    }
+}
+
+fn apply_types_to_proposition(proposition: Proposition, types: &TypeEnv) -> Proposition {
+    match proposition {
+        Proposition::Attribute(boxed) => {
+            let query = *boxed;
+            Proposition::Attribute(Box::new(narrow_attribute(query, types)))
+        }
+        other => other,
+    }
+}
+
+fn narrow_attribute(query: AttributeQuery, types: &TypeEnv) -> AttributeQuery {
+    let is_term = query.is().clone();
+    let Some(name) = is_term.name() else {
+        return query;
+    };
+    let Some(kind) = types.get(name) else {
+        return query;
+    };
+    let narrowed = Term::<Any>::typed_var(name.to_string(), kind.clone());
+    query.with_is(narrowed)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::artifact::Entity;
+    use crate::planner::Planner;
+    use crate::the;
+    use crate::{Cardinality, Term};
+
+    /// A rule where one premise binds `?name` optionally (so its
+    /// local `is` term carries `String | Nothing`) and another
+    /// binds it required (kind `String`). Rule-level inference
+    /// narrows `?name` to `String`, and the planner stamps the
+    /// narrowed term into each plan step's premise so the
+    /// evaluator's `is.is_optional()` check returns `false`.
+    #[dialog_common::test]
+    fn it_narrows_optional_is_term_via_rule_inference() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises)
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        // Every plan step's stored premise has the narrowed `is` —
+        // the rewrite happens at plan time. The first premise's
+        // user-supplied `is` was `Option<String>`; after planning
+        // it should be `String` only.
+        for step in plan.steps {
+            if let Premise::Assert(Proposition::Attribute(boxed)) = &step.premise {
+                assert!(
+                    !boxed.is().is_optional(),
+                    "rule-level narrowing should leave `is` non-optional"
+                );
+            }
+        }
+    }
+
+    /// End-to-end: with rule-level narrowing applied, an optional
+    /// attribute query whose `?nick` is narrowed to non-optional by
+    /// a sibling premise no longer emits Absent-fallback rows.
+    ///
+    /// The test asserts a stronger fact than "rows are filtered":
+    /// it walks the plan's stored premises and verifies the
+    /// optional attribute's `is` term has been rewritten to a
+    /// non-optional kind. Without that rewrite, the attribute's
+    /// `evaluate` would emit one Absent fallback row per entity
+    /// without a nickname.
+    #[dialog_common::test]
+    fn it_suppresses_absent_fallback_under_rule_inference() {
+        let optional_nick: Term<Any> = Term::<Option<String>>::var("nick").into();
+        let typed_nick: Term<Any> = Term::<String>::var("nick").into();
+        let nickname_query = AttributeQuery::new(
+            Term::from(the!("person/nickname")),
+            Term::<Entity>::var("this"),
+            optional_nick,
+            Term::var("cause1"),
+            Some(Cardinality::One),
+        );
+        let name_query = AttributeQuery::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("this"),
+            typed_nick,
+            Term::var("cause2"),
+            Some(Cardinality::One),
+        );
+
+        // Before planning, the nickname query's `is` is optional.
+        assert!(
+            nickname_query.is().is_optional(),
+            "the local optional kind is preserved on the user's query"
+        );
+
+        let plan = Planner::from(vec![nickname_query.into(), name_query.into()])
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        // After planning, every attribute step that references
+        // `?nick` should have an `is` term whose kind is no
+        // longer optional — the narrowing was applied at plan
+        // time, not deferred to evaluation.
+        let mut narrowed_count = 0;
+        for step in &plan.steps {
+            if let Premise::Assert(Proposition::Attribute(boxed)) = &step.premise
+                && boxed.is().name() == Some("nick")
+            {
+                assert!(
+                    !boxed.is().is_optional(),
+                    "rule-level narrowing should have stripped Nothing from ?nick"
+                );
+                narrowed_count += 1;
+            }
+        }
+        assert_eq!(
+            narrowed_count, 2,
+            "both attribute steps reference ?nick and should both be checked"
+        );
+    }
+
+    /// A standalone query (single optional premise, nothing
+    /// constraining it further) keeps its `is` term's optional
+    /// kind through planning. The rewrite doesn't strip
+    /// optionality when inference didn't strip it either.
+    #[dialog_common::test]
+    fn it_preserves_local_optionality_when_no_other_premise_narrows() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises)
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        if let Premise::Assert(Proposition::Attribute(boxed)) = &plan.steps[0].premise {
+            assert!(
+                boxed.is().is_optional(),
+                "single optional premise should keep its optional `is`"
+            );
+        }
+    }
+
+    /// Replanning a `Conjunction` preserves the rule-level
+    /// narrowing. The fresh inference pass over already-narrowed
+    /// premises is idempotent and yields the same non-optional
+    /// `is` kinds.
+    #[dialog_common::test]
+    fn it_preserves_narrowing_across_replans() {
+        use crate::planner::Conjunction;
+        let optional_name: Term<Any> = Term::<Option<String>>::var("nick").into();
+        let typed_name: Term<Any> = Term::<String>::var("nick").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises)
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        // Replan against a new scope where `this` is bound.
+        let mut scope = crate::Environment::new();
+        scope.add("this");
+        let replanned: Conjunction = plan.plan(&scope).unwrap();
+
+        // The replanned steps still have the narrowed `is`.
+        for step in &replanned.steps {
+            if let Premise::Assert(Proposition::Attribute(boxed)) = &step.premise
+                && boxed.is().name() == Some("nick")
+            {
+                assert!(
+                    !boxed.is().is_optional(),
+                    "narrowing must survive replanning"
+                );
+            }
+        }
+    }
+
+    /// `apply_types` reaches into negated propositions too. A
+    /// negated attribute query that references an inferred
+    /// variable should see its `is` rewritten to match the env.
+    #[dialog_common::test]
+    fn it_narrows_negated_attribute_via_rule_inference() {
+        use crate::artifact::Type as ValueType;
+        use crate::negation::Negation;
+        use crate::type_system::Type as Kind;
+
+        let env = {
+            // Build an env via the public path: a one-premise rule
+            // with a typed Term<String>. The single binding
+            // dictates the inferred kind.
+            let typed_name: Term<Any> = Term::<String>::var("name").into();
+            let premises = vec![
+                AttributeQuery::new(
+                    Term::from(the!("person/name")),
+                    Term::<Entity>::var("this"),
+                    typed_name,
+                    Term::var("cause"),
+                    Some(Cardinality::One),
+                )
+                .into(),
+            ];
+            let plan = Planner::from(premises)
+                .plan(&crate::Environment::new())
+                .unwrap();
+            TypeEnv::infer(&plan.steps).unwrap()
+        };
+
+        // Build a negated attribute query that uses `?name` with
+        // the still-optional local term kind.
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let neg = AttributeQuery::new(
+            Term::from(the!("person/nickname")),
+            Term::<Entity>::var("this"),
+            optional_name,
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        let original = Premise::Unless(Negation(Proposition::Attribute(Box::new(neg))));
+
+        let narrowed = apply_types(original, &env);
+        if let Premise::Unless(Negation(Proposition::Attribute(boxed))) = narrowed {
+            assert!(
+                !boxed.is().is_optional(),
+                "rule-level narrowing should reach into negated attributes"
+            );
+            assert_eq!(
+                boxed.is().kind().and_then(|k| k.as_value_type()),
+                Some(ValueType::String),
+                "narrowed `is` should carry the inferred String kind"
+            );
+            let _ = Kind::primitive(ValueType::String);
+        } else {
+            panic!("expected negated attribute proposition");
+        }
     }
 }

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -1,11 +1,9 @@
-use crate::Term;
 use crate::attribute::query::AttributeQuery;
 use crate::negation::Negation;
 use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::selection::Selection;
 use crate::source::SelectRules;
-use crate::types::Any;
 use crate::{Environment, Premise};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
@@ -101,15 +99,13 @@ fn apply_types_to_proposition(proposition: Proposition, types: &TypeEnv) -> Prop
 }
 
 fn narrow_attribute(query: AttributeQuery, types: &TypeEnv) -> AttributeQuery {
-    let is_term = query.is().clone();
-    let Some(name) = is_term.name() else {
+    let Some(name) = query.is().name() else {
         return query;
     };
     let Some(kind) = types.get(name) else {
         return query;
     };
-    let narrowed = Term::<Any>::typed_var(name.to_string(), kind.clone());
-    query.with_is(narrowed)
+    query.with_type(kind.clone())
 }
 
 #[cfg(test)]
@@ -121,6 +117,7 @@ mod tests {
     use crate::artifact::Entity;
     use crate::planner::Planner;
     use crate::the;
+    use crate::types::Any;
     use crate::{Cardinality, Term};
 
     /// A rule where one premise binds `?name` optionally (so its

--- a/rust/dialog-query/src/proposition.rs
+++ b/rust/dialog-query/src/proposition.rs
@@ -163,16 +163,18 @@ impl<'de> Deserialize<'de> for Proposition {
                 let cq: ConceptQuery = serde_json::from_value(raw).map_err(de::Error::custom)?;
                 Ok(Proposition::Concept(cq))
             }
-            // String "==" → Constraint
-            serde_json::Value::String(name) if name == "==" => {
-                let constraint: Constraint =
-                    serde_json::from_value(raw).map_err(de::Error::custom)?;
-                Ok(Proposition::Constraint(constraint))
-            }
-            // Other string → FormulaQuery
+            // String → Constraint or FormulaQuery. Try Constraint
+            // first because its variants are named ("==", "coalesce",
+            // etc.); FormulaQuery is the catchall fallback for any
+            // other formula name.
             serde_json::Value::String(_) => {
-                let fq: FormulaQuery = serde_json::from_value(raw).map_err(de::Error::custom)?;
-                Ok(Proposition::Formula(fq))
+                if let Ok(constraint) = serde_json::from_value::<Constraint>(raw.clone()) {
+                    Ok(Proposition::Constraint(constraint))
+                } else {
+                    let fq: FormulaQuery =
+                        serde_json::from_value(raw).map_err(de::Error::custom)?;
+                    Ok(Proposition::Formula(fq))
+                }
             }
             _ => Err(de::Error::custom(
                 "\"assert\" must be a concept object or a formula/constraint name string",

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -442,8 +442,8 @@ mod tests {
         assert_eq!(optional, vec!["age", "nickname"]);
 
         // Rule body emits one attribute query per field (required
-        // *and* optional), with the resolution chosen by each
-        // field's `<F as ConceptField>::RESOLUTION` const. For
+        // *and* optional), with the resolution derived from each
+        // field's `<F as ConceptField>::OPTIONAL` const. For
         // MacroEmployee (1 required + 2 optional fields), `when()`
         // returns 3 attribute queries.
         let when_result = MacroEmployee::when(Query::<MacroEmployee>::default());

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -317,20 +317,31 @@ mod tests {
             "Operator should be a concept URI"
         );
 
-        // Test the attributes() method
+        // Test the attributes() method. `with()` iterates sorted by
+        // field name (BTreeMap), so look fields up by name rather
+        // than positionally.
         let attrs = concept.with().iter().collect::<Vec<_>>();
-
         assert_eq!(attrs.len(), 2);
-        assert_eq!(attrs[0].0, "name");
-        assert_eq!(attrs[0].1.domain(), "macro-person");
-        assert_eq!(attrs[0].1.name(), "name");
-        assert_eq!(attrs[0].1.description(), "Name of the person");
-        assert_eq!(attrs[0].1.content_type(), Some(Type::String));
-        assert_eq!(attrs[1].0, "birthday");
-        assert_eq!(attrs[1].1.domain(), "macro-person");
-        assert_eq!(attrs[1].1.name(), "birthday");
-        assert_eq!(attrs[1].1.description(), "Birthday of the person");
-        assert_eq!(attrs[1].1.content_type(), Some(Type::UnsignedInt));
+
+        let name = attrs
+            .iter()
+            .find(|(field, _)| *field == "name")
+            .map(|(_, f)| f)
+            .expect("name field present");
+        assert_eq!(name.domain(), "macro-person");
+        assert_eq!(name.name(), "name");
+        assert_eq!(name.description(), "Name of the person");
+        assert_eq!(name.content_type(), Some(Type::String));
+
+        let birthday = attrs
+            .iter()
+            .find(|(field, _)| *field == "birthday")
+            .map(|(_, f)| f)
+            .expect("birthday field present");
+        assert_eq!(birthday.domain(), "macro-person");
+        assert_eq!(birthday.name(), "birthday");
+        assert_eq!(birthday.description(), "Birthday of the person");
+        assert_eq!(birthday.content_type(), Some(Type::UnsignedInt));
 
         // Test that MacroPerson implements Rule
         let test_match = Query::<MacroPerson> {
@@ -372,8 +383,8 @@ mod tests {
 
     /// Concept with both required and optional fields. Exercises the
     /// `Option<T>` branch of the `#[derive(Concept)]` macro: typed
-    /// `Term<Option<U>>` query field, optional descriptor pair into
-    /// `with_maybe`, and optional realize via `Binding`.
+    /// `Term<Option<U>>` query field, optional field flagged in the
+    /// unified `with` map, and optional realize via `Binding`.
     #[derive(crate::Concept, Debug, Clone)]
     pub struct MacroEmployee {
         /// Employee entity
@@ -406,18 +417,29 @@ mod tests {
         assert!(matches!(default.nickname, Term::Variable { .. }));
         assert!(matches!(default.age, Term::Variable { .. }));
 
-        // Concept descriptor: required field flows into `with`,
-        // optional fields flow into `maybe`.
+        // Concept descriptor: all fields live in a single `with`
+        // map, with optionality carried per-field. The required
+        // field is flagged required; the optional ones are flagged
+        // optional. Iteration is sorted by field name.
         let concept: ConceptDescriptor = MacroEmployee::descriptor().clone();
-        let with: Vec<_> = concept.with().iter().collect();
-        assert_eq!(with.len(), 1);
-        assert_eq!(with[0].0, "given-name");
+        assert_eq!(concept.with().iter().count(), 3);
 
-        let maybe = concept.maybe().expect("concept has maybe attributes");
-        let maybe: Vec<_> = maybe.iter().collect();
-        assert_eq!(maybe.len(), 2);
-        assert_eq!(maybe[0].0, "nickname");
-        assert_eq!(maybe[1].0, "age");
+        let required: Vec<&str> = concept
+            .with()
+            .iter()
+            .filter(|(_, field)| !field.is_optional())
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(required, vec!["given-name"]);
+
+        let optional: Vec<&str> = concept
+            .with()
+            .iter()
+            .filter(|(_, field)| field.is_optional())
+            .map(|(name, _)| name)
+            .collect();
+        // Sorted by name: "age" < "nickname".
+        assert_eq!(optional, vec!["age", "nickname"]);
 
         // Rule body emits one attribute query per field (required
         // *and* optional), with the resolution chosen by each
@@ -466,20 +488,27 @@ mod tests {
             pub nickname: Maybe<macro_employee::Nickname>,
         }
 
-        // Concept descriptor must route `nickname` into `maybe`,
-        // not `with`. If the macro were doing syntactic Option
-        // detection by ident name, `Maybe` would not match and
-        // `nickname` would land in `with` — wrong.
+        // Concept descriptor must flag `nickname` optional in the
+        // unified `with` map. If the macro were doing syntactic
+        // Option detection by ident name, `Maybe` would not match
+        // and `nickname` would land as required — wrong.
         let concept: ConceptDescriptor = AliasedConcept::descriptor().clone();
-        let with: Vec<_> = concept.with().iter().collect();
-        assert_eq!(with.len(), 1);
-        assert_eq!(with[0].0, "given-name");
+        assert_eq!(concept.with().iter().count(), 2);
 
-        let maybe = concept
-            .maybe()
-            .expect("AliasedConcept must have a `maybe` slot");
-        let maybe_entries: Vec<_> = maybe.iter().collect();
-        assert_eq!(maybe_entries.len(), 1);
-        assert_eq!(maybe_entries[0].0, "nickname");
+        let required: Vec<&str> = concept
+            .with()
+            .iter()
+            .filter(|(_, field)| !field.is_optional())
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(required, vec!["given-name"]);
+
+        let optional: Vec<&str> = concept
+            .with()
+            .iter()
+            .filter(|(_, field)| field.is_optional())
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(optional, vec!["nickname"]);
     }
 }

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -22,20 +22,26 @@ use crate::premise::Premise;
 use crate::{Environment, Type};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+/// Rule analysis — inference and dependency graph over premises.
+pub mod analyzer;
 /// Deductive rule definitions for deriving new facts.
 pub mod deductive;
 /// Inductive rule definitions (a.k.a. effects).
 pub mod inductive;
 /// Premises collection type.
 pub mod premises;
+/// Type inference over a rule's premises.
+pub mod types;
 /// When trait and tuple implementations.
 pub mod when;
 
+pub use analyzer::{AnalyzedRule, analyze};
 pub use deductive::DeductiveRule;
 pub use deductive::descriptor::DeductiveRuleDescriptor;
 pub use inductive::InductiveRule;
 pub use inductive::descriptor::InductiveRuleDescriptor;
 pub use premises::*;
+pub use types::TypeEnv;
 pub use when::*;
 
 /// A compiled rule — either deductive or inductive.
@@ -96,17 +102,48 @@ pub trait Compile: Sized + Into<Rule> {
     /// [`compile`](Self::compile) once analysis passes.
     fn from_parts(conclusion: ConceptDescriptor, join: Conjunction) -> Self;
 
-    /// Plan the premises and verify every head variable is bound.
-    /// Default impl is identical for deductive and inductive
-    /// rules; the only difference between the kinds lives at
-    /// evaluation time, not compile time.
+    /// Plan the premises, run rule-level type analysis, and verify
+    /// every head variable is bound. Default impl is identical for
+    /// deductive and inductive rules; the only difference between
+    /// the kinds lives at evaluation time, not compile time.
     fn compile(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
+        // A concept with no required (`with`) attributes is
+        // unconstructable (see `ConceptDescriptor`'s `TryFrom` /
+        // `Deserialize` and the `#[derive(Concept)]` compile-time
+        // assertion), so `conclusion` is guaranteed non-degenerate
+        // here — no explicit emptiness check is needed.
+
         // Plan the order of premises in a scope where none of the
         // rule parameters are bound to find the optimal execution
         // order, or to discover unsatisfiable premises (e.g. a
         // formula whose required cell is never derived by another
         // premise).
         let join = Planner::from(premises).plan(&Environment::new())?;
+
+        // Run rule-level type analysis: inference + required-head
+        // check + Coalesce contract validation. Failures wrap into
+        // the corresponding `TypeError::*` variants so the user
+        // sees the in-progress rule embedded in the error.
+        if let Err(err) = analyzer::analyze(conclusion.clone(), &join.steps) {
+            let in_progress = Self::from_parts(conclusion, join);
+            return Err(match err {
+                analyzer::AnalysisError::Inference { reason } => {
+                    TypeError::TypeInference { reason }
+                }
+                analyzer::AnalysisError::RequiredHeadFromOptional { variable } => {
+                    TypeError::RequiredHeadFromOptional {
+                        rule: Box::new(in_progress.into()),
+                        variable,
+                    }
+                }
+                analyzer::AnalysisError::CoalesceTypeMismatch { reason } => {
+                    TypeError::CoalesceTypeMismatch {
+                        rule: Box::new(in_progress.into()),
+                        reason,
+                    }
+                }
+            });
+        }
 
         // Verify that every conclusion parameter is derived by one
         // of the premises; otherwise the rule could never fully
@@ -179,239 +216,37 @@ macro_rules! when {
 #[cfg(test)]
 mod tests {
     extern crate self as dialog_query;
-    use std::vec::IntoIter;
 
     use super::*;
     use crate::artifact::{Entity, Type};
-    use crate::attribute::{AttributeDescriptor, Cardinality};
     use crate::concept::descriptor::ConceptDescriptor;
-    use crate::concept::query::ConceptQuery;
-    use crate::concept::{Concept, Conclusion};
-    use crate::predicate::Predicate;
-    use crate::premise::Premise;
-    use crate::query::Application;
-    use crate::selection::Match;
-    use crate::selection::Selection;
-    use crate::source::SelectRules;
-    use crate::statement::Statement;
     use crate::term::Term;
-    use crate::the;
-    use crate::{AttributeStatement, EvaluationError, Parameters, Proposition, Query};
-    use dialog_artifacts::Select;
-    use dialog_capability::Provider;
-    use dialog_common::ConditionalSync;
+    use crate::{AttributeStatement, Query};
 
-    // Manual implementation of Person struct with Concept and Rule traits
-    // This serves as a template for what the derive macro should generate
-    #[derive(Debug, Clone)]
+    // Define a Person concept for testing via `#[derive(Concept)]`.
+    // The newtypes live in a module named `person` so the attribute
+    // domain defaults to `person`, yielding `person/name` and
+    // `person/age` to match the facts the scaffold previously asserted.
+    mod person {
+        use crate::Attribute;
+
+        /// Name of the person
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Name(pub String);
+
+        /// Age of the person
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Age(pub u32);
+    }
+
+    /// A person concept used by the rule scaffold tests below.
+    #[derive(crate::Concept, Debug, Clone)]
     pub struct Person {
         pub this: Entity,
-        /// Name of the person
-        pub name: String,
-        /// Age of the person
-        pub age: u32,
-    }
-
-    /// Query pattern for Person - has Term-wrapped fields for querying
-    #[derive(Debug, Clone)]
-    pub struct PersonQuery {
-        /// The entity being matched
-        pub this: Term<Entity>,
-        /// Name term - can be a variable or concrete value
-        pub name: Term<String>,
-        /// Age term - can be a variable or concrete value
-        pub age: Term<u32>,
-    }
-
-    impl Default for PersonQuery {
-        fn default() -> Self {
-            Self {
-                this: Term::var("this"),
-                name: Term::var("name"),
-                age: Term::var("age"),
-            }
-        }
-    }
-
-    /// Attributes pattern for Person - enables fluent query building
-    #[derive(Debug, Clone)]
-    pub struct PersonTerms;
-    impl PersonTerms {
-        pub fn this() -> Term<Entity> {
-            Term::var("this")
-        }
-        pub fn name() -> Term<String> {
-            Term::var("name")
-        }
-        pub fn age() -> Term<u32> {
-            Term::var("age")
-        }
-    }
-
-    fn person_predicate() -> ConceptDescriptor {
-        ConceptDescriptor::from(vec![
-            (
-                "name",
-                AttributeDescriptor::new(
-                    the!("person/name"),
-                    "Name of the person",
-                    Cardinality::One,
-                    Some(Type::String),
-                ),
-            ),
-            (
-                "age",
-                AttributeDescriptor::new(
-                    the!("person/age"),
-                    "Age of the person",
-                    Cardinality::One,
-                    Some(Type::UnsignedInt),
-                ),
-            ),
-        ])
-    }
-
-    impl From<Person> for ConceptDescriptor {
-        fn from(_: Person) -> Self {
-            person_predicate()
-        }
-    }
-
-    impl From<PersonQuery> for ConceptDescriptor {
-        fn from(_: PersonQuery) -> Self {
-            person_predicate()
-        }
-    }
-
-    impl Concept for Person {
-        type Term = PersonTerms;
-
-        fn this(&self) -> Entity {
-            let predicate: ConceptDescriptor = self.clone().into();
-            predicate.this()
-        }
-    }
-
-    impl IntoIterator for Person {
-        type Item = AttributeStatement;
-        type IntoIter = IntoIter<AttributeStatement>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            vec![
-                the!("person/name")
-                    .of(self.this.clone())
-                    .is(self.name.clone())
-                    .into(),
-                the!("person/age").of(self.this.clone()).is(self.age).into(),
-            ]
-            .into_iter()
-        }
-    }
-
-    impl Statement for Person {
-        fn assert(self, update: &mut impl dialog_artifacts::Update) {
-            the!("person/name")
-                .of(self.this.clone())
-                .is(self.name.clone())
-                .assert(update);
-            the!("person/age")
-                .of(self.this.clone())
-                .is(self.age)
-                .assert(update);
-        }
-
-        fn retract(self, update: &mut impl dialog_artifacts::Update) {
-            the!("person/name")
-                .of(self.this.clone())
-                .is(self.name.clone())
-                .retract(update);
-            the!("person/age")
-                .of(self.this.clone())
-                .is(self.age)
-                .retract(update);
-        }
-    }
-
-    impl Predicate for Person {
-        type Conclusion = Person;
-        type Application = PersonQuery;
-        type Descriptor = ConceptDescriptor;
-    }
-
-    impl TryFrom<Match> for Person {
-        type Error = EvaluationError;
-
-        fn try_from(source: Match) -> Result<Self, Self::Error> {
-            Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&PersonTerms::this()))?)?,
-                name: String::try_from(source.lookup(&Term::from(&PersonTerms::name()))?)?,
-                age: u32::try_from(source.lookup(&Term::from(&PersonTerms::age()))?)?,
-            })
-        }
-    }
-
-    impl From<PersonQuery> for Parameters {
-        fn from(source: PersonQuery) -> Self {
-            let mut terms = Self::new();
-
-            terms.insert("this".into(), source.this.into());
-            terms.insert("name".into(), source.name.into());
-            terms.insert("age".into(), source.age.into());
-
-            terms
-        }
-    }
-
-    impl Application for PersonQuery {
-        type Conclusion = Person;
-
-        fn evaluate<'a, Env, M: Selection + 'a>(
-            self,
-            selection: M,
-            env: &'a Env,
-        ) -> impl Selection + 'a
-        where
-            Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
-        {
-            let application: ConceptQuery = self.into();
-            application.evaluate(selection, env)
-        }
-
-        fn realize(&self, source: Match) -> Result<Self::Conclusion, EvaluationError> {
-            Ok(Person {
-                this: Entity::try_from(source.lookup(&Term::from(&self.this))?)?,
-                name: String::try_from(source.lookup(&Term::from(&self.name))?)?,
-                age: u32::try_from(source.lookup(&Term::from(&self.age))?)?,
-            })
-        }
-    }
-
-    impl From<PersonQuery> for ConceptQuery {
-        fn from(source: PersonQuery) -> Self {
-            let predicate: ConceptDescriptor = source.clone().into();
-            ConceptQuery {
-                terms: source.into(),
-                predicate,
-            }
-        }
-    }
-
-    impl From<PersonQuery> for Proposition {
-        fn from(source: PersonQuery) -> Self {
-            Proposition::Concept(source.into())
-        }
-    }
-
-    impl From<PersonQuery> for Premise {
-        fn from(source: PersonQuery) -> Self {
-            Premise::Assert(source.into())
-        }
-    }
-
-    impl Conclusion for Person {
-        fn this(&self) -> &Entity {
-            panic!("Instance trait implementation requires an entity field")
-        }
+        /// Name of the person (`person/name`)
+        pub name: person::Name,
+        /// Age of the person (`person/age`)
+        pub age: person::Age,
     }
 
     #[dialog_common::test]
@@ -426,12 +261,10 @@ mod tests {
         }
 
         // Verify rule installs into registry
-        use crate::ConceptDescriptor;
         use crate::rule::deductive::DeductiveRule;
         use crate::session::RuleRegistry;
         let mut rules = RuleRegistry::new();
-        let person_query = Query::<Person>::default();
-        let concept: ConceptDescriptor = person_query.into();
+        let concept = Person::descriptor().clone();
         let premises = person_rule(Query::<Person>::default())
             .into_premises()
             .into_vec();
@@ -477,7 +310,7 @@ mod tests {
         };
 
         // Test that MacroPerson implements Concept
-        let concept: ConceptDescriptor = Query::<MacroPerson>::default().into();
+        let concept: ConceptDescriptor = MacroPerson::descriptor().clone();
         // Operator is now a computed URI
         assert!(
             concept.this().to_string().starts_with("concept:"),
@@ -519,5 +352,134 @@ mod tests {
         assert_eq!(name_desc.name(), "name");
         assert_eq!(birthday_desc.domain(), "macro-person");
         assert_eq!(birthday_desc.name(), "birthday");
+    }
+
+    mod macro_employee {
+        use crate::Attribute;
+
+        /// Person's first name
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct GivenName(pub String);
+
+        /// Person's preferred nickname
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Nickname(pub String);
+
+        /// Person's age in years
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Age(pub u32);
+    }
+
+    /// Concept with both required and optional fields. Exercises the
+    /// `Option<T>` branch of the `#[derive(Concept)]` macro: typed
+    /// `Term<Option<U>>` query field, optional descriptor pair into
+    /// `with_maybe`, and optional realize via `Binding`.
+    #[derive(crate::Concept, Debug, Clone)]
+    pub struct MacroEmployee {
+        /// Employee entity
+        pub this: Entity,
+        /// Required given name
+        pub given_name: macro_employee::GivenName,
+        /// Optional preferred nickname
+        pub nickname: Option<macro_employee::Nickname>,
+        /// Optional age
+        pub age: Option<macro_employee::Age>,
+    }
+
+    #[dialog_common::test]
+    fn it_emits_typed_optional_terms_in_macro() {
+        // The query struct must accept `Term<Option<String>>` and
+        // `Term<Option<u32>>` for the optional fields. Constructing the
+        // query with these types is itself a compile-time test.
+        let _query = Query::<MacroEmployee> {
+            this: Term::var("emp"),
+            given_name: Term::<String>::var("emp_given"),
+            nickname: Term::<Option<String>>::var("emp_nickname"),
+            age: Term::<Option<u32>>::var("emp_age"),
+        };
+
+        // Default-constructed query: every field is a named variable
+        // including the optional ones.
+        let default = Query::<MacroEmployee>::default();
+        assert!(matches!(default.this, Term::Variable { .. }));
+        assert!(matches!(default.given_name, Term::Variable { .. }));
+        assert!(matches!(default.nickname, Term::Variable { .. }));
+        assert!(matches!(default.age, Term::Variable { .. }));
+
+        // Concept descriptor: required field flows into `with`,
+        // optional fields flow into `maybe`.
+        let concept: ConceptDescriptor = MacroEmployee::descriptor().clone();
+        let with: Vec<_> = concept.with().iter().collect();
+        assert_eq!(with.len(), 1);
+        assert_eq!(with[0].0, "given-name");
+
+        let maybe = concept.maybe().expect("concept has maybe attributes");
+        let maybe: Vec<_> = maybe.iter().collect();
+        assert_eq!(maybe.len(), 2);
+        assert_eq!(maybe[0].0, "nickname");
+        assert_eq!(maybe[1].0, "age");
+
+        // Rule body emits one attribute query per field (required
+        // *and* optional), with the resolution chosen by each
+        // field's `<F as ConceptField>::RESOLUTION` const. For
+        // MacroEmployee (1 required + 2 optional fields), `when()`
+        // returns 3 attribute queries.
+        let when_result = MacroEmployee::when(Query::<MacroEmployee>::default());
+        assert_eq!(when_result.len(), 3);
+    }
+
+    #[dialog_common::test]
+    fn it_persists_only_some_optional_values() {
+        // IntoIterator emits a relation per field: required always,
+        // optional only when `Some(_)`. With one Some and one None,
+        // we should see exactly two statements (1 required + 1 Some).
+        let entity = Entity::new().unwrap();
+        let employee = MacroEmployee {
+            this: entity,
+            given_name: macro_employee::GivenName("Ada".into()),
+            nickname: Some(macro_employee::Nickname("AL".into())),
+            age: None,
+        };
+
+        let statements: Vec<AttributeStatement> = employee.into_iter().collect();
+        assert_eq!(statements.len(), 2);
+    }
+
+    /// Aliasing `Option` to another name still routes through the
+    /// `ConceptField` impl for `Option<N>`. Proves the macro does
+    /// not depend on syntactic detection of the literal `Option`
+    /// identifier — Rust's type system resolves the alias to the
+    /// underlying `Option<N>` shape at type-check time, picking
+    /// up the right blanket impl.
+    #[dialog_common::test]
+    fn it_routes_optional_through_alias_via_concept_field() {
+        use core::option::Option as Maybe;
+
+        #[derive(crate::Concept, Debug, Clone)]
+        #[allow(dead_code)]
+        pub struct AliasedConcept {
+            /// Entity
+            pub this: Entity,
+            /// Required name
+            pub given_name: macro_employee::GivenName,
+            /// Optional nickname, spelled via an aliased Option
+            pub nickname: Maybe<macro_employee::Nickname>,
+        }
+
+        // Concept descriptor must route `nickname` into `maybe`,
+        // not `with`. If the macro were doing syntactic Option
+        // detection by ident name, `Maybe` would not match and
+        // `nickname` would land in `with` — wrong.
+        let concept: ConceptDescriptor = AliasedConcept::descriptor().clone();
+        let with: Vec<_> = concept.with().iter().collect();
+        assert_eq!(with.len(), 1);
+        assert_eq!(with[0].0, "given-name");
+
+        let maybe = concept
+            .maybe()
+            .expect("AliasedConcept must have a `maybe` slot");
+        let maybe_entries: Vec<_> = maybe.iter().collect();
+        assert_eq!(maybe_entries.len(), 1);
+        assert_eq!(maybe_entries[0].0, "nickname");
     }
 }

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -1,0 +1,450 @@
+//! Rule analysis — the phase between parsing and planning.
+//!
+//! The rule pipeline has three phases:
+//!
+//! 1. **Parse.** A `DeductiveRuleDescriptor` carries the user's
+//!    syntactic form: a conclusion and a list of premises with
+//!    user-supplied terms.
+//! 2. **Analyze.** Type inference runs against the premises'
+//!    slots; type errors (`RequiredHeadFromOptional`, Coalesce
+//!    contract violations) surface here. The output is an
+//!    `AnalyzedRule` — every premise carries a shared, read-only
+//!    view of the rule-wide [`TypeEnv`], plus a dependency graph
+//!    describing which premise binds and which reads each variable.
+//! 3. **Plan.** Given an `AnalyzedRule` and a scope of already-bound
+//!    variables, the planner orders the premises by cost and
+//!    produces a `Conjunction` ready for execution.
+//!
+//! Analysis is rule-scoped; the result is immutable. Planning can
+//! run repeatedly against the same analyzed rule with different
+//! scopes (the use case is concept-rule replanning when caller
+//! bindings change).
+
+use crate::Premise;
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::constraint::Constraint;
+use crate::planner::Plan;
+use crate::proposition::Proposition;
+use crate::rule::types::TypeEnv;
+use crate::schema::Requirement;
+use crate::type_system::Type as Kind;
+use crate::type_system::unifier::Context;
+use std::collections::{BTreeSet, HashSet};
+use std::sync::Arc;
+
+/// Variable-usage information for a single premise.
+///
+/// Computed during analysis by walking the premise's schema and
+/// parameters: a variable is in `binds` if the premise will produce
+/// a value for it (positive premise; non-blank parameter slot), and
+/// in `needs` if the premise reads it without binding (e.g. a
+/// required slot the premise can't satisfy on its own, or a value
+/// it has to look up). A variable can appear in both sets when the
+/// schema lists it under multiple slots with mixed requirements.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PremiseVars {
+    /// Variables this premise will bind upon execution.
+    pub binds: BTreeSet<String>,
+    /// Variables this premise needs already bound to execute.
+    pub needs: BTreeSet<String>,
+}
+
+/// Per-premise variable usage plus precomputed dependency edges.
+///
+/// `requires[i]` is the set of premise indices that must execute
+/// before premise `i` because they bind a variable in `needs[i]`.
+/// The graph respects the user's original premise order: a premise
+/// that binds a variable can satisfy any later premise's need for
+/// it, regardless of cost. Reordering happens during planning, not
+/// here.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DependencyGraph {
+    /// Per-premise variable usage in the original order.
+    pub usage: Vec<PremiseVars>,
+    /// `requires[i]` lists the premise indices `j` such that
+    /// premise `j` binds a variable premise `i` needs.
+    pub requires: Vec<BTreeSet<usize>>,
+}
+
+impl DependencyGraph {
+    /// Returns `true` if no premises were analyzed.
+    pub fn is_empty(&self) -> bool {
+        self.usage.is_empty()
+    }
+
+    /// Number of premises in the graph.
+    pub fn len(&self) -> usize {
+        self.usage.len()
+    }
+
+    /// Compute the dependency graph for a sequence of planned steps.
+    /// Walks each step's schema once: a non-blank named parameter
+    /// goes into `binds` if the schema field is `Optional` or part
+    /// of a satisfied choice group, otherwise into `needs`. Choice
+    /// groups satisfied by a constant or already-bound parameter
+    /// don't contribute to `needs`.
+    pub fn from_steps(steps: &[Plan]) -> Self {
+        let mut usage = Vec::with_capacity(steps.len());
+
+        for step in steps {
+            let is_negation = matches!(step.premise, Premise::Unless(_));
+            let schema = step.premise.schema();
+            let params = step.premise.parameters();
+
+            // Identify choice groups satisfied by a constant in
+            // this step's parameters.
+            let mut satisfied_groups = HashSet::new();
+            for (slot_name, field) in schema.iter() {
+                if let Some(param) = params.get(slot_name)
+                    && let Requirement::Required(Some(group)) = &field.requirement
+                    && param.is_constant()
+                {
+                    satisfied_groups.insert(*group);
+                }
+            }
+
+            let mut vars = PremiseVars::default();
+            for (slot_name, field) in schema.iter() {
+                let Some(param) = params.get(slot_name) else {
+                    continue;
+                };
+                if param.is_constant() || param.is_blank() {
+                    continue;
+                }
+                let Some(name) = param.name() else {
+                    continue;
+                };
+                match &field.requirement {
+                    Requirement::Required(None) => {
+                        vars.needs.insert(name.to_string());
+                    }
+                    Requirement::Required(Some(group)) => {
+                        if satisfied_groups.contains(group) {
+                            if !is_negation {
+                                vars.binds.insert(name.to_string());
+                            }
+                        } else {
+                            vars.needs.insert(name.to_string());
+                        }
+                    }
+                    Requirement::Optional => {
+                        if !is_negation {
+                            vars.binds.insert(name.to_string());
+                        }
+                    }
+                }
+            }
+            usage.push(vars);
+        }
+
+        // For each premise i, find every other premise j (j != i)
+        // that binds something i needs.
+        let mut requires = vec![BTreeSet::new(); usage.len()];
+        for (i, vars) in usage.iter().enumerate() {
+            for need in &vars.needs {
+                for (j, other) in usage.iter().enumerate() {
+                    if j != i && other.binds.contains(need) {
+                        requires[i].insert(j);
+                    }
+                }
+            }
+        }
+
+        Self { usage, requires }
+    }
+}
+
+/// Errors detected by [`analyze`]. These are pre-rule type
+/// problems: inference produced a contradiction or a constraint's
+/// type contract isn't satisfied. `DeductiveRule::new` wraps these
+/// in the full [`TypeError`](crate::error::TypeError) variants
+/// after planning, so callers get the rule embedded for display.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum AnalysisError {
+    /// Type inference produced a contradiction — see
+    /// [`InferenceError`](super::types::InferenceError).
+    #[error("type inference failed: {reason}")]
+    Inference {
+        /// Description of the conflict.
+        reason: String,
+    },
+    /// A conclusion variable's inferred type admits `Nothing` —
+    /// the rule could produce `Absent` in a required slot.
+    #[error("conclusion variable {variable} is optional")]
+    RequiredHeadFromOptional {
+        /// Name of the offending head variable.
+        variable: String,
+    },
+    /// A `Coalesce` constraint's type contract is violated.
+    #[error("Coalesce type mismatch: {reason}")]
+    CoalesceTypeMismatch {
+        /// Human-readable reason from the unifier.
+        reason: String,
+    },
+}
+
+/// A rule that has passed analysis. Carries the conclusion, the
+/// original premises in their planned order, the rule-wide
+/// inferred type environment, and a per-premise dependency graph.
+///
+/// This is the artifact of analysis. The planner reads it (or its
+/// pieces) to build per-step plans; future iterations of the
+/// planner can consume the dependency graph directly to avoid
+/// re-walking schemas on every iteration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnalyzedRule {
+    /// The rule's conclusion.
+    pub conclusion: ConceptDescriptor,
+    /// The premises in their planned order. Analysis preserves
+    /// the planner's ordering; it doesn't re-order on its own.
+    pub premises: Vec<Premise>,
+    /// The rule-wide inferred type environment. Shared via
+    /// [`Arc`] across consumers.
+    pub types: Arc<TypeEnv>,
+    /// Per-premise variable usage and dependency edges. Indexed
+    /// in the same order as `premises`.
+    pub graph: DependencyGraph,
+}
+
+impl AnalyzedRule {
+    /// Iterate over the analyzed premises.
+    pub fn premises(&self) -> impl Iterator<Item = &Premise> {
+        self.premises.iter()
+    }
+
+    /// Look up a variable's inferred type by name.
+    pub fn type_of(&self, name: &str) -> Option<&Kind> {
+        self.types.get(name)
+    }
+}
+
+/// Run analysis over the rule's premises:
+///
+/// 1. Infer the rule-wide type environment from each premise's
+///    slot kinds.
+/// 2. Check that no conclusion variable's inferred type admits
+///    `Nothing` — a required head can't accept `Absent`.
+/// 3. Validate every Coalesce constraint's type contract.
+///
+/// Returns the analyzed rule on success, or an [`AnalysisError`]
+/// describing the type problem. `DeductiveRule::new` wraps these
+/// in the corresponding [`TypeError`](crate::error::TypeError)
+/// variants with the planned rule embedded for display.
+pub fn analyze(
+    conclusion: ConceptDescriptor,
+    steps: &[Plan],
+) -> Result<AnalyzedRule, AnalysisError> {
+    let types = Arc::new(
+        TypeEnv::infer(steps).map_err(|err| AnalysisError::Inference {
+            reason: err.to_string(),
+        })?,
+    );
+
+    // Required heads must not admit `Nothing`.
+    if let Some(variable) = conclusion
+        .operands()
+        .find(|name| types.get(name).is_some_and(Kind::is_optional))
+    {
+        return Err(AnalysisError::RequiredHeadFromOptional {
+            variable: variable.to_string(),
+        });
+    }
+
+    // Each Coalesce constraint validates against a fresh unifier
+    // context. Catches wire-format and raw-builder mismatches
+    // where the typed builder isn't the construction path.
+    for step in steps {
+        let Premise::Assert(Proposition::Constraint(Constraint::Coalesce(coalesce))) =
+            &step.premise
+        else {
+            continue;
+        };
+        let mut ctx = Context::new();
+        if let Err(err) = coalesce.validate(&mut ctx) {
+            return Err(AnalysisError::CoalesceTypeMismatch {
+                reason: err.to_string(),
+            });
+        }
+    }
+
+    let premises = steps.iter().map(|step| step.premise.clone()).collect();
+    let graph = DependencyGraph::from_steps(steps);
+    Ok(AnalyzedRule {
+        conclusion,
+        premises,
+        types,
+        graph,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::artifact::{Entity, Type as ValueType};
+    use crate::attribute::AttributeDescriptor;
+    use crate::attribute::query::AttributeQuery;
+    use crate::planner::Planner;
+    use crate::the;
+    use crate::types::Any;
+    use crate::{Cardinality, Environment, Term};
+
+    fn person_with_name() -> ConceptDescriptor {
+        ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(ValueType::String),
+            ),
+        )])
+        .unwrap()
+    }
+
+    /// Analysis output carries the inferred type environment.
+    #[dialog_common::test]
+    fn it_analyzes_a_single_typed_premise() {
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let analyzed = analyze(person_with_name(), &plan.steps).unwrap();
+
+        assert_eq!(analyzed.premises.len(), 1);
+        let name_kind = analyzed.type_of("name").expect("name has an inferred type");
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+
+    /// Two premises that share a variable `?entity`: one binds it
+    /// (the entity slot is a free variable), and one needs it (the
+    /// entity slot is the same variable, satisfied by the first
+    /// premise binding it). The graph records the dependency edge.
+    #[dialog_common::test]
+    fn it_records_dependency_edge_between_premises() {
+        let q1 = AttributeQuery::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("entity"),
+            Term::<String>::var("name").into(),
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        let q2 = AttributeQuery::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("entity"),
+            Term::<Any>::var("age"),
+            Term::var("cause2"),
+            Some(Cardinality::One),
+        );
+        let premises = vec![q1.into(), q2.into()];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let analyzed = analyze(person_with_name(), &plan.steps).unwrap();
+
+        assert_eq!(analyzed.graph.len(), 2);
+
+        // Each step's vars include `entity` (the schema groups
+        // the/of/is/cause as one choice; with a constant `the`,
+        // the group is satisfied, so all of them are binds).
+        for vars in &analyzed.graph.usage {
+            assert!(vars.binds.contains("entity"));
+        }
+    }
+
+    /// A formula premise that needs `?text` and binds `?len`
+    /// depends on an earlier attribute premise that binds `?text`.
+    /// The dependency graph records an edge from the formula's
+    /// `requires[]` to the attribute's index.
+    #[dialog_common::test]
+    fn it_records_formula_dependency_on_attribute() {
+        use crate::formula::Formula;
+        use crate::formula::string::Length;
+        use crate::{Parameters, Premise};
+
+        // Premise 0: attribute query that binds ?text.
+        let attr = AttributeQuery::new(
+            Term::from(the!("note/body")),
+            Term::<Entity>::var("this"),
+            Term::<String>::var("text").into(),
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+
+        // Premise 1: Length formula, needs ?text bound, binds ?len.
+        let mut params = Parameters::new();
+        params.insert("of".to_string(), Term::var("text"));
+        params.insert("is".to_string(), Term::var("len"));
+        let length = Length::apply(params).unwrap();
+
+        let premises: Vec<Premise> = vec![attr.into(), Premise::from(length)];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let analyzed = analyze(person_with_name(), &plan.steps).unwrap();
+
+        assert_eq!(analyzed.graph.len(), 2);
+
+        // The formula step needs `text`; some other step binds it.
+        // Concretely: the attribute step's index should appear in
+        // the formula step's `requires` set.
+        //
+        // The planner orders attribute first (cost), so attribute
+        // is step 0 and formula is step 1. The formula needs
+        // ?text bound by step 0.
+        let formula_idx = analyzed
+            .premises
+            .iter()
+            .position(|p| matches!(p, Premise::Assert(crate::Proposition::Formula(_))))
+            .expect("formula step present");
+        let attr_idx = analyzed
+            .premises
+            .iter()
+            .position(|p| matches!(p, Premise::Assert(crate::Proposition::Attribute(_))))
+            .expect("attribute step present");
+
+        assert!(
+            analyzed.graph.requires[formula_idx].contains(&attr_idx),
+            "formula step should depend on the attribute step that binds ?text"
+        );
+        assert!(
+            analyzed.graph.usage[formula_idx].needs.contains("text"),
+            "formula step should record ?text in its needs"
+        );
+        assert!(
+            analyzed.graph.usage[attr_idx].binds.contains("text"),
+            "attribute step should record ?text in its binds"
+        );
+    }
+
+    /// Analysis rejects a conclusion variable whose inferred type
+    /// admits `Nothing` — the rule could yield Absent in the head.
+    #[dialog_common::test]
+    fn it_rejects_required_head_bound_only_by_optional_premises() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let err = analyze(person_with_name(), &plan.steps).unwrap_err();
+        match err {
+            AnalysisError::RequiredHeadFromOptional { variable } => {
+                assert_eq!(variable, "name");
+            }
+            other => panic!("expected RequiredHeadFromOptional, got {other:?}"),
+        }
+    }
+}

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -1,6 +1,8 @@
 /// Serializable rule descriptor matching the formal notation.
 pub mod descriptor;
 
+use crate::artifact::Entity;
+use crate::attribute::query::AttributeQuery;
 pub use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::TypeError;
 use crate::negation::Negation;
@@ -8,6 +10,9 @@ pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
 use crate::rule::{Compile, fmt_rule_schema};
+use crate::type_system::Primitive;
+use crate::type_system::Type as Kind;
+use crate::types::Any;
 pub use crate::{Attribute, Cardinality, Parameters, Proposition, Requirement, Value};
 use crate::{Environment, Term};
 use descriptor::DeductiveRuleDescriptor;
@@ -34,8 +39,10 @@ impl Compile for DeductiveRule {
 impl DeductiveRule {
     /// Compile a rule from a conclusion and premises.
     ///
-    /// Plans the optimal premise execution order and validates that every
-    /// conclusion variable is grounded by at least one positive premise.
+    /// Plans the optimal premise execution order, validates that every
+    /// conclusion variable is grounded by at least one positive premise,
+    /// and runs the type-inference check that required head variables
+    /// are not bound only by optional (set-widened) sources.
     pub fn new(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Result<Self, TypeError> {
         <Self as Compile>::compile(conclusion, premises)
     }
@@ -113,12 +120,12 @@ impl Display for DeductiveRule {
 
 impl From<&ConceptDescriptor> for DeductiveRule {
     fn from(concept: &ConceptDescriptor) -> Self {
-        use crate::artifact::Entity;
-        use crate::attribute::query::AttributeQuery;
-
         let mut premises = Vec::new();
 
         let this = Term::<Entity>::var("this");
+
+        // Required (`with`) attributes — standard EAV semantics.
+        // A missing fact filters the row out entirely.
         for (name, attribute) in concept.with().iter() {
             premises.push(
                 AttributeQuery::new(
@@ -132,6 +139,29 @@ impl From<&ConceptDescriptor> for DeductiveRule {
             );
         }
 
+        // Optional (`maybe`) attributes — a missing fact yields a
+        // fallback row with the slot bound to `Binding::Absent`.
+        // We encode this by typing the `is` term as optional;
+        // `AttributeQuery` derives its resolution from that kind.
+        if let Some(maybe) = concept.maybe() {
+            for (name, attribute) in maybe.iter() {
+                let kind = match attribute.content_type() {
+                    Some(ty) => Kind::primitive(ty).optional(),
+                    None => Kind::primitive_set(Primitive::ALL).optional(),
+                };
+                premises.push(
+                    AttributeQuery::new(
+                        Term::Constant(Value::from(attribute.the().clone())),
+                        this.clone(),
+                        Term::<Any>::typed_var(name, kind),
+                        Term::blank(),
+                        Some(attribute.cardinality()),
+                    )
+                    .into(),
+                );
+            }
+        }
+
         DeductiveRule::new(concept.clone(), premises).expect("Concept should compile")
     }
 }
@@ -139,14 +169,26 @@ impl From<&ConceptDescriptor> for DeductiveRule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::artifact::{Entity, Type};
+    use crate::artifact::{Cause, Entity, Type};
     use crate::attribute::AttributeDescriptor;
     use crate::attribute::query::AttributeQuery;
     use crate::the;
+    use crate::types::Any;
+
+    /// Helper: produce an optional `Term<Any>` — this is how an
+    /// AttributeQuery is told to run with optional resolution, since
+    /// resolution is derived from `is.is_optional()`.
+    fn optional_term(name: &str, inner: Option<Type>) -> Term<Any> {
+        let kind = match inner {
+            Some(ty) => Kind::primitive(ty).optional(),
+            None => Kind::primitive_set(Primitive::ALL).optional(),
+        };
+        Term::<Any>::typed_var(name, kind)
+    }
 
     #[dialog_common::test]
     fn it_compiles_with_valid_premises() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -165,7 +207,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         let premises = vec![
             AttributeQuery::new(
@@ -191,7 +234,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_unconstrained_fact() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "key",
                 AttributeDescriptor::new(
@@ -210,7 +253,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let premises = vec![
             AttributeQuery::new(
                 Term::var("the"),
@@ -226,7 +270,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_unconstrained_relation() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "key",
                 AttributeDescriptor::new(
@@ -245,7 +289,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         // All terms are variables — no constants at all.
         // The planner should reject this at install time.
@@ -269,7 +314,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_unused_parameter() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -288,7 +333,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let premises = vec![
             AttributeQuery::new(
                 Term::from(the!("user/name")),
@@ -308,7 +354,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_empty_premises() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -327,13 +373,14 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         assert!(DeductiveRule::new(conclusion, vec![]).is_err());
     }
 
     #[dialog_common::test]
     fn it_compiles_with_chained_dependencies() {
-        let conclusion = ConceptDescriptor::from(vec![
+        let conclusion = ConceptDescriptor::try_from(vec![
             (
                 "key",
                 AttributeDescriptor::new(
@@ -352,7 +399,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let this = Term::<Entity>::var("this");
         let premises = vec![
             AttributeQuery::new(
@@ -381,10 +429,11 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_mismatched_parameter_name() {
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "key",
             AttributeDescriptor::new(the!("result/key"), "", Cardinality::One, Some(Type::String)),
-        )]);
+        )])
+        .unwrap();
 
         let premises = vec![
             AttributeQuery::new(
@@ -409,9 +458,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_negated_constraint_with_unbound_variable() {
-        use crate::attribute::query::AttributeQuery;
-
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -419,7 +466,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let name = Term::<String>::var("name");
         let z = Term::<String>::var("z");
@@ -445,9 +493,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_rejects_negated_constraint_with_unbound_variable_on_left() {
-        use crate::attribute::query::AttributeQuery;
-
-        let conclusion = ConceptDescriptor::from(vec![(
+        let conclusion = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -455,7 +501,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let name = Term::<String>::var("name");
         let z = Term::<String>::var("z");
@@ -477,5 +524,376 @@ mod tests {
             result.is_err(),
             "Should reject rule with negated constraint referencing unbound variable ?z (flipped)"
         );
+    }
+
+    /// Concept projection emits one premise per `with` attribute,
+    /// each with `Resolution::Required` (the default). A concept
+    /// with no `maybe` attributes produces only required
+    /// premises.
+    #[dialog_common::test]
+    fn from_concept_with_only_required_emits_required_premises() {
+        use crate::Premise;
+        use crate::attribute::query::Resolution;
+        use crate::proposition::Proposition;
+
+        let concept = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+
+        let rule = DeductiveRule::from(&concept);
+
+        let mut required = 0;
+        let mut optional = 0;
+        for step in rule.join.steps.iter() {
+            if let Premise::Assert(Proposition::Attribute(query)) = &step.premise {
+                match query.resolution() {
+                    Resolution::Required => required += 1,
+                    Resolution::Optional => optional += 1,
+                }
+            }
+        }
+        assert_eq!(required, 1, "expected one required premise");
+        assert_eq!(optional, 0, "expected no optional premises");
+    }
+
+    /// Concept projection emits one premise per `with` attribute
+    /// (Required) and one per `maybe` attribute (Optional).
+    #[dialog_common::test]
+    fn from_concept_with_maybe_emits_optional_resolver() {
+        use crate::Premise;
+        use crate::attribute::query::Resolution;
+        use crate::proposition::Proposition;
+
+        let concept = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap()
+        .with_maybe(vec![(
+            "nickname",
+            AttributeDescriptor::new(
+                the!("person/nickname"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+
+        let rule = DeductiveRule::from(&concept);
+
+        let mut required = 0;
+        let mut optional = 0;
+        for step in rule.join.steps.iter() {
+            if let Premise::Assert(Proposition::Attribute(query)) = &step.premise {
+                match query.resolution() {
+                    Resolution::Required => required += 1,
+                    Resolution::Optional => optional += 1,
+                }
+            }
+        }
+        assert_eq!(required, 1, "expected one required premise (name)");
+        assert_eq!(optional, 1, "expected one optional premise (nickname)");
+    }
+
+    /// The degenerate "rule body binds only optionals" shape, at the
+    /// concept layer — rejected by construction.
+    ///
+    /// A concept with zero required (`with`) attributes constrains
+    /// nothing, so every entity would match it; a rule built from it
+    /// would have a body of only optional premises (each yielding an
+    /// Absent fallback on miss). This is unsound, and it is now
+    /// *unconstructable*: `ConceptDescriptor::try_from` of an empty
+    /// required set returns [`TypeError::EmptyConcept`], so the
+    /// degenerate concept can never reach the rule compiler at all.
+    /// `maybe` attributes do not change this — only `with` counts.
+    ///
+    /// (A required head bound *only* by an optional premise — the
+    /// distinct shape where a `with` field exists but is fed from an
+    /// optional source — is caught separately by
+    /// `RequiredHeadFromOptional`; see
+    /// `it_rejects_required_head_from_optional_premise`.)
+    #[dialog_common::test]
+    fn it_rejects_concept_with_no_required_attributes_by_construction() {
+        // Empty required set: construction fails outright.
+        let empty: Vec<(&str, AttributeDescriptor)> = Vec::new();
+        match ConceptDescriptor::try_from(empty) {
+            Err(TypeError::EmptyConcept) => {}
+            other => panic!("expected EmptyConcept, got {other:?}"),
+        }
+    }
+
+    /// `with_maybe` builder installs the maybe attributes; an
+    /// empty input clears the maybe slot.
+    #[dialog_common::test]
+    fn with_maybe_installs_and_clears() {
+        let concept = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        assert!(concept.maybe().is_none(), "no maybe by default");
+
+        let with_maybe = concept.clone().with_maybe(vec![(
+            "nickname",
+            AttributeDescriptor::new(
+                the!("person/nickname"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )]);
+        assert!(with_maybe.maybe().is_some(), "maybe installed");
+        assert_eq!(with_maybe.maybe().unwrap().iter().count(), 1);
+
+        let empty: Vec<(&str, AttributeDescriptor)> = Vec::new();
+        let cleared = with_maybe.with_maybe(empty);
+        assert!(cleared.maybe().is_none(), "empty input clears maybe");
+    }
+
+    /// A conclusion variable bound only by an optional attribute
+    /// query carries `Nothing` in its meet. Required heads cannot
+    /// accept that — the rule could produce an Absent value in a
+    /// required slot. Reject.
+    #[dialog_common::test]
+    fn it_rejects_required_head_from_optional_premise() {
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let this = Term::<Entity>::var("this");
+        // Bind ?name with an optional `is` term — the meet for ?name
+        // includes Nothing.
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("user/name")),
+                this,
+                optional_term("name", None),
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        match result {
+            Err(TypeError::RequiredHeadFromOptional { variable, .. }) => {
+                assert_eq!(variable, "name");
+            }
+            other => panic!("expected RequiredHeadFromOptional, got {other:?}"),
+        }
+    }
+
+    /// A conclusion variable bound by *both* an optional and a
+    /// required premise (with a typed `is` slot) has the Nothing
+    /// bit removed by the meet — at least one premise guarantees
+    /// Present. Accept.
+    #[dialog_common::test]
+    fn it_accepts_required_head_when_inference_strips_nothing() {
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let this = Term::<Entity>::var("this");
+        // The `is` slot must carry a typed kind so the meet has
+        // information to combine. An untyped `Term::var` produces
+        // `None` content_type, which contributes nothing to the
+        // meet — the optional side then wins.
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+
+        let premises = vec![
+            // Optional `is` term: contributes a slot type with Nothing.
+            AttributeQuery::new(
+                Term::from(the!("user/name")),
+                this.clone(),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            // Required `is` term: contributes a slot type without Nothing.
+            AttributeQuery::new(
+                Term::from(the!("user/canonical-name")),
+                this,
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        assert!(
+            result.is_ok(),
+            "meet of Required + Optional strips Nothing — should compile (got {:?})",
+            result.err()
+        );
+    }
+
+    /// Symmetric case: an *untyped* Required premise paired with a
+    /// typed Optional premise should also strip Nothing from the
+    /// meet. The untyped Required contribution is "any present
+    /// value" (`Primitive::ALL`), so intersected with
+    /// `Optional<String>` (i.e. `{String, Nothing}`) the meet
+    /// resolves to `{String}` — no Nothing. Rule compiles.
+    #[dialog_common::test]
+    fn it_accepts_untyped_required_paired_with_typed_optional() {
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let this = Term::<Entity>::var("this");
+        let optional_name = optional_term("name", Some(Type::String));
+
+        let premises = vec![
+            // Optional `is` (typed): contributes `{String, Nothing}`.
+            AttributeQuery::new(
+                Term::from(the!("user/name")),
+                this.clone(),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            // Required with *untyped* `is` (Term::var without a
+            // kind). Contributes "any present value" to the meet
+            // via the None-content_type branch.
+            AttributeQuery::new(
+                Term::from(the!("user/canonical-name")),
+                this,
+                Term::<Any>::var("name"),
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        assert!(
+            result.is_ok(),
+            "untyped Required + typed Optional should compile (got {:?})",
+            result.err()
+        );
+    }
+
+    /// The `cause` slot of an Optional attribute query is set-
+    /// widened in the schema (since the fallback row binds it to
+    /// `Absent`). A rule where a required-head variable shares
+    /// its name with such a cause is therefore rejected by the
+    /// meet algebra.
+    #[dialog_common::test]
+    fn it_rejects_required_head_from_optional_cause() {
+        // Conclusion has a required `mark` field expecting a
+        // typed value (Bytes).
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "mark",
+            AttributeDescriptor::new(the!("person/mark"), "", Cardinality::One, Some(Type::Bytes)),
+        )])
+        .unwrap();
+        let this = Term::<Entity>::var("this");
+        // The optional attribute's cause slot shares the name
+        // `?mark` with the conclusion's required head — the
+        // meet's cause contribution carries Nothing, so the
+        // required head sees Optional.
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("user/name")),
+                this,
+                optional_term("name", None),
+                Term::<Cause>::var("mark"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        match result {
+            Err(TypeError::RequiredHeadFromOptional { variable, .. }) => {
+                assert_eq!(variable, "mark");
+            }
+            other => panic!("expected RequiredHeadFromOptional, got {other:?}"),
+        }
+    }
+
+    /// A rule containing a malformed Coalesce (non-Optional source)
+    /// is rejected at compile time. This is the regression test for
+    /// validate-not-called: previously `Coalesce::validate` existed
+    /// but no production path invoked it, so wire-format or
+    /// raw-constructor mismatches silently passed.
+    #[dialog_common::test]
+    fn it_rejects_coalesce_with_non_optional_source() {
+        use crate::constraint::{Coalesce, Constraint};
+        use crate::premise::Premise;
+
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("person/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let this = Term::<Entity>::var("this");
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+
+        // Source is a `Term<Any>` carrying `String` (not Optional<String>).
+        let bad_source: Term<Any> = Term::<String>::var("source").into();
+        let bad_coalesce = Coalesce::new(
+            bad_source,
+            Term::<Any>::constant("Anon".to_string()),
+            typed_name.clone(),
+        );
+
+        let premises = vec![
+            // Required premise so the rule has a chance of compiling
+            // up to the coalesce-validation step.
+            AttributeQuery::new(
+                Term::from(the!("user/name")),
+                this,
+                typed_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            Premise::Assert(Proposition::Constraint(Constraint::Coalesce(bad_coalesce))),
+        ];
+        let result = DeductiveRule::new(conclusion, premises);
+        match result {
+            Err(TypeError::CoalesceTypeMismatch { .. }) => {}
+            other => panic!("expected CoalesceTypeMismatch, got {other:?}"),
+        }
     }
 }

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -124,42 +124,32 @@ impl From<&ConceptDescriptor> for DeductiveRule {
 
         let this = Term::<Entity>::var("this");
 
-        // Required (`with`) attributes — standard EAV semantics.
-        // A missing fact filters the row out entirely.
-        for (name, attribute) in concept.with().iter() {
-            premises.push(
-                AttributeQuery::new(
-                    Term::Constant(Value::from(attribute.the().clone())),
-                    this.clone(),
-                    Term::var(name),
-                    Term::blank(),
-                    Some(attribute.cardinality()),
-                )
-                .into(),
-            );
-        }
-
-        // Optional (`maybe`) attributes — a missing fact yields a
-        // fallback row with the slot bound to `Binding::Absent`.
-        // We encode this by typing the `is` term as optional;
-        // `AttributeQuery` derives its resolution from that kind.
-        if let Some(maybe) = concept.maybe() {
-            for (name, attribute) in maybe.iter() {
-                let kind = match attribute.content_type() {
+        for (name, field) in concept.with().iter() {
+            // Required field: standard EAV semantics — a missing fact
+            // filters the row out. Optional field: the `is` term is
+            // typed set-widened, so `AttributeQuery` runs with
+            // `Resolution::Optional` and a missing fact yields a
+            // fallback row with the slot bound to `Binding::Absent`.
+            let value = if field.is_optional() {
+                let kind = match field.content_type() {
                     Some(ty) => Kind::primitive(ty).optional(),
                     None => Kind::primitive_set(Primitive::ALL).optional(),
                 };
-                premises.push(
-                    AttributeQuery::new(
-                        Term::Constant(Value::from(attribute.the().clone())),
-                        this.clone(),
-                        Term::<Any>::typed_var(name, kind),
-                        Term::blank(),
-                        Some(attribute.cardinality()),
-                    )
-                    .into(),
-                );
-            }
+                Term::<Any>::typed_var(name, kind)
+            } else {
+                Term::var(name)
+            };
+
+            premises.push(
+                AttributeQuery::new(
+                    Term::Constant(Value::from(field.the().clone())),
+                    this.clone(),
+                    value,
+                    Term::blank(),
+                    Some(field.cardinality()),
+                )
+                .into(),
+            );
         }
 
         DeductiveRule::new(concept.clone(), premises).expect("Concept should compile")
@@ -563,33 +553,36 @@ mod tests {
         assert_eq!(optional, 0, "expected no optional premises");
     }
 
-    /// Concept projection emits one premise per `with` attribute
-    /// (Required) and one per `maybe` attribute (Optional).
+    /// Concept projection emits one premise per required attribute
+    /// (Required) and one per optional attribute (Optional).
     #[dialog_common::test]
-    fn from_concept_with_maybe_emits_optional_resolver() {
+    fn from_concept_with_optional_field_emits_optional_resolver() {
+        use crate::ConceptFieldDescriptor;
         use crate::Premise;
         use crate::attribute::query::Resolution;
         use crate::proposition::Proposition;
 
-        let concept = ConceptDescriptor::try_from(vec![(
-            "name",
-            AttributeDescriptor::new(
-                the!("person/name"),
-                "",
-                Cardinality::One,
-                Some(Type::String),
+        let concept = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
             ),
-        )])
-        .unwrap()
-        .with_maybe(vec![(
-            "nickname",
-            AttributeDescriptor::new(
-                the!("person/nickname"),
-                "",
-                Cardinality::One,
-                Some(Type::String),
+            (
+                "nickname".to_string(),
+                ConceptFieldDescriptor::optional(AttributeDescriptor::new(
+                    the!("person/nickname"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
             ),
-        )]);
+        ])
+        .unwrap();
 
         let rule = DeductiveRule::from(&concept);
 
@@ -617,7 +610,7 @@ mod tests {
     /// *unconstructable*: `ConceptDescriptor::try_from` of an empty
     /// required set returns [`TypeError::EmptyConcept`], so the
     /// degenerate concept can never reach the rule compiler at all.
-    /// `maybe` attributes do not change this — only `with` counts.
+    /// Optional fields do not change this — only required ones count.
     ///
     /// (A required head bound *only* by an optional premise — the
     /// distinct shape where a `with` field exists but is fed from an
@@ -634,10 +627,12 @@ mod tests {
         }
     }
 
-    /// `with_maybe` builder installs the maybe attributes; an
-    /// empty input clears the maybe slot.
+    /// A required-only concept carries no optional fields; building
+    /// with an optional field flags exactly that field optional.
     #[dialog_common::test]
-    fn with_maybe_installs_and_clears() {
+    fn optional_field_is_flagged_optional() {
+        use crate::ConceptFieldDescriptor;
+
         let concept = ConceptDescriptor::try_from(vec![(
             "name",
             AttributeDescriptor::new(
@@ -648,23 +643,40 @@ mod tests {
             ),
         )])
         .unwrap();
-        assert!(concept.maybe().is_none(), "no maybe by default");
+        assert!(
+            concept.with().iter().all(|(_, field)| !field.is_optional()),
+            "no optional fields by default"
+        );
 
-        let with_maybe = concept.clone().with_maybe(vec![(
-            "nickname",
-            AttributeDescriptor::new(
-                the!("person/nickname"),
-                "",
-                Cardinality::One,
-                Some(Type::String),
+        let with_optional = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
             ),
-        )]);
-        assert!(with_maybe.maybe().is_some(), "maybe installed");
-        assert_eq!(with_maybe.maybe().unwrap().iter().count(), 1);
+            (
+                "nickname".to_string(),
+                ConceptFieldDescriptor::optional(AttributeDescriptor::new(
+                    the!("person/nickname"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+        ])
+        .unwrap();
 
-        let empty: Vec<(&str, AttributeDescriptor)> = Vec::new();
-        let cleared = with_maybe.with_maybe(empty);
-        assert!(cleared.maybe().is_none(), "empty input clears maybe");
+        let optional: Vec<&str> = with_optional
+            .with()
+            .iter()
+            .filter(|(_, field)| field.is_optional())
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(optional, vec!["nickname"], "one optional field installed");
     }
 
     /// A conclusion variable bound only by an optional attribute

--- a/rust/dialog-query/src/rule/inductive.rs
+++ b/rust/dialog-query/src/rule/inductive.rs
@@ -141,7 +141,7 @@ mod tests {
 
     /// Build the head: a counter row with a `count` field.
     fn counter_head() -> ConceptDescriptor {
-        ConceptDescriptor::from(vec![(
+        ConceptDescriptor::try_from(vec![(
             "count",
             AttributeDescriptor::new(
                 the!("counter/count"),
@@ -150,6 +150,7 @@ mod tests {
                 Some(Type::UnsignedInt),
             ),
         )])
+        .unwrap()
     }
 
     /// Body premises:
@@ -185,7 +186,7 @@ mod tests {
     #[dialog_common::test]
     fn it_rejects_unbound_head_variable() {
         // Head adds a `name` field that no premise binds.
-        let head = ConceptDescriptor::from(vec![
+        let head = ConceptDescriptor::try_from(vec![
             (
                 "count",
                 AttributeDescriptor::new(
@@ -204,7 +205,8 @@ mod tests {
                     Some(Type::String),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
         let result = InductiveRule::new(head, increment_body());
         assert!(matches!(result, Err(TypeError::UnboundVariable { .. })));
         if let Err(TypeError::UnboundVariable { variable, .. }) = result {

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -1,0 +1,365 @@
+//! Type inference over a rule's premises.
+//!
+//! Every named variable a rule's positive premises mention places a
+//! constraint on that variable's type: each slot it appears in claims
+//! a kind (from the slot's schema), and the variable's rule-level
+//! type is the unification of those claims.
+//!
+//! This module runs that inference using the [`Context`] from
+//! [`crate::type_system::unifier`] and produces a [`TypeEnv`] —
+//! a name-keyed map from each variable to its inferred type. The
+//! planner consumes the env to rewrite each premise's variable
+//! terms so they carry the inferred kinds at evaluation time.
+//!
+//! Untyped slots (those with no static `content_type`) still
+//! contribute to inference via their requirement shape:
+//!
+//! - `Required` slots contribute `Primitive::ALL` — "any present
+//!   value." This excludes `Nothing` from the variable's type.
+//! - `Optional` slots contribute `Primitive::ANY` — "any present or
+//!   absent value." This lets `Nothing` survive unification when
+//!   every slot the variable visits is optional.
+//!
+//! Negation premises do not contribute. They filter on existing
+//! bindings rather than introducing them.
+
+use crate::Premise;
+use crate::planner::Plan;
+use crate::schema::Requirement;
+use crate::type_system::Primitive;
+use crate::type_system::Type as Kind;
+use crate::type_system::unifier::{Context, Type as Inferred, lift};
+use std::collections::HashMap;
+
+/// Errors raised by [`TypeEnv::infer`].
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum InferenceError {
+    /// A variable appears in slots whose declared kinds have no
+    /// common type — unification produced a contradiction.
+    #[error("variable {variable} has conflicting kinds across premises: {reason}")]
+    Conflict {
+        /// Name of the offending variable.
+        variable: String,
+        /// Underlying unifier error message.
+        reason: String,
+    },
+}
+
+/// Inferred types for every named variable referenced by a rule's
+/// positive premises.
+///
+/// Built by [`TypeEnv::infer`] during planning. The planner uses
+/// the result to narrow each premise's variable terms so they
+/// carry rule-level kinds at evaluation time. Also carried on
+/// [`AnalyzedRule`](super::AnalyzedRule) (wrapped in an `Arc`) for
+/// later phases that want type-by-variable lookups.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TypeEnv {
+    by_name: HashMap<String, Kind>,
+}
+
+impl TypeEnv {
+    /// Empty environment — no variables inferred.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a `TypeEnv` by walking the given plan steps. For each
+    /// named variable mentioned by any positive premise's slots,
+    /// unify the slot kinds and record the resulting type.
+    ///
+    /// Returns `Err` if any variable's kind is contradictory across
+    /// slots (e.g. `?x` is `String` in one premise and `Entity` in
+    /// another). The variable name is returned with the error so
+    /// the caller can surface a useful diagnostic.
+    pub fn infer(steps: &[Plan]) -> Result<Self, InferenceError> {
+        let mut ctx = Context::new();
+        for step in steps {
+            // Negation premises don't contribute — they filter on
+            // bindings rather than introducing them.
+            let Premise::Assert(_) = &step.premise else {
+                continue;
+            };
+            let schema = step.premise.schema();
+            let params = step.premise.parameters();
+
+            for (slot_name, field) in schema.iter() {
+                let Some(param) = params.get(slot_name) else {
+                    continue;
+                };
+                let Some(var_name) = param.name() else {
+                    continue;
+                };
+                let slot_kind: Kind = match field.content_type() {
+                    Some(t) => t.clone(),
+                    None => match field.requirement {
+                        Requirement::Required(_) => Kind::primitive_set(Primitive::ALL),
+                        Requirement::Optional => Kind::primitive_set(Primitive::ANY),
+                    },
+                };
+                let var = ctx.var_for_name(var_name);
+                if let Err(reason) = ctx.unify(&lift(&slot_kind), &Inferred::Variable(var)) {
+                    return Err(InferenceError::Conflict {
+                        variable: var_name.to_string(),
+                        reason: reason.to_string(),
+                    });
+                }
+            }
+        }
+
+        let mut by_name = HashMap::new();
+        for (name, var_id) in ctx.named_vars() {
+            if let Inferred::Static(kind) = ctx.apply(&Inferred::Variable(*var_id)) {
+                by_name.insert(name.clone(), kind);
+            } else {
+                // Variable never resolved to a static type — record
+                // its constraint as a primitive set. This is the
+                // "no slot ever gave us a concrete shape" case; the
+                // rule compiler treats it as fully unconstrained.
+                by_name.insert(name.clone(), Kind::primitive_set(ctx.constraint(*var_id)));
+            }
+        }
+        Ok(Self { by_name })
+    }
+
+    /// Look up the inferred type for a variable by name.
+    pub fn get(&self, name: &str) -> Option<&Kind> {
+        self.by_name.get(name)
+    }
+
+    /// Iterate over `(name, inferred kind)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Kind)> {
+        self.by_name.iter()
+    }
+
+    /// Number of variables inferred.
+    pub fn len(&self) -> usize {
+        self.by_name.len()
+    }
+
+    /// `true` if no variables were inferred.
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::artifact::{Entity, Type as ValueType};
+    use crate::attribute::query::AttributeQuery;
+    use crate::planner::Planner;
+    use crate::types::Any;
+    use crate::{Cardinality, Environment, Term, the};
+
+    /// A typed slot kind flows into the variable's inferred type.
+    #[dialog_common::test]
+    fn it_records_inferred_kind_for_typed_slot() {
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps).unwrap();
+        let name_kind = env.get("name").expect("name inferred");
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+
+    /// A variable bound only by optional slots keeps the `Nothing`
+    /// bit in its inferred type.
+    #[dialog_common::test]
+    fn it_preserves_nothing_when_only_optional_bindings_exist() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps).unwrap();
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            name_kind.is_optional(),
+            "single optional binding leaves Nothing in the inferred type"
+        );
+    }
+
+    /// A variable bound by both an optional and a required slot has
+    /// `Nothing` removed by the intersection — the required slot
+    /// wins.
+    #[dialog_common::test]
+    fn it_strips_nothing_when_a_required_binding_also_exists() {
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let typed_name: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                optional_name,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                typed_name,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps).unwrap();
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            !name_kind.is_optional(),
+            "Required + Optional bindings strip Nothing from the inferred type"
+        );
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+
+    /// Three premises, all referencing `?name`: two optional, one
+    /// required. The required one alone is enough to strip
+    /// `Nothing` from the inferred type. Verifies that
+    /// inference is *intersection*, not union.
+    #[dialog_common::test]
+    fn it_strips_nothing_when_any_premise_is_required() {
+        let opt_a: Term<Any> = Term::<Option<String>>::var("name").into();
+        let opt_b: Term<Any> = Term::<Option<String>>::var("name").into();
+        let req: Term<Any> = Term::<String>::var("name").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("person/nickname")),
+                Term::<Entity>::var("this"),
+                opt_a,
+                Term::var("c1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/alias")),
+                Term::<Entity>::var("this"),
+                opt_b,
+                Term::var("c2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("person/name")),
+                Term::<Entity>::var("this"),
+                req,
+                Term::var("c3"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps).unwrap();
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            !name_kind.is_optional(),
+            "a single required binding among many optional ones strips Nothing"
+        );
+        assert_eq!(name_kind.as_value_type(), Some(ValueType::String));
+    }
+
+    /// Negation premises don't contribute to inference. A
+    /// negation that mentions `?x` with kind `String` doesn't
+    /// constrain the rule-level type of `?x`; the positive
+    /// premise that binds `?x` is the sole contributor.
+    #[dialog_common::test]
+    fn it_ignores_negation_contributions_during_inference() {
+        use crate::Proposition;
+        use crate::negation::Negation;
+        // Positive premise binds ?name optionally (Option<String>).
+        let optional_name: Term<Any> = Term::<Option<String>>::var("name").into();
+        let positive = AttributeQuery::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("this"),
+            optional_name,
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        // Negation references ?name as Term<String> (non-optional).
+        // If this contributed to inference, ?name's inferred kind
+        // would be narrowed to String (no Nothing). But it doesn't,
+        // so ?name stays Optional<String>.
+        let strict_name: Term<Any> = Term::<String>::var("name").into();
+        let neg_query = AttributeQuery::new(
+            Term::from(the!("person/nickname")),
+            Term::<Entity>::var("this"),
+            strict_name,
+            Term::blank(),
+            Some(Cardinality::One),
+        );
+        let premises = vec![
+            positive.into(),
+            Premise::Unless(Negation(Proposition::Attribute(Box::new(neg_query)))),
+        ];
+        let plan = Planner::from(premises).plan(&Environment::new()).unwrap();
+        let env = TypeEnv::infer(&plan.steps).unwrap();
+        let name_kind = env.get("name").expect("name inferred");
+        assert!(
+            name_kind.is_optional(),
+            "negation should not strip Nothing from `?name`'s inferred kind"
+        );
+    }
+
+    /// A variable used as `Term<String>` in one premise and as
+    /// `Term<u32>` in another has no consistent type — inference
+    /// must report a conflict rather than silently producing one
+    /// or the other. The planner surfaces this as
+    /// `TypeError::TypeInference`.
+    #[dialog_common::test]
+    fn it_rejects_planning_when_variable_kinds_disagree() {
+        use crate::error::TypeError;
+        let as_string: Term<Any> = Term::<String>::var("x").into();
+        let as_u32: Term<Any> = Term::<u32>::var("x").into();
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("thing/label")),
+                Term::<Entity>::var("this"),
+                as_string,
+                Term::var("cause1"),
+                Some(Cardinality::One),
+            )
+            .into(),
+            AttributeQuery::new(
+                Term::from(the!("thing/count")),
+                Term::<Entity>::var("this"),
+                as_u32,
+                Term::var("cause2"),
+                Some(Cardinality::One),
+            )
+            .into(),
+        ];
+        let err = Planner::from(premises)
+            .plan(&Environment::new())
+            .unwrap_err();
+        match err {
+            TypeError::TypeInference { reason } => {
+                assert!(
+                    reason.contains("x"),
+                    "error mentions the conflicting variable name; got: {reason}"
+                );
+            }
+            other => panic!("expected TypeInference, got {other:?}"),
+        }
+    }
+}

--- a/rust/dialog-query/src/schema.rs
+++ b/rust/dialog-query/src/schema.rs
@@ -2,8 +2,14 @@
 //!
 //! This module provides a schema system that describes the structure,
 //! types, and requirements of parameters for different premise types.
+//!
+//! As of v2, [`Field::content_type`] uses the unified
+//! [`type_system::Type`] enum rather than the legacy
+//! `Option<artifact::Type>`. The conversion between them is
+//! lossless: `None` becomes a fresh anonymous type variable,
+//! `Some(vt)` becomes `Type::Primitive(singleton(vt))`.
 
-use crate::Type;
+use crate::type_system;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -158,16 +164,16 @@ impl Cardinality {
 
 /// Metadata for a single named parameter in a [`Schema`].
 ///
-/// Captures the parameter's expected value type, whether it accepts one or
-/// many values ([`Cardinality`]), and whether it must be bound before the
-/// premise can execute ([`Requirement`]). The planner reads these fields
-/// to classify each parameter as a prerequisite or a produced binding.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// `content_type` is the unified
+/// [`type_system::Type`], wrapped in `Option` so that "no static
+/// info known" is representable directly (the unifier resolves
+/// it at rule-compile time).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Field {
     /// Human-readable description of the field.
     pub description: String,
-    /// Expected value type, or `None` if unconstrained.
-    pub content_type: Option<Type>,
+    /// Expected value type, or `None` if unknown.
+    pub content_type: Option<type_system::Type>,
     /// Whether the field is required or optional.
     pub requirement: Requirement,
     /// Whether the field holds one or many values.
@@ -177,7 +183,11 @@ pub struct Field {
 impl Field {
     /// Creates a new field with the given description, type, and requirement.
     /// Cardinality defaults to [`Cardinality::One`].
-    pub fn new(description: String, content_type: Option<Type>, requirement: Requirement) -> Self {
+    pub fn new(
+        description: String,
+        content_type: Option<type_system::Type>,
+        requirement: Requirement,
+    ) -> Self {
         Self {
             description,
             content_type,
@@ -191,9 +201,9 @@ impl Field {
         &self.description
     }
 
-    /// Returns the expected content type, if any.
-    pub fn content_type(&self) -> Option<Type> {
-        self.content_type
+    /// Returns the expected content type, if known.
+    pub fn content_type(&self) -> Option<&type_system::Type> {
+        self.content_type.as_ref()
     }
 
     /// Returns the field's requirement level.
@@ -293,6 +303,8 @@ impl Group {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::artifact::Type as ValueType;
+    use crate::type_system::Type as Kind;
 
     #[dialog_common::test]
     fn it_tracks_requirement_properties() {
@@ -301,5 +313,27 @@ mod tests {
 
         assert!(required.is_required());
         assert!(!derived.is_required());
+    }
+
+    /// `Field::new` accepts the unified type directly.
+    #[dialog_common::test]
+    fn field_new_accepts_unified_type() {
+        let f = Field::new(
+            "test".into(),
+            Some(Kind::primitive(ValueType::Boolean)),
+            Requirement::Required(None),
+        );
+        assert_eq!(
+            f.content_type().unwrap().as_value_type(),
+            Some(ValueType::Boolean)
+        );
+        assert!(matches!(f.requirement(), Requirement::Required(_)));
+    }
+
+    /// A field with no static info reports `None`.
+    #[dialog_common::test]
+    fn field_unknown_type_reports_none() {
+        let f = Field::new("x".into(), None, Requirement::Optional);
+        assert!(f.content_type().is_none());
     }
 }

--- a/rust/dialog-query/src/selection.rs
+++ b/rust/dialog-query/src/selection.rs
@@ -92,6 +92,7 @@ mod tests {
 
         let result = candidate
             .lookup(&name_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "Alice");
@@ -106,6 +107,7 @@ mod tests {
 
         let result = candidate
             .lookup(&age_param)
+            .and_then(|b| b.content())
             .and_then(|v| u32::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 25);
@@ -120,6 +122,7 @@ mod tests {
 
         let result = candidate
             .lookup(&score_param)
+            .and_then(|b| b.content())
             .and_then(|v| i32::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), -10);
@@ -134,6 +137,7 @@ mod tests {
 
         let result = candidate
             .lookup(&active_param)
+            .and_then(|b| b.content())
             .and_then(|v| bool::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert!(result.unwrap());
@@ -151,6 +155,7 @@ mod tests {
 
         let result = candidate
             .lookup(&entity_param)
+            .and_then(|b| b.content())
             .and_then(|v| Entity::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), entity_value);
@@ -163,6 +168,7 @@ mod tests {
 
         let result = candidate
             .lookup(&constant_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "constant_value");
@@ -175,6 +181,7 @@ mod tests {
 
         let result = candidate
             .lookup(&name_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -192,6 +199,7 @@ mod tests {
 
         let result = candidate
             .lookup(&blank_param)
+            .and_then(|b| b.content())
             .and_then(|v| String::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -211,6 +219,7 @@ mod tests {
 
         let result = candidate
             .lookup(&name_param)
+            .and_then(|b| b.content())
             .and_then(|v| u32::try_from(v).map_err(EvaluationError::from));
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -229,7 +238,10 @@ mod tests {
         candidate.bind(&name_term, value.clone()).unwrap();
         candidate.bind(&name_term, value.clone()).unwrap();
 
-        assert_eq!(candidate.lookup(&name_term).unwrap(), value);
+        assert_eq!(
+            candidate.lookup(&name_term).unwrap().content().unwrap(),
+            value
+        );
     }
 
     #[dialog_common::test]
@@ -258,10 +270,30 @@ mod tests {
             .bind(&Term::var("active"), Value::Boolean(true))
             .unwrap();
 
-        let name_result = String::try_from(candidate.lookup(&Term::var("name")).unwrap()).unwrap();
-        let age_result = u32::try_from(candidate.lookup(&Term::var("age")).unwrap()).unwrap();
-        let active_result =
-            bool::try_from(candidate.lookup(&Term::var("active")).unwrap()).unwrap();
+        let name_result = String::try_from(
+            candidate
+                .lookup(&Term::var("name"))
+                .unwrap()
+                .content()
+                .unwrap(),
+        )
+        .unwrap();
+        let age_result = u32::try_from(
+            candidate
+                .lookup(&Term::var("age"))
+                .unwrap()
+                .content()
+                .unwrap(),
+        )
+        .unwrap();
+        let active_result = bool::try_from(
+            candidate
+                .lookup(&Term::var("active"))
+                .unwrap()
+                .content()
+                .unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(name_result, "Bob");
         assert_eq!(age_result, 30);

--- a/rust/dialog-query/src/selection/match.rs
+++ b/rust/dialog-query/src/selection/match.rs
@@ -11,19 +11,95 @@ use crate::types::Record;
 
 use super::Selection;
 
+/// A row-level binding for a variable.
+///
+/// Distinguishes [`Binding::Present`] (the variable resolved to a
+/// concrete [`Value`]) from [`Binding::Absent`] (an optional
+/// resolution premise looked up the entity's attribute and found
+/// no fact). `Absent` is structurally distinct from "no binding at
+/// all" — variables that no premise has touched aren't in the
+/// bindings map and produce
+/// [`EvaluationError::UnboundVariable`] from
+/// [`Match::lookup`]; variables that have been touched by an
+/// optional resolver are *always* in the map, with either a
+/// `Present` or an `Absent` entry.
+///
+/// This three-state distinction (unbound / Present / Absent) is
+/// what makes set-widening optionality work without persisting any
+/// `None` value at the storage layer. See `notes/optional-fields.md`
+/// for the design rationale.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Binding {
+    /// The variable resolved to a concrete value.
+    Present(Value),
+    /// An optional resolver looked up the variable's attribute for
+    /// this entity and found no fact. Distinct from "not yet
+    /// bound."
+    Absent,
+}
+
+impl Binding {
+    /// Extract the contained [`Value`], returning
+    /// [`EvaluationError::Absent`] if this binding is `Absent`.
+    /// Use this when the caller cannot tolerate absence — e.g.
+    /// realization paths for required fields, formula inputs.
+    /// Callers that handle optionality (Coalesce, optional
+    /// realize) should pattern-match on `Binding` directly.
+    pub fn content(self) -> Result<Value, EvaluationError> {
+        self.content_for(None)
+    }
+
+    /// Like [`Self::content`] but attaches a variable name to the
+    /// resulting [`EvaluationError::Absent`] so callers can report
+    /// which slot was Absent.
+    pub fn content_for(self, variable_name: Option<&str>) -> Result<Value, EvaluationError> {
+        match self {
+            Binding::Present(value) => Ok(value),
+            Binding::Absent => Err(EvaluationError::Absent {
+                variable_name: variable_name.unwrap_or("_").into(),
+            }),
+        }
+    }
+
+    /// Returns the contained [`Value`] reference if `Present`,
+    /// `None` otherwise.
+    pub fn as_value(&self) -> Option<&Value> {
+        match self {
+            Binding::Present(value) => Some(value),
+            Binding::Absent => None,
+        }
+    }
+
+    /// Returns `true` iff this binding is [`Binding::Absent`].
+    pub fn is_absent(&self) -> bool {
+        matches!(self, Binding::Absent)
+    }
+
+    /// Returns `true` iff this binding is [`Binding::Present`].
+    pub fn is_present(&self) -> bool {
+        matches!(self, Binding::Present(_))
+    }
+}
+
 /// A single result row produced during query evaluation.
 ///
-/// A `Match` accumulates variable bindings as premises are evaluated in
-/// sequence. Each binding maps a variable name to its resolved [`Value`].
+/// A `Match` accumulates variable bindings as premises are
+/// evaluated in sequence. Each binding maps a variable name to a
+/// [`Binding`], which is either `Present(value)` (the variable
+/// resolved to a concrete value) or `Absent` (an optional resolver
+/// found no fact for the entity).
 ///
 /// Matches flow through the evaluation pipeline as a stream
-/// ([`Selection`](super::Selection)): each premise receives the stream,
-/// potentially expands each match into zero or more new matches, and
-/// passes them to the next premise.
+/// ([`Selection`](super::Selection)): each premise receives the
+/// stream, potentially expands each match into zero or more new
+/// matches, and passes them to the next premise.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct Match {
-    /// Named variable bindings: maps variable names to their resolved values.
-    bindings: HashMap<String, Value>,
+    /// Named variable bindings: maps variable names to their
+    /// row-level binding (Present or Absent). A name absent from
+    /// this map means "no premise has touched this variable" —
+    /// distinct from [`Binding::Absent`].
+    bindings: HashMap<String, Binding>,
     // TODO: Once Value::Record supports the RecordFormat trait proposed in
     // https://github.com/dialog-db/dialog-db/pull/221 claims can be stored
     // directly as Value::Record in bindings, eliminating this separate map.
@@ -76,27 +152,43 @@ impl Match {
         Ok(())
     }
 
-    /// Bind a term to a value. For named variables, stores the value in
-    /// the bindings map; checks consistency if already bound. Constants
-    /// and blanks are no-ops.
+    /// Bind a term to a [`Binding::Present`] value. For named
+    /// variables, stores the value in the bindings map; checks
+    /// consistency if already bound:
+    ///
+    /// - existing `Present` with the same value is OK (idempotent).
+    /// - existing `Present` with a different value conflicts.
+    /// - existing `Absent` conflicts with an incoming `Present`.
+    ///
+    /// Constants and blanks are no-ops.
     pub fn bind(&mut self, term: &Term<Any>, value: Value) -> Result<(), EvaluationError> {
         match term {
             Term::Variable {
                 name: Some(name), ..
             } => {
                 if let Some(existing) = self.bindings.get(name) {
-                    if *existing != value {
-                        Err(EvaluationError::Assignment {
+                    match existing {
+                        Binding::Present(existing_value) => {
+                            if *existing_value != value {
+                                Err(EvaluationError::Assignment {
+                                    reason: format!(
+                                        "Can not set {:?} to {:?} because it is already set to {:?}.",
+                                        name, value, existing_value
+                                    ),
+                                })
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        Binding::Absent => Err(EvaluationError::Assignment {
                             reason: format!(
-                                "Can not set {:?} to {:?} because it is already set to {:?}.",
-                                name, value, existing
+                                "Can not set {:?} to {:?} because it is already bound to Absent.",
+                                name, value
                             ),
-                        })
-                    } else {
-                        Ok(())
+                        }),
                     }
                 } else {
-                    self.bindings.insert(name.into(), value);
+                    self.bindings.insert(name.into(), Binding::Present(value));
                     Ok(())
                 }
             }
@@ -104,7 +196,37 @@ impl Match {
         }
     }
 
-    /// Returns true if the parameter is bound in this match.
+    /// Bind a term to [`Binding::Absent`]. Used by optional
+    /// resolution premises that looked up an attribute and found
+    /// no fact. Errors if the variable is already bound to a
+    /// `Present` value. Constants and blanks are no-ops.
+    pub fn bind_absent(&mut self, term: &Term<Any>) -> Result<(), EvaluationError> {
+        match term {
+            Term::Variable {
+                name: Some(name), ..
+            } => {
+                if let Some(existing) = self.bindings.get(name) {
+                    match existing {
+                        Binding::Absent => Ok(()),
+                        Binding::Present(value) => Err(EvaluationError::Assignment {
+                            reason: format!(
+                                "Can not set {:?} to Absent because it is already set to {:?}.",
+                                name, value
+                            ),
+                        }),
+                    }
+                } else {
+                    self.bindings.insert(name.into(), Binding::Absent);
+                    Ok(())
+                }
+            }
+            Term::Variable { name: None, .. } | Term::Constant(_) => Ok(()),
+        }
+    }
+
+    /// Returns `true` iff the term is bound (Present *or* Absent)
+    /// in this match. Use [`Self::is_present`] to check for
+    /// `Present`-only.
     pub fn contains(&self, term: &Term<Any>) -> bool {
         match term {
             Term::Variable {
@@ -115,17 +237,40 @@ impl Match {
         }
     }
 
-    /// Look up the value bound to a term.
+    /// Returns `true` iff the term is bound to a `Present` value
+    /// (excluding `Absent`). Constants always count as Present.
+    pub fn is_present(&self, term: &Term<Any>) -> bool {
+        match term {
+            Term::Variable {
+                name: Some(key), ..
+            } => self
+                .bindings
+                .get(key)
+                .map(|b| b.is_present())
+                .unwrap_or(false),
+            Term::Variable { name: None, .. } => false,
+            Term::Constant(_) => true,
+        }
+    }
+
+    /// Look up the binding for a term.
     ///
-    /// For variables, looks up the binding. For constants, returns the
-    /// constant value. Returns an error if the variable is not bound.
-    pub fn lookup(&self, term: &Term<Any>) -> Result<Value, EvaluationError> {
+    /// For named variables, returns the binding (Present or
+    /// Absent). For constants, returns `Present(value)`. Returns
+    /// [`EvaluationError::UnboundVariable`] for blank variables
+    /// or for named variables that no premise has touched.
+    ///
+    /// Callers that want a `Value` should chain
+    /// `.lookup(&term)?.content()` to convert `Absent` into an
+    /// error. Callers that handle optionality (Coalesce, optional
+    /// realize) pattern-match on `Binding` directly.
+    pub fn lookup(&self, term: &Term<Any>) -> Result<Binding, EvaluationError> {
         match term {
             Term::Variable {
                 name: Some(key), ..
             } => {
-                if let Some(value) = self.bindings.get(key) {
-                    Ok(value.clone())
+                if let Some(binding) = self.bindings.get(key) {
+                    Ok(binding.clone())
                 } else {
                     Err(EvaluationError::UnboundVariable {
                         variable_name: key.clone(),
@@ -135,7 +280,108 @@ impl Match {
             Term::Variable { name: None, .. } => Err(EvaluationError::UnboundVariable {
                 variable_name: "_".into(),
             }),
-            Term::Constant(value) => Ok(value.clone()),
+            Term::Constant(value) => Ok(Binding::Present(value.clone())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::Value;
+
+    #[dialog_common::test]
+    fn binding_content_returns_value_for_present() {
+        let b = Binding::Present(Value::String("hello".into()));
+        assert_eq!(b.content(), Ok(Value::String("hello".into())));
+    }
+
+    #[dialog_common::test]
+    fn binding_content_errors_on_absent() {
+        let b = Binding::Absent;
+        match b.content() {
+            Err(EvaluationError::Absent { variable_name }) => {
+                assert_eq!(variable_name, "_");
+            }
+            other => panic!("expected Absent error, got {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn binding_content_for_attaches_variable_name() {
+        let b = Binding::Absent;
+        match b.content_for(Some("nickname")) {
+            Err(EvaluationError::Absent { variable_name }) => {
+                assert_eq!(variable_name, "nickname");
+            }
+            other => panic!("expected Absent error, got {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn binding_predicates() {
+        assert!(Binding::Present(Value::UnsignedInt(0)).is_present());
+        assert!(!Binding::Present(Value::UnsignedInt(0)).is_absent());
+        assert!(Binding::Absent.is_absent());
+        assert!(!Binding::Absent.is_present());
+    }
+
+    #[dialog_common::test]
+    fn match_bind_absent_creates_absent_binding() {
+        let mut m = Match::new();
+        let term = Term::var("nickname");
+        m.bind_absent(&term).unwrap();
+        assert_eq!(m.lookup(&term).unwrap(), Binding::Absent);
+    }
+
+    #[dialog_common::test]
+    fn match_bind_then_bind_absent_conflicts() {
+        let mut m = Match::new();
+        let term = Term::var("name");
+        m.bind(&term, Value::String("Alice".into())).unwrap();
+        let result = m.bind_absent(&term);
+        assert!(matches!(result, Err(EvaluationError::Assignment { .. })));
+    }
+
+    #[dialog_common::test]
+    fn match_bind_absent_then_bind_conflicts() {
+        let mut m = Match::new();
+        let term = Term::var("name");
+        m.bind_absent(&term).unwrap();
+        let result = m.bind(&term, Value::String("Alice".into()));
+        assert!(matches!(result, Err(EvaluationError::Assignment { .. })));
+    }
+
+    #[dialog_common::test]
+    fn match_bind_absent_is_idempotent() {
+        let mut m = Match::new();
+        let term = Term::var("nickname");
+        m.bind_absent(&term).unwrap();
+        m.bind_absent(&term).unwrap();
+        assert_eq!(m.lookup(&term).unwrap(), Binding::Absent);
+    }
+
+    #[dialog_common::test]
+    fn match_lookup_unbound_returns_unbound_error() {
+        let m = Match::new();
+        match m.lookup(&Term::var("nope")) {
+            Err(EvaluationError::UnboundVariable { variable_name }) => {
+                assert_eq!(variable_name, "nope");
+            }
+            other => panic!("expected UnboundVariable, got {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn match_is_present_distinguishes_present_from_absent() {
+        let mut m = Match::new();
+        let pname = Term::var("name");
+        let nname = Term::var("nickname");
+        m.bind(&pname, Value::String("Alice".into())).unwrap();
+        m.bind_absent(&nname).unwrap();
+        assert!(m.is_present(&pname));
+        assert!(!m.is_present(&nname));
+        assert!(m.contains(&pname));
+        assert!(m.contains(&nname));
     }
 }

--- a/rust/dialog-query/src/session.rs
+++ b/rust/dialog-query/src/session.rs
@@ -61,7 +61,7 @@ mod tests {
         }
         let session = TestEnv::new(&branch, &operator, RuleRegistry::new());
 
-        let person = ConceptDescriptor::from([
+        let person = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -80,7 +80,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let name_param = Term::var("name");
         let age_param = Term::var("age");
@@ -102,8 +103,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let person_name = match_result.lookup(&name_param)?;
-            let person_age = match_result.lookup(&age_param)?;
+            let person_name = match_result.lookup(&name_param)?.content()?;
+            let person_age = match_result.lookup(&age_param)?.content()?;
 
             match person_name {
                 Value::String(name_str) if name_str == "Alice" => {
@@ -147,7 +148,7 @@ mod tests {
             ),
         );
 
-        let person = ConceptDescriptor::from(attributes);
+        let person = ConceptDescriptor::try_from(attributes).unwrap();
 
         // Mixed case - valid parameters with some matching attributes (should succeed)
         let mut mixed_params = Parameters::new();
@@ -165,7 +166,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
 
-        let person = ConceptDescriptor::from([
+        let person = ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -184,7 +185,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let alice = person
             .create()
@@ -227,8 +229,8 @@ mod tests {
         let mut found_bob = false;
 
         for match_result in selection.iter() {
-            let person_name = match_result.lookup(&name_param)?;
-            let person_age = match_result.lookup(&age_param)?;
+            let person_name = match_result.lookup(&name_param)?.content()?;
+            let person_age = match_result.lookup(&age_param)?.content()?;
 
             match person_name {
                 Value::String(name_str) if name_str == "Alice" => {
@@ -291,7 +293,7 @@ mod tests {
         }
 
         // employee can be derived from the stuff concept
-        let employee_predicate: ConceptDescriptor = Query::<Employee>::default().into();
+        let employee_predicate: ConceptDescriptor = Employee::descriptor().clone();
         let employee_from_stuff = DeductiveRule::new(
             employee_predicate,
             vec![
@@ -320,7 +322,7 @@ mod tests {
         let mut rules = RuleRegistry::new();
         rules.register(employee_from_stuff)?;
 
-        let stuff_predicate: ConceptDescriptor = Query::<Stuff>::default().into();
+        let stuff_predicate: ConceptDescriptor = Stuff::descriptor().clone();
         let alice = stuff_predicate
             .create()
             .with("name", "Alice".to_string())
@@ -443,7 +445,7 @@ mod tests {
 
         // Replicate Session::install logic for RuleRegistry
         let query = Query::<Employee>::default();
-        let concept: ConceptDescriptor = query.clone().into();
+        let concept: ConceptDescriptor = Employee::descriptor().clone();
         let when = employee_from_stuff(query).into_premises();
         let premises = when.into_vec();
         let install_rule =
@@ -454,7 +456,7 @@ mod tests {
         rules.register(install_rule)?;
 
         // Create test data as Stuff
-        let stuff_predicate: ConceptDescriptor = Query::<Stuff>::default().into();
+        let stuff_predicate: ConceptDescriptor = Stuff::descriptor().clone();
         let alice = stuff_predicate
             .create()
             .with("name", "Alice".to_string())
@@ -533,7 +535,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let _branch = repo.branch("main").open().perform(&operator).await?;
 
-        let adult_conclusion = ConceptDescriptor::from(vec![
+        let adult_conclusion = ConceptDescriptor::try_from(vec![
             (
                 "name",
                 AttributeDescriptor::new(
@@ -552,7 +554,8 @@ mod tests {
                     Some(Type::UnsignedInt),
                 ),
             ),
-        ]);
+        ])
+        .unwrap();
 
         let rule = DeductiveRule::from(&adult_conclusion);
 
@@ -577,7 +580,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
 
-        let concept = ConceptDescriptor::from([(
+        let concept = ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -585,7 +588,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
         let rule = DeductiveRule::from(&concept);
 
         // Test with RuleRegistry + TestEnv
@@ -605,7 +609,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let _branch = repo.branch("main").open().perform(&operator).await?;
 
-        let adult_concept = ConceptDescriptor::from([(
+        let adult_concept = ConceptDescriptor::try_from([(
             "name".to_string(),
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -613,7 +617,8 @@ mod tests {
                 Cardinality::One,
                 Some(Type::String),
             ),
-        )]);
+        )])
+        .unwrap();
 
         let adult_rule = DeductiveRule::from(&adult_concept);
 
@@ -684,7 +689,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
         let query_m = Query::<MatchingNote>::default();
-        let concept_m: ConceptDescriptor = query_m.clone().into();
+        let concept_m: ConceptDescriptor = MatchingNote::descriptor().clone();
         let when_m = matching_notes(query_m).into_premises();
         let rule_m = DeductiveRule::new(concept_m, when_m.into_vec()).map_err(|e| {
             EvaluationError::Planning {
@@ -783,7 +788,7 @@ mod tests {
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
         let query_n = Query::<NonDraftNote>::default();
-        let concept_n: ConceptDescriptor = query_n.clone().into();
+        let concept_n: ConceptDescriptor = NonDraftNote::descriptor().clone();
         let when_n = non_draft_notes(query_n).into_premises();
         let rule_n = DeductiveRule::new(concept_n, when_n.into_vec()).map_err(|e| {
             EvaluationError::Planning {
@@ -889,7 +894,7 @@ mod tests {
         // Install the rule using the clean API - no turbofish needed!
         // The type inference works: Employee is inferred from the function parameter
         let query_e = Query::<Employee>::default();
-        let concept_e: ConceptDescriptor = query_e.clone().into();
+        let concept_e: ConceptDescriptor = Employee::descriptor().clone();
         let when_e = employee_with_implicit_title(query_e).into_premises();
         let rule_e = DeductiveRule::new(concept_e, when_e.into_vec()).map_err(|e| {
             EvaluationError::Planning {
@@ -956,7 +961,7 @@ mod tests {
 
     /// Helper: build a person concept predicate with name and age attributes.
     fn person_concept() -> ConceptDescriptor {
-        ConceptDescriptor::from([
+        ConceptDescriptor::try_from([
             (
                 "name",
                 AttributeDescriptor::new(
@@ -976,6 +981,7 @@ mod tests {
                 ),
             ),
         ])
+        .unwrap()
     }
 
     #[dialog_common::test]
@@ -1066,10 +1072,11 @@ mod tests {
         let plan_before = person_rules.plan(&terms, &candidate);
 
         // Install a rule for a DIFFERENT concept entity
-        let unrelated = ConceptDescriptor::from([(
+        let unrelated = ConceptDescriptor::try_from([(
             "title",
             AttributeDescriptor::new(the!("book/title"), "", Cardinality::One, Some(Type::String)),
-        )]);
+        )])
+        .unwrap();
         let rule = DeductiveRule::from(&unrelated);
         registry.register(rule).unwrap();
 
@@ -1294,12 +1301,12 @@ mod tests {
 
         assert_eq!(results.len(), 1, "Should find exactly one person (Alice)");
         assert_eq!(
-            results[0].lookup(&name_param)?,
+            results[0].lookup(&name_param)?.content()?,
             Value::String("Alice".into()),
             "Should resolve to Alice"
         );
         assert_eq!(
-            results[0].lookup(&age_param)?,
+            results[0].lookup(&age_param)?.content()?,
             Value::UnsignedInt(30),
             "Should have Alice's age"
         );

--- a/rust/dialog-query/src/session/rule_registry.rs
+++ b/rust/dialog-query/src/session/rule_registry.rs
@@ -103,7 +103,7 @@ mod tests {
     use crate::the;
 
     fn person_concept() -> ConceptDescriptor {
-        ConceptDescriptor::from([(
+        ConceptDescriptor::try_from([(
             "name",
             AttributeDescriptor::new(
                 the!("person/name"),
@@ -112,6 +112,7 @@ mod tests {
                 Some(Type::String),
             ),
         )])
+        .unwrap()
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -18,10 +18,11 @@ use crate::Environment;
 use crate::Premise;
 use crate::artifact::{ArtifactsAttribute, Entity, Type, Value};
 use crate::attribute::The;
-use crate::constraint::{Constraint, Equality};
+use crate::constraint::{Coalesce, Constraint, Equality};
 use crate::error::{FieldTypeError, TypeError};
 use crate::proposition::Proposition;
 use crate::selection;
+use crate::type_system;
 use crate::types::{Any, Scalar, TypeDescriptor, Typed};
 use serde::de::Error as DeserializeError;
 use std::hash::Hash;
@@ -104,12 +105,13 @@ where
         }
     }
 
-    /// Resolve this term against a match. If the term is a variable
-    /// bound in the match, returns a constant term with the bound value.
-    /// Otherwise returns the term unchanged.
+    /// Resolve this term against a match. If the term is a
+    /// variable bound to a [`Binding::Present`](crate::Binding::Present)
+    /// value, returns a constant term with the bound value.
+    /// Otherwise (unbound or `Absent`) returns the term unchanged.
     pub fn resolve(&self, source: &selection::Match) -> Self {
         let term: Term<Any> = self.clone().into();
-        match source.lookup(&term) {
+        match source.lookup(&term).and_then(|b| b.content()) {
             Ok(value) => {
                 if let Ok(converted) = T::try_from(value) {
                     Term::Constant(converted.into())
@@ -181,19 +183,30 @@ impl<T: Typed> Term<T> {
         }
     }
 
-    /// Get the content type for this term.
+    /// Get the unified type kind for this term.
     ///
-    /// For variables: returns the type from the descriptor. For concrete
-    /// typed terms this is always `Some(Type::...)`. For `Any` it
-    /// depends on the runtime tag.
-    ///
-    /// For constants: inspects the stored `Value` to determine the type.
-    pub fn content_type(&self) -> Option<Type> {
+    /// For variables: delegates to the descriptor's `kind()`.
+    /// For constants: lifts the stored value's type into a
+    /// singleton [`type_system::Type::Primitive`].
+    pub fn kind(&self) -> Option<type_system::Type> {
         match self {
-            Term::Variable { descriptor, .. } => <<T as Typed>::Descriptor as TypeDescriptor>::TYPE
-                .or_else(|| descriptor.content_type()),
-            Term::Constant(value) => Some(Type::from(value)),
+            Term::Variable { descriptor, .. } => descriptor.kind(),
+            Term::Constant(value) => Some(type_system::Type::primitive(Type::from(value))),
         }
+    }
+
+    /// Legacy storage-codec view: collapse the unified kind to its
+    /// singleton primitive. Returns `None` for unknown or
+    /// non-singleton shapes.
+    pub fn content_type(&self) -> Option<Type> {
+        self.kind().and_then(|k| k.as_value_type())
+    }
+
+    /// Returns `true` iff this term's kind admits the `Nothing`
+    /// atom — i.e. the slot is set-widened. Untyped terms (no
+    /// kind) return `false`.
+    pub fn is_optional(&self) -> bool {
+        self.kind().is_some_and(|k| k.is_optional())
     }
 
     /// Get the constant value if this term is a constant.
@@ -259,9 +272,7 @@ where
                 name: Some(name),
                 descriptor,
             } => {
-                if let Some(data_type) = <<T as Typed>::Descriptor as TypeDescriptor>::TYPE
-                    .or_else(|| descriptor.content_type())
-                {
+                if let Some(data_type) = descriptor.kind().and_then(|k| k.as_value_type()) {
                     write!(f, "?{}<{:?}>", name, data_type)
                 } else {
                     write!(f, "?{}<Value>", name)
@@ -408,7 +419,7 @@ impl<T: Scalar> From<Term<T>> for Term<Any> {
         match term {
             Term::Variable { name, .. } => Term::Variable {
                 name,
-                descriptor: Any(<<T as Typed>::Descriptor as TypeDescriptor>::TYPE),
+                descriptor: Any(<<T as Typed>::Descriptor>::default().kind()),
             },
             Term::Constant(value) => Term::Constant(value),
         }
@@ -422,17 +433,93 @@ impl<T: Scalar> From<&Term<T>> for Term<Any> {
     }
 }
 
+/// Type-erase a `Term<Option<U>>` to `Term<Any>`. The descriptor
+/// is widened to carry the `Nothing` bit so that downstream
+/// type-checking (e.g. `Coalesce::validate`) can recognize the
+/// term as set-widened. At evaluation time the value flows
+/// through the same `Term<Any>` path as any other term, with the
+/// row-layer [`Binding::Absent`](crate::Binding::Absent) carrying
+/// the absence signal at runtime.
+impl<U: Scalar> From<Term<Option<U>>> for Term<Any> {
+    fn from(term: Term<Option<U>>) -> Self {
+        match term {
+            Term::Variable { name, .. } => Term::Variable {
+                name,
+                descriptor: Any(<<U as Typed>::Descriptor>::default()
+                    .kind()
+                    .map(|k| k.optional())),
+            },
+            Term::Constant(value) => Term::Constant(value),
+        }
+    }
+}
+
+/// Borrow form of the optional-to-Any erasure.
+impl<U: Scalar> From<&Term<Option<U>>> for Term<Any> {
+    fn from(term: &Term<Option<U>>) -> Self {
+        Term::<Any>::from(term.clone())
+    }
+}
+
+/// Builder for a [`Coalesce`](crate::constraint::Coalesce)
+/// constraint. Produced by
+/// [`Term::<Option<U>>::unwrap_or`](Term::unwrap_or); finalized
+/// by [`UnwrapOr::is`].
+///
+/// The type parameter `U` is the inner scalar type — the source
+/// term has kind `Option<U>` and the fallback has kind `U`. The
+/// final output term passed to `is` must also have kind `U`,
+/// guaranteed by the `impl Into<Term<U>>` bound.
+pub struct UnwrapOr<U: Scalar> {
+    source: Term<Option<U>>,
+    fallback: Term<U>,
+}
+
+impl<U: Scalar> Term<Option<U>> {
+    /// Begin building a `Coalesce` constraint. Returns a builder
+    /// that completes when `.is(output)` is called.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use dialog_query::Term;
+    /// let nickname: Term<Option<String>> = Term::var("nickname");
+    /// let display_name: Term<String> = Term::var("display_name");
+    /// let premise = nickname.unwrap_or("Anon").is(display_name);
+    /// ```
+    pub fn unwrap_or<F: Into<Term<U>>>(self, fallback: F) -> UnwrapOr<U> {
+        UnwrapOr {
+            source: self,
+            fallback: fallback.into(),
+        }
+    }
+}
+
+impl<U: Scalar> UnwrapOr<U> {
+    /// Bind the output term, producing a finished
+    /// [`Coalesce`](crate::constraint::Coalesce) constraint
+    /// wrapped in a [`Premise`] ready to drop into a rule body.
+    pub fn is<O: Into<Term<U>>>(self, output: O) -> Premise {
+        let source: Term<Any> = self.source.into();
+        let fallback: Term<Any> = self.fallback.into();
+        let is: Term<Any> = output.into().into();
+        Premise::Assert(Proposition::Constraint(Constraint::Coalesce(
+            Coalesce::new(source, fallback, is),
+        )))
+    }
+}
+
 /// Methods specific to `Term<Any>` — the dynamically-typed term.
 impl Term<Any> {
-    /// Create a named variable with a specific type constraint.
+    /// Create a named variable with a specific type kind.
     ///
-    /// Use `Term::<Any>::var("x")` for an untyped variable (inherited from
-    /// `impl<T: Typed> Term<T>`). Use this method when you need a runtime
-    /// type tag.
-    pub fn typed_var(name: impl Into<String>, typ: Option<Type>) -> Self {
+    /// Use `Term::<Any>::var("x")` for an untyped variable
+    /// (inherited from `impl<T: Typed> Term<T>`). Use this method
+    /// when you need a runtime type kind.
+    pub fn typed_var(name: impl Into<String>, kind: type_system::Type) -> Self {
         Term::Variable {
             name: Some(name.into()),
-            descriptor: Any(typ),
+            descriptor: Any(Some(kind)),
         }
     }
 
@@ -451,10 +538,9 @@ impl Term<Any> {
 
     /// Narrow a `Term<Any>` to a concrete `Term<T>`.
     ///
-    /// Both variables and constants are validated: if the term carries a known
-    /// type (via the `Any` descriptor or the constant's value) and `T` has a
-    /// statically known type, they must match. Returns
-    /// [`FieldTypeError::TypeMismatch`] on incompatible types.
+    /// Both variables and constants are validated: if the term
+    /// carries a known type and `T` has a statically known type,
+    /// they must match.
     pub fn narrow<T: Typed>(self) -> Result<Term<T>, FieldTypeError> {
         let target = <<T as Typed>::Descriptor as TypeDescriptor>::TYPE;
         let source = self.content_type();
@@ -496,7 +582,7 @@ impl From<Term<Value>> for Term<Any> {
         match term {
             Term::Variable { name, .. } => Term::Variable {
                 name,
-                descriptor: Any(<<Value as Typed>::Descriptor as TypeDescriptor>::TYPE),
+                descriptor: Any(<<Value as Typed>::Descriptor>::default().kind()),
             },
             Term::Constant(value) => Term::Constant(value),
         }
@@ -533,13 +619,17 @@ impl<T: Scalar> From<Term<T>> for Term<Value> {
     }
 }
 
-/// Serde helper for the variable inner object: `{"name": "x", "type": "Text"}`.
+/// Serde helper for the variable inner object: `{"name": "x", "type": <type_system::Type>}`.
+///
+/// The `type` field carries the full unified [`type_system::Type`]
+/// rather than a legacy [`ValueType`](Type) — `None` denotes an
+/// "untyped" variable.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct VarInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    content_type: Option<Type>,
+    content_type: Option<type_system::Type>,
 }
 
 /// Serde helper enum for `Term<T>`.
@@ -562,16 +652,12 @@ impl<T: Typed> serde::Serialize for Term<T> {
         let repr = match self {
             Term::Variable {
                 name, descriptor, ..
-            } => {
-                let content_type = <<T as Typed>::Descriptor as TypeDescriptor>::TYPE
-                    .or_else(|| descriptor.content_type());
-                TermRepr::Variable {
-                    var: VarInfo {
-                        name: name.clone(),
-                        content_type,
-                    },
-                }
-            }
+            } => TermRepr::Variable {
+                var: VarInfo {
+                    name: name.clone(),
+                    content_type: descriptor.kind(),
+                },
+            },
             Term::Constant(value) => TermRepr::Constant(value.clone()),
         };
         repr.serialize(serializer)
@@ -590,7 +676,7 @@ impl<'de, T: Typed> serde::Deserialize<'de> for Term<T> {
                     serde_json::from_value(map["?"].clone()).map_err(DeserializeError::custom)?;
                 Ok(Term::Variable {
                     name: var.name,
-                    descriptor: <T as Typed>::Descriptor::from_content_type(var.content_type),
+                    descriptor: <T as Typed>::Descriptor::from_kind(var.content_type),
                 })
             }
             serde_json::Value::Number(n) => {
@@ -616,6 +702,102 @@ impl<'de, T: Typed> serde::Deserialize<'de> for Term<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash as HashTrait, Hasher};
+
+    fn hash_of<T: HashTrait>(t: &T) -> u64 {
+        let mut h = DefaultHasher::new();
+        t.hash(&mut h);
+        h.finish()
+    }
+
+    /// Two `Term<Any>` values constructed with the same name in
+    /// independent calls hash to the same value. This is the
+    /// stability guarantee that container caches (planner plans,
+    /// rule registries) depend on.
+    #[dialog_common::test]
+    fn it_hashes_equivalent_terms_to_same_value() {
+        let a: Term<Any> = Term::var("x");
+        let b: Term<Any> = Term::var("x");
+        assert_eq!(a, b, "structurally equivalent terms must compare equal");
+        assert_eq!(
+            hash_of(&a),
+            hash_of(&b),
+            "structurally equivalent terms must hash to the same value"
+        );
+
+        let c: Term<Any> = Term::Variable {
+            name: Some("x".into()),
+            descriptor: Some(Type::String).into(),
+        };
+        let d: Term<Any> = Term::Variable {
+            name: Some("x".into()),
+            descriptor: Some(Type::String).into(),
+        };
+        assert_eq!(c, d);
+        assert_eq!(hash_of(&c), hash_of(&d));
+    }
+
+    /// The `unwrap_or(...).is(...)` builder yields a Premise
+    /// containing a `Constraint::Coalesce` with the three slots
+    /// wired correctly. `U`'s static type enforces the source's
+    /// inner type, the fallback's type, and the output's type
+    /// must all match — call sites with type mismatches fail to
+    /// compile.
+    #[dialog_common::test]
+    fn it_builds_coalesce_via_unwrap_or() {
+        let nickname: Term<Option<String>> = Term::var("nickname");
+        let display: Term<String> = Term::var("display");
+        let premise = nickname.unwrap_or("Anon").is(display);
+
+        match premise {
+            Premise::Assert(Proposition::Constraint(Constraint::Coalesce(c))) => {
+                assert_eq!(c.source.name(), Some("nickname"));
+                assert_eq!(c.is.name(), Some("display"));
+                match &c.fallback {
+                    Term::Constant(Value::String(s)) => assert_eq!(s, "Anon"),
+                    other => panic!("expected fallback constant, got {:?}", other),
+                }
+                // The source's erased kind must preserve the
+                // Nothing bit so downstream type-checking can
+                // recognize it as set-widened. Without this,
+                // Coalesce::validate would reject the builder's
+                // own output with `SourceNotOptional`.
+                let source_kind = c.source.kind().expect("erased source has a kind");
+                assert!(
+                    source_kind.is_optional(),
+                    "Term<Option<String>>::into::<Term<Any>>() must preserve Nothing"
+                );
+            }
+            other => panic!(
+                "expected Premise::Assert(Constraint::Coalesce), got {:?}",
+                other
+            ),
+        }
+    }
+
+    /// The erased Coalesce from the typed builder passes
+    /// `Coalesce::validate` against a fresh unifier context.
+    /// This is the regression test for the bug where the
+    /// `Term<Option<U>> -> Term<Any>` conversion stripped the
+    /// Nothing bit.
+    #[dialog_common::test]
+    fn it_validates_builder_coalesce_end_to_end() {
+        use crate::type_system::unifier::Context;
+
+        let nickname: Term<Option<String>> = Term::var("nickname");
+        let display: Term<String> = Term::var("display");
+        let premise = nickname.unwrap_or("Anon").is(display);
+
+        match premise {
+            Premise::Assert(Proposition::Constraint(Constraint::Coalesce(c))) => {
+                let mut ctx = Context::new();
+                c.validate(&mut ctx)
+                    .expect("builder-produced Coalesce must validate");
+            }
+            other => panic!("expected Constraint::Coalesce, got {:?}", other),
+        }
+    }
 
     #[dialog_common::test]
     fn it_serializes_and_deserializes() {
@@ -802,7 +984,7 @@ mod tests {
             param,
             Term::Variable {
                 name: Some("name".into()),
-                descriptor: Any(Some(Type::String))
+                descriptor: Some(Type::String).into(),
             }
         );
     }
@@ -815,7 +997,7 @@ mod tests {
             param,
             Term::Variable {
                 name: None,
-                descriptor: Any(Some(Type::String))
+                descriptor: Some(Type::String).into(),
             }
         );
     }
@@ -835,7 +1017,7 @@ mod tests {
             param,
             Term::Variable {
                 name: Some("entity".into()),
-                descriptor: Any(Some(Type::Entity))
+                descriptor: Some(Type::Entity).into(),
             }
         );
     }
@@ -851,12 +1033,16 @@ mod tests {
     fn it_serializes_any_with_type() {
         let param: Term<Any> = Term::Variable {
             name: Some("x".into()),
-            descriptor: Any(Some(Type::String)),
+            descriptor: Some(Type::String).into(),
         };
         let json = serde_json::to_value(&param).unwrap();
+        // The wire format now carries the full unified type;
+        // a singleton String primitive serializes as the bitfield.
+        let expected_type = serde_json::to_value(type_system::Type::primitive(Type::String))
+            .expect("type serializes");
         assert_eq!(
             json,
-            serde_json::json!({"?": {"name": "x", "type": "Text"}})
+            serde_json::json!({"?": {"name": "x", "type": expected_type}})
         );
     }
 
@@ -886,9 +1072,12 @@ mod tests {
 
     #[dialog_common::test]
     fn it_deserializes_any_with_type() {
-        let json = serde_json::json!({"?": {"name": "x", "type": "Text"}});
+        let type_value = serde_json::to_value(type_system::Type::primitive(Type::String))
+            .expect("type serializes");
+        let json = serde_json::json!({"?": {"name": "x", "type": type_value}});
         let param: Term<Any> = serde_json::from_value(json).unwrap();
         assert_eq!(param.name(), Some("x"));
+        assert_eq!(param.content_type(), Some(Type::String));
     }
 
     #[dialog_common::test]
@@ -962,7 +1151,7 @@ mod tests {
     fn it_displays_any_correctly() {
         assert_eq!(Term::<Any>::blank().to_string(), "_");
         assert_eq!(
-            Term::<Any>::typed_var("x", Some(Type::String)).to_string(),
+            Term::<Any>::typed_var("x", type_system::Type::primitive(Type::String)).to_string(),
             "?x<String>"
         );
         assert_eq!(Term::<Any>::var("y").to_string(), "?y<Value>");
@@ -979,7 +1168,7 @@ mod tests {
 
         let variable: Term<Any> = Term::Variable {
             name: Some("x".into()),
-            descriptor: Any(Some(Type::String)),
+            descriptor: Some(Type::String).into(),
         };
         assert!(!variable.is_blank());
         assert!(!variable.is_constant());

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -1,0 +1,950 @@
+//! Unified type system for the query engine.
+//!
+//! This module defines the static, derive-friendly user-facing
+//! [`Type`] used by [`Term`](crate::Term),
+//! [`Equality`](crate::constraint::Equality),
+//! [`Premise`](crate::Premise), [`DeductiveRule`](crate::DeductiveRule),
+//! and the schema layer.
+//!
+//! A [`Type`] is the set of admissible value shapes a slot may
+//! bind. It is built from a [`Primitive`] bitfield (the atomic
+//! shapes, plus a `Nothing` bit for set-widened optionality) and an
+//! optional set of [`Composite`] shapes (Product records, Variant
+//! tags). The two parts compose by set-union: a value satisfies
+//! [`Type`] iff it inhabits at least one of the primitive bits or
+//! one of the composite shapes.
+//!
+//! Type variables — used for compile-time unification of rules —
+//! live in the [`unifier`] submodule, never in the user-facing
+//! [`Type`]. This split lets the user-facing types derive
+//! [`PartialEq`]/[`Eq`]/[`Hash`] cleanly: equivalent rules produce
+//! stable hashes regardless of how many anonymous variables they
+//! have.
+//!
+//! See `notes/optional-fields.md` for the design rationale.
+
+pub mod unifier;
+
+use crate::artifact::Type as ValueType;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A bitfield over [`ValueType`] variants plus a `Nothing` bit —
+/// the set of admissible primitive shapes.
+///
+/// Used everywhere a "kind constraint" is needed: type variables
+/// declare their constraint as a `Primitive`, formula schemas
+/// declare per-variable constraints, and unification intersects
+/// them. The `Nothing` bit (position 9) is a synthetic atom with
+/// no corresponding [`ValueType`]; it marks "Absent" admissibility
+/// at the row layer — the new home for what used to be the outer
+/// `Optional` variant.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct Primitive {
+    /// One bit per [`ValueType`] variant (positions 0-8), plus a
+    /// `Nothing` bit at position 9.
+    bits: u16,
+}
+
+/// Bit position for the synthetic `Nothing` atom.
+const NOTHING_BIT: u16 = 1 << 9;
+
+impl Primitive {
+    /// Empty set — no admissible shapes. Rejected at unification
+    /// time.
+    pub const EMPTY: Self = Self { bits: 0 };
+
+    /// Every concrete [`ValueType`] variant, without `Nothing`.
+    /// This is the right default for constraint widening — a
+    /// variable that "accepts anything" still demands a Present
+    /// value.
+    pub const ALL: Self = Self {
+        bits: 0b1_1111_1111,
+    };
+
+    /// Every shape including the `Nothing` atom — the broadest
+    /// possible set, including row-level absence.
+    pub const ANY: Self = Self {
+        bits: Self::ALL.bits | NOTHING_BIT,
+    };
+
+    /// Singleton set containing only the `Nothing` atom.
+    pub const NOTHING: Self = Self { bits: NOTHING_BIT };
+
+    /// Numeric primitives: `UnsignedInt`, `SignedInt`, `Float`.
+    pub const NUMERIC: Self = Self {
+        bits: Self::bit_for(ValueType::UnsignedInt)
+            | Self::bit_for(ValueType::SignedInt)
+            | Self::bit_for(ValueType::Float),
+    };
+
+    /// String-like primitives: `String`, `Symbol`.
+    pub const STRING_LIKE: Self = Self {
+        bits: Self::bit_for(ValueType::String) | Self::bit_for(ValueType::Symbol),
+    };
+
+    /// Comparable primitives: numeric, string-like, entity, bytes.
+    pub const COMPARABLE: Self = Self {
+        bits: Self::NUMERIC.bits
+            | Self::STRING_LIKE.bits
+            | Self::bit_for(ValueType::Entity)
+            | Self::bit_for(ValueType::Bytes),
+    };
+
+    /// Construct a singleton set from a single `ValueType`.
+    pub const fn singleton(vt: ValueType) -> Self {
+        Self {
+            bits: Self::bit_for(vt),
+        }
+    }
+
+    /// Bitfield position for a `ValueType` variant. Stable across
+    /// builds so serialization round-trips.
+    const fn bit_for(vt: ValueType) -> u16 {
+        match vt {
+            ValueType::String => 1 << 0,
+            ValueType::Boolean => 1 << 1,
+            ValueType::UnsignedInt => 1 << 2,
+            ValueType::SignedInt => 1 << 3,
+            ValueType::Float => 1 << 4,
+            ValueType::Bytes => 1 << 5,
+            ValueType::Entity => 1 << 6,
+            ValueType::Symbol => 1 << 7,
+            ValueType::Record => 1 << 8,
+        }
+    }
+
+    /// Returns `true` iff this set has no members.
+    pub fn is_empty(self) -> bool {
+        self.bits == 0
+    }
+
+    /// Returns `true` iff `vt` is a member of this set.
+    pub fn contains(self, vt: ValueType) -> bool {
+        (self.bits & Self::bit_for(vt)) != 0
+    }
+
+    /// Returns `true` iff the `Nothing` atom is a member.
+    pub fn contains_nothing(self) -> bool {
+        (self.bits & NOTHING_BIT) != 0
+    }
+
+    /// Returns a copy of this set with the `Nothing` atom removed.
+    /// Used to strip set-widening from an `Optional<T>` type back
+    /// to its underlying `T` shape.
+    pub fn without_nothing(self) -> Self {
+        Self {
+            bits: self.bits & !NOTHING_BIT,
+        }
+    }
+
+    /// Set intersection. Returns `None` iff the result is empty.
+    pub fn intersect(self, other: Self) -> Option<Self> {
+        let merged = Self {
+            bits: self.bits & other.bits,
+        };
+        if merged.is_empty() {
+            None
+        } else {
+            Some(merged)
+        }
+    }
+
+    /// Set union. Always non-empty if either input is.
+    pub fn union(self, other: Self) -> Self {
+        Self {
+            bits: self.bits | other.bits,
+        }
+    }
+
+    /// Returns `true` iff `self` is a (non-strict) superset of `other`.
+    pub fn includes(self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+
+    /// If this set has exactly one `ValueType` member (and nothing
+    /// else, not even `Nothing`), return it. A `Nothing`-only set
+    /// returns `None` — it has no `ValueType`.
+    pub fn as_singleton(self) -> Option<ValueType> {
+        if self.bits.count_ones() != 1 {
+            return None;
+        }
+        let pos = self.bits.trailing_zeros();
+        value_type_for_bit(pos)
+    }
+
+    /// Iterate the [`ValueType`] members in discriminant order.
+    /// Does **not** yield the `Nothing` atom.
+    pub fn iter(self) -> impl Iterator<Item = ValueType> {
+        let bits = self.bits;
+        (0..9u32).filter_map(move |pos| {
+            if (bits & (1 << pos)) != 0 {
+                value_type_for_bit(pos)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+fn value_type_for_bit(pos: u32) -> Option<ValueType> {
+    Some(match pos {
+        0 => ValueType::String,
+        1 => ValueType::Boolean,
+        2 => ValueType::UnsignedInt,
+        3 => ValueType::SignedInt,
+        4 => ValueType::Float,
+        5 => ValueType::Bytes,
+        6 => ValueType::Entity,
+        7 => ValueType::Symbol,
+        8 => ValueType::Record,
+        _ => return None,
+    })
+}
+
+impl From<ValueType> for Primitive {
+    fn from(vt: ValueType) -> Self {
+        Self::singleton(vt)
+    }
+}
+
+impl From<ValueType> for Type {
+    fn from(vt: ValueType) -> Self {
+        Self::primitive(vt)
+    }
+}
+
+/// Schema-layer type — the set of admissible value shapes a slot
+/// can bind.
+///
+/// A [`Type`] is the union of two parts:
+///
+/// - A [`Primitive`] bitfield carrying atomic [`ValueType`] bits
+///   plus an optional `Nothing` atom (row-level absence).
+/// - An optional non-empty set of [`Composite`] shapes for
+///   structured values (records, variants).
+///
+/// Smart constructors enforce the invariant that
+/// `Composite(_, set)` always has `!set.is_empty()`; a request to
+/// build a composite with an empty set collapses to a plain
+/// `Primitive`.
+///
+/// Composites live in a [`BTreeSet`] rather than a [`HashSet`].
+/// Two reasons:
+///
+/// 1. `Type` derives [`Hash`]. `BTreeSet` iterates in a stable
+///    `Ord`-based order, so the derived hash is canonical:
+///    `Type::Composite(p, {a, b})` and `Type::Composite(p, {b, a})`
+///    have identical hashes. `HashSet` does not implement `Hash`
+///    in std, and any hand-rolled order-independent hash would
+///    have to sort internally anyway — `BTreeSet` is that already.
+///
+/// 2. Insertion order at construction never affects equality.
+///    Building the same set via different paths (different unions,
+///    different insert orders) yields equal [`Type`]s.
+///
+/// The cost is requiring [`Ord`] on [`Composite`], [`Type`], and
+/// [`Primitive`]. The ordering is structural plumbing — it has no
+/// semantic meaning (no claim that `u32 < String`); it exists only
+/// to keep the set canonical.
+///
+/// `Type` is fully static — no type variables, no allocation
+/// state. Deriving [`PartialEq`]/[`Eq`]/[`Hash`] is safe and
+/// produces stable values for equivalent types.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Type {
+    /// Pure primitive set (no composite shapes admitted).
+    Primitive(Primitive),
+    /// Primitive set together with at least one composite shape.
+    /// Invariant: the composite set is never empty.
+    Composite(Primitive, BTreeSet<Composite>),
+}
+
+/// A composite (structured) value shape. Ordered by derived
+/// [`Ord`] for stable iteration and hashing inside a [`BTreeSet`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Composite {
+    /// Product (record) type with named fields. Field names ordered
+    /// by [`BTreeMap`] for stable equality and hashing.
+    Product(BTreeMap<String, Type>),
+    /// Sum-type variant carrying a single label and its payload.
+    Variant {
+        /// The discriminator label.
+        label: String,
+        /// The payload type for this label.
+        value: Type,
+    },
+}
+
+impl Type {
+    /// Construct a [`Type::Primitive`] containing the single
+    /// `ValueType`.
+    pub fn primitive(vt: ValueType) -> Type {
+        Type::Primitive(Primitive::singleton(vt))
+    }
+
+    /// Construct a [`Type::Primitive`] wrapping the given bitfield.
+    pub fn primitive_set(p: Primitive) -> Type {
+        Type::Primitive(p)
+    }
+
+    /// The type whose only inhabitant is the `Nothing` atom — the
+    /// "absent" row-layer value.
+    pub fn nothing() -> Type {
+        Type::Primitive(Primitive::NOTHING)
+    }
+
+    /// Widen this type to also admit `Nothing` — the new home for
+    /// what used to be the outer `Optional` variant. Idempotent.
+    pub fn optional(self) -> Type {
+        match self {
+            Type::Primitive(p) => Type::Primitive(p.union(Primitive::NOTHING)),
+            Type::Composite(p, c) => Type::Composite(p.union(Primitive::NOTHING), c),
+        }
+    }
+
+    /// The inverse of [`optional`]: strip the `Nothing` atom if
+    /// present, yielding the underlying non-widened type.
+    /// Idempotent.
+    pub fn without_nothing(self) -> Type {
+        match self {
+            Type::Primitive(p) => Type::Primitive(p.without_nothing()),
+            Type::Composite(p, c) => Type::Composite(p.without_nothing(), c),
+        }
+    }
+
+    /// Smart constructor. Collapses `Composite(p, empty)` to
+    /// `Primitive(p)`. Use this rather than building the
+    /// `Composite` variant directly.
+    pub fn composite(primitive: Primitive, composite: BTreeSet<Composite>) -> Type {
+        if composite.is_empty() {
+            Type::Primitive(primitive)
+        } else {
+            Type::Composite(primitive, composite)
+        }
+    }
+
+    /// Build a record type from named fields.
+    pub fn product(fields: BTreeMap<String, Type>) -> Type {
+        let mut set = BTreeSet::new();
+        set.insert(Composite::Product(fields));
+        Type::Composite(Primitive::EMPTY, set)
+    }
+
+    /// Build a singleton variant type from a label and payload.
+    pub fn variant(label: impl Into<String>, value: Type) -> Type {
+        let mut set = BTreeSet::new();
+        set.insert(Composite::Variant {
+            label: label.into(),
+            value,
+        });
+        Type::Composite(Primitive::EMPTY, set)
+    }
+
+    /// Set intersection over both primitive and composite parts.
+    /// Returns `None` when the result is empty — no admissible
+    /// shapes survive.
+    ///
+    /// Composite shapes narrow structurally: two
+    /// `Composite::Product` values with the same field-name set
+    /// intersect their field types recursively (if any field
+    /// intersection is empty, the product is eliminated). Products
+    /// with disjoint field-name sets do not intersect — they
+    /// describe disjoint records. Variants intersect by matching
+    /// label, recursing into payload types.
+    pub fn intersect(&self, other: &Type) -> Option<Type> {
+        let p_self = self.primitive_part();
+        let p_other = other.primitive_part();
+        let p = Primitive {
+            bits: p_self.bits & p_other.bits,
+        };
+
+        let composite_intersection: BTreeSet<Composite> =
+            match (self.composite_part(), other.composite_part()) {
+                (Some(a), Some(b)) => intersect_composite_sets(a, b),
+                _ => BTreeSet::new(),
+            };
+
+        if p.is_empty() && composite_intersection.is_empty() {
+            None
+        } else {
+            Some(Type::composite(p, composite_intersection))
+        }
+    }
+
+    /// Set union over both primitive and composite parts.
+    pub fn union(&self, other: &Type) -> Type {
+        let p = self.primitive_part().union(other.primitive_part());
+        let mut composites: BTreeSet<Composite> = BTreeSet::new();
+        if let Some(s) = self.composite_part() {
+            composites.extend(s.iter().cloned());
+        }
+        if let Some(s) = other.composite_part() {
+            composites.extend(s.iter().cloned());
+        }
+        Type::composite(p, composites)
+    }
+
+    /// Subtype check. Returns `true` iff every shape `other`
+    /// admits is also admitted by `self`.
+    ///
+    /// For composites: each shape in `other` must be included by
+    /// some shape in `self`. Inclusion is structural — a Product
+    /// `{x: T1, y: T2}` includes a Product `{x: T1', y: T2'}` when
+    /// the field-name sets match and each `Ti` includes `Ti'`. A
+    /// product with extra fields includes one with fewer fields
+    /// (width subtyping is not assumed; equal field sets only).
+    pub fn includes(&self, other: &Type) -> bool {
+        if !self.primitive_part().includes(other.primitive_part()) {
+            return false;
+        }
+        match (self.composite_part(), other.composite_part()) {
+            (_, None) => true,
+            (None, Some(b)) => b.is_empty(),
+            (Some(a), Some(b)) => b
+                .iter()
+                .all(|b_shape| a.iter().any(|a_shape| composite_includes(a_shape, b_shape))),
+        }
+    }
+
+    /// Returns `true` iff this type admits the `Nothing` atom.
+    pub fn is_optional(&self) -> bool {
+        self.primitive_part().contains_nothing()
+    }
+
+    /// The primitive part of this type, regardless of variant.
+    pub fn primitive_part(&self) -> Primitive {
+        match self {
+            Type::Primitive(p) => *p,
+            Type::Composite(p, _) => *p,
+        }
+    }
+
+    /// The composite part of this type, or `None` if the type has
+    /// only a primitive part.
+    pub fn composite_part(&self) -> Option<&BTreeSet<Composite>> {
+        match self {
+            Type::Primitive(_) => None,
+            Type::Composite(_, c) => Some(c),
+        }
+    }
+
+    /// Legacy storage-codec view: if this type reduces to exactly
+    /// one [`ValueType`] (no `Nothing`, no composites), return it.
+    pub fn as_value_type(&self) -> Option<ValueType> {
+        match self {
+            Type::Primitive(p) => p.as_singleton(),
+            Type::Composite(_, _) => None,
+        }
+    }
+}
+
+/// Structurally intersect two sets of [`Composite`] shapes.
+///
+/// For each `Composite::Product` in `a`, look for a same-field-set
+/// `Composite::Product` in `b` and intersect their field types
+/// pairwise; if any field intersection is empty, the product is
+/// eliminated. For each `Composite::Variant` in `a`, look for a
+/// same-label `Composite::Variant` in `b` and intersect their
+/// payload types. Anything in `a` or `b` without a structural
+/// counterpart on the other side is dropped — set intersection
+/// only keeps shapes admitted by both sides.
+fn intersect_composite_sets(
+    a: &BTreeSet<Composite>,
+    b: &BTreeSet<Composite>,
+) -> BTreeSet<Composite> {
+    let mut result = BTreeSet::new();
+    for a_shape in a {
+        for b_shape in b {
+            if let Some(merged) = intersect_composite(a_shape, b_shape) {
+                result.insert(merged);
+            }
+        }
+    }
+    result
+}
+
+/// Pairwise intersection of two [`Composite`] shapes. Two
+/// products intersect iff they share the same set of field names;
+/// two variants iff they share the same label.
+fn intersect_composite(a: &Composite, b: &Composite) -> Option<Composite> {
+    match (a, b) {
+        (Composite::Product(fa), Composite::Product(fb)) => {
+            if fa.len() != fb.len() {
+                return None;
+            }
+            let mut out = BTreeMap::new();
+            for (name, ta) in fa {
+                let tb = fb.get(name)?;
+                let merged = ta.intersect(tb)?;
+                out.insert(name.clone(), merged);
+            }
+            Some(Composite::Product(out))
+        }
+        (
+            Composite::Variant {
+                label: la,
+                value: va,
+            },
+            Composite::Variant {
+                label: lb,
+                value: vb,
+            },
+        ) => {
+            if la != lb {
+                return None;
+            }
+            let merged = va.intersect(vb)?;
+            Some(Composite::Variant {
+                label: la.clone(),
+                value: merged,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Structural inclusion check between two [`Composite`] shapes.
+/// `a` includes `b` iff they are the same shape kind, have matching
+/// keys/labels, and each of `a`'s recursive types includes `b`'s.
+fn composite_includes(a: &Composite, b: &Composite) -> bool {
+    match (a, b) {
+        (Composite::Product(fa), Composite::Product(fb)) => {
+            if fa.len() != fb.len() {
+                return false;
+            }
+            for (name, ta) in fa {
+                let Some(tb) = fb.get(name) else {
+                    return false;
+                };
+                if !ta.includes(tb) {
+                    return false;
+                }
+            }
+            true
+        }
+        (
+            Composite::Variant {
+                label: la,
+                value: va,
+            },
+            Composite::Variant {
+                label: lb,
+                value: vb,
+            },
+        ) => la == lb && va.includes(vb),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash as HashTrait, Hasher};
+
+    fn hash_of<T: HashTrait>(t: &T) -> u64 {
+        let mut h = DefaultHasher::new();
+        t.hash(&mut h);
+        h.finish()
+    }
+
+    fn p(vt: ValueType) -> Type {
+        Type::primitive(vt)
+    }
+    fn o(vt: ValueType) -> Type {
+        Type::primitive(vt).optional()
+    }
+
+    #[dialog_common::test]
+    fn primitive_singleton() {
+        let s = Primitive::singleton(ValueType::String);
+        assert!(s.contains(ValueType::String));
+        assert!(!s.contains(ValueType::UnsignedInt));
+        assert!(!s.contains_nothing());
+        assert_eq!(s.as_singleton(), Some(ValueType::String));
+    }
+
+    #[dialog_common::test]
+    fn primitive_intersect_overlap() {
+        let s = Primitive::NUMERIC
+            .intersect(Primitive::singleton(ValueType::UnsignedInt))
+            .unwrap();
+        assert_eq!(s.as_singleton(), Some(ValueType::UnsignedInt));
+    }
+
+    #[dialog_common::test]
+    fn primitive_intersect_disjoint() {
+        assert!(
+            Primitive::singleton(ValueType::String)
+                .intersect(Primitive::singleton(ValueType::Entity))
+                .is_none()
+        );
+    }
+
+    #[dialog_common::test]
+    fn primitive_includes_self() {
+        assert!(Primitive::ALL.includes(Primitive::ALL));
+        assert!(Primitive::NUMERIC.includes(Primitive::singleton(ValueType::UnsignedInt)));
+    }
+
+    #[dialog_common::test]
+    fn primitive_iter_skips_nothing() {
+        let s = Primitive::NUMERIC.union(Primitive::NOTHING);
+        let members: Vec<_> = s.iter().collect();
+        assert_eq!(members.len(), 3);
+        assert!(members.contains(&ValueType::UnsignedInt));
+        assert!(members.contains(&ValueType::SignedInt));
+        assert!(members.contains(&ValueType::Float));
+        assert!(s.contains_nothing());
+    }
+
+    #[dialog_common::test]
+    fn primitive_nothing_singleton_returns_none() {
+        assert_eq!(Primitive::NOTHING.as_singleton(), None);
+    }
+
+    #[dialog_common::test]
+    fn primitive_all_excludes_nothing() {
+        assert!(!Primitive::ALL.contains_nothing());
+        assert!(Primitive::ANY.contains_nothing());
+        assert!(Primitive::ANY.includes(Primitive::ALL));
+        assert!(Primitive::ANY.includes(Primitive::NOTHING));
+    }
+
+    #[dialog_common::test]
+    fn primitive_serde_round_trip() {
+        let s = Primitive::NUMERIC;
+        let j = serde_json::to_string(&s).unwrap();
+        let back: Primitive = serde_json::from_str(&j).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[dialog_common::test]
+    fn type_primitive_is_not_optional() {
+        let t = p(ValueType::String);
+        assert!(matches!(t, Type::Primitive(_)));
+        assert!(!t.is_optional());
+    }
+
+    #[dialog_common::test]
+    fn type_optional_widens_with_nothing() {
+        let t = o(ValueType::String);
+        assert!(t.is_optional());
+        assert_eq!(t.as_value_type(), None);
+        assert_eq!(t.primitive_part().as_singleton(), None);
+        assert!(t.primitive_part().contains(ValueType::String));
+        assert!(t.primitive_part().contains_nothing());
+    }
+
+    #[dialog_common::test]
+    fn type_optional_is_idempotent() {
+        let a = p(ValueType::String).optional();
+        let b = a.clone().optional();
+        assert_eq!(a, b);
+    }
+
+    #[dialog_common::test]
+    fn type_serde_round_trip_primitive() {
+        let t = p(ValueType::String);
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
+    }
+
+    #[dialog_common::test]
+    fn type_serde_round_trip_optional() {
+        let t = o(ValueType::Entity);
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
+    }
+
+    /// Equivalent types hash and compare equal regardless of how
+    /// they were constructed.
+    #[dialog_common::test]
+    fn type_hash_is_stable_across_constructions() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let a = p(ValueType::String);
+        let b = Type::primitive_set(Primitive::singleton(ValueType::String));
+        let mut ha = DefaultHasher::new();
+        let mut hb = DefaultHasher::new();
+        a.hash(&mut ha);
+        b.hash(&mut hb);
+        assert_eq!(ha.finish(), hb.finish());
+        assert_eq!(a, b);
+    }
+
+    #[dialog_common::test]
+    fn product_constructor_round_trip() {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), Type::primitive(ValueType::String));
+        fields.insert("age".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let a = Type::product(fields.clone());
+        let b = Type::product(fields);
+        assert_eq!(a, b);
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut ha = DefaultHasher::new();
+        let mut hb = DefaultHasher::new();
+        a.hash(&mut ha);
+        b.hash(&mut hb);
+        assert_eq!(ha.finish(), hb.finish());
+    }
+
+    #[dialog_common::test]
+    fn variant_constructor_carries_label_and_payload() {
+        let some = Type::variant("Some", Type::primitive(ValueType::String));
+        let composites = some.composite_part().unwrap();
+        assert_eq!(composites.len(), 1);
+        let first = composites.iter().next().unwrap();
+        match first {
+            Composite::Variant { label, value } => {
+                assert_eq!(label, "Some");
+                assert_eq!(*value, Type::primitive(ValueType::String));
+            }
+            other => panic!("expected Variant, got {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn intersect_two_records_same_fields() {
+        let mut fields = BTreeMap::new();
+        fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(fields.clone());
+        let b = Type::product(fields);
+        let c = a.intersect(&b).expect("intersection non-empty");
+        assert_eq!(a, c);
+    }
+
+    /// Two products with the same field names but different field
+    /// types narrow structurally: intersect each field's type
+    /// recursively. If every field intersection is non-empty, the
+    /// product survives with the narrowed fields.
+    #[dialog_common::test]
+    fn intersect_products_narrows_field_types() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive_set(Primitive::NUMERIC));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        let merged = a.intersect(&b).expect("narrows to UnsignedInt");
+        let composite = merged.composite_part().expect("composite present");
+        let product = composite.iter().next().expect("one product");
+        match product {
+            Composite::Product(fields) => {
+                let x_type = fields.get("x").expect("x field");
+                assert_eq!(x_type.as_value_type(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("expected Product, got {other:?}"),
+        }
+    }
+
+    /// Two products with disjoint field types fail to intersect.
+    #[dialog_common::test]
+    fn intersect_products_disjoint_fields_eliminated() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        assert!(a.intersect(&b).is_none());
+    }
+
+    /// Two products with different field-name sets do not
+    /// intersect — they describe disjoint record shapes.
+    #[dialog_common::test]
+    fn intersect_products_different_keys_eliminated() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::String));
+        let b = Type::product(b_fields);
+
+        assert!(a.intersect(&b).is_none());
+    }
+
+    /// Two variants with the same label intersect their payloads;
+    /// different labels do not intersect.
+    #[dialog_common::test]
+    fn intersect_variants_by_label() {
+        let a = Type::variant("Some", Type::primitive_set(Primitive::NUMERIC));
+        let b = Type::variant("Some", Type::primitive(ValueType::UnsignedInt));
+        let merged = a.intersect(&b).expect("same label narrows payload");
+        let composite = merged.composite_part().expect("composite present");
+        match composite.iter().next().expect("one variant") {
+            Composite::Variant { label, value } => {
+                assert_eq!(label, "Some");
+                assert_eq!(value.as_value_type(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("expected Variant, got {other:?}"),
+        }
+
+        let c = Type::variant("Other", Type::primitive(ValueType::UnsignedInt));
+        assert!(a.intersect(&c).is_none());
+    }
+
+    #[dialog_common::test]
+    fn intersect_primitive_and_composite_keeps_primitive_only() {
+        let mut fields = BTreeMap::new();
+        fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let composite = Type::product(fields);
+        let prim = Type::primitive(ValueType::String);
+        // primitive part of `composite` is EMPTY; composite part of `prim` is None.
+        // Intersection of primitive parts: EMPTY ∩ {String} = EMPTY.
+        // Intersection of composite parts: None ∩ {Product{...}} = empty.
+        // Overall: empty → None.
+        assert!(prim.intersect(&composite).is_none());
+
+        // But if the composite carries a Record primitive bit, the
+        // intersection has that bit alone.
+        let composite_with_record = Type::composite(
+            Primitive::singleton(ValueType::Record),
+            composite
+                .composite_part()
+                .cloned()
+                .unwrap_or_else(BTreeSet::new),
+        );
+        let record_prim = Type::primitive(ValueType::Record);
+        let intersected = record_prim.intersect(&composite_with_record).unwrap();
+        assert_eq!(
+            intersected.primitive_part().as_singleton(),
+            Some(ValueType::Record)
+        );
+        assert!(intersected.composite_part().is_none());
+    }
+
+    #[dialog_common::test]
+    fn includes_product_subtype_extra_fields_in_subject() {
+        // A type T "includes" U iff T admits every shape U admits.
+        // For our set semantics, T includes U requires every
+        // composite of U to be present in T's composite set. So
+        // larger composite sets in T are fine; an extra Product in
+        // U not in T breaks inclusion.
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields.clone());
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        // a and b are different products; neither includes the other.
+        assert!(!a.includes(&b));
+        assert!(!b.includes(&a));
+
+        // a includes itself.
+        assert!(a.includes(&a));
+
+        // Union of {a, b} includes both.
+        let union = a.union(&b);
+        assert!(union.includes(&a));
+        assert!(union.includes(&b));
+    }
+
+    #[dialog_common::test]
+    fn smart_constructor_collapses_empty_composite_set() {
+        let collapsed = Type::composite(Primitive::singleton(ValueType::String), BTreeSet::new());
+        assert!(matches!(collapsed, Type::Primitive(_)));
+        assert_eq!(collapsed.as_value_type(), Some(ValueType::String));
+    }
+
+    #[dialog_common::test]
+    fn nothing_constructor_yields_only_nothing() {
+        let t = Type::nothing();
+        assert!(t.is_optional());
+        assert_eq!(t.primitive_part().as_singleton(), None);
+        assert_eq!(t.as_value_type(), None);
+    }
+
+    #[dialog_common::test]
+    fn as_value_type_unique_singleton() {
+        assert_eq!(
+            p(ValueType::String).as_value_type(),
+            Some(ValueType::String)
+        );
+        assert_eq!(o(ValueType::String).as_value_type(), None);
+        assert_eq!(
+            Type::primitive_set(Primitive::NUMERIC).as_value_type(),
+            None
+        );
+    }
+
+    /// Insertion order of composite elements does not affect
+    /// equality or hash. The [`BTreeSet`] storage canonicalizes
+    /// the set, so different paths to the same set of shapes
+    /// produce equal `Type`s with equal hashes.
+    #[dialog_common::test]
+    fn composite_set_is_insertion_order_independent() {
+        let a = Type::variant("A", p(ValueType::String));
+        let b = Type::variant("B", p(ValueType::UnsignedInt));
+
+        // Build the same multi-element set two different ways:
+        // ({A, B}) via a.union(b), and ({B, A}) via b.union(a).
+        let ab = a.union(&b);
+        let ba = b.union(&a);
+
+        assert_eq!(ab, ba, "set equality is order-independent");
+        assert_eq!(hash_of(&ab), hash_of(&ba), "set hash is order-independent");
+    }
+
+    /// Field insertion order into a `BTreeMap<String, Type>` does
+    /// not affect product equality or hash — the BTreeMap sorts
+    /// by key. Same product built via `{x, y}` vs `{y, x}` insert
+    /// orders must compare equal and hash equal.
+    #[dialog_common::test]
+    fn product_field_insertion_order_independent() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        a_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        b_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let b = Type::product(b_fields);
+
+        assert_eq!(
+            a, b,
+            "product equality is field-insertion-order independent"
+        );
+        assert_eq!(
+            hash_of(&a),
+            hash_of(&b),
+            "product hash is field-insertion-order independent"
+        );
+    }
+
+    /// Combining two products via union also produces identical
+    /// hashes regardless of which product was unioned first.
+    #[dialog_common::test]
+    fn product_union_is_order_independent() {
+        let mut a_fields = BTreeMap::new();
+        a_fields.insert("x".to_string(), Type::primitive(ValueType::String));
+        let a = Type::product(a_fields);
+
+        let mut b_fields = BTreeMap::new();
+        b_fields.insert("y".to_string(), Type::primitive(ValueType::UnsignedInt));
+        let b = Type::product(b_fields);
+
+        let ab = a.union(&b);
+        let ba = b.union(&a);
+
+        assert_eq!(ab, ba);
+        assert_eq!(hash_of(&ab), hash_of(&ba));
+    }
+}

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -1,0 +1,448 @@
+//! Unifier-internal type representation and unification.
+//!
+//! This submodule owns everything that needs to talk about
+//! per-rule type variables: [`VarId`] allocation, the
+//! [`Type`] enum with its `Static`/`Variable` distinction, and
+//! the [`Context`] that drives unification.
+//!
+//! Variables never escape into the user-facing
+//! [`StaticType`]. Lifting between layers happens via [`lift`]
+//! and [`Context::infer`].
+
+use crate::artifact::Type as ValueType;
+use crate::type_system::Primitive;
+use crate::type_system::Type as StaticType;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A unique identifier for a type variable within a unification
+/// context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct VarId(u32);
+
+/// Unifier-internal type — either a static
+/// [user-facing type](StaticType) or a fresh type variable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Type {
+    /// A static, user-facing type lifted into the unifier domain.
+    Static(StaticType),
+    /// A type variable allocated by a [`Context`].
+    Variable(VarId),
+}
+
+impl Type {
+    /// Build a static primitive type, wrapped for unification.
+    pub fn primitive(vt: ValueType) -> Self {
+        Type::Static(StaticType::primitive(vt))
+    }
+
+    /// Build a static primitive set, wrapped for unification.
+    pub fn primitive_set(set: Primitive) -> Self {
+        Type::Static(StaticType::primitive_set(set))
+    }
+
+    /// Build a static optional primitive, wrapped for unification.
+    pub fn optional(vt: ValueType) -> Self {
+        Type::Static(StaticType::primitive(vt).optional())
+    }
+}
+
+/// Lift a static [user-facing type](StaticType) into the unifier
+/// domain. Always wraps in [`Type::Static`].
+pub fn lift(ty: &StaticType) -> Type {
+    Type::Static(ty.clone())
+}
+
+/// Errors raised by unification.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum UnifyError {
+    /// Two types' primitive constraint sets have empty
+    /// intersection — no shape can satisfy both.
+    #[error("constraint conflict between {left:?} and {right:?}")]
+    ConstraintConflict {
+        /// The narrower side.
+        left: Primitive,
+        /// The other narrower side.
+        right: Primitive,
+    },
+    /// Occurs check: unifying a variable with a type that
+    /// transitively contains the variable would produce an
+    /// infinite type. Reserved for future composite shapes.
+    #[error("occurs check failed for variable {var:?}")]
+    OccursCheck {
+        /// The offending variable.
+        var: VarId,
+    },
+    /// A `Coalesce` source type was expected to be set-widened
+    /// with `Nothing` but is not. Raised by
+    /// [`Coalesce::validate`](crate::constraint::Coalesce::validate).
+    #[error("Coalesce source is not Optional")]
+    SourceNotOptional,
+}
+
+/// Per-rule unification context. Tracks the substitution map,
+/// per-variable constraints, named variables in lexical scope,
+/// and a fresh-id counter.
+#[derive(Debug, Clone, Default)]
+pub struct Context {
+    /// Substitution: variable → resolved (or partially-resolved)
+    /// type. Updated in-place by [`Self::unify`].
+    substitution: HashMap<VarId, Type>,
+    /// Per-variable primitive constraint.
+    constraints: HashMap<VarId, Primitive>,
+    /// Lexically-scoped name → `VarId` map; ensures that the same
+    /// name within a scope refers to the same variable.
+    names: HashMap<String, VarId>,
+    /// Counter for fresh `VarId` allocation within this context.
+    next_id: u32,
+}
+
+impl Context {
+    /// Create an empty context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a fresh `VarId` with the given constraint.
+    pub fn fresh(&mut self, constraint: Primitive) -> VarId {
+        let id = VarId(self.next_id);
+        self.next_id += 1;
+        self.constraints.insert(id, constraint);
+        id
+    }
+
+    /// Allocate a fresh anonymous variable type with constraint
+    /// [`Primitive::ALL`].
+    pub fn fresh_var(&mut self) -> Type {
+        Type::Variable(self.fresh(Primitive::ALL))
+    }
+
+    /// Look up or allocate the `VarId` associated with a name in
+    /// this scope. The first call for a given name allocates with
+    /// the maximally-permissive constraint [`Primitive::ANY`] —
+    /// includes `Nothing`, so optionality can survive unification.
+    /// Narrowing happens when slot kinds without `Nothing` unify
+    /// against the variable.
+    /// Later calls return the same id.
+    pub fn var_for_name(&mut self, name: &str) -> VarId {
+        if let Some(id) = self.names.get(name) {
+            return *id;
+        }
+        let id = self.fresh(Primitive::ANY);
+        self.names.insert(name.to_string(), id);
+        id
+    }
+
+    /// Iterate over `(name, VarId)` pairs for every named variable
+    /// allocated in this context. The order is unspecified.
+    pub fn named_vars(&self) -> impl Iterator<Item = (&String, &VarId)> {
+        self.names.iter()
+    }
+
+    /// Look up the constraint for a variable. Returns
+    /// [`Primitive::ALL`] if the variable is unknown to this
+    /// context.
+    pub fn constraint(&self, var: VarId) -> Primitive {
+        self.constraints
+            .get(&var)
+            .copied()
+            .unwrap_or(Primitive::ALL)
+    }
+
+    /// Materialize a [`Type`] for a slot from optional name and
+    /// optional static kind:
+    ///
+    /// - `(Some(_), Some(t))` and `(None, Some(t))`:
+    ///   wrap `t` as [`Type::Static`] (the user supplied a static
+    ///   type, so no variable is needed).
+    /// - `(Some(name), None)`: look up or allocate a variable for
+    ///   the name; return [`Type::Variable`].
+    /// - `(None, None)`: allocate a fresh anonymous variable;
+    ///   return [`Type::Variable`].
+    pub fn infer(&mut self, name: Option<&str>, kind: Option<StaticType>) -> Type {
+        match (name, kind) {
+            (_, Some(t)) => Type::Static(t),
+            (Some(n), None) => Type::Variable(self.var_for_name(n)),
+            (None, None) => self.fresh_var(),
+        }
+    }
+
+    /// Apply the current substitution to a [`Type`], recursively
+    /// resolving any variables that have been bound.
+    pub fn apply(&self, ty: &Type) -> Type {
+        match ty {
+            Type::Static(s) => Type::Static(s.clone()),
+            Type::Variable(id) => {
+                if let Some(resolved) = self.substitution.get(id) {
+                    self.apply(resolved)
+                } else {
+                    Type::Variable(*id)
+                }
+            }
+        }
+    }
+
+    /// Walk the substitution following variable-to-variable links
+    /// (union-find style), returning the canonical [`VarId`] for
+    /// the chain. Stops at the first non-variable substitution or
+    /// at an unsubstituted variable.
+    fn root(&self, mut id: VarId) -> VarId {
+        while let Some(Type::Variable(next)) = self.substitution.get(&id) {
+            if *next == id {
+                break;
+            }
+            id = *next;
+        }
+        id
+    }
+
+    /// Robinson unification with constraint propagation. Updates
+    /// `self` in-place. Returns `Err` on constraint conflict.
+    ///
+    /// Static types intersect via [`StaticType::intersect`], which
+    /// narrows both primitive and composite parts (products by
+    /// shared field-name set, variants by label). Variables carry
+    /// a [`Primitive`] constraint that's intersected with the
+    /// primitive part of any concrete type they're unified with.
+    pub fn unify(&mut self, a: &Type, b: &Type) -> Result<(), UnifyError> {
+        match (a, b) {
+            (Type::Variable(x), Type::Variable(y)) => {
+                let x = self.root(*x);
+                let y = self.root(*y);
+                if x == y {
+                    return Ok(());
+                }
+                // If either side has already been resolved to a
+                // static, unify that resolved static against the
+                // other variable instead.
+                let xs = self.substitution.get(&x).cloned();
+                let ys = self.substitution.get(&y).cloned();
+                match (xs, ys) {
+                    (Some(Type::Static(sx)), _) => {
+                        return self.unify(&Type::Static(sx), &Type::Variable(y));
+                    }
+                    (_, Some(Type::Static(sy))) => {
+                        return self.unify(&Type::Variable(x), &Type::Static(sy));
+                    }
+                    _ => {}
+                }
+                let cx = self.constraint(x);
+                let cy = self.constraint(y);
+                let merged = cx.intersect(cy).ok_or(UnifyError::ConstraintConflict {
+                    left: cx,
+                    right: cy,
+                })?;
+                self.constraints.insert(x, merged);
+                self.constraints.insert(y, merged);
+                self.substitution.insert(y, Type::Variable(x));
+                Ok(())
+            }
+            (Type::Variable(x), Type::Static(s)) | (Type::Static(s), Type::Variable(x)) => {
+                let x = self.root(*x);
+                // If `x` is already resolved to a static, intersect
+                // the previous resolution with the new static — the
+                // variable's resolved type is the narrowest static
+                // satisfying every unify call that touched it.
+                let prev = match self.substitution.get(&x) {
+                    Some(Type::Static(prev)) => Some(prev.clone()),
+                    _ => None,
+                };
+                let narrowed_static = match prev {
+                    Some(prev) => {
+                        prev.intersect(s)
+                            .ok_or_else(|| UnifyError::ConstraintConflict {
+                                left: prev.primitive_part(),
+                                right: s.primitive_part(),
+                            })?
+                    }
+                    None => s.clone(),
+                };
+                let cx = self.constraint(x);
+                let p = narrowed_static.primitive_part();
+                let merged = cx
+                    .intersect(p)
+                    .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
+                self.constraints.insert(x, merged);
+                let resolved = match narrowed_static.composite_part() {
+                    Some(c) if !c.is_empty() => StaticType::composite(merged, c.clone()),
+                    _ => StaticType::primitive_set(merged),
+                };
+                self.substitution.insert(x, Type::Static(resolved));
+                Ok(())
+            }
+            (Type::Static(a), Type::Static(b)) => {
+                a.intersect(b)
+                    .map(|_| ())
+                    .ok_or_else(|| UnifyError::ConstraintConflict {
+                        left: a.primitive_part(),
+                        right: b.primitive_part(),
+                    })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(vt: ValueType) -> Type {
+        Type::primitive(vt)
+    }
+
+    #[dialog_common::test]
+    fn fresh_variables_are_distinct() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(Primitive::ALL);
+        let b = ctx.fresh(Primitive::ALL);
+        assert_ne!(a, b);
+    }
+
+    #[dialog_common::test]
+    fn fresh_records_constraint() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(Primitive::NUMERIC);
+        assert_eq!(ctx.constraint(a), Primitive::NUMERIC);
+    }
+
+    #[dialog_common::test]
+    fn unify_two_concrete_primitives_same_succeeds() {
+        let mut ctx = Context::new();
+        ctx.unify(&p(ValueType::String), &p(ValueType::String))
+            .unwrap();
+    }
+
+    #[dialog_common::test]
+    fn unify_two_concrete_primitives_different_fails() {
+        let mut ctx = Context::new();
+        let result = ctx.unify(&p(ValueType::String), &p(ValueType::Entity));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[dialog_common::test]
+    fn unify_variable_with_concrete_substitutes() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(Primitive::NUMERIC);
+        ctx.unify(&Type::Variable(v), &p(ValueType::UnsignedInt))
+            .unwrap();
+        let resolved = ctx.apply(&Type::Variable(v));
+        match resolved {
+            Type::Static(s) => {
+                assert_eq!(s.as_value_type(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("expected static, got {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn unify_variable_with_concrete_outside_constraint_fails() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(Primitive::NUMERIC);
+        let result = ctx.unify(&Type::Variable(v), &p(ValueType::String));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[dialog_common::test]
+    fn unify_variable_constraint_propagates() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(Primitive::NUMERIC);
+        let v_ty = Type::Variable(v);
+        let comparable = Type::primitive_set(Primitive::COMPARABLE);
+        ctx.unify(&v_ty, &comparable).unwrap();
+        let resolved = ctx.apply(&v_ty);
+        match resolved {
+            Type::Static(s) => assert_eq!(s.primitive_part(), Primitive::NUMERIC),
+            other => panic!("expected static, got {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn unify_two_variables_intersects_constraints() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(Primitive::NUMERIC);
+        let b = ctx.fresh(Primitive::COMPARABLE);
+        ctx.unify(&Type::Variable(a), &Type::Variable(b)).unwrap();
+        assert_eq!(ctx.constraint(a), Primitive::NUMERIC);
+        assert_eq!(ctx.constraint(b), Primitive::NUMERIC);
+    }
+
+    #[dialog_common::test]
+    fn unify_two_variables_disjoint_fails() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(Primitive::NUMERIC);
+        let b = ctx.fresh(Primitive::singleton(ValueType::String));
+        let result = ctx.unify(&Type::Variable(a), &Type::Variable(b));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    #[dialog_common::test]
+    fn chained_unification_propagates() {
+        let mut ctx = Context::new();
+        let t = ctx.fresh(Primitive::NUMERIC);
+        let u = ctx.fresh(Primitive::NUMERIC);
+        ctx.unify(&Type::Variable(t), &Type::Variable(u)).unwrap();
+        ctx.unify(&Type::Variable(t), &p(ValueType::UnsignedInt))
+            .unwrap();
+        let t_resolved = ctx.apply(&Type::Variable(t));
+        let u_resolved = ctx.apply(&Type::Variable(u));
+        match (t_resolved, u_resolved) {
+            (Type::Static(t), Type::Static(u)) => {
+                assert_eq!(t.as_value_type(), Some(ValueType::UnsignedInt));
+                assert_eq!(u.as_value_type(), Some(ValueType::UnsignedInt));
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[dialog_common::test]
+    fn unify_optional_with_definite_same_shape_succeeds() {
+        let mut ctx = Context::new();
+        ctx.unify(&p(ValueType::String), &Type::optional(ValueType::String))
+            .unwrap();
+    }
+
+    #[dialog_common::test]
+    fn unify_optional_with_definite_disjoint_fails() {
+        let mut ctx = Context::new();
+        let result = ctx.unify(&p(ValueType::String), &Type::optional(ValueType::Entity));
+        assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    /// `infer` with no name and no kind allocates a fresh
+    /// anonymous variable.
+    #[dialog_common::test]
+    fn infer_anonymous_unconstrained() {
+        let mut ctx = Context::new();
+        let a = ctx.infer(None, None);
+        let b = ctx.infer(None, None);
+        match (&a, &b) {
+            (Type::Variable(x), Type::Variable(y)) => assert_ne!(x, y),
+            _ => panic!("expected two distinct variables"),
+        }
+    }
+
+    /// `infer` with a name (no kind) allocates once per name in
+    /// scope; repeated calls return the same variable.
+    #[dialog_common::test]
+    fn infer_named_is_stable_within_scope() {
+        let mut ctx = Context::new();
+        let a = ctx.infer(Some("x"), None);
+        let b = ctx.infer(Some("x"), None);
+        match (&a, &b) {
+            (Type::Variable(x), Type::Variable(y)) => assert_eq!(x, y),
+            _ => panic!("expected variables"),
+        }
+    }
+
+    /// `infer` with a kind always wraps statically — no variable
+    /// is allocated even when a name is given.
+    #[dialog_common::test]
+    fn infer_with_kind_wraps_statically() {
+        let mut ctx = Context::new();
+        let a = ctx.infer(Some("x"), Some(StaticType::primitive(ValueType::String)));
+        match a {
+            Type::Static(_) => {}
+            other => panic!("expected static, got {:?}", other),
+        }
+    }
+}

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -1,69 +1,69 @@
 //! Type system utilities for dialog-query
 //!
-//! This module provides the bridge between Rust's compile-time type system and
-//! dialog-artifacts' runtime [`Type`] system. The core abstractions are:
+//! This module bridges Rust's compile-time type system to the
+//! query engine's runtime type system. The core abstractions are:
 //!
-//! - [`TypeDescriptor`] — a trait implemented by named ZSTs (like [`Text`],
-//!   [`Boolean`]) that carry a static `TYPE` constant and can report the
-//!   runtime type of a value.
-//! - [`Typed`] — maps a Rust type (e.g. `String`) to its [`TypeDescriptor`]
-//!   (e.g. `Text`). Also implemented by the ZSTs themselves so that
-//!   `Term<String>` and `Term<Text>` are interchangeable.
-//! - [`Scalar`] — concrete types with bidirectional [`Value`] conversion.
-//! - [`Any`] — a descriptor that carries a runtime `Option<Type>`, used for
-//!   type-erased terms (`Term<Any>` replaces the old `Parameter`).
+//! - [`TypeDescriptor`] — a trait implemented by named ZSTs (like
+//!   [`Text`], [`Boolean`]) that report a unified
+//!   [`type_system::Type`] for a value via
+//!   [`kind`](TypeDescriptor::kind).
+//! - [`Typed`] — maps a Rust type (e.g. `String`) to its
+//!   [`TypeDescriptor`] (e.g. `Text`).
+//! - [`Scalar`] — concrete types with bidirectional [`Value`]
+//!   conversion.
+//! - [`Any`] — a descriptor that carries a runtime
+//!   `Option<type_system::Type>`. Used for type-erased terms.
+//! - [`OptionalOf`] — a wrapper descriptor for `Term<Option<U>>`.
+//!   Widens the inner descriptor's kind with the `Nothing` atom via
+//!   [`type_system::Type::optional`].
 
+use crate::type_system;
+use crate::type_system::Type as Kind;
 use dialog_common::ConditionalSend;
 use std::fmt;
 use std::hash::Hash;
+use std::marker::PhantomData;
 
 pub use crate::artifact::{ArtifactsAttribute, Cause, Entity, Type, Value};
 use crate::attribute::The;
 
-/// Trait implemented by type descriptors — named ZSTs that represent a
-/// dialog-artifacts type at the Rust type level.
+/// Trait implemented by type descriptors — named ZSTs that
+/// represent a runtime type at the Rust type level.
 ///
-/// Each descriptor answers two questions:
-/// 1. **What is the static type?** — via `TYPE` (compile-time constant).
-///    `Some(Type::String)` for concrete types, `None` for [`Any`].
-/// 2. **What is the runtime type of a given value?** — via `content_type()`.
-///    For concrete descriptors this always returns `TYPE`. For [`Any`] it
-///    inspects the wrapped `Option<Type>`.
+/// Each descriptor reports its represented type via
+/// [`Self::kind`] returning `Option<type_system::Type>`. `None`
+/// means "unknown — the unifier decides at rule-compile time."
 pub trait TypeDescriptor:
     Clone + fmt::Debug + Default + PartialEq + Eq + Hash + Send + Sync + 'static
 {
-    /// The dialog-artifacts type, if statically known.
-    /// `None` means "any type" — determined at runtime.
+    /// The legacy storage tag, if statically known. `None` means
+    /// "any type."
     const TYPE: Option<Type>;
 
-    /// Report the runtime type this descriptor represents.
+    /// Report the unified [`type_system::Type`] this descriptor
+    /// represents. `None` means "no static info — leave to the
+    /// unifier."
     ///
-    /// For concrete descriptors (e.g. [`Text`]) this returns `Self::TYPE`.
-    /// For [`Any`] this returns the wrapped `Option<Type>`.
-    fn content_type(&self) -> Option<Type>;
+    /// Default implementation lifts [`Self::TYPE`]:
+    /// `Some(vt) → Some(Type::primitive(vt))`, `None → None`.
+    fn kind(&self) -> Option<type_system::Type> {
+        Self::TYPE.map(Kind::primitive)
+    }
 
-    /// Reconstruct a descriptor from a runtime type tag.
+    /// Reconstruct a descriptor from a unified type kind.
     ///
-    /// For concrete descriptors this ignores the input and returns `Self::default()`.
-    /// For [`Any`] this wraps the type tag.
-    fn from_content_type(_type: Option<Type>) -> Self {
+    /// Concrete descriptors ignore the input. [`Any`] wraps it.
+    fn from_kind(_kind: Option<type_system::Type>) -> Self {
         Self::default()
     }
 }
 
 /// Maps a Rust type to its [`TypeDescriptor`].
-///
-/// For concrete types like `String`, this maps to a named ZST (`Text`).
-/// Each ZST also implements `Typed` mapping to itself, so `Term<String>`
-/// and `Term<Text>` use the same internal representation.
 pub trait Typed {
-    /// The descriptor type that represents this type in the term system.
+    /// The descriptor type that represents this type in the term
+    /// system.
     type Descriptor: TypeDescriptor;
 }
-
-// Named ZST descriptors and their TypeDescriptor + Typed implementations.
-// Each descriptor is a zero-sized type that carries type information at the
-// Rust type level, enabling Term<T> to store type metadata without overhead.
 
 macro_rules! define_descriptor {
     (
@@ -76,10 +76,6 @@ macro_rules! define_descriptor {
 
         impl TypeDescriptor for $name {
             const TYPE: Option<Type> = Some($variant);
-
-            fn content_type(&self) -> Option<Type> {
-                Some($variant)
-            }
         }
 
         impl Typed for $name {
@@ -133,20 +129,21 @@ define_descriptor!(
     Record, Type::Record
 );
 
-/// Descriptor for dynamically-typed values — carries an optional runtime
-/// type tag. `Term<Any>` is the unified replacement for the old `Parameter`.
+/// Descriptor for dynamically-typed values — carries an optional
+/// runtime type kind. `Term<Any>` is the unified replacement for
+/// the old `Parameter`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-pub struct Any(pub Option<Type>);
+pub struct Any(pub Option<type_system::Type>);
 
 impl TypeDescriptor for Any {
     const TYPE: Option<Type> = None;
 
-    fn content_type(&self) -> Option<Type> {
-        self.0
+    fn kind(&self) -> Option<type_system::Type> {
+        self.0.clone()
     }
 
-    fn from_content_type(typ: Option<Type>) -> Self {
-        Any(typ)
+    fn from_kind(kind: Option<type_system::Type>) -> Self {
+        Any(kind)
     }
 }
 
@@ -154,8 +151,28 @@ impl Typed for Any {
     type Descriptor = Self;
 }
 
-// Typed implementations for Rust primitive and dialog-artifacts types.
-// Each maps to the appropriate named ZST descriptor.
+impl From<Option<Type>> for Any {
+    /// Lift a legacy storage tag into an `Any` descriptor.
+    /// `Some(vt) → Some(Type::primitive(vt))`, `None → None`.
+    fn from(value: Option<Type>) -> Self {
+        Any(value.map(Kind::primitive))
+    }
+}
+
+/// Wrapper descriptor widening an inner [`TypeDescriptor`]'s kind
+/// with the `Nothing` atom — used by `Term<Option<U>>`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct OptionalOf<D: TypeDescriptor>(PhantomData<D>);
+
+impl<D: TypeDescriptor> TypeDescriptor for OptionalOf<D> {
+    const TYPE: Option<Type> = D::TYPE;
+
+    /// Widen the inner descriptor's `kind()` with the `Nothing`
+    /// atom via [`type_system::Type::optional`]. `None → None`.
+    fn kind(&self) -> Option<type_system::Type> {
+        D::default().kind().map(|k| k.optional())
+    }
+}
 
 macro_rules! impl_typed {
     ($rust_type:ty, $descriptor:ty) => {
@@ -187,11 +204,14 @@ impl_typed!(The, Symbol);
 impl_typed!(Cause, Bytes);
 impl_typed!(Value, Any);
 
-/// A concrete type that can be used as a term value with bidirectional Value conversion.
-///
-/// `Scalar` types have a known static [`TypeDescriptor`] (their `Tag` is `()`-like —
-/// a ZST) and can convert to/from [`Value`]. Every `Scalar` type must implement
-/// `Into<Value>` (typically via `From<T> for Value`) for the forward direction.
+/// `Option<U>: Typed` for any [`Scalar`] `U`. Maps to
+/// [`OptionalOf<U::Descriptor>`].
+impl<U: Scalar> Typed for Option<U> {
+    type Descriptor = OptionalOf<<U as Typed>::Descriptor>;
+}
+
+/// A concrete type that can be used as a term value with
+/// bidirectional Value conversion.
 pub trait Scalar:
     Typed + Clone + fmt::Debug + Into<Value> + 'static + ConditionalSend + TryFrom<Value>
 {
@@ -224,3 +244,215 @@ impl_scalar!(
 );
 
 impl Scalar for usize {}
+
+// Kind-marker trait family — classify types by *shape* for
+// compile-time bounds, orthogonal to [`Typed`] (which is the
+// mechanical "what descriptor represents this Rust type" map).
+//
+// Membership table:
+// - `ScalarType`  — atomic value types ([`Scalar`] members).
+// - `ProductType` — record/product shapes. Reserved.
+// - `VariantType` — sum/variant shapes. Reserved.
+// - `OptionalType` — `Option<T>` for `T: DefiniteType`.
+// - `AnyType`     — the dynamic top, [`Any`].
+// - `DefiniteType` — umbrella over `Scalar`/`Product`/`Variant`,
+//   the canonical "any concrete shape, not optional, not dynamic"
+//   predicate. Used as the bound on `Option<T>`'s `Typed` impl,
+//   which is what structurally rejects `Option<Option<U>>` and
+//   `Option<Any>` at compile time.
+
+/// Kind marker for atomic (scalar) shapes — types like `String`,
+/// `i32`, `Entity`. Every [`Scalar`] is `ScalarType` via the
+/// blanket impl below.
+///
+/// New code that needs a pure kind bound (without the practical
+/// `Clone + Into<Value> + ...` bag carried by [`Scalar`]) should
+/// use `ScalarType`.
+pub trait ScalarType: Typed {}
+
+impl<T: Scalar> ScalarType for T {}
+
+/// Kind marker for product (record) shapes. Reserved for future
+/// use; no types impl this trait yet, but the slot exists so that
+/// product-only generic code reads symmetrically with
+/// [`ScalarType`] and [`VariantType`].
+pub trait ProductType: Typed {}
+
+/// Kind marker for variant (sum) shapes. Reserved for future
+/// use; no types impl this trait yet.
+pub trait VariantType: Typed {}
+
+/// Kind marker for the dynamic top type, [`Any`].
+///
+/// `Any` is deliberately *not* a [`DefiniteType`]: it already
+/// admits absence implicitly (via [`Binding`](crate::Binding))
+/// and wrapping it in `Option` would be a category error. This
+/// exclusion is what makes `Option<Any>` rejected at compile time.
+pub trait AnyType: Typed {}
+
+impl AnyType for Any {}
+
+/// Kind marker for the `Option<T>` shape family.
+///
+/// `Option<T>` impls `OptionalType` for any `T: DefiniteType`.
+/// The bound on `T` is the structural fence that makes:
+///
+/// - `Option<Option<U>>` reject (nested optionality is meaningless
+///   under set-widening; `OptionalType` does not impl
+///   `DefiniteType`).
+/// - `Option<Any>` reject (`AnyType` does not impl `DefiniteType`).
+///
+/// The compile-fail doctests below prove both rejections.
+///
+/// Nested optionality is rejected:
+///
+/// ```compile_fail
+/// # use dialog_query::Term;
+/// // Option<Option<String>> does not satisfy Typed because
+/// // Option<String> is not DefiniteType.
+/// let _: Term<Option<Option<String>>> = Term::var("x");
+/// ```
+///
+/// Optional-of-Any is rejected:
+///
+/// ```compile_fail
+/// # use dialog_query::{Term, types::Any};
+/// // Option<Any> does not satisfy Typed because Any is not
+/// // DefiniteType.
+/// let _: Term<Option<Any>> = Term::var("x");
+/// ```
+pub trait OptionalType: Typed {}
+
+impl<T: Scalar> OptionalType for Option<T> {}
+
+/// Umbrella supertrait for **definite** types — any concrete shape
+/// that is not the dynamic top ([`AnyType`]) and not set-widened
+/// ([`OptionalType`]).
+///
+/// **Membership.** Every [`Scalar`] is `DefiniteType` via a
+/// blanket impl. Future products and variants will join via their
+/// own `impl … for X` lines.
+///
+/// **Where the bound is used.** This is the bound on `T` in
+/// `Option<T>`'s [`Typed`] impl, and the canonical "any concrete
+/// value type, but not Any, not Optional" predicate. Rust trait
+/// bounds compose by intersection (`T: A + B` = both), so an
+/// umbrella supertrait is the right shape for *union* of
+/// `Scalar`/`Product`/`Variant`.
+pub trait DefiniteType: Typed {}
+
+impl<T: Scalar> DefiniteType for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Text::kind()` reports `Some(Type::Primitive({String}))`.
+    #[dialog_common::test]
+    fn text_descriptor_kind_is_primitive_string() {
+        let kind = Text.kind().expect("Text has a static kind");
+        assert_eq!(kind.as_value_type(), Some(Type::String));
+        assert!(!kind.is_optional());
+    }
+
+    /// Each named ZST descriptor reports the right primitive.
+    #[dialog_common::test]
+    fn named_descriptors_report_their_primitives() {
+        let to_singleton = |k: Option<Kind>| k.unwrap().as_value_type();
+        assert_eq!(to_singleton(Text.kind()), Some(Type::String));
+        assert_eq!(to_singleton(Boolean.kind()), Some(Type::Boolean));
+        assert_eq!(
+            to_singleton(UnsignedInteger.kind()),
+            Some(Type::UnsignedInt)
+        );
+        assert_eq!(to_singleton(SignedInteger.kind()), Some(Type::SignedInt));
+        assert_eq!(to_singleton(Float.kind()), Some(Type::Float));
+        assert_eq!(to_singleton(Bytes.kind()), Some(Type::Bytes));
+        assert_eq!(to_singleton(EntityType.kind()), Some(Type::Entity));
+        assert_eq!(to_singleton(Symbol.kind()), Some(Type::Symbol));
+        assert_eq!(to_singleton(Record.kind()), Some(Type::Record));
+    }
+
+    /// `Any(Some(Type::primitive(vt)))` reports the wrapped kind.
+    #[dialog_common::test]
+    fn any_descriptor_with_tag_reports_primitive() {
+        let descriptor = Any(Some(Kind::primitive(Type::Entity)));
+        let kind = descriptor.kind().expect("kind present");
+        assert!(!kind.is_optional());
+        assert_eq!(kind.as_value_type(), Some(Type::Entity));
+    }
+
+    /// `Any(None)` reports `None` — no static info.
+    #[dialog_common::test]
+    fn any_descriptor_without_tag_reports_none() {
+        let descriptor = Any(None);
+        assert!(descriptor.kind().is_none());
+    }
+
+    /// `Any::default()` yields `Any(None)`.
+    #[dialog_common::test]
+    fn any_default_is_none() {
+        let descriptor = Any::default();
+        assert_eq!(descriptor, Any(None));
+        assert!(descriptor.kind().is_none());
+    }
+
+    /// `From<Option<Type>> for Any` lifts a legacy storage tag.
+    #[dialog_common::test]
+    fn from_option_value_type_lifts_into_any() {
+        let a: Any = Some(Type::String).into();
+        assert_eq!(a.kind(), Some(Kind::primitive(Type::String)));
+        let b: Any = None.into();
+        assert_eq!(b, Any(None));
+    }
+
+    /// `OptionalOf<Text>::kind()` widens String with `Nothing`.
+    #[dialog_common::test]
+    fn optional_of_text_widens_with_nothing() {
+        let descriptor: OptionalOf<Text> = OptionalOf::default();
+        let kind = descriptor.kind().expect("present");
+        assert!(kind.is_optional());
+        assert!(kind.primitive_part().contains(Type::String));
+    }
+
+    /// `OptionalOf<EntityType>::kind()` widens Entity with `Nothing`.
+    #[dialog_common::test]
+    fn optional_of_entity_widens_with_nothing() {
+        let descriptor: OptionalOf<EntityType> = OptionalOf::default();
+        let kind = descriptor.kind().expect("present");
+        assert!(kind.is_optional());
+        assert!(kind.primitive_part().contains(Type::Entity));
+    }
+
+    /// `OptionalOf<Any>` passes through `None` since `Any`'s
+    /// default kind is `None`.
+    #[dialog_common::test]
+    fn optional_of_any_passes_through_none() {
+        let descriptor: OptionalOf<Any> = OptionalOf::default();
+        assert!(descriptor.kind().is_none());
+    }
+
+    /// Kind-marker family is consistent: scalar types are
+    /// `ScalarType` and `DefiniteType`; `Any` is `AnyType` but not
+    /// `DefiniteType`; `Option<T>` is `OptionalType`.
+    ///
+    /// These are compile-time checks: the test body uses
+    /// function-bound helpers that only accept types that satisfy
+    /// the corresponding marker trait.
+    #[dialog_common::test]
+    fn kind_markers_classify_consistently() {
+        fn requires_scalar<T: ScalarType>() {}
+        fn requires_definite<T: DefiniteType>() {}
+        fn requires_optional<T: OptionalType>() {}
+        fn requires_any<T: AnyType>() {}
+
+        requires_scalar::<String>();
+        requires_scalar::<u32>();
+        requires_scalar::<Entity>();
+        requires_definite::<String>();
+        requires_definite::<u32>();
+        requires_optional::<Option<String>>();
+        requires_optional::<Option<u32>>();
+        requires_any::<Any>();
+    }
+}


### PR DESCRIPTION
## Overview

Rebased successor to #344 (based on `fix/tr-metadata` instead of `fix/concept-description`). Lands two layered concerns plus the review fixes from #344.

1. **Set-widening optional concept fields.** A concept field declared `Option<T>` (or a `maybe` attribute) resolves to `Absent` at the row layer when no fact exists, instead of dropping the row. Absence is row-level, never persisted — no `Nothing` value is stored.

2. **Rule-level type inference.** Every named variable a rule mentions places a type constraint (from the slot it appears in). A per-rule unifier folds those via a meet lattice at rule-compile time, and the planner narrows premise terms before evaluation. The optional query consults the inferred kind for its `is` variable; if the rule narrowed it to non-optional, the Absent fallback is suppressed at the source.

## How it works

A rule moves through three phases: **Parse → Analyze → Plan**.

- **Analyze** (`rule::analyzer::analyze`): type inference (`TypeEnv::infer` unifies each slot's kind per variable; negations don't contribute), a required-head check (no conclusion variable may admit `Nothing`), and Coalesce contract validation.
- The unified type system is `Type = Primitive | Composite` with a meet/intersect lattice; the unifier resolves per-rule type variables. The inferred `TypeEnv` is projected onto each plan step to narrow terms before evaluation.

## Review fixes (carried in)

These address findings raised in review of #344:

- **Coalesce** reconciles a pre-bound `is` as a filter instead of binding unconditionally — previously a pre-bound `is` (to a different value or to Absent) made `?` abort the whole result stream.
- **Optional attribute queries** no longer emit a phantom `Absent` fallback on a value mismatch (a fact exists with a different value) or for an unbound entity; the fallback now requires a determined entity and a genuine "no fact" miss (in both `only.rs` and `all.rs`).
- **`ConceptDescriptor` is valid-by-construction.** The collection constructors are fallible `TryFrom` (`Error = TypeError::EmptyConcept`) and `Deserialize` rejects an empty attribute map, so a concept with no required (`with`) attribute — which would match every entity — is unconstructable. Concept types expose their descriptor via `Descriptor<ConceptDescriptor>` (cached, mirroring attributes) and an inherent `descriptor()`; the redundant derive-generated `From<Struct>/From<Query> for ConceptDescriptor` is removed. `#[derive(Concept)]` emits a compile-time assertion (over the `ConceptField::OPTIONAL` const, not syntactic `Option` detection) that a concept declares at least one required field — all-optional and no-attribute structs fail to compile, covered by `compile_fail` doctests.

## Compatibility

- `#[derive(Concept)]` now rejects all-optional / no-attribute concept structs at compile time.
- `ConceptDescriptor::from(<collection>)` is now `try_from` (returns `Result`).
