### PR TITLE
fix(dialog-storage): load must not create the backing store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "tower-http",
  "url",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-time",
 ]

--- a/rust/dialog-storage/Cargo.toml
+++ b/rust/dialog-storage/Cargo.toml
@@ -67,6 +67,7 @@ dirs = { workspace = true }
 js-sys = { workspace = true }
 rexie = { workspace = true }
 wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 web-time = { workspace = true }
 
 [dev-dependencies]

--- a/rust/dialog-storage/src/resource.rs
+++ b/rust/dialog-storage/src/resource.rs
@@ -7,6 +7,8 @@
 mod pool;
 pub use pool::*;
 
+use dialog_common::ConditionalSync;
+
 /// A resource that can be opened from an address.
 ///
 /// The address carries all information needed to construct the resource
@@ -17,6 +19,24 @@ pub trait Resource<Address>: Sized {
     /// Error that can occur when opening the resource.
     type Error;
 
-    /// Open a new resource from the given address.
+    /// Open a resource at the given address, creating its backing store
+    /// if absent. This is the open-or-create path.
     async fn open(address: &Address) -> Result<Self, Self::Error>;
+
+    /// Open an *existing* resource at the given address, failing if it
+    /// does not already exist. Unlike [`open`](Resource::open) this must
+    /// never bring the backing store into being.
+    ///
+    /// The default delegates to [`open`](Resource::open), which is correct
+    /// for backends whose `open` is lazy — it constructs a handle without
+    /// materializing anything (e.g. a filesystem path is created only on
+    /// first write). A backend whose `open` eagerly creates its store
+    /// (IndexedDB opens a database into existence) MUST override this to
+    /// probe for existence first and error when absent.
+    async fn load(address: &Address) -> Result<Self, Self::Error>
+    where
+        Address: ConditionalSync,
+    {
+        Self::open(address).await
+    }
 }

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -504,7 +504,11 @@ mod tests {
 
         // On disk the colon is escaped, never present.
         let names = space.certificate().unwrap().list().await.unwrap();
-        assert_eq!(names, vec![did.to_string()], "list recovers the logical name");
+        assert_eq!(
+            names,
+            vec![did.to_string()],
+            "list recovers the logical name"
+        );
 
         // The decoded name resolves back to the same bytes, no double-encoding.
         let again = space.certificate().unwrap().resolve(&names[0]).unwrap();

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -55,11 +55,13 @@ mod certificate;
 mod credential;
 mod memory;
 
-use js_sys::Uint8Array;
+use js_sys::{Array, Function, Promise, Reflect, Uint8Array, global};
 use rexie::{ObjectStore, Rexie, RexieBuilder, TransactionMode};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 
 /// Convert bytes to a JS Uint8Array.
 fn to_uint8array(bytes: &[u8]) -> Uint8Array {
@@ -271,18 +273,69 @@ impl Drop for IndexedDb {
 use crate::resource::Resource;
 use dialog_effects::storage::{Directory, Location};
 
+/// Derive the IndexedDB database name for a [`Location`].
+fn database_name(location: &Location) -> String {
+    match &location.directory {
+        Directory::Profile => format!("{}.profile", location.name),
+        Directory::Current => location.name.clone(),
+        Directory::Temp => format!("temp.{}", location.name),
+        Directory::At(path) => format!("{}/{}", path, location.name),
+    }
+}
+
+/// Whether an IndexedDB database with this name currently exists.
+///
+/// Uses `indexedDB.databases()`, which enumerates existing databases
+/// *without opening* (so it never creates one). The factory is read off
+/// the global scope (`self`) rather than `window`, so it works in a
+/// worker where `window` is absent.
+async fn database_exists(name: &str) -> Result<bool, IndexedDbError> {
+    let err = |m: String| IndexedDbError::Database(m);
+
+    let scope = global();
+    let factory = Reflect::get(&scope, &JsValue::from_str("indexedDB"))
+        .map_err(|e| err(format!("reading global indexedDB: {e:?}")))?;
+    let databases: Function = Reflect::get(&factory, &JsValue::from_str("databases"))
+        .map_err(|e| err(format!("reading indexedDB.databases: {e:?}")))?
+        .dyn_into()
+        .map_err(|_| err("indexedDB.databases is not callable".into()))?;
+    let promise: Promise = databases
+        .call0(&factory)
+        .map_err(|e| err(format!("calling indexedDB.databases(): {e:?}")))?
+        .dyn_into()
+        .map_err(|_| err("indexedDB.databases() did not return a promise".into()))?;
+    let list = JsFuture::from(promise)
+        .await
+        .map_err(|e| err(format!("indexedDB.databases() rejected: {e:?}")))?;
+
+    Ok(Array::from(&list).iter().any(|info| {
+        Reflect::get(&info, &JsValue::from_str("name"))
+            .ok()
+            .and_then(|n| n.as_string())
+            .as_deref()
+            == Some(name)
+    }))
+}
+
 #[async_trait::async_trait(?Send)]
 impl Resource<Location> for IndexedDb {
     type Error = IndexedDbError;
 
     async fn open(location: &Location) -> Result<Self, Self::Error> {
-        let name = match &location.directory {
-            Directory::Profile => format!("{}.profile", location.name),
-            Directory::Current => location.name.clone(),
-            Directory::Temp => format!("temp.{}", location.name),
-            Directory::At(path) => format!("{}/{}", path, location.name),
-        };
+        Self::connect(database_name(location)).await
+    }
 
+    /// Open an existing database, failing if it was never created.
+    ///
+    /// IndexedDB's `open` brings a database into being, so the base
+    /// `Resource::load` (which delegates to `open`) would leak a fresh
+    /// empty database on every miss. Probe `indexedDB.databases()` first
+    /// and refuse when absent — creating nothing.
+    async fn load(location: &Location) -> Result<Self, Self::Error> {
+        let name = database_name(location);
+        if !database_exists(&name).await? {
+            return Err(IndexedDbError::NotFound(name));
+        }
         Self::connect(name).await
     }
 }
@@ -305,6 +358,11 @@ pub enum IndexedDbError {
     /// Value conversion failed.
     #[error("Value conversion error: {0}")]
     Conversion(String),
+
+    /// No database exists at the requested name (a `load` of something
+    /// that was never created).
+    #[error("IndexedDB database not found: {0}")]
+    NotFound(String),
 }
 
 use dialog_capability::access::AuthorizeError;

--- a/rust/dialog-storage/src/storage/provider/space.rs
+++ b/rust/dialog-storage/src/storage/provider/space.rs
@@ -183,4 +183,21 @@ where
                 .map_err(|e| StorageError::Storage(e.to_string()))?,
         })
     }
+
+    async fn load(location: &Location) -> Result<Self, StorageError> {
+        Ok(Space {
+            archive: A::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+            memory: M::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+            credential: C::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+            certificate: P::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+        })
+    }
 }

--- a/rust/dialog-storage/src/storage/provider/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/storage.rs
@@ -362,6 +362,35 @@ mod tests {
             assert_eq!(result.unwrap(), Some(content));
         }
 
+        // `load` is "open an existing space, fail if absent" — it must
+        // never bring a space into being. A `load` of a name that was
+        // never created has to error AND leave nothing behind on disk
+        // (the bug it guards: a missing-name `load` materializing an
+        // empty backing store, e.g. a stray IndexedDB database).
+        #[dialog_common::test]
+        async fn it_does_not_create_on_load_of_missing_space() {
+            use std::path::PathBuf;
+
+            let env = Storage::temp();
+            let name = unique_name("fs-load-missing");
+
+            // Where `TempFileSystem` roots a `Directory::Profile` space.
+            let root: PathBuf = std::env::temp_dir()
+                .join("dialog")
+                .join("profile")
+                .join(&name);
+            assert!(!root.exists(), "precondition: space must not exist yet");
+
+            let result = StorageFx::profile(&name).load().perform(&env).await;
+
+            assert!(result.is_err(), "load of a missing space must fail");
+            assert!(
+                !root.exists(),
+                "load must not create the space directory: {}",
+                root.display(),
+            );
+        }
+
         #[dialog_common::test]
         async fn it_rejects_duplicate_create_on_filesystem() {
             let env = Storage::temp();
@@ -380,6 +409,73 @@ mod tests {
                 .perform(&env)
                 .await;
             assert!(result.is_err(), "duplicate create should fail");
+        }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    mod web_tests {
+        use super::*;
+        use crate::helpers::unique_name;
+
+        // `load` is "open an existing space, fail if absent" — it must never
+        // bring a space into being. On IndexedDB a space is one database, so a
+        // `load` of a never-created profile has to error AND leave no database
+        // behind (the bug it guards: a missing-name load materializing a stray
+        // IndexedDB database, e.g. the literal `{subject}` DB an unbound
+        // template once produced).
+        #[dialog_common::test]
+        async fn it_does_not_create_on_load_of_missing_space() {
+            use crate::provider::storage::WebSpace;
+
+            let env: Storage<WebSpace> = Storage::default();
+            let name = unique_name("idb-load-missing");
+            // `Directory::Profile` names the database `"{name}.profile"`.
+            let db_name = format!("{name}.profile");
+
+            assert!(
+                !idb_database_exists(&db_name).await,
+                "precondition: database must not exist yet",
+            );
+
+            let result = StorageFx::profile(&name).load().perform(&env).await;
+
+            assert!(result.is_err(), "load of a missing space must fail");
+            assert!(
+                !idb_database_exists(&db_name).await,
+                "load must not create the IndexedDB database `{db_name}`",
+            );
+        }
+
+        /// True if an IndexedDB database with this name currently exists.
+        ///
+        /// Calls `indexedDB.databases()` (which lists without opening, so it
+        /// never creates one) off the worker/window global — the test runs in
+        /// a dedicated worker where `window` is absent, so the factory is read
+        /// from `self`, not `window`.
+        async fn idb_database_exists(name: &str) -> bool {
+            use js_sys::{Array, Function, Promise, Reflect};
+            use wasm_bindgen::{JsCast, JsValue};
+            use wasm_bindgen_futures::JsFuture;
+
+            let global = js_sys::global();
+            let factory =
+                Reflect::get(&global, &JsValue::from_str("indexedDB")).expect("global indexedDB");
+            let databases: Function = Reflect::get(&factory, &JsValue::from_str("databases"))
+                .expect("indexedDB.databases")
+                .unchecked_into();
+            let promise: Promise = databases
+                .call0(&factory)
+                .expect("databases() call")
+                .unchecked_into();
+            let list = JsFuture::from(promise).await.expect("databases() resolves");
+
+            Array::from(&list).iter().any(|info| {
+                Reflect::get(&info, &JsValue::from_str("name"))
+                    .ok()
+                    .and_then(|n| n.as_string())
+                    .as_deref()
+                    == Some(name)
+            })
         }
     }
 }

--- a/rust/dialog-storage/src/storage/provider/storage/loader.rs
+++ b/rust/dialog-storage/src/storage/provider/storage/loader.rs
@@ -74,9 +74,12 @@ where
                 .map_err(|e| StorageError::NotFound(e.to_string()));
         }
 
-        let store = S::open(location)
+        // `load`, not `open`: a `storage::Load` of a space that was never
+        // created must fail without materializing its backing store (an
+        // `open` here would, on IndexedDB, create the database into being).
+        let store = S::load(location)
             .await
-            .map_err(|e| StorageError::Storage(e.to_string()))?;
+            .map_err(|e| StorageError::NotFound(e.to_string()))?;
 
         let cred: Credential = did!("local:storage")
             .credential()


### PR DESCRIPTION
## Why

A `storage::Load` of a space that was never created should fail, not bring the space into being. Today it opens the space through `Resource::open`, and on IndexedDB `open` materializes the database — so a missing-name load leaves an empty `{name}.profile` IndexedDB behind. (This is what produced stray databases like a literal `{subject}` one downstream: an unbound name reached the load path, the credential read failed with `NotFound`, but the empty DB persisted.)

The filesystem backend never had this problem because its `open` is lazy (a path is created only on first write). The fix makes the contract explicit rather than relying on each backend's `open` happening to be lazy.

## How

Split `open` (open-or-create) from a new `load` (open-existing-only, must create nothing):

- `Resource::load` defaults to `open` — correct for lazy backends, which materialize nothing until a write.
- `IndexedDb` overrides `load` to probe `indexedDB.databases()` (which enumerates without opening) and return `NotFound` when the database is absent, so it never creates one. The factory is read off the worker/window global so it works in a dedicated worker.
- `Space` forwards `load` to each field provider.
- The loader's `storage::Load` calls `load` instead of `open`.

## Test

Added a failing-first test (`it_does_not_create_on_load_of_missing_space`) in both the native and web suites: load a never-created profile, assert it errors **and** that no backing store was created (no directory on FS; no IndexedDB database via `databases()`). It failed before the fix (the IDB database was created on the miss) and passes after.

Native: 134 pass. Web (Chrome): 118 pass.