### PR TITLE
refactor(dialog-query): refinement predicates and scan-range pushdown

### DIFF
--- a/notes/formula-schemes.md
+++ b/notes/formula-schemes.md
@@ -129,16 +129,37 @@ per-type variants. Three properties fall out:
   lexical grammar (entity URIs, `domain/name` symbols), so a literal
   prefix that cannot begin a value of some member type drops that
   member from the subject's inferred kind — a space excludes
-  entities and symbols, narrowing the subject to `String`. If every
-  member drops, the predicate is statically never-matching: a
-  *logical no-match* (the premise filters everything), surfaced as a
-  vacuous-premise diagnostic rather than an error.
+  entities, a prefix longer than any symbol excludes symbols. As
+  built (`constraint/starts_with.rs`), the refinement is
+  conservative: only *certainly impossible* members drop. A symbol's
+  validator enforces just a 64-byte cap (its charset is unenforced
+  upstream), so only length excludes `Symbol`; an entity's
+  serialized URL always begins `scheme:` and never contains raw
+  whitespace or control characters, so those exclude `Entity`; and
+  `String` admits any prefix, so the contributed set is never
+  empty — the all-members-drop case cannot arise from the prefix
+  alone. Statically-known no-matches surface instead as an empty
+  *meet* when the refined set collides with a subject already
+  narrowed elsewhere (`?x.entity()` plus a prefix with a space),
+  which is the ordinary known-types-misalign compile error.
 - **Filter semantics per row**: instantiate to the value's type,
   compare the lexical prefix; non-textual values are non-matches via
   the bound, like every other scheme mismatch.
 - **Pushdown-ready**: the refined kind plus the prefix is exactly
   the per-stratum index range bound the scan pushdown consumes.
 
-Numeric range predicates (`<`, `<=`, `>`, `>=`) ride the NUMERIC
-scheme identically; their refinement payload is an interval instead
-of a prefix.
+Numeric range predicates (`<`, `<=`, `>`, `>=`) follow the same
+shape with an interval-flavored payload instead of a prefix. As
+built (`constraint/compare.rs`): both sides are bounded NUMERIC at
+inference and a row orders only within one numeric type — mixed
+data is a non-match, exactly the formula arithmetic semantics — with
+the polymorphic-literal release valve: a *constant* side adapts
+losslessly to the data's type per row (`1` orders against floats as
+`1.0`; `1.5` against integer data is a non-match), data never
+adapts. One deliberate gap from the formula schemes: a comparison's
+sides are bounded but not *linked* to one shared instantiation
+(constraints go through the generic schema walk, which has no
+scheme labels), so `?a < ?b` does not statically force `?a` and
+`?b` to one numeric type. Soundness lives in evaluation; the
+planned per-atom interval refinements are the place linking (and
+range pushdown) becomes worth carrying through the lattice.

--- a/notes/guide.md
+++ b/notes/guide.md
@@ -148,8 +148,11 @@ This is ordinary relational semantics. A premise is a predicate on
 the row set, and a predicate that demands presence filters rows
 lacking it, exactly the way the scalar nickname lookup filtered Bob.
 Think of it as occurrence typing: using `?age` in a context that
-requires a number *is* the evidence of presence, the same way a
-future `?x.text()` type predicate would narrow `?x` to strings.
+requires a number *is* the evidence of presence, the same way the
+`?x.text()` type predicate narrows `?x` to strings, or
+`?x.starts_with("did:")` narrows it to the textual kinds a literal
+prefix could begin, or `?x.less_than(?y)` narrows both sides to
+numbers.
 
 The planner exploits the narrowing: when inference proves a sibling
 premise guarantees the value is present, the optional lookup can

--- a/notes/refinements.md
+++ b/notes/refinements.md
@@ -1,0 +1,128 @@
+# Refinements: value-level constraints on the type lattice, and scan-range pushdown
+
+> Design note for the refinement layer (dialog-db-51): how a constraint a rule
+> proves about a variable's *values* (not just its types) travels from the
+> predicate that proved it, through inference, to the storage boundary, where it
+> becomes index key-range bounds. Companion to
+> [`formula-schemes.md`](./formula-schemes.md) (the predicates that produce
+> refinements) and the planned order-preserving value encoding (dialog-db-57,
+> which widens what can consume them).
+
+## Goal
+
+`?a.starts_with("person/")` narrows `?a`'s kind to the textual members the
+prefix could begin — that landed with the predicates. But the *prefix itself*
+is knowledge too: a scan feeding `?a` need not read the whole attribute index
+and filter; it can read only the `person/*` key range. The refinement layer
+makes such constraints first-class on the type lattice so that one mechanism
+carries them end to end:
+
+```
+starts-with schema  →  inference (meet)  →  planner stamp  →  selector  →  key range
+```
+
+Downstream, the same narrowed kinds are what demand covers are computed from,
+so subscriptions watch less and partial replication pulls less (M5); M3's
+concept-membership constraints on Entity are the same mechanism with a
+different payload.
+
+## The lattice layer
+
+`type_system::Type` gains a third shape:
+
+```rust
+enum Type {
+    Primitive(Primitive),
+    Composite(Primitive, BTreeSet<Composite>),
+    Refined(Primitive, Refinement),
+}
+
+struct Refinement {
+    prefix: String,   // non-empty; lexical prefix over TEXTUAL members
+}
+```
+
+A refined type admits a value when its membership admits the value's type
+*and* the refinement admits the value itself (`Type::admits` checks both — so
+every existing admits-site, scans included, enforces refinements with no new
+code). The lattice operations treat a refinement as a constraint:
+
+- **Meet** (`intersect`): the conjunction. Two prefixes are jointly
+  satisfiable iff one extends the other; the meet keeps the longer. Disjoint
+  prefixes are an empty meet — the ordinary known-types-misalign compile
+  error. A refined side admits no composite shapes, so composites on the
+  other side drop out of the meet.
+- **Join** (`union`): the weakest common implication — the longest common
+  prefix, or no refinement at all when joined with an unrefined side (the
+  union must admit everything either side admits).
+- **Inclusion**: constraint-ordered. `[prefix "did:"]` includes
+  `[prefix "did:key:"]`; unrefined includes refined; never the reverse.
+
+`Refinement` is a struct, not an enum, so numeric intervals (dialog-db-57's
+consumer) and M3's Entity concept-membership extend it with fields rather
+than new lattice variants; the meet/join shape stays put.
+
+The `starts-with` schema attaches the refinement to its subject slot's content
+type, and the generic schema walk plus the unifier's principal meet do the
+rest — no inference changes. One unifier fix was load-bearing: variable
+resolution used to *reconstruct* the resolved static from the merged primitive
+set, which would have silently shed the refinement; resolution now rebuilds
+around the merged membership preserving the type's structure
+(`Type::with_primitive_part`).
+
+## Transport: kinds stamped on scan terms
+
+The planner already stamped rule-level kinds onto the scan's value term
+(`with_type`). The attribute and entity terms now get the same treatment
+(`with_subject_kinds`): their descriptors (`Symbol`, `EntityType`) graduated
+from unit structs to carrying an `Option<Type>`, normalized to `None` whenever
+the kind says no more than the static type — so unnarrowed terms compare,
+hash, and serde-roundtrip exactly as before (the wire format already had a
+`type` field per variable; it previously dropped on deserialize, now it is
+preserved).
+
+Alternative considered: stamping refinements onto the query struct as
+plan-time decoration fields. Rejected — kinds live on terms everywhere else,
+and the wire `type` slot already existed; a parallel channel would have been
+a second source of truth.
+
+## The storage boundary
+
+`ArtifactSelector` gains prefix bounds beside its exact fields:
+`the_starting_with(prefix)` / `of_starting_with(prefix)` (both produce a
+`Constrained` selector — a prefix is a constraint). The scan
+(`ArtifactTreeExt::scan`):
+
+- picks the index as before by exact fields (entity / value / attribute), and
+  a prefix on a leading dimension picks its index when no exact field does;
+- tightens every branch's `(start, end)` keys with whatever prefix bounds the
+  selector carries: the bound segment is the prefix's raw bytes followed by
+  `0x00` (lower) or `0xFF` (upper) fill. Applying a bound to a non-leading
+  dimension is sound (the range stays a superset; `matches_selector` filters
+  per entry) and tight when every more-significant dimension is exact;
+- `matches_selector` re-checks prefixes per entry, so range construction can
+  over-approximate freely.
+
+What each segment's encoding permits (the dialog-db-57 analysis):
+
+- **Attribute** (64 bytes, raw, zero-padded): prefix ranges are *exact*. A
+  prefix longer than 64 bytes matches nothing, which the per-entry check
+  yields naturally.
+- **Entity** (32 raw bytes + 32-byte hash of the URI tail): ranges are tight
+  up to 32 bytes; a longer prefix ranges over its 32-byte truncation and the
+  per-entry check confirms the remainder against the stored datum's URI
+  (`ENTITY_RAW_HEAD`).
+- **Value** (type tag + blake3 hash): *no* range pushdown is possible — the
+  hash destroys order. Value refinements still travel (inference, `admits`
+  filtering, demand-cover input) so dialog-db-57's re-encoding turns them
+  into ranges with only a selector-conversion change.
+
+## What this deliberately does not do
+
+- No cost-model change: the planner does not yet prefer prefix-bounded scans.
+  Range bounds only shrink what the chosen scan reads.
+- No numeric intervals in `Refinement` yet: with the value segment hashed
+  there is no consumer, and the comparison predicates' sides are not
+  scheme-linked. Both land together with dialog-db-57.
+- No `the!`-macro-level surface: prefixes arrive via `starts_with` premises
+  on attribute/entity variables, not via new scan syntax.

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -549,6 +549,119 @@ mod tests {
         Ok(())
     }
 
+    /// An attribute-prefix selector ranges over the AEV index:
+    /// attribute names are stored raw in the key, so the range is
+    /// exact.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_selects_by_attribute_prefix() -> Result<()> {
+        let (storage_backend, _temp_directory) = make_target_storage().await?;
+        let mut facts = Artifacts::anonymous(storage_backend).await?;
+        let alice = Entity::new()?;
+
+        let data = vec![
+            Artifact {
+                the: Attribute::from_str("person/name")?,
+                of: alice.clone(),
+                is: Value::String("Alice".into()),
+                cause: None,
+            },
+            Artifact {
+                the: Attribute::from_str("person/age")?,
+                of: alice.clone(),
+                is: Value::UnsignedInt(40),
+                cause: None,
+            },
+            Artifact {
+                the: Attribute::from_str("group/name")?,
+                of: alice,
+                is: Value::String("Admins".into()),
+                cause: None,
+            },
+        ];
+        facts
+            .commit(data.into_iter().map(Instruction::Assert))
+            .await?;
+
+        let selected: Vec<Artifact> = facts
+            .select(ArtifactSelector::new().the_starting_with("person/"))
+            .try_collect()
+            .await?;
+        assert_eq!(selected.len(), 2, "two person/* facts");
+        assert!(
+            selected
+                .iter()
+                .all(|fact| String::from(&fact.the).starts_with("person/")),
+            "every selected fact carries the prefix"
+        );
+        Ok(())
+    }
+
+    /// An entity-prefix selector ranges over the EAV index. The
+    /// entity key stores only the first 32 URI bytes raw, so a
+    /// prefix longer than that must be confirmed against the stored
+    /// datum — the second half of this test diverges two URIs past
+    /// byte 32 to force that path.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_selects_by_entity_prefix() -> Result<()> {
+        let (storage_backend, _temp_directory) = make_target_storage().await?;
+        let mut facts = Artifacts::anonymous(storage_backend).await?;
+
+        let name = Attribute::from_str("person/name")?;
+        let fact = |entity: Entity, value: &str| Artifact {
+            the: name.clone(),
+            of: entity,
+            is: Value::String(value.into()),
+            cause: None,
+        };
+
+        // Short prefixes (within the raw head) discriminate on key
+        // bytes alone.
+        let urn_alpha = Entity::from_str("urn:alpha:1")?;
+        let urn_beta = Entity::from_str("urn:beta:1")?;
+        // Long shared head: these two agree for well over 32 bytes
+        // and diverge only in the hashed tail of the key.
+        let shared = "urn:shared:0000000000000000000000000000:";
+        let long_a = Entity::from_str(&format!("{shared}aaaa"))?;
+        let long_b = Entity::from_str(&format!("{shared}bbbb"))?;
+
+        facts
+            .commit(
+                [
+                    fact(urn_alpha.clone(), "Alpha"),
+                    fact(urn_beta, "Beta"),
+                    fact(long_a.clone(), "LongA"),
+                    fact(long_b, "LongB"),
+                ]
+                .into_iter()
+                .map(Instruction::Assert),
+            )
+            .await?;
+
+        let selected: Vec<Artifact> = facts
+            .select(ArtifactSelector::new().of_starting_with("urn:alpha:"))
+            .try_collect()
+            .await?;
+        assert_eq!(selected.len(), 1, "short prefix selects on key bytes");
+        assert_eq!(selected[0].of, urn_alpha);
+
+        let long_prefix = format!("{shared}aaaa");
+        assert!(long_prefix.len() > 32, "the prefix outruns the raw head");
+        let selected: Vec<Artifact> = facts
+            .select(ArtifactSelector::new().of_starting_with(long_prefix))
+            .try_collect()
+            .await?;
+        assert_eq!(
+            selected.len(),
+            1,
+            "the datum re-check discriminates beyond the raw head"
+        );
+        assert_eq!(selected[0].of, long_a);
+
+        Ok(())
+    }
+
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_pins_a_stream_at_the_version_where_iteration_begins() -> Result<()> {

--- a/rust/dialog-artifacts/src/artifacts/match.rs
+++ b/rust/dialog-artifacts/src/artifacts/match.rs
@@ -6,8 +6,8 @@
 use dialog_search_tree::Entry;
 
 use crate::{
-    ATTRIBUTE_KEY_TAG, ArtifactSelector, AttributeKey, Datum, ENTITY_KEY_TAG, EntityKey, Key,
-    KeyView, State, VALUE_KEY_TAG, ValueKey, artifacts::selector::Constrained,
+    ATTRIBUTE_KEY_TAG, ArtifactSelector, AttributeKey, Datum, ENTITY_KEY_TAG, ENTITY_RAW_HEAD,
+    EntityKey, Key, KeyView, State, VALUE_KEY_TAG, ValueKey, artifacts::selector::Constrained,
 };
 
 /// Checks if a key view matches the constraints in an artifact selector.
@@ -42,6 +42,32 @@ where
         return false;
     }
 
+    // Attribute names are stored raw (zero-padded) in the key, so a
+    // byte-prefix check is exact; a prefix longer than the field
+    // matches no attribute at all.
+    if let Some(prefix) = selector.attribute_prefix() {
+        let bytes = prefix.as_bytes();
+        let part = key.attribute();
+        let segment = part.raw();
+        if bytes.len() > segment.len() || &segment[..bytes.len()] != bytes {
+            return false;
+        }
+    }
+
+    // Only the first [`ENTITY_RAW_HEAD`] bytes of the entity URI are
+    // stored raw; the tail is hashed. Check what the key can prove —
+    // the remainder is re-checked against the datum by
+    // [`MatchCandidate::matches_selector`].
+    if let Some(prefix) = selector.entity_prefix() {
+        let bytes = prefix.as_bytes();
+        let head = bytes.len().min(ENTITY_RAW_HEAD);
+        let part = key.entity();
+        let segment = part.raw();
+        if segment[..head] != bytes[..head] {
+            return false;
+        }
+    }
+
     true
 }
 
@@ -55,11 +81,28 @@ pub trait MatchCandidate {
 
 impl MatchCandidate for Entry<Key, State<Datum>> {
     fn matches_selector(&self, selector: &ArtifactSelector<Constrained>) -> bool {
-        match self.key.tag() {
+        let key_matches = match self.key.tag() {
             ENTITY_KEY_TAG => match_selector_and_key_view(selector, EntityKey(&self.key)),
             ATTRIBUTE_KEY_TAG => match_selector_and_key_view(selector, AttributeKey(&self.key)),
             VALUE_KEY_TAG => match_selector_and_key_view(selector, ValueKey(&self.key)),
             _ => false,
+        };
+        if !key_matches {
+            return false;
         }
+
+        // An entity prefix longer than the raw head outruns what the
+        // key bytes can prove: confirm against the stored URI. A
+        // `Removed` entry has no datum to check; it is discarded by
+        // the scan regardless of what we answer here.
+        if let Some(prefix) = selector.entity_prefix()
+            && prefix.len() > ENTITY_RAW_HEAD
+            && let State::Added(datum) = &self.value
+            && !datum.entity.starts_with(prefix)
+        {
+            return false;
+        }
+
+        true
     }
 }

--- a/rust/dialog-artifacts/src/artifacts/selector.rs
+++ b/rust/dialog-artifacts/src/artifacts/selector.rs
@@ -47,6 +47,18 @@ where
     value: Option<Value>,
 
     value_reference: Option<Blake3Hash>,
+
+    /// Prefix bound on the entity URI: selected [`Artifact`]s'
+    /// entities must have URIs beginning with this string. The
+    /// entity key stores the first 32 URI bytes raw (the rest is
+    /// hashed), so scans range over the raw head and re-check
+    /// longer prefixes against the stored datum.
+    entity_prefix: Option<String>,
+    /// Prefix bound on the attribute name: selected [`Artifact`]s'
+    /// attributes must have names beginning with this string. The
+    /// attribute key stores the full (64-byte-capped) name raw, so
+    /// this bound is an exact key range.
+    attribute_prefix: Option<String>,
     state_type: PhantomData<State>,
 }
 
@@ -66,6 +78,8 @@ impl ArtifactSelector<Unconstrained> {
             attribute: None,
             value: None,
             value_reference: None,
+            entity_prefix: None,
+            attribute_prefix: None,
             state_type: PhantomData,
         }
     }
@@ -95,6 +109,16 @@ where
         self.value_reference.as_ref()
     }
 
+    /// The prefix bound on entity URIs, if any
+    pub fn entity_prefix(&self) -> Option<&str> {
+        self.entity_prefix.as_deref()
+    }
+
+    /// The prefix bound on attribute names, if any
+    pub fn attribute_prefix(&self) -> Option<&str> {
+        self.attribute_prefix.as_deref()
+    }
+
     /// Set the [`Attribute`] field (the predicate) of the [`ArtifactSelector`]
     pub fn the(self, attribute: Attribute) -> ArtifactSelector<Constrained> {
         ArtifactSelector::<Constrained> {
@@ -102,6 +126,8 @@ where
             entity: self.entity,
             value_reference: self.value_reference,
             value: self.value,
+            entity_prefix: self.entity_prefix,
+            attribute_prefix: self.attribute_prefix,
             state_type: PhantomData,
         }
     }
@@ -113,6 +139,8 @@ where
             entity: Some(entity),
             value_reference: self.value_reference,
             value: self.value,
+            entity_prefix: self.entity_prefix,
+            attribute_prefix: self.attribute_prefix,
             state_type: PhantomData,
         }
     }
@@ -124,6 +152,40 @@ where
             entity: self.entity,
             value_reference: Some(value.to_reference()),
             value: Some(value),
+            entity_prefix: self.entity_prefix,
+            attribute_prefix: self.attribute_prefix,
+            state_type: PhantomData,
+        }
+    }
+
+    /// Constrain selected [`Artifact`]s to attributes whose name begins
+    /// with `prefix`. A prefix is a constraint, so the resulting
+    /// selector is [`Constrained`]; an exact attribute set via
+    /// [`ArtifactSelector::the`] takes precedence during scans.
+    pub fn the_starting_with(self, prefix: impl Into<String>) -> ArtifactSelector<Constrained> {
+        ArtifactSelector::<Constrained> {
+            attribute: self.attribute,
+            entity: self.entity,
+            value_reference: self.value_reference,
+            value: self.value,
+            entity_prefix: self.entity_prefix,
+            attribute_prefix: Some(prefix.into()),
+            state_type: PhantomData,
+        }
+    }
+
+    /// Constrain selected [`Artifact`]s to entities whose URI begins
+    /// with `prefix`. A prefix is a constraint, so the resulting
+    /// selector is [`Constrained`]; an exact entity set via
+    /// [`ArtifactSelector::of`] takes precedence during scans.
+    pub fn of_starting_with(self, prefix: impl Into<String>) -> ArtifactSelector<Constrained> {
+        ArtifactSelector::<Constrained> {
+            attribute: self.attribute,
+            entity: self.entity,
+            value_reference: self.value_reference,
+            value: self.value,
+            entity_prefix: Some(prefix.into()),
+            attribute_prefix: self.attribute_prefix,
             state_type: PhantomData,
         }
     }

--- a/rust/dialog-artifacts/src/key.rs
+++ b/rust/dialog-artifacts/src/key.rs
@@ -58,6 +58,12 @@ use crate::{ArtifactSelector, DialogArtifactsError, ValueDataType, selector::Con
 pub(crate) const TAG_LENGTH: usize = 1;
 /// Length of the entity field in key bytes
 pub(crate) const ENTITY_LENGTH: usize = 64;
+/// Number of leading entity-URI bytes stored *raw* (and therefore
+/// order-preserving) in the entity field; the remainder of the
+/// field is a hash of the URI's tail (see [`Uri::key_bytes`](crate::Uri::key_bytes)).
+/// Prefix scans can range over at most this many bytes of the URI;
+/// longer prefixes re-check against the stored datum.
+pub(crate) const ENTITY_RAW_HEAD: usize = 32;
 /// Length of the attribute field in key bytes
 pub(crate) const ATTRIBUTE_LENGTH: usize = 64;
 /// Length of the value data type field in key bytes

--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -33,7 +33,8 @@ use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
 use futures_util::{Stream, StreamExt};
 
 use crate::{
-    Artifact, ArtifactSelector, AttributeKey, Datum, DialogArtifactsError, EntityKey, FromKey,
+    ATTRIBUTE_LENGTH, Artifact, ArtifactSelector, AttributeKey, AttributeKeyPart, Datum,
+    DialogArtifactsError, ENTITY_LENGTH, ENTITY_RAW_HEAD, EntityKey, EntityKeyPart, FromKey,
     Instruction, Key, KeyBytes, KeyView, KeyViewConstruct, KeyViewMut, MatchCandidate, State,
     ValueKey, selector::Constrained,
 };
@@ -71,6 +72,53 @@ where
     async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
         self.0.get(key.as_bytes()).await
     }
+}
+
+/// A fixed-width key segment bounding a string prefix: the prefix's
+/// raw bytes (capped at `head` — the order-preserving span of the
+/// segment) followed by `fill`. With `fill = 0x00` this is the
+/// smallest segment any matching value can have, with `fill = 0xFF`
+/// the largest, so the pair brackets the prefix's key range.
+fn prefix_segment<const N: usize>(prefix: &str, head: usize, fill: u8) -> [u8; N] {
+    let mut segment = [fill; N];
+    let raw = prefix.as_bytes();
+    let take = raw.len().min(head).min(N);
+    segment[..take].copy_from_slice(&raw[..take]);
+    segment
+}
+
+/// Tighten a scan's `(start, end)` key pair with the selector's
+/// prefix bounds. A prefix on a field that also has an exact
+/// constraint is skipped — the exact value is already in the keys
+/// and is strictly tighter. Applying a prefix to a non-leading key
+/// dimension is sound (the range stays a superset of the matches;
+/// [`MatchCandidate::matches_selector`] filters the rest) and
+/// tightens the range whenever every more-significant dimension is
+/// exact.
+fn apply_prefix_bounds<K: KeyViewMut>(
+    start: K,
+    end: K,
+    selector: &ArtifactSelector<Constrained>,
+) -> (K, K) {
+    let mut start = start;
+    let mut end = end;
+    if selector.attribute().is_none()
+        && let Some(prefix) = selector.attribute_prefix()
+    {
+        let lo = prefix_segment::<ATTRIBUTE_LENGTH>(prefix, ATTRIBUTE_LENGTH, u8::MIN);
+        let hi = prefix_segment::<ATTRIBUTE_LENGTH>(prefix, ATTRIBUTE_LENGTH, u8::MAX);
+        start = start.set_attribute(AttributeKeyPart(&lo));
+        end = end.set_attribute(AttributeKeyPart(&hi));
+    }
+    if selector.entity().is_none()
+        && let Some(prefix) = selector.entity_prefix()
+    {
+        let lo = prefix_segment::<ENTITY_LENGTH>(prefix, ENTITY_RAW_HEAD, u8::MIN);
+        let hi = prefix_segment::<ENTITY_LENGTH>(prefix, ENTITY_RAW_HEAD, u8::MAX);
+        start = start.set_entity(EntityKeyPart(&lo));
+        end = end.set_entity(EntityKeyPart(&hi));
+    }
+    (start, end)
 }
 
 /// Shared mutation + scan operations on an [`ArtifactTree`].
@@ -289,42 +337,42 @@ impl ArtifactTreeExt for ArtifactTree {
         let tree = self;
         let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
         try_stream! {
-            // Inclusive ranges: when every key component is constrained by
-            // the selector, the lower and upper bounds are the same exact
-            // key and the scan must still select it.
-            let range = if selector.entity().is_some() {
-                KeyBytes::from(
-                    <EntityKey<Key> as KeyViewConstruct>::min()
-                        .apply_selector(&selector)
-                        .into_key(),
-                )
-                    ..=KeyBytes::from(
-                        <EntityKey<Key> as KeyViewConstruct>::max()
-                            .apply_selector(&selector)
-                            .into_key(),
-                    )
+            // Index choice: exact fields take priority (entity /
+            // value / attribute, as before); prefix bounds pick the
+            // index whose leading dimension they constrain when no
+            // exact field does. Every branch additionally tightens
+            // its key range with whatever prefix bounds the selector
+            // carries (sound on any dimension, tight on leading ones)
+            // via `apply_prefix_bounds`, and `matches_selector`
+            // re-checks per entry. The lower/upper bounds collapse to
+            // the same exact key when every component is constrained,
+            // and the inclusive range still selects it.
+            let range = if selector.entity().is_some()
+                || (selector.entity_prefix().is_some()
+                    && selector.value().is_none()
+                    && selector.attribute().is_none()
+                    && selector.attribute_prefix().is_none())
+            {
+                let (start, end) = apply_prefix_bounds(
+                    <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(&selector),
+                    <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(&selector),
+                    &selector,
+                );
+                KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
             } else if selector.value().is_some() {
-                KeyBytes::from(
-                    <ValueKey<Key> as KeyViewConstruct>::min()
-                        .apply_selector(&selector)
-                        .into_key(),
-                )
-                    ..=KeyBytes::from(
-                        <ValueKey<Key> as KeyViewConstruct>::max()
-                            .apply_selector(&selector)
-                            .into_key(),
-                    )
-            } else if selector.attribute().is_some() {
-                KeyBytes::from(
-                    <AttributeKey<Key> as KeyViewConstruct>::min()
-                        .apply_selector(&selector)
-                        .into_key(),
-                )
-                    ..=KeyBytes::from(
-                        <AttributeKey<Key> as KeyViewConstruct>::max()
-                            .apply_selector(&selector)
-                            .into_key(),
-                    )
+                let (start, end) = apply_prefix_bounds(
+                    <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(&selector),
+                    <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(&selector),
+                    &selector,
+                );
+                KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
+            } else if selector.attribute().is_some() || selector.attribute_prefix().is_some() {
+                let (start, end) = apply_prefix_bounds(
+                    <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(&selector),
+                    <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(&selector),
+                    &selector,
+                );
+                KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
             } else {
                 // `Constrained` guarantees at least one field is set.
                 unreachable!("ArtifactSelector will always have at least one field specified")

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -92,6 +92,24 @@ impl AttributeQueryAll {
         Self { is, ..self }
     }
 
+    /// Return a copy with the `the`/`of` variable terms carrying
+    /// the given kinds. The planner stamps what rule-level
+    /// inference proved about the attribute and entity variables —
+    /// in particular prefix refinements, which the selector
+    /// conversion turns into index-range bounds. Constants and
+    /// `None` kinds are left unchanged.
+    pub(crate) fn with_subject_kinds(self, the: Option<Kind>, of: Option<Kind>) -> Self {
+        let the = match the {
+            Some(kind) => self.the.with_kind(kind),
+            None => self.the,
+        };
+        let of = match of {
+            Some(kind) => self.of.with_kind(kind),
+            None => self.of,
+        };
+        Self { the, of, ..self }
+    }
+
     /// Get the 'cause' term.
     pub fn cause(&self) -> &Term<Cause> {
         &self.cause
@@ -329,14 +347,27 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
     fn try_from(from: &AttributeQueryAll) -> Result<Self, Self::Error> {
         let mut selector: Option<ArtifactSelector<Constrained>> = None;
 
-        if let Term::Constant(the) = &from.the {
-            let relation = ArtifactsAttribute::try_from(the.clone()).map_err(|_| {
-                EvaluationError::Store("Could not convert value to Attribute".to_string())
-            })?;
-            selector = Some(match selector {
-                None => ArtifactSelector::new().the(relation),
-                Some(s) => s.the(relation),
-            });
+        match &from.the {
+            Term::Constant(the) => {
+                let relation = ArtifactsAttribute::try_from(the.clone()).map_err(|_| {
+                    EvaluationError::Store("Could not convert value to Attribute".to_string())
+                })?;
+                selector = Some(match selector {
+                    None => ArtifactSelector::new().the(relation),
+                    Some(s) => s.the(relation),
+                });
+            }
+            Term::Variable { .. } => {
+                // A prefix refinement the planner stamped onto the
+                // attribute variable becomes an AEV range bound.
+                if let Some(refinement) = from.the.kind().as_ref().and_then(Kind::refinement) {
+                    let prefix = refinement.prefix.clone();
+                    selector = Some(match selector {
+                        None => ArtifactSelector::new().the_starting_with(prefix),
+                        Some(s) => s.the_starting_with(prefix),
+                    });
+                }
+            }
         }
 
         match &from.of {
@@ -349,7 +380,17 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
                     Some(s) => s.of(entity),
                 });
             }
-            Term::Variable { .. } => {}
+            Term::Variable { .. } => {
+                // A prefix refinement on the entity variable becomes
+                // an EAV range bound over the URI's raw head.
+                if let Some(refinement) = from.of.kind().as_ref().and_then(Kind::refinement) {
+                    let prefix = refinement.prefix.clone();
+                    selector = Some(match selector {
+                        None => ArtifactSelector::new().of_starting_with(prefix),
+                        Some(s) => s.of_starting_with(prefix),
+                    });
+                }
+            }
         }
 
         match &from.is {
@@ -390,6 +431,48 @@ mod tests {
     use crate::source::test::TestEnv;
     use crate::the;
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+
+    /// A prefix refinement stamped onto a variable term becomes a
+    /// range bound on the selector — the end of the
+    /// predicate → inference → planner → scan pipeline.
+    #[dialog_common::test]
+    fn it_pushes_prefix_refinements_into_the_selector() -> anyhow::Result<()> {
+        let entity_kind = Kind::from(Type::Entity)
+            .with_prefix("did:key:")
+            .expect("entity is textual");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("e").with_kind(entity_kind),
+            Term::var("v"),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert_eq!(selector.entity_prefix(), Some("did:key:"));
+
+        let attribute_kind = Kind::from(Type::Symbol)
+            .with_prefix("person/")
+            .expect("symbol is textual");
+        let query = AttributeQueryAll::new(
+            Term::<The>::var("a").with_kind(attribute_kind),
+            Term::<Entity>::var("e"),
+            Term::var("v"),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert_eq!(selector.attribute_prefix(), Some("person/"));
+
+        // An unrefined variable contributes nothing, as before.
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("e"),
+            Term::var("v"),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert_eq!(selector.entity_prefix(), None);
+        assert_eq!(selector.attribute_prefix(), None);
+        Ok(())
+    }
 
     #[dialog_common::test]
     async fn it_scans_with_all_variables() -> anyhow::Result<()> {

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -96,6 +96,19 @@ impl DynamicAttributeQuery {
         }
     }
 
+    /// Return a copy with the `the`/`of` variable terms carrying
+    /// the given kinds. See [`AttributeQueryAll::with_subject_kinds`].
+    pub(crate) fn with_subject_kinds(self, the: Option<Kind>, of: Option<Kind>) -> Self {
+        match self {
+            DynamicAttributeQuery::All(q) => {
+                DynamicAttributeQuery::All(q.with_subject_kinds(the, of))
+            }
+            DynamicAttributeQuery::Only(q) => {
+                DynamicAttributeQuery::Only(q.with_subject_kinds(the, of))
+            }
+        }
+    }
+
     /// Get the 'cause' term.
     pub fn cause(&self) -> &Term<Cause> {
         match self {

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -135,6 +135,13 @@ impl AttributeQueryOnly {
         }
     }
 
+    /// See [`AttributeQueryAll::with_subject_kinds`].
+    pub(crate) fn with_subject_kinds(self, the: Option<Kind>, of: Option<Kind>) -> Self {
+        Self {
+            query: self.query.with_subject_kinds(the, of),
+        }
+    }
+
     /// Get the 'cause' term.
     pub fn cause(&self) -> &Term<Cause> {
         self.query.cause()

--- a/rust/dialog-query/src/constraint.rs
+++ b/rust/dialog-query/src/constraint.rs
@@ -6,11 +6,13 @@
 
 pub mod coalesce;
 pub mod equality;
+pub mod type_of;
 
 use std::fmt;
 
 pub use coalesce::Coalesce;
 pub use equality::Equality;
+pub use type_of::TypeOf;
 
 use crate::selection::Selection;
 use crate::{Environment, Parameters, Schema};
@@ -32,6 +34,10 @@ pub enum Constraint {
     /// else from `fallback`. Set-widening unwrap.
     #[serde(rename = "coalesce")]
     Coalesce(Coalesce),
+    /// Type predicate — the subject's value inhabits a kind
+    /// (`?x.text()`, `?x.number()`). Occurrence typing as a premise.
+    #[serde(rename = "type")]
+    TypeOf(TypeOf),
 }
 
 impl Constraint {
@@ -40,6 +46,7 @@ impl Constraint {
         match self {
             Constraint::Equality(c) => c.schema(),
             Constraint::Coalesce(c) => c.schema(),
+            Constraint::TypeOf(c) => c.schema(),
         }
     }
 
@@ -48,6 +55,7 @@ impl Constraint {
         match self {
             Constraint::Equality(c) => c.estimate(env),
             Constraint::Coalesce(c) => c.estimate(env),
+            Constraint::TypeOf(c) => c.estimate(env),
         }
     }
 
@@ -56,6 +64,7 @@ impl Constraint {
         match self {
             Constraint::Equality(c) => c.parameters(),
             Constraint::Coalesce(c) => c.parameters(),
+            Constraint::TypeOf(c) => c.parameters(),
         }
     }
 
@@ -65,6 +74,7 @@ impl Constraint {
         match self {
             Constraint::Equality(c) => c.evaluate(selection),
             Constraint::Coalesce(c) => c.evaluate(selection),
+            Constraint::TypeOf(c) => c.evaluate(selection),
         }
     }
 }
@@ -74,6 +84,7 @@ impl Display for Constraint {
         match self {
             Constraint::Equality(c) => Display::fmt(c, f),
             Constraint::Coalesce(c) => Display::fmt(c, f),
+            Constraint::TypeOf(c) => Display::fmt(c, f),
         }
     }
 }

--- a/rust/dialog-query/src/constraint.rs
+++ b/rust/dialog-query/src/constraint.rs
@@ -5,13 +5,17 @@
 //! operate on variable bindings to filter, infer, or validate values.
 
 pub mod coalesce;
+pub mod compare;
 pub mod equality;
+pub mod starts_with;
 pub mod type_of;
 
 use std::fmt;
 
 pub use coalesce::Coalesce;
+pub use compare::{AtLeast, AtMost, GreaterThan, LessThan};
 pub use equality::Equality;
+pub use starts_with::StartsWith;
 pub use type_of::TypeOf;
 
 use crate::selection::Selection;
@@ -38,6 +42,24 @@ pub enum Constraint {
     /// (`?x.text()`, `?x.number()`). Occurrence typing as a premise.
     #[serde(rename = "type")]
     TypeOf(TypeOf),
+    /// Prefix predicate — the subject's lexical form begins with a
+    /// string prefix, over the TEXTUAL kinds.
+    #[serde(rename = "starts-with")]
+    StartsWith(StartsWith),
+    /// Range predicate — strictly less than, over the NUMERIC kinds.
+    #[serde(rename = "<")]
+    LessThan(LessThan),
+    /// Range predicate — less than or equal, over the NUMERIC kinds.
+    #[serde(rename = "<=")]
+    AtMost(AtMost),
+    /// Range predicate — strictly greater than, over the NUMERIC
+    /// kinds.
+    #[serde(rename = ">")]
+    GreaterThan(GreaterThan),
+    /// Range predicate — greater than or equal, over the NUMERIC
+    /// kinds.
+    #[serde(rename = ">=")]
+    AtLeast(AtLeast),
 }
 
 impl Constraint {
@@ -47,6 +69,11 @@ impl Constraint {
             Constraint::Equality(c) => c.schema(),
             Constraint::Coalesce(c) => c.schema(),
             Constraint::TypeOf(c) => c.schema(),
+            Constraint::StartsWith(c) => c.schema(),
+            Constraint::LessThan(c) => c.schema(),
+            Constraint::AtMost(c) => c.schema(),
+            Constraint::GreaterThan(c) => c.schema(),
+            Constraint::AtLeast(c) => c.schema(),
         }
     }
 
@@ -56,6 +83,11 @@ impl Constraint {
             Constraint::Equality(c) => c.estimate(env),
             Constraint::Coalesce(c) => c.estimate(env),
             Constraint::TypeOf(c) => c.estimate(env),
+            Constraint::StartsWith(c) => c.estimate(env),
+            Constraint::LessThan(c) => c.estimate(env),
+            Constraint::AtMost(c) => c.estimate(env),
+            Constraint::GreaterThan(c) => c.estimate(env),
+            Constraint::AtLeast(c) => c.estimate(env),
         }
     }
 
@@ -65,6 +97,11 @@ impl Constraint {
             Constraint::Equality(c) => c.parameters(),
             Constraint::Coalesce(c) => c.parameters(),
             Constraint::TypeOf(c) => c.parameters(),
+            Constraint::StartsWith(c) => c.parameters(),
+            Constraint::LessThan(c) => c.parameters(),
+            Constraint::AtMost(c) => c.parameters(),
+            Constraint::GreaterThan(c) => c.parameters(),
+            Constraint::AtLeast(c) => c.parameters(),
         }
     }
 
@@ -75,6 +112,11 @@ impl Constraint {
             Constraint::Equality(c) => c.evaluate(selection),
             Constraint::Coalesce(c) => c.evaluate(selection),
             Constraint::TypeOf(c) => c.evaluate(selection),
+            Constraint::StartsWith(c) => c.evaluate(selection),
+            Constraint::LessThan(c) => c.evaluate(selection),
+            Constraint::AtMost(c) => c.evaluate(selection),
+            Constraint::GreaterThan(c) => c.evaluate(selection),
+            Constraint::AtLeast(c) => c.evaluate(selection),
         }
     }
 }
@@ -85,6 +127,11 @@ impl Display for Constraint {
             Constraint::Equality(c) => Display::fmt(c, f),
             Constraint::Coalesce(c) => Display::fmt(c, f),
             Constraint::TypeOf(c) => Display::fmt(c, f),
+            Constraint::StartsWith(c) => Display::fmt(c, f),
+            Constraint::LessThan(c) => Display::fmt(c, f),
+            Constraint::AtMost(c) => Display::fmt(c, f),
+            Constraint::GreaterThan(c) => Display::fmt(c, f),
+            Constraint::AtLeast(c) => Display::fmt(c, f),
         }
     }
 }

--- a/rust/dialog-query/src/constraint/compare.rs
+++ b/rust/dialog-query/src/constraint/compare.rs
@@ -1,0 +1,358 @@
+//! Numeric range predicates: `<`, `<=`, `>`, `>=` as premises.
+//!
+//! Four constraints over the NUMERIC kinds, sharing one comparison
+//! core. Like every scalar premise they *filter*: a row whose sides
+//! cannot be ordered — a non-numeric value, a mixed-type pair, a
+//! NaN — is a non-match, never an error and never a coercion. The
+//! same strict no-promotion semantics as formula arithmetic
+//! (`notes/formula-schemes.md`), with the same release valve: a
+//! *constant* side is a polymorphic literal that adapts losslessly
+//! to the data's type per row (`1` compares against floats as
+//! `1.0`; `1.5` against integer data is a non-match because no
+//! integer is `1.5`). Data is never adapted.
+//!
+//! Inference: both slots carry the NUMERIC bound, narrowing the
+//! variables on use. The slots are not yet *linked* (a comparison
+//! does not force its sides to one instantiation the way a formula
+//! scheme does); the planned per-atom interval refinements will
+//! ride these same predicates into scan-range pushdown.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::fmt::Display;
+use std::ops::Not;
+
+use crate::artifact::Value;
+use crate::error::EvaluationError;
+use crate::formula::number::Numeric;
+use crate::selection::Selection;
+use crate::type_system::Primitive;
+use crate::type_system::Type as Kind;
+use crate::types::Any;
+use crate::{Binding, Cardinality, Environment, Field, Parameters, Requirement, Schema, Term};
+use crate::{Constraint, Negation, Premise, Proposition, try_stream};
+
+/// Cost for evaluating a comparison (single row lookup + ordering).
+const COMPARE_COST: usize = 1;
+
+/// Order two values for comparison, adapting literal sides.
+///
+/// `None` is a non-match: a non-numeric value, a NaN, or a
+/// mixed-type pair neither side of which is a literal that adapts
+/// losslessly to the other's type.
+fn ordering(
+    of: &Value,
+    of_is_literal: bool,
+    with: &Value,
+    with_is_literal: bool,
+) -> Option<Ordering> {
+    let of = Numeric::try_from(of.clone()).ok()?;
+    let with = Numeric::try_from(with.clone()).ok()?;
+    if of.value_type() == with.value_type() {
+        return of.compare(with);
+    }
+    if with_is_literal && let Some(adapted) = with.instantiate(of.value_type()) {
+        return of.compare(adapted);
+    }
+    if of_is_literal && let Some(adapted) = of.instantiate(with.value_type()) {
+        return adapted.compare(with);
+    }
+    None
+}
+
+macro_rules! define_comparison {
+    (
+        $(#[$doc:meta])*
+        $name:ident, $symbol:literal, [$($accepts:pat),+], $sugar:ident
+    ) => {
+        $(#[$doc])*
+        ///
+        /// Constructed via the [`Term`] sugar of the same name.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        pub struct $name {
+            /// The left side of the comparison.
+            pub of: Term<Any>,
+            /// The right side of the comparison.
+            pub with: Term<Any>,
+        }
+
+        impl $name {
+            /// Create a comparison over the given sides.
+            pub fn new(of: Term<Any>, with: Term<Any>) -> Self {
+                Self { of, with }
+            }
+
+            /// Schema: both sides are *hard* requirements (the
+            /// predicate consumes bound values; the planner orders
+            /// it after the premises binding them), bounded NUMERIC.
+            pub fn schema(&self) -> Schema {
+                let mut schema = Schema::new();
+                schema.insert(
+                    "of".to_string(),
+                    Field {
+                        description: "Left side of the comparison".to_string(),
+                        content_type: Some(Kind::primitive_set(Primitive::NUMERIC)),
+                        requirement: Requirement::required(),
+                        cardinality: Cardinality::One,
+                    },
+                );
+                schema.insert(
+                    "with".to_string(),
+                    Field {
+                        description: "Right side of the comparison".to_string(),
+                        content_type: Some(Kind::primitive_set(Primitive::NUMERIC)),
+                        requirement: Requirement::required(),
+                        cardinality: Cardinality::One,
+                    },
+                );
+                schema
+            }
+
+            /// Estimate cost. Constant — a row-local ordering.
+            pub fn estimate(&self, _env: &Environment) -> Option<usize> {
+                Some(COMPARE_COST)
+            }
+
+            /// Returns the named parameters for this constraint.
+            pub fn parameters(&self) -> Parameters {
+                let mut params = Parameters::new();
+                params.insert("of".to_string(), self.of.clone());
+                params.insert("with".to_string(), self.with.clone());
+                params
+            }
+
+            /// Evaluate: filter rows whose sides do not stand in the
+            /// relation — or cannot be ordered at all (non-numeric,
+            /// mixed types with no adaptable literal, NaN). An
+            /// `Absent` side matches nothing; an unbound side is a
+            /// planner-contract violation, surfaced as an error.
+            pub fn evaluate<M: Selection>(self, selection: M) -> impl Selection {
+                let of = self.of;
+                let with = self.with;
+                let of_is_literal = of.is_constant();
+                let with_is_literal = with.is_constant();
+                try_stream! {
+                    for await candidate in selection {
+                        let base = candidate?;
+                        match (base.lookup(&of), base.lookup(&with)) {
+                            (Ok(Binding::Present(left)), Ok(Binding::Present(right))) => {
+                                if let Some(order) =
+                                    ordering(&left, of_is_literal, &right, with_is_literal)
+                                    && matches!(order, $($accepts)|+)
+                                {
+                                    yield base;
+                                }
+                            }
+                            (Ok(_), Ok(_)) => {}
+                            (Err(_), _) => {
+                                Err(EvaluationError::UnboundVariable {
+                                    variable_name: of.name().unwrap_or("of").to_string(),
+                                })?;
+                            }
+                            (_, Err(_)) => {
+                                Err(EvaluationError::UnboundVariable {
+                                    variable_name: with.name().unwrap_or("with").to_string(),
+                                })?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{} {} {}", self.of, $symbol, self.with)
+            }
+        }
+
+        impl From<$name> for Constraint {
+            fn from(predicate: $name) -> Self {
+                Constraint::$name(predicate)
+            }
+        }
+
+        impl Not for $name {
+            type Output = Premise;
+
+            fn not(self) -> Self::Output {
+                Premise::Unless(Negation::not(Proposition::Constraint(
+                    Constraint::$name(self),
+                )))
+            }
+        }
+
+        impl Term<Any> {
+            $(#[$doc])*
+            pub fn $sugar(self, with: impl Into<Term<Any>>) -> Premise {
+                Premise::Assert(Proposition::Constraint(Constraint::$name(
+                    $name::new(self, with.into()),
+                )))
+            }
+        }
+    };
+}
+
+define_comparison!(
+    /// Range predicate: `of` is strictly less than `with`.
+    LessThan, "<", [Ordering::Less], less_than
+);
+
+define_comparison!(
+    /// Range predicate: `of` is less than or equal to `with`.
+    AtMost, "<=", [Ordering::Less, Ordering::Equal], at_most
+);
+
+define_comparison!(
+    /// Range predicate: `of` is strictly greater than `with`.
+    GreaterThan, ">", [Ordering::Greater], greater_than
+);
+
+define_comparison!(
+    /// Range predicate: `of` is greater than or equal to `with`.
+    AtLeast, ">=", [Ordering::Greater, Ordering::Equal], at_least
+);
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::rule::TypeEnv;
+    use crate::selection::Match;
+    use crate::types::Scalar;
+    use futures_util::TryStreamExt;
+
+    async fn count(premise: LessThan, x: Value) -> Result<usize, EvaluationError> {
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), x)?;
+        let results: Vec<Match> = premise.evaluate(row.seed()).try_collect().await?;
+        Ok(results.len())
+    }
+
+    fn below(limit: impl Scalar) -> LessThan {
+        LessThan::new(Term::var("x"), Term::constant(limit))
+    }
+
+    /// Same-type sides order by value; each relation accepts its
+    /// orderings.
+    #[dialog_common::test]
+    async fn it_orders_within_one_type() -> Result<(), EvaluationError> {
+        assert_eq!(count(below(5u64), Value::UnsignedInt(3)).await?, 1);
+        assert_eq!(count(below(5u64), Value::UnsignedInt(5)).await?, 0);
+        assert_eq!(count(below(5u64), Value::UnsignedInt(7)).await?, 0);
+
+        let at_most = AtMost::new(Term::var("x"), Term::constant(5u64));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::UnsignedInt(5))?;
+        let results: Vec<Match> = at_most.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 1, "<= accepts equality");
+
+        let at_least = AtLeast::new(Term::var("x"), Term::constant(-2i64));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::SignedInt(-1))?;
+        let results: Vec<Match> = at_least.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 1, "signed comparison orders negatives");
+
+        let greater = GreaterThan::new(Term::var("x"), Term::constant(0.5f64));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::Float(1.5))?;
+        let results: Vec<Match> = greater.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 1, "float comparison orders");
+        Ok(())
+    }
+
+    /// A literal side adapts losslessly to the data's type; data is
+    /// never adapted, so an unadaptable literal is a non-match even
+    /// when the mathematical ordering is defined.
+    #[dialog_common::test]
+    async fn it_adapts_literals_losslessly() -> Result<(), EvaluationError> {
+        assert_eq!(
+            count(below(1u64), Value::Float(0.5)).await?,
+            1,
+            "integer literal compares against float data as 1.0"
+        );
+        assert_eq!(
+            count(below(1.5f64), Value::UnsignedInt(1)).await?,
+            0,
+            "no integer is 1.5: the literal cannot adapt, non-match"
+        );
+        assert_eq!(
+            count(below(2u64), Value::SignedInt(-3)).await?,
+            1,
+            "unsigned literal adapts to signed data"
+        );
+        Ok(())
+    }
+
+    /// Two data sides of different numeric types are a non-match —
+    /// strict no-promotion, like formula arithmetic.
+    #[dialog_common::test]
+    async fn it_filters_mixed_data() -> Result<(), EvaluationError> {
+        let premise = LessThan::new(Term::var("x"), Term::var("y"));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::UnsignedInt(1))?;
+        row.bind(&Term::var("y"), Value::Float(2.0))?;
+        let results: Vec<Match> = premise.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0, "neither side is a literal: no adaptation");
+        Ok(())
+    }
+
+    /// Values outside NUMERIC, NaN, and Absent are non-matches.
+    #[dialog_common::test]
+    async fn it_filters_unorderable_rows() -> Result<(), EvaluationError> {
+        assert_eq!(count(below(5u64), Value::String("3".into())).await?, 0);
+        assert_eq!(count(below(f64::MAX), Value::Float(f64::NAN)).await?, 0);
+
+        let premise = AtLeast::new(Term::var("x"), Term::constant(f64::NAN));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::Float(1.0))?;
+        let results: Vec<Match> = premise.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0, "NaN stands in no relation");
+
+        let premise = below(5u64);
+        let mut row = Match::new();
+        row.bind_absent(&Term::var("x"))?;
+        let results: Vec<Match> = premise.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0, "Absent matches nothing scalar");
+        Ok(())
+    }
+
+    /// An unbound side is a planner-contract violation.
+    #[dialog_common::test]
+    async fn it_errors_on_unbound_sides() {
+        let premise = below(5u64);
+        let results: Result<Vec<Match>, _> =
+            premise.evaluate(Match::new().seed()).try_collect().await;
+        assert!(results.is_err(), "unbound left side must error");
+    }
+
+    /// Comparisons narrow both sides to NUMERIC rule-wide.
+    #[dialog_common::test]
+    fn it_bounds_both_sides_numeric() -> anyhow::Result<()> {
+        let premises = vec![Term::<Any>::var("x").less_than(Term::<Any>::var("y"))];
+        let env = TypeEnv::infer(&premises)?;
+        for var in ["x", "y"] {
+            assert_eq!(
+                env.get(var).expect("inferred").primitive_part(),
+                Primitive::NUMERIC,
+                "{var} is bounded by the comparison"
+            );
+        }
+        Ok(())
+    }
+
+    /// A side already known non-numeric is a compile-time conflict.
+    #[dialog_common::test]
+    fn it_rejects_known_non_numeric_sides() {
+        let premises = vec![
+            Term::<Any>::var("x").text(),
+            Term::<Any>::var("x").less_than(Term::constant(5u64)),
+        ];
+        assert!(
+            TypeEnv::infer(&premises).is_err(),
+            "String and NUMERIC have an empty meet"
+        );
+    }
+}

--- a/rust/dialog-query/src/constraint/compare.rs
+++ b/rust/dialog-query/src/constraint/compare.rs
@@ -91,7 +91,7 @@ macro_rules! define_comparison {
                     "of".to_string(),
                     Field {
                         description: "Left side of the comparison".to_string(),
-                        content_type: Some(Kind::primitive_set(Primitive::NUMERIC)),
+                        content_type: Some(Kind::from(Primitive::NUMERIC)),
                         requirement: Requirement::required(),
                         cardinality: Cardinality::One,
                     },
@@ -100,7 +100,7 @@ macro_rules! define_comparison {
                     "with".to_string(),
                     Field {
                         description: "Right side of the comparison".to_string(),
-                        content_type: Some(Kind::primitive_set(Primitive::NUMERIC)),
+                        content_type: Some(Kind::from(Primitive::NUMERIC)),
                         requirement: Requirement::required(),
                         cardinality: Cardinality::One,
                     },

--- a/rust/dialog-query/src/constraint/starts_with.rs
+++ b/rust/dialog-query/src/constraint/starts_with.rs
@@ -1,0 +1,469 @@
+//! Prefix predicate over the textual kinds.
+//!
+//! `StartsWith` asserts that the lexical form of a term's value
+//! begins with a string prefix. One predicate ranges over every
+//! kind with a lexical form — strings, symbols, entities — via the
+//! TEXTUAL bound, rather than a variant per kind. Like
+//! [`TypeOf`](super::TypeOf), one declaration has two effects:
+//!
+//! - **Inference**: the subject slot's content type is the set of
+//!   TEXTUAL members the prefix could actually begin. Each member
+//!   has a lexical grammar (symbols are length-bounded
+//!   `namespace/predicate` names, entities are serialized URLs), so
+//!   a constant prefix that no value of some member could start
+//!   with drops that member from the subject's inferred kind: a
+//!   space drops Entity, a 65-byte prefix drops Symbol. Only
+//!   *certainly impossible* members are dropped — String admits any
+//!   prefix, so the contributed kind is never empty.
+//! - **Evaluation**: a row whose value's lexical form does not begin
+//!   with the prefix is a non-match — filtered, never an error —
+//!   and so is a value with no lexical form at all.
+//!
+//! The refined kind plus the prefix is exactly the per-member index
+//! range bound the planned scan pushdown consumes.
+
+use std::fmt;
+use std::fmt::Display;
+use std::ops::Not;
+
+use crate::artifact::Type as ValueType;
+use crate::artifact::Value;
+use crate::error::EvaluationError;
+use crate::selection::Selection;
+use crate::type_system::Primitive;
+use crate::type_system::Type as Kind;
+use crate::types::Any;
+use crate::{Binding, Cardinality, Environment, Field, Parameters, Requirement, Schema, Term};
+use crate::{Constraint, Negation, Premise, Proposition, try_stream};
+
+/// Cost for evaluating a prefix predicate (single row lookup + string
+/// comparison).
+const STARTS_WITH_COST: usize = 1;
+
+/// The longest lexical form a symbol can have, in bytes. Mirrors
+/// `dialog_artifacts::ATTRIBUTE_LENGTH`, which is crate-private;
+/// pinned against the real validator by test.
+const SYMBOL_LEXICAL_LIMIT: usize = 64;
+
+/// Prefix predicate: the lexical form of `of`'s value begins with
+/// `prefix`.
+///
+/// Constructed via the [`Term::starts_with`] sugar. The subject
+/// ranges over the TEXTUAL kinds; the prefix is a string.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct StartsWith {
+    /// The subject term, whose value's lexical form is compared.
+    pub of: Term<Any>,
+    /// The prefix the lexical form must begin with.
+    pub prefix: Term<String>,
+}
+
+/// The TEXTUAL members whose lexical grammar admits a value
+/// beginning with `prefix`. Conservative: a member is dropped only
+/// when *no* value of that kind can start with the prefix.
+///
+/// - `String` admits anything; never dropped.
+/// - `Symbol` lexical forms are at most [`SYMBOL_LEXICAL_LIMIT`]
+///   bytes (the only constraint the validator enforces besides the
+///   mandatory `/`, which a prefix cannot rule out).
+/// - `Entity` lexical forms are serialized URLs; see
+///   [`could_begin_entity`].
+fn admissible_members(prefix: &str) -> Primitive {
+    let mut members = Primitive::singleton(ValueType::String);
+    if prefix.len() <= SYMBOL_LEXICAL_LIMIT {
+        members = members.union(Primitive::singleton(ValueType::Symbol));
+    }
+    if could_begin_entity(prefix) {
+        members = members.union(Primitive::singleton(ValueType::Entity));
+    }
+    members
+}
+
+/// Whether `prefix` could begin the serialized form of an entity
+/// URI.
+///
+/// Entities serialize through the WHATWG URL algorithm, whose
+/// output always begins `scheme:` — an ASCII-alphabetic head
+/// followed by alphanumerics or `+`/`-`/`.` — and never contains
+/// raw whitespace or control characters (those are percent-encoded
+/// away). Anything not certainly impossible stays admissible; URI
+/// length is unbounded (index keys hash the tail), so length never
+/// excludes.
+fn could_begin_entity(prefix: &str) -> bool {
+    if prefix.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return false;
+    }
+    let scheme = prefix.split(':').next().unwrap_or("");
+    let mut chars = scheme.chars();
+    match chars.next() {
+        // The empty prefix begins everything; a leading `:` means an
+        // empty scheme, which no URL has.
+        None => prefix.is_empty(),
+        Some(head) => {
+            head.is_ascii_alphabetic()
+                && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+        }
+    }
+}
+
+/// The lexical form of a value, if its kind has one.
+fn lexical_form(value: &Value) -> Option<String> {
+    match value {
+        Value::String(content) => Some(content.clone()),
+        Value::Symbol(symbol) => Some(String::from(symbol)),
+        Value::Entity(entity) => Some(entity.as_str().to_string()),
+        _ => None,
+    }
+}
+
+impl StartsWith {
+    /// Create a prefix predicate over the given subject and prefix.
+    pub fn new(of: Term<Any>, prefix: Term<String>) -> Self {
+        Self { of, prefix }
+    }
+
+    /// Schema: both slots are *hard* requirements (the predicate
+    /// consumes bound values; the planner orders it after the
+    /// premises binding them). The subject's content type is the
+    /// admissible TEXTUAL member set — the lexical-grammar
+    /// refinement a constant prefix performs — and the prefix's is
+    /// `String`.
+    pub fn schema(&self) -> Schema {
+        let members = match self.prefix.as_constant() {
+            Some(Value::String(prefix)) => admissible_members(prefix),
+            _ => Primitive::TEXTUAL,
+        };
+        let mut schema = Schema::new();
+        schema.insert(
+            "of".to_string(),
+            Field {
+                description: "Term whose value's lexical form is compared".to_string(),
+                content_type: Some(Kind::primitive_set(members)),
+                requirement: Requirement::required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema.insert(
+            "prefix".to_string(),
+            Field {
+                description: "Prefix the lexical form must begin with".to_string(),
+                content_type: Some(Kind::primitive(ValueType::String)),
+                requirement: Requirement::required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema
+    }
+
+    /// Estimate cost. Constant — a row-local string comparison.
+    pub fn estimate(&self, _env: &Environment) -> Option<usize> {
+        Some(STARTS_WITH_COST)
+    }
+
+    /// Returns the named parameters for this constraint.
+    pub fn parameters(&self) -> Parameters {
+        let mut params = Parameters::new();
+        params.insert("of".to_string(), self.of.clone());
+        params.insert("prefix".to_string(), Term::from(&self.prefix));
+        params
+    }
+
+    /// Evaluate: filter rows whose value's lexical form does not
+    /// begin with the prefix.
+    ///
+    /// - Subject and prefix both `Present`: yield iff the subject
+    ///   has a lexical form beginning with the (string) prefix. A
+    ///   non-textual subject or a non-string prefix is a non-match.
+    /// - Either `Absent`: a non-match (a scalar slot matches nothing
+    ///   against a claimed absence).
+    /// - Either unbound: a planner-contract violation — the schema
+    ///   hard-requires both — surfaced as an error.
+    pub fn evaluate<M: Selection>(self, selection: M) -> impl Selection {
+        let of = self.of;
+        let prefix: Term<Any> = Term::from(&self.prefix);
+        try_stream! {
+            for await candidate in selection {
+                let base = candidate?;
+                match (base.lookup(&of), base.lookup(&prefix)) {
+                    (Ok(Binding::Present(subject)), Ok(Binding::Present(Value::String(needle)))) => {
+                        if let Some(form) = lexical_form(&subject)
+                            && form.starts_with(needle.as_str())
+                        {
+                            yield base;
+                        }
+                    }
+                    (Ok(_), Ok(_)) => {}
+                    (Err(_), _) => {
+                        Err(EvaluationError::UnboundVariable {
+                            variable_name: of.name().unwrap_or("of").to_string(),
+                        })?;
+                    }
+                    (_, Err(_)) => {
+                        Err(EvaluationError::UnboundVariable {
+                            variable_name: prefix.name().unwrap_or("prefix").to_string(),
+                        })?;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Display for StartsWith {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "starts-with({}, {})", self.of, self.prefix)
+    }
+}
+
+impl Term<Any> {
+    /// Prefix predicate: this term's value has a lexical form
+    /// beginning with `prefix`. Ranges over the TEXTUAL kinds; a
+    /// constant prefix narrows the subject to the members it could
+    /// begin (see [`TypeOf`](super::TypeOf) for the narrowing
+    /// mechanics).
+    pub fn starts_with(self, prefix: impl Into<Term<String>>) -> Premise {
+        Premise::Assert(Proposition::Constraint(Constraint::StartsWith(
+            StartsWith::new(self, prefix.into()),
+        )))
+    }
+}
+
+impl From<StartsWith> for Constraint {
+    fn from(predicate: StartsWith) -> Self {
+        Constraint::StartsWith(predicate)
+    }
+}
+
+impl Not for StartsWith {
+    type Output = Premise;
+
+    fn not(self) -> Self::Output {
+        Premise::Unless(Negation::not(Proposition::Constraint(
+            Constraint::StartsWith(self),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::artifact::{ArtifactsAttribute, Entity};
+    use crate::rule::TypeEnv;
+    use crate::selection::Match;
+    use futures_util::TryStreamExt;
+
+    fn symbol(name: &str) -> Value {
+        Value::Symbol(ArtifactsAttribute::try_from(name.to_string()).expect("valid attribute"))
+    }
+
+    async fn matches(predicate: StartsWith, value: Value) -> Result<usize, EvaluationError> {
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), value)?;
+        let results: Vec<Match> = predicate.evaluate(row.seed()).try_collect().await?;
+        Ok(results.len())
+    }
+
+    fn prefix(text: &str) -> StartsWith {
+        StartsWith::new(Term::var("x"), Term::from(text))
+    }
+
+    /// Every textual kind compares its lexical form.
+    #[dialog_common::test]
+    async fn it_compares_lexical_forms() -> Result<(), EvaluationError> {
+        assert_eq!(
+            matches(prefix("he"), Value::String("hello".into())).await?,
+            1,
+            "string prefix matches"
+        );
+        assert_eq!(
+            matches(prefix("lo"), Value::String("hello".into())).await?,
+            0,
+            "non-prefix is a non-match"
+        );
+        assert_eq!(
+            matches(prefix("user/"), symbol("user/name")).await?,
+            1,
+            "symbol compares its namespace/predicate form"
+        );
+        assert_eq!(
+            matches(prefix("group/"), symbol("user/name")).await?,
+            0,
+            "symbol outside the prefix is a non-match"
+        );
+
+        let entity = Entity::new().expect("fresh entity");
+        let did = Value::Entity(entity);
+        assert_eq!(
+            matches(prefix("did:key:"), did.clone()).await?,
+            1,
+            "entity compares its URI form"
+        );
+        assert_eq!(
+            matches(prefix("http:"), did).await?,
+            0,
+            "entity outside the prefix is a non-match"
+        );
+        Ok(())
+    }
+
+    /// A value with no lexical form is a non-match, not an error.
+    #[dialog_common::test]
+    async fn it_filters_non_textual_values() -> Result<(), EvaluationError> {
+        assert_eq!(matches(prefix(""), Value::UnsignedInt(7)).await?, 0);
+        assert_eq!(matches(prefix(""), Value::Boolean(true)).await?, 0);
+        Ok(())
+    }
+
+    /// An Absent subject matches nothing, both slots being scalar.
+    #[dialog_common::test]
+    async fn it_filters_absent_subjects() -> Result<(), EvaluationError> {
+        let predicate = prefix("he");
+        let mut row = Match::new();
+        row.bind_absent(&Term::var("x"))?;
+        let results: Vec<Match> = predicate.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0, "Absent matches nothing scalar");
+        Ok(())
+    }
+
+    /// A prefix bound to a non-string value is a non-match.
+    #[dialog_common::test]
+    async fn it_filters_non_string_prefixes() -> Result<(), EvaluationError> {
+        let predicate = StartsWith::new(Term::var("x"), Term::var("p"));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::String("hello".into()))?;
+        row.bind(&Term::<Any>::var("p"), Value::UnsignedInt(7))?;
+        let results: Vec<Match> = predicate.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0, "a numeric prefix matches nothing");
+        Ok(())
+    }
+
+    /// An unbound slot is a planner-contract violation.
+    #[dialog_common::test]
+    async fn it_errors_on_unbound_slots() {
+        let predicate = prefix("he");
+        let results: Result<Vec<Match>, _> =
+            predicate.evaluate(Match::new().seed()).try_collect().await;
+        assert!(results.is_err(), "unbound subject must error");
+
+        let predicate = StartsWith::new(Term::var("x"), Term::var("p"));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::String("hello".into()))
+            .expect("binds");
+        let results: Result<Vec<Match>, _> = predicate.evaluate(row.seed()).try_collect().await;
+        assert!(results.is_err(), "unbound prefix must error");
+    }
+
+    /// The lexical-grammar refinement: a constant prefix drops the
+    /// TEXTUAL members no value of which could begin with it.
+    #[dialog_common::test]
+    fn it_refines_members_by_lexical_grammar() {
+        let string_only = Primitive::singleton(ValueType::String);
+        let string_and_symbol = string_only.union(Primitive::singleton(ValueType::Symbol));
+        let string_and_entity = string_only.union(Primitive::singleton(ValueType::Entity));
+
+        assert_eq!(
+            admissible_members(""),
+            Primitive::TEXTUAL,
+            "the empty prefix begins everything"
+        );
+        assert_eq!(
+            admissible_members("did:key:z6Mk"),
+            Primitive::TEXTUAL,
+            "a URI-shaped prefix begins symbols and strings too"
+        );
+        assert_eq!(
+            admissible_members("has space"),
+            string_and_symbol,
+            "whitespace never appears in a serialized URL"
+        );
+        assert_eq!(
+            admissible_members("1user/"),
+            string_and_symbol,
+            "a URL scheme cannot begin with a digit"
+        );
+        assert_eq!(
+            admissible_members(":oops"),
+            string_and_symbol,
+            "no URL has an empty scheme"
+        );
+        assert_eq!(
+            admissible_members(&"a".repeat(SYMBOL_LEXICAL_LIMIT + 1)),
+            string_and_entity,
+            "a prefix longer than any symbol drops Symbol"
+        );
+        assert_eq!(
+            admissible_members(&" ".repeat(SYMBOL_LEXICAL_LIMIT + 1)),
+            string_only,
+            "both grammars can drop at once; String always remains"
+        );
+    }
+
+    /// Pin [`SYMBOL_LEXICAL_LIMIT`] against the real validator.
+    #[dialog_common::test]
+    fn it_mirrors_the_attribute_length_limit() {
+        let longest = format!("ns/{}", "a".repeat(SYMBOL_LEXICAL_LIMIT - 3));
+        assert!(
+            ArtifactsAttribute::try_from(longest.clone()).is_ok(),
+            "a symbol of exactly the limit is valid"
+        );
+        assert!(
+            ArtifactsAttribute::try_from(format!("{longest}a")).is_err(),
+            "one byte past the limit is rejected"
+        );
+    }
+
+    /// Inference consumes the refinement: a constant prefix narrows
+    /// the subject's kind rule-wide.
+    #[dialog_common::test]
+    fn it_narrows_subjects_via_prefix_refinement() -> anyhow::Result<()> {
+        let premises = vec![Term::<Any>::var("x").starts_with("has space")];
+        let env = TypeEnv::infer(&premises)?;
+        let kind = env.get("x").expect("inferred");
+        assert_eq!(
+            kind.primitive_part(),
+            Primitive::singleton(ValueType::String).union(Primitive::singleton(ValueType::Symbol)),
+            "a prefix with a space excludes entities"
+        );
+        Ok(())
+    }
+
+    /// A variable prefix contributes the full TEXTUAL bound to the
+    /// subject and String to itself.
+    #[dialog_common::test]
+    fn it_bounds_with_full_textual_for_variable_prefixes() -> anyhow::Result<()> {
+        let predicate = StartsWith::new(Term::var("x"), Term::var("p"));
+        let premises = vec![Premise::Assert(Proposition::Constraint(
+            Constraint::StartsWith(predicate),
+        ))];
+        let env = TypeEnv::infer(&premises)?;
+        assert_eq!(
+            env.get("x").expect("inferred").primitive_part(),
+            Primitive::TEXTUAL,
+            "the subject stays bounded TEXTUAL"
+        );
+        assert_eq!(
+            env.get("p").expect("inferred").primitive_part(),
+            Primitive::singleton(ValueType::String),
+            "the prefix is a string"
+        );
+        Ok(())
+    }
+
+    /// Known misalignment is a compile-time conflict: a subject
+    /// already narrowed to Entity cannot start with a prefix no URL
+    /// begins with.
+    #[dialog_common::test]
+    fn it_rejects_entity_subject_with_impossible_prefix() {
+        let premises = vec![
+            Term::<Any>::var("x").entity(),
+            Term::<Any>::var("x").starts_with("has space"),
+        ];
+        assert!(
+            TypeEnv::infer(&premises).is_err(),
+            "Entity and String|Symbol have an empty meet"
+        );
+    }
+}

--- a/rust/dialog-query/src/constraint/starts_with.rs
+++ b/rust/dialog-query/src/constraint/starts_with.rs
@@ -32,6 +32,7 @@ use crate::error::EvaluationError;
 use crate::selection::Selection;
 use crate::type_system::Primitive;
 use crate::type_system::Type as Kind;
+use crate::type_system::lexical_form;
 use crate::types::Any;
 use crate::{Binding, Cardinality, Environment, Field, Parameters, Requirement, Schema, Term};
 use crate::{Constraint, Negation, Premise, Proposition, try_stream};
@@ -106,16 +107,6 @@ fn could_begin_entity(prefix: &str) -> bool {
     }
 }
 
-/// The lexical form of a value, if its kind has one.
-fn lexical_form(value: &Value) -> Option<String> {
-    match value {
-        Value::String(content) => Some(content.clone()),
-        Value::Symbol(symbol) => Some(String::from(symbol)),
-        Value::Entity(entity) => Some(entity.as_str().to_string()),
-        _ => None,
-    }
-}
-
 impl StartsWith {
     /// Create a prefix predicate over the given subject and prefix.
     pub fn new(of: Term<Any>, prefix: Term<String>) -> Self {
@@ -124,21 +115,29 @@ impl StartsWith {
 
     /// Schema: both slots are *hard* requirements (the predicate
     /// consumes bound values; the planner orders it after the
-    /// premises binding them). The subject's content type is the
-    /// admissible TEXTUAL member set — the lexical-grammar
-    /// refinement a constant prefix performs — and the prefix's is
-    /// `String`.
+    /// premises binding them). The subject's content type carries
+    /// both halves of what a constant prefix proves: the admissible
+    /// TEXTUAL member set (the lexical-grammar refinement) and the
+    /// prefix itself as a [`Refinement`](crate::type_system::Refinement)
+    /// — which is how the prefix travels through inference to the
+    /// scan-range pushdown. The prefix slot is a `String`.
     pub fn schema(&self) -> Schema {
-        let members = match self.prefix.as_constant() {
-            Some(Value::String(prefix)) => admissible_members(prefix),
-            _ => Primitive::TEXTUAL,
+        let content = match self.prefix.as_constant() {
+            Some(Value::String(prefix)) => {
+                let members = Kind::from(admissible_members(prefix));
+                members
+                    .clone()
+                    .with_prefix(prefix.clone())
+                    .unwrap_or(members)
+            }
+            _ => Kind::from(Primitive::TEXTUAL),
         };
         let mut schema = Schema::new();
         schema.insert(
             "of".to_string(),
             Field {
                 description: "Term whose value's lexical form is compared".to_string(),
-                content_type: Some(Kind::primitive_set(members)),
+                content_type: Some(content),
                 requirement: Requirement::required(),
                 cardinality: Cardinality::One,
             },
@@ -147,7 +146,7 @@ impl StartsWith {
             "prefix".to_string(),
             Field {
                 description: "Prefix the lexical form must begin with".to_string(),
-                content_type: Some(Kind::primitive(ValueType::String)),
+                content_type: Some(Kind::from(ValueType::String)),
                 requirement: Requirement::required(),
                 cardinality: Cardinality::One,
             },
@@ -416,7 +415,9 @@ mod tests {
     }
 
     /// Inference consumes the refinement: a constant prefix narrows
-    /// the subject's kind rule-wide.
+    /// the subject's kind rule-wide — both the member set and the
+    /// prefix itself, which the scan boundary turns into range
+    /// bounds.
     #[dialog_common::test]
     fn it_narrows_subjects_via_prefix_refinement() -> anyhow::Result<()> {
         let premises = vec![Term::<Any>::var("x").starts_with("has space")];
@@ -426,6 +427,11 @@ mod tests {
             kind.primitive_part(),
             Primitive::singleton(ValueType::String).union(Primitive::singleton(ValueType::Symbol)),
             "a prefix with a space excludes entities"
+        );
+        assert_eq!(
+            kind.refinement().expect("the prefix travels").prefix,
+            "has space",
+            "the inferred kind carries the prefix refinement"
         );
         Ok(())
     }

--- a/rust/dialog-query/src/constraint/type_of.rs
+++ b/rust/dialog-query/src/constraint/type_of.rs
@@ -1,0 +1,236 @@
+//! Type predicate — occurrence typing as a premise.
+//!
+//! `TypeOf` asserts that a term's value inhabits a kind:
+//! `?x.text()`, `?x.number()`, `?x.entity()`. Two effects, one
+//! declaration:
+//!
+//! - **Inference**: the predicate's schema carries the kind as its
+//!   slot content type, so rule-level inference narrows the
+//!   variable — every premise reading `?x` afterwards (including
+//!   the scans feeding it) sees the narrowed kind, and a conflict
+//!   with another slot's kind is a compile-time error.
+//! - **Evaluation**: a row whose value does not inhabit the kind is
+//!   a non-match — filtered, never an error, like every scalar
+//!   slot.
+//!
+//! The planned range predicates (`starts-with` over TEXTUAL,
+//! numeric comparisons) extend this same shape with a refinement
+//! payload.
+
+use std::fmt;
+use std::fmt::Display;
+use std::ops::Not;
+
+use crate::artifact::Type as ValueType;
+use crate::error::EvaluationError;
+use crate::selection::Selection;
+use crate::type_system::Primitive;
+use crate::type_system::Type as Kind;
+use crate::types::Any;
+use crate::{Binding, Cardinality, Environment, Field, Parameters, Requirement, Schema, Term};
+use crate::{Constraint, Negation, Premise, Proposition, try_stream};
+
+/// Cost for evaluating a type predicate (single row lookup + bitmask
+/// test).
+const TYPE_OF_COST: usize = 1;
+
+/// Type predicate: the value of `of` inhabits the kind `is`.
+///
+/// Constructed via the [`Term`] sugar — [`Term::text`],
+/// [`Term::number`], [`Term::textual`], … — or directly for an
+/// arbitrary kind.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TypeOf {
+    /// The subject term.
+    pub of: Term<Any>,
+    /// The kind the subject's value must inhabit.
+    pub is: Kind,
+}
+
+impl TypeOf {
+    /// Create a type predicate over the given term and kind.
+    pub fn new(of: Term<Any>, is: Kind) -> Self {
+        Self { of, is }
+    }
+
+    /// Schema: the subject is a *hard* requirement (the predicate
+    /// consumes a bound value; the planner orders it after the
+    /// premise binding it), and the slot's content type is the
+    /// demanded kind — which is how the narrowing reaches
+    /// inference.
+    pub fn schema(&self) -> Schema {
+        let mut schema = Schema::new();
+        schema.insert(
+            "of".to_string(),
+            Field {
+                description: "Term whose value must inhabit the kind".to_string(),
+                content_type: Some(self.is.clone()),
+                requirement: Requirement::required(),
+                cardinality: Cardinality::One,
+            },
+        );
+        schema
+    }
+
+    /// Estimate cost. Constant — a row-local bitmask test.
+    pub fn estimate(&self, _env: &Environment) -> Option<usize> {
+        Some(TYPE_OF_COST)
+    }
+
+    /// Returns the named parameters for this constraint.
+    pub fn parameters(&self) -> Parameters {
+        let mut params = Parameters::new();
+        params.insert("of".to_string(), self.of.clone());
+        params
+    }
+
+    /// Evaluate: filter rows whose value does not inhabit the kind.
+    ///
+    /// - `Present(v)`: yield iff the kind admits `v`.
+    /// - `Absent`: yield iff the kind explicitly admits `Nothing`
+    ///   (a scalar kind matches nothing against a claimed absence).
+    /// - Unbound: a planner-contract violation — the schema
+    ///   hard-requires the subject — surfaced as an error.
+    pub fn evaluate<M: Selection>(self, selection: M) -> impl Selection {
+        let of = self.of;
+        let kind = self.is;
+        try_stream! {
+            for await candidate in selection {
+                let base = candidate?;
+                match base.lookup(&of) {
+                    Ok(Binding::Present(value)) => {
+                        if kind.admits(&value) {
+                            yield base;
+                        }
+                    }
+                    Ok(Binding::Absent) => {
+                        if kind.is_optional() {
+                            yield base;
+                        }
+                    }
+                    Err(_) => {
+                        Err(EvaluationError::UnboundVariable {
+                            variable_name: of.name().unwrap_or("of").to_string(),
+                        })?;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Display for TypeOf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "type({}) == {}", self.of, self.is)
+    }
+}
+
+impl Term<Any> {
+    /// Type predicate: this term's value inhabits `kind`.
+    pub fn typed_as(self, kind: Kind) -> Premise {
+        Premise::Assert(Proposition::Constraint(Constraint::TypeOf(TypeOf::new(
+            self, kind,
+        ))))
+    }
+
+    /// `?x` is a string.
+    pub fn text(self) -> Premise {
+        self.typed_as(Kind::primitive(ValueType::String))
+    }
+
+    /// `?x` is textual: a string, a symbol, or an entity — the kinds
+    /// a lexical prefix can range over.
+    pub fn textual(self) -> Premise {
+        self.typed_as(Kind::primitive_set(Primitive::TEXTUAL))
+    }
+
+    /// `?x` is numeric: an unsigned integer, a signed integer, or a
+    /// float.
+    pub fn number(self) -> Premise {
+        self.typed_as(Kind::primitive_set(Primitive::NUMERIC))
+    }
+
+    /// `?x` is an entity.
+    pub fn entity(self) -> Premise {
+        self.typed_as(Kind::primitive(ValueType::Entity))
+    }
+
+    /// `?x` is a symbol (an attribute name).
+    pub fn symbol(self) -> Premise {
+        self.typed_as(Kind::primitive(ValueType::Symbol))
+    }
+
+    /// `?x` is a boolean.
+    pub fn boolean(self) -> Premise {
+        self.typed_as(Kind::primitive(ValueType::Boolean))
+    }
+
+    /// `?x` is bytes.
+    pub fn bytes(self) -> Premise {
+        self.typed_as(Kind::primitive(ValueType::Bytes))
+    }
+}
+
+impl From<TypeOf> for Constraint {
+    fn from(predicate: TypeOf) -> Self {
+        Constraint::TypeOf(predicate)
+    }
+}
+
+impl Not for TypeOf {
+    type Output = Premise;
+
+    fn not(self) -> Self::Output {
+        Premise::Unless(Negation::not(Proposition::Constraint(Constraint::TypeOf(
+            self,
+        ))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::Value;
+    use crate::selection::Match;
+    use futures_util::TryStreamExt;
+
+    /// Present values filter by kind membership.
+    #[dialog_common::test]
+    async fn it_filters_by_kind() -> Result<(), EvaluationError> {
+        let predicate = TypeOf::new(Term::var("x"), Kind::primitive(ValueType::String));
+
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::String("hi".into()))?;
+        let results: Vec<Match> = predicate.clone().evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 1, "a String inhabits text");
+
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::UnsignedInt(7))?;
+        let results: Vec<Match> = predicate.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0, "a number does not inhabit text");
+        Ok(())
+    }
+
+    /// An Absent binding matches nothing in a scalar kind.
+    #[dialog_common::test]
+    async fn it_filters_absent_for_scalar_kinds() -> Result<(), EvaluationError> {
+        let predicate = TypeOf::new(Term::var("x"), Kind::primitive(ValueType::String));
+        let mut row = Match::new();
+        row.bind_absent(&Term::var("x"))?;
+        let results: Vec<Match> = predicate.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0, "Absent matches nothing scalar");
+        Ok(())
+    }
+
+    /// An unbound subject is a planner-contract violation.
+    #[dialog_common::test]
+    async fn it_errors_on_unbound_subject() {
+        let predicate = TypeOf::new(Term::var("x"), Kind::primitive(ValueType::String));
+        let results: Result<Vec<Match>, _> =
+            predicate.evaluate(Match::new().seed()).try_collect().await;
+        assert!(results.is_err(), "unbound subject must error");
+    }
+}

--- a/rust/dialog-query/src/constraint/type_of.rs
+++ b/rust/dialog-query/src/constraint/type_of.rs
@@ -135,39 +135,39 @@ impl Term<Any> {
 
     /// `?x` is a string.
     pub fn text(self) -> Premise {
-        self.typed_as(Kind::primitive(ValueType::String))
+        self.typed_as(Kind::from(ValueType::String))
     }
 
     /// `?x` is textual: a string, a symbol, or an entity — the kinds
     /// a lexical prefix can range over.
     pub fn textual(self) -> Premise {
-        self.typed_as(Kind::primitive_set(Primitive::TEXTUAL))
+        self.typed_as(Kind::from(Primitive::TEXTUAL))
     }
 
     /// `?x` is numeric: an unsigned integer, a signed integer, or a
     /// float.
     pub fn number(self) -> Premise {
-        self.typed_as(Kind::primitive_set(Primitive::NUMERIC))
+        self.typed_as(Kind::from(Primitive::NUMERIC))
     }
 
     /// `?x` is an entity.
     pub fn entity(self) -> Premise {
-        self.typed_as(Kind::primitive(ValueType::Entity))
+        self.typed_as(Kind::from(ValueType::Entity))
     }
 
     /// `?x` is a symbol (an attribute name).
     pub fn symbol(self) -> Premise {
-        self.typed_as(Kind::primitive(ValueType::Symbol))
+        self.typed_as(Kind::from(ValueType::Symbol))
     }
 
     /// `?x` is a boolean.
     pub fn boolean(self) -> Premise {
-        self.typed_as(Kind::primitive(ValueType::Boolean))
+        self.typed_as(Kind::from(ValueType::Boolean))
     }
 
     /// `?x` is bytes.
     pub fn bytes(self) -> Premise {
-        self.typed_as(Kind::primitive(ValueType::Bytes))
+        self.typed_as(Kind::from(ValueType::Bytes))
     }
 }
 
@@ -200,7 +200,7 @@ mod tests {
     /// Present values filter by kind membership.
     #[dialog_common::test]
     async fn it_filters_by_kind() -> Result<(), EvaluationError> {
-        let predicate = TypeOf::new(Term::var("x"), Kind::primitive(ValueType::String));
+        let predicate = TypeOf::new(Term::var("x"), Kind::from(ValueType::String));
 
         let mut row = Match::new();
         row.bind(&Term::var("x"), Value::String("hi".into()))?;
@@ -217,7 +217,7 @@ mod tests {
     /// An Absent binding matches nothing in a scalar kind.
     #[dialog_common::test]
     async fn it_filters_absent_for_scalar_kinds() -> Result<(), EvaluationError> {
-        let predicate = TypeOf::new(Term::var("x"), Kind::primitive(ValueType::String));
+        let predicate = TypeOf::new(Term::var("x"), Kind::from(ValueType::String));
         let mut row = Match::new();
         row.bind_absent(&Term::var("x"))?;
         let results: Vec<Match> = predicate.evaluate(row.seed()).try_collect().await?;
@@ -228,7 +228,7 @@ mod tests {
     /// An unbound subject is a planner-contract violation.
     #[dialog_common::test]
     async fn it_errors_on_unbound_subject() {
-        let predicate = TypeOf::new(Term::var("x"), Kind::primitive(ValueType::String));
+        let predicate = TypeOf::new(Term::var("x"), Kind::from(ValueType::String));
         let results: Result<Vec<Match>, _> =
             predicate.evaluate(Match::new().seed()).try_collect().await;
         assert!(results.is_err(), "unbound subject must error");

--- a/rust/dialog-query/src/formula/number.rs
+++ b/rust/dialog-query/src/formula/number.rs
@@ -24,6 +24,7 @@
 use crate::artifact::{ArtifactTypeError, Type as ValueType, Value};
 use crate::type_system::{Primitive, Type as Kind};
 use crate::types::{Scalar, TypeDescriptor, Typed};
+use std::cmp::Ordering;
 use std::fmt::{self, Display};
 
 /// The lattice bound a scheme variable ranges over.
@@ -188,6 +189,27 @@ impl Numeric {
                 let f = v as f64;
                 (f.is_finite() && f as i128 == v).then_some(Numeric::Float(f))
             }
+            _ => None,
+        }
+    }
+
+    /// The numeric [`ValueType`] of this variant.
+    pub fn value_type(&self) -> ValueType {
+        match self {
+            Numeric::UnsignedInt(_) => ValueType::UnsignedInt,
+            Numeric::SignedInt(_) => ValueType::SignedInt,
+            Numeric::Float(_) => ValueType::Float,
+        }
+    }
+
+    /// Same-variant ordering: `None` for mixed variants (the strict
+    /// no-promotion semantics, exactly like the arithmetic) and for
+    /// incomparable floats (NaN).
+    pub fn compare(self, other: Self) -> Option<Ordering> {
+        match (self, other) {
+            (Numeric::UnsignedInt(a), Numeric::UnsignedInt(b)) => Some(a.cmp(&b)),
+            (Numeric::SignedInt(a), Numeric::SignedInt(b)) => Some(a.cmp(&b)),
+            (Numeric::Float(a), Numeric::Float(b)) => a.partial_cmp(&b),
             _ => None,
         }
     }

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -472,6 +472,51 @@ mod tests {
         Ok(())
     }
 
+    /// A type predicate filters heterogeneous data and narrows the
+    /// feeding scan: `?tag.number()` keeps the numeric facts and the
+    /// narrowing stamps the scan so non-numeric facts never reach
+    /// the predicate.
+    #[dialog_common::test]
+    async fn it_filters_rows_through_type_predicates() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("misc/tag").of(alice.clone()).is("blue".to_string()))
+            .assert(the!("misc/tag").of(alice.clone()).is(7u32))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let scan = AttributeQuery::new(
+            Term::from(the!("misc/tag")),
+            Term::<Entity>::var("this"),
+            Term::var("tag"),
+            Term::var("c1"),
+            Some(Cardinality::Many),
+        );
+        let plan = Planner::from(vec![
+            Premise::Assert(Proposition::Attribute(Box::new(scan))),
+            Term::<Any>::var("tag").number(),
+        ])
+        .plan(&Environment::new())?;
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+
+        assert_eq!(results.len(), 1, "only the numeric fact survives");
+        assert_eq!(
+            results[0].lookup(&Term::var("tag"))?.content()?,
+            Value::UnsignedInt(7)
+        );
+        Ok(())
+    }
+
     /// Characterization of the agreed filter semantics, passing
     /// today: a formula slot demanding a present value narrows a
     /// set-widened attribute variable rule-wide (occurrence typing),

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -291,6 +291,18 @@ fn apply_types_to_proposition(proposition: Proposition, types: &TypeEnv) -> Prop
 }
 
 fn narrow_attribute(query: AttributeQuery, types: &TypeEnv) -> AttributeQuery {
+    // Stamp the attribute/entity variables with their rule-level
+    // kinds. This is how a prefix refinement proved by a sibling
+    // premise reaches the scan boundary, where the selector
+    // conversion turns it into index-range bounds.
+    let kind_of = |term_name: Option<&str>| term_name.and_then(|name| types.get(name)).cloned();
+    let the_kind = kind_of(query.the().name());
+    let of_kind = kind_of(query.of().name());
+    let query = match (&the_kind, &of_kind) {
+        (None, None) => query,
+        _ => query.with_subject_kinds(the_kind, of_kind),
+    };
+
     let Some(name) = query.is().name() else {
         return query;
     };
@@ -312,6 +324,7 @@ mod tests {
     use crate::optional::OptionalAttributeQuery;
     use crate::planner::Planner;
     use crate::the;
+    use crate::types::Any;
     use crate::{AttributeDescriptor, Cardinality, ConceptDescriptor, Term};
 
     fn optional_nickname_premise(var: &str) -> Premise {
@@ -359,6 +372,37 @@ mod tests {
                 other => panic!("expected only scalar scans after demotion, got {other}"),
             }
         }
+    }
+
+    /// A prefix refinement proved by a sibling `starts-with`
+    /// premise is stamped onto the scan's entity term, where the
+    /// selector conversion turns it into an index-range bound.
+    #[dialog_common::test]
+    fn it_stamps_prefix_refinements_onto_scan_subjects() {
+        let scan: Premise = AttributeQuery::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("e"),
+            Term::<String>::var("name").into(),
+            Term::blank(),
+            Some(Cardinality::One),
+        )
+        .into();
+        let predicate = Term::<Any>::var("e").starts_with("did:key:");
+
+        let plan = Planner::from(vec![scan, predicate])
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        let stamped = plan.steps.iter().find_map(|step| match step.as_premise() {
+            Premise::Assert(Proposition::Attribute(boxed)) => boxed.of().kind(),
+            _ => None,
+        });
+        let kind = stamped.expect("the scan's entity term carries a kind");
+        assert_eq!(
+            kind.refinement().expect("refined").prefix,
+            "did:key:",
+            "the proved prefix reaches the scan boundary"
+        );
     }
 
     /// A standalone `Maybe` premise cannot be planned at empty

--- a/rust/dialog-query/src/rule/types.rs
+++ b/rust/dialog-query/src/rule/types.rs
@@ -260,6 +260,39 @@ mod tests {
         .into()
     }
 
+    /// A type predicate narrows its subject rule-wide: occurrence
+    /// typing as a premise.
+    #[dialog_common::test]
+    fn it_narrows_variables_via_type_predicates() -> anyhow::Result<()> {
+        let scan = AttributeQuery::new(
+            Term::from(the!("misc/tag")),
+            Term::<Entity>::var("this"),
+            Term::var("tag"),
+            Term::var("cause"),
+            Some(Cardinality::One),
+        );
+        let premises = vec![scan.into(), Term::<Any>::var("tag").number()];
+
+        let env = TypeEnv::infer(&premises)?;
+        let kind = env.get("tag").expect("inferred");
+        assert_eq!(
+            kind.primitive_part(),
+            Primitive::NUMERIC,
+            "the predicate narrowed the scan variable"
+        );
+        Ok(())
+    }
+
+    /// Conflicting type predicates are a compile-time error.
+    #[dialog_common::test]
+    fn it_rejects_conflicting_type_predicates() {
+        let premises = vec![Term::<Any>::var("x").text(), Term::<Any>::var("x").number()];
+        assert!(
+            TypeEnv::infer(&premises).is_err(),
+            "text and number have an empty meet"
+        );
+    }
+
     /// A formula scheme links its cells: one bounded type variable
     /// per label, shared by every cell carrying it, instantiated
     /// fresh for this use of the formula.

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -146,6 +146,21 @@ impl<T: Typed> Term<T> {
         Self::default()
     }
 
+    /// Return a copy of this term carrying `kind` in its
+    /// descriptor — the planner's stamp of what rule-level
+    /// inference proved about the variable. Descriptors that
+    /// cannot store a kind keep their static one; constants are
+    /// returned unchanged.
+    pub fn with_kind(self, kind: type_system::Type) -> Self {
+        match self {
+            Term::Variable { name, .. } => Term::Variable {
+                name,
+                descriptor: <T as Typed>::Descriptor::from_kind(Some(kind)),
+            },
+            constant => constant,
+        }
+    }
+
     /// Create a uniquely-named variable.
     ///
     /// Like a named variable, it participates in bindings, but the name is

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -294,6 +294,7 @@ impl Display for Type {
         match self {
             Type::Primitive(p) => write!(f, "{p}"),
             Type::Composite(p, c) => write!(f, "{p}+{} composite", c.len()),
+            Type::Refined(p, r) => write!(f, "{p}[starts-with {:?}]", r.prefix),
         }
     }
 }
@@ -329,6 +330,82 @@ pub enum Type {
     /// giving a pure composite type. Invariant: the composite set is
     /// never empty (an empty one collapses to `Primitive`).
     Composite(Primitive, BTreeSet<Composite>),
+    /// Primitive set narrowed by a [`Refinement`] on the *values*
+    /// of the member types — not just which types are admitted, but
+    /// which of their inhabitants. Produced by refinement
+    /// predicates (`starts-with`); consumed by scan-range pushdown
+    /// and, like every kind, by [`Type::admits`] at the data
+    /// boundary. Admits no composite shapes (refinements constrain
+    /// lexical forms, which composites do not have).
+    Refined(Primitive, Refinement),
+}
+
+/// A value-level constraint layered onto a primitive membership
+/// set. The meet of two refinements is their conjunction (both
+/// constraints), the join their weakest common implication — see
+/// [`Refinement::meet`] and [`Refinement::join`].
+///
+/// Today one refinement exists: a lexical prefix over the TEXTUAL
+/// kinds. Numeric intervals and Entity concept-membership (M3)
+/// extend this struct rather than adding lattice variants.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Refinement {
+    /// Lexical prefix every admitted value must begin with.
+    /// Invariant: non-empty (an empty prefix is no refinement; the
+    /// constructors collapse it).
+    pub prefix: String,
+}
+
+impl Refinement {
+    /// Meet: the conjunction of both constraints. Two prefixes are
+    /// jointly satisfiable iff one extends the other, and the meet
+    /// is the longer; disjoint prefixes admit nothing.
+    fn meet(&self, other: &Refinement) -> Option<Refinement> {
+        if self.prefix.starts_with(&other.prefix) {
+            Some(self.clone())
+        } else if other.prefix.starts_with(&self.prefix) {
+            Some(other.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Join: the weakest constraint both sides imply — the longest
+    /// common prefix. `None` when nothing is common (the join
+    /// carries no refinement).
+    fn join(&self, other: &Refinement) -> Option<Refinement> {
+        let common: String = self
+            .prefix
+            .chars()
+            .zip(other.prefix.chars())
+            .take_while(|(a, b)| a == b)
+            .map(|(a, _)| a)
+            .collect();
+        if common.is_empty() {
+            None
+        } else {
+            Some(Refinement { prefix: common })
+        }
+    }
+
+    /// True when the value's lexical form satisfies the refinement.
+    /// Values without a lexical form satisfy no prefix.
+    pub fn admits(&self, value: &Value) -> bool {
+        lexical_form(value).is_some_and(|form| form.starts_with(&self.prefix))
+    }
+}
+
+/// The lexical form of a value, if its kind has one: the string
+/// content, the symbol's `namespace/predicate` name, or the
+/// entity's URI. This is the form prefix refinements and the
+/// `starts-with` predicate compare against.
+pub fn lexical_form(value: &Value) -> Option<String> {
+    match value {
+        Value::String(content) => Some(content.clone()),
+        Value::Symbol(symbol) => Some(String::from(symbol)),
+        Value::Entity(entity) => Some(entity.as_str().to_string()),
+        _ => None,
+    }
 }
 
 /// A composite (structured) value shape. Ordered by derived
@@ -361,15 +438,23 @@ impl Type {
         match self {
             Type::Primitive(p) => Type::Primitive(p.union(Primitive::NOTHING)),
             Type::Composite(p, c) => Type::Composite(p.union(Primitive::NOTHING), c),
+            Type::Refined(p, r) => Type::Refined(p.union(Primitive::NOTHING), r),
         }
     }
 
     /// True when the given runtime value inhabits this type: the
-    /// value's data type is a member of the primitive part.
+    /// value's data type is a member of the primitive part, and the
+    /// refinement (if any) admits the value itself.
     /// Composite refinements are not yet checked; no composite
     /// values flow through evaluation today.
     pub fn admits(&self, value: &Value) -> bool {
-        self.primitive_part().contains(value.data_type())
+        if !self.primitive_part().contains(value.data_type()) {
+            return false;
+        }
+        match self {
+            Type::Refined(_, r) => r.admits(value),
+            _ => true,
+        }
     }
 
     /// The inverse of [`optional`]: strip the `Nothing` atom if
@@ -379,6 +464,54 @@ impl Type {
         match self {
             Type::Primitive(p) => Type::Primitive(p.required()),
             Type::Composite(p, c) => Type::Composite(p.required(), c),
+            Type::Refined(p, r) => Type::Refined(p.required(), r),
+        }
+    }
+
+    /// Refine this type with a lexical prefix constraint.
+    ///
+    /// The membership is narrowed to the TEXTUAL kinds (the kinds
+    /// with a lexical form; the `Nothing` bit, if present, rides
+    /// along untouched — refinements constrain present values).
+    /// Returns `None` when no member could carry a lexical form —
+    /// an empty meet. An empty prefix is no constraint and returns
+    /// the type unchanged; an existing prefix refinement is met
+    /// against the new one.
+    pub fn with_prefix(self, prefix: impl Into<String>) -> Option<Type> {
+        let prefix = prefix.into();
+        if prefix.is_empty() {
+            return Some(self);
+        }
+        let membership = self
+            .primitive_part()
+            .intersect(Primitive::TEXTUAL.union(Primitive::NOTHING))?;
+        if membership.required().is_empty() {
+            return None;
+        }
+        let refinement = match &self {
+            Type::Refined(_, existing) => existing.meet(&Refinement { prefix })?,
+            _ => Refinement { prefix },
+        };
+        Some(Type::Refined(membership, refinement))
+    }
+
+    /// The refinement layered onto this type, if any.
+    pub fn refinement(&self) -> Option<&Refinement> {
+        match self {
+            Type::Refined(_, r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Rebuild this type around a replacement primitive part,
+    /// preserving its composite or refinement structure. The
+    /// unifier uses this so a resolution that narrows membership
+    /// does not silently shed the rest of the type.
+    pub(crate) fn with_primitive_part(&self, p: Primitive) -> Type {
+        match self {
+            Type::Primitive(_) => Type::Primitive(p),
+            Type::Composite(_, c) => Type::composite(p, c.clone()),
+            Type::Refined(_, r) => Type::Refined(p, r.clone()),
         }
     }
 
@@ -428,6 +561,24 @@ impl Type {
             bits: p_self.bits & p_other.bits,
         };
 
+        // Refinements are constraints: the meet carries the
+        // conjunction. Two refined sides must have jointly
+        // satisfiable refinements; a refined side admits no
+        // composite shapes, so any composite part on the other
+        // side is dropped.
+        let refinement = match (self.refinement(), other.refinement()) {
+            (Some(a), Some(b)) => Some(a.meet(b)?),
+            (Some(r), None) | (None, Some(r)) => Some(r.clone()),
+            (None, None) => None,
+        };
+        if let Some(refinement) = refinement {
+            return if p.is_empty() {
+                None
+            } else {
+                Some(Type::Refined(p, refinement))
+            };
+        }
+
         let composite_intersection: BTreeSet<Composite> =
             match (self.composite_part(), other.composite_part()) {
                 (Some(a), Some(b)) => intersect_composite_sets(a, b),
@@ -442,8 +593,21 @@ impl Type {
     }
 
     /// Set union over both primitive and composite parts.
+    ///
+    /// Refinements weaken at a join: two refined sides keep their
+    /// weakest common implication (the longest common prefix), a
+    /// refined side joined with an unrefined one sheds the
+    /// refinement entirely — the union must admit everything either
+    /// side admits.
     pub fn union(&self, other: &Type) -> Type {
         let p = self.primitive_part().union(other.primitive_part());
+
+        if let (Some(a), Some(b)) = (self.refinement(), other.refinement())
+            && let Some(joined) = a.join(b)
+        {
+            return Type::Refined(p, joined);
+        }
+
         let mut composites: BTreeSet<Composite> = BTreeSet::new();
         if let Some(s) = self.composite_part() {
             composites.extend(s.iter().cloned());
@@ -467,6 +631,19 @@ impl Type {
         if !self.primitive_part().includes(other.primitive_part()) {
             return false;
         }
+        // A refined type admits fewer values than its membership: it
+        // includes `other` only if `other` is at least as
+        // constrained (other's prefix extends ours). An unrefined
+        // type over-approximates any refinement of its membership.
+        match (self.refinement(), other.refinement()) {
+            (Some(a), Some(b)) => {
+                if !b.prefix.starts_with(&a.prefix) {
+                    return false;
+                }
+            }
+            (Some(_), None) => return false,
+            (None, _) => {}
+        }
         match (self.composite_part(), other.composite_part()) {
             (_, None) => true,
             (None, Some(b)) => b.is_empty(),
@@ -486,6 +663,7 @@ impl Type {
         match self {
             Type::Primitive(p) => *p,
             Type::Composite(p, _) => *p,
+            Type::Refined(p, _) => *p,
         }
     }
 
@@ -495,15 +673,19 @@ impl Type {
         match self {
             Type::Primitive(_) => None,
             Type::Composite(_, c) => Some(c),
+            Type::Refined(_, _) => None,
         }
     }
 
     /// Legacy storage-codec view: if this type reduces to exactly
     /// one [`ValueType`] (no `Nothing`, no composites), return it.
+    /// A refinement does not change the storage type, so a refined
+    /// singleton still reports its member.
     pub fn as_value_type(&self) -> Option<ValueType> {
         match self {
             Type::Primitive(p) => p.as_singleton(),
             Type::Composite(_, _) => None,
+            Type::Refined(p, _) => p.as_singleton(),
         }
     }
 }
@@ -985,6 +1167,118 @@ mod tests {
             hash_of(&b),
             "product hash is field-insertion-order independent"
         );
+    }
+
+    /// `with_prefix` narrows membership to the TEXTUAL kinds and
+    /// attaches the refinement; non-textual membership is an empty
+    /// meet.
+    #[dialog_common::test]
+    fn with_prefix_narrows_to_textual() {
+        let refined = Type::from(Primitive::ALL)
+            .with_prefix("did:")
+            .expect("textual members remain");
+        assert_eq!(refined.primitive_part(), Primitive::TEXTUAL);
+        assert_eq!(refined.refinement().expect("refined").prefix, "did:");
+
+        assert!(
+            Type::from(Primitive::NUMERIC).with_prefix("did:").is_none(),
+            "no numeric value has a lexical form"
+        );
+        assert_eq!(
+            Type::from(ValueType::String).with_prefix(""),
+            Some(Type::from(ValueType::String)),
+            "an empty prefix is no refinement"
+        );
+    }
+
+    /// The meet of two refined types takes the stronger prefix;
+    /// disjoint prefixes are an empty meet.
+    #[dialog_common::test]
+    fn refined_intersect_takes_the_stronger_prefix() {
+        let did = Type::from(ValueType::Entity).with_prefix("did:").unwrap();
+        let did_key = Type::from(ValueType::Entity)
+            .with_prefix("did:key:")
+            .unwrap();
+        let met = did.intersect(&did_key).expect("compatible prefixes");
+        assert_eq!(met.refinement().unwrap().prefix, "did:key:");
+
+        let http = Type::from(ValueType::Entity).with_prefix("http:").unwrap();
+        assert!(
+            did.intersect(&http).is_none(),
+            "no value starts with both prefixes"
+        );
+
+        let unrefined = Type::from(Primitive::TEXTUAL);
+        let met = did.intersect(&unrefined).expect("memberships overlap");
+        assert_eq!(
+            met.refinement().unwrap().prefix,
+            "did:",
+            "the refinement survives a meet with an unrefined side"
+        );
+        assert_eq!(met.primitive_part().as_singleton(), Some(ValueType::Entity));
+    }
+
+    /// The join weakens: common prefix when there is one, no
+    /// refinement otherwise (including against an unrefined side).
+    #[dialog_common::test]
+    fn refined_union_weakens() {
+        let a = Type::from(ValueType::String)
+            .with_prefix("user/admin")
+            .unwrap();
+        let b = Type::from(ValueType::String)
+            .with_prefix("user/guest")
+            .unwrap();
+        let joined = a.union(&b);
+        assert_eq!(joined.refinement().unwrap().prefix, "user/");
+
+        let unrefined = Type::from(ValueType::String);
+        assert_eq!(
+            a.union(&unrefined),
+            Type::from(ValueType::String),
+            "a join with an unrefined side sheds the refinement"
+        );
+
+        let disjoint = Type::from(ValueType::String).with_prefix("group/").unwrap();
+        assert!(
+            a.union(&disjoint).refinement().is_none(),
+            "no common prefix, no refinement"
+        );
+    }
+
+    /// Inclusion: the more-refined side is the subtype.
+    #[dialog_common::test]
+    fn refined_includes_is_constraint_ordered() {
+        let did = Type::from(ValueType::Entity).with_prefix("did:").unwrap();
+        let did_key = Type::from(ValueType::Entity)
+            .with_prefix("did:key:")
+            .unwrap();
+        let unrefined = Type::from(ValueType::Entity);
+
+        assert!(did.includes(&did_key), "longer prefix is more constrained");
+        assert!(!did_key.includes(&did));
+        assert!(unrefined.includes(&did), "unrefined over-approximates");
+        assert!(!did.includes(&unrefined));
+    }
+
+    /// `admits` enforces the refinement against the value's lexical
+    /// form — membership alone is not enough.
+    #[dialog_common::test]
+    fn refined_admits_checks_lexical_form() {
+        let refined = Type::from(Primitive::TEXTUAL).with_prefix("user/").unwrap();
+        assert!(refined.admits(&Value::String("user/name".into())));
+        assert!(!refined.admits(&Value::String("group/name".into())));
+        assert!(!refined.admits(&Value::UnsignedInt(7)));
+    }
+
+    /// Refined types survive serde.
+    #[dialog_common::test]
+    fn refined_serde_round_trip() {
+        let t = Type::from(ValueType::Entity)
+            .with_prefix("did:key:")
+            .unwrap();
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
     }
 
     /// Combining two products via union also produces identical

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -252,10 +252,10 @@ impl Context {
                     .intersect(p)
                     .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
                 self.constraints.insert(x, merged);
-                let resolved = match narrowed_static.composite_part() {
-                    Some(c) if !c.is_empty() => StaticType::composite(merged, c.clone()),
-                    _ => StaticType::from(merged),
-                };
+                // Rebuild around the merged membership without
+                // shedding the static's composite or refinement
+                // structure.
+                let resolved = narrowed_static.with_primitive_part(merged);
                 self.substitution.insert(x, Type::Static(resolved.clone()));
                 Ok(Type::Static(resolved))
             }
@@ -457,5 +457,31 @@ mod tests {
         let mut ctx = Context::new();
         let result = ctx.unify(&p(ValueType::String), &Type::optional(ValueType::Entity));
         assert!(matches!(result, Err(UnifyError::ConstraintConflict { .. })));
+    }
+
+    /// A variable resolved against a refined static keeps the
+    /// refinement: resolution narrows membership without shedding
+    /// the rest of the type's structure.
+    #[dialog_common::test]
+    fn unify_variable_with_refined_static_keeps_the_refinement() {
+        let mut ctx = Context::new();
+        let v = ctx.fresh(Primitive::ANY);
+        let refined = StaticType::from(Primitive::TEXTUAL)
+            .with_prefix("did:")
+            .expect("textual members");
+        ctx.unify(&Type::Variable(v), &Type::Static(refined))
+            .unwrap();
+        // A later premise narrows membership further; the prefix
+        // must survive that narrowing too.
+        ctx.unify(&Type::Variable(v), &Type::primitive(ValueType::Entity))
+            .unwrap();
+        let resolved = ctx.resolve(&Type::Variable(v));
+        match resolved {
+            Type::Static(s) => {
+                assert_eq!(s.primitive_part().as_singleton(), Some(ValueType::Entity));
+                assert_eq!(s.refinement().expect("refinement preserved").prefix, "did:");
+            }
+            other => panic!("expected static, got {other:?}"),
+        }
     }
 }

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -114,12 +114,52 @@ define_descriptor!(
     Bytes, Type::Bytes
 );
 
-define_descriptor!(
+/// Descriptors whose terms can carry a *narrowed* kind at plan
+/// time — a refinement the rule proved about the variable (an
+/// entity URI prefix, an attribute-name prefix) that the scan
+/// boundary turns into index-range bounds. The stored kind is
+/// `None` whenever it adds nothing over the static type, so terms
+/// without narrowing compare, hash, and round-trip exactly like
+/// the unit descriptors they replace.
+macro_rules! define_refinable_descriptor {
+    (
+        $(#[$meta:meta])*
+        $name:ident, $variant:expr
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+        pub struct $name(Option<type_system::Type>);
+
+        impl TypeDescriptor for $name {
+            const TYPE: Option<Type> = Some($variant);
+
+            fn kind(&self) -> Option<type_system::Type> {
+                self.0
+                    .clone()
+                    .or_else(|| Self::TYPE.map(Kind::from))
+            }
+
+            fn from_kind(kind: Option<type_system::Type>) -> Self {
+                // Normalize: a kind that says no more than the
+                // static type is not stored, so unnarrowed terms
+                // stay equal to their pre-roundtrip selves.
+                let stored = kind.filter(|k| Some(k) != Self::TYPE.map(Kind::from).as_ref());
+                $name(stored)
+            }
+        }
+
+        impl Typed for $name {
+            type Descriptor = Self;
+        }
+    };
+}
+
+define_refinable_descriptor!(
     /// Descriptor for entity references.
     EntityType, Type::Entity
 );
 
-define_descriptor!(
+define_refinable_descriptor!(
     /// Descriptor for attribute symbols.
     Symbol, Type::Symbol
 );
@@ -368,8 +408,11 @@ mod tests {
         assert_eq!(to_singleton(SignedInteger.kind()), Some(Type::SignedInt));
         assert_eq!(to_singleton(Float.kind()), Some(Type::Float));
         assert_eq!(to_singleton(Bytes.kind()), Some(Type::Bytes));
-        assert_eq!(to_singleton(EntityType.kind()), Some(Type::Entity));
-        assert_eq!(to_singleton(Symbol.kind()), Some(Type::Symbol));
+        assert_eq!(
+            to_singleton(EntityType::default().kind()),
+            Some(Type::Entity)
+        );
+        assert_eq!(to_singleton(Symbol::default().kind()), Some(Type::Symbol));
         assert_eq!(to_singleton(Record.kind()), Some(Type::Record));
     }
 


### PR DESCRIPTION
Stacked on #350 (feat/type-checker). Three commits, each a complete layer:

**Type predicates** (`?x.text()`, `?x.number()`, `?x.textual()`, ...): occurrence typing as a premise. The predicate's schema carries the demanded kind as its slot content type, so rule-level inference narrows the variable everywhere it flows; evaluation filters rows whose value does not inhabit the kind. `Constraint::TypeOf`, wire tag `"type"`.

**Range/prefix predicates**: one `StartsWith` predicate over the TEXTUAL bound (`String | Symbol | Entity`) comparing each value's lexical form, plus `LessThan`/`AtMost`/`GreaterThan`/`AtLeast` over NUMERIC (wire `<`, `<=`, `>`, `>=`). A constant prefix refines inference by dropping members whose lexical grammar it cannot begin: a 65-byte prefix drops Symbol (the validator caps attribute names at 64 bytes, pinned by test), whitespace or a non-scheme head drops Entity (serialized URLs always begin `scheme:`), and String always remains, so the contributed kind is never empty. Comparisons order within one numeric type with the same strict no-promotion semantics as formula arithmetic; a constant side is a polymorphic literal adapting losslessly per row, data never adapts.

**Refinement layer + pushdown**: `Type::Refined(Primitive, Refinement)` makes the prefix itself first-class on the lattice. The meet keeps the stronger of compatible prefixes (disjoint prefixes are an empty meet, the ordinary compile error), the join keeps the longest common prefix, and `Type::admits` enforces refinements at every data boundary for free. The planner stamps inferred kinds onto scan attribute/entity terms (the `Symbol`/`EntityType` descriptors now carry an `Option<Kind>`, normalized away when it adds nothing, so unnarrowed terms compare and round-trip unchanged), and the selector conversion turns them into `ArtifactSelector::the_starting_with` / `of_starting_with` range bounds: exact AEV key ranges for attribute prefixes, EAV ranges over the 32-byte raw URI head with a datum re-check beyond it for entities. Value refinements travel through all of this but stop at the hashed VAE segment; that consumer is dialog-db-57 (order-preserving value encoding), kept out of scope as a deliberate storage-format decision.

Design records: `notes/refinements.md`, `notes/formula-schemes.md` (addenda).

Suite: 1585 passed, 0 skipped at d2f03382.