### PR TITLE
feat(dialog-repository): create repository with a caller-supplied credential

### DIFF
--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -242,6 +242,38 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn create_with_credential_names_from_did() {
+        let (operator, profile) = test_operator_with_profile().await;
+
+        // Generate the keypair first, derive the space name from the
+        // last 8 chars of its did:key, then create with that same signer.
+        let signer = Ed25519Signer::generate().await.unwrap();
+        let did = signer.did().to_string();
+        let name = did[did.len() - 8..].to_string();
+
+        let created = profile
+            .repository(name.clone())
+            .create()
+            .with_credential(signer)
+            .perform(&operator)
+            .await
+            .unwrap();
+
+        // The repository's DID is the supplied credential's DID, and the
+        // name is its last 8 chars.
+        assert_eq!(created.did().to_string(), did);
+        assert!(did.ends_with(&name));
+
+        let loaded = profile
+            .repository(name)
+            .load()
+            .perform(&operator)
+            .await
+            .unwrap();
+        assert_eq!(created.did(), loaded.did());
+    }
+
+    #[dialog_common::test]
     async fn it_opens_branch_via_repository() -> Result<()> {
         let (operator, profile) = test_operator_with_profile().await;
         let repo = test_repo(&operator, &profile).await;

--- a/rust/dialog-repository/src/repository/create.rs
+++ b/rust/dialog-repository/src/repository/create.rs
@@ -12,6 +12,67 @@ use dialog_effects::space::{self, SpaceExt};
 pub struct CreateRepository(pub Capability<space::Space>);
 
 impl CreateRepository {
+    /// Create the repository with a freshly generated keypair.
+    pub async fn perform<Env>(
+        self,
+        env: &Env,
+    ) -> Result<Repository<SignerCredential>, CreateRepositoryError>
+    where
+        Env: Provider<space::Create> + ConditionalSync,
+    {
+        self.with_credential(Ed25519Signer::generate().await?)
+            .perform(env)
+            .await
+    }
+
+    /// Create the repository with a caller-supplied credential instead
+    /// of generating a fresh keypair.
+    ///
+    /// Useful when the space name is derived from the credential's DID:
+    /// generate the signer first, derive the name, then create the
+    /// repository with that same signer.
+    ///
+    /// ```no_run
+    /// # async fn example(
+    /// #     profile: &dialog_operator::Profile,
+    /// #     operator: &impl dialog_capability::Provider<dialog_effects::space::Create>,
+    /// # ) -> Result<(), Box<dyn std::error::Error>> {
+    /// use dialog_credentials::Ed25519Signer;
+    /// use dialog_repository::RepositoryExt;
+    /// use dialog_varsig::Principal;
+    ///
+    /// let signer = Ed25519Signer::generate().await?;
+    /// let did = signer.did().to_string();
+    /// let name = &did[did.len() - 8..];
+    ///
+    /// let repo = profile
+    ///     .repository(name)
+    ///     .create()
+    ///     .with_credential(signer)
+    ///     .perform(operator)
+    ///     .await?;
+    /// # let _ = repo;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_credential(self, credential: impl Into<SignerCredential>) -> CreateRepositoryWith {
+        CreateRepositoryWith {
+            space: self.0,
+            credential: credential.into(),
+        }
+    }
+}
+
+/// A [`CreateRepository`] command bound to a caller-supplied credential.
+///
+/// Because the credential is already provided, `perform` cannot fail to
+/// generate a keypair — the only failure is backend storage.
+pub struct CreateRepositoryWith {
+    space: Capability<space::Space>,
+    credential: SignerCredential,
+}
+
+impl CreateRepositoryWith {
     /// Execute against an operator.
     pub async fn perform<Env>(
         self,
@@ -20,11 +81,10 @@ impl CreateRepository {
     where
         Env: Provider<space::Create> + ConditionalSync,
     {
-        let signer = SignerCredential::from(Ed25519Signer::generate().await?);
-        self.0
-            .create(Credential::Signer(signer.clone()))
+        self.space
+            .create(Credential::Signer(self.credential.clone()))
             .perform(env)
             .await?;
-        Ok(Repository::from(signer))
+        Ok(Repository::from(self.credential))
     }
 }


### PR DESCRIPTION
## Motivation

Naming a new repository after its own `did:key` (e.g. the last 8 chars) is a chicken-and-egg problem: the name must exist before `profile.repository(name)`, but the DID only exists once a keypair is generated — and `CreateRepository::perform` generated that keypair internally, *after* the name was already locked in.

## Change

The seam was already present at the effect layer: `space::Create` carries a `Credential` and stores whatever it's handed; only the `CreateRepository` convenience wrapper minted the signer itself. This exposes that seam instead of fighting it.

- `CreateRepository::with_credential(impl Into<SignerCredential>)` accepts a pre-generated signer and returns a `CreateRepositoryWith` builder.
- `perform` now delegates to `with_credential(Ed25519Signer::generate().await?)`, so the auto-generate default is unchanged and existing callers are untouched.

Call site:

```rust
let signer = Ed25519Signer::generate().await?;
let did = signer.did().to_string();
let name = &did[did.len() - 8..];

let repo = profile
    .repository(name)
    .create()
    .with_credential(signer)
    .perform(&operator)
    .await?;
```

## Design notes

- **Naming policy stays out of the library.** The caller derives the name; the "last 8 chars" rule lives in their code, not in an API method.
- **`impl Into<SignerCredential>`** accepts an `Ed25519Signer` today or other signer types later.
- **A distinct `CreateRepositoryWith` builder** rather than an `Option<credential>` field: once a credential is supplied, keypair generation is statically impossible, so that path's only failure mode is storage.

Adds a round-trip test that generates a signer, names the space from its DID, creates, and loads it back. Full suite green (1392 tests), clippy clean.