### PR TITLE
fix(dialog-storage): don't hold the cache lock across the backend fetch

### DIFF
--- a/rust/dialog-storage/src/storage/cache.rs
+++ b/rust/dialog-storage/src/storage/cache.rs
@@ -65,12 +65,28 @@ where
     }
 
     async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
-        let mut cache = self.cache.lock().await;
-        if let Some(value) = cache.get(key) {
-            return Ok(Some(value.clone()));
+        // Check the cache under a BRIEF lock, released before any backend I/O.
+        // Holding the lock across `backend.get(...).await` (below) serializes
+        // every block read in the process behind that single round-trip: the
+        // cache is one shared mutex, so on a single-threaded executor a miss's
+        // network fetch stalls all other reads — every other branch's queries
+        // and syncs included — for its full duration.
+        {
+            let mut cache = self.cache.lock().await;
+            if let Some(value) = cache.get(key) {
+                return Ok(Some(value.clone()));
+            }
         }
-        if let Some(value) = self.backend.get(key).await? {
-            cache.insert(key.clone(), value.clone());
+
+        // Fetch from the backend WITHOUT the cache lock held. Two concurrent
+        // misses for the same key may both fetch; that's harmless (blocks are
+        // content-addressed, so the value is identical) and far cheaper than
+        // serializing every reader behind one in-flight fetch. Resolve the
+        // result fully before re-acquiring the lock so the (non-`Send`) error
+        // type never straddles the `lock().await`.
+        let fetched = self.backend.get(key).await?;
+        if let Some(value) = fetched {
+            self.cache.lock().await.insert(key.clone(), value.clone());
             return Ok(Some(value));
         }
 


### PR DESCRIPTION
## Problem

`StorageCache::get` acquires the single shared cache mutex and holds it **across `backend.get(...).await`** on a cache miss — the network round-trip that fills the cache:

```rust
async fn get(&self, key) -> ... {
    let mut cache = self.cache.lock().await;      // lock
    if let Some(v) = cache.get(key) { return ... } // hit
    if let Some(v) = self.backend.get(key).await? { // MISS: network fetch, lock still held
        cache.insert(...); return ...
    }
    Ok(None)
}
```

Every block read in the process funnels through this one lock. On a single-threaded executor (e.g. the wasm service worker), an in-flight miss serializes **all** other reads — every branch's queries and syncs — for its entire fetch. A slow sync froze unrelated operations completely.

## Fix

Release the lock before the backend fetch; re-acquire only to insert. Two concurrent misses for the same key may both fetch, which is harmless (blocks are content-addressed, so the value is identical) and far cheaper than serializing every reader behind one round-trip.

## Measured impact (in a downstream wasm worker)

- Cross-repo query during a sync: **~1.8s → ~0.3s** (was blocked for the whole sync).
- No-op sync latency: **6-8s → ~1s** — block reads within the sync no longer serialize against each other either.

`cargo test -p dialog-storage` green (134 tests), native + wasm build clean.