### PR TITLE
Formula type schemes: generic formulas over bounded type variables

### DIFF
--- a/notes/formula-schemes.md
+++ b/notes/formula-schemes.md
@@ -117,3 +117,28 @@ Compile time: empty meets (known types misaligned), literal outside a cell's bou
 no type errors — rows that cannot instantiate the scheme are non-matches, and inference must be
 inspectable (the planned diagnostics surface reports what narrowed each variable and what was
 filtered where).
+
+## Addendum: the TEXTUAL scheme (prefix predicates)
+
+User direction after the numeric scheme landed: `starts-with` and its
+relatives are **one predicate over a TEXTUAL bound**
+(`String | Symbol | Entity`, now `Primitive::TEXTUAL`) rather than
+per-type variants. Three properties fall out:
+
+- **The prefix literal refines the scheme.** Each textual type has a
+  lexical grammar (entity URIs, `domain/name` symbols), so a literal
+  prefix that cannot begin a value of some member type drops that
+  member from the subject's inferred kind — a space excludes
+  entities and symbols, narrowing the subject to `String`. If every
+  member drops, the predicate is statically never-matching: a
+  *logical no-match* (the premise filters everything), surfaced as a
+  vacuous-premise diagnostic rather than an error.
+- **Filter semantics per row**: instantiate to the value's type,
+  compare the lexical prefix; non-textual values are non-matches via
+  the bound, like every other scheme mismatch.
+- **Pushdown-ready**: the refined kind plus the prefix is exactly
+  the per-stratum index range bound the scan pushdown consumes.
+
+Numeric range predicates (`<`, `<=`, `>`, `>=`) ride the NUMERIC
+scheme identically; their refinement payload is an interval instead
+of a prefix.

--- a/notes/formula-schemes.md
+++ b/notes/formula-schemes.md
@@ -1,0 +1,119 @@
+# Formula type schemes
+
+> Design note for generic formulas: `math/sum` as "forall `N` ⊆ NUMERIC: `(of: N, with: N) → is: N`"
+> rather than a fixed `u32` signature. Records the declaration surface, the runtime model, the
+> inference wiring, the numeric-promotion decision, and the alternatives considered. Companion to
+> [`guide.md`](./guide.md) (the "Inference in an open world" section is the user-facing account) and
+> the planned range-refinement predicates (which share the lattice-typed cell prerequisite).
+
+## Goal
+
+Built-in and user-defined formulas should be polymorphic where their semantics are: addition works on
+any numeric type, comparison on any comparable one, concatenation on string-likes. Today every formula
+fixes concrete Rust types (`Sum { of: u32, with: u32, is: u32 }`), so `math/sum` over `i64` facts
+matches nothing. The type system should carry the polymorphism: a scheme with a *bounded type
+variable*, instantiated fresh at every use site, so that inference flows bidirectionally — a `u64`
+input narrows the output to `u64`, a `Float` output requirement narrows the inputs, and a `String`
+anywhere is a compile-time conflict.
+
+## Declaration: Rust generics
+
+```rust
+#[derive(Formula)]
+pub struct Sum<N: Number> {
+    of: N,
+    with: N,
+    #[output(cost = 5)]
+    is: N,
+}
+
+impl<N: Number> Sum<N> {
+    fn compute(input: Input<Self>) -> Vec<Self> { ... }
+}
+```
+
+The type parameter *is* the scheme variable: sharing is expressed by using `N` in several fields,
+scoping and checking come from rustc, and multi-parameter schemes (`Convert<A: Number, B: Number>`)
+need no extra machinery. The bound trait carries the lattice bound as an associated constant
+(`<N as SchemeBound>::BOUND = Primitive::NUMERIC`), so the derive emits trait-qualified code and never
+matches type names syntactically — a bound without a scheme fails to compile rather than silently
+degrading.
+
+## Runtime: one visitor over a closed type set
+
+A registered formula must serve every instantiation at runtime, and Rust cannot call a generic
+function with a runtime-chosen type without enumerating somewhere. The enumeration lives in exactly
+one place: the value lattice's numeric set is *closed* (`UnsignedInt`, `SignedInt`, `Float`), so
+`dialog-query` provides one hand-written visitor (`with_numeric(data_type, visitor)`) that routes to
+the matching monomorphization; the derive emits a visitor impl per generic formula. Per row, the
+instantiation type is determined from the bound input values, the matching `compute::<N>` runs, and
+the result is a `Value` of that same type. Other bounds (COMPARABLE, STRING_LIKE) get their own
+visitors when a formula needs them; each is a closed set.
+
+## Inference: instantiate per use
+
+When `TypeEnv::infer` walks a `Sum` premise, the scheme allocates one fresh unifier variable with the
+NUMERIC constraint and contributes it as the slot type of `of`, `with`, and `is` together — the
+per-use instantiation of a rank-1 scheme. The unifier's per-variable `Primitive` constraint *is* the
+bounded type variable, and `unify` returning the principal meet (landed ahead of this work) is what
+lets composed unifications surface their results. Consequences:
+
+- `sum(?age, 1, ?next)` with `?age` known `u64` infers `?next : u64`.
+- `?next` demanded as `Float` downstream infers `?age : Float`.
+- `?age` demanded as `String` anywhere is an empty meet: compile error.
+- Nothing known: all three stay bounded NUMERIC, and the bound is stamped onto the feeding scans
+  (filtering non-numeric facts at the data boundary, per the narrow-on-use semantics).
+
+## Prerequisite: cells carry lattice types
+
+`Cell::content_type` is today a single concrete `artifact::Type`; a scheme-bounded or
+range-refined slot cannot be expressed. Cells graduate to the lattice `type_system::Type` (and, for
+scheme slots, to the unifier-facing variable form). This same change is the prerequisite for the
+planned range-refinement predicates, where a cell's type is "String with prefix `p`".
+
+## No implicit numeric promotion
+
+A row whose inputs cannot share the scheme variable — `sum(2u64, 3.5f64)` — is a **non-match**, not a
+promotion. Filtered, like every other type mismatch at a scalar slot. The reasons, in order of force:
+
+1. **Promotion cannot be lossless here.** Datomic promotes safely because the JVM supplies
+   BigInt/BigDecimal to widen into. Dialog's value lattice tops out at `u64`/`i64`/`f64`:
+   `u64 → f64` silently loses precision above 2^53, and `u64`/`i64` have no common type covering both
+   ranges. Promotion would not remove the runtime surprise, it would relocate it from "row excluded"
+   to "row matched with a quietly wrong value". If promotion is ever genuinely wanted, the honest
+   prerequisite is widening the value lattice (BigInt/Decimal) — a storage-format decision to take
+   deliberately, not to back into.
+2. **Data-dependent output types poison inference and joins.** Under promotion the output's type
+   depends on sibling inputs per row, so analysis can only ever say NUMERIC — weakening exactly the
+   narrowing that index-range pushdown wants — and `2u64`/`2.0f64` are distinct values with distinct
+   index keys, so promoted outputs join inconsistently downstream.
+3. **Consistency.** Typed scan slots filter heterogeneous facts; a formula slot that coerced instead
+   would make two halves of one type system disagree.
+
+The SQLite comparison that calibrated this: SQLite coerces everything (`'abc' + 1 = 1`) and never
+errors; PostgreSQL errors at runtime; dialog filters. Filtering keeps SQLite's
+"queries never die on data" ergonomics without fabricating values.
+
+**The ergonomic release valve is literals, not data.** `sum(?age, 1, ?next)` must not die because `1`
+defaulted to the wrong width: numeric literals are *polymorphic constants* carrying the NUMERIC bound,
+instantiated per row to the data's type with a checked-lossless conversion (`1` fits everywhere;
+`1.5` can only instantiate to `Float`; `-1` only to signed). Data-derived values stay strict, and
+explicit conversion formulas (`number/to-float`, …) are the opt-in for crossing type strata — exactly
+parallel to `Coalesce` being the explicit opt-in for absence.
+
+## Alternatives considered
+
+- **Scheme labels as field attributes** (`#[scheme(a)] of: Number`): rejected. Invents an annotation
+  language rustc cannot check, handles multi-parameter schemes awkwardly, and the `Number` newtype
+  hides which cells share a variable.
+- **Hand-written `Cells` for generic formulas only**: rejected; gives up the derive ergonomics that
+  make formulas pleasant, precisely for the formulas users touch most.
+- **Implicit promotion**: rejected above; recorded with its prerequisite (a wider value lattice)
+  should it ever be revisited.
+
+## Where errors surface (summary)
+
+Compile time: empty meets (known types misaligned), literal outside a cell's bound. Evaluation:
+no type errors — rows that cannot instantiate the scheme are non-matches, and inference must be
+inspectable (the planned diagnostics surface reports what narrowed each variable and what was
+filtered where).

--- a/notes/guide.md
+++ b/notes/guide.md
@@ -284,6 +284,86 @@ narrowing should flow *into* a negated subquery), are design-note
 territory rather than user-facing behavior: see
 `notes/polarity-and-negation.md`.
 
+## Where errors surface
+
+The engine has exactly two error surfaces, and only one of them is
+reachable from a rule that compiled.
+
+**Compile time** (rule construction, whether authored locally or
+hydrated from the wire) rejects every misalignment between *known*
+types: a variable demanded as `String` by one slot and as a number by
+another (an empty meet), a required head fed by an optional source, a
+negated optional lookup, a malformed `Coalesce`, a literal that
+cannot inhabit a formula's cell. If the knowledge exists to catch a
+mistake, it is caught here.
+
+**Evaluation time has no type errors — only membership.** A row
+either inhabits the types a premise demands or it is a non-match: a
+`String` fact under a numeric slot is filtered the same way a wrong
+*value* under a pinned constant is, an `Absent` in a scalar slot is
+filtered, and a row whose values cannot share a formula's type
+variable is filtered. Nothing throws and nothing is coerced. The few
+runtime errors that remain in the engine are *contract* violations
+(an optional lookup scheduled with an unbound entity, a bind outside
+a variable's kind): they indicate an engine or construction-path bug,
+are unreachable from any rule that compiled, and exist as defense in
+depth.
+
+For comparison, the three corners of this design space: PostgreSQL
+*errors* at runtime (a bad cast kills the query); SQLite *coerces*
+(`'abc' + 1 = 1`, no error, occasionally nonsense — its `STRICT`
+tables exist because of how that felt in practice); dialog *filters*.
+Filtering keeps SQLite's ergonomic guarantee — a query never dies
+mid-stream on data — without ever fabricating a value.
+
+## Inference in an open world
+
+No annotation is ever required. Inference reconstructs everything
+reconstructable — slot kinds, concept schemas, formula schemes — and
+an untyped wire concept compiles fine; its fields are simply wide.
+The guarantee a compiled rule carries:
+
+> A rule that compiles never produces a runtime type error, and every
+> row it yields inhabits its inferred types.
+
+This is the closed-world (Elm-style) soundness property restated for
+an open world. The data layer is schema-on-query: an attribute may
+hold values of several types across facts, and wire concepts need not
+declare field types, so no amount of inference can make unknown data
+known at compile time. Where inference can only establish a *bound*
+(say NUMERIC, or "any present value"), the bound's runtime meaning is
+the filter semantics above: types narrow on use, and rows outside the
+narrowed type are non-matches. One worked example, with `person/age`
+undeclared on the wire:
+
+```rust
+// person/age(?p, ?age)
+// math/sum { of: ?age, with: 1, is: ?next }
+```
+
+Analysis puts `?age` and `?next` in one type variable bounded NUMERIC
+(the formula's scheme) and stamps that bound onto the age scan. Then,
+per row: an entity with `age = 30` (unsigned) instantiates the
+variable to unsigned, the literal `1` follows losslessly, and
+`?next = 31`; an entity with `age = 2.5` instantiates to float and
+yields `3.5`; an entity whose `age` fact is the *string* `"old"` is
+filtered at the scan by the stamped bound, before the formula ever
+runs. And if some other premise in the same rule demanded `?age` as a
+`String`, the rule would not compile: there the types were known, and
+they misalign.
+
+Two consequences worth naming. There is no implicit numeric
+promotion: a row mixing unsigned and float inputs in one scheme
+variable is a non-match, not a lossy widening (dialog's value lattice
+has no arbitrary-precision type to promote into, so promotion would
+trade "row excluded" for "row matched with a quietly wrong value").
+Conversions are explicit formulas, parallel to `Coalesce` being the
+explicit form of defaulting. And because exclusion is silent by
+design — the excluded fact may be someone else's perfectly valid
+data — the inference must be *inspectable*: the planned diagnostics
+surface reports what each variable narrowed to and which premise
+narrowed it.
+
 ## Why it is layered this way
 
 Keeping the associative layer scalar and pushing all optionality into
@@ -314,6 +394,6 @@ entity (a finite, checkable range), only consumes it through explicit
 operators (`Coalesce`), and treats it as matching nothing everywhere
 else.
 
-For the design history see `notes/scalar-associative-layer.md`,
-`notes/optional-fields.md`, and `notes/query-engine-design.md` at the
-repository root.
+For the design history see [`scalar-associative-layer.md`](./scalar-associative-layer.md),
+[`optional-fields.md`](./optional-fields.md), and
+[`query-engine-design.md`](./query-engine-design.md).

--- a/notes/optional-fields.md
+++ b/notes/optional-fields.md
@@ -427,4 +427,4 @@ contract is now structural rather than kind-driven. The deltas:
   a contract check. `RequiredHeadFromOptional` also fires across
   concept boundaries now that the boundary declares its widening.
 
-User-facing semantics: `rust/dialog-query/guide.md`.
+User-facing semantics: `notes/guide.md`.

--- a/notes/polarity-and-negation.md
+++ b/notes/polarity-and-negation.md
@@ -3,7 +3,7 @@
 > Design note. Records the polarity discipline adopted for rule-level
 > type narrowing, the reasoning behind each direction, and the part
 > that remains an open judgment call. User-facing behavior is
-> summarized in `rust/dialog-query/guide.md`; this note is the
+> summarized in `notes/guide.md`; this note is the
 > rationale and the uncertainty.
 
 Rule-level inference computes, per variable, the meet of the kinds of

--- a/notes/query-engine-design.md
+++ b/notes/query-engine-design.md
@@ -5,7 +5,7 @@
 > sequencing record ([`operator-ir.md`](./operator-ir.md)), the planner design
 > ([`planning-adornment-and-cost.md`](./planning-adornment-and-cost.md)), and the forward-looking
 > [`incremental-subscriptions.md`](./incremental-subscriptions.md). User-facing optionality semantics
-> are documented in [`rust/dialog-query/guide.md`](../rust/dialog-query/guide.md).
+> are documented in [`guide.md`](./guide.md).
 
 ## The pipeline
 

--- a/notes/scalar-associative-layer.md
+++ b/notes/scalar-associative-layer.md
@@ -127,4 +127,4 @@ is settled:
 - The remaining row-multiplicity guards (`saw_fact`, `entity_known`)
   were deleted with `Resolution`; their semantics live in
   `OptionalAttributeQuery::evaluate`'s four-case contract. User-facing semantics
-  are documented in `rust/dialog-query/guide.md`.
+  are documented in `notes/guide.md`.

--- a/rust/dialog-macros/src/query/formula.rs
+++ b/rust/dialog-macros/src/query/formula.rs
@@ -80,6 +80,25 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let struct_name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    // Type-parameter idents: a field whose type is exactly one of
+    // these is a *scheme* field — its cell carries the parameter's
+    // SchemeBound and a scheme label, and cells sharing a parameter
+    // share one type variable at inference time.
+    let scheme_params: Vec<syn::Ident> = generics.type_params().map(|p| p.ident.clone()).collect();
+    let scheme_param_of = |ty: &syn::Type| -> Option<syn::Ident> {
+        if let syn::Type::Path(tp) = ty
+            && tp.qself.is_none()
+            && tp.path.segments.len() == 1
+        {
+            let ident = &tp.path.segments[0].ident;
+            if tp.path.segments[0].arguments.is_none() && scheme_params.contains(ident) {
+                return Some(ident.clone());
+            }
+        }
+        None
+    };
 
     // Extract fields from the struct
     let fields = match &input.data {
@@ -195,13 +214,32 @@ pub fn derive(input: TokenStream) -> TokenStream {
             let name_str = name.to_string();
             let name_lit = syn::LitStr::new(&name_str, proc_macro2::Span::call_site());
             let doc_lit = syn::LitStr::new(doc, proc_macro2::Span::call_site());
-            let data_type = type_to_value_data_type(ty);
+
+            // A scheme field's cell carries the bound of its type
+            // parameter and the parameter name as the scheme label;
+            // a concrete field's cell carries its singleton kind.
+            let (data_type, scheme) = match scheme_param_of(ty) {
+                Some(param) => {
+                    let label =
+                        syn::LitStr::new(&param.to_string(), proc_macro2::Span::call_site());
+                    (
+                        quote! {
+                            Some(dialog_query::type_system::Type::primitive_set(
+                                <#param as dialog_query::SchemeBound>::BOUND,
+                            ))
+                        },
+                        Some(quote! { .scheme(#label) }),
+                    )
+                }
+                None => (type_to_value_data_type(ty), None),
+            };
 
             if *is_output {
                 quote! {
                     builder
                         .cell(#name_lit, #data_type)
                         .the(#doc_lit)
+                        #scheme
                         .output(#cost);
                 }
             } else {
@@ -209,6 +247,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                     builder
                         .cell(#name_lit, #data_type)
                         .the(#doc_lit)
+                        #scheme
                         .required();
                 }
             }
@@ -277,6 +316,18 @@ pub fn derive(input: TokenStream) -> TokenStream {
         proc_macro2::Span::call_site(),
     );
 
+    // Impls that convert through `FormulaQuery` only exist for the
+    // instantiation(s) registered in `define_formulas!` (the
+    // canonical dynamic instantiation for generic formulas), so they
+    // are bounded on that conversion existing.
+    let mut fq_where: syn::WhereClause = generics
+        .where_clause
+        .clone()
+        .unwrap_or_else(|| syn::parse_quote!(where));
+    fq_where.predicates.push(syn::parse_quote!(
+        dialog_query::FormulaQuery: ::std::convert::From<#query_name #ty_generics>
+    ));
+
     let expanded = quote! {
             /// Input structure for #struct_name formula
             ///
@@ -284,7 +335,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
             /// to compute the formula.
             #[doc = #input_struct_doc]
             #[derive(Debug, Clone)]
-            pub struct #input_name {
+            pub struct #input_name #generics #where_clause {
                 #(#input_struct_fields),*
             }
 
@@ -293,22 +344,22 @@ pub fn derive(input: TokenStream) -> TokenStream {
             /// Contains all fields (both input and output) as Term<T> for pattern matching.
             #[doc = #query_struct_doc]
             #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-            pub struct #query_name {
+            pub struct #query_name #generics #where_clause {
                 #(#query_struct_fields),*
             }
 
             /// Static storage for formula cells
             static #cells_name: ::std::sync::OnceLock<dialog_query::Cells> = ::std::sync::OnceLock::new();
 
-            impl dialog_query::Predicate for #struct_name {
-                type Conclusion = #struct_name;
-                type Application = #query_name;
+            impl #impl_generics dialog_query::Predicate for #struct_name #ty_generics #fq_where {
+                type Conclusion = #struct_name #ty_generics;
+                type Application = #query_name #ty_generics;
                 type Descriptor = dialog_query::Entity;
             }
 
-            impl dialog_query::Application for #query_name
+            impl #impl_generics dialog_query::Application for #query_name #ty_generics #fq_where
     {
-                type Conclusion = #struct_name;
+                type Conclusion = #struct_name #ty_generics;
 
                 fn evaluate<'__a, __Env, __M: dialog_query::Selection + '__a>(
                     self,
@@ -331,31 +382,31 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl ::std::convert::From<#query_name> for dialog_query::Parameters {
-                fn from(terms: #query_name) -> Self {
+            impl #impl_generics ::std::convert::From<#query_name #ty_generics> for dialog_query::Parameters #where_clause {
+                fn from(terms: #query_name #ty_generics) -> Self {
                     let mut parameters = Self::new();
                     #(parameters.insert(#all_field_name_lits.into(), dialog_query::Term::<dialog_query::types::Any>::from(terms.#all_field_names));)*
                     parameters
                 }
             }
 
-            impl From<#query_name> for dialog_query::Premise
+            impl #impl_generics From<#query_name #ty_generics> for dialog_query::Premise #fq_where
     {
-                fn from(source: #query_name) -> Self {
+                fn from(source: #query_name #ty_generics) -> Self {
                     let formula: dialog_query::FormulaQuery = source.into();
                     dialog_query::Premise::Assert(dialog_query::Proposition::from(formula))
                 }
             }
 
-            impl From<#query_name> for dialog_query::Proposition
+            impl #impl_generics From<#query_name #ty_generics> for dialog_query::Proposition #fq_where
     {
-                fn from(source: #query_name) -> Self {
+                fn from(source: #query_name #ty_generics) -> Self {
                     let formula: dialog_query::FormulaQuery = source.into();
                     dialog_query::Proposition::from(formula)
                 }
             }
 
-            impl ::std::ops::Not for #query_name
+            impl #impl_generics ::std::ops::Not for #query_name #ty_generics #fq_where
     {
                 type Output = dialog_query::Premise;
 
@@ -365,7 +416,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl ::std::convert::TryFrom<&mut dialog_query::Bindings> for #input_name {
+            impl #impl_generics ::std::convert::TryFrom<&mut dialog_query::Bindings> for #input_name #ty_generics #where_clause {
                 type Error = dialog_query::EvaluationError;
 
                 fn try_from(bindings: &mut dialog_query::Bindings) -> ::std::result::Result<Self, Self::Error> {
@@ -375,8 +426,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl dialog_query::Formula for #struct_name {
-                type Input = #input_name;
+            impl #impl_generics dialog_query::Formula for #struct_name #ty_generics #fq_where {
+                type Input = #input_name #ty_generics;
 
                 fn cells() -> &'static dialog_query::Cells {
                     #cells_name.get_or_init(|| {
@@ -390,8 +441,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
                     #total_cost
                 }
 
-                fn apply(terms: dialog_query::Parameters) -> ::std::result::Result<#query_name, dialog_query::error::TypeError> {
-                    let cells = <#struct_name as dialog_query::Formula>::cells();
+                fn apply(terms: dialog_query::Parameters) -> ::std::result::Result<#query_name #ty_generics, dialog_query::error::TypeError> {
+                    let cells = <#struct_name #ty_generics as dialog_query::Formula>::cells();
                     let conformed = cells.conform(terms)?;
                     ::std::result::Result::Ok(#query_name {
                         #(#all_field_names: conformed

--- a/rust/dialog-macros/src/query/formula.rs
+++ b/rust/dialog-macros/src/query/formula.rs
@@ -224,7 +224,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                         syn::LitStr::new(&param.to_string(), proc_macro2::Span::call_site());
                     (
                         quote! {
-                            Some(dialog_query::type_system::Type::primitive_set(
+                            Some(dialog_query::type_system::Type::from(
                                 <#param as dialog_query::SchemeBound>::BOUND,
                             ))
                         },

--- a/rust/dialog-macros/src/query/helpers.rs
+++ b/rust/dialog-macros/src/query/helpers.rs
@@ -16,6 +16,7 @@ use syn::{Attribute, Expr, Lit, Meta, Type};
 pub fn type_to_value_data_type(ty: &Type) -> TokenStream {
     quote! {
         <<#ty as dialog_query::Typed>::Descriptor as dialog_query::TypeDescriptor>::TYPE
+            .map(dialog_query::type_system::Type::primitive)
     }
 }
 

--- a/rust/dialog-macros/src/query/helpers.rs
+++ b/rust/dialog-macros/src/query/helpers.rs
@@ -16,7 +16,7 @@ use syn::{Attribute, Expr, Lit, Meta, Type};
 pub fn type_to_value_data_type(ty: &Type) -> TokenStream {
     quote! {
         <<#ty as dialog_query::Typed>::Descriptor as dialog_query::TypeDescriptor>::TYPE
-            .map(dialog_query::type_system::Type::primitive)
+            .map(dialog_query::type_system::Type::from)
     }
 }
 

--- a/rust/dialog-query/README.md
+++ b/rust/dialog-query/README.md
@@ -2,7 +2,7 @@
 
 Datalog-inspired query engine for Dialog. Operates over the associative model's claim store, providing typed pattern matching, deductive rules, and built-in formulas.
 
-For a worked explanation of optional fields, `Absent`, negation, and the rationale behind the scalar/semantic layering, see [guide.md](./guide.md).
+For a worked explanation of optional fields, `Absent`, negation, and the rationale behind the scalar/semantic layering, see [guide.md](../../notes/guide.md).
 
 ## Information Model
 

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -11,6 +11,7 @@ pub use crate::proposition::Proposition;
 pub use crate::rule::Rule;
 pub use crate::rule::deductive::DeductiveRule;
 use crate::term::Term;
+use crate::type_system::Type as Kind;
 use crate::types::Any;
 pub use thiserror::Error;
 
@@ -25,6 +26,17 @@ pub enum TypeError {
         binding: String,
         /// Expected type.
         expected: Type,
+        /// Actual term provided.
+        actual: Box<Term<Any>>,
+    },
+
+    /// A binding's term cannot inhabit the slot's kind (lattice type).
+    #[error("Expected binding \"{binding}\" whose kind meets {expected}, instead got {actual}")]
+    KindMismatch {
+        /// Name of the binding.
+        binding: String,
+        /// The slot's kind.
+        expected: Kind,
         /// Actual term provided.
         actual: Box<Term<Any>>,
     },
@@ -270,6 +282,14 @@ pub enum FieldTypeError {
         /// Actual term provided.
         actual: Box<Term<Any>>,
     },
+    /// The term cannot inhabit the slot's kind (lattice type).
+    #[error("Expected a term whose kind meets {expected}, instead got {actual}")]
+    KindMismatch {
+        /// The slot's kind.
+        expected: Kind,
+        /// Actual term provided.
+        actual: Box<Term<Any>>,
+    },
     /// A required term is missing.
     #[error("Required term is missing")]
     OmittedRequirement,
@@ -283,6 +303,11 @@ impl FieldTypeError {
     pub fn at(self, binding: String) -> TypeError {
         match self {
             FieldTypeError::TypeMismatch { expected, actual } => TypeError::TypeMismatch {
+                binding,
+                expected,
+                actual,
+            },
+            FieldTypeError::KindMismatch { expected, actual } => TypeError::KindMismatch {
                 binding,
                 expected,
                 actual,

--- a/rust/dialog-query/src/formula.rs
+++ b/rust/dialog-query/src/formula.rs
@@ -9,14 +9,18 @@
 pub mod bindings;
 /// Formula cell types for parameter slot definitions.
 pub mod cell;
+
 /// Input type alias for formula input cells.
 pub mod input;
+/// Numeric scheme machinery: `Number`, `Numeric`, `SchemeBound`.
+pub mod number;
 /// Formula query for computed values.
 pub mod query;
 
 pub use bindings::*;
 pub use cell::*;
 pub use input::*;
+pub use number::*;
 pub use query::*;
 
 /// Type conversion formulas (to_string, parse_number)

--- a/rust/dialog-query/src/formula/cell.rs
+++ b/rust/dialog-query/src/formula/cell.rs
@@ -33,6 +33,12 @@ pub struct Cell {
     content_type: Option<Kind>,
     /// Requirement for this cell
     requirement: Requirement,
+    /// Scheme label: cells sharing a label share one type variable,
+    /// instantiated fresh per use of the formula. `None` for
+    /// concrete (non-generic) cells. The label is the formula's
+    /// type-parameter name (e.g. `"N"`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    scheme: Option<String>,
 }
 
 impl Cell {
@@ -43,6 +49,7 @@ impl Cell {
             description: String::new(),
             content_type,
             requirement: Requirement::Optional,
+            scheme: None,
         }
     }
 
@@ -56,6 +63,19 @@ impl Cell {
     pub fn the(&mut self, description: &'static str) -> &mut Self {
         self.description = description.to_string();
         self
+    }
+
+    /// Labels this cell as a scheme slot: cells of one formula
+    /// sharing a label share one bounded type variable. The cell's
+    /// `content_type` carries the bound.
+    pub fn scheme(&mut self, label: &'static str) -> &mut Self {
+        self.scheme = Some(label.to_string());
+        self
+    }
+
+    /// Returns the scheme label of this cell, if it is a scheme slot.
+    pub fn scheme_label(&self) -> Option<&str> {
+        self.scheme.as_deref()
     }
 
     /// Marks this cell as required, returning `self` for chaining.

--- a/rust/dialog-query/src/formula/cell.rs
+++ b/rust/dialog-query/src/formula/cell.rs
@@ -286,18 +286,18 @@ impl From<&Cells> for Schema {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Requirement, Type};
+    use crate::Type;
 
     #[dialog_common::test]
     fn it_evaluates_cells() -> anyhow::Result<()> {
         let cells = Cells::define(|builder| {
             builder
-                .cell("name", Some(Kind::primitive(Type::String)))
+                .cell("name", Some(Kind::from(Type::String)))
                 .the("name field")
                 .required();
 
             builder
-                .cell("age", Some(Kind::primitive(Type::UnsignedInt)))
+                .cell("age", Some(Kind::from(Type::UnsignedInt)))
                 .the("age field")
                 .output(15);
         });
@@ -306,7 +306,7 @@ mod tests {
         assert_eq!(cells.get("name").unwrap().name(), "name");
         assert_eq!(
             *cells.get("name").unwrap().content_type(),
-            Some(Kind::primitive(Type::String))
+            Some(Kind::from(Type::String))
         );
         assert_eq!(cells.get("name").unwrap().description(), "name field");
         assert_eq!(
@@ -317,7 +317,7 @@ mod tests {
         assert_eq!(cells.get("age").unwrap().name(), "age");
         assert_eq!(
             *cells.get("age").unwrap().content_type(),
-            Some(Kind::primitive(Type::UnsignedInt))
+            Some(Kind::from(Type::UnsignedInt))
         );
         assert_eq!(cells.get("age").unwrap().description(), "age field");
         assert_eq!(
@@ -336,7 +336,7 @@ mod tests {
     fn schema_from_cells_lifts_content_types() {
         let cells = Cells::define(|builder| {
             builder
-                .cell("name", Some(Kind::primitive(Type::String)))
+                .cell("name", Some(Kind::from(Type::String)))
                 .required();
             builder.cell("untyped", None).required();
         });

--- a/rust/dialog-query/src/formula/cell.rs
+++ b/rust/dialog-query/src/formula/cell.rs
@@ -5,7 +5,7 @@ use crate::error::{FieldTypeError, TypeError};
 use crate::term::Term;
 use crate::type_system::Type as Kind;
 use crate::types::Any;
-use crate::{Cardinality, Field, Parameters, Requirement, Schema, Type};
+use crate::{Cardinality, Field, Parameters, Requirement, Schema};
 use serde::{Deserialize, Serialize};
 
 /// A single named parameter slot in a formula's schema.
@@ -26,16 +26,18 @@ pub struct Cell {
     name: String,
     /// Description of this cell
     description: String,
-    /// Data type of this cell
+    /// Kind (lattice type) of this cell. A concrete formula cell
+    /// carries a singleton; a scheme-bounded cell carries the set
+    /// the scheme variable ranges over (e.g. NUMERIC).
     #[serde(rename = "type")]
-    content_type: Option<Type>,
+    content_type: Option<Kind>,
     /// Requirement for this cell
     requirement: Requirement,
 }
 
 impl Cell {
     /// Creates a new optional cell with the given name and optional content type.
-    pub fn new(name: &'static str, content_type: Option<Type>) -> Self {
+    pub fn new(name: &'static str, content_type: Option<Kind>) -> Self {
         Cell {
             name: name.to_string(),
             description: String::new(),
@@ -45,7 +47,7 @@ impl Cell {
     }
 
     /// Sets the content type for this cell, returning `self` for chaining.
-    pub fn typed(&mut self, content_type: Type) -> &mut Self {
+    pub fn typed(&mut self, content_type: Kind) -> &mut Self {
         self.content_type = Some(content_type);
         self
     }
@@ -84,7 +86,7 @@ impl Cell {
     }
 
     /// Returns the content type of this cell, if specified.
-    pub fn content_type(&self) -> &Option<Type> {
+    pub fn content_type(&self) -> &Option<Kind> {
         &self.content_type
     }
 
@@ -93,23 +95,19 @@ impl Cell {
         &self.requirement
     }
 
-    /// Type checks that the provided parameter matches this cell's content type.
+    /// Type checks that the provided parameter is compatible with
+    /// this cell's kind: the meet of the two must be inhabited. A
+    /// kindless cell accepts anything; a kindless term is accepted
+    /// by any cell (inference resolves it at rule-compile time).
     pub fn check(&self, param: &Term<Any>) -> Result<(), FieldTypeError> {
-        // First we type check the input to ensure it matches cell's content type
-        match (self.content_type(), param.content_type()) {
-            // if expected is any (has no type) it checks
-            (None, _) => Ok(()),
-            // if cell is of some type and we're given term of unknown
-            // type that's also fine.
-            (_, None) => Ok(()),
-            // if expected isn't any (has no type) it must be equal
-            // to actual or it's a type mismatch.
-            (Some(expected), actual) => {
-                if Some(*expected) == actual {
+        match (self.content_type(), param.kind()) {
+            (None, _) | (_, None) => Ok(()),
+            (Some(expected), Some(actual)) => {
+                if expected.intersect(&actual).is_some() {
                     Ok(())
                 } else {
-                    Err(FieldTypeError::TypeMismatch {
-                        expected: *expected,
+                    Err(FieldTypeError::KindMismatch {
+                        expected: expected.clone(),
                         actual: Box::new(param.clone()),
                     })
                 }
@@ -146,7 +144,7 @@ impl Display for Cell {
             "?"
         };
 
-        if let Some(content_type) = self.content_type {
+        if let Some(content_type) = &self.content_type {
             write!(f, "{}{}: {}", prefix, self.name, content_type)
         } else {
             write!(f, "{}{}: Value", prefix, self.name)
@@ -161,7 +159,7 @@ pub struct CellsBuilder {
 
 impl CellsBuilder {
     /// Adds a new cell with the given name and optional type, returning it for further configuration.
-    pub fn cell(&mut self, name: &'static str, content_type: Option<Type>) -> &mut Cell {
+    pub fn cell(&mut self, name: &'static str, content_type: Option<Kind>) -> &mut Cell {
         let cell = Cell::new(name, content_type);
         self.cells.insert(name.to_string(), cell);
         self.cells.get_mut(name).unwrap()
@@ -255,7 +253,7 @@ impl From<&Cells> for Schema {
                 name.into(),
                 Field {
                     description: cell.description.clone(),
-                    content_type: cell.content_type.map(Kind::from),
+                    content_type: cell.content_type.clone(),
                     requirement: cell.requirement.clone(),
                     cardinality: Cardinality::One,
                 },
@@ -274,12 +272,12 @@ mod tests {
     fn it_evaluates_cells() -> anyhow::Result<()> {
         let cells = Cells::define(|builder| {
             builder
-                .cell("name", Some(Type::String))
+                .cell("name", Some(Kind::primitive(Type::String)))
                 .the("name field")
                 .required();
 
             builder
-                .cell("age", Some(Type::UnsignedInt))
+                .cell("age", Some(Kind::primitive(Type::UnsignedInt)))
                 .the("age field")
                 .output(15);
         });
@@ -288,7 +286,7 @@ mod tests {
         assert_eq!(cells.get("name").unwrap().name(), "name");
         assert_eq!(
             *cells.get("name").unwrap().content_type(),
-            Some(Type::String)
+            Some(Kind::primitive(Type::String))
         );
         assert_eq!(cells.get("name").unwrap().description(), "name field");
         assert_eq!(
@@ -299,7 +297,7 @@ mod tests {
         assert_eq!(cells.get("age").unwrap().name(), "age");
         assert_eq!(
             *cells.get("age").unwrap().content_type(),
-            Some(Type::UnsignedInt)
+            Some(Kind::primitive(Type::UnsignedInt))
         );
         assert_eq!(cells.get("age").unwrap().description(), "age field");
         assert_eq!(
@@ -317,7 +315,9 @@ mod tests {
     #[dialog_common::test]
     fn schema_from_cells_lifts_content_types() {
         let cells = Cells::define(|builder| {
-            builder.cell("name", Some(Type::String)).required();
+            builder
+                .cell("name", Some(Kind::primitive(Type::String)))
+                .required();
             builder.cell("untyped", None).required();
         });
         let schema = Schema::from(&cells);

--- a/rust/dialog-query/src/formula/math.rs
+++ b/rust/dialog-query/src/formula/math.rs
@@ -1,126 +1,148 @@
-use crate::{Formula, formula::Input};
+use crate::Formula;
+use crate::formula::number::{Number, Numeric};
 
-/// Sum formula that adds two numbers
+/// Sum formula: `is = of + with`, generic over the numeric types.
+///
+/// The type parameter is the formula's *scheme variable*: all three
+/// cells share it, so inference links their types (a `u64` input
+/// narrows the output to `u64`) and a row whose values cannot share
+/// one type is a non-match. The engine evaluates the canonical
+/// [`Numeric`] instantiation; arithmetic that produces no value of
+/// the shared type (mixed variants, overflow) yields no rows. See
+/// `notes/formula-schemes.md`.
 #[derive(Debug, Clone, Formula)]
-pub struct Sum {
+pub struct Sum<N: Number = Numeric> {
     /// First operand
-    pub of: u32,
+    pub of: N,
     /// Second operand
-    pub with: u32,
+    pub with: N,
     /// Computed sum
     #[output(cost = 5)]
-    pub is: u32,
+    pub is: N,
 }
 
-impl Sum {
-    /// Compute the sum of `of` and `with`
-    pub fn compute(input: Input<Self>) -> Vec<Self> {
-        vec![Sum {
-            of: input.of,
-            with: input.with,
-            is: input.of + input.with,
-        }]
-    }
-}
-
-/// Difference formula that subtracts two numbers
-#[derive(Debug, Clone, Formula)]
-pub struct Difference {
-    /// Number to subtract from
-    pub of: u32,
-    /// Number to subtract
-    pub subtract: u32,
-    /// Difference
-    #[output(cost = 2)]
-    pub is: u32,
-}
-
-impl Difference {
-    /// Compute the difference of `of` minus `subtract`
-    pub fn compute(input: Input<Self>) -> Vec<Self> {
-        vec![Difference {
-            of: input.of,
-            subtract: input.subtract,
-            is: input.of.saturating_sub(input.subtract),
-        }]
-    }
-}
-
-/// Product formula that multiplies two numbers
-#[derive(Debug, Clone, Formula)]
-pub struct Product {
-    /// Number to multiply
-    pub of: u32,
-    /// Times to multiply
-    pub times: u32,
-    /// Result of multiplication
-    #[output(cost = 5)]
-    pub is: u32,
-}
-
-impl Product {
-    /// Compute the product of `of` times `times`
-    pub fn compute(input: Input<Self>) -> Vec<Self> {
-        vec![Product {
-            of: input.of,
-            times: input.times,
-            is: input.of * input.times,
-        }]
-    }
-}
-
-/// Quotient formula that divides two numbers
-#[derive(Debug, Clone, Formula)]
-pub struct Quotient {
-    /// Number to divide
-    pub of: u32,
-    /// Number to divide by
-    pub by: u32,
-    /// Result of division
-    #[output(cost = 5)]
-    pub is: u32,
-}
-
-impl Quotient {
-    /// Compute the quotient of `of` divided by `by`, returning empty on division by zero
-    pub fn compute(input: Input<Self>) -> Vec<Self> {
-        if input.by == 0 {
-            // Return empty Vec for division by zero - this will be filtered out
-            vec![]
-        } else {
-            vec![Quotient {
+impl<N: Number> Sum<N> {
+    /// Compute the sum of `of` and `with`. No rows when the
+    /// operation has no value of the shared type.
+    pub fn compute(input: SumInput<N>) -> Vec<Self> {
+        match input.of.clone().add(input.with.clone()) {
+            Some(is) => vec![Sum {
                 of: input.of,
-                by: input.by,
-                is: input.of / input.by,
-            }]
+                with: input.with,
+                is,
+            }],
+            None => vec![],
         }
     }
 }
 
-/// Modulo formula that computes remainder of division
+/// Difference formula: `is = of - subtract`, generic over the
+/// numeric types (see [`Sum`] for the scheme semantics).
 #[derive(Debug, Clone, Formula)]
-pub struct Modulo {
-    /// Number to compute modulo of
-    pub of: u32,
-    /// Number to compute modulo by
-    pub by: u32,
-    /// Result of modulo operation
-    #[output(cost = 10)]
-    pub is: u32,
+pub struct Difference<N: Number = Numeric> {
+    /// Number to subtract from
+    pub of: N,
+    /// Number to subtract
+    pub subtract: N,
+    /// Difference
+    #[output(cost = 2)]
+    pub is: N,
 }
 
-impl Modulo {
-    /// Compute `of` modulo `by`, returning empty on modulo by zero
-    pub fn compute(input: Input<Self>) -> Vec<Self> {
-        if input.by == 0 {
-            // Return empty Vec for modulo by zero
-            vec![]
-        } else {
-            vec![Modulo {
+impl<N: Number> Difference<N> {
+    /// Compute `of - subtract`. No rows when the operation has no
+    /// value of the shared type (including unsigned underflow).
+    pub fn compute(input: DifferenceInput<N>) -> Vec<Self> {
+        match input.of.clone().subtract(input.subtract.clone()) {
+            Some(is) => vec![Difference {
+                of: input.of,
+                subtract: input.subtract,
+                is,
+            }],
+            None => vec![],
+        }
+    }
+}
+
+/// Product formula: `is = of * times`, generic over the numeric
+/// types (see [`Sum`] for the scheme semantics).
+#[derive(Debug, Clone, Formula)]
+pub struct Product<N: Number = Numeric> {
+    /// Number to multiply
+    pub of: N,
+    /// Times to multiply
+    pub times: N,
+    /// Result of multiplication
+    #[output(cost = 5)]
+    pub is: N,
+}
+
+impl<N: Number> Product<N> {
+    /// Compute `of * times`. No rows when the operation has no value
+    /// of the shared type.
+    pub fn compute(input: ProductInput<N>) -> Vec<Self> {
+        match input.of.clone().multiply(input.times.clone()) {
+            Some(is) => vec![Product {
+                of: input.of,
+                times: input.times,
+                is,
+            }],
+            None => vec![],
+        }
+    }
+}
+
+/// Quotient formula: `is = of / by`, generic over the numeric types
+/// (see [`Sum`] for the scheme semantics).
+#[derive(Debug, Clone, Formula)]
+pub struct Quotient<N: Number = Numeric> {
+    /// Number to divide
+    pub of: N,
+    /// Number to divide by
+    pub by: N,
+    /// Result of division
+    #[output(cost = 5)]
+    pub is: N,
+}
+
+impl<N: Number> Quotient<N> {
+    /// Compute `of / by`. No rows on integer division by zero
+    /// (floats follow IEEE-754 and stay total).
+    pub fn compute(input: QuotientInput<N>) -> Vec<Self> {
+        match input.of.clone().divide(input.by.clone()) {
+            Some(is) => vec![Quotient {
                 of: input.of,
                 by: input.by,
-                is: input.of % input.by,
-            }]
+                is,
+            }],
+            None => vec![],
+        }
+    }
+}
+
+/// Modulo formula: `is = of % by`, generic over the numeric types
+/// (see [`Sum`] for the scheme semantics).
+#[derive(Debug, Clone, Formula)]
+pub struct Modulo<N: Number = Numeric> {
+    /// Number to compute modulo of
+    pub of: N,
+    /// Number to compute modulo by
+    pub by: N,
+    /// Result of modulo operation
+    #[output(cost = 10)]
+    pub is: N,
+}
+
+impl<N: Number> Modulo<N> {
+    /// Compute `of % by`. No rows on an integer zero divisor.
+    pub fn compute(input: ModuloInput<N>) -> Vec<Self> {
+        match input.of.clone().remainder(input.by.clone()) {
+            Some(is) => vec![Modulo {
+                of: input.of,
+                by: input.by,
+                is,
+            }],
+            None => vec![],
         }
     }
 }
@@ -325,8 +347,10 @@ mod tests {
         Ok(())
     }
 
+    /// Unsigned underflow has no value of the shared type: the row
+    /// is a non-match, never a saturated (fabricated) zero.
     #[dialog_common::test]
-    fn it_handles_difference_underflow() -> anyhow::Result<()> {
+    fn it_filters_difference_underflow() -> anyhow::Result<()> {
         let mut terms = Parameters::new();
         terms.insert("of".to_string(), Term::var("x"));
         terms.insert("subtract".to_string(), Term::var("y"));
@@ -339,19 +363,9 @@ mod tests {
         let app: FormulaQuery = Difference::apply(terms)?.into();
         let results = app
             .compute(input)
-            .expect("Difference underflow should be handled");
+            .expect("underflow is a non-match, not an error");
 
-        assert_eq!(results.len(), 1);
-        let result = &results[0];
-        // Should saturate at 0
-        assert_eq!(
-            result
-                .lookup(&Term::var("result"))
-                .ok()
-                .and_then(|b| b.content().ok())
-                .and_then(|v| u32::try_from(v).ok()),
-            Some(0)
-        );
+        assert_eq!(results.len(), 0, "no value of the type is the result");
         Ok(())
     }
 
@@ -576,9 +590,9 @@ mod tests {
 
         // Now test realize: should reconstruct the Sum proof struct
         let proof = query_copy.realize(matches[0].clone())?;
-        assert_eq!(proof.of, 5);
-        assert_eq!(proof.with, 3);
-        assert_eq!(proof.is, 8);
+        assert_eq!(proof.of, Numeric::UnsignedInt(5));
+        assert_eq!(proof.with, Numeric::UnsignedInt(3));
+        assert_eq!(proof.is, Numeric::UnsignedInt(8));
 
         Ok(())
     }
@@ -587,8 +601,8 @@ mod tests {
     async fn it_performs_formula_with_constant_inputs() -> anyhow::Result<()> {
         // Input fields are constants, output field is a variable
         let query = Query::<Sum> {
-            of: Term::from(5u32),
-            with: Term::from(3u32),
+            of: Term::Constant(Value::from(5u32)),
+            with: Term::Constant(Value::from(3u32)),
             is: Term::var("result"),
         };
 
@@ -605,9 +619,9 @@ mod tests {
 
         assert_eq!(selection.len(), 1);
         let proof = query_copy.realize(selection[0].clone())?;
-        assert_eq!(proof.of, 5);
-        assert_eq!(proof.with, 3);
-        assert_eq!(proof.is, 8);
+        assert_eq!(proof.of, Numeric::UnsignedInt(5));
+        assert_eq!(proof.with, Numeric::UnsignedInt(3));
+        assert_eq!(proof.is, Numeric::UnsignedInt(8));
 
         Ok(())
     }
@@ -618,7 +632,7 @@ mod tests {
         let query = Query::<Sum> {
             of: Term::var("x"),
             with: Term::var("y"),
-            is: Term::from(8u32),
+            is: Term::Constant(Value::from(8u32)),
         };
 
         let (operator, profile) = test_operator_with_profile().await;
@@ -636,9 +650,9 @@ mod tests {
         // Should succeed: the formula computes 8, and the constant 8 is consistent
         assert_eq!(matches.len(), 1);
         let proof = query_copy.realize(matches[0].clone())?;
-        assert_eq!(proof.of, 5);
-        assert_eq!(proof.with, 3);
-        assert_eq!(proof.is, 8);
+        assert_eq!(proof.of, Numeric::UnsignedInt(5));
+        assert_eq!(proof.with, Numeric::UnsignedInt(3));
+        assert_eq!(proof.is, Numeric::UnsignedInt(8));
 
         Ok(())
     }
@@ -649,7 +663,7 @@ mod tests {
         let query = Query::<Sum> {
             of: Term::var("x"),
             with: Term::var("y"),
-            is: Term::from(99u32),
+            is: Term::Constant(Value::from(99u32)),
         };
 
         let (operator, profile) = test_operator_with_profile().await;
@@ -678,7 +692,7 @@ mod tests {
     async fn it_performs_formula_with_mixed_terms() -> anyhow::Result<()> {
         // Mix: one input is constant, one is variable, output is variable
         let query = Query::<Sum> {
-            of: Term::from(10u32),
+            of: Term::Constant(Value::from(10u32)),
             with: Term::var("y"),
             is: Term::var("result"),
         };
@@ -696,9 +710,9 @@ mod tests {
 
         assert_eq!(selection.len(), 1);
         let proof = query_copy.realize(selection[0].clone())?;
-        assert_eq!(proof.of, 10);
-        assert_eq!(proof.with, 7);
-        assert_eq!(proof.is, 17);
+        assert_eq!(proof.of, Numeric::UnsignedInt(10));
+        assert_eq!(proof.with, Numeric::UnsignedInt(7));
+        assert_eq!(proof.is, Numeric::UnsignedInt(17));
 
         Ok(())
     }
@@ -725,9 +739,9 @@ mod tests {
 
         assert_eq!(matches.len(), 1);
         let proof = query_copy.realize(matches[0].clone())?;
-        assert_eq!(proof.of, 4);
-        assert_eq!(proof.with, 4);
-        assert_eq!(proof.is, 8);
+        assert_eq!(proof.of, Numeric::UnsignedInt(4));
+        assert_eq!(proof.with, Numeric::UnsignedInt(4));
+        assert_eq!(proof.is, Numeric::UnsignedInt(8));
 
         Ok(())
     }

--- a/rust/dialog-query/src/formula/number.rs
+++ b/rust/dialog-query/src/formula/number.rs
@@ -1,0 +1,313 @@
+//! Numeric scheme machinery for generic formulas.
+//!
+//! A generic formula like `Sum<N: Number>` is polymorphic over the
+//! numeric value types. The pieces:
+//!
+//! - [`SchemeBound`] carries the lattice bound a scheme variable
+//!   ranges over, as data the `#[derive(Formula)]` macro can emit
+//!   into the formula's cells.
+//! - [`Number`] is the bound trait for numeric schemes: conversion
+//!   to and from [`Value`] plus *fallible* arithmetic. Fallibility
+//!   is where the no-implicit-promotion semantics lives — an
+//!   operation that cannot produce a value of the same type (a
+//!   mixed-type pair, an integer overflow, an integer division by
+//!   zero) yields `None`, and the formula yields no rows for that
+//!   input: a non-match, never an error and never a coercion (see
+//!   `notes/formula-schemes.md`).
+//! - [`Numeric`] is the *dynamic* number: an enum over the numeric
+//!   [`Value`] variants that itself implements [`Number`] by
+//!   delegating same-variant operations and refusing mixed ones.
+//!   The engine registers the canonical instantiation
+//!   `Formula<Numeric>`, so dynamic evaluation is just another
+//!   monomorphization; typed Rust callers use `u64`/`i64`/`f64`.
+
+use crate::artifact::{ArtifactTypeError, Type as ValueType, Value};
+use crate::type_system::{Primitive, Type as Kind};
+use crate::types::{TypeDescriptor, Typed};
+use std::fmt::{self, Display};
+
+/// The lattice bound a scheme variable ranges over.
+///
+/// Every type usable as a formula scheme instantiation reports the
+/// *bound of its scheme*, not its own type: all [`Number`]
+/// implementors report [`Primitive::NUMERIC`]. This uniformity is
+/// load-bearing — a generic formula's cells are built once in a
+/// static shared across instantiations, so the bound must not vary
+/// by instantiation.
+pub trait SchemeBound {
+    /// The set of primitive types the scheme variable ranges over.
+    const BOUND: Primitive;
+}
+
+/// The bound trait for numeric formula schemes.
+///
+/// Arithmetic is *fallible*: `None` means "no value of this type is
+/// the result" — a mixed-type pair (on [`Numeric`]), an integer
+/// overflow, or an integer division/remainder by zero. A formula
+/// computing over a `Number` turns `None` into zero output rows.
+/// Floating point follows IEEE-754 and is total (division by zero
+/// is infinity, not `None`).
+pub trait Number:
+    SchemeBound
+    + Sized
+    + Clone
+    + fmt::Debug
+    + PartialEq
+    + TryFrom<Value, Error = ArtifactTypeError>
+    + Into<Value>
+    + Typed
+    + dialog_common::ConditionalSend
+    + dialog_common::ConditionalSync
+    + 'static
+{
+    /// Addition; `None` on overflow or mixed types.
+    fn add(self, other: Self) -> Option<Self>;
+    /// Subtraction; `None` on overflow or mixed types.
+    fn subtract(self, other: Self) -> Option<Self>;
+    /// Multiplication; `None` on overflow or mixed types.
+    fn multiply(self, other: Self) -> Option<Self>;
+    /// Division; `None` on division by zero (integers), overflow, or
+    /// mixed types.
+    fn divide(self, other: Self) -> Option<Self>;
+    /// Remainder; `None` on a zero divisor (integers), overflow, or
+    /// mixed types.
+    fn remainder(self, other: Self) -> Option<Self>;
+}
+
+macro_rules! impl_integer_number {
+    ($ty:ty) => {
+        impl SchemeBound for $ty {
+            const BOUND: Primitive = Primitive::NUMERIC;
+        }
+
+        impl Number for $ty {
+            fn add(self, other: Self) -> Option<Self> {
+                self.checked_add(other)
+            }
+            fn subtract(self, other: Self) -> Option<Self> {
+                self.checked_sub(other)
+            }
+            fn multiply(self, other: Self) -> Option<Self> {
+                self.checked_mul(other)
+            }
+            fn divide(self, other: Self) -> Option<Self> {
+                self.checked_div(other)
+            }
+            fn remainder(self, other: Self) -> Option<Self> {
+                self.checked_rem(other)
+            }
+        }
+    };
+}
+
+impl_integer_number!(u64);
+impl_integer_number!(i64);
+impl_integer_number!(u128);
+impl_integer_number!(i128);
+
+impl SchemeBound for f64 {
+    const BOUND: Primitive = Primitive::NUMERIC;
+}
+
+impl Number for f64 {
+    fn add(self, other: Self) -> Option<Self> {
+        Some(self + other)
+    }
+    fn subtract(self, other: Self) -> Option<Self> {
+        Some(self - other)
+    }
+    fn multiply(self, other: Self) -> Option<Self> {
+        Some(self * other)
+    }
+    fn divide(self, other: Self) -> Option<Self> {
+        Some(self / other)
+    }
+    fn remainder(self, other: Self) -> Option<Self> {
+        Some(self % other)
+    }
+}
+
+/// The dynamic number: a numeric [`Value`] with the non-numeric
+/// variants excluded.
+///
+/// Implements [`Number`] by delegating same-variant operations and
+/// refusing mixed-variant ones (`None`), which is the strict
+/// no-promotion semantics: a row pairing an unsigned integer with a
+/// float in one scheme variable is a non-match. The engine registers
+/// generic formulas at their `Numeric` instantiation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Numeric {
+    /// An unsigned 128-bit integer (the width [`Value`] stores).
+    UnsignedInt(u128),
+    /// A signed 128-bit integer (the width [`Value`] stores).
+    SignedInt(i128),
+    /// A 64-bit IEEE-754 float.
+    Float(f64),
+}
+
+impl Numeric {
+    fn binary(
+        self,
+        other: Self,
+        u: impl FnOnce(u128, u128) -> Option<u128>,
+        i: impl FnOnce(i128, i128) -> Option<i128>,
+        f: impl FnOnce(f64, f64) -> Option<f64>,
+    ) -> Option<Self> {
+        match (self, other) {
+            (Numeric::UnsignedInt(a), Numeric::UnsignedInt(b)) => u(a, b).map(Numeric::UnsignedInt),
+            (Numeric::SignedInt(a), Numeric::SignedInt(b)) => i(a, b).map(Numeric::SignedInt),
+            (Numeric::Float(a), Numeric::Float(b)) => f(a, b).map(Numeric::Float),
+            // Mixed variants: no value of a single type is the
+            // result — strict, no promotion.
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<Value> for Numeric {
+    type Error = ArtifactTypeError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::UnsignedInt(v) => Ok(Numeric::UnsignedInt(v)),
+            Value::SignedInt(v) => Ok(Numeric::SignedInt(v)),
+            Value::Float(v) => Ok(Numeric::Float(v)),
+            other => Err(ArtifactTypeError::TypeMismatch(
+                ValueType::Float,
+                other.data_type(),
+            )),
+        }
+    }
+}
+
+impl From<Numeric> for Value {
+    fn from(n: Numeric) -> Self {
+        match n {
+            Numeric::UnsignedInt(v) => Value::UnsignedInt(v),
+            Numeric::SignedInt(v) => Value::SignedInt(v),
+            Numeric::Float(v) => Value::Float(v),
+        }
+    }
+}
+
+impl Display for Numeric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Numeric::UnsignedInt(v) => write!(f, "{v}"),
+            Numeric::SignedInt(v) => write!(f, "{v}"),
+            Numeric::Float(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+/// Descriptor for the dynamic [`Numeric`] type: no single storage
+/// tag, kind is the NUMERIC set.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct NumericDescriptor;
+
+impl TypeDescriptor for NumericDescriptor {
+    const TYPE: Option<ValueType> = None;
+
+    fn kind(&self) -> Option<Kind> {
+        Some(Kind::primitive_set(Primitive::NUMERIC))
+    }
+}
+
+impl Typed for Numeric {
+    type Descriptor = NumericDescriptor;
+}
+
+impl SchemeBound for Numeric {
+    const BOUND: Primitive = Primitive::NUMERIC;
+}
+
+impl Number for Numeric {
+    fn add(self, other: Self) -> Option<Self> {
+        self.binary(other, u128::checked_add, i128::checked_add, |a, b| {
+            Some(a + b)
+        })
+    }
+    fn subtract(self, other: Self) -> Option<Self> {
+        self.binary(other, u128::checked_sub, i128::checked_sub, |a, b| {
+            Some(a - b)
+        })
+    }
+    fn multiply(self, other: Self) -> Option<Self> {
+        self.binary(other, u128::checked_mul, i128::checked_mul, |a, b| {
+            Some(a * b)
+        })
+    }
+    fn divide(self, other: Self) -> Option<Self> {
+        self.binary(other, u128::checked_div, i128::checked_div, |a, b| {
+            Some(a / b)
+        })
+    }
+    fn remainder(self, other: Self) -> Option<Self> {
+        self.binary(other, u128::checked_rem, i128::checked_rem, |a, b| {
+            Some(a % b)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_computes_within_one_variant() {
+        let a = Numeric::UnsignedInt(2);
+        let b = Numeric::UnsignedInt(3);
+        assert_eq!(a.add(b), Some(Numeric::UnsignedInt(5)));
+
+        let a = Numeric::Float(2.0);
+        let b = Numeric::Float(1.5);
+        assert_eq!(a.add(b), Some(Numeric::Float(3.5)));
+    }
+
+    /// Mixed variants are a non-match, never a promotion: dialog's
+    /// value lattice has no type that holds both ranges losslessly.
+    #[dialog_common::test]
+    fn it_refuses_mixed_variants() {
+        let a = Numeric::UnsignedInt(2);
+        let b = Numeric::Float(3.5);
+        assert_eq!(a.add(b), None);
+        assert_eq!(b.multiply(a), None);
+    }
+
+    /// Integer edge cases produce no value instead of wrapping or
+    /// trapping: overflow and zero division are non-matches.
+    #[dialog_common::test]
+    fn it_refuses_overflow_and_zero_division() {
+        assert_eq!(u64::MAX.add(1), None);
+        assert_eq!(0u64.subtract(1), None);
+        assert_eq!(1u64.divide(0), None);
+        assert_eq!(
+            Numeric::SignedInt(i128::MIN).divide(Numeric::SignedInt(-1)),
+            None
+        );
+        // IEEE float is total.
+        assert_eq!(1f64.divide(0.0), Some(f64::INFINITY));
+    }
+
+    /// The dynamic descriptor reports the NUMERIC set as its kind.
+    #[dialog_common::test]
+    fn it_reports_the_numeric_kind() {
+        let kind = NumericDescriptor.kind().expect("kind");
+        assert_eq!(kind.primitive_part(), Primitive::NUMERIC);
+    }
+
+    /// Round trip through Value preserves the variant.
+    #[dialog_common::test]
+    fn it_round_trips_values() -> anyhow::Result<()> {
+        for v in [
+            Value::UnsignedInt(7),
+            Value::SignedInt(-7),
+            Value::Float(0.5),
+        ] {
+            let n = Numeric::try_from(v.clone())?;
+            assert_eq!(Value::from(n), v);
+        }
+        assert!(Numeric::try_from(Value::String("x".into())).is_err());
+        Ok(())
+    }
+}

--- a/rust/dialog-query/src/formula/number.rs
+++ b/rust/dialog-query/src/formula/number.rs
@@ -23,7 +23,7 @@
 
 use crate::artifact::{ArtifactTypeError, Type as ValueType, Value};
 use crate::type_system::{Primitive, Type as Kind};
-use crate::types::{TypeDescriptor, Typed};
+use crate::types::{Scalar, TypeDescriptor, Typed};
 use std::fmt::{self, Display};
 
 /// The lattice bound a scheme variable ranges over.
@@ -49,16 +49,10 @@ pub trait SchemeBound {
 /// is infinity, not `None`).
 pub trait Number:
     SchemeBound
-    + Sized
-    + Clone
-    + fmt::Debug
+    + Scalar
     + PartialEq
     + TryFrom<Value, Error = ArtifactTypeError>
-    + Into<Value>
-    + Typed
-    + dialog_common::ConditionalSend
     + dialog_common::ConditionalSync
-    + 'static
 {
     /// Addition; `None` on overflow or mixed types.
     fn add(self, other: Self) -> Option<Self>;
@@ -135,7 +129,8 @@ impl Number for f64 {
 /// no-promotion semantics: a row pairing an unsigned integer with a
 /// float in one scheme variable is a non-match. The engine registers
 /// generic formulas at their `Numeric` instantiation.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
 pub enum Numeric {
     /// An unsigned 128-bit integer (the width [`Value`] stores).
     UnsignedInt(u128),
@@ -216,6 +211,8 @@ impl TypeDescriptor for NumericDescriptor {
 impl Typed for Numeric {
     type Descriptor = NumericDescriptor;
 }
+
+impl Scalar for Numeric {}
 
 impl SchemeBound for Numeric {
     const BOUND: Primitive = Primitive::NUMERIC;

--- a/rust/dialog-query/src/formula/number.rs
+++ b/rust/dialog-query/src/formula/number.rs
@@ -159,6 +159,58 @@ impl Numeric {
     }
 }
 
+impl Numeric {
+    /// Convert into the given numeric type *losslessly*: `None` when
+    /// the value is not exactly representable there. The literal
+    /// adaptation primitive: a polymorphic literal instantiates to a
+    /// row's type through this, so a literal never changes value and
+    /// data is never coerced.
+    ///
+    /// Float literals stay float (the author wrote float syntax);
+    /// integer literals adapt wherever they fit exactly, including
+    /// to float below 2^53.
+    pub fn instantiate(self, target: ValueType) -> Option<Numeric> {
+        match (self, target) {
+            (n @ Numeric::UnsignedInt(_), ValueType::UnsignedInt) => Some(n),
+            (n @ Numeric::SignedInt(_), ValueType::SignedInt) => Some(n),
+            (n @ Numeric::Float(_), ValueType::Float) => Some(n),
+            (Numeric::UnsignedInt(v), ValueType::SignedInt) => {
+                i128::try_from(v).ok().map(Numeric::SignedInt)
+            }
+            (Numeric::SignedInt(v), ValueType::UnsignedInt) => {
+                u128::try_from(v).ok().map(Numeric::UnsignedInt)
+            }
+            (Numeric::UnsignedInt(v), ValueType::Float) => {
+                let f = v as f64;
+                (f.is_finite() && f as u128 == v && f >= 0.0).then_some(Numeric::Float(f))
+            }
+            (Numeric::SignedInt(v), ValueType::Float) => {
+                let f = v as f64;
+                (f.is_finite() && f as i128 == v).then_some(Numeric::Float(f))
+            }
+            _ => None,
+        }
+    }
+
+    /// The set of numeric types this value can instantiate to
+    /// losslessly — the kind a polymorphic literal contributes to
+    /// inference (so `1` does not pin a scheme, while `1.5` pins it
+    /// to Float).
+    pub fn admissible(&self) -> Primitive {
+        let mut set = Primitive::EMPTY;
+        for target in [
+            ValueType::UnsignedInt,
+            ValueType::SignedInt,
+            ValueType::Float,
+        ] {
+            if self.instantiate(target).is_some() {
+                set = set.union(Primitive::singleton(target));
+            }
+        }
+        set
+    }
+}
+
 impl TryFrom<Value> for Numeric {
     type Error = ArtifactTypeError;
 
@@ -204,7 +256,7 @@ impl TypeDescriptor for NumericDescriptor {
     const TYPE: Option<ValueType> = None;
 
     fn kind(&self) -> Option<Kind> {
-        Some(Kind::primitive_set(Primitive::NUMERIC))
+        Some(Kind::from(Primitive::NUMERIC))
     }
 }
 
@@ -291,6 +343,51 @@ mod tests {
     fn it_reports_the_numeric_kind() {
         let kind = NumericDescriptor.kind().expect("kind");
         assert_eq!(kind.primitive_part(), Primitive::NUMERIC);
+    }
+
+    /// Lossless instantiation: integer literals adapt wherever they
+    /// fit exactly; floats stay float; nothing ever changes value.
+    #[dialog_common::test]
+    fn it_instantiates_losslessly() {
+        let one = Numeric::UnsignedInt(1);
+        assert_eq!(
+            one.instantiate(ValueType::SignedInt),
+            Some(Numeric::SignedInt(1))
+        );
+        assert_eq!(one.instantiate(ValueType::Float), Some(Numeric::Float(1.0)));
+
+        // Above 2^53 a float is no longer exact.
+        let big = Numeric::UnsignedInt((1u128 << 53) + 1);
+        assert_eq!(big.instantiate(ValueType::Float), None);
+        assert!(big.instantiate(ValueType::SignedInt).is_some());
+
+        // Negatives have no unsigned form.
+        let neg = Numeric::SignedInt(-1);
+        assert_eq!(neg.instantiate(ValueType::UnsignedInt), None);
+        assert_eq!(
+            neg.instantiate(ValueType::Float),
+            Some(Numeric::Float(-1.0))
+        );
+
+        // Float literals stay float.
+        let frac = Numeric::Float(1.5);
+        assert_eq!(frac.instantiate(ValueType::UnsignedInt), None);
+        assert_eq!(frac.instantiate(ValueType::SignedInt), None);
+    }
+
+    /// The admissible set is what a polymorphic literal contributes
+    /// to inference.
+    #[dialog_common::test]
+    fn it_reports_admissible_sets() {
+        assert_eq!(Numeric::UnsignedInt(1).admissible(), Primitive::NUMERIC);
+        assert_eq!(
+            Numeric::Float(1.5).admissible(),
+            Primitive::singleton(ValueType::Float)
+        );
+        let neg = Numeric::SignedInt(-1).admissible();
+        assert!(!neg.contains(ValueType::UnsignedInt));
+        assert!(neg.contains(ValueType::SignedInt));
+        assert!(neg.contains(ValueType::Float));
     }
 
     /// Round trip through Value preserves the variant.

--- a/rust/dialog-query/src/formula/query.rs
+++ b/rust/dialog-query/src/formula/query.rs
@@ -8,7 +8,7 @@ use crate::formula::logic::{And, Not, Or};
 use crate::formula::math::{Difference, Modulo, Product, Quotient, Sum};
 use crate::formula::string::{Concatenate, Length, Like, Lowercase, Uppercase};
 use crate::selection::{Match, Selection};
-use crate::{Environment, Formula, Parameters, Query, Schema, try_stream};
+use crate::{Environment, Formula, Parameters, Schema, try_stream};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::sync::Arc;
@@ -16,14 +16,21 @@ use std::sync::Arc;
 /// Cost per parameter for formula evaluation
 pub const PARAM_COST: usize = 10;
 
-/// Defines the [`FormulaQuery`] enum from a list of `"formal/name" => Variant(Type)` entries.
+/// Defines the [`FormulaQuery`] enum from a list of
+/// `"formal/name" => Variant(FormulaType, QueryType)` entries.
 ///
 /// Generates:
 /// - The enum with `#[serde(tag = "assert", content = "where")]` and per-variant renames
 /// - Per-variant dispatch: `name()`, `cells()`, `resolve()`, `cost()`, `parameters()`
-/// - `From<Query<T>> for FormulaQuery` for each variant
+/// - `From<QueryType> for FormulaQuery` for each variant
+///
+/// The variant payload names the query struct *directly* rather than
+/// through the `Query<T>` projection: the projection requires
+/// `Predicate`, which (for generic formulas) is conditional on the
+/// very `From` impls this macro generates — naming the struct breaks
+/// that cycle.
 macro_rules! define_formulas {
-    ( $( $name:literal => $variant:ident($ty:ty) ),* $(,)? ) => {
+    ( $( $name:literal => $variant:ident($ty:ty, $q:ty) ),* $(,)? ) => {
         /// A formula premise bound to specific term arguments.
         ///
         /// Each variant wraps the typed `Query<T>` struct (e.g. `SumQuery`) generated
@@ -34,7 +41,7 @@ macro_rules! define_formulas {
             $(
                 #[doc = concat!("Formula `", $name, "`")]
                 #[serde(rename = $name)]
-                $variant(Query<$ty>),
+                $variant($q),
             )*
         }
 
@@ -45,7 +52,7 @@ macro_rules! define_formulas {
             }
 
             /// Returns the static cell definitions for this formula.
-            fn cells(&self) -> &'static Cells {
+            pub(crate) fn cells(&self) -> &'static Cells {
                 match self { $( Self::$variant(_) => <$ty>::cells(), )* }
             }
 
@@ -66,33 +73,33 @@ macro_rules! define_formulas {
         }
 
         $(
-            impl From<Query<$ty>> for FormulaQuery {
-                fn from(q: Query<$ty>) -> Self { Self::$variant(q) }
+            impl From<$q> for FormulaQuery {
+                fn from(q: $q) -> Self { Self::$variant(q) }
             }
         )*
     };
 }
 
 define_formulas! {
-    "math/sum"                => Sum(Sum),
-    "math/difference"         => Difference(Difference),
-    "math/product"            => Product(Product),
-    "math/quotient"           => Quotient(Quotient),
-    "math/modulo"             => Modulo(Modulo),
-    "text/concatenate"        => Concatenate(Concatenate),
-    "text/length"             => Length(Length),
-    "text/upper-case"         => Uppercase(Uppercase),
-    "text/lower-case"         => Lowercase(Lowercase),
-    "text/like"               => Like(Like),
+    "math/sum"                => Sum(Sum, super::math::SumQuery),
+    "math/difference"         => Difference(Difference, super::math::DifferenceQuery),
+    "math/product"            => Product(Product, super::math::ProductQuery),
+    "math/quotient"           => Quotient(Quotient, super::math::QuotientQuery),
+    "math/modulo"             => Modulo(Modulo, super::math::ModuloQuery),
+    "text/concatenate"        => Concatenate(Concatenate, super::string::ConcatenateQuery),
+    "text/length"             => Length(Length, super::string::LengthQuery),
+    "text/upper-case"         => Uppercase(Uppercase, super::string::UppercaseQuery),
+    "text/lower-case"         => Lowercase(Lowercase, super::string::LowercaseQuery),
+    "text/like"               => Like(Like, super::string::LikeQuery),
 
-    "boolean/and"             => And(And),
-    "boolean/or"              => Or(Or),
-    "boolean/not"             => Not(Not),
+    "boolean/and"             => And(And, super::logic::AndQuery),
+    "boolean/or"              => Or(Or, super::logic::OrQuery),
+    "boolean/not"             => Not(Not, super::logic::NotQuery),
 
-    "text/from"               => ToString(conversions::ToString),
-    "unsigned-integer/parse"  => ParseUnsignedInteger(ParseUnsignedInteger),
-    "signed-integer/parse"    => ParseSignedInteger(ParseSignedInteger),
-    "float/parse"             => ParseFloat(ParseFloat),
+    "text/from"               => ToString(conversions::ToString, conversions::ToStringQuery),
+    "unsigned-integer/parse"  => ParseUnsignedInteger(ParseUnsignedInteger, conversions::ParseUnsignedIntegerQuery),
+    "signed-integer/parse"    => ParseSignedInteger(ParseSignedInteger, conversions::ParseSignedIntegerQuery),
+    "float/parse"             => ParseFloat(ParseFloat, conversions::ParseFloatQuery),
 }
 
 impl FormulaQuery {
@@ -171,6 +178,7 @@ impl Display for FormulaQuery {
 mod tests {
     use super::*;
     use crate::Proposition;
+    use crate::Query;
     use crate::constraint::Constraint;
     use crate::constraint::coalesce::Coalesce;
     use crate::constraint::equality::Equality;

--- a/rust/dialog-query/src/formula/query.rs
+++ b/rust/dialog-query/src/formula/query.rs
@@ -1,15 +1,20 @@
 use std::fmt;
 
+use crate::artifact::Type as ValueType;
 use crate::error::EvaluationError;
 use crate::formula::bindings::Bindings;
 use crate::formula::cell::Cells;
 use crate::formula::conversions::{self, ParseFloat, ParseSignedInteger, ParseUnsignedInteger};
 use crate::formula::logic::{And, Not, Or};
 use crate::formula::math::{Difference, Modulo, Product, Quotient, Sum};
+use crate::formula::number::Numeric;
 use crate::formula::string::{Concatenate, Length, Like, Lowercase, Uppercase};
 use crate::selection::{Match, Selection};
-use crate::{Environment, Formula, Parameters, Schema, try_stream};
+use crate::term::Term;
+use crate::types::Any;
+use crate::{Binding, Environment, Formula, Parameters, Schema, Value, try_stream};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -113,10 +118,73 @@ impl FormulaQuery {
         Some(self.cost())
     }
 
+    /// Adapt polymorphic literals to the row's scheme instantiation.
+    ///
+    /// For each scheme group, the row's *variable* members determine
+    /// the instantiation (the data's type); *constant* numeric
+    /// members — literals — are then converted into it losslessly.
+    /// `None` means some literal has no lossless form in the row's
+    /// type: the row is a non-match. Data values are never touched —
+    /// only literals adapt, which is the strict-data /
+    /// polymorphic-literal split (see notes/formula-schemes.md).
+    fn adapt_literals(&self, row: &Match) -> Option<Parameters> {
+        let mut parameters = self.parameters();
+        let mut instantiation: HashMap<&str, ValueType> = HashMap::new();
+
+        // First pass: the row's instantiation per scheme group, from
+        // variable members bound to numeric values.
+        for (slot, cell) in self.cells().iter() {
+            let Some(label) = cell.scheme_label() else {
+                continue;
+            };
+            let Some(term) = parameters.get(slot) else {
+                continue;
+            };
+            if term.name().is_some()
+                && let Ok(Binding::Present(value)) = row.lookup(term)
+                && Numeric::try_from(value.clone()).is_ok()
+            {
+                instantiation.entry(label).or_insert(value.data_type());
+            }
+        }
+
+        if instantiation.is_empty() {
+            return Some(parameters);
+        }
+
+        // Second pass: adapt constant members into their group's
+        // instantiation.
+        let mut adapted: Vec<(String, Term<Any>)> = Vec::new();
+        for (slot, cell) in self.cells().iter() {
+            let Some(label) = cell.scheme_label() else {
+                continue;
+            };
+            let Some(target) = instantiation.get(label) else {
+                continue;
+            };
+            let Some(Term::Constant(value)) = parameters.get(slot) else {
+                continue;
+            };
+            let Ok(literal) = Numeric::try_from(value.clone()) else {
+                continue;
+            };
+            let instantiated = literal.instantiate(*target)?;
+            adapted.push((slot.to_string(), Term::Constant(Value::from(instantiated))));
+        }
+        for (slot, term) in adapted {
+            parameters.insert(slot, term);
+        }
+        Some(parameters)
+    }
+
     /// Computes matches using this formula
     pub fn compute(&self, input: Match) -> Result<Vec<Match>, EvaluationError> {
         let formula = Arc::new(self.clone());
-        let parameters = self.parameters();
+        let Some(parameters) = self.adapt_literals(&input) else {
+            // A literal has no lossless form in the row's type: the
+            // row is a non-match.
+            return Ok(vec![]);
+        };
         let mut bindings = Bindings::new(formula, input, parameters);
         self.resolve(&mut bindings)
     }
@@ -139,13 +207,19 @@ impl FormulaQuery {
     /// a genuine evaluation failure and propagates.
     pub fn expand(&self, matched: Match) -> Result<Vec<Match>, EvaluationError> {
         let formula = Arc::new(self.clone());
-        let parameters = self.parameters();
+        let Some(parameters) = self.adapt_literals(&matched) else {
+            // A literal has no lossless form in the row's type: the
+            // row is a non-match.
+            return Ok(vec![]);
+        };
         let mut bindings = Bindings::new(formula, matched, parameters);
         match self.resolve(&mut bindings) {
             Ok(output) => Ok(output),
-            Err(EvaluationError::Conflict { .. }) | Err(EvaluationError::Absent { .. }) => {
-                Ok(vec![])
-            }
+            Err(EvaluationError::Conflict { .. })
+            | Err(EvaluationError::Absent { .. })
+            // A row value outside an input's type is a row-local
+            // non-match (a scalar slot filters), same as at a scan.
+            | Err(EvaluationError::TypeMismatch { .. }) => Ok(vec![]),
             Err(e) => Err(e),
         }
     }

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -348,6 +348,75 @@ mod tests {
         Ok(())
     }
 
+    /// Formulas are polymorphic over the numeric types: one
+    /// math/sum premise computes over signed-integer facts (its
+    /// scheme instantiates per row), and a row whose inputs cannot
+    /// share a single type is a non-match — no promotion, no error.
+    #[dialog_common::test]
+    async fn it_sums_signed_integers_and_filters_mixed_rows() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("game/score").of(alice.clone()).is(-5i64))
+            .assert(the!("game/bonus").of(alice.clone()).is(-3i64))
+            .assert(the!("game/score").of(bob.clone()).is(2i64))
+            // Bob's bonus is a float: his row cannot instantiate the
+            // scheme to one type.
+            .assert(the!("game/bonus").of(bob.clone()).is(0.5f64))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let score_scan = AttributeQuery::new(
+            Term::from(the!("game/score")),
+            Term::<Entity>::var("player"),
+            Term::var("score"),
+            Term::var("c1"),
+            Some(Cardinality::One),
+        );
+        let bonus_scan = AttributeQuery::new(
+            Term::from(the!("game/bonus")),
+            Term::<Entity>::var("player"),
+            Term::var("bonus"),
+            Term::var("c2"),
+            Some(Cardinality::One),
+        );
+        let mut sum_terms = Parameters::new();
+        sum_terms.insert("of".to_string(), Term::var("score"));
+        sum_terms.insert("with".to_string(), Term::var("bonus"));
+        sum_terms.insert("is".to_string(), Term::var("total"));
+        let sum = Premise::Assert(Proposition::Formula(Sum::apply(sum_terms)?.into()));
+
+        let plan = Planner::from(vec![
+            Premise::Assert(Proposition::Attribute(Box::new(score_scan))),
+            Premise::Assert(Proposition::Attribute(Box::new(bonus_scan))),
+            sum,
+        ])
+        .plan(&Environment::new())?;
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+
+        assert_eq!(
+            results.len(),
+            1,
+            "Alice computes within one type; Bob's mixed row is a non-match"
+        );
+        assert_eq!(
+            results[0].lookup(&Term::var("total"))?.content()?,
+            Value::SignedInt(-8),
+            "signed arithmetic, previously inexpressible, just works"
+        );
+        Ok(())
+    }
+
     /// Characterization of the agreed filter semantics, passing
     /// today: a formula slot demanding a present value narrows a
     /// set-widened attribute variable rule-wide (occurrence typing),

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -417,6 +417,61 @@ mod tests {
         Ok(())
     }
 
+    /// Polymorphic literals: an integer literal adapts losslessly to
+    /// each row's instantiation, so one premise with a literal works
+    /// over signed data — the literal follows the data, never the
+    /// other way around.
+    #[dialog_common::test]
+    async fn it_adapts_integer_literals_to_the_rows_type() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("game/score").of(alice.clone()).is(-5i64))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let score_scan = AttributeQuery::new(
+            Term::from(the!("game/score")),
+            Term::<Entity>::var("player"),
+            Term::var("score"),
+            Term::var("c1"),
+            Some(Cardinality::One),
+        );
+        let mut sum_terms = Parameters::new();
+        sum_terms.insert("of".to_string(), Term::var("score"));
+        // An unsigned literal over signed data: adapts to -5 + 1.
+        sum_terms.insert(
+            "with".to_string(),
+            Term::<Any>::Constant(Value::UnsignedInt(1)),
+        );
+        sum_terms.insert("is".to_string(), Term::var("total"));
+        let sum = Premise::Assert(Proposition::Formula(Sum::apply(sum_terms)?.into()));
+
+        let plan = Planner::from(vec![
+            Premise::Assert(Proposition::Attribute(Box::new(score_scan))),
+            sum,
+        ])
+        .plan(&Environment::new())?;
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].lookup(&Term::var("total"))?.content()?,
+            Value::SignedInt(-4),
+            "the literal instantiated to the row's signed type"
+        );
+        Ok(())
+    }
+
     /// Characterization of the agreed filter semantics, passing
     /// today: a formula slot demanding a present value narrows a
     /// set-widened attribute variable rule-wide (occurrence typing),

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -22,8 +22,12 @@
 //! Negation premises do not contribute. They filter on existing
 //! bindings rather than introducing them.
 
+use crate::FormulaQuery;
 use crate::Premise;
+use crate::Proposition;
+use crate::Term;
 use crate::error::InferenceError;
+use crate::formula::number::Numeric;
 use crate::type_system::Primitive;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::{Context, Type as Inferred, lift};
@@ -72,7 +76,7 @@ impl TypeEnv {
             // scheme) is expressed against the formula's cells
             // directly, so formulas take this arm instead of the
             // generic schema walk below.
-            if let crate::Proposition::Formula(formula) = proposition {
+            if let Proposition::Formula(formula) = proposition {
                 Self::infer_formula(&mut ctx, formula)?;
                 continue;
             }
@@ -133,11 +137,7 @@ impl TypeEnv {
     /// too — a literal narrows the scheme it instantiates, and a
     /// literal outside a concrete cell's bound is a compile-time
     /// conflict.
-    fn infer_formula(
-        ctx: &mut Context,
-        formula: &crate::FormulaQuery,
-    ) -> Result<(), InferenceError> {
-        use crate::type_system::unifier::Type as Inferred;
+    fn infer_formula(ctx: &mut Context, formula: &FormulaQuery) -> Result<(), InferenceError> {
         let params = formula.parameters();
         let mut schemes: HashMap<String, Inferred> = HashMap::new();
 
@@ -160,18 +160,37 @@ impl TypeEnv {
                     .clone(),
                 None => match cell.content_type() {
                     Some(kind) => lift(kind),
-                    None => lift(&Kind::primitive_set(Primitive::ALL)),
+                    None => lift(&Kind::from(Primitive::ALL)),
                 },
             };
 
             let argument = match param.name() {
                 Some(var_name) => Inferred::Variable(ctx.var_for_name(var_name)),
-                None => match param.kind() {
-                    // A constant: its kind narrows the slot (and the
-                    // scheme, when the slot is a scheme cell).
-                    Some(kind) => lift(&kind),
-                    // A blank contributes nothing.
-                    None => continue,
+                None => match (param, cell.scheme_label()) {
+                    // A numeric constant in a *scheme* slot is a
+                    // polymorphic literal: it contributes the set of
+                    // types it instantiates to losslessly, so `1`
+                    // does not pin the scheme while `1.5` pins it to
+                    // Float. (At evaluation the literal adapts to the
+                    // row's instantiation; data never does.)
+                    (Term::Constant(value), Some(_)) => {
+                        match Numeric::try_from(value.clone()) {
+                            Ok(literal) => Inferred::Static(Kind::from(literal.admissible())),
+                            // Not numeric: its singleton kind applies
+                            // (and conflicts with a numeric bound).
+                            Err(_) => match param.kind() {
+                                Some(kind) => lift(&kind),
+                                None => continue,
+                            },
+                        }
+                    }
+                    // A constant in a concrete slot: its kind narrows
+                    // the slot.
+                    _ => match param.kind() {
+                        Some(kind) => lift(&kind),
+                        // A blank contributes nothing.
+                        None => continue,
+                    },
                 },
             };
 
@@ -216,13 +235,15 @@ mod tests {
     use crate::attribute::The;
     use crate::attribute::query::AttributeQuery;
     use crate::error::TypeError;
+    use crate::formula::Formula;
+    use crate::formula::math::Sum;
     use crate::negation::Negation;
     use crate::optional::OptionalAttributeQuery;
     use crate::planner::Planner;
     use crate::types::Any;
     use crate::{
         AttributeDescriptor, Cardinality, ConceptDescriptor, ConceptFieldDescriptor, ConceptQuery,
-        Environment, Parameters, Proposition, Term, the,
+        Environment, Parameters, Proposition, Term, Value, the,
     };
 
     /// Helper: an optional (set-widening) binding for `?name`, a
@@ -244,11 +265,7 @@ mod tests {
     /// fresh for this use of the formula.
     #[dialog_common::test]
     fn it_instantiates_formula_schemes() -> anyhow::Result<()> {
-        use crate::Proposition;
-        use crate::formula::Formula;
-        use crate::formula::math::Sum;
-
-        let mut terms = crate::Parameters::new();
+        let mut terms = Parameters::new();
         terms.insert("of".to_string(), Term::var("a"));
         terms.insert("with".to_string(), Term::var("b"));
         terms.insert("is".to_string(), Term::var("c"));
@@ -268,16 +285,39 @@ mod tests {
         Ok(())
     }
 
+    /// An *integer* literal is polymorphic: it fits every numeric
+    /// type losslessly, so it does not pin the scheme — the linked
+    /// variables stay bounded NUMERIC and the row's data decides.
+    #[dialog_common::test]
+    fn it_keeps_schemes_open_for_integer_literals() -> anyhow::Result<()> {
+        let mut terms = Parameters::new();
+        terms.insert("of".to_string(), Term::var("a"));
+        terms.insert(
+            "with".to_string(),
+            Term::<Any>::Constant(Value::UnsignedInt(1)),
+        );
+        terms.insert("is".to_string(), Term::var("c"));
+        let premises = vec![Premise::Assert(Proposition::Formula(
+            Sum::apply(terms)?.into(),
+        ))];
+
+        let env = TypeEnv::infer(&premises)?;
+        for var in ["a", "c"] {
+            let kind = env.get(var).expect("inferred");
+            assert_eq!(
+                kind.primitive_part(),
+                Primitive::NUMERIC,
+                "the integer literal must not pin {var}"
+            );
+        }
+        Ok(())
+    }
+
     /// A constant argument narrows the scheme it instantiates: a
     /// float literal makes every linked cell Float.
     #[dialog_common::test]
     fn it_narrows_schemes_by_constant_arguments() -> anyhow::Result<()> {
-        use crate::Proposition;
-        use crate::Value;
-        use crate::formula::Formula;
-        use crate::formula::math::Sum;
-
-        let mut terms = crate::Parameters::new();
+        let mut terms = Parameters::new();
         terms.insert("of".to_string(), Term::var("a"));
         terms.insert("with".to_string(), Term::<Any>::Constant(Value::Float(1.5)));
         terms.insert("is".to_string(), Term::var("c"));

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -61,9 +61,22 @@ impl TypeEnv {
         for premise in premises {
             // Negation premises don't contribute; they filter on
             // bindings rather than introducing them.
-            if let Premise::Unless(_) = premise {
+            let Premise::Assert(proposition) = premise else {
+                continue;
+            };
+
+            // Formula premises may declare *schemes*: cells sharing a
+            // label share one bounded type variable, instantiated
+            // fresh per use of the formula. That linkage (and the
+            // contribution of constant arguments, which narrow the
+            // scheme) is expressed against the formula's cells
+            // directly, so formulas take this arm instead of the
+            // generic schema walk below.
+            if let crate::Proposition::Formula(formula) = proposition {
+                Self::infer_formula(&mut ctx, formula)?;
                 continue;
             }
+
             let schema = premise.schema();
             let params = premise.parameters();
 
@@ -109,6 +122,67 @@ impl TypeEnv {
             }
         }
         Ok(Self { by_name })
+    }
+
+    /// Contribute one formula premise to the unification context.
+    ///
+    /// Scheme-labeled cells sharing a label share one fresh type
+    /// variable bounded by the cell's kind (the per-use
+    /// instantiation of the formula's scheme); concrete cells
+    /// contribute their kinds as before. Constant arguments unify
+    /// too — a literal narrows the scheme it instantiates, and a
+    /// literal outside a concrete cell's bound is a compile-time
+    /// conflict.
+    fn infer_formula(
+        ctx: &mut Context,
+        formula: &crate::FormulaQuery,
+    ) -> Result<(), InferenceError> {
+        use crate::type_system::unifier::Type as Inferred;
+        let params = formula.parameters();
+        let mut schemes: HashMap<String, Inferred> = HashMap::new();
+
+        for (slot_name, cell) in formula.cells().iter() {
+            let Some(param) = params.get(slot_name) else {
+                continue;
+            };
+
+            let slot_ty = match cell.scheme_label() {
+                Some(label) => schemes
+                    .entry(label.to_string())
+                    .or_insert_with(|| {
+                        let bound = cell
+                            .content_type()
+                            .as_ref()
+                            .map(|kind| kind.primitive_part())
+                            .unwrap_or(Primitive::ALL);
+                        Inferred::Variable(ctx.fresh(bound))
+                    })
+                    .clone(),
+                None => match cell.content_type() {
+                    Some(kind) => lift(kind),
+                    None => lift(&Kind::primitive_set(Primitive::ALL)),
+                },
+            };
+
+            let argument = match param.name() {
+                Some(var_name) => Inferred::Variable(ctx.var_for_name(var_name)),
+                None => match param.kind() {
+                    // A constant: its kind narrows the slot (and the
+                    // scheme, when the slot is a scheme cell).
+                    Some(kind) => lift(&kind),
+                    // A blank contributes nothing.
+                    None => continue,
+                },
+            };
+
+            if let Err(reason) = ctx.unify(&slot_ty, &argument) {
+                return Err(InferenceError::Conflict {
+                    variable: param.name().unwrap_or(slot_name).to_string(),
+                    reason: reason.to_string(),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Look up the inferred type for a variable by name.
@@ -163,6 +237,64 @@ mod tests {
             Some(Cardinality::One),
         )
         .into()
+    }
+
+    /// A formula scheme links its cells: one bounded type variable
+    /// per label, shared by every cell carrying it, instantiated
+    /// fresh for this use of the formula.
+    #[dialog_common::test]
+    fn it_instantiates_formula_schemes() -> anyhow::Result<()> {
+        use crate::Proposition;
+        use crate::formula::Formula;
+        use crate::formula::math::Sum;
+
+        let mut terms = crate::Parameters::new();
+        terms.insert("of".to_string(), Term::var("a"));
+        terms.insert("with".to_string(), Term::var("b"));
+        terms.insert("is".to_string(), Term::var("c"));
+        let premises = vec![Premise::Assert(Proposition::Formula(
+            Sum::apply(terms)?.into(),
+        ))];
+
+        let env = TypeEnv::infer(&premises)?;
+        for var in ["a", "b", "c"] {
+            let kind = env.get(var).expect("inferred");
+            assert_eq!(
+                kind.primitive_part(),
+                Primitive::NUMERIC,
+                "{var} is bounded by the scheme"
+            );
+        }
+        Ok(())
+    }
+
+    /// A constant argument narrows the scheme it instantiates: a
+    /// float literal makes every linked cell Float.
+    #[dialog_common::test]
+    fn it_narrows_schemes_by_constant_arguments() -> anyhow::Result<()> {
+        use crate::Proposition;
+        use crate::Value;
+        use crate::formula::Formula;
+        use crate::formula::math::Sum;
+
+        let mut terms = crate::Parameters::new();
+        terms.insert("of".to_string(), Term::var("a"));
+        terms.insert("with".to_string(), Term::<Any>::Constant(Value::Float(1.5)));
+        terms.insert("is".to_string(), Term::var("c"));
+        let premises = vec![Premise::Assert(Proposition::Formula(
+            Sum::apply(terms)?.into(),
+        ))];
+
+        let env = TypeEnv::infer(&premises)?;
+        for var in ["a", "c"] {
+            let kind = env.get(var).expect("inferred");
+            assert_eq!(
+                kind.as_value_type(),
+                Some(ValueType::Float),
+                "the literal narrowed {var} through the scheme"
+            );
+        }
+        Ok(())
     }
 
     /// A typed slot kind flows into the variable's inferred type.

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -27,6 +27,7 @@ use crate::artifact::Type as ValueType;
 use crate::artifact::Value;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// A bitfield over [`ValueType`] variants plus a `Nothing` bit:
 /// the set of admissible primitive shapes.
@@ -44,6 +45,47 @@ pub struct Primitive {
     /// One bit per [`ValueType`] variant (positions 0-8), plus a
     /// `Nothing` bit at position 9.
     bits: u16,
+}
+
+impl Display for Primitive {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        if *self == Self::EMPTY {
+            return write!(f, "Never");
+        }
+        if self.without_nothing() == Self::ALL {
+            write!(f, "Value")?;
+        } else {
+            const ATOMS: [ValueType; 9] = [
+                ValueType::String,
+                ValueType::Boolean,
+                ValueType::UnsignedInt,
+                ValueType::SignedInt,
+                ValueType::Float,
+                ValueType::Bytes,
+                ValueType::Entity,
+                ValueType::Symbol,
+                ValueType::Record,
+            ];
+            let mut first = true;
+            for atom in ATOMS {
+                if self.contains(atom) {
+                    if !first {
+                        write!(f, "|")?;
+                    }
+                    write!(f, "{atom}")?;
+                    first = false;
+                }
+            }
+            if first {
+                // Only the Nothing bit is set.
+                return write!(f, "Nothing");
+            }
+        }
+        if self.contains_nothing() {
+            write!(f, "|Nothing")?;
+        }
+        Ok(())
+    }
 }
 
 /// Bit position for the synthetic `Nothing` atom.
@@ -237,6 +279,15 @@ impl From<Primitive> for Type {
 /// Composites live in a [`BTreeSet`] rather than a [`HashSet`].
 /// Two reasons:
 ///
+impl Display for Type {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Type::Primitive(p) => write!(f, "{p}"),
+            Type::Composite(p, c) => write!(f, "{p}+{} composite", c.len()),
+        }
+    }
+}
+
 /// 1. `Type` derives [`Hash`]. `BTreeSet` iterates in a stable
 ///    `Ord`-based order, so the derived hash is canonical:
 ///    `Type::Composite(p, {a, b})` and `Type::Composite(p, {b, a})`

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -52,7 +52,7 @@ impl Display for Primitive {
         if *self == Self::EMPTY {
             return write!(f, "Never");
         }
-        if self.without_nothing() == Self::ALL {
+        if self.required() == Self::ALL {
             write!(f, "Value")?;
         } else {
             const ATOMS: [ValueType; 9] = [

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -125,6 +125,16 @@ impl Primitive {
         bits: Self::bit_for(ValueType::String) | Self::bit_for(ValueType::Symbol),
     };
 
+    /// Textual primitives: the types whose values have a lexical
+    /// form a prefix predicate can range over — strings, symbols
+    /// (attribute names), and entities (URIs). The bound for
+    /// `starts-with`-style predicates: one predicate over TEXTUAL
+    /// instead of per-type variants, with each member's lexical
+    /// grammar deciding whether a given prefix can match it at all.
+    pub const TEXTUAL: Self = Self {
+        bits: Self::STRING_LIKE.bits | Self::bit_for(ValueType::Entity),
+    };
+
     /// Comparable primitives: numeric, string-like, entity, bytes.
     pub const COMPARABLE: Self = Self {
         bits: Self::NUMERIC.bits

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -302,8 +302,8 @@ mod tests {
         let mut ctx = Context::new();
         let unified = ctx
             .unify(
-                &Type::primitive_set(Primitive::NUMERIC),
-                &Type::primitive_set(Primitive::COMPARABLE),
+                &Type::Static(StaticType::from(Primitive::NUMERIC)),
+                &Type::Static(StaticType::from(Primitive::COMPARABLE)),
             )
             .unwrap();
         match unified {
@@ -325,7 +325,7 @@ mod tests {
         let unified = ctx
             .unify(
                 &Type::Variable(v),
-                &Type::primitive_set(Primitive::COMPARABLE),
+                &Type::Static(StaticType::from(Primitive::COMPARABLE)),
             )
             .unwrap();
         match unified {

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -176,20 +176,30 @@ impl Context {
     }
 
     /// Robinson unification with constraint propagation. Updates
-    /// `self` in-place. Returns `Err` on constraint conflict.
+    /// `self` in-place and returns the *unified type* — the
+    /// principal meet of the two sides — so the result of every
+    /// unification flows to the caller instead of being discarded:
+    ///
+    /// - variable / variable: the canonical variable of the merged
+    ///   chain (its constraint is the met constraint);
+    /// - variable / static: the narrowed static the variable now
+    ///   resolves to;
+    /// - static / static: the meet of the two statics.
+    ///
+    /// Returns `Err` on constraint conflict (an empty meet).
     ///
     /// Static types intersect via [`StaticType::intersect`], which
     /// narrows both primitive and composite parts (products by
     /// shared field-name set, variants by label). Variables carry
     /// a [`Primitive`] constraint that's intersected with the
     /// primitive part of any concrete type they're unified with.
-    pub fn unify(&mut self, a: &Type, b: &Type) -> Result<(), UnifyError> {
+    pub fn unify(&mut self, a: &Type, b: &Type) -> Result<Type, UnifyError> {
         match (a, b) {
             (Type::Variable(x), Type::Variable(y)) => {
                 let x = self.root(*x);
                 let y = self.root(*y);
                 if x == y {
-                    return Ok(());
+                    return Ok(Type::Variable(x));
                 }
                 // If either side has already been resolved to a
                 // static, unify that resolved static against the
@@ -214,7 +224,7 @@ impl Context {
                 self.constraints.insert(x, merged);
                 self.constraints.insert(y, merged);
                 self.substitution.insert(y, Type::Variable(x));
-                Ok(())
+                Ok(Type::Variable(x))
             }
             (Type::Variable(x), Type::Static(s)) | (Type::Static(s), Type::Variable(x)) => {
                 let x = self.root(*x);
@@ -246,12 +256,12 @@ impl Context {
                     Some(c) if !c.is_empty() => StaticType::composite(merged, c.clone()),
                     _ => StaticType::from(merged),
                 };
-                self.substitution.insert(x, Type::Static(resolved));
-                Ok(())
+                self.substitution.insert(x, Type::Static(resolved.clone()));
+                Ok(Type::Static(resolved))
             }
             (Type::Static(a), Type::Static(b)) => {
                 a.intersect(b)
-                    .map(|_| ())
+                    .map(Type::Static)
                     .ok_or_else(|| UnifyError::ConstraintConflict {
                         left: a.primitive_part(),
                         right: b.primitive_part(),
@@ -282,6 +292,68 @@ mod tests {
         let mut ctx = Context::new();
         let a = ctx.fresh(Primitive::NUMERIC);
         assert_eq!(ctx.constraint(a), Primitive::NUMERIC);
+    }
+
+    /// Static-static unification returns the meet, not merely a
+    /// compatibility verdict: the result of every unification flows
+    /// to the caller. Foundation for scheme instantiation.
+    #[dialog_common::test]
+    fn unify_static_static_returns_the_meet() {
+        let mut ctx = Context::new();
+        let unified = ctx
+            .unify(
+                &Type::primitive_set(Primitive::NUMERIC),
+                &Type::primitive_set(Primitive::COMPARABLE),
+            )
+            .unwrap();
+        match unified {
+            Type::Static(s) => assert_eq!(
+                s.primitive_part(),
+                Primitive::NUMERIC.intersect(Primitive::COMPARABLE).unwrap(),
+                "the meet of the two statics is returned"
+            ),
+            other => panic!("expected static, got {other:?}"),
+        }
+    }
+
+    /// Variable-static unification returns the narrowed static the
+    /// variable now resolves to.
+    #[dialog_common::test]
+    fn unify_var_static_returns_the_narrowed_static() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(Primitive::NUMERIC);
+        let unified = ctx
+            .unify(
+                &Type::Variable(v),
+                &Type::primitive_set(Primitive::COMPARABLE),
+            )
+            .unwrap();
+        match unified {
+            Type::Static(s) => assert_eq!(
+                s.primitive_part(),
+                Primitive::NUMERIC.intersect(Primitive::COMPARABLE).unwrap(),
+                "the variable's constraint participates in the returned meet"
+            ),
+            other => panic!("expected static, got {other:?}"),
+        }
+    }
+
+    /// Variable-variable unification returns the canonical variable
+    /// of the merged chain.
+    #[dialog_common::test]
+    fn unify_var_var_returns_the_canonical_variable() {
+        let mut ctx = Context::new();
+        let a = ctx.fresh(Primitive::NUMERIC);
+        let b = ctx.fresh(Primitive::COMPARABLE);
+        let unified = ctx.unify(&Type::Variable(a), &Type::Variable(b)).unwrap();
+        match unified {
+            Type::Variable(root) => assert_eq!(
+                ctx.constraint(root),
+                Primitive::NUMERIC.intersect(Primitive::COMPARABLE).unwrap(),
+                "the canonical variable carries the met constraint"
+            ),
+            other => panic!("expected variable, got {other:?}"),
+        }
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
## Overview

Formulas become polymorphic where their semantics are: `math/sum` is now "forall `N` ⊆ NUMERIC: `(of: N, with: N) → is: N`" instead of a fixed `u32` signature, with inference linking the cells rule-wide and strict, promotion-free semantics per row. Design record: `notes/formula-schemes.md`.

## Declaration: the type parameter is the scheme variable

```rust
#[derive(Formula)]
pub struct Sum<N: Number = Numeric> {
    of: N,
    with: N,
    #[output(cost = 5)]
    is: N,
}
```

The derive threads the struct's generics through every emitted item and detects scheme fields (a field whose type is a bare type parameter): their cells carry the parameter's `SchemeBound` as a lattice kind plus a scheme label linking them. The `Numeric` default makes the canonical dynamic instantiation the unannotated spelling, so `define_formulas!` entries and call sites keep their shape. Impls that route through `FormulaQuery` are bounded on the conversion existing, restricting them to registered instantiations; `define_formulas!` names query structs directly to break the `Query<T>`-projection cycle.

## Runtime: the dynamic number is just another monomorphization

`Numeric` mirrors `Value`'s numeric variants (`u128`/`i128`/`f64`) and implements `Number` itself: same-variant arithmetic delegates, mixed variants refuse. `Number`'s operations are *fallible* — mixed types, integer overflow, and integer zero-division yield `None` and the formula yields no rows: a non-match, never an error, never a coercion. `Difference`'s silent saturate-to-zero is gone; unsigned underflow is now a non-match instead of a fabricated value.

## Inference: instantiate per use

`TypeEnv::infer` allocates one fresh bounded variable per scheme label per formula use, so `of`/`with`/`is` narrow together: a `u64` input narrows the output, a `Float` output requirement narrows the inputs, a `String` anywhere is a compile-time conflict. `Context::unify` now returns the principal meet on every arm (the static-static result was previously discarded). Constant arguments participate: a literal outside a concrete cell's bound is a compile-time conflict.

## Polymorphic literals: strict data, flexible literals

Integer literals contribute their *lossless-instantiation set* to inference (`1` fits everywhere and does not pin the scheme; `1.5` pins Float; `-1` admits signed and float), and at evaluation `adapt_literals` converts literals per row into the data's instantiation — losslessly or the row is a non-match. Data values are never adapted. `sum(?score, 1, ?total)` over signed facts computes `-4` where it previously matched nothing.

## Groundwork and prerequisites landed alongside

- Formula cells carry lattice types (`type_system::Type`) instead of single storage tags; compatibility is checked by inhabited meet, with new `KindMismatch` errors and `Display` for the type lattice. Shared prerequisite with the planned range-refinement predicates.
- `Primitive::TEXTUAL` (`String | Symbol | Entity`): the bound for the planned unified `starts-with` predicate, whose literal prefix will drop lexically-impossible member types from the inferred kind.
- A row value outside a formula input's type now filters (joining `Conflict`/`Absent` as row-local non-matches), consistent with scan slots.
- `notes/guide.md` (migrated from `rust/dialog-query/`) gains "Where errors surface" and "Inference in an open world": the two error surfaces, the Postgres-errors / SQLite-coerces / dialog-filters comparison, and the open-world restatement of closed-world inference soundness.

## Compatibility

- `math/*` formulas operate on `Value`-native numeric widths and are strict: mixed-type rows, overflow, and integer zero-division are non-matches (previously: fixed `u32`, saturating subtraction).
- `Cell`'s serialized `type` field is now a lattice kind; cells may carry a `scheme` label.
- Generic formulas are `Formula`/`Predicate` only at instantiations registered in `define_formulas!`.