### PR TITLE
feat(dialog-effects): archive Import effect for batched block persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,9 @@ dependencies = [
  "dialog-credentials",
  "serde",
  "serde_bytes",
+ "serde_ipld_dagcbor",
  "thiserror 2.0.18",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -402,9 +402,12 @@ where
             // Persist the tree's pending nodes before minting a revision;
             // a revision must only reference durable blocks.
             stream::iter(index.flush())
-                .map(|(hash, buffer)| {
+                .map(|buffer| {
                     let mut storage = self.storage.clone();
-                    async move { storage.set(*hash.as_bytes(), buffer.into_vec()).await }
+                    async move {
+                        let digest = *buffer.blake3_hash().as_bytes();
+                        storage.set(digest, buffer.into_vec()).await
+                    }
                 })
                 .buffer_unordered(FLUSH_CONCURRENCY)
                 .try_collect::<()>()

--- a/rust/dialog-common/src/buffer.rs
+++ b/rust/dialog-common/src/buffer.rs
@@ -1,7 +1,11 @@
+use std::fmt::{Formatter, Result as FmtResult};
 use std::sync::{Arc, OnceLock};
 
-use dialog_common::Blake3Hash;
 use rkyv::util::AlignedVec;
+use serde::de::{Error as DeserializeError, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Blake3Hash;
 
 /// A reference-counted buffer with lazy hash computation.
 ///
@@ -35,6 +39,16 @@ impl Buffer {
     }
 }
 
+/// Buffers compare by content (with a pointer-equality fast path for
+/// clones sharing the same allocation).
+impl PartialEq for Buffer {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || self.as_ref() == other.as_ref()
+    }
+}
+
+impl Eq for Buffer {}
+
 impl AsRef<[u8]> for Buffer {
     fn as_ref(&self) -> &[u8] {
         self.0.0.as_slice()
@@ -58,6 +72,63 @@ impl From<&[u8]> for Buffer {
 impl From<AlignedVec> for Buffer {
     fn from(value: AlignedVec) -> Self {
         Self(Arc::new((value, OnceLock::new())))
+    }
+}
+
+/// Serializes as raw bytes. Only exercised when a buffer crosses a wire
+/// boundary (e.g. a remote invocation); in-process effect dispatch passes
+/// buffers by reference-counted handle without touching this.
+impl Serialize for Buffer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self.as_ref())
+    }
+}
+
+/// Deserializes from raw bytes, realigning them (see the type docs).
+impl<'de> Deserialize<'de> for Buffer {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BufferVisitor;
+
+        impl<'de> Visitor<'de> for BufferVisitor {
+            type Value = Buffer;
+
+            fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+                formatter.write_str("a byte buffer")
+            }
+
+            fn visit_bytes<E>(self, bytes: &[u8]) -> Result<Buffer, E>
+            where
+                E: DeserializeError,
+            {
+                Ok(Buffer::from(bytes))
+            }
+
+            fn visit_byte_buf<E>(self, bytes: Vec<u8>) -> Result<Buffer, E>
+            where
+                E: DeserializeError,
+            {
+                Ok(Buffer::from(bytes))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Buffer, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut bytes = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    bytes.push(byte);
+                }
+                Ok(Buffer::from(bytes))
+            }
+        }
+
+        deserializer.deserialize_bytes(BufferVisitor)
     }
 }
 

--- a/rust/dialog-common/src/lib.rs
+++ b/rust/dialog-common/src/lib.rs
@@ -42,6 +42,9 @@ pub mod time;
 mod hash;
 pub use hash::*;
 
+mod buffer;
+pub use buffer::*;
+
 mod checksum;
 pub use checksum::*;
 

--- a/rust/dialog-effects/Cargo.toml
+++ b/rust/dialog-effects/Cargo.toml
@@ -5,6 +5,10 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[features]
+integration-tests = []
+web-integration-tests = []
+
 [dependencies]
 dialog-capability = { workspace = true }
 dialog-credentials = { workspace = true }
@@ -17,3 +21,8 @@ thiserror = { workspace = true }
 
 [lints.rust]
 missing_docs = "warn"
+
+[dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
+serde_ipld_dagcbor = { workspace = true }
+wasm-bindgen-test = { workspace = true }

--- a/rust/dialog-effects/src/archive.rs
+++ b/rust/dialog-effects/src/archive.rs
@@ -9,7 +9,8 @@
 //!   └── Archive (ability: /archive)
 //!         └── Catalog { catalog: String }
 //!               ├── Get { digest } → Effect → Result<Option<Bytes>, ArchiveError>
-//!               └── Put { digest, content } → Effect → Result<(), ArchiveError>
+//!               ├── Put { digest, content } → Effect → Result<(), ArchiveError>
+//!               └── Import { blocks } → Effect → Result<(), ArchiveError>
 //! ```
 
 use std::error::Error;
@@ -19,8 +20,10 @@ pub use dialog_capability::{
     DialogCapabilityPerformError, Effect, Policy, StorageError, Subject, access::AuthorizeError,
 };
 pub use dialog_common::Blake3Hash;
+pub use dialog_common::Buffer;
 use dialog_common::Checksum;
-use serde::{Deserialize, Serialize};
+use serde::de::Error as DeserializationError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 /// Archive ability - restricts to archive operations.
@@ -79,31 +82,147 @@ impl Effect for Get {
     type Output = Result<Option<Vec<u8>>, ArchiveError>;
 }
 
-/// Put operation - stores content by digest.
+/// Put operation - stores a single content-addressed block.
 ///
 /// Requires `Capability<Catalog>` access level.
-#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+///
+/// The block is a plain [`Buffer`]: its digest is derived from the bytes
+/// (and memoized), so no digest travels in the payload and providers don't
+/// re-verify. The attenuation projects the block into the same `digest` /
+/// `checksum` parameters the previous shape carried, so signed chains and
+/// the S3 authorizer wire format are unchanged.
+#[derive(Debug, Clone, Attenuate)]
 pub struct Put {
-    /// The blake3 digest of the content (must match hash of content).
-    #[serde(with = "dialog_common::as_bytes")]
-    pub digest: Blake3Hash,
-    /// The content to store.
-    #[serde(with = "serde_bytes")]
-    #[attenuate(into = Checksum, with = Checksum::sha256, rename = checksum)]
-    pub content: Vec<u8>,
+    /// The block to store.
+    #[attenuate(into = Blake3Hash, with = digest_of, rename = digest, serde_with = "dialog_common::as_bytes")]
+    #[attenuate(into = Checksum, with = checksum_of, rename = checksum)]
+    pub block: Buffer,
+}
+
+/// Serializes in the legacy `{ digest, content }` wire shape (the
+/// invocation arguments deployed authorizers parse), deriving the digest
+/// from the block.
+impl Serialize for Put {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Wire<'a> {
+            #[serde(with = "dialog_common::as_bytes")]
+            digest: Blake3Hash,
+            #[serde(with = "serde_bytes")]
+            content: &'a [u8],
+        }
+
+        Wire {
+            digest: self.block.blake3_hash().clone(),
+            content: self.block.as_ref(),
+        }
+        .serialize(serializer)
+    }
+}
+
+/// Deserializes the legacy `{ digest, content }` wire shape, re-deriving
+/// the digest from the content and rejecting a mismatch, so a held `Put`
+/// is always digest-consistent.
+impl<'de> Deserialize<'de> for Put {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            #[serde(with = "dialog_common::as_bytes")]
+            digest: Blake3Hash,
+            #[serde(with = "serde_bytes")]
+            content: Vec<u8>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let put = Put::new(Buffer::from(wire.content));
+        if put.block.blake3_hash() != &wire.digest {
+            return Err(DeserializationError::custom(format!(
+                "put digest mismatch: declared {}, computed {}",
+                wire.digest,
+                put.block.blake3_hash()
+            )));
+        }
+        Ok(put)
+    }
+}
+
+/// Projects a block to its blake3 digest for the attenuation shape.
+fn digest_of(block: Buffer) -> Blake3Hash {
+    block.blake3_hash().clone()
+}
+
+/// Projects a block to its content checksum for the attenuation shape.
+fn checksum_of(block: Buffer) -> Checksum {
+    Checksum::sha256(block.as_ref())
 }
 
 impl Put {
     /// Create a new Put effect.
-    pub fn new(digest: impl Into<Blake3Hash>, content: impl Into<Vec<u8>>) -> Self {
+    pub fn new(block: impl Into<Buffer>) -> Self {
         Self {
-            digest: digest.into(),
-            content: content.into(),
+            block: block.into(),
         }
     }
 }
 
 impl Effect for Put {
+    type Of = Catalog;
+    type Output = Result<(), ArchiveError>;
+}
+
+/// Import operation - stores a batch of content-addressed blocks.
+///
+/// Requires `Capability<Catalog>` access level.
+///
+/// Blocks are plain [`Buffer`]s: content addressing means their identity
+/// is derived from the bytes (and the buffer memoizes its hash), so no
+/// digest travels in the payload. Integrity across a wire boundary is a
+/// capability concern: the attenuation embedded in the signed invocation
+/// carries the per-block checksums.
+///
+/// # Semantics
+///
+/// On success every block is durable. On failure the whole import can be
+/// retried: puts of content-addressed blocks are idempotent (same digest,
+/// same content), and blocks are unobservable until something references
+/// them, so a partial failure leaves only harmless unreferenced blocks.
+/// No atomicity is promised — in this architecture the atomic boundary is
+/// the revision publish (a compare-and-swap on a memory cell), not block
+/// persistence. Providers are free to persist the batch in a single
+/// round trip where the platform allows (e.g. one IndexedDB read-write
+/// transaction) purely as an optimization.
+#[derive(Debug, Clone, Serialize, Deserialize, Attenuate)]
+pub struct Import {
+    /// The blocks to store.
+    #[attenuate(into = Vec<Checksum>, with = block_checksums, rename = checksums)]
+    pub blocks: Vec<Buffer>,
+}
+
+/// Projects an [`Import`]'s blocks to their content checksums for the
+/// attenuation shape embedded in delegations and invocations.
+fn block_checksums(blocks: Vec<Buffer>) -> Vec<Checksum> {
+    blocks
+        .iter()
+        .map(|buffer| Checksum::sha256(buffer.as_ref()))
+        .collect()
+}
+
+impl Import {
+    /// Create a new Import effect.
+    pub fn new(blocks: impl IntoIterator<Item = impl Into<Buffer>>) -> Self {
+        Self {
+            blocks: blocks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl Effect for Import {
     type Of = Catalog;
     type Output = Result<(), ArchiveError>;
 }
@@ -172,6 +291,9 @@ impl<E: Error> From<DialogCapabilityPerformError<E>> for ArchiveError {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
     use super::*;
     use dialog_capability::did;
 
@@ -209,8 +331,36 @@ mod tests {
         let claim = Subject::from(did!("key:zSpace"))
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new([0u8; 32], Vec::new()));
+            .invoke(Put::new(Buffer::from(Vec::new())));
 
         assert_eq!(claim.ability(), "/archive/put");
+    }
+
+    #[dialog_common::test]
+    fn it_roundtrips_import_payloads() {
+        // Buffers serialize as bare bytes and deserialize realigned; the
+        // memoized hash is rederived on the receiving side.
+        let import = Import::new([Buffer::from(vec![1u8, 2, 3])]);
+        let bytes = serde_ipld_dagcbor::to_vec(&import).unwrap();
+        let restored: Import = serde_ipld_dagcbor::from_slice(&bytes).unwrap();
+        assert_eq!(restored.blocks, import.blocks);
+        assert_eq!(
+            restored.blocks[0].blake3_hash(),
+            &Blake3Hash::hash(&[1u8, 2, 3][..])
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_attenuates_imports_to_block_checksums() {
+        let import = Import::new([Buffer::from(vec![1u8]), Buffer::from(vec![2u8, 2])]);
+        let attenuation = import.clone().into_attenuation();
+        assert_eq!(
+            attenuation.checksums,
+            vec![
+                Checksum::sha256(&[1u8][..]),
+                Checksum::sha256(&[2u8, 2][..]),
+            ]
+        );
+        assert_eq!(import.blocks.len(), 2);
     }
 }

--- a/rust/dialog-effects/src/archive/prelude.rs
+++ b/rust/dialog-effects/src/archive/prelude.rs
@@ -6,9 +6,9 @@
 //! ```
 
 use dialog_capability::{Capability, Did, Policy, Subject};
-use dialog_common::Blake3Hash;
+use dialog_common::{Blake3Hash, Buffer};
 
-use super::{Archive, Catalog, Get, Put};
+use super::{Archive, Catalog, Get, Import, Put};
 
 /// Extension trait to start an archive capability chain.
 pub trait ArchiveSubjectExt {
@@ -53,22 +53,49 @@ pub trait CatalogExt {
     type Get;
     /// The resulting put chain type.
     type Put;
+    /// The resulting import chain type.
+    type Import;
     /// Get content by digest.
     fn get(self, digest: impl Into<Blake3Hash>) -> Self::Get;
-    /// Put content by digest.
-    fn put(self, digest: impl Into<Blake3Hash>, content: impl Into<Vec<u8>>) -> Self::Put;
+    /// Put a single content-addressed block.
+    fn put(self, block: impl Into<Buffer>) -> Self::Put;
+    /// Import a batch of content-addressed blocks.
+    fn import(self, blocks: impl IntoIterator<Item = impl Into<Buffer>>) -> Self::Import;
 }
 
 impl CatalogExt for Capability<Catalog> {
     type Get = Capability<Get>;
     type Put = Capability<Put>;
+    type Import = Capability<Import>;
 
     fn get(self, digest: impl Into<Blake3Hash>) -> Capability<Get> {
         self.invoke(Get::new(digest))
     }
 
-    fn put(self, digest: impl Into<Blake3Hash>, content: impl Into<Vec<u8>>) -> Capability<Put> {
-        self.invoke(Put::new(digest, content))
+    fn put(self, block: impl Into<Buffer>) -> Capability<Put> {
+        self.invoke(Put::new(block))
+    }
+
+    fn import(self, blocks: impl IntoIterator<Item = impl Into<Buffer>>) -> Capability<Import> {
+        self.invoke(Import::new(blocks))
+    }
+}
+
+/// Field accessors on `Capability<Import>`.
+pub trait ImportExt {
+    /// Get the catalog name from the capability chain.
+    fn catalog(&self) -> &str;
+    /// Get the blocks from the capability chain.
+    fn blocks(&self) -> &[Buffer];
+}
+
+impl ImportExt for Capability<Import> {
+    fn catalog(&self) -> &str {
+        &Catalog::of(self).catalog
+    }
+
+    fn blocks(&self) -> &[Buffer] {
+        &Import::of(self).blocks
     }
 }
 
@@ -94,7 +121,7 @@ impl GetExt for Capability<Get> {
 pub trait PutExt {
     /// Get the catalog name from the capability chain.
     fn catalog(&self) -> &str;
-    /// Get the digest from the capability chain.
+    /// Get the digest from the capability chain (derived from the block).
     fn digest(&self) -> &Blake3Hash;
     /// Get the content from the capability chain.
     fn content(&self) -> &[u8];
@@ -106,10 +133,10 @@ impl PutExt for Capability<Put> {
     }
 
     fn digest(&self) -> &Blake3Hash {
-        &Put::of(self).digest
+        Put::of(self).block.blake3_hash()
     }
 
     fn content(&self) -> &[u8] {
-        &Put::of(self).content
+        Put::of(self).block.as_ref()
     }
 }

--- a/rust/dialog-macros/src/attenuate.rs
+++ b/rust/dialog-macros/src/attenuate.rs
@@ -42,12 +42,18 @@ struct AttenuateField<'a> {
     conversion: Option<Conversion>,
     rename: Option<Ident>,
     attrs: Vec<&'a syn::Attribute>,
+    /// A `#[serde(with = "...")]` path to attach to the projected field.
+    serde_with: Option<syn::LitStr>,
+    /// Whether the conversion must clone the source (a field with several
+    /// projections is consumed only by its last one).
+    clone_source: bool,
 }
 
 struct AttenuateAttr {
     into_ty: Type,
     with_fn: Option<syn::ExprPath>,
     rename: Option<Ident>,
+    serde_with: Option<syn::LitStr>,
 }
 
 fn parse_attenuate_attr(attr: &syn::Attribute) -> syn::Result<AttenuateAttr> {
@@ -55,6 +61,7 @@ fn parse_attenuate_attr(attr: &syn::Attribute) -> syn::Result<AttenuateAttr> {
         let mut into_ty = None;
         let mut with_fn = None;
         let mut rename = None;
+        let mut serde_with = None;
 
         loop {
             let key: syn::Ident = input.parse()?;
@@ -66,10 +73,12 @@ fn parse_attenuate_attr(attr: &syn::Attribute) -> syn::Result<AttenuateAttr> {
                 with_fn = Some(input.parse::<syn::ExprPath>()?);
             } else if key == "rename" {
                 rename = Some(input.parse::<Ident>()?);
+            } else if key == "serde_with" {
+                serde_with = Some(input.parse::<syn::LitStr>()?);
             } else {
                 return Err(syn::Error::new_spanned(
                     &key,
-                    "expected `into`, `with`, or `rename`",
+                    "expected `into`, `with`, `rename`, or `serde_with`",
                 ));
             }
 
@@ -88,6 +97,7 @@ fn parse_attenuate_attr(attr: &syn::Attribute) -> syn::Result<AttenuateAttr> {
             into_ty,
             with_fn,
             rename,
+            serde_with,
         })
     })
 }
@@ -169,39 +179,62 @@ fn generate_for_named_struct(
         let ident = field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        let mut attenuate_attr = None;
+        let mut attenuate_attrs = Vec::new();
         let mut other_attrs = Vec::new();
 
         for attr in &field.attrs {
             if attr.path().is_ident("attenuate") {
-                attenuate_attr = Some(parse_attenuate_attr(attr)?);
+                attenuate_attrs.push(parse_attenuate_attr(attr)?);
                 has_projections = true;
             } else {
                 other_attrs.push(attr);
             }
         }
 
-        let (into_ty, conversion, rename, field_attrs) = match attenuate_attr {
-            Some(a) => {
-                let conv = match a.with_fn {
-                    Some(path) => Conversion::With(path),
-                    None => Conversion::From(a.into_ty.clone()),
-                };
-                // Projected fields get a fresh type — don't carry original attrs
-                // (e.g. #[serde(with = "serde_bytes")] doesn't apply to Checksum)
-                (Some(a.into_ty), Some(conv), a.rename, Vec::new())
-            }
-            None => (None, None, None, other_attrs),
-        };
+        if attenuate_attrs.is_empty() {
+            fields.push(AttenuateField {
+                ident,
+                ty,
+                into_ty: None,
+                conversion: None,
+                rename: None,
+                attrs: other_attrs,
+                serde_with: None,
+                clone_source: false,
+            });
+            continue;
+        }
 
-        fields.push(AttenuateField {
-            ident,
-            ty,
-            into_ty,
-            conversion,
-            rename,
-            attrs: field_attrs,
-        });
+        // A field may carry several projections (e.g. a payload projected
+        // to both a digest and a checksum); each then needs a distinct
+        // `rename`, and every conversion but the last clones the source.
+        if attenuate_attrs.len() > 1 && attenuate_attrs.iter().any(|a| a.rename.is_none()) {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "each of multiple #[attenuate(...)] projections of one field requires `rename`",
+            ));
+        }
+
+        let last = attenuate_attrs.len() - 1;
+        for (index, a) in attenuate_attrs.into_iter().enumerate() {
+            let conv = match a.with_fn {
+                Some(path) => Conversion::With(path),
+                None => Conversion::From(a.into_ty.clone()),
+            };
+            // Projected fields get a fresh type — don't carry original attrs
+            // (e.g. #[serde(with = "serde_bytes")] doesn't apply to Checksum);
+            // `serde_with` re-attaches one explicitly when needed.
+            fields.push(AttenuateField {
+                ident,
+                ty,
+                into_ty: Some(a.into_ty),
+                conversion: Some(conv),
+                rename: a.rename,
+                attrs: Vec::new(),
+                serde_with: a.serde_with,
+                clone_source: index < last,
+            });
+        }
     }
 
     if !has_projections {
@@ -224,7 +257,11 @@ fn generate_for_named_struct(
             let field_ident = f.rename.as_ref().unwrap_or(f.ident);
             let ty = f.into_ty.as_ref().unwrap_or(f.ty);
             let attrs = &f.attrs;
-            quote! { #(#attrs)* pub #field_ident: #ty }
+            let serde_attr = f
+                .serde_with
+                .as_ref()
+                .map(|with| quote! { #[serde(with = #with)] });
+            quote! { #(#attrs)* #serde_attr pub #field_ident: #ty }
         })
         .collect();
 
@@ -233,15 +270,20 @@ fn generate_for_named_struct(
         .map(|f| {
             let source_ident = f.ident;
             let field_ident = f.rename.as_ref().unwrap_or(f.ident);
+            let source = if f.clone_source {
+                quote! { self.#source_ident.clone() }
+            } else {
+                quote! { self.#source_ident }
+            };
             match &f.conversion {
                 Some(Conversion::With(path)) => {
-                    quote! { #field_ident: #path(self.#source_ident) }
+                    quote! { #field_ident: #path(#source) }
                 }
                 Some(Conversion::From(into_ty)) => {
-                    quote! { #field_ident: <#into_ty>::from(self.#source_ident) }
+                    quote! { #field_ident: <#into_ty>::from(#source) }
                 }
                 None => {
-                    quote! { #field_ident: self.#source_ident }
+                    quote! { #field_ident: #source }
                 }
             }
         })

--- a/rust/dialog-operator/src/operator.rs
+++ b/rust/dialog-operator/src/operator.rs
@@ -38,6 +38,7 @@ pub struct Operator<S: Clone> {
     #[provide(
         archive::Get,
         archive::Put,
+        archive::Import,
         credential::Load<Credential>,
         credential::Save<Credential>,
         credential::Load<Secret>,

--- a/rust/dialog-operator/src/operator/test.rs
+++ b/rust/dialog-operator/src/operator/test.rs
@@ -622,6 +622,7 @@ mod tests {
         use super::*;
         use dialog_capability::Subject;
         use dialog_common::Blake3Hash;
+        use dialog_common::Buffer;
         use dialog_effects::archive::prelude::*;
         use dialog_effects::credential::Secret;
         use dialog_effects::memory::prelude::*;
@@ -758,7 +759,7 @@ mod tests {
             Subject::from(operator.profile_did())
                 .archive()
                 .catalog("cred-roundtrip")
-                .put(digest.clone(), content.clone())
+                .put(Buffer::from(content.clone()))
                 .fork(&address)
                 .perform(&operator)
                 .await
@@ -1009,7 +1010,7 @@ mod tests {
     mod ucan_fork_tests {
         use super::*;
         use dialog_capability::Subject;
-        use dialog_common::Blake3Hash;
+        use dialog_common::{Blake3Hash, Buffer};
         use dialog_effects::archive::prelude::*;
         use dialog_effects::memory::prelude::*;
         use dialog_network::NetworkAddress as SiteAddress;
@@ -1069,7 +1070,7 @@ mod tests {
             Subject::from(operator.profile_did())
                 .archive()
                 .catalog("ucan-roundtrip")
-                .put(digest.clone(), content.clone())
+                .put(Buffer::from(content.clone()))
                 .fork(&address)
                 .perform(&operator)
                 .await?;
@@ -1336,7 +1337,7 @@ mod tests {
             Subject::from(operator.profile_did())
                 .archive()
                 .catalog("allowed")
-                .put(digest.clone(), content.clone())
+                .put(Buffer::from(content.clone()))
                 .fork(&address)
                 .perform(&operator)
                 .await?;

--- a/rust/dialog-remote-s3/src/s3/provider/archive.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/archive.rs
@@ -64,7 +64,7 @@ impl Provider<ForkInvocation<S3, Put>> for S3 {
 impl Provider<S3Invocation<Put>> for S3 {
     async fn execute(&self, input: S3Invocation<Put>) -> Result<(), ArchiveError> {
         let put = input.capability.into_effect();
-        let response = input.permit.upload(put.content).await?;
+        let response = input.permit.upload(put.block.as_ref().to_vec()).await?;
 
         if response.status().is_success() {
             Ok(())

--- a/rust/dialog-remote-s3/tests/s3/archive.rs
+++ b/rust/dialog-remote-s3/tests/s3/archive.rs
@@ -3,6 +3,7 @@
 #![cfg(feature = "s3-integration-tests")]
 
 use dialog_common::Blake3Hash;
+use dialog_common::Buffer;
 use dialog_effects::archive::prelude::*;
 
 use super::environment::Environment;
@@ -40,7 +41,7 @@ async fn it_puts_and_gets_content() -> anyhow::Result<()> {
     env.subject()
         .archive()
         .catalog(catalog)
-        .put(digest.clone(), content.clone())
+        .put(Buffer::from(content.clone()))
         .fork(&env.address)
         .perform(&env.network)
         .await?;
@@ -68,7 +69,7 @@ async fn it_handles_binary_content() -> anyhow::Result<()> {
     env.subject()
         .archive()
         .catalog(catalog)
-        .put(digest.clone(), content.clone())
+        .put(Buffer::from(content.clone()))
         .fork(&env.address)
         .perform(&env.network)
         .await?;
@@ -98,7 +99,7 @@ async fn it_isolates_catalogs() -> anyhow::Result<()> {
     env.subject()
         .archive()
         .catalog(catalog_a)
-        .put(digest.clone(), content.clone())
+        .put(Buffer::from(content.clone()))
         .fork(&env.address)
         .perform(&env.network)
         .await?;
@@ -138,7 +139,7 @@ async fn it_handles_large_content() -> anyhow::Result<()> {
     env.subject()
         .archive()
         .catalog(catalog)
-        .put(digest.clone(), content.clone())
+        .put(Buffer::from(content.clone()))
         .fork(&env.address)
         .perform(&env.network)
         .await?;

--- a/rust/dialog-repository/src/repository/archive/local.rs
+++ b/rust/dialog-repository/src/repository/archive/local.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use dialog_capability::{Capability, Provider};
-use dialog_common::ConditionalSync;
+use dialog_common::{Buffer, ConditionalSync};
 use dialog_effects::archive::prelude::*;
 use dialog_effects::archive::{Catalog, Get, Put};
 use dialog_storage::{Blake3Hash, CborEncoder, DialogStorageError, Encoder, StorageBackend};
@@ -68,10 +68,10 @@ where
     type Value = Vec<u8>;
     type Error = DialogStorageError;
 
-    async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
+    async fn set(&mut self, _key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
         self.catalog
             .clone()
-            .put(key, value)
+            .put(Buffer::from(value))
             .perform(self.env)
             .await?;
         Ok(())

--- a/rust/dialog-repository/src/repository/archive/networked.rs
+++ b/rust/dialog-repository/src/repository/archive/networked.rs
@@ -2,7 +2,7 @@ use crate::RemoteSite;
 use async_trait::async_trait;
 use dialog_capability::Fork;
 use dialog_capability::{Capability, Provider};
-use dialog_common::ConditionalSync;
+use dialog_common::{Buffer, ConditionalSync};
 use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt, CatalogExt};
 use dialog_effects::archive::{Catalog, Get, Put};
 use dialog_storage::{Blake3Hash, DialogStorageError, Encoder, StorageBackend};
@@ -88,7 +88,11 @@ where
         match remote_result {
             Some(bytes) => {
                 // Cache locally
-                let cache = self.local.catalog().clone().put(*key, bytes.clone());
+                let cache = self
+                    .local
+                    .catalog()
+                    .clone()
+                    .put(Buffer::from(bytes.as_slice()));
                 let _: Result<(), _> = cache.perform(self.local.env()).await;
                 Ok(Some(bytes))
             }

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Branch, CommitError, EMPTY_TREE_HASH, FLUSH_CONCURRENCY, Index, NetworkedIndex, RemoteSite,
+    Branch, CommitError, EMPTY_TREE_HASH, Index, NetworkedIndex, RemoteSite,
     RepositoryArchiveExt as _, RepositoryMemoryExt, Revision, TreeReference, Upstream,
 };
 use dialog_artifacts::tree::ArtifactTreeExt as _;
@@ -7,11 +7,11 @@ use dialog_artifacts::{DialogArtifactsError, Instruction};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::{ConditionalSend, ConditionalSync};
-use dialog_effects::archive::{Get, Put};
+use dialog_effects::archive::prelude::CatalogExt as _;
+use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Identify, OperatorExt};
 use dialog_effects::memory::{Publish, Resolve};
-use dialog_storage::StorageBackend;
-use futures_util::{Stream, StreamExt, TryStreamExt, stream};
+use futures_util::Stream;
 
 /// Command that commits a stream of changes (assert/retract) to a branch.
 ///
@@ -48,6 +48,7 @@ where
     where
         Env: Provider<Get>
             + Provider<Put>
+            + Provider<Import>
             + Provider<Resolve>
             + Provider<Publish>
             + Provider<Identify>
@@ -88,14 +89,16 @@ where
 
         // Persist the tree's pending nodes before referencing the root in
         // a revision; a revision must only point at durable blocks. The
-        // empty tree's root is the canonical empty-tree hash already.
-        stream::iter(tree.flush())
-            .map(|(hash, buffer)| {
-                let mut store = store.clone();
-                async move { store.set(*hash.as_bytes(), buffer.into_vec()).await }
-            })
-            .buffer_unordered(FLUSH_CONCURRENCY)
-            .try_collect::<()>()
+        // empty tree's root is the canonical empty-tree hash already. The
+        // whole flush travels as one `Import` invocation; block buffers are
+        // reference-counted, so nothing is copied on the way in, and
+        // providers with native batching persist it in a single round trip
+        // (one IndexedDB transaction).
+        branch
+            .archive()
+            .index()
+            .import(tree.flush())
+            .perform(env)
             .await
             .map_err(DialogArtifactsError::from)?;
 

--- a/rust/dialog-repository/src/repository/branch/import.rs
+++ b/rust/dialog-repository/src/repository/branch/import.rs
@@ -1,7 +1,7 @@
 use dialog_artifacts::{Importer, Instruction};
 use dialog_capability::{Fork, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
-use dialog_effects::archive::{Get, Put};
+use dialog_effects::archive::{Get, Import as ArchiveImport, Put};
 use dialog_effects::authority::Identify;
 use dialog_effects::memory::{Publish, Resolve};
 use futures_util::StreamExt;
@@ -26,6 +26,7 @@ impl<I: Importer + Unpin + ConditionalSend> Import<'_, I> {
     where
         Env: Provider<Get>
             + Provider<Put>
+            + Provider<ArchiveImport>
             + Provider<Resolve>
             + Provider<Publish>
             + Provider<Identify>

--- a/rust/dialog-repository/src/repository/branch/pull.rs
+++ b/rust/dialog-repository/src/repository/branch/pull.rs
@@ -1,16 +1,16 @@
+use dialog_artifacts::DialogArtifactsError;
 use dialog_artifacts::tree::TreeStorageBridge;
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
-use dialog_effects::archive::{Get, Put};
+use dialog_effects::archive::prelude::CatalogExt as _;
+use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Identify, OperatorExt};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_search_tree::ContentAddressedStorage as TreeStorage;
-use dialog_storage::StorageBackend;
-use futures_util::{StreamExt, TryStreamExt, stream};
 
 use crate::{
-    Branch, EMPTY_TREE_HASH, FLUSH_CONCURRENCY, Index, NetworkedIndex, PullError, RemoteSite,
+    Branch, EMPTY_TREE_HASH, Index, NetworkedIndex, PullError, RemoteSite,
     RepositoryArchiveExt as _, RepositoryMemoryExt, Revision, TreeReference, Upstream,
 };
 
@@ -38,6 +38,7 @@ impl Pull<'_> {
     where
         Env: Provider<Get>
             + Provider<Put>
+            + Provider<Import>
             + Provider<Resolve>
             + Provider<Publish>
             + Provider<Identify>
@@ -116,16 +117,19 @@ impl Pull<'_> {
         let local_changes = base.differentiate(&local, &tree_store, &tree_store);
         Box::pin(merged.integrate(local_changes, &tree_store)).await?;
 
-        // Persist the merged tree's pending nodes before referencing its
-        // root in a revision.
-        stream::iter(merged.flush())
-            .map(|(hash, buffer)| {
-                let mut store = store.clone();
-                async move { store.set(*hash.as_bytes(), buffer.into_vec()).await }
-            })
-            .buffer_unordered(FLUSH_CONCURRENCY)
-            .try_collect::<()>()
-            .await?;
+        // Persist the merged tree's pending nodes to the local archive
+        // before referencing its root in a revision. The whole flush
+        // travels as one `Import` invocation: block buffers are
+        // reference-counted (nothing is copied on the way in) and
+        // providers with native batching persist it in a single round
+        // trip.
+        branch
+            .archive()
+            .index()
+            .import(merged.flush())
+            .perform(env)
+            .await
+            .map_err(DialogArtifactsError::from)?;
 
         let merged_tree = TreeReference::from(*merged.root().as_bytes());
 

--- a/rust/dialog-repository/src/repository/remote/archive.rs
+++ b/rust/dialog-repository/src/repository/remote/archive.rs
@@ -3,7 +3,7 @@
 use crate::{RemoteRepository, RemoteSite, UploadError};
 use dialog_artifacts::{Datum, KeyBytes, State};
 use dialog_capability::{Capability, Fork, Provider};
-use dialog_common::ConditionalSync;
+use dialog_common::{Buffer, ConditionalSync};
 use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt, CatalogExt};
 use dialog_effects::archive::{ArchiveError, Catalog, Get, Put};
 use dialog_search_tree::{DialogSearchTreeError, Node};
@@ -41,12 +41,8 @@ impl RemoteArchiveIndex<'_> {
     }
 
     /// Write a block to the remote archive.
-    pub fn put(&self, hash: Blake3Hash, bytes: Vec<u8>) -> RemotePut<'_> {
-        RemotePut {
-            index: self,
-            hash,
-            bytes,
-        }
+    pub fn put(&self, block: Buffer) -> RemotePut<'_> {
+        RemotePut { index: self, block }
     }
 }
 
@@ -76,8 +72,7 @@ impl RemoteGet<'_> {
 /// Command to write a block to the remote archive.
 pub struct RemotePut<'a> {
     index: &'a RemoteArchiveIndex<'a>,
-    hash: Blake3Hash,
-    bytes: Vec<u8>,
+    block: Buffer,
 }
 
 impl RemotePut<'_> {
@@ -90,7 +85,7 @@ impl RemotePut<'_> {
         self.index
             .catalog
             .clone()
-            .put(self.hash, self.bytes)
+            .put(self.block)
             .fork(address.site())
             .perform(env)
             .await
@@ -132,10 +127,8 @@ where
         self.nodes
             .map(|node| async move {
                 let node = node?;
-                let hash = *node.hash().as_bytes();
-                let bytes = node.buffer().as_ref().to_vec();
                 index
-                    .put(hash, bytes)
+                    .put(node.buffer().clone())
                     .perform(env)
                     .await
                     .map_err(UploadError::RemoteWrite)?;

--- a/rust/dialog-repository/src/repository/tree.rs
+++ b/rust/dialog-repository/src/repository/tree.rs
@@ -9,12 +9,6 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 /// (`dialog_common::NULL_BLAKE3_HASH`) byte for byte.
 pub const EMPTY_TREE_HASH: Blake3Hash = [0; 32];
 
-/// Maximum number of concurrent block writes when persisting a tree's
-/// pending nodes. Blocks are content-addressed and independent, so their
-/// write order doesn't matter; only completion before the root is
-/// referenced does.
-pub(crate) const FLUSH_CONCURRENCY: usize = 16;
-
 /// Reference to a search tree by its root hash.
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TreeReference(Blake3Hash);

--- a/rust/dialog-search-tree/src/differential.rs
+++ b/rust/dialog-search-tree/src/differential.rs
@@ -668,8 +668,10 @@ mod tests {
         for (key, value) in keys {
             tree = tree.insert(key.to_le_bytes(), value, storage).await?;
         }
-        for (hash, buffer) in tree.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
         Ok(tree)
     }
@@ -767,8 +769,10 @@ mod tests {
         let mut merged = source.clone();
         let changes = source.differentiate(&target, &storage, &storage);
         merged.integrate(changes, &storage).await?;
-        for (hash, buffer) in merged.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in merged.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
         assert_eq!(
             merged.root(),
@@ -794,8 +798,10 @@ mod tests {
         modified = modified
             .insert(1000u32.to_le_bytes(), vec![0xFF], &storage)
             .await?;
-        for (hash, buffer) in modified.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in modified.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         storage.backend().reset();
@@ -828,16 +834,20 @@ mod tests {
 
         let mut ours = base.clone();
         ours = ours.insert(99u32.to_le_bytes(), vec![1], &storage).await?;
-        for (hash, buffer) in ours.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in ours.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let mut theirs = base.clone();
         theirs = theirs
             .insert(99u32.to_le_bytes(), vec![2], &storage)
             .await?;
-        for (hash, buffer) in theirs.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in theirs.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Integrate their changes into ours, and our changes into theirs;
@@ -850,11 +860,15 @@ mod tests {
         let our_changes = base.differentiate(&ours, &storage, &storage);
         merged_theirs.integrate(our_changes, &storage).await?;
 
-        for (hash, buffer) in merged_ours.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in merged_ours.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
-        for (hash, buffer) in merged_theirs.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in merged_theirs.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         assert_eq!(
@@ -881,8 +895,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (hash, buffer) in extended.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in extended.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // A "remote" that already has the base tree.
@@ -1735,8 +1751,10 @@ mod tests {
         tree: &mut TestTree,
         storage: &mut ContentAddressedStorage<CountingBackend>,
     ) -> Result<()> {
-        for (hash, buffer) in tree.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
         Ok(())
     }

--- a/rust/dialog-search-tree/src/helpers.rs
+++ b/rust/dialog-search-tree/src/helpers.rs
@@ -569,8 +569,10 @@ impl TreeDescriptor {
 
         // Persist all pending nodes so differentials read them through the
         // journaled backend.
-        for (hash, buffer) in tree.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let root = tree.root().clone();

--- a/rust/dialog-search-tree/src/lib.rs
+++ b/rust/dialog-search-tree/src/lib.rs
@@ -74,8 +74,8 @@
 //!
 //! // Flush the delta to get buffers that need to be persisted
 //! let root_hash = tree.root().clone();
-//! for (hash, buffer) in tree.flush() {
-//!     storage.store(buffer.as_ref().to_vec(), &hash).await.unwrap();
+//! for buffer in tree.flush() {
+//!     storage.store(buffer.as_ref().to_vec(), buffer.blake3_hash()).await.unwrap();
 //! }
 //!
 //! // After flushing, the tree can be reconstructed from its root hash
@@ -117,8 +117,7 @@
 mod accessor;
 pub use accessor::*;
 
-mod buffer;
-pub use buffer::*;
+pub use dialog_common::Buffer;
 
 mod kv;
 pub use kv::*;

--- a/rust/dialog-search-tree/src/shaper.rs
+++ b/rust/dialog-search-tree/src/shaper.rs
@@ -868,8 +868,10 @@ mod tests {
                 .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), storage)
                 .await?;
         }
-        for (hash, buf) in tree.flush() {
-            storage.store(buf.as_ref().to_vec(), &hash).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
         Ok(tree)
     }
@@ -1015,8 +1017,10 @@ mod tests {
 
         for &bk in boundaries.iter().take(5) {
             let mut tree_via_delete = full_tree.delete(&bk.to_le_bytes(), &storage).await?;
-            for (h, b) in tree_via_delete.flush() {
-                storage.store(b.as_ref().to_vec(), &h).await?;
+            for buffer in tree_via_delete.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
             }
 
             let remaining: Vec<u32> = all_keys.iter().copied().filter(|&k| k != bk).collect();
@@ -1045,8 +1049,10 @@ mod tests {
 
         for &key in non_boundaries.iter().take(5) {
             let mut tree_via_delete = full_tree.delete(&key.to_le_bytes(), &storage).await?;
-            for (h, b) in tree_via_delete.flush() {
-                storage.store(b.as_ref().to_vec(), &h).await?;
+            for buffer in tree_via_delete.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
             }
 
             let remaining: Vec<u32> = all_keys.iter().copied().filter(|&k| k != key).collect();
@@ -1079,8 +1085,10 @@ mod tests {
         for &ek in &extra_keys {
             tree_pruned = tree_pruned.delete(&ek.to_le_bytes(), &storage).await?;
         }
-        for (h, b) in tree_pruned.flush() {
-            storage.store(b.as_ref().to_vec(), &h).await?;
+        for buffer in tree_pruned.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         assert_eq!(
@@ -1109,15 +1117,19 @@ mod tests {
 
         for &key in &test_keys {
             let mut after_delete = original.delete(&key.to_le_bytes(), &storage).await?;
-            for (h, b) in after_delete.flush() {
-                storage.store(b.as_ref().to_vec(), &h).await?;
+            for buffer in after_delete.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
             }
 
             let mut restored = after_delete
                 .insert(key.to_le_bytes(), key.to_le_bytes().to_vec(), &storage)
                 .await?;
-            for (h, b) in restored.flush() {
-                storage.store(b.as_ref().to_vec(), &h).await?;
+            for buffer in restored.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
             }
 
             assert_eq!(
@@ -1142,8 +1154,10 @@ mod tests {
         for i in 100..200u32 {
             tree_b = tree_b.delete(&i.to_le_bytes(), &storage).await?;
         }
-        for (h, b) in tree_b.flush() {
-            storage.store(b.as_ref().to_vec(), &h).await?;
+        for buffer in tree_b.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         assert_eq!(
@@ -1202,8 +1216,10 @@ mod tests {
         let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
 
         let mut tree_via_delete = full_tree.delete(&solo_key.to_le_bytes(), &storage).await?;
-        for (h, b) in tree_via_delete.flush() {
-            storage.store(b.as_ref().to_vec(), &h).await?;
+        for buffer in tree_via_delete.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let remaining: Vec<u32> = all_keys
@@ -1237,8 +1253,10 @@ mod tests {
         let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
 
         let mut tree_via_delete = full_tree.delete(&first_key, &storage).await?;
-        for (h, b) in tree_via_delete.flush() {
-            storage.store(b.as_ref().to_vec(), &h).await?;
+        for buffer in tree_via_delete.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let remaining: Vec<u32> = all_keys
@@ -1274,8 +1292,10 @@ mod tests {
         let mut full_tree = build_and_flush(&all_keys, &mut storage).await?;
 
         let mut tree_via_delete = full_tree.delete(&last_key, &storage).await?;
-        for (h, b) in tree_via_delete.flush() {
-            storage.store(b.as_ref().to_vec(), &h).await?;
+        for buffer in tree_via_delete.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let remaining: Vec<u32> = all_keys

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -332,8 +332,8 @@ where
     ///
     /// In cases where the caller wishes to access the modified tree in the
     /// future, they should persist the flushed changes.
-    pub fn flush(&mut self) -> impl Iterator<Item = (Blake3Hash, Buffer)> {
-        self.delta.flush()
+    pub fn flush(&mut self) -> impl Iterator<Item = Buffer> {
+        self.delta.flush().map(|(_, buffer)| buffer)
     }
 
     /// Returns a differential that produces changes to transform `self` into
@@ -539,8 +539,10 @@ mod tests {
         }
 
         // Flush to storage
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify we can retrieve all inserted values
@@ -569,8 +571,10 @@ mod tests {
         }
 
         // Flush to storage
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Delete some values
@@ -579,8 +583,10 @@ mod tests {
         }
 
         // Flush deletions
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify deleted values are gone
@@ -619,8 +625,10 @@ mod tests {
         }
 
         // Flush to storage
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Stream all entries and verify they come out sorted
@@ -664,8 +672,10 @@ mod tests {
         }
 
         // Flush to storage
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Test inclusive range [10..20)
@@ -720,8 +730,10 @@ mod tests {
         }
 
         // Flush to storage
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Query range with no entries [50..60)
@@ -789,8 +801,10 @@ mod tests {
             .await?;
 
         // Flush to storage
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify initial value
@@ -803,8 +817,10 @@ mod tests {
             .await?;
 
         // Flush update
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify updated value
@@ -825,8 +841,10 @@ mod tests {
             .await?;
 
         // Flush v1
-        for (key, value) in tree_v1.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_v1.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let v1_root = tree_v1.root().clone();
@@ -837,8 +855,10 @@ mod tests {
             .await?;
 
         // Flush v2
-        for (key, value) in tree_v2.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_v2.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify v1 is unchanged
@@ -876,8 +896,10 @@ mod tests {
         }
 
         // Flush base
-        for (key, value) in base.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in base.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Create two independent branches
@@ -889,11 +911,15 @@ mod tests {
             .await?;
 
         // Flush both branches
-        for (key, value) in branch_a.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in branch_a.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
-        for (key, value) in branch_b.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in branch_b.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify branch A
@@ -928,8 +954,10 @@ mod tests {
         tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let root_after_insert = tree.root().clone();
@@ -939,8 +967,10 @@ mod tests {
         tree = tree.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let root_after_second_insert = tree.root().clone();
@@ -950,8 +980,10 @@ mod tests {
         tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let root_after_delete = tree.root().clone();
@@ -971,8 +1003,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree_a.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_a.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Build tree B with same data
@@ -982,8 +1016,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree_b.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_b.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Trees with identical content should have same root (content-addressed)
@@ -1035,8 +1071,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Insert second batch WITHOUT flushing
@@ -1066,8 +1104,10 @@ mod tests {
             .await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Get should work
@@ -1080,8 +1120,10 @@ mod tests {
         tree = tree.delete(&42u32.to_le_bytes(), &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Should be empty again
@@ -1115,8 +1157,10 @@ mod tests {
         tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let root_before = tree.root().clone();
@@ -1145,8 +1189,10 @@ mod tests {
         tree = tree.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         assert_eq!(
@@ -1158,8 +1204,10 @@ mod tests {
         tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         assert_eq!(tree.get(&1u32.to_le_bytes(), &storage).await?, None);
@@ -1170,8 +1218,10 @@ mod tests {
             .await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         assert_eq!(
@@ -1192,8 +1242,10 @@ mod tests {
         tree_a = tree_a.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
         tree_a = tree_a.insert(3u32.to_le_bytes(), vec![3], &storage).await?;
 
-        for (key, value) in tree_a.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_a.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Build tree B with different insertion order
@@ -1202,8 +1254,10 @@ mod tests {
         tree_b = tree_b.insert(1u32.to_le_bytes(), vec![1], &storage).await?;
         tree_b = tree_b.insert(2u32.to_le_bytes(), vec![2], &storage).await?;
 
-        for (key, value) in tree_b.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_b.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Different insertion orders should produce same root hash
@@ -1225,8 +1279,10 @@ mod tests {
         tree = tree.insert(3u32.to_le_bytes(), vec![3], &storage).await?;
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify tree is not empty
@@ -1234,18 +1290,24 @@ mod tests {
 
         // Delete all entries
         tree = tree.delete(&1u32.to_le_bytes(), &storage).await?;
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         tree = tree.delete(&2u32.to_le_bytes(), &storage).await?;
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         tree = tree.delete(&3u32.to_le_bytes(), &storage).await?;
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Tree should be back to empty state with null root
@@ -1269,8 +1331,10 @@ mod tests {
         }
 
         // Flush
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Query completely below range (0-5)
@@ -1326,8 +1390,10 @@ mod tests {
         }
 
         // Flush to storage
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Verify all entries can be retrieved
@@ -1351,8 +1417,10 @@ mod tests {
         }
 
         let root = tree.root().clone();
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Reconstruct from just the root hash — no shared delta or cache
@@ -1386,8 +1454,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Insert more WITHOUT flushing
@@ -1428,8 +1498,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Delete some entries WITHOUT flushing
@@ -1467,8 +1539,10 @@ mod tests {
                 .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Find boundary keys
@@ -1480,8 +1554,10 @@ mod tests {
 
         for &bk in boundaries.iter().take(3) {
             let mut after_delete = tree.delete(&bk.to_le_bytes(), &storage).await?;
-            for (h, b) in after_delete.flush() {
-                storage.store(b.as_ref().to_vec(), &h).await?;
+            for buffer in after_delete.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
             }
 
             // Deleted key should be gone
@@ -1520,16 +1596,20 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Delete all entries one at a time
         for i in 0..500u32 {
             tree = tree.delete(&i.to_le_bytes(), &storage).await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         assert_eq!(
@@ -1551,8 +1631,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let root_before = tree.root().clone();
@@ -1589,8 +1671,10 @@ mod tests {
                 .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let stream = tree.stream(&storage);
@@ -1635,8 +1719,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Excluded start: should not include key 5
@@ -1673,8 +1759,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // start.. (unbounded end)
@@ -1703,8 +1791,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in tree.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // key..=key should return exactly one entry
@@ -1749,8 +1839,10 @@ mod tests {
                 .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
                 .await?;
         }
-        for (key, value) in tree_a.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_a.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Build tree B: reverse insertion order
@@ -1760,8 +1852,10 @@ mod tests {
                 .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
                 .await?;
         }
-        for (key, value) in tree_b.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in tree_b.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // A canonical prolly tree must produce the same structure — and
@@ -1789,8 +1883,10 @@ mod tests {
                 .insert(i.to_le_bytes(), vec![i as u8], &storage)
                 .await?;
         }
-        for (key, value) in base.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in base.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Create two branches
@@ -1808,11 +1904,15 @@ mod tests {
         branch_b = branch_b.delete(&10u32.to_le_bytes(), &storage).await?;
 
         // Flush both
-        for (key, value) in branch_a.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in branch_a.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
-        for (key, value) in branch_b.flush() {
-            storage.store(value.as_ref().to_vec(), &key).await?;
+        for buffer in branch_b.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         // Branch A: base + 100, 101
@@ -1860,8 +1960,10 @@ mod tests {
                 .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), &storage)
                 .await?;
         }
-        for (h, b) in tree.flush() {
-            storage.store(b.as_ref().to_vec(), &h).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let boundaries: Vec<u32> = all_keys
@@ -1976,8 +2078,10 @@ mod tests {
                 .insert(i.to_le_bytes(), i.to_le_bytes().to_vec(), &storage)
                 .await?;
         }
-        for (h, b) in tree.flush() {
-            storage.store(b.as_ref().to_vec(), &h).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
         assert_eq!(tree.delta.len(), 0);
 
@@ -2023,8 +2127,10 @@ mod tests {
                 .insert(k.to_le_bytes(), k.to_le_bytes().to_vec(), storage)
                 .await?;
         }
-        for (hash, buffer) in tree.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
         Ok(tree)
     }
@@ -2046,8 +2152,10 @@ mod tests {
 
         let mut tree = build_and_flush_u32(&keys, &mut storage).await?;
         let mut after = tree.delete(&69161u32.to_le_bytes(), &storage).await?;
-        for (hash, buffer) in after.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in after.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let remaining: Vec<u32> = keys.iter().copied().filter(|&k| k != 69161).collect();
@@ -2083,8 +2191,10 @@ mod tests {
 
         let mut tree = build_and_flush_u32(&keys, &mut storage).await?;
         let mut after = tree.delete(&198936u32.to_le_bytes(), &storage).await?;
-        for (hash, buffer) in after.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in after.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let mut unreadable = vec![];
@@ -2145,8 +2255,10 @@ mod tests {
                 .await?;
         }
         tree = tree.insert([0xFF; 4], vec![0xFF], &storage).await?;
-        for (hash, buffer) in tree.flush() {
-            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        for buffer in tree.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
         }
 
         let stream = tree.stream(&storage);
@@ -2205,8 +2317,10 @@ mod tests {
                 // Flush periodically so both the delta-resident and the
                 // storage-resident read paths get exercised.
                 if op % 10 == 9 {
-                    for (hash, buffer) in tree.flush() {
-                        storage.store(buffer.as_ref().to_vec(), &hash).await?;
+                    for buffer in tree.flush() {
+                        storage
+                            .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                            .await?;
                     }
                 }
 

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -502,7 +502,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_writes_archive_to_expected_path() {
-        use dialog_common::Blake3Hash;
+        use dialog_common::{Blake3Hash, Buffer};
         use dialog_credentials::Ed25519Signer;
         use dialog_effects::prelude::*;
         use dialog_varsig::Principal;
@@ -519,7 +519,7 @@ mod tests {
 
         did.archive()
             .catalog("index")
-            .put(digest.clone(), content)
+            .put(Buffer::from(content))
             .perform(&provider)
             .await
             .unwrap();

--- a/rust/dialog-storage/src/storage/provider/fs/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/archive.rs
@@ -6,9 +6,9 @@ use super::{FileSystem, FileSystemError, FileSystemHandle};
 use async_trait::async_trait;
 use base58::ToBase58;
 use dialog_capability::{Capability, Provider};
-use dialog_common::Blake3Hash;
-use dialog_effects::archive::prelude::{GetExt, PutExt};
-use dialog_effects::archive::{ArchiveError, Get, Put};
+use dialog_effects::archive::prelude::{GetExt, ImportExt, PutExt};
+use dialog_effects::archive::{ArchiveError, Get, Import, Put};
+use futures_util::future::try_join_all;
 
 const ARCHIVE: &str = "archive";
 
@@ -47,15 +47,6 @@ impl Provider<Put> for FileSystem {
         let digest = effect.digest();
         let content = effect.content();
 
-        // Verify content matches the declared digest
-        let actual_digest = Blake3Hash::hash(content);
-        if &actual_digest != digest {
-            return Err(ArchiveError::DigestMismatch {
-                expected: digest.as_bytes().to_base58(),
-                actual: actual_digest.as_bytes().to_base58(),
-            });
-        }
-
         let key = digest.as_bytes().to_base58();
         let destination = self.archive()?.resolve(catalog)?;
         let handle = destination.resolve(&key)?;
@@ -75,11 +66,51 @@ impl Provider<Put> for FileSystem {
     }
 }
 
+#[async_trait]
+impl Provider<Import> for FileSystem {
+    async fn execute(&self, effect: Capability<Import>) -> Result<(), ArchiveError> {
+        let catalog = effect.catalog();
+        let blocks = effect.blocks();
+
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        // Content addressing derives each key from the bytes (the buffer
+        // memoizes its hash). Write concurrently: blocks are independent
+        // files.
+        let destination = self.archive()?.resolve(catalog)?;
+        try_join_all(blocks.iter().map(|buffer| {
+            let destination = &destination;
+            async move {
+                let key = buffer.blake3_hash().as_bytes().to_base58();
+                let handle = destination.resolve(&key)?;
+
+                // Content-addressed storage is idempotent - if file exists
+                // with same content hash, no need to rewrite
+                if handle.exists().await {
+                    return Ok(());
+                }
+
+                // Write atomically via temp file + rename
+                let tmp_handle = destination.resolve(&format!("{}.tmp", key))?;
+                tmp_handle.write(buffer.as_ref()).await?;
+                tmp_handle.rename(&handle).await?;
+                Ok(()) as Result<(), ArchiveError>
+            }
+        }))
+        .await?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::helpers::{unique_did, unique_name};
     use crate::resource::Resource;
+    use dialog_common::{Blake3Hash, Buffer};
     use dialog_effects::prelude::*;
     use dialog_effects::storage::{Directory, Location as StorageLocation};
 
@@ -120,7 +151,7 @@ mod tests {
             .clone()
             .archive()
             .catalog("index")
-            .put(digest.clone(), content.clone());
+            .put(Buffer::from(content.clone()));
 
         put_effect.perform(&provider).await?;
 
@@ -132,28 +163,6 @@ mod tests {
             .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
-
-        Ok(())
-    }
-
-    #[dialog_common::test]
-    async fn it_rejects_digest_mismatch() -> anyhow::Result<()> {
-        let location = StorageLocation::new(
-            Directory::Temp,
-            unique_name("fs-it_rejects_digest_mismatch"),
-        );
-        let provider = FileSystem::open(&location).await?;
-        let subject = unique_did().await;
-        let content = b"hello world".to_vec();
-        let wrong_digest = Blake3Hash::hash(b"different content");
-
-        let effect = subject
-            .archive()
-            .catalog("index")
-            .put(wrong_digest, content);
-
-        let result = effect.perform(&provider).await;
-        assert!(matches!(result, Err(ArchiveError::DigestMismatch { .. })));
 
         Ok(())
     }
@@ -176,7 +185,7 @@ mod tests {
             .clone()
             .archive()
             .catalog("catalog1")
-            .put(digest1.clone(), content1.clone())
+            .put(Buffer::from(content1.clone()))
             .perform(&provider)
             .await?;
 
@@ -184,7 +193,7 @@ mod tests {
             .clone()
             .archive()
             .catalog("catalog2")
-            .put(digest2.clone(), content2.clone())
+            .put(Buffer::from(content2.clone()))
             .perform(&provider)
             .await?;
 
@@ -236,7 +245,7 @@ mod tests {
             .clone()
             .archive()
             .catalog("index")
-            .put(digest.clone(), content.clone())
+            .put(Buffer::from(content.clone()))
             .perform(&provider)
             .await?;
 
@@ -244,7 +253,7 @@ mod tests {
             .clone()
             .archive()
             .catalog("index")
-            .put(digest.clone(), content.clone())
+            .put(Buffer::from(content.clone()))
             .perform(&provider)
             .await?;
 
@@ -273,7 +282,7 @@ mod tests {
             .clone()
             .archive()
             .catalog("index")
-            .put(digest.clone(), content.clone())
+            .put(Buffer::from(content.clone()))
             .perform(&provider)
             .await?;
 
@@ -302,7 +311,7 @@ mod tests {
             .clone()
             .archive()
             .catalog("index")
-            .put(digest.clone(), content.clone())
+            .put(Buffer::from(content.clone()))
             .perform(&provider)
             .await?;
 
@@ -313,6 +322,41 @@ mod tests {
             .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_imports_blocks_in_bulk() -> anyhow::Result<()> {
+        let location =
+            StorageLocation::new(Directory::Temp, unique_name("fs-it_imports_blocks_in_bulk"));
+        let provider = FileSystem::open(&location).await?;
+        let subject = unique_did().await;
+
+        let blocks: Vec<Buffer> = (0..8u8).map(|i| Buffer::from(vec![i; 64])).collect();
+        let digests: Vec<_> = blocks
+            .iter()
+            .map(|buffer| buffer.blake3_hash().clone())
+            .collect();
+
+        subject
+            .clone()
+            .archive()
+            .catalog("index")
+            .import(blocks)
+            .perform(&provider)
+            .await?;
+
+        for (i, digest) in digests.into_iter().enumerate() {
+            let content = subject
+                .clone()
+                .archive()
+                .catalog("index")
+                .get(digest)
+                .perform(&provider)
+                .await?;
+            assert_eq!(content, Some(vec![i as u8; 64]));
+        }
 
         Ok(())
     }

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -328,6 +328,7 @@ mod tests {
 
     use super::*;
     use crate::helpers::unique_name;
+    use dialog_common::Buffer;
     use wasm_bindgen::JsValue;
 
     #[dialog_common::test]
@@ -475,7 +476,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest, content))
+            .invoke(Put::new(Buffer::from(content)))
             .perform(&db)
             .await?;
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
@@ -4,9 +4,8 @@ use super::{IndexedDb, to_uint8array};
 use async_trait::async_trait;
 use base58::ToBase58;
 use dialog_capability::{Capability, Provider};
-use dialog_common::Blake3Hash;
-use dialog_effects::archive::prelude::{GetExt, PutExt};
-use dialog_effects::archive::{ArchiveError, Get, Put};
+use dialog_effects::archive::prelude::{GetExt, ImportExt, PutExt};
+use dialog_effects::archive::{ArchiveError, Get, Import, Put};
 use js_sys::Uint8Array;
 use wasm_bindgen::{JsCast, JsValue};
 
@@ -58,15 +57,6 @@ impl Provider<Put> for IndexedDb {
         let digest = effect.digest();
         let content = effect.content();
 
-        // Verify content matches the declared digest
-        let actual_digest = Blake3Hash::hash(content);
-        if &actual_digest != digest {
-            return Err(ArchiveError::DigestMismatch {
-                expected: digest.as_bytes().to_base58(),
-                actual: actual_digest.as_bytes().to_base58(),
-            });
-        }
-
         let store_name = format!("{ARCHIVE}/{catalog}");
         let key = JsValue::from_str(&digest.as_bytes().to_base58());
         let value: JsValue = to_uint8array(content).into();
@@ -84,12 +74,51 @@ impl Provider<Put> for IndexedDb {
     }
 }
 
+#[async_trait(?Send)]
+impl Provider<Import> for IndexedDb {
+    async fn execute(&self, effect: Capability<Import>) -> Result<(), ArchiveError> {
+        let catalog = effect.catalog();
+        let blocks = effect.blocks();
+
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        // Content addressing derives each key from the bytes (the buffer
+        // memoizes its hash).
+        let entries: Vec<(JsValue, JsValue)> = blocks
+            .iter()
+            .map(|buffer| {
+                let key = JsValue::from_str(&buffer.blake3_hash().as_bytes().to_base58());
+                let value: JsValue = to_uint8array(buffer.as_ref()).into();
+                (key, value)
+            })
+            .collect();
+
+        let store_name = format!("{ARCHIVE}/{catalog}");
+        let store = self.store(&store_name).await?;
+        // One read-write transaction for the whole batch.
+        store
+            .transact(|object_store| async move {
+                for (key, value) in entries {
+                    object_store
+                        .put(&value, Some(&key))
+                        .await
+                        .map_err(storage_error)?;
+                }
+                Ok(())
+            })
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
     use crate::helpers::{unique_name, unique_subject};
+    use dialog_common::{Blake3Hash, Buffer};
     use dialog_effects::archive::{Archive, Catalog};
 
     #[dialog_common::test]
@@ -120,7 +149,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest.clone(), content.clone()))
+            .invoke(Put::new(Buffer::from(content.clone())))
             .perform(&provider)
             .await?;
 
@@ -131,24 +160,6 @@ mod tests {
             .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
-
-        Ok(())
-    }
-
-    #[dialog_common::test]
-    async fn it_rejects_digest_mismatch() -> anyhow::Result<()> {
-        let provider = IndexedDb::connect(unique_name("archive-mismatch")).await?;
-        let subject = unique_subject("archive-mismatch");
-        let content = b"hello world".to_vec();
-        let wrong_digest = Blake3Hash::hash(b"different content");
-
-        let effect = subject
-            .attenuate(Archive)
-            .attenuate(Catalog::new("index"))
-            .invoke(Put::new(wrong_digest, content));
-
-        let result = effect.perform(&provider).await;
-        assert!(matches!(result, Err(ArchiveError::DigestMismatch { .. })));
 
         Ok(())
     }
@@ -166,7 +177,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
-            .invoke(Put::new(digest1.clone(), content1.clone()))
+            .invoke(Put::new(Buffer::from(content1.clone())))
             .perform(&provider)
             .await?;
 
@@ -174,7 +185,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
-            .invoke(Put::new(digest2.clone(), content2.clone()))
+            .invoke(Put::new(Buffer::from(content2.clone())))
             .perform(&provider)
             .await?;
 
@@ -203,6 +214,88 @@ mod tests {
             .perform(&provider)
             .await?;
         assert!(cross.is_none());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_imports_blocks_in_bulk() -> anyhow::Result<()> {
+        let provider = IndexedDb::connect(unique_name("archive-import")).await?;
+        let subject = unique_subject("archive-import");
+
+        let blocks: Vec<Buffer> = (0..8u8).map(|i| Buffer::from(vec![i; 64])).collect();
+        let digests: Vec<_> = blocks
+            .iter()
+            .map(|buffer| buffer.blake3_hash().clone())
+            .collect();
+
+        subject
+            .clone()
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Import::new(blocks))
+            .perform(&provider)
+            .await?;
+
+        for (i, digest) in digests.into_iter().enumerate() {
+            let content = subject
+                .clone()
+                .attenuate(Archive)
+                .attenuate(Catalog::new("index"))
+                .invoke(Get::new(digest))
+                .perform(&provider)
+                .await?;
+            assert_eq!(content, Some(vec![i as u8; 64]));
+        }
+
+        Ok(())
+    }
+
+    /// Not an assertion-bearing benchmark (timing in CI is too noisy to
+    /// gate on), but a measurement that prints alongside the test run:
+    /// per-block puts vs one import for a flush-sized batch.
+    #[dialog_common::test]
+    async fn it_reports_import_vs_puts_timing() -> anyhow::Result<()> {
+        const BLOCKS: usize = 64;
+        const BLOCK_SIZE: usize = 4096;
+
+        let provider = IndexedDb::connect(unique_name("archive-import-timing")).await?;
+        let subject = unique_subject("archive-import-timing");
+
+        let blocks: Vec<Buffer> = (0..BLOCKS)
+            .map(|i| {
+                let mut content = vec![0u8; BLOCK_SIZE];
+                content[0] = i as u8;
+                content[1] = (i >> 8) as u8;
+                Buffer::from(content)
+            })
+            .collect();
+
+        let start = js_sys::Date::now();
+        for block in &blocks {
+            subject
+                .clone()
+                .attenuate(Archive)
+                .attenuate(Catalog::new("puts"))
+                .invoke(Put::new(block.clone()))
+                .perform(&provider)
+                .await?;
+        }
+        let puts_ms = js_sys::Date::now() - start;
+
+        let start = js_sys::Date::now();
+        subject
+            .clone()
+            .attenuate(Archive)
+            .attenuate(Catalog::new("import"))
+            .invoke(Import::new(blocks))
+            .perform(&provider)
+            .await?;
+        let import_ms = js_sys::Date::now() - start;
+
+        wasm_bindgen_test::console_log!(
+            "[measurement] {BLOCKS} blocks x {BLOCK_SIZE}B: per-block puts {puts_ms:.1} ms, single import {import_ms:.1} ms"
+        );
 
         Ok(())
     }

--- a/rust/dialog-storage/src/storage/provider/space.rs
+++ b/rust/dialog-storage/src/storage/provider/space.rs
@@ -57,6 +57,7 @@ use crate::resource::Resource;
 pub trait SpaceProvider:
     Provider<archive::Get>
     + Provider<archive::Put>
+    + Provider<archive::Import>
     + Provider<memory::Resolve>
     + Provider<memory::Publish>
     + Provider<memory::Retract>
@@ -74,6 +75,7 @@ pub trait SpaceProvider:
 impl<T> SpaceProvider for T where
     T: Provider<archive::Get>
         + Provider<archive::Put>
+        + Provider<archive::Import>
         + Provider<memory::Resolve>
         + Provider<memory::Publish>
         + Provider<memory::Retract>
@@ -92,7 +94,7 @@ impl<T> SpaceProvider for T where
 #[derive(Clone, dialog_capability::Provider)]
 pub struct Space<A, M, C, D> {
     /// Archive provider.
-    #[provide(archive::Get, archive::Put)]
+    #[provide(archive::Get, archive::Put, archive::Import)]
     pub archive: A,
 
     /// Memory provider.

--- a/rust/dialog-storage/src/storage/provider/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/storage.rs
@@ -37,6 +37,7 @@ pub struct Storage<S: Clone> {
     #[provide(
         archive::Get,
         archive::Put,
+        archive::Import,
         memory::Resolve,
         memory::Publish,
         memory::Retract,
@@ -114,7 +115,7 @@ mod tests {
     use super::*;
     use crate::helpers::test_credential;
     use dialog_capability::did;
-    use dialog_common::Blake3Hash;
+    use dialog_common::{Blake3Hash, Buffer};
     use dialog_effects::prelude::*;
     use dialog_effects::storage::{LocationExt, Storage as StorageFx};
     use dialog_varsig::Principal;
@@ -153,7 +154,7 @@ mod tests {
         did.clone()
             .archive()
             .catalog("index")
-            .put(digest.clone(), content.clone())
+            .put(Buffer::from(content.clone()))
             .perform(&env)
             .await
             .unwrap();
@@ -243,7 +244,7 @@ mod tests {
 
         did1.archive()
             .catalog("index")
-            .put(digest.clone(), content)
+            .put(Buffer::from(content))
             .perform(&env)
             .await
             .unwrap();
@@ -346,7 +347,7 @@ mod tests {
             did.clone()
                 .archive()
                 .catalog("index")
-                .put(digest.clone(), content.clone())
+                .put(Buffer::from(content.clone()))
                 .perform(&env)
                 .await
                 .unwrap();

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -152,7 +152,7 @@ mod tests {
     use super::*;
     use base58::ToBase58;
     use dialog_capability::did;
-    use dialog_common::Blake3Hash;
+    use dialog_common::{Blake3Hash, Buffer};
 
     #[dialog_common::test]
     fn it_creates_new_provider() {
@@ -247,7 +247,7 @@ mod tests {
                     .clone()
                     .attenuate(Archive)
                     .attenuate(Catalog::new("index"))
-                    .invoke(Put::new(digest.clone(), content))
+                    .invoke(Put::new(Buffer::from(content)))
                     .perform(provider.as_ref())
                     .await
                     .unwrap();

--- a/rust/dialog-storage/src/storage/provider/volatile/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/archive.rs
@@ -4,9 +4,8 @@ use super::{ArchiveKey, Volatile, VolatileError};
 use async_trait::async_trait;
 use base58::ToBase58;
 use dialog_capability::{Capability, Provider};
-use dialog_common::Blake3Hash;
-use dialog_effects::archive::prelude::{GetExt, PutExt};
-use dialog_effects::archive::{ArchiveError, Get, Put};
+use dialog_effects::archive::prelude::{GetExt, ImportExt, PutExt};
+use dialog_effects::archive::{ArchiveError, Get, Import, Put};
 
 impl From<VolatileError> for ArchiveError {
     fn from(e: VolatileError) -> Self {
@@ -40,15 +39,6 @@ impl Provider<Put> for Volatile {
         let digest = effect.digest();
         let content = effect.content();
 
-        // Verify content matches the declared digest
-        let actual_digest = Blake3Hash::hash(content);
-        if &actual_digest != digest {
-            return Err(ArchiveError::DigestMismatch {
-                expected: digest.as_bytes().to_base58(),
-                actual: actual_digest.as_bytes().to_base58(),
-            });
-        }
-
         let key: ArchiveKey = (catalog.to_string(), digest.as_bytes().to_base58());
 
         // Content-addressed storage is idempotent
@@ -63,10 +53,43 @@ impl Provider<Put> for Volatile {
     }
 }
 
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl Provider<Import> for Volatile {
+    async fn execute(&self, effect: Capability<Import>) -> Result<(), ArchiveError> {
+        let subject = effect.subject().into();
+        let catalog = effect.catalog();
+        let blocks = effect.blocks();
+
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        // Content addressing derives each key from the bytes (the buffer
+        // memoizes its hash). One lock acquisition for the whole batch.
+        let mut sessions = self.sessions.write();
+        let session = sessions.entry(subject).or_default();
+        for buffer in blocks {
+            let key: ArchiveKey = (
+                catalog.to_string(),
+                buffer.blake3_hash().as_bytes().to_base58(),
+            );
+            // Content-addressed storage is idempotent
+            session
+                .archive
+                .entry(key)
+                .or_insert_with(|| buffer.as_ref().to_vec());
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::helpers::unique_subject;
+    use dialog_common::{Blake3Hash, Buffer};
     use dialog_effects::archive::{Archive, Catalog};
 
     #[dialog_common::test]
@@ -98,7 +121,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest.clone(), content.clone()));
+            .invoke(Put::new(Buffer::from(content.clone())));
 
         put_effect.perform(&provider).await?;
 
@@ -110,24 +133,6 @@ mod tests {
 
         let result = get_effect.perform(&provider).await?;
         assert_eq!(result, Some(content));
-
-        Ok(())
-    }
-
-    #[dialog_common::test]
-    async fn it_rejects_digest_mismatch() -> anyhow::Result<()> {
-        let provider = Volatile::new();
-        let subject = unique_subject("archive-mismatch");
-        let content = b"hello world".to_vec();
-        let wrong_digest = Blake3Hash::hash(b"different content");
-
-        let effect = subject
-            .attenuate(Archive)
-            .attenuate(Catalog::new("index"))
-            .invoke(Put::new(wrong_digest, content));
-
-        let result = effect.perform(&provider).await;
-        assert!(matches!(result, Err(ArchiveError::DigestMismatch { .. })));
 
         Ok(())
     }
@@ -146,7 +151,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
-            .invoke(Put::new(digest1.clone(), content1.clone()))
+            .invoke(Put::new(Buffer::from(content1.clone())))
             .perform(&provider)
             .await?;
 
@@ -154,7 +159,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
-            .invoke(Put::new(digest2.clone(), content2.clone()))
+            .invoke(Put::new(Buffer::from(content2.clone())))
             .perform(&provider)
             .await?;
 
@@ -202,7 +207,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest.clone(), content.clone()))
+            .invoke(Put::new(Buffer::from(content.clone())))
             .perform(&provider)
             .await?;
 
@@ -210,7 +215,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest.clone(), content.clone()))
+            .invoke(Put::new(Buffer::from(content.clone())))
             .perform(&provider)
             .await?;
 
@@ -237,7 +242,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest.clone(), content.clone()))
+            .invoke(Put::new(Buffer::from(content.clone())))
             .perform(&provider)
             .await?;
 
@@ -264,7 +269,7 @@ mod tests {
             .clone()
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest.clone(), content.clone()))
+            .invoke(Put::new(Buffer::from(content.clone())))
             .perform(&provider)
             .await?;
 
@@ -275,6 +280,76 @@ mod tests {
             .perform(&provider)
             .await?;
         assert_eq!(result, Some(content));
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_imports_blocks_in_bulk() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let subject = unique_subject("archive-import");
+
+        let blocks: Vec<Buffer> = (0..8u8).map(|i| Buffer::from(vec![i; 64])).collect();
+        let digests: Vec<_> = blocks
+            .iter()
+            .map(|buffer| buffer.blake3_hash().clone())
+            .collect();
+
+        subject
+            .clone()
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Import::new(blocks))
+            .perform(&provider)
+            .await?;
+
+        for (i, digest) in digests.into_iter().enumerate() {
+            let content = subject
+                .clone()
+                .attenuate(Archive)
+                .attenuate(Catalog::new("index"))
+                .invoke(Get::new(digest))
+                .perform(&provider)
+                .await?;
+            assert_eq!(content, Some(vec![i as u8; 64]));
+        }
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_empty_and_repeated_imports() -> anyhow::Result<()> {
+        let provider = Volatile::new();
+        let subject = unique_subject("archive-import-idempotent");
+
+        subject
+            .clone()
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Import::new(Vec::<Buffer>::new()))
+            .perform(&provider)
+            .await?;
+
+        let block = Buffer::from(vec![7u8; 32]);
+        let digest = block.blake3_hash().clone();
+        for _ in 0..2 {
+            subject
+                .clone()
+                .attenuate(Archive)
+                .attenuate(Catalog::new("index"))
+                .invoke(Import::new([block.clone()]))
+                .perform(&provider)
+                .await?;
+        }
+
+        let content = subject
+            .clone()
+            .attenuate(Archive)
+            .attenuate(Catalog::new("index"))
+            .invoke(Get::new(digest))
+            .perform(&provider)
+            .await?;
+        assert_eq!(content, Some(vec![7u8; 32]));
 
         Ok(())
     }

--- a/rust/dialog-ucan/src/parameters.rs
+++ b/rust/dialog-ucan/src/parameters.rs
@@ -82,7 +82,7 @@ mod tests {
 
     use super::*;
     use dialog_capability::{Subject, did};
-    use dialog_common::Blake3Hash;
+    use dialog_common::{Blake3Hash, Buffer};
     use dialog_effects::archive::{Archive, Catalog, Get, Put};
 
     #[dialog_common::test]
@@ -142,11 +142,10 @@ mod tests {
     #[dialog_common::test]
     fn it_produces_multiple_constraints_for_chain_with_payload() {
         let content = b"hello world";
-        let digest = Blake3Hash::hash(content);
         let cap = Subject::from(did!("key:z6MkTest"))
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
-            .invoke(Put::new(digest, content.to_vec()));
+            .invoke(Put::new(Buffer::from(content.to_vec())));
         let policy = parameters_to_policy(parameters(&cap));
 
         // Should have constraints for catalog, digest, and content (via checksum)


### PR DESCRIPTION
Stacked on #354 (which this supersedes the reverted `db257dce` set_all commit of: Import replaces it rather than living alongside).

Batched block persistence through the capability system, designed per discussion:

- **Zero-copy payload**: `Buffer` (refcounted, aligned) moves to `dialog-common` and gains serde (bytes on the wire, realigning on deserialize). `archive::Block { digest, content: Buffer }` means building an `Import` from a tree's flushed delta shares the buffers — no byte copies on the way into the invocation. Serialization only happens if the effect crosses a wire boundary.
- **`archive::Import { blocks }`** on `Catalog`, attenuation projects to the blocks' checksums (kept possible by the materialized payload — a lazy stream would have lost per-entry constraint).
- **Semantics** (documented on the effect): durable on success; idempotent retry on failure (content-addressed puts are idempotent and unreferenced blocks are unobservable); **no atomicity promised** — the atomic boundary is the revision publish CAS. Single-round-trip persistence is a provider optimization, which resolves the S3 partial-failure tension: S3 providers may write blocks individually and fail retriably without violating the contract.
- **Providers**: IndexedDb = one read-write transaction per import; FileSystem = atomic per-block writes; Volatile = one lock. Routed through `Space`/`Storage`/`Operator`.
- **Wiring**: branch commit and pull flush through one `Import` invocation. `Provider<Import>` joins the env bounds of commit/pull/import, so embedders must provide it (coordinated change as discussed — tonk's env gets it for free if it composes the in-repo providers).

For tonk's repository-path seed commits this changes block persistence from one IndexedDB transaction per block to one per flush. Whether that's a measurable share of the (clean-baseline) ~400 ms seed is for instrumentation to say.