### PR TITLE
fix: search tree delete canonicity and stream range bounds

### DIFF
--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -5,7 +5,7 @@
 //! from the read-only [`Tree`] interface, we achieve clearer separation of
 //! concerns and make the codebase more maintainable.
 
-use std::{collections::VecDeque, marker::PhantomData};
+use std::marker::PhantomData;
 
 use dialog_common::Blake3Hash;
 use hashbrown::HashMap;
@@ -232,20 +232,26 @@ where
     /// 1. **Key doesn't exist in segment**: Returns the current root unchanged
     ///    with the original delta (no-op).
     ///
-    /// 2. **Segment becomes empty**: Removes the empty segment by merging its
-    ///    siblings at the parent level, then rebuilds the tree upward.
+    /// 2. **Boundary-delete overflow**: The deleted entry was the segment's
+    ///    last entry (its boundary) and a right-adjacent segment exists. The
+    ///    right-adjacent segment adopts the orphans (possibly none, when the
+    ///    deletion emptied the segment): the combined entries are
+    ///    redistributed and the two affected subtrees are stitched back
+    ///    together at their lowest common ancestor. Requires the
+    ///    `right_neighbor` prefetch on the search result. See
+    ///    `Self::let_right_neighbor_adopt_orphans`.
     ///
-    /// 3. **Boundary-delete overflow**: The deleted entry was the segment's
-    ///    last entry (its boundary), the segment still has orphan entries, and
-    ///    a right-adjacent segment exists. The right-adjacent segment adopts
-    ///    the orphans: the combined entries are redistributed and the two
-    ///    affected subtrees are stitched back together at their lowest common
-    ///    ancestor. Requires the `right_neighbor` prefetch on the search
-    ///    result. See `Self::let_right_neighbor_adopt_orphans`.
+    /// 3. **Rightmost segment becomes empty**: There is no right-adjacent
+    ///    segment to adopt anything, so the empty segment is removed from its
+    ///    parent and the tree is rebuilt upward.
     ///
     /// 4. **Ordinary shrink**: The segment still has entries after removal and
     ///    there is no overflow. The remaining entries are redistributed using
     ///    their intrinsic ranks and the tree path is rebuilt.
+    ///
+    /// A deletion can leave a stale chain of single-child index nodes at the
+    /// root (when the deleted key's rank was what demanded those levels);
+    /// callers must collapse it, see `Tree::collapse_root_chain`.
     pub fn delete(
         self,
         key: &Key,
@@ -270,13 +276,13 @@ where
         let mut segment = into_owned::<Segment<Key, Value>>(segment)?;
         segment.entries.remove(removal_index);
 
-        // Boundary-delete with non-empty orphans and a right-adjacent segment
-        // triggers overflow: the orphans must fold into the next segment so
-        // the resulting tree matches a from-scratch build.
-        if deleted_boundary
-            && !segment.entries.is_empty()
-            && let Some(right_neighbor) = search_result.right_neighbor
-        {
+        // Boundary-delete with a right-adjacent segment triggers overflow:
+        // the dissolved boundary demands fusion with the right-adjacent
+        // subtree so the resulting tree matches a from-scratch build. This
+        // applies even when the deletion emptied the segment (zero orphans):
+        // the boundary may have terminated index groups at several levels,
+        // and all of them fuse with their right-adjacent peers.
+        if deleted_boundary && let Some(right_neighbor) = search_result.right_neighbor {
             let main_leaf_hash = search_result.leaf.hash().clone();
             return self.let_right_neighbor_adopt_orphans(
                 segment.entries,
@@ -291,18 +297,25 @@ where
         // remaining entries redistribute in place), a boundary delete with no
         // right-adjacent segment (the segment was the rightmost in the tree,
         // so there is no neighbor to adopt the remaining entries and they
-        // redistribute in place), or a delete that emptied the segment
-        // entirely (the segment itself must be removed from its parent).
+        // redistribute in place), or a delete that emptied the rightmost
+        // segment entirely (the segment itself must be removed from its
+        // parent).
         match NonEmpty::from_vec(segment.entries) {
             Some(entries) => self.distribute(entries, Some(search_result)),
-            None => self.remove_from_path(search_result.path),
+            None => {
+                let main_leaf_hash = search_result.leaf.hash().clone();
+                self.remove_from_path(main_leaf_hash, search_result.path)
+            }
         }
     }
 
     /// Resolves a boundary-delete overflow by letting the prefetched
     /// right-adjacent segment adopt the orphaned entries.
     ///
-    /// See case (3) in [`Self::delete`] for the high-level contract.
+    /// See case (2) in [`Self::delete`] for the high-level contract. The
+    /// `orphans` list may be empty (the deletion emptied the segment); the
+    /// fusion below the lowest common ancestor is required regardless,
+    /// because it is driven by the dissolved boundary, not by the orphans.
     ///
     /// Throughout this method "LCA" stands for *lowest common ancestor*: the
     /// deepest node on the search path that is an ancestor of both the
@@ -460,16 +473,12 @@ where
             context.delta().remove(lca_layer.host.hash());
 
             if above_lca.is_empty() {
-                // The LCA was the tree root; the unified subtree is the new
-                // root. Forcing another collect here would inject an extra
-                // level (a 1-child index) that never appears in a from-scratch
-                // build.
-                context.delta().add_all(
-                    unified
-                        .iter()
-                        .map(|(n, _)| (n.hash().clone(), n.buffer().clone())),
-                );
-                return Ok((unified.head.0.hash().clone(), context.take_delta()));
+                // The LCA was the tree root; the unified subtree becomes the
+                // new root via the standard merge with nothing left to merge
+                // against. This can leave a stale single-child wrapper on
+                // top (the merge cannot know that nothing above demands the
+                // level); `Tree::collapse_root_chain` strips it.
+                return Self::merge_with_path(unified, vec![], context, level_minimum_rank);
             }
 
             // Promote the unified subtree to the LCA's level so it can slot
@@ -631,77 +640,61 @@ where
     /// Removes a segment from the tree when it becomes empty after deletion.
     ///
     /// This method handles the case where deleting an entry leaves a segment
-    /// with no entries. It removes the segment by merging its left and right
-    /// siblings at the parent level, then rebuilds the tree upward.
+    /// with no entries. It removes the segment from its parent (the deepest
+    /// layer of the path), regroups the parent's surviving children, and
+    /// rebuilds the tree upward.
     ///
     /// If the removed segment was the only child (no siblings), the removal
-    /// propagates upward. If it was the last segment in the entire tree, the
-    /// tree becomes empty.
+    /// cascades: the now-childless parent is removed from *its* parent, and
+    /// so on toward the root. Because the path is ordered root-first, the
+    /// cascade pops layers from the back, and it tracks how many levels it
+    /// has climbed so the survivors are regrouped with the rank threshold of
+    /// the level actually being rebuilt. If the cascade consumes the whole
+    /// path, the tree has become empty.
     fn remove_from_path(
         self,
-        path: Vec<TreeLayer<Key, Value>>,
-    ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
-        let context = MutationContext::<Key>::new(self.delta.branch());
-
-        Self::remove_from_path_with_context(path.into(), context)
-    }
-
-    /// Internal helper for `remove_from_path` that works with a
-    /// [`MutationContext`] directly.
-    ///
-    /// Takes a [`VecDeque`] rather than [`Vec`] so recursive/cascading removal
-    /// can `pop_front` each layer in O(1); a `Vec::remove(0)` here would push
-    /// the shift cost to O(H²) across a chain of collapsed ancestors.
-    fn remove_from_path_with_context(
-        mut path: VecDeque<TreeLayer<Key, Value>>,
-        mut context: MutationContext<Key>,
+        leaf_hash: Blake3Hash,
+        mut path: Vec<TreeLayer<Key, Value>>,
     ) -> Result<(Blake3Hash, Delta<Blake3Hash, Buffer>), DialogSearchTreeError> {
         use dialog_common::NULL_BLAKE3_HASH;
 
-        // If there's no parent, the tree becomes empty
-        let Some(layer) = path.pop_front() else {
-            return Ok((NULL_BLAKE3_HASH.clone(), Delta::zero()));
-        };
+        let mut context = MutationContext::<Key>::new(self.delta.branch());
+        context.delta().remove(&leaf_hash);
 
-        context.delta().remove(layer.host.hash());
+        // The level of the removed child at the layer currently being
+        // popped; the leaf's parent hosts level-0 children (segments).
+        let mut level: Rank = 0;
 
-        // Collect left and right siblings, excluding the removed segment
-        let mut links = Vec::new();
+        while let Some(layer) = path.pop() {
+            context.delta().remove(layer.host.hash());
 
-        if let Some(left_siblings) = layer.left_siblings {
-            links.extend(left_siblings);
-        }
+            // Collect left and right siblings, excluding the removed child
+            let mut links = Vec::new();
+            if let Some(left_siblings) = layer.left_siblings {
+                links.extend(left_siblings);
+            }
+            if let Some(right_siblings) = layer.right_siblings {
+                links.extend(right_siblings);
+            }
 
-        // Note: we skip the removed segment's link here
-
-        if let Some(right_siblings) = layer.right_siblings {
-            links.extend(right_siblings);
-        }
-
-        // If no siblings remain, propagate the removal upward
-        if links.is_empty() {
-            return if path.is_empty() {
-                Ok((NULL_BLAKE3_HASH.clone(), context.take_delta()))
-            } else {
-                // Continue removing up the path with the same context
-                Self::remove_from_path_with_context(path, context)
+            let Some(links) = NonEmpty::from_vec(links) else {
+                // The removed child was the layer's only child; the layer's
+                // host dissolves and the removal cascades one level up.
+                level += 1;
+                continue;
             };
+
+            // The survivors are level-`level` nodes; regroup them into
+            // parents one level up and continue the standard merge from
+            // there. Both thresholds follow the "level `L` is built with
+            // threshold `L + 1`" rule.
+            let ranked_links = into_ranked_links(links, &mut context);
+            let nodes = Self::collect::<Link<_>>(ranked_links, FIRST_INDEX_RANK + level)?;
+            return Self::merge_with_path(nodes, path, context, FIRST_INDEX_RANK + level + 1);
         }
 
-        // We have siblings; rebuild with them
-        let Some(links) = NonEmpty::from_vec(links) else {
-            return Err(DialogSearchTreeError::Node(
-                "Unexpectedly empty link list".into(),
-            ));
-        };
-        let ranked_links = into_ranked_links(links, &mut context);
-
-        // Create nodes from the remaining links
-        let nodes = Self::collect::<Link<_>>(ranked_links, 1)?;
-
-        // Merge up the remaining path. `merge_with_path` pops from the back,
-        // so hand it back a `Vec` of the still-pending ancestors.
-        Self::merge_with_path(nodes, path.into(), context, FIRST_INDEX_RANK)
+        // Every layer cascaded away: the tree is empty.
+        Ok((NULL_BLAKE3_HASH.clone(), context.take_delta()))
     }
 
     /// Collects a sequence of ranked children into nodes based on a minimum

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -14,8 +14,9 @@ use rkyv::{
 };
 
 use crate::{
-    Accessor, Buffer, Cache, ContentAddressedStorage, Delta, DialogSearchTreeError, Entry, Key,
-    SearchOptions, SearchResult, SymmetryWith, TreeShaper, TreeWalker, Value, into_owned,
+    Accessor, ArchivedNodeBody, Buffer, Cache, ContentAddressedStorage, Delta,
+    DialogSearchTreeError, Entry, Key, Node, SearchOptions, SearchResult, SymmetryWith, TreeShaper,
+    TreeWalker, Value, into_owned,
 };
 
 /// A key-value store backed by a ranked prolly tree with content-addressed
@@ -196,12 +197,67 @@ where
         };
         if let Some(search_result) = self.search(key, storage, options).await? {
             let shaper = TreeShaper::new(self.root.clone(), self.delta.clone());
-            let (next_root, delta) = shaper.delete(key, search_result)?;
+            let (next_root, mut delta) = shaper.delete(key, search_result)?;
+            let next_root = Self::collapse_root_chain(next_root, &mut delta, storage).await?;
             Ok(self.advance(next_root, delta))
         } else {
             // Key not found in tree - nothing to delete
             Ok(self.clone())
         }
+    }
+
+    /// Collapses a stale chain of single-child index nodes at the root after
+    /// a deletion.
+    ///
+    /// A canonical tree never has an index root whose only child is another
+    /// index: building from scratch stops at the first level that holds a
+    /// single node (the only legitimate single-child root is an index over a
+    /// lone segment). Such chains can survive a delete when the deleted key's
+    /// rank was what created the upper levels: with the boundary gone, the
+    /// levels it terminated dissolve, but the rebuild works bottom-up along
+    /// the search path and cannot see that nothing above demanded them.
+    /// Walking down from the root and discarding wrappers restores the
+    /// canonical shape.
+    async fn collapse_root_chain<Backend>(
+        mut root: Blake3Hash,
+        delta: &mut Delta<Blake3Hash, Buffer>,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Blake3Hash, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync
+            + 'static,
+    {
+        if &root == NULL_BLAKE3_HASH {
+            return Ok(root);
+        }
+
+        // The accessor shares `delta` by reference counting, so removals
+        // below remain visible to it.
+        let accessor = Accessor::new(delta.clone(), Cache::new(), storage.clone());
+
+        loop {
+            let node: Node<Key, Value> = accessor.get_node(&root).await?;
+            let child_hash = match node.body()? {
+                ArchivedNodeBody::Index(index) if index.links.len() == 1 => {
+                    <&Blake3Hash>::from(&index.links[0].node).clone()
+                }
+                _ => break,
+            };
+
+            let child: Node<Key, Value> = accessor.get_node(&child_hash).await?;
+            match child.body()? {
+                ArchivedNodeBody::Index(_) => {
+                    // The wrapper is unreachable in the new tree; drop it
+                    // from the pending changes if it originated there.
+                    delta.remove(&root);
+                    root = child_hash;
+                }
+                ArchivedNodeBody::Segment(_) => break,
+            }
+        }
+
+        Ok(root)
     }
 
     /// Returns an async stream over all entries in the tree.
@@ -221,10 +277,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        self.stream_range(
-            <Key as self::Key>::min()..<Key as self::Key>::max(),
-            storage,
-        )
+        self.stream_range(.., storage)
     }
 
     /// Returns an async stream over entries with keys within the provided
@@ -1852,12 +1905,13 @@ mod tests {
     /// Deleting a boundary whose removal collapses the root must produce the
     /// same tree as building the remaining keys from scratch.
     ///
-    /// In this dataset the tree has exactly two segments under the root and
-    /// 69161 is the boundary of the first one. Deleting it makes the right
-    /// segment adopt the orphans, the root's two children fuse into one, and
-    /// the early-return in `let_right_neighbor_adopt_orphans` then returns
-    /// the fused node at the wrong level (here: a bare segment as the tree
-    /// root, where a canonical tree always has an index root).
+    /// Regression guard: in this dataset the tree has exactly two segments
+    /// under the root and 69161 is the boundary of the first one. Deleting
+    /// it makes the right segment adopt the orphans and the root's two
+    /// children fuse into one. `let_right_neighbor_adopt_orphans` used to
+    /// return the fused node at whatever level the fold reached (here: a
+    /// bare segment as the tree root, where a canonical tree always has an
+    /// index root) instead of collapsing to the canonical height.
     #[dialog_common::test]
     async fn it_produces_canonical_tree_when_boundary_delete_collapses_the_root() -> Result<()> {
         let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
@@ -1883,13 +1937,14 @@ mod tests {
     /// Deleting the sole entry of a segment must leave every other entry
     /// readable and produce the canonical tree.
     ///
-    /// In this dataset 198936 is a boundary that forms a single-entry
-    /// segment in a tree of height two, so deleting it sends a multi-layer
-    /// search path through `TreeShaper::remove_from_path`. That path
-    /// processes the layers in root-to-leaf order while `merge_with_path`
-    /// consumes them leaf-to-root, so the rebuilt subtrees come out in the
-    /// wrong key order: keys 10554, 83265 and 167706 land to the right of
-    /// larger keys and become unreachable through search.
+    /// Regression guard: in this dataset 198936 is a boundary that forms a
+    /// single-entry segment in a tree of height two, so deleting it walks a
+    /// multi-layer search path through the empty-segment repair.
+    /// `TreeShaper::remove_from_path` used to process the layers in
+    /// root-to-leaf order while `merge_with_path` consumes them leaf-to-root,
+    /// so the rebuilt subtrees came out in the wrong key order: keys 10554,
+    /// 83265 and 167706 landed to the right of larger keys and became
+    /// unreachable through search.
     #[dialog_common::test]
     async fn it_keeps_entries_readable_after_a_delete_empties_a_segment() -> Result<()> {
         let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
@@ -1927,8 +1982,8 @@ mod tests {
     }
 
     /// A range with an unbounded start bound must stream every entry below
-    /// the end bound. `TreeWalker::stream` currently returns immediately on
-    /// `Bound::Unbounded` and yields nothing.
+    /// the end bound. Regression guard: `TreeWalker::stream` used to return
+    /// immediately on `Bound::Unbounded`, yielding nothing.
     #[dialog_common::test]
     async fn it_streams_ranges_with_unbounded_start() -> Result<()> {
         use futures_util::StreamExt;
@@ -1948,9 +2003,9 @@ mod tests {
     }
 
     /// Streaming the whole tree must include an entry whose key is the
-    /// maximum key. `Tree::stream` currently delegates to
-    /// `stream_range(Key::min()..Key::max())`, and the exclusive end bound
-    /// drops the maximum key.
+    /// maximum key. Regression guard: `Tree::stream` used to delegate to
+    /// `stream_range(Key::min()..Key::max())`, whose exclusive end bound
+    /// dropped the maximum key.
     #[dialog_common::test]
     async fn it_streams_the_maximum_key() -> Result<()> {
         use futures_util::StreamExt;
@@ -1975,6 +2030,71 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 6, "stream should include the maximum key");
+        Ok(())
+    }
+
+    /// After every mutation, the tree must be byte-identical to a tree built
+    /// from scratch over the same logical content. This is the invariant the
+    /// whole crate is built around: same entries, same root hash, regardless
+    /// of the operation history. Random insert/delete sequences over random
+    /// key sets exercise every mutation path (in-place redistribution,
+    /// orphan adoption across parents, empty-segment removal, cascade
+    /// collapse, root chain stripping) without hand-picking datasets.
+    #[dialog_common::test]
+    async fn it_converges_to_canonical_form_after_every_operation() -> Result<()> {
+        use std::collections::BTreeSet;
+
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+
+        let mut rng = StdRng::seed_from_u64(0x_D1A1_06DB);
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        for trial in 0..2 {
+            // Seed the tree with a random key set.
+            let mut live = BTreeSet::new();
+            let initial_size = rng.gen_range(40..120);
+            while live.len() < initial_size {
+                live.insert(rng.gen_range(0..200_000u32));
+            }
+            let initial: Vec<u32> = live.iter().copied().collect();
+            let mut tree = build_and_flush_u32(&initial, &mut storage).await?;
+
+            for op in 0..120 {
+                // Half deletes of present keys, half inserts of fresh keys
+                // (which occasionally hit a present key and become updates).
+                if !live.is_empty() && rng.gen_bool(0.5) {
+                    let index = rng.gen_range(0..live.len());
+                    let key = *live.iter().nth(index).expect("index is in range");
+                    tree = tree.delete(&key.to_le_bytes(), &storage).await?;
+                    live.remove(&key);
+                } else {
+                    let key = rng.gen_range(0..200_000u32);
+                    tree = tree
+                        .insert(key.to_le_bytes(), key.to_le_bytes().to_vec(), &storage)
+                        .await?;
+                    live.insert(key);
+                }
+
+                // Flush periodically so both the delta-resident and the
+                // storage-resident read paths get exercised.
+                if op % 10 == 9 {
+                    for (hash, buffer) in tree.flush() {
+                        storage.store(buffer.as_ref().to_vec(), &hash).await?;
+                    }
+                }
+
+                let content: Vec<u32> = live.iter().copied().collect();
+                let scratch = build_and_flush_u32(&content, &mut storage).await?;
+                assert_eq!(
+                    tree.root(),
+                    scratch.root(),
+                    "trial {trial}, operation {op}: tree diverged from the \
+                     canonical form of its {} entries",
+                    content.len(),
+                );
+            }
+        }
+
         Ok(())
     }
 }

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -1828,4 +1828,153 @@ mod tests {
 
         Ok(())
     }
+
+    /// Builds a tree by inserting the given u32 keys (little-endian encoded)
+    /// in order and flushing the result to storage.
+    async fn build_and_flush_u32(
+        keys: &[u32],
+        storage: &mut ContentAddressedStorage<
+            MemoryStorageBackend<dialog_common::Blake3Hash, Vec<u8>>,
+        >,
+    ) -> Result<Tree<[u8; 4], Vec<u8>>> {
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        for &k in keys {
+            tree = tree
+                .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), storage)
+                .await?;
+        }
+        for (hash, buffer) in tree.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+        Ok(tree)
+    }
+
+    /// Deleting a boundary whose removal collapses the root must produce the
+    /// same tree as building the remaining keys from scratch.
+    ///
+    /// In this dataset the tree has exactly two segments under the root and
+    /// 69161 is the boundary of the first one. Deleting it makes the right
+    /// segment adopt the orphans, the root's two children fuse into one, and
+    /// the early-return in `let_right_neighbor_adopt_orphans` then returns
+    /// the fused node at the wrong level (here: a bare segment as the tree
+    /// root, where a canonical tree always has an index root).
+    #[dialog_common::test]
+    async fn it_produces_canonical_tree_when_boundary_delete_collapses_the_root() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let keys: Vec<u32> = vec![69161, 101527, 102790, 164389, 171478, 193283];
+
+        let mut tree = build_and_flush_u32(&keys, &mut storage).await?;
+        let mut after = tree.delete(&69161u32.to_le_bytes(), &storage).await?;
+        for (hash, buffer) in after.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+
+        let remaining: Vec<u32> = keys.iter().copied().filter(|&k| k != 69161).collect();
+        let scratch = build_and_flush_u32(&remaining, &mut storage).await?;
+
+        assert_eq!(
+            after.root(),
+            scratch.root(),
+            "boundary delete that collapses the root should be canonical"
+        );
+        Ok(())
+    }
+
+    /// Deleting the sole entry of a segment must leave every other entry
+    /// readable and produce the canonical tree.
+    ///
+    /// In this dataset 198936 is a boundary that forms a single-entry
+    /// segment in a tree of height two, so deleting it sends a multi-layer
+    /// search path through `TreeShaper::remove_from_path`. That path
+    /// processes the layers in root-to-leaf order while `merge_with_path`
+    /// consumes them leaf-to-root, so the rebuilt subtrees come out in the
+    /// wrong key order: keys 10554, 83265 and 167706 land to the right of
+    /// larger keys and become unreachable through search.
+    #[dialog_common::test]
+    async fn it_keeps_entries_readable_after_a_delete_empties_a_segment() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let keys: Vec<u32> = vec![
+            10554, 28619, 40390, 43764, 45237, 48124, 64082, 66285, 67399, 67838, 81131, 83265,
+            92896, 94186, 98645, 103270, 110189, 114100, 123267, 127869, 135162, 136309, 147808,
+            153518, 154310, 156529, 161523, 167706, 172145, 172489, 176828, 187970, 189253, 198936,
+        ];
+
+        let mut tree = build_and_flush_u32(&keys, &mut storage).await?;
+        let mut after = tree.delete(&198936u32.to_le_bytes(), &storage).await?;
+        for (hash, buffer) in after.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+
+        let mut unreadable = vec![];
+        for &k in keys.iter().filter(|&&k| k != 198936) {
+            if after.get(&k.to_le_bytes(), &storage).await?.is_none() {
+                unreadable.push(k);
+            }
+        }
+        assert!(
+            unreadable.is_empty(),
+            "live keys unreadable after emptying a segment: {unreadable:?}"
+        );
+
+        let remaining: Vec<u32> = keys.iter().copied().filter(|&k| k != 198936).collect();
+        let scratch = build_and_flush_u32(&remaining, &mut storage).await?;
+        assert_eq!(
+            after.root(),
+            scratch.root(),
+            "emptying a segment should produce the canonical tree"
+        );
+        Ok(())
+    }
+
+    /// A range with an unbounded start bound must stream every entry below
+    /// the end bound. `TreeWalker::stream` currently returns immediately on
+    /// `Bound::Unbounded` and yields nothing.
+    #[dialog_common::test]
+    async fn it_streams_ranges_with_unbounded_start() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let tree = build_and_flush_u32(&(0..10).collect::<Vec<_>>(), &mut storage).await?;
+
+        let stream = tree.stream_range(..5u32.to_le_bytes(), &storage);
+        futures_util::pin_mut!(stream);
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 5, "..end range should yield entries below end");
+        Ok(())
+    }
+
+    /// Streaming the whole tree must include an entry whose key is the
+    /// maximum key. `Tree::stream` currently delegates to
+    /// `stream_range(Key::min()..Key::max())`, and the exclusive end bound
+    /// drops the maximum key.
+    #[dialog_common::test]
+    async fn it_streams_the_maximum_key() -> Result<()> {
+        use futures_util::StreamExt;
+
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::<[u8; 4], Vec<u8>>::empty();
+        for i in 0..5u32 {
+            tree = tree
+                .insert(i.to_le_bytes(), vec![i as u8], &storage)
+                .await?;
+        }
+        tree = tree.insert([0xFF; 4], vec![0xFF], &storage).await?;
+        for (hash, buffer) in tree.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+
+        let stream = tree.stream(&storage);
+        futures_util::pin_mut!(stream);
+        let mut count = 0;
+        while let Some(entry) = stream.next().await {
+            entry?;
+            count += 1;
+        }
+        assert_eq!(count, 6, "stream should include the maximum key");
+        Ok(())
+    }
 }

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -86,13 +86,12 @@ where
             // Get the start key. Included/Excluded ranges are identical here,
             // the check if key is in range is below, and this will at most read
             // one unnecessary segment iff `Bound::Excluded(K)` and `K` is a
-            // boundary node.
+            // boundary node. An unbounded start begins at the leftmost leaf,
+            // which searching for the minimum key descends to.
             let start_key = match range.start_bound() {
                 Bound::Included(start) => start.clone(),
                 Bound::Excluded(start) => start.clone(),
-                Bound::Unbounded => {
-                    return;
-                },
+                Bound::Unbounded => <Key as crate::Key>::min(),
             };
             let Some(search_result) = self
                 .search(&start_key, accessor.clone(), SearchOptions::default())


### PR DESCRIPTION
Stacked on #332. A deep review of `dialog-search-tree` surfaced four bugs; this PR adds minimal failing tests that document each one. **CI is expected to be red on this branch**: the tests go green as the fixes land.

## 1. Emptying a segment corrupts key ordering (data loss for reads)

`TreeShaper::remove_from_path_with_context` consumes the search path with `pop_front()` (root first) while `merge_with_path` consumes it from the back (leaf first), and it collects the surviving sibling links with `minimum_rank = 1` instead of the threshold for the level being rebuilt. When a delete empties a segment in a tree of height >= 2, the rebuilt subtrees come out in the wrong key order. In the repro, deleting key `198936` makes keys `10554`, `83265` and `167706` unreadable via `get` even though their entries still exist. This does not self-heal.

Existing coverage missed this because `it_produces_canonical_tree_after_emptying_a_segment` silently returns `Ok(())` when its dataset contains no single-entry segment, and `0..2000` contains none, so the repair path was never actually exercised.

## 2. Boundary delete that collapses the root is non-canonical

The early return in `let_right_neighbor_adopt_orphans` (LCA is the root and has no surviving siblings) returns the fused node at whatever level the fold reached. For a two-segment tree the new root is a bare segment node, where a canonical tree always has an index root; for deeper trees stale single-child index levels survive. Reads still work and the next insert heals the shape, but identical content no longer implies an identical root hash. Randomized testing of the overflow path shows the other two branches (LCA keeps siblings, promote above LCA) are correct; only this early return diverges.

## 3. `stream_range` with an unbounded start yields nothing

`TreeWalker::stream` returns immediately on `Bound::Unbounded`, so `tree.stream_range(..end)` is always empty.

## 4. `Tree::stream` drops an entry keyed by `Key::max()`

`stream` delegates to `stream_range(Key::min()..Key::max())` and the exclusive end bound excludes a key of all `0xFF` bytes.

## Not included here

The rank distribution skew in `distribution::compute_geometric_rank` (7-bit batches straddle byte boundaries and are zero-filled, making promotion probabilities 1/2, 1/4, 1/8... instead of 1/128 above the first level) is left out of this PR since fixing it changes every persisted root hash; that conversation continues on #242.

## How these compare to dialog-prolly-tree

Since the goal of `dialog-search-tree` is to replace `dialog-prolly-tree` without introducing bugs, it matters which of these are regressions and which are inherited:

| Bug | dialog-search-tree | dialog-prolly-tree |
|---|---|---|
| Empty-segment delete corrupts key order (1) | yes, live keys become unreadable | **no, regression**: the old `remove` pops the branch stack from the back, which is the correct leaf-first order; the rewrite switched to `VecDeque::pop_front` over a root-first path |
| `stream_range(..end)` yields nothing (3) | yes | **no, regression**: the old `get_range` handles `Bound::Unbounded` by descending to the leftmost child |
| `stream()` drops the `Key::max()` entry (4) | yes | **no, regression**: the old `stream()` delegates to `stream_range(..)` rather than `min()..max()` |
| Boundary delete non-canonical (2) | only the LCA-is-root collapse branch | **worse there**: the old tree has no orphan adoption at all, so every boundary delete is non-canonical; #332 is a strict improvement, just incomplete in this one branch |
| Sibling regrouping with `minimum_rank = 1` after a segment removal | yes (part of bug 1) | **inherited**: same logic at `node.rs:308`, producing the same non-canonical shapes |
| Rank distribution skew | yes | **inherited**: byte-identical bit-batch code; #242 fixes both crates |

In short: three of the four behavioral bugs here are new in the rewrite and all have small, contained fixes; the boundary-delete work in #332 is a genuine improvement over the old tree with one remaining broken branch.

## Update: fixes included

This PR now also contains the fixes, so CI should be green; the repro tests above remain as regression guards, and their doc comments describe the original failure modes.

1. **Empty-segment deletion** (`TreeShaper::remove_from_path`): the cascade now pops the search path leaf-first (matching `merge_with_path`), tracks how many levels it has climbed, and regroups the surviving siblings with the rank threshold of the level actually being rebuilt. The previous code popped root-first via `VecDeque::pop_front` and always collected with `minimum_rank = 1`.

2. **Boundary deletes that empty the segment** now route through `let_right_neighbor_adopt_orphans` with zero orphans instead of `remove_from_path`. The dissolved boundary may have terminated index groups at several levels, and all of them need the cross-parent fusion; the repair-by-sibling-regrouping path can only rebuild within one parent. `remove_from_path` is now reached only when the rightmost segment of the tree empties (no right neighbor exists).

3. **Root collapse** (`Tree::collapse_root_chain`): after a delete, a stale chain of single-child index nodes can survive at the root when the deleted key's rank was what demanded those levels. A canonical root is never an index whose only child is another index (from-scratch builds stop at the first single-node level), so the tree walks down from the root after every delete and discards such wrappers. This replaces the adopt path's early return, which used to hand back the fused node at whatever level the fold reached (including a bare segment as root).

4. **Stream bounds**: `TreeWalker::stream` descends to the leftmost leaf for an unbounded start bound (it used to return an empty stream), and `Tree::stream` delegates to `stream_range(..)` (it used to use `Key::min()..Key::max()`, dropping an entry keyed by all `0xFF` bytes).

## Verification

A new property test (`it_converges_to_canonical_form_after_every_operation`) asserts after every operation of a seeded random insert/delete sequence that the tree's root is byte-identical to a from-scratch build of the same logical content, with periodic flushes so both delta-resident and storage-resident paths are exercised. This is the invariant all five bugs in this saga violated, and it now runs in CI.
