### PR TITLE
perf: bulk-build empty-tree batches and validate node buffers once

### DIFF
--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -23,9 +23,11 @@
 //! orphan rule rules out inherent methods — the operations are exposed as
 //! an extension trait instead.
 
+use std::collections::BTreeMap;
+
 use async_stream::try_stream;
 use async_trait::async_trait;
-use dialog_common::{Blake3Hash as NodeHash, ConditionalSend, ConditionalSync};
+use dialog_common::{Blake3Hash as NodeHash, ConditionalSend, ConditionalSync, NULL_BLAKE3_HASH};
 use dialog_search_tree::{ContentAddressedStorage, Entry, Tree, Value as TreeValue};
 use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
 use futures_util::{Stream, StreamExt};
@@ -144,6 +146,16 @@ impl ArtifactTreeExt for ArtifactTree {
             + ConditionalSync,
         I: Stream<Item = Instruction> + ConditionalSend,
     {
+        // A batch applied to an empty tree (the seeding path) stages
+        // entirely in memory and builds the tree bottom-up in one pass:
+        // every key is ranked once and every node is serialized and hashed
+        // exactly once. The per-instruction loop below instead rewrites
+        // each touched segment once per insert, which dominates seed
+        // commits.
+        if self.root() == NULL_BLAKE3_HASH {
+            return apply_to_empty(self, instructions).await;
+        }
+
         let storage = ContentAddressedStorage::new(TreeStorageBridge(store.clone()));
 
         tokio::pin!(instructions);
@@ -324,5 +336,190 @@ impl ArtifactTreeExt for ArtifactTree {
                 }
             }
         }
+    }
+}
+
+/// Applies a batch of instructions to an empty tree by staging the final
+/// key/value set in memory and bulk-building the tree in one bottom-up
+/// pass ([`Tree::from_entries`]).
+///
+/// Semantically identical to the per-instruction loop in
+/// [`ArtifactTreeExt::apply`]: because the base tree is empty, the staged
+/// map is at every point exactly the state the incremental loop's tree
+/// would hold, so `Replace` supersession scans the map instead of the
+/// tree.
+async fn apply_to_empty<I>(
+    tree: &mut ArtifactTree,
+    instructions: I,
+) -> Result<(), DialogArtifactsError>
+where
+    I: Stream<Item = Instruction> + ConditionalSend,
+{
+    let mut staged: BTreeMap<KeyBytes, State<Datum>> = BTreeMap::new();
+
+    tokio::pin!(instructions);
+    while let Some(instruction) = instructions.next().await {
+        match instruction {
+            Instruction::Assert(artifact) => {
+                let entity_key = EntityKey::from(&artifact);
+                let value_key = ValueKey::from_key(&entity_key);
+                let attribute_key = AttributeKey::from_key(&entity_key);
+
+                let datum = Datum::from(artifact);
+                let added = State::Added(datum);
+                staged.insert(entity_key.into_key().into(), added.clone());
+                staged.insert(attribute_key.into_key().into(), added.clone());
+                staged.insert(value_key.into_key().into(), added);
+            }
+            Instruction::Replace(artifact) => {
+                let entity_key = EntityKey::from(&artifact);
+
+                // Scan staged priors at this (entity, attribute); the
+                // base tree is empty, so the staged batch is the entire
+                // state. Same-valued priors already represent the desired
+                // state; only different-valued ones need superseding.
+                let search_start = <EntityKey<Key> as KeyViewConstruct>::min()
+                    .set_entity(entity_key.entity())
+                    .set_attribute(entity_key.attribute())
+                    .into_key();
+                let search_end = <EntityKey<Key> as KeyViewConstruct>::max()
+                    .set_entity(entity_key.entity())
+                    .set_attribute(entity_key.attribute())
+                    .into_key();
+
+                let mut superseded_keys: Vec<Key> = Vec::new();
+                let mut found_same_value = false;
+                for (key, state) in
+                    staged.range(KeyBytes::from(search_start)..=KeyBytes::from(search_end))
+                {
+                    if let State::Added(current_element) = state {
+                        let current = Artifact::try_from(current_element.clone())?;
+                        if current.is == artifact.is {
+                            found_same_value = true;
+                        } else {
+                            superseded_keys.push(Key::from(*key));
+                        }
+                    }
+                }
+
+                for key in superseded_keys {
+                    let entity_key = EntityKey(key);
+                    let value_key = ValueKey::from_key(&entity_key);
+                    let attribute_key = AttributeKey::from_key(&entity_key);
+
+                    staged.remove(&KeyBytes::from(entity_key.into_key()));
+                    staged.remove(&KeyBytes::from(value_key.into_key()));
+                    staged.remove(&KeyBytes::from(attribute_key.into_key()));
+                }
+
+                if found_same_value {
+                    continue;
+                }
+
+                let entity_key = EntityKey::from(&artifact);
+                let value_key = ValueKey::from_key(&entity_key);
+                let attribute_key = AttributeKey::from_key(&entity_key);
+                let datum = Datum::from(artifact);
+                let added = State::Added(datum);
+                staged.insert(entity_key.into_key().into(), added.clone());
+                staged.insert(attribute_key.into_key().into(), added.clone());
+                staged.insert(value_key.into_key().into(), added);
+            }
+            Instruction::Retract(artifact) => {
+                let entity_key = EntityKey::from(&artifact);
+                let value_key = ValueKey::from_key(&entity_key);
+                let attribute_key = AttributeKey::from_key(&entity_key);
+
+                let removed: State<Datum> = State::Removed;
+                staged.insert(entity_key.into_key().into(), removed.clone());
+                staged.insert(attribute_key.into_key().into(), removed.clone());
+                staged.insert(value_key.into_key().into(), removed);
+            }
+        }
+    }
+
+    *tree = ArtifactTree::from_entries(staged)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use anyhow::Result;
+    use dialog_storage::MemoryStorageBackend;
+    use futures_util::stream;
+
+    use super::{ArtifactTree, ArtifactTreeExt as _};
+    use crate::{Artifact, Instruction, Value};
+
+    fn artifact(entity: u32, attribute: &str, value: &str) -> Artifact {
+        Artifact {
+            the: attribute.parse().expect("valid attribute"),
+            of: format!("user:{entity}").parse().expect("valid entity"),
+            is: Value::String(value.to_string()),
+            cause: None,
+        }
+    }
+
+    /// The bulk (empty-tree) apply path must produce the byte-identical
+    /// canonical tree the per-instruction path produces. The incremental
+    /// side seeds one instruction first (taking the bulk path for a tree
+    /// of one instruction), then applies the rest through the non-empty
+    /// per-insert path.
+    fn instructions() -> Vec<Instruction> {
+        let mut instructions = Vec::new();
+        for entity in 0..24u32 {
+            instructions.push(Instruction::Assert(artifact(
+                entity,
+                "test/name",
+                &format!("name-{entity}"),
+            )));
+            instructions.push(Instruction::Assert(artifact(
+                entity,
+                "test/role",
+                &format!("role-{entity}"),
+            )));
+        }
+        // Cardinality-one updates: supersede some priors, repeat one
+        // same-valued write (a no-op), and retract a fact.
+        for entity in 0..8u32 {
+            instructions.push(Instruction::Replace(artifact(
+                entity,
+                "test/role",
+                &format!("role-updated-{entity}"),
+            )));
+        }
+        instructions.push(Instruction::Replace(artifact(3, "test/name", "name-3")));
+        instructions.push(Instruction::Retract(artifact(9, "test/name", "name-9")));
+        instructions
+    }
+
+    #[dialog_common::test]
+    async fn it_bulk_applies_to_an_empty_tree_canonically() -> Result<()> {
+        let mut bulk_store = MemoryStorageBackend::default();
+        let mut bulk = ArtifactTree::empty();
+        bulk.apply(&mut bulk_store, stream::iter(instructions()))
+            .await?;
+
+        let mut incremental_store = MemoryStorageBackend::default();
+        let mut incremental = ArtifactTree::empty();
+        let mut first = instructions();
+        let rest = first.split_off(1);
+        incremental
+            .apply(&mut incremental_store, stream::iter(first))
+            .await?;
+        incremental
+            .apply(&mut incremental_store, stream::iter(rest))
+            .await?;
+
+        assert_eq!(
+            bulk.root(),
+            incremental.root(),
+            "bulk apply must build the same canonical tree as incremental apply"
+        );
+
+        Ok(())
     }
 }

--- a/rust/dialog-search-tree/Cargo.toml
+++ b/rust/dialog-search-tree/Cargo.toml
@@ -43,6 +43,10 @@ futures-util = { workspace = true }
 tokio-test = { workspace = true }
 
 [[bench]]
+name = "bulk"
+harness = false
+
+[[bench]]
 name = "insert"
 harness = false
 

--- a/rust/dialog-search-tree/benches/bulk.rs
+++ b/rust/dialog-search-tree/benches/bulk.rs
@@ -1,0 +1,85 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_common::helpers::BenchData;
+use dialog_search_tree::{ContentAddressedStorage, Tree};
+use dialog_storage::MemoryStorageBackend;
+
+const BENCH_SEED: u64 = 42;
+
+/// Compares materializing a batch through a per-key insert loop against
+/// the one-pass bulk build (`Tree::from_entries`). The insert loop
+/// rewrites every touched segment once per insert; the bulk build ranks
+/// every key and serializes every node exactly once. Both produce the
+/// same canonical tree, so the gap between the two lines is pure
+/// redundant work.
+fn bench_build_sequential(c: &mut Criterion) {
+    let mut group = c.benchmark_group("build_sequential");
+    let mut data = BenchData::new(BENCH_SEED);
+
+    for size in [10, 100, 1000, 10000] {
+        let keys = data.sequential_buffers::<16>(size);
+        let values = data.random_buffers::<32>(size);
+
+        group.bench_with_input(BenchmarkId::new("insert_loop", size), &size, |b, _size| {
+            b.to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter(|| async {
+                    let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+                    let mut tree = Tree::<[u8; 16], Vec<u8>>::empty();
+
+                    for (key, value) in keys.iter().zip(values.iter()) {
+                        tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+                    }
+                });
+        });
+
+        group.bench_with_input(BenchmarkId::new("from_entries", size), &size, |b, _size| {
+            b.iter(|| {
+                Tree::<[u8; 16], Vec<u8>>::from_entries(
+                    keys.iter()
+                        .zip(values.iter())
+                        .map(|(key, value)| (*key, value.to_vec())),
+                )
+                .unwrap()
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_build_random(c: &mut Criterion) {
+    let mut group = c.benchmark_group("build_random");
+    let mut data = BenchData::new(BENCH_SEED);
+
+    for size in [10, 100, 1000, 10000] {
+        let keys = data.random_buffers::<16>(size);
+        let values = data.random_buffers::<32>(size);
+
+        group.bench_with_input(BenchmarkId::new("insert_loop", size), &size, |b, _size| {
+            b.to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter(|| async {
+                    let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+                    let mut tree = Tree::<[u8; 16], Vec<u8>>::empty();
+
+                    for (key, value) in keys.iter().zip(values.iter()) {
+                        tree = tree.insert(*key, value.to_vec(), &storage).await.unwrap();
+                    }
+                });
+        });
+
+        group.bench_with_input(BenchmarkId::new("from_entries", size), &size, |b, _size| {
+            b.iter(|| {
+                Tree::<[u8; 16], Vec<u8>>::from_entries(
+                    keys.iter()
+                        .zip(values.iter())
+                        .map(|(key, value)| (*key, value.to_vec())),
+                )
+                .unwrap()
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_build_sequential, bench_build_random);
+criterion_main!(benches);

--- a/rust/dialog-search-tree/src/buffer.rs
+++ b/rust/dialog-search-tree/src/buffer.rs
@@ -14,7 +14,7 @@ use rkyv::util::AlignedVec;
 /// free to return odd addresses for align-1 allocations, which surfaced as
 /// "unaligned pointer" errors when accessing nodes loaded from storage.
 #[derive(Clone, Debug)]
-pub struct Buffer(Arc<(AlignedVec, OnceLock<Blake3Hash>)>);
+pub struct Buffer(Arc<(AlignedVec, OnceLock<Blake3Hash>, OnceLock<()>)>);
 
 impl Buffer {
     /// Returns the [`Blake3Hash`] of this buffer's contents, computing it if
@@ -23,6 +23,21 @@ impl Buffer {
         self.0
             .1
             .get_or_init(|| Blake3Hash::hash(self.0.0.as_slice()))
+    }
+
+    /// Records that this buffer's contents passed archive validation, so
+    /// subsequent accesses can skip the (linear) bytecheck pass. The marker
+    /// is shared across clones, including copies handed out by the node
+    /// cache and the delta. Buffers are immutable, so a single successful
+    /// validation holds for the buffer's lifetime.
+    pub(crate) fn mark_validated(&self) {
+        let _ = self.0.2.set(());
+    }
+
+    /// Returns whether this buffer's contents have already passed archive
+    /// validation.
+    pub(crate) fn is_validated(&self) -> bool {
+        self.0.2.get().is_some()
     }
 
     /// Converts this [`Buffer`] into an owned `Vec<u8>`.
@@ -51,13 +66,13 @@ impl From<&[u8]> for Buffer {
     fn from(value: &[u8]) -> Self {
         let mut bytes = AlignedVec::with_capacity(value.len());
         bytes.extend_from_slice(value);
-        Self(Arc::new((bytes, OnceLock::new())))
+        Self(Arc::new((bytes, OnceLock::new(), OnceLock::new())))
     }
 }
 
 impl From<AlignedVec> for Buffer {
     fn from(value: AlignedVec) -> Self {
-        Self(Arc::new((value, OnceLock::new())))
+        Self(Arc::new((value, OnceLock::new(), OnceLock::new())))
     }
 }
 

--- a/rust/dialog-search-tree/src/buffer.rs
+++ b/rust/dialog-search-tree/src/buffer.rs
@@ -14,7 +14,7 @@ use rkyv::util::AlignedVec;
 /// free to return odd addresses for align-1 allocations, which surfaced as
 /// "unaligned pointer" errors when accessing nodes loaded from storage.
 #[derive(Clone, Debug)]
-pub struct Buffer(Arc<(AlignedVec, OnceLock<Blake3Hash>, OnceLock<()>)>);
+pub struct Buffer(Arc<(AlignedVec, OnceLock<Blake3Hash>)>);
 
 impl Buffer {
     /// Returns the [`Blake3Hash`] of this buffer's contents, computing it if
@@ -23,21 +23,6 @@ impl Buffer {
         self.0
             .1
             .get_or_init(|| Blake3Hash::hash(self.0.0.as_slice()))
-    }
-
-    /// Records that this buffer's contents passed archive validation, so
-    /// subsequent accesses can skip the (linear) bytecheck pass. The marker
-    /// is shared across clones, including copies handed out by the node
-    /// cache and the delta. Buffers are immutable, so a single successful
-    /// validation holds for the buffer's lifetime.
-    pub(crate) fn mark_validated(&self) {
-        let _ = self.0.2.set(());
-    }
-
-    /// Returns whether this buffer's contents have already passed archive
-    /// validation.
-    pub(crate) fn is_validated(&self) -> bool {
-        self.0.2.get().is_some()
     }
 
     /// Converts this [`Buffer`] into an owned `Vec<u8>`.
@@ -66,13 +51,13 @@ impl From<&[u8]> for Buffer {
     fn from(value: &[u8]) -> Self {
         let mut bytes = AlignedVec::with_capacity(value.len());
         bytes.extend_from_slice(value);
-        Self(Arc::new((bytes, OnceLock::new(), OnceLock::new())))
+        Self(Arc::new((bytes, OnceLock::new())))
     }
 }
 
 impl From<AlignedVec> for Buffer {
     fn from(value: AlignedVec) -> Self {
-        Self(Arc::new((value, OnceLock::new(), OnceLock::new())))
+        Self(Arc::new((value, OnceLock::new())))
     }
 }
 

--- a/rust/dialog-search-tree/src/node.rs
+++ b/rust/dialog-search-tree/src/node.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, OnceLock};
+
 use dialog_common::Blake3Hash;
 use rkyv::{
     Deserialize,
@@ -24,6 +26,13 @@ pub struct Node<Key, Value> {
     value: PhantomData<Value>,
 
     buffer: Buffer,
+
+    /// Proof that `buffer` passed archive validation as
+    /// `ArchivedNodeBody<Key, Value>`. Living on the typed node (rather
+    /// than the type-erased buffer) ties the proof to the exact archived
+    /// type by construction; sharing it across clones lets one validation
+    /// cover every copy of this node.
+    validated: Arc<OnceLock<()>>,
 }
 
 impl<Key, Value> Node<Key, Value>
@@ -47,6 +56,7 @@ where
             buffer,
             key: PhantomData,
             value: PhantomData,
+            validated: Arc::new(OnceLock::new()),
         }
     }
 
@@ -81,14 +91,14 @@ where
 
     /// Accesses the deserialized body of this node.
     pub fn body(&self) -> Result<&ArchivedNodeBody<Key, Value>, DialogSearchTreeError> {
-        if self.buffer.is_validated() {
-            // SAFETY: this exact buffer already passed a full `rkyv::access`
-            // validation as `ArchivedNodeBody` (the marker is only ever set
-            // on that path), buffers are immutable and 16-byte aligned, and
-            // content addressing guarantees stored bytes are byte-identical
-            // to what was validated. Skipping re-validation turns every
-            // subsequent body access from a linear bytecheck pass into a
-            // pointer cast.
+        if self.validated.get().is_some() {
+            // SAFETY: the marker is set only after this node's buffer passed
+            // a full `rkyv::access` validation as exactly this
+            // `ArchivedNodeBody<Key, Value>` (the marker lives on the typed
+            // node, so no other archived type can set it), and buffers are
+            // immutable and 16-byte aligned. Skipping re-validation turns
+            // every subsequent body access from a linear bytecheck pass
+            // into a pointer cast.
             return Ok(unsafe {
                 rkyv::access_unchecked::<ArchivedNodeBody<Key, Value>>(self.buffer.as_ref())
             });
@@ -96,7 +106,7 @@ where
 
         let body = rkyv::access::<_, rkyv::rancor::Error>(self.buffer.as_ref())
             .map_err(|error| DialogSearchTreeError::Access(format!("{error}")))?;
-        self.buffer.mark_validated();
+        let _ = self.validated.set(());
         Ok(body)
     }
 

--- a/rust/dialog-search-tree/src/node.rs
+++ b/rust/dialog-search-tree/src/node.rs
@@ -81,8 +81,23 @@ where
 
     /// Accesses the deserialized body of this node.
     pub fn body(&self) -> Result<&ArchivedNodeBody<Key, Value>, DialogSearchTreeError> {
-        rkyv::access::<_, rkyv::rancor::Error>(self.buffer.as_ref())
-            .map_err(|error| DialogSearchTreeError::Access(format!("{error}")))
+        if self.buffer.is_validated() {
+            // SAFETY: this exact buffer already passed a full `rkyv::access`
+            // validation as `ArchivedNodeBody` (the marker is only ever set
+            // on that path), buffers are immutable and 16-byte aligned, and
+            // content addressing guarantees stored bytes are byte-identical
+            // to what was validated. Skipping re-validation turns every
+            // subsequent body access from a linear bytecheck pass into a
+            // pointer cast.
+            return Ok(unsafe {
+                rkyv::access_unchecked::<ArchivedNodeBody<Key, Value>>(self.buffer.as_ref())
+            });
+        }
+
+        let body = rkyv::access::<_, rkyv::rancor::Error>(self.buffer.as_ref())
+            .map_err(|error| DialogSearchTreeError::Access(format!("{error}")))?;
+        self.buffer.mark_validated();
+        Ok(body)
     }
 
     /// Interprets this node as an index node, returning an error if it's a

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -526,7 +526,7 @@ where
     ///
     /// Returns the new root hash and a delta containing all newly created
     /// nodes.
-    fn distribute(
+    pub(crate) fn distribute(
         self,
         entries: NonEmpty<Entry<Key, Value>>,
         search_result: Option<SearchResult<Key, Value>>,

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -1,4 +1,6 @@
-use std::{marker::PhantomData, ops::RangeBounds};
+use std::{collections::BTreeMap, marker::PhantomData, ops::RangeBounds};
+
+use nonempty::NonEmpty;
 
 use dialog_common::{Blake3Hash, ConditionalSend, ConditionalSync, NULL_BLAKE3_HASH};
 use dialog_storage::{DialogStorageError, StorageBackend};
@@ -151,6 +153,43 @@ where
             node_cache: Cache::new(),
             delta: Delta::zero(),
         }
+    }
+
+    /// Builds a tree from a collection of entries in one bottom-up pass.
+    ///
+    /// Every key is ranked once and every node is serialized and hashed
+    /// exactly once. A per-key insert loop produces the same canonical tree
+    /// (byte-identical root) but rewrites each touched segment once per
+    /// insert, so batch construction should prefer this constructor.
+    /// Duplicate keys resolve to the last value in iteration order.
+    ///
+    /// The build performs no reads: every produced node accumulates in the
+    /// tree's delta, to be persisted via [`flush`](Self::flush).
+    pub fn from_entries<I>(entries: I) -> Result<Self, DialogSearchTreeError>
+    where
+        I: IntoIterator<Item = (Key, Value)>,
+    {
+        let collection: BTreeMap<Key, Value> = entries.into_iter().collect();
+        let Some(entries) = NonEmpty::from_vec(
+            collection
+                .into_iter()
+                .map(|(key, value)| Entry { key, value })
+                .collect(),
+        ) else {
+            return Ok(Self::empty());
+        };
+
+        let shaper = TreeShaper::<Key, Value, D>::new(NULL_BLAKE3_HASH.clone(), Delta::zero());
+        let (root, delta) = shaper.distribute(entries, None)?;
+
+        Ok(Self {
+            key: PhantomData,
+            value: PhantomData,
+            distribution: PhantomData,
+            root,
+            node_cache: Cache::new(),
+            delta,
+        })
     }
 
     /// Retrieves the value associated with `key` from the tree.
@@ -2221,6 +2260,37 @@ mod tests {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    /// Bulk construction must be canonical: byte-identical root to the
+    /// same entries arriving through a per-key insert loop, regardless of
+    /// insertion order or duplicate keys (last value wins).
+    #[dialog_common::test]
+    async fn it_bulk_builds_the_same_canonical_tree_as_an_insert_loop() -> Result<()> {
+        let storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        let entries: Vec<([u8; 4], Vec<u8>)> = (0..1000u32)
+            .map(|i| (i.to_le_bytes(), vec![(i % 251) as u8]))
+            .collect();
+
+        let mut incremental = Tree::<[u8; 4], Vec<u8>>::empty();
+        // Insert in reverse order to exercise order independence.
+        for (key, value) in entries.iter().rev() {
+            incremental = incremental.insert(*key, value.clone(), &storage).await?;
+        }
+
+        // Bulk build with a stale duplicate first; the later value must win.
+        let mut with_duplicates: Vec<([u8; 4], Vec<u8>)> = vec![(7u32.to_le_bytes(), vec![0xFF])];
+        with_duplicates.extend(entries);
+        let bulk = Tree::<[u8; 4], Vec<u8>>::from_entries(with_duplicates)?;
+
+        assert_eq!(
+            bulk.root(),
+            incremental.root(),
+            "bulk build must produce the canonical tree"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Stacked on #354. Targets the seed-commit numbers measured in the tonk app (51-expression scaffold: ~1416 ms at `1bf3f48c`), which are CPU-bound in the per-insert mutation path: each insert rewrites the whole touched segment (~176 entries deserialized, re-ranked, re-serialized, re-hashed per level), three inserts per instruction, and `Node::body` ran a full bytecheck validation on every access.

- `Tree::from_entries`: one-pass bottom-up bulk construction. Every key ranked once, every node serialized and hashed exactly once, zero reads. A property test pins that the result is byte-identical to the canonical tree an insert loop produces (reverse insertion order, duplicate keys included).
- `ArtifactTreeExt::apply` empty-tree fast path: batches applied to an empty tree (the seeding path) stage the final key/value set in memory, including `Replace` cardinality-one supersession against the staged state, then bulk-build. An equivalence test pins chunked applies == single bulk apply.
- Validate-once node access: buffers carry a shared validated marker; after the first successful `rkyv::access` validation, body access is a pointer cast. Note for review: this introduces the crate's first `unsafe` block (`access_unchecked`), with the safety argument documented inline (immutable aligned buffers, marker only set by the validating path, content addressing pins the bytes).
- `benches/bulk.rs`: criterion comparison of `insert_loop` vs `from_entries` at 10/100/1k/10k entries, sequential and random keys, for the graphs validating the change.