### PR TITLE
perf(repository): reuse a per-branch node cache across reads

### DIFF
--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -3,9 +3,11 @@ use crate::Revision;
 
 use dialog_artifacts::{Exporter, Importer};
 use dialog_capability::{Capability, Did, Subject};
+use dialog_common::Blake3Hash;
 use dialog_effects::archive::Archive;
 use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
 use dialog_query::query::Application;
+use dialog_search_tree::{Buffer, Cache};
 
 mod claims;
 pub use claims::*;
@@ -73,6 +75,11 @@ pub struct Branch {
     reference: BranchReference,
     revision: Cell<Revision>,
     upstream: Cell<Upstream>,
+    /// Shared node cache for tree reads. Created once per opened branch and
+    /// carried (as a shared handle) into every `Select`'s tree, so blocks read
+    /// by one query stay warm for the next instead of being re-fetched from
+    /// storage. Content-addressed keys make sharing across revisions safe.
+    node_cache: Cache<Blake3Hash, Buffer>,
 }
 
 impl Branch {
@@ -122,5 +129,10 @@ impl Branch {
     /// Query with an application. Shortcut for `branch.query().select(query)`.
     pub fn select<Q: Application>(&self, query: Q) -> SelectQuery<'_, Q> {
         SelectQuery::new(self, query)
+    }
+
+    /// A shared handle to this branch's node cache, for seeding a read tree.
+    pub(crate) fn node_cache(&self) -> Cache<Blake3Hash, Buffer> {
+        self.node_cache.clone()
     }
 }

--- a/rust/dialog-repository/src/repository/branch/open.rs
+++ b/rust/dialog-repository/src/repository/branch/open.rs
@@ -31,6 +31,7 @@ impl OpenBranch {
             reference: self.branch,
             revision,
             upstream,
+            node_cache: dialog_search_tree::Cache::new(),
         })
     }
 }

--- a/rust/dialog-repository/src/repository/branch/select.rs
+++ b/rust/dialog-repository/src/repository/branch/select.rs
@@ -116,7 +116,7 @@ impl Select<'_> {
             })?;
         }
 
-        let tree = Index::from_hash(NodeHash::from(tree_hash));
+        let tree = Index::from_hash_with_cache(NodeHash::from(tree_hash), self.branch.node_cache());
 
         // EAV/AEV/VAE dispatch + per-entry filtering lives in the shared
         // `ArtifactTreeExt::scan` so branch scans and Changes-overlay

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -152,6 +152,18 @@ where
         }
     }
 
+    /// Creates a [`PersistentTree`] from a known root hash, reusing an existing
+    /// node cache instead of allocating a fresh empty one.
+    ///
+    /// Nodes are content-addressed: a [`Blake3Hash`] always maps to the same
+    /// bytes, so a cache may be shared freely across tree versions and revisions
+    /// without ever serving a stale entry. Use this to keep a cache warm across
+    /// successive reconstructions of a tree from a moving root (e.g. a branch
+    /// that reuses one cache across every read).
+    pub fn from_hash_with_cache(root: Blake3Hash, node_cache: Cache<Blake3Hash, Buffer>) -> Self {
+        Self::seal(root, node_cache)
+    }
+
     /// Retrieves the value associated with `key` from the tree.
     ///
     /// This method performs a binary search through the tree hierarchy to


### PR DESCRIPTION
## Problem

`Branch::select` (`branch/select.rs`) builds its read tree with `Index::from_hash(tree_hash)`, which allocates a **fresh empty node cache on every call**. A concept query fans out to many internal selects, so the same root/leaf blocks get re-fetched from storage on each one.

Measured in the tonk worker (wasm/IndexedDB) on a cold page load, instrumenting `Accessor::get_node` for accesses vs fetches per request:

- **0% cache hit rate** — every block access was an IndexedDB fetch.
- A ~28-node tree generated **168 block reads** across a load, each its own IndexedDB transaction; individual `meta/query` requests did `34 accesses / 34 fetches` of just 2 distinct blocks (~17× re-read).

## Fix

Give `Branch` a shared `node_cache` (created once at `open`, an `Rc`/sharded handle that `#[derive(Clone)]` shares), and seed every read tree from it via a new `PersistentTree::from_hash_with_cache(root, cache)` (forwards to the existing `seal`). Because nodes are content-addressed, a cache shared across revisions never serves a stale entry — the tree root still advances per read; only the cache is carried.

The worker reuses one `Branch` per branch, so the cache stays warm across all its queries.

## Result (same instrumentation, after)

| | accesses | fetches | hits | hit rate |
|---|---:|---:|---:|---:|
| before | 168 | 168 | 0 | 0% |
| after | 174 | **4** | 170 | **98%** |

First read of each block is cold; everything after hits the cache. Block reads collapse 168 → 4 on a cold load. The per-block IndexedDB transaction storm is eliminated.