### PR TITLE
feat(dialog-query): M3 composite types via conformance refinements and ordered variants

### DIFF
--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -77,7 +77,7 @@ use quote::quote;
 use syn::ext::IdentExt;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
-use super::helpers::{extract_doc_comments, parse_dialog_rename_attribute};
+use super::helpers::{extract_doc_comments, parse_dialog_field_attributes};
 
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -171,11 +171,15 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
         let field_type = &field.ty;
 
-        // Check for #[dialog(rename = "...")] to override the string key
-        let effective_name_str = match parse_dialog_rename_attribute(&field.attrs) {
-            Ok(rename) => rename.unwrap_or_else(|| field_name_str.clone()),
+        // Field-level #[dialog(...)] parameters: rename overrides
+        // the string key; conforms marks a concept-typed field.
+        let dialog_attrs = match parse_dialog_field_attributes(&field.attrs) {
+            Ok(parsed) => parsed,
             Err(e) => return e.to_compile_error().into(),
         };
+        let effective_name_str = dialog_attrs
+            .rename
+            .unwrap_or_else(|| field_name_str.clone());
         let field_name_lit = syn::LitStr::new(&effective_name_str, proc_macro2::Span::call_site());
 
         // Forward the user's field doc when present, otherwise synthesize a
@@ -234,12 +238,32 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // attribute's descriptor with this field's optionality
         // (tagged from the `OPTIONAL` const, never by syntactic
         // `Option<_>` inspection).
-        descriptor_pair_pushes.push(quote! {
-            __fields.push((
-                #field_name_lit.to_string(),
-                <#field_type as dialog_query::ConceptField>::field_descriptor(),
-            ));
-        });
+        //
+        // A `#[dialog(conforms = C)]` field goes through
+        // `ConformingField::conforming_descriptor` instead, which
+        // tags the descriptor with the target concept. The trait is
+        // implemented only for required, entity-valued attribute
+        // newtypes, so a non-entity or `Option<_>` field fails to
+        // compile rather than producing an invalid descriptor.
+        match &dialog_attrs.conforms {
+            Some(target) => descriptor_pair_pushes.push(quote! {
+                __fields.push((
+                    #field_name_lit.to_string(),
+                    <#field_type as dialog_query::ConformingField>::conforming_descriptor(
+                        <#target as dialog_query::Descriptor<
+                            dialog_query::ConceptDescriptor,
+                        >>::descriptor()
+                        .clone(),
+                    ),
+                ));
+            }),
+            None => descriptor_pair_pushes.push(quote! {
+                __fields.push((
+                    #field_name_lit.to_string(),
+                    <#field_type as dialog_query::ConceptField>::field_descriptor(),
+                ));
+            }),
+        }
 
         // Statement emission via the trait method. The concept's
         // `this` field is an `Entity` (concept structs always have

--- a/rust/dialog-macros/src/query/helpers.rs
+++ b/rust/dialog-macros/src/query/helpers.rs
@@ -154,38 +154,55 @@ pub fn parse_domain_attribute(attrs: &[Attribute]) -> Option<String> {
     None
 }
 
-/// Parse the `#[dialog(rename = "...")]` attribute.
-///
-/// Allows overriding the generated name for an attribute or concept field.
+/// Field-level `#[dialog(...)]` parameters on a `#[derive(Concept)]`
+/// field.
+#[derive(Default)]
+pub struct DialogFieldAttributes {
+    /// `rename = "..."`: overrides the generated field key.
+    pub rename: Option<String>,
+    /// `conforms = SomeConcept`: marks a concept-typed field; the
+    /// path names the target concept type.
+    pub conforms: Option<syn::Path>,
+}
+
+/// Parse the field-level `#[dialog(...)]` attribute.
 ///
 /// Supports:
-/// - `#[dialog(rename = "type")]` - rename to a specific string
+/// - `#[dialog(rename = "type")]` - rename the field key to a
+///   specific string
+/// - `#[dialog(conforms = Employee)]` - concept-typed field whose
+///   target entity must conform to the named concept
 ///
-/// Returns `Ok(Some(name))` if rename is specified, `Ok(None)` to use default.
-pub fn parse_dialog_rename_attribute(attrs: &[Attribute]) -> Result<Option<String>, syn::Error> {
+/// Both parameters may appear together.
+pub fn parse_dialog_field_attributes(
+    attrs: &[Attribute],
+) -> Result<DialogFieldAttributes, syn::Error> {
+    let mut parsed = DialogFieldAttributes::default();
     for attr in attrs {
         if attr.path().is_ident("dialog") {
-            let mut rename_value = None;
-
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("rename") {
                     let value = meta.value()?;
                     let lit: Lit = value.parse()?;
                     if let Lit::Str(lit_str) = lit {
-                        rename_value = Some(lit_str.value());
+                        parsed.rename = Some(lit_str.value());
                         Ok(())
                     } else {
                         Err(meta.error("rename value must be a string literal"))
                     }
+                } else if meta.path.is_ident("conforms") {
+                    let value = meta.value()?;
+                    parsed.conforms = Some(value.parse::<syn::Path>()?);
+                    Ok(())
                 } else {
-                    Err(meta.error("unknown dialog attribute parameter; expected `rename`"))
+                    Err(meta.error(
+                        "unknown dialog attribute parameter; expected `rename` or `conforms`",
+                    ))
                 }
             })?;
-
-            return Ok(rename_value);
         }
     }
-    Ok(None)
+    Ok(parsed)
 }
 
 /// Parse the `#[cardinality(one)]` or `#[cardinality(many)]` attribute.

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -360,8 +360,15 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
             Term::Variable { .. } => {
                 // A prefix refinement the planner stamped onto the
                 // attribute variable becomes an AEV range bound.
-                if let Some(refinement) = from.the.kind().as_ref().and_then(Kind::refinement) {
-                    let prefix = refinement.prefix.clone();
+                // Conformance-only refinements carry no prefix and
+                // produce no range bound.
+                if let Some(prefix) = from
+                    .the
+                    .kind()
+                    .as_ref()
+                    .and_then(Kind::refinement)
+                    .and_then(|refinement| refinement.prefix.clone())
+                {
                     selector = Some(match selector {
                         None => ArtifactSelector::new().the_starting_with(prefix),
                         Some(s) => s.the_starting_with(prefix),
@@ -383,8 +390,15 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
             Term::Variable { .. } => {
                 // A prefix refinement on the entity variable becomes
                 // an EAV range bound over the URI's raw head.
-                if let Some(refinement) = from.of.kind().as_ref().and_then(Kind::refinement) {
-                    let prefix = refinement.prefix.clone();
+                // Conformance-only refinements carry no prefix and
+                // produce no range bound.
+                if let Some(prefix) = from
+                    .of
+                    .kind()
+                    .as_ref()
+                    .and_then(Kind::refinement)
+                    .and_then(|refinement| refinement.prefix.clone())
+                {
                     selector = Some(match selector {
                         None => ArtifactSelector::new().of_starting_with(prefix),
                         Some(s) => s.of_starting_with(prefix),

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -1361,6 +1361,100 @@ mod tests {
         Ok(())
     }
 
+    // Ordered variants: first-to-conform via desugared negation.
+    mod contact {
+        use crate::Attribute;
+
+        /// Preferred way to reach the user.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Handle(pub String);
+    }
+
+    /// How to reach a user: their email when they have one,
+    /// otherwise their phone number.
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct Contact {
+        pub this: Entity,
+        pub handle: contact::Handle,
+    }
+
+    #[dialog_common::test]
+    async fn it_evaluates_ordered_variants_first_to_conform() -> Result<()> {
+        use crate::attribute::{AttributeDescriptor, The};
+        use crate::rule::deductive::DeductiveRule;
+        use crate::{Cardinality, ConceptDescriptor};
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let variant = |the: The| {
+            ConceptDescriptor::try_from(vec![(
+                "handle",
+                AttributeDescriptor::new(the, "", Cardinality::One, Some(ValueType::String)),
+            )])
+            .unwrap()
+        };
+        let email = variant(the!("user/email"));
+        let phone = variant(the!("user/phone"));
+
+        let rules = DeductiveRule::variants(Contact::descriptor().clone(), vec![email, phone])
+            .expect("variants compile");
+
+        let mut registry = RuleRegistry::new();
+        for rule in rules {
+            registry.register(rule).expect("rule registers");
+        }
+
+        let alice = Entity::new()?; // email AND phone: email wins
+        let bob = Entity::new()?; // phone only: phone row
+
+        branch
+            .transaction()
+            .assert(
+                the!("user/email")
+                    .of(alice.clone())
+                    .is("alice@mail".to_string()),
+            )
+            .assert(
+                the!("user/phone")
+                    .of(alice.clone())
+                    .is("555-0100".to_string()),
+            )
+            .assert(
+                the!("user/phone")
+                    .of(bob.clone())
+                    .is("555-0199".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, registry);
+        let mut contacts: Vec<Contact> = Query::<Contact>::default()
+            .perform(&source)
+            .try_collect()
+            .await?;
+        contacts.sort_by(|a, b| a.handle.value().cmp(b.handle.value()));
+
+        assert_eq!(
+            contacts,
+            vec![
+                Contact {
+                    this: bob,
+                    handle: contact::Handle("555-0199".into()),
+                },
+                Contact {
+                    this: alice,
+                    handle: contact::Handle("alice@mail".into()),
+                },
+            ],
+            "the first conforming variant wins; later variants fill the rest"
+        );
+
+        Ok(())
+    }
+
     // Tests migrated from tests/concept_query_shortcut_test.rs
     mod shortcut_employee {
         use crate::Attribute;

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -249,6 +249,35 @@ where
     }
 }
 
+/// Marker + constructor for *concept-typed* fields: a required,
+/// entity-valued attribute whose target entity must conform to a
+/// concept. `#[dialog(conforms = C)]` in `#[derive(Concept)]`
+/// dispatches through this trait, so both constraints are enforced
+/// at compile time rather than syntactically:
+///
+/// - a non-entity attribute fails the `Attribute<Type = Entity>`
+///   bound of the single blanket impl;
+/// - an `Option<_>` field has no impl at all — optional conformance
+///   is absence over a derived predicate, which stratification has
+///   to own before it can be evaluated soundly.
+pub trait ConformingField: ConceptField {
+    /// The [`ConceptFieldDescriptor`] for this field conforming to
+    /// `target`: the underlying attribute's descriptor tagged with
+    /// the target concept.
+    fn conforming_descriptor(target: ConceptDescriptor) -> ConceptFieldDescriptor {
+        ConceptFieldDescriptor::conforming(
+            <Self::Attribute as Descriptor<AttributeDescriptor>>::descriptor().clone(),
+            target,
+        )
+        .expect("the ConformingField bound guarantees an entity-valued attribute")
+    }
+}
+
+impl<N> ConformingField for N where
+    N: Attribute<Type = Entity> + Descriptor<AttributeDescriptor> + Clone + From<Entity>
+{
+}
+
 // Blanket impl for &T -> Parameters that uses the generated From<T> impl
 impl<T> From<&T> for Parameters
 where
@@ -1227,6 +1256,107 @@ mod tests {
 
         assert_eq!(name_facts.len(), 0);
         assert_eq!(birthday_facts.len(), 0);
+
+        Ok(())
+    }
+
+    // Concept-typed fields: `#[dialog(conforms = C)]`.
+    mod org {
+        use crate::Attribute;
+        use crate::Entity;
+
+        /// Employee badge number.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Badge(pub String);
+
+        /// The person's manager.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Manager(pub Entity);
+    }
+
+    /// Someone with a badge.
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct BadgeHolder {
+        pub this: Entity,
+        pub badge: org::Badge,
+    }
+
+    /// Someone reporting to a badge holder.
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct Report {
+        pub this: Entity,
+        pub badge: org::Badge,
+        /// The report's manager, who must hold a badge.
+        #[dialog(conforms = BadgeHolder)]
+        pub manager: org::Manager,
+    }
+
+    #[dialog_common::test]
+    fn it_tags_conforming_field_in_descriptor() {
+        let descriptor = Report::descriptor();
+        let manager = descriptor
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "manager")
+            .map(|(_, field)| field)
+            .expect("manager field present");
+        assert_eq!(
+            manager.conforms().map(|target| target.this()),
+            Some(BadgeHolder::descriptor().this()),
+            "the descriptor names the target concept"
+        );
+        assert_eq!(
+            manager.content_type(),
+            Some(ValueType::Entity),
+            "the conforming field is entity-valued"
+        );
+
+        let badge = descriptor
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "badge")
+            .map(|(_, field)| field)
+            .expect("badge field present");
+        assert!(badge.conforms().is_none(), "plain fields stay untagged");
+    }
+
+    /// End to end: a concept-typed field filters rows whose target
+    /// entity does not satisfy the target concept.
+    #[dialog_common::test]
+    async fn it_enforces_conformance_structurally() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?; // manager WITH a badge
+        let carol = Entity::new()?; // manager WITHOUT a badge
+        let bob = Entity::new()?; // reports to alice: conforms
+        let mallory = Entity::new()?; // reports to carol: does not
+
+        branch
+            .transaction()
+            .assert(org::Badge::of(alice.clone()).is("A-1"))
+            .assert(org::Badge::of(bob.clone()).is("B-2"))
+            .assert(org::Manager::of(bob.clone()).is(alice.clone()))
+            .assert(org::Badge::of(mallory.clone()).is("M-3"))
+            .assert(org::Manager::of(mallory.clone()).is(carol.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let reports: Vec<Report> = Query::<Report>::default()
+            .perform(&source)
+            .try_collect()
+            .await?;
+
+        assert_eq!(
+            reports.len(),
+            1,
+            "only the report whose manager holds a badge conforms, got {reports:?}"
+        );
+        assert_eq!(reports[0].this, bob);
+        assert_eq!(reports[0].manager.value(), &alice);
 
         Ok(())
     }

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -14,7 +14,7 @@ use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
 use crate::statement::Retraction;
 use crate::term::Term;
-use crate::type_system::{Primitive, Type as Kind};
+use crate::type_system::{ConceptRef, Primitive, Type as Kind};
 use crate::types::Scalar;
 use crate::{
     Cardinality, Entity, EvaluationError, Field, Parameters, Proposition, Requirement, Schema,
@@ -136,21 +136,29 @@ impl ConceptDescriptor {
     /// - The value for a **required** attribute is an empty map `{}`.
     /// - The value for an **optional** attribute is `{ "optional":
     ///   true }`.
+    /// - The value for a **concept-typed** attribute carries the
+    ///   target's URI: `{ "conforms": "concept:{hash}" }`. The
+    ///   target participates by identity, not by embedding, so a
+    ///   conforming field adds one URI to the encoding rather than
+    ///   the target's whole attribute set.
     ///
-    /// A concept with no optional attributes therefore hashes
-    /// exactly as it did before optionality existed (every value is
-    /// `{}`), so existing concept identities are preserved. Marking
-    /// an attribute optional changes its value object, and thus the
-    /// concept's identity.
+    /// A concept with no optional or conforming attributes therefore
+    /// hashes exactly as it did before either existed (every value
+    /// is `{}`), so existing concept identities are preserved.
+    /// Marking an attribute optional or conforming changes its value
+    /// object, and thus the concept's identity.
     pub fn to_cbor_bytes(&self) -> Vec<u8> {
         /// Per-attribute hash value: `{}` for required,
-        /// `{ "optional": true }` for optional. `optional` is omitted
-        /// when false, so a required attribute encodes as an empty
-        /// map, byte-identical to the pre-optionality encoding.
+        /// `{ "optional": true }` for optional, `{ "conforms":
+        /// "concept:.." }` for concept-typed. Both keys are omitted
+        /// when absent, so a plain required attribute encodes as an
+        /// empty map, byte-identical to the earlier encodings.
         #[derive(Serialize)]
         struct AttributeIdentity {
             #[serde(skip_serializing_if = "Not::not")]
             optional: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            conforms: Option<String>,
         }
 
         let mut attr_map: BTreeMap<String, AttributeIdentity> = BTreeMap::new();
@@ -161,6 +169,7 @@ impl ConceptDescriptor {
                 uri,
                 AttributeIdentity {
                     optional: schema.is_optional(),
+                    conforms: schema.conforms().map(|target| target.this().to_string()),
                 },
             );
         }
@@ -322,6 +331,18 @@ impl From<&ConceptDescriptor> for Schema {
                 (Some(ty), true) => Some(Kind::from(ty).optional()),
                 (None, true) => Some(Kind::from(Primitive::ALL).optional()),
                 (None, false) => None,
+            };
+            // A concept-typed field's slot carries the conformance
+            // refinement, so a consuming rule's TypeEnv sees which
+            // concept the entity must satisfy. The field is
+            // entity-valued by construction, so the meet is never
+            // empty.
+            let content_type = match (content_type, field.conforms()) {
+                (Some(kind), Some(target)) => Some(
+                    kind.with_conformance(ConceptRef(target.this().to_string()))
+                        .expect("a conforming field is entity-valued by construction"),
+                ),
+                (kind, _) => kind,
             };
             schema.insert(
                 name.into(),
@@ -1614,6 +1635,190 @@ mod tests {
         );
     }
 
+    /// Helpers shared by the conformance tests below.
+    fn badge_target() -> ConceptDescriptor {
+        ConceptDescriptor::try_from(vec![(
+            "badge",
+            AttributeDescriptor::new(
+                the!("employee/badge"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap()
+    }
+
+    fn manager_attr(content: Option<Type>) -> AttributeDescriptor {
+        AttributeDescriptor::new(the!("person/manager"), "", Cardinality::One, content)
+    }
+
+    /// Only entity-valued attributes can conform to a concept.
+    #[dialog_common::test]
+    fn it_rejects_non_entity_conformance() {
+        let result =
+            ConceptFieldDescriptor::conforming(manager_attr(Some(Type::String)), badge_target());
+        match result {
+            Err(crate::TypeError::NonEntityConformance { the, .. }) => {
+                assert_eq!(the, "person/manager");
+            }
+            other => panic!("expected NonEntityConformance, got {other:?}"),
+        }
+
+        let untyped = ConceptFieldDescriptor::conforming(manager_attr(None), badge_target());
+        assert!(
+            untyped.is_err(),
+            "an attribute without a declared value type cannot conform"
+        );
+    }
+
+    /// The wire path enforces the same invariants: a conforming
+    /// field that is optional, or not entity-valued, fails to parse.
+    #[dialog_common::test]
+    fn it_validates_conformance_on_the_wire() {
+        let target = serde_json::to_value(badge_target()).unwrap();
+
+        let optional = serde_json::json!({
+            "with": {
+                "name": { "the": "person/name", "as": "Text" },
+                "manager": {
+                    "the": "person/manager",
+                    "as": "Entity",
+                    "optional": true,
+                    "conforms": target,
+                }
+            }
+        });
+        assert!(
+            serde_json::from_value::<ConceptDescriptor>(optional).is_err(),
+            "optional conformance is absence-over-IDB; rejected until stratification"
+        );
+
+        let non_entity = serde_json::json!({
+            "with": {
+                "name": { "the": "person/name", "as": "Text" },
+                "manager": {
+                    "the": "person/manager",
+                    "as": "Text",
+                    "conforms": target,
+                }
+            }
+        });
+        assert!(
+            serde_json::from_value::<ConceptDescriptor>(non_entity).is_err(),
+            "a conforming field must be entity-valued"
+        );
+    }
+
+    /// A conforming field round-trips through JSON, carrying the
+    /// full target descriptor under `conforms`; plain fields stay
+    /// free of the key.
+    #[dialog_common::test]
+    fn it_round_trips_a_conforming_field() {
+        let target = badge_target();
+        let concept = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    manager_attr(Some(Type::Entity)),
+                    target.clone(),
+                )
+                .unwrap(),
+            ),
+        ])
+        .unwrap();
+
+        let json = serde_json::to_value(&concept).expect("serialize");
+        let with = json["with"].as_object().expect("with map");
+        assert!(
+            with["manager"]["conforms"].is_object(),
+            "conforming field carries the target descriptor"
+        );
+        assert!(
+            with["name"].as_object().unwrap().get("conforms").is_none(),
+            "plain field omits the key"
+        );
+
+        let back: ConceptDescriptor = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back.this(), concept.this());
+        let manager = back
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "manager")
+            .map(|(_, field)| field)
+            .expect("manager present");
+        assert_eq!(
+            manager.conforms().map(|c| c.this()),
+            Some(target.this()),
+            "the target survives the round-trip"
+        );
+    }
+
+    /// Conformance participates in the concept's identity by the
+    /// target's URI: tagging a field changes the hash, and the hash
+    /// depends on the target's identity rather than its embedding.
+    #[dialog_common::test]
+    fn it_hashes_conformance_into_identity() {
+        let plain = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::required(manager_attr(Some(Type::Entity))),
+            ),
+        ])
+        .unwrap();
+
+        let conforming = |target: ConceptDescriptor| {
+            ConceptDescriptor::try_from(vec![
+                (
+                    "name".to_string(),
+                    ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                        the!("person/name"),
+                        "",
+                        Cardinality::One,
+                        Some(Type::String),
+                    )),
+                ),
+                (
+                    "manager".to_string(),
+                    ConceptFieldDescriptor::conforming(manager_attr(Some(Type::Entity)), target)
+                        .unwrap(),
+                ),
+            ])
+            .unwrap()
+        };
+
+        let a = conforming(badge_target());
+        assert_ne!(
+            plain.hash(),
+            a.hash(),
+            "tagging a field with conformance changes the identity"
+        );
+
+        // The same target built independently hashes identically, so
+        // the concept identity is a function of the target's URI.
+        let b = conforming(badge_target());
+        assert_eq!(a.hash(), b.hash());
+        assert_eq!(a.this(), b.this());
+    }
+
     /// `From<&ConceptDescriptor> for Schema` lifts a typed
     /// attribute's content_type into the unified `type_system::Type`.
     #[dialog_common::test]
@@ -1708,6 +1913,48 @@ mod tests {
         assert!(
             tag.content_type().expect("tag kind").is_optional(),
             "an untyped optional field widens the full value set"
+        );
+    }
+
+    /// A conforming field's schema slot carries the conformance
+    /// refinement, so consuming rules see which concept the entity
+    /// must satisfy.
+    #[dialog_common::test]
+    fn schema_from_concept_stamps_conformance() {
+        use crate::type_system::ConceptRef;
+
+        let target = badge_target();
+        let descriptor = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    manager_attr(Some(Type::Entity)),
+                    target.clone(),
+                )
+                .unwrap(),
+            ),
+        ])
+        .unwrap();
+
+        let schema = Schema::from(&descriptor);
+        let manager = schema.get("manager").expect("manager field present");
+        let kind = manager.content_type().expect("typed slot");
+        assert_eq!(kind.primitive_part().as_singleton(), Some(Type::Entity));
+        assert!(
+            kind.refinement()
+                .expect("refined")
+                .conforms
+                .contains(&ConceptRef(target.this().to_string())),
+            "the slot kind names the target concept"
         );
     }
 

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -1,6 +1,7 @@
 use crate::Cardinality;
 use crate::artifact::Type;
 use crate::attribute::{AttributeDescriptor, The};
+use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::TypeError;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
@@ -34,7 +35,7 @@ fn is_not_optional(optional: &bool) -> bool {
 ///
 /// A required field omits `optional`, so it is byte-identical to the
 /// pre-optionality encoding.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ConceptFieldDescriptor {
     #[serde(flatten)]
     descriptor: AttributeDescriptor,
@@ -44,6 +45,18 @@ pub struct ConceptFieldDescriptor {
     /// the wire.
     #[serde(default, skip_serializing_if = "is_not_optional")]
     optional: bool,
+    /// The concept the field's target entity must conform to — a
+    /// *concept-typed* field. Only entity-valued attributes can
+    /// conform (validated at every construction path), and a
+    /// conforming field cannot be optional: the left-join over
+    /// "edge exists AND target conforms" is absence-over-IDB, which
+    /// stratification (M4) has to own first.
+    ///
+    /// Carried as the full target descriptor so rule lowering can
+    /// conjoin the target's premises without a registry; identity
+    /// hashing uses only the target's `concept:{hash}` URI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    conforms: Option<Box<ConceptDescriptor>>,
 }
 
 impl ConceptFieldDescriptor {
@@ -52,6 +65,7 @@ impl ConceptFieldDescriptor {
         Self {
             descriptor,
             optional: false,
+            conforms: None,
         }
     }
 
@@ -61,7 +75,30 @@ impl ConceptFieldDescriptor {
         Self {
             descriptor,
             optional: true,
+            conforms: None,
         }
+    }
+
+    /// A *concept-typed* field: a required, entity-valued attribute
+    /// whose target entity must conform to `target`. Errors when the
+    /// attribute's value type is not `Entity` — only entities can
+    /// conform to a concept.
+    pub fn conforming(
+        descriptor: AttributeDescriptor,
+        target: ConceptDescriptor,
+    ) -> Result<Self, TypeError> {
+        if descriptor.content_type() != Some(Type::Entity) {
+            return Err(TypeError::NonEntityConformance {
+                the: descriptor.the().to_string(),
+                concept: target.this().to_string(),
+                actual: descriptor.content_type(),
+            });
+        }
+        Ok(Self {
+            descriptor,
+            optional: false,
+            conforms: Some(Box::new(target)),
+        })
     }
 
     /// The underlying attribute descriptor.
@@ -72,6 +109,12 @@ impl ConceptFieldDescriptor {
     /// Returns `true` iff this field is optional (set-widened).
     pub fn is_optional(&self) -> bool {
         self.optional
+    }
+
+    /// The concept this field's target entity must conform to, if
+    /// the field is concept-typed.
+    pub fn conforms(&self) -> Option<&ConceptDescriptor> {
+        self.conforms.as_deref()
     }
 
     /// Convenience: the attribute's relation identifier.
@@ -155,10 +198,29 @@ impl NamedAttributes {
 
     /// Fallible builder shared by the [`TryFrom`] impls: rejects an
     /// empty set, or a set with no required field, with
-    /// [`TypeError::EmptyConcept`].
+    /// [`TypeError::EmptyConcept`]; rejects malformed concept-typed
+    /// fields (non-entity value type, or optional conformance) so
+    /// the wire path enforces the same invariants
+    /// [`ConceptFieldDescriptor::conforming`] does.
     fn try_new(map: BTreeMap<String, ConceptFieldDescriptor>) -> Result<Self, TypeError> {
         if map.is_empty() || map.values().all(|field| field.is_optional()) {
             return Err(TypeError::EmptyConcept);
+        }
+        for field in map.values() {
+            if let Some(target) = field.conforms() {
+                if field.content_type() != Some(Type::Entity) {
+                    return Err(TypeError::NonEntityConformance {
+                        the: field.the().to_string(),
+                        concept: target.this().to_string(),
+                        actual: field.content_type(),
+                    });
+                }
+                if field.is_optional() {
+                    return Err(TypeError::OptionalConformance {
+                        the: field.the().to_string(),
+                    });
+                }
+            }
         }
         Ok(NamedAttributes(map))
     }

--- a/rust/dialog-query/src/constraint/starts_with.rs
+++ b/rust/dialog-query/src/constraint/starts_with.rs
@@ -429,8 +429,11 @@ mod tests {
             "a prefix with a space excludes entities"
         );
         assert_eq!(
-            kind.refinement().expect("the prefix travels").prefix,
-            "has space",
+            kind.refinement()
+                .expect("the prefix travels")
+                .prefix
+                .as_deref(),
+            Some("has space"),
             "the inferred kind carries the prefix refinement"
         );
         Ok(())

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -68,6 +68,37 @@ pub enum TypeError {
     #[error("Concept declares no required attributes; at least one `with` attribute is required")]
     EmptyConcept,
 
+    /// A concept-typed field's attribute is not entity-valued. Only
+    /// an entity can conform to a concept, so a field that declares
+    /// `conforms` must have `Entity` as its value type.
+    #[error(
+        "Attribute \"{the}\" declares conformance to {concept} but its value type is \
+         {actual:?}; a concept-typed field must be entity-valued"
+    )]
+    NonEntityConformance {
+        /// The offending attribute selector.
+        the: String,
+        /// The target concept's URI.
+        concept: String,
+        /// The attribute's declared value type.
+        actual: Option<Type>,
+    },
+
+    /// A concept-typed field is marked optional. An optional
+    /// concept-typed field is a left-join over "edge exists AND the
+    /// target conforms" — absence over a rule-derived (IDB)
+    /// predicate — which requires stratification to evaluate
+    /// soundly. Not supported yet; make the field required or drop
+    /// the conformance.
+    #[error(
+        "Attribute \"{the}\" is both optional and concept-typed; optional conformance \
+         (absence over a derived predicate) is not supported yet"
+    )]
+    OptionalConformance {
+        /// The offending attribute selector.
+        the: String,
+    },
+
     /// A rule declares a parameter that none of its premises use.
     #[error("Rule {rule} does not use parameter \"{parameter}\"")]
     UnusedParameter {

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -159,6 +159,19 @@ pub enum TypeError {
         rule: Box<Rule>,
     },
 
+    /// A rule negates its own conclusion concept: a negative
+    /// self-loop no stratification can order (the rule would derive
+    /// a row exactly when it doesn't). Cycles through negation that
+    /// span multiple rules are the global stratification pass's
+    /// job; this is the local, always detectable case.
+    #[error("Rule {rule} negates its own conclusion {concept}")]
+    SelfNegation {
+        /// The offending rule.
+        rule: Box<Rule>,
+        /// The conclusion concept's URI.
+        concept: String,
+    },
+
     /// Type inference over a rule's premises produced a
     /// contradiction (a variable appears in slots with conflicting
     /// kinds). The planner cannot proceed because the rule has no
@@ -685,4 +698,14 @@ pub enum AnalysisError {
     /// be vacuously false.
     #[error("negation over an optional (maybe) premise is always false")]
     NegatedOptional,
+    /// A rule negates its own conclusion concept: a negative
+    /// self-loop no stratification can order. The local, always
+    /// detectable case of recursion through negation; cycles
+    /// spanning multiple rules are the global stratification
+    /// pass's job.
+    #[error("rule negates its own conclusion {concept}")]
+    SelfNegation {
+        /// The conclusion concept's URI.
+        concept: String,
+    },
 }

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -77,7 +77,7 @@ pub mod stream;
 /// Term types for pattern matching with variables and constants.
 pub mod term;
 /// Unified schema-layer type system (`Type`, `Primitive`,
-/// `Composite`, set-operations).
+/// `Refinement`, set-operations).
 pub mod type_system;
 /// Type system utilities bridging Rust types to dialog-artifacts types.
 pub mod types;

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -88,7 +88,7 @@ pub use attribute::*;
 pub use claim::Claim;
 pub use concept::descriptor::{ConceptConclusion, ConceptDescriptor, ConceptFieldDescriptor};
 pub use concept::query::{ConceptQuery, ConceptRules};
-pub use concept::{Concept, ConceptField, Conclusion};
+pub use concept::{Concept, ConceptField, Conclusion, ConformingField};
 pub use constraint::Constraint;
 pub use descriptor::Descriptor;
 pub use environment::*;

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -399,8 +399,8 @@ mod tests {
         });
         let kind = stamped.expect("the scan's entity term carries a kind");
         assert_eq!(
-            kind.refinement().expect("refined").prefix,
-            "did:key:",
+            kind.refinement().expect("refined").prefix.as_deref(),
+            Some("did:key:"),
             "the proved prefix reaches the scan boundary"
         );
     }

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -155,6 +155,10 @@ pub trait Compile: Sized + Into<Rule> {
                     AnalysisError::NegatedOptional => TypeError::NegatedOptional {
                         rule: Box::new(rule.into()),
                     },
+                    AnalysisError::SelfNegation { concept } => TypeError::SelfNegation {
+                        rule: Box::new(rule.into()),
+                        concept,
+                    },
                 });
             }
         };

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -36,7 +36,7 @@ use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
-use crate::{Environment, Premise};
+use crate::{Entity, Environment, Premise};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -218,6 +218,19 @@ impl AnalyzedRule {
     pub fn type_of(&self, name: &str) -> Option<&Kind> {
         self.types.get(name)
     }
+
+    /// The concepts this rule negates: its *negative IDB edges*.
+    /// One entry per `unless` premise over a concept, identified by
+    /// the concept's content-addressed URI. Self-negation is
+    /// rejected at analysis, so none of these is the rule's own
+    /// conclusion; the global stratification pass consumes these
+    /// edges to order (or reject) cycles that span multiple rules.
+    pub fn negated_concepts(&self) -> impl Iterator<Item = Entity> + '_ {
+        self.premises.iter().filter_map(|premise| match premise {
+            Premise::Unless(Negation(Proposition::Concept(query))) => Some(query.predicate.this()),
+            _ => None,
+        })
+    }
 }
 
 /// Run analysis over the rule's premises:
@@ -275,6 +288,23 @@ pub fn analyze(
     for premise in &premises {
         if let Premise::Unless(Negation(Proposition::OptionalAttribute(_))) = premise {
             return Err(AnalysisError::NegatedOptional);
+        }
+    }
+
+    // A rule that negates its own conclusion is a negative
+    // self-loop: it would derive a row exactly when it doesn't, and
+    // no stratification can order it. This is the local, always
+    // detectable case; negation over *other* derived concepts is a
+    // negative IDB edge, surfaced per rule by
+    // [`AnalyzedRule::negated_concepts`] for the global
+    // stratification pass to consume.
+    for premise in &premises {
+        if let Premise::Unless(Negation(Proposition::Concept(query))) = premise
+            && query.predicate.this() == conclusion.this()
+        {
+            return Err(AnalysisError::SelfNegation {
+                concept: conclusion.this().to_string(),
+            });
         }
     }
 

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -195,79 +195,130 @@ impl Display for DeductiveRule {
     }
 }
 
+impl DeductiveRule {
+    /// Compile *ordered variants* of a concept: spec-style
+    /// first-to-conform alternatives, each an alternative body for
+    /// the same conclusion.
+    ///
+    /// Variant `k` desugars to a rule whose body is the variant's
+    /// own premises plus one negated premise per *earlier* variant:
+    /// the entity yields variant `k`'s row only when no earlier
+    /// variant matched it. Order is semantic; the returned rules are
+    /// installed together (e.g. via
+    /// [`ConceptRules::install`](crate::ConceptRules)) and their
+    /// disjunction is deterministic per entity because the
+    /// negations make the variants pairwise disjoint.
+    ///
+    /// Every variant must ground the conclusion's required operands
+    /// with its own fields (the ordinary head-grounding contract);
+    /// a variant that doesn't fails compilation like any other rule.
+    pub fn variants(
+        conclusion: ConceptDescriptor,
+        ordered: Vec<ConceptDescriptor>,
+    ) -> Result<Vec<DeductiveRule>, TypeError> {
+        use crate::concept::query::ConceptQuery;
+
+        let mut rules = Vec::new();
+        for (position, variant) in ordered.iter().enumerate() {
+            let mut premises = concept_premises(variant);
+            for earlier in &ordered[..position] {
+                let mut terms = Parameters::new();
+                terms.insert("this".to_string(), Term::<Entity>::var("this").into());
+                premises.push(Premise::Unless(Negation(Proposition::Concept(
+                    ConceptQuery {
+                        terms,
+                        predicate: earlier.clone(),
+                    },
+                ))));
+            }
+            rules.push(DeductiveRule::new(conclusion.clone(), premises)?);
+        }
+        Ok(rules)
+    }
+}
+
+/// Lower a concept's fields into the body premises of its implicit
+/// rule: one scan (or left-join) per field, plus a conjoined target
+/// premise per concept-typed field. Shared by
+/// `From<&ConceptDescriptor>` and [`DeductiveRule::variants`].
+fn concept_premises(concept: &ConceptDescriptor) -> Vec<Premise> {
+    use crate::concept::query::ConceptQuery;
+    use crate::type_system::ConceptRef;
+
+    let mut premises = Vec::new();
+
+    let this = Term::<Entity>::var("this");
+
+    for (name, field) in concept.with().iter() {
+        // The value term stays scalar in both cases; the
+        // associative layer never carries optionality. A
+        // required field lowers to a plain scan (a missing fact
+        // filters the row out); an optional field lowers to a
+        // `OptionalAttributeQuery` left-join, which set-widens at the
+        // projection: `this` is bound by the required fields, so
+        // a miss yields one row with the slot bound to
+        // `Binding::Absent`.
+        //
+        // A concept-typed field's slot additionally carries the
+        // conformance refinement, and the constraint itself is
+        // enforced structurally: the target concept is conjoined
+        // as a premise over the field's variable below.
+        let kind = match (field.content_type().map(Kind::from), field.conforms()) {
+            (Some(kind), Some(target)) => Some(
+                kind.with_conformance(ConceptRef(target.this().to_string()))
+                    .expect("a conforming field is entity-valued by construction"),
+            ),
+            (kind, _) => kind,
+        };
+        let value = match kind {
+            Some(kind) => Term::<Any>::typed_var(name, kind),
+            None => Term::var(name),
+        };
+
+        let premise: Premise = if field.is_optional() {
+            OptionalAttributeQuery::new(
+                Term::Constant(Value::from(field.the().clone())),
+                this.clone(),
+                value.clone(),
+                Term::blank(),
+                Some(field.cardinality()),
+            )
+            .into()
+        } else {
+            AttributeQuery::new(
+                Term::Constant(Value::from(field.the().clone())),
+                this.clone(),
+                value.clone(),
+                Term::blank(),
+                Some(field.cardinality()),
+            )
+            .into()
+        };
+        premises.push(premise);
+
+        // Conformance is "facts exist", not a property of the
+        // scalar, so it desugars to the target concept applied
+        // to the field's entity: the row survives only when the
+        // target entity satisfies the concept. Only `this` is
+        // projected; the target's own fields stay internal to
+        // the premise.
+        if let Some(target) = field.conforms() {
+            let mut terms = Parameters::new();
+            terms.insert("this".to_string(), value);
+            premises.push(Premise::Assert(Proposition::Concept(ConceptQuery {
+                terms,
+                predicate: target.clone(),
+            })));
+        }
+    }
+
+    premises
+}
+
 impl From<&ConceptDescriptor> for DeductiveRule {
     fn from(concept: &ConceptDescriptor) -> Self {
-        use crate::concept::query::ConceptQuery;
-        use crate::type_system::ConceptRef;
-
-        let mut premises = Vec::new();
-
-        let this = Term::<Entity>::var("this");
-
-        for (name, field) in concept.with().iter() {
-            // The value term stays scalar in both cases; the
-            // associative layer never carries optionality. A
-            // required field lowers to a plain scan (a missing fact
-            // filters the row out); an optional field lowers to a
-            // `OptionalAttributeQuery` left-join, which set-widens at the
-            // projection: `this` is bound by the required fields, so
-            // a miss yields one row with the slot bound to
-            // `Binding::Absent`.
-            //
-            // A concept-typed field's slot additionally carries the
-            // conformance refinement, and the constraint itself is
-            // enforced structurally: the target concept is conjoined
-            // as a premise over the field's variable below.
-            let kind = match (field.content_type().map(Kind::from), field.conforms()) {
-                (Some(kind), Some(target)) => Some(
-                    kind.with_conformance(ConceptRef(target.this().to_string()))
-                        .expect("a conforming field is entity-valued by construction"),
-                ),
-                (kind, _) => kind,
-            };
-            let value = match kind {
-                Some(kind) => Term::<Any>::typed_var(name, kind),
-                None => Term::var(name),
-            };
-
-            let premise: Premise = if field.is_optional() {
-                OptionalAttributeQuery::new(
-                    Term::Constant(Value::from(field.the().clone())),
-                    this.clone(),
-                    value.clone(),
-                    Term::blank(),
-                    Some(field.cardinality()),
-                )
-                .into()
-            } else {
-                AttributeQuery::new(
-                    Term::Constant(Value::from(field.the().clone())),
-                    this.clone(),
-                    value.clone(),
-                    Term::blank(),
-                    Some(field.cardinality()),
-                )
-                .into()
-            };
-            premises.push(premise);
-
-            // Conformance is "facts exist", not a property of the
-            // scalar, so it desugars to the target concept applied
-            // to the field's entity: the row survives only when the
-            // target entity satisfies the concept. Only `this` is
-            // projected; the target's own fields stay internal to
-            // the premise.
-            if let Some(target) = field.conforms() {
-                let mut terms = Parameters::new();
-                terms.insert("this".to_string(), value);
-                premises.push(Premise::Assert(Proposition::Concept(ConceptQuery {
-                    terms,
-                    predicate: target.clone(),
-                })));
-            }
-        }
-
-        DeductiveRule::new(concept.clone(), premises).expect("Concept should compile")
+        DeductiveRule::new(concept.clone(), concept_premises(concept))
+            .expect("Concept should compile")
     }
 }
 
@@ -818,6 +869,153 @@ mod tests {
         }
         assert_eq!(scans, 1, "expected one scalar scan (name)");
         assert_eq!(maybes, 1, "expected one Maybe left-join (nickname)");
+    }
+
+    /// Ordered variants desugar to negated premises: variant `k`
+    /// carries one `Unless` per earlier variant, joined on `this`,
+    /// so the first conforming variant wins.
+    #[dialog_common::test]
+    fn variants_desugar_to_ordered_negations() {
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let email = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/email"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let phone = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/phone"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+
+        let rules = DeductiveRule::variants(conclusion, vec![email.clone(), phone.clone()])
+            .expect("variants compile");
+        assert_eq!(rules.len(), 2);
+
+        let negations = |rule: &DeductiveRule| {
+            rule.analysis()
+                .premises
+                .iter()
+                .filter_map(|premise| match premise {
+                    Premise::Unless(Negation(Proposition::Concept(query))) => Some(query.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert!(
+            negations(&rules[0]).is_empty(),
+            "the first variant negates nothing"
+        );
+
+        let unless = negations(&rules[1]);
+        assert_eq!(unless.len(), 1, "one negation per earlier variant");
+        assert_eq!(
+            unless[0].predicate.this(),
+            email.this(),
+            "the later variant excludes the earlier one"
+        );
+        assert_eq!(
+            unless[0].terms.iter().count(),
+            1,
+            "the negation joins on `this` alone"
+        );
+        assert_eq!(
+            unless[0].terms.get("this").and_then(|term| term.name()),
+            Some("this")
+        );
+    }
+
+    /// A rule that negates its own conclusion concept is a negative
+    /// self-loop: rejected at analysis.
+    #[dialog_common::test]
+    fn it_rejects_self_negating_rule() {
+        use crate::concept::query::ConceptQuery;
+        use crate::negation::Negation;
+
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Entity>::var("this").into());
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("user/email")),
+                Term::<Entity>::var("this"),
+                Term::var("handle"),
+                Term::blank(),
+                Some(Cardinality::One),
+            )
+            .into(),
+            Premise::Unless(Negation(Proposition::Concept(ConceptQuery {
+                terms,
+                predicate: conclusion.clone(),
+            }))),
+        ];
+
+        match DeductiveRule::new(conclusion, premises) {
+            Err(TypeError::SelfNegation { concept, .. }) => {
+                assert!(concept.starts_with("concept:"));
+            }
+            other => panic!("expected SelfNegation, got {other:?}"),
+        }
+    }
+
+    /// Negation over *another* concept is a negative IDB edge,
+    /// surfaced by the analysis for the stratification pass.
+    #[dialog_common::test]
+    fn analysis_surfaces_negative_idb_edges() {
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let email = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/email"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let phone = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/phone"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+
+        let rules =
+            DeductiveRule::variants(conclusion, vec![email.clone(), phone]).expect("compiles");
+
+        assert_eq!(
+            rules[0].analysis().negated_concepts().count(),
+            0,
+            "the first variant carries no negative edges"
+        );
+        assert_eq!(
+            rules[1].analysis().negated_concepts().collect::<Vec<_>>(),
+            vec![email.this()],
+            "the later variant's negative edge names the earlier variant"
+        );
     }
 
     /// A concept-typed field conjoins the target concept as a

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -197,6 +197,9 @@ impl Display for DeductiveRule {
 
 impl From<&ConceptDescriptor> for DeductiveRule {
     fn from(concept: &ConceptDescriptor) -> Self {
+        use crate::concept::query::ConceptQuery;
+        use crate::type_system::ConceptRef;
+
         let mut premises = Vec::new();
 
         let this = Term::<Entity>::var("this");
@@ -210,8 +213,20 @@ impl From<&ConceptDescriptor> for DeductiveRule {
             // projection: `this` is bound by the required fields, so
             // a miss yields one row with the slot bound to
             // `Binding::Absent`.
-            let value = match field.content_type() {
-                Some(ty) => Term::<Any>::typed_var(name, Kind::from(ty)),
+            //
+            // A concept-typed field's slot additionally carries the
+            // conformance refinement, and the constraint itself is
+            // enforced structurally: the target concept is conjoined
+            // as a premise over the field's variable below.
+            let kind = match (field.content_type().map(Kind::from), field.conforms()) {
+                (Some(kind), Some(target)) => Some(
+                    kind.with_conformance(ConceptRef(target.this().to_string()))
+                        .expect("a conforming field is entity-valued by construction"),
+                ),
+                (kind, _) => kind,
+            };
+            let value = match kind {
+                Some(kind) => Term::<Any>::typed_var(name, kind),
                 None => Term::var(name),
             };
 
@@ -219,7 +234,7 @@ impl From<&ConceptDescriptor> for DeductiveRule {
                 OptionalAttributeQuery::new(
                     Term::Constant(Value::from(field.the().clone())),
                     this.clone(),
-                    value,
+                    value.clone(),
                     Term::blank(),
                     Some(field.cardinality()),
                 )
@@ -228,13 +243,28 @@ impl From<&ConceptDescriptor> for DeductiveRule {
                 AttributeQuery::new(
                     Term::Constant(Value::from(field.the().clone())),
                     this.clone(),
-                    value,
+                    value.clone(),
                     Term::blank(),
                     Some(field.cardinality()),
                 )
                 .into()
             };
             premises.push(premise);
+
+            // Conformance is "facts exist", not a property of the
+            // scalar, so it desugars to the target concept applied
+            // to the field's entity: the row survives only when the
+            // target entity satisfies the concept. Only `this` is
+            // projected; the target's own fields stay internal to
+            // the premise.
+            if let Some(target) = field.conforms() {
+                let mut terms = Parameters::new();
+                terms.insert("this".to_string(), value);
+                premises.push(Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms,
+                    predicate: target.clone(),
+                })));
+            }
         }
 
         DeductiveRule::new(concept.clone(), premises).expect("Concept should compile")
@@ -788,6 +818,92 @@ mod tests {
         }
         assert_eq!(scans, 1, "expected one scalar scan (name)");
         assert_eq!(maybes, 1, "expected one Maybe left-join (nickname)");
+    }
+
+    /// A concept-typed field conjoins the target concept as a
+    /// premise over the field's variable, and the field's slot kind
+    /// carries the conformance refinement.
+    #[dialog_common::test]
+    fn from_concept_with_conforming_field_conjoins_target_premise() {
+        use crate::type_system::ConceptRef;
+
+        let target = ConceptDescriptor::try_from(vec![(
+            "badge",
+            AttributeDescriptor::new(
+                the!("employee/badge"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+
+        let concept = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    AttributeDescriptor::new(
+                        the!("person/manager"),
+                        "",
+                        Cardinality::One,
+                        Some(Type::Entity),
+                    ),
+                    target.clone(),
+                )
+                .expect("entity-valued attribute conforms"),
+            ),
+        ])
+        .unwrap();
+
+        let rule = DeductiveRule::from(&concept);
+
+        let mut scans = Vec::new();
+        let mut concepts = Vec::new();
+        for premise in rule.analysis().premises.iter() {
+            match premise {
+                Premise::Assert(Proposition::Attribute(query)) => scans.push(query),
+                Premise::Assert(Proposition::Concept(query)) => concepts.push(query),
+                other => panic!("unexpected premise {other:?}"),
+            }
+        }
+        assert_eq!(scans.len(), 2, "one scan per attribute");
+        assert_eq!(concepts.len(), 1, "one conjoined target premise");
+
+        let conformance = &concepts[0];
+        assert_eq!(
+            conformance.predicate.this(),
+            target.this(),
+            "the conjoined premise applies the target concept"
+        );
+        assert_eq!(
+            conformance.terms.iter().count(),
+            1,
+            "only `this` is projected into the target"
+        );
+        let this = conformance.terms.get("this").expect("this bound");
+        assert_eq!(this.name(), Some("manager"), "joins on the field variable");
+
+        let manager_scan = scans
+            .iter()
+            .find(|scan| scan.is().name() == Some("manager"))
+            .expect("manager scan present");
+        let kind = manager_scan.is().kind().expect("typed slot");
+        assert!(
+            kind.refinement()
+                .expect("conformance refinement stamped")
+                .conforms
+                .contains(&ConceptRef(target.this().to_string())),
+            "the slot kind names the target concept"
+        );
     }
 
     /// The degenerate "rule body binds only optionals" shape, at the

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -7,12 +7,11 @@
 //! and the schema layer.
 //!
 //! A [`Type`] is the set of admissible value shapes a slot may
-//! bind. It is built from a [`Primitive`] bitfield (the atomic
-//! shapes, plus a `Nothing` bit for set-widened optionality) and an
-//! optional set of [`Composite`] shapes (Product records, Variant
-//! tags). The two parts compose by set-union: a value satisfies
-//! [`Type`] iff it inhabits at least one of the primitive bits or
-//! one of the composite shapes.
+//! bind: a [`Primitive`] bitfield (the atomic shapes, plus a
+//! `Nothing` bit for set-widened optionality), optionally narrowed
+//! by a value-level [`Refinement`]. A value satisfies [`Type`] iff
+//! its data type is a member of the primitive set and the
+//! refinement (if any) admits the value itself.
 //!
 //! Type variables (used for compile-time unification of rules)
 //! live in the [`unifier`] submodule, never in the user-facing
@@ -26,7 +25,7 @@ pub mod unifier;
 use crate::artifact::Type as ValueType;
 use crate::artifact::Value;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// A bitfield over [`ValueType`] variants plus a `Nothing` bit:
@@ -271,49 +270,21 @@ impl From<Primitive> for Type {
     }
 }
 
-/// Schema-layer type: the set of admissible value shapes a slot
-/// can bind.
-///
-/// A [`Type`] is the union of two parts:
-///
-/// - A [`Primitive`] bitfield carrying atomic [`ValueType`] bits
-///   plus an optional `Nothing` atom (row-level absence).
-/// - An optional non-empty set of [`Composite`] shapes for
-///   structured values (records, variants).
-///
-/// Smart constructors enforce the invariant that
-/// `Composite(_, set)` always has `!set.is_empty()`; a request to
-/// build a composite with an empty set collapses to a plain
-/// `Primitive`.
-///
-/// Composites live in a [`BTreeSet`] rather than a [`HashSet`].
-/// Two reasons:
-///
 impl Display for Type {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Type::Primitive(p) => write!(f, "{p}"),
-            Type::Composite(p, c) => write!(f, "{p}+{} composite", c.len()),
-            Type::Refined(p, r) => write!(f, "{p}[starts-with {:?}]", r.prefix),
+            Type::Refined(p, r) => write!(f, "{p}[{r}]"),
         }
     }
 }
 
-/// 1. `Type` derives [`Hash`]. `BTreeSet` iterates in a stable
-///    `Ord`-based order, so the derived hash is canonical:
-///    `Type::Composite(p, {a, b})` and `Type::Composite(p, {b, a})`
-///    have identical hashes. `HashSet` does not implement `Hash`
-///    in std, and any hand-rolled order-independent hash would
-///    have to sort internally anyway, and `BTreeSet` is that already.
+/// Schema-layer type: the set of admissible value shapes a slot
+/// can bind.
 ///
-/// 2. Insertion order at construction never affects equality.
-///    Building the same set via different paths (different unions,
-///    different insert orders) yields equal [`Type`]s.
-///
-/// The cost is requiring [`Ord`] on [`Composite`], [`Type`], and
-/// [`Primitive`]. The ordering is structural plumbing; it has no
-/// semantic meaning (no claim that `u32 < String`); it exists only
-/// to keep the set canonical.
+/// A [`Type`] is a [`Primitive`] bitfield carrying atomic
+/// [`ValueType`] bits plus an optional `Nothing` atom (row-level
+/// absence), optionally narrowed by a value-level [`Refinement`].
 ///
 /// `Type` is fully static: no type variables, no allocation
 /// state. Deriving [`PartialEq`]/[`Eq`]/[`Hash`] is safe and
@@ -321,23 +292,32 @@ impl Display for Type {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
-    /// Pure primitive set (no composite shapes admitted).
+    /// Pure primitive membership set.
     Primitive(Primitive),
-    /// The union of a primitive set and a non-empty set of composite
-    /// shapes: a value satisfies it if it inhabits one of the
-    /// primitive bits OR matches one of the composite shapes (not
-    /// the intersection of the two). The primitive set may be empty,
-    /// giving a pure composite type. Invariant: the composite set is
-    /// never empty (an empty one collapses to `Primitive`).
-    Composite(Primitive, BTreeSet<Composite>),
     /// Primitive set narrowed by a [`Refinement`] on the *values*
     /// of the member types — not just which types are admitted, but
     /// which of their inhabitants. Produced by refinement
     /// predicates (`starts-with`); consumed by scan-range pushdown
     /// and, like every kind, by [`Type::admits`] at the data
-    /// boundary. Admits no composite shapes (refinements constrain
-    /// lexical forms, which composites do not have).
+    /// boundary.
     Refined(Primitive, Refinement),
+}
+
+/// Opaque identity of a concept an entity must conform to — the
+/// concept's content-derived entity URI (`concept:{hash}`).
+///
+/// Deliberately opaque on the lattice: subsumption *between*
+/// concepts (attribute-set inclusion) needs their descriptors,
+/// which the lattice does not carry. The analyzer canonicalizes
+/// conformance sets against the registry before refinements enter
+/// unification; the lattice orders them by plain set inclusion.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ConceptRef(pub String);
+
+impl Display for ConceptRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", self.0)
+    }
 }
 
 /// A value-level constraint layered onto a primitive membership
@@ -345,53 +325,142 @@ pub enum Type {
 /// constraints), the join their weakest common implication — see
 /// [`Refinement::meet`] and [`Refinement::join`].
 ///
-/// Today one refinement exists: a lexical prefix over the TEXTUAL
-/// kinds. Numeric intervals and Entity concept-membership (M3)
-/// extend this struct rather than adding lattice variants.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+/// Two constraints exist: a lexical prefix over the TEXTUAL kinds,
+/// and a conformance set over Entity — the value must satisfy a
+/// concept-typed field's target concepts. Numeric intervals extend
+/// this struct the same way rather than adding lattice variants.
+///
+/// Invariant: never empty (no prefix and no conformance is no
+/// refinement; the constructors collapse it to an unrefined type).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Refinement {
     /// Lexical prefix every admitted value must begin with.
-    /// Invariant: non-empty (an empty prefix is no refinement; the
-    /// constructors collapse it).
-    pub prefix: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+    /// Concepts the value's entity must conform to — all of them
+    /// (the meet unions this set). Carried as *information*: an
+    /// entity's conformance is not a property of the scalar (it is
+    /// "facts exist"), so enforcement is structural — the analyzer
+    /// conjoins the target concept's premises on the field — while
+    /// this set feeds inclusion ordering, demand covers, and
+    /// diagnostics.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub conforms: BTreeSet<ConceptRef>,
 }
 
 impl Refinement {
-    /// Meet: the conjunction of both constraints. Two prefixes are
-    /// jointly satisfiable iff one extends the other, and the meet
-    /// is the longer; disjoint prefixes admit nothing.
-    fn meet(&self, other: &Refinement) -> Option<Refinement> {
-        if self.prefix.starts_with(&other.prefix) {
-            Some(self.clone())
-        } else if other.prefix.starts_with(&self.prefix) {
-            Some(other.clone())
-        } else {
-            None
+    /// A prefix-only refinement.
+    fn prefix(prefix: String) -> Refinement {
+        Refinement {
+            prefix: Some(prefix),
+            conforms: BTreeSet::new(),
         }
+    }
+
+    /// True when the refinement constrains nothing — the shape the
+    /// constructors collapse to an unrefined type.
+    fn is_empty(&self) -> bool {
+        self.prefix.is_none() && self.conforms.is_empty()
+    }
+
+    /// Meet: the conjunction of both constraints. Two prefixes are
+    /// jointly satisfiable iff one extends the other (the meet is
+    /// the longer; disjoint prefixes admit nothing); conformance
+    /// sets union — the value must satisfy both sides' concepts.
+    fn meet(&self, other: &Refinement) -> Option<Refinement> {
+        let prefix = match (&self.prefix, &other.prefix) {
+            (Some(a), Some(b)) => {
+                if a.starts_with(b.as_str()) {
+                    Some(a.clone())
+                } else if b.starts_with(a.as_str()) {
+                    Some(b.clone())
+                } else {
+                    return None;
+                }
+            }
+            (Some(p), None) | (None, Some(p)) => Some(p.clone()),
+            (None, None) => None,
+        };
+        let conforms = self.conforms.union(&other.conforms).cloned().collect();
+        Some(Refinement { prefix, conforms })
     }
 
     /// Join: the weakest constraint both sides imply — the longest
-    /// common prefix. `None` when nothing is common (the join
-    /// carries no refinement).
+    /// common prefix (a side without one implies none) and the
+    /// intersection of the conformance sets. `None` when nothing
+    /// remains (the join carries no refinement).
     fn join(&self, other: &Refinement) -> Option<Refinement> {
-        let common: String = self
-            .prefix
-            .chars()
-            .zip(other.prefix.chars())
-            .take_while(|(a, b)| a == b)
-            .map(|(a, _)| a)
+        let prefix = match (&self.prefix, &other.prefix) {
+            (Some(a), Some(b)) => {
+                let common: String = a
+                    .chars()
+                    .zip(b.chars())
+                    .take_while(|(x, y)| x == y)
+                    .map(|(x, _)| x)
+                    .collect();
+                if common.is_empty() {
+                    None
+                } else {
+                    Some(common)
+                }
+            }
+            _ => None,
+        };
+        let conforms: BTreeSet<ConceptRef> = self
+            .conforms
+            .intersection(&other.conforms)
+            .cloned()
             .collect();
-        if common.is_empty() {
+        let joined = Refinement { prefix, conforms };
+        if joined.is_empty() {
             None
         } else {
-            Some(Refinement { prefix: common })
+            Some(joined)
         }
     }
 
-    /// True when the value's lexical form satisfies the refinement.
-    /// Values without a lexical form satisfy no prefix.
+    /// True when `other` is at least as constrained as `self` —
+    /// every value satisfying `other` satisfies `self`. The
+    /// inclusion check behind [`Type::includes`].
+    fn implied_by(&self, other: &Refinement) -> bool {
+        let prefix_implied = match (&self.prefix, &other.prefix) {
+            (Some(a), Some(b)) => b.starts_with(a.as_str()),
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        prefix_implied && self.conforms.is_subset(&other.conforms)
+    }
+
+    /// True when the value satisfies the row-locally checkable half
+    /// of the refinement: the lexical prefix. Values without a
+    /// lexical form satisfy no prefix. Conformance is deliberately
+    /// not checked here — see the field doc; its enforcement is the
+    /// desugared premises' job.
     pub fn admits(&self, value: &Value) -> bool {
-        lexical_form(value).is_some_and(|form| form.starts_with(&self.prefix))
+        match &self.prefix {
+            Some(prefix) => {
+                lexical_form(value).is_some_and(|form| form.starts_with(prefix.as_str()))
+            }
+            None => true,
+        }
+    }
+}
+
+impl Display for Refinement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let mut separate = false;
+        if let Some(prefix) = &self.prefix {
+            write!(f, "starts-with {prefix:?}")?;
+            separate = true;
+        }
+        for concept in &self.conforms {
+            if separate {
+                write!(f, " & ")?;
+            }
+            write!(f, "conforms-to {concept}")?;
+            separate = true;
+        }
+        Ok(())
     }
 }
 
@@ -408,23 +477,6 @@ pub fn lexical_form(value: &Value) -> Option<String> {
     }
 }
 
-/// A composite (structured) value shape. Ordered by derived
-/// [`Ord`] for stable iteration and hashing inside a [`BTreeSet`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Composite {
-    /// Product (record) type with named fields. Field names ordered
-    /// by [`BTreeMap`] for stable equality and hashing.
-    Product(BTreeMap<String, Type>),
-    /// Sum-type variant carrying a single label and its payload.
-    Variant {
-        /// The discriminator label.
-        label: String,
-        /// The payload type for this label.
-        value: Type,
-    },
-}
-
 impl Type {
     /// The type whose only inhabitant is the `Nothing` atom: the
     /// "absent" row-layer value.
@@ -437,7 +489,6 @@ impl Type {
     pub fn optional(self) -> Type {
         match self {
             Type::Primitive(p) => Type::Primitive(p.union(Primitive::NOTHING)),
-            Type::Composite(p, c) => Type::Composite(p.union(Primitive::NOTHING), c),
             Type::Refined(p, r) => Type::Refined(p.union(Primitive::NOTHING), r),
         }
     }
@@ -445,15 +496,13 @@ impl Type {
     /// True when the given runtime value inhabits this type: the
     /// value's data type is a member of the primitive part, and the
     /// refinement (if any) admits the value itself.
-    /// Composite refinements are not yet checked; no composite
-    /// values flow through evaluation today.
     pub fn admits(&self, value: &Value) -> bool {
         if !self.primitive_part().contains(value.data_type()) {
             return false;
         }
         match self {
             Type::Refined(_, r) => r.admits(value),
-            _ => true,
+            Type::Primitive(_) => true,
         }
     }
 
@@ -463,7 +512,6 @@ impl Type {
     pub fn required(self) -> Type {
         match self {
             Type::Primitive(p) => Type::Primitive(p.required()),
-            Type::Composite(p, c) => Type::Composite(p.required(), c),
             Type::Refined(p, r) => Type::Refined(p.required(), r),
         }
     }
@@ -489,9 +537,33 @@ impl Type {
             return None;
         }
         let refinement = match &self {
-            Type::Refined(_, existing) => existing.meet(&Refinement { prefix })?,
-            _ => Refinement { prefix },
+            Type::Refined(_, existing) => existing.meet(&Refinement::prefix(prefix))?,
+            _ => Refinement::prefix(prefix),
         };
+        Some(Type::Refined(membership, refinement))
+    }
+
+    /// Constrain this type's values to entities conforming to the
+    /// given concept — the lattice form of a concept-typed field.
+    ///
+    /// The membership narrows to Entity (the `Nothing` bit, if
+    /// present, rides along — an optional concept-typed field is
+    /// still optional). Returns `None` when no entity could inhabit
+    /// the type — an empty meet, the ordinary
+    /// known-types-misalign conflict. Conformance accumulates: an
+    /// existing refinement gains the concept.
+    pub fn with_conformance(self, concept: ConceptRef) -> Option<Type> {
+        let membership = self
+            .primitive_part()
+            .intersect(Primitive::from(ValueType::Entity).union(Primitive::NOTHING))?;
+        if membership.required().is_empty() {
+            return None;
+        }
+        let mut refinement = match self {
+            Type::Refined(_, r) => r,
+            Type::Primitive(_) => Refinement::default(),
+        };
+        refinement.conforms.insert(concept);
         Some(Type::Refined(membership, refinement))
     }
 
@@ -499,100 +571,42 @@ impl Type {
     pub fn refinement(&self) -> Option<&Refinement> {
         match self {
             Type::Refined(_, r) => Some(r),
-            _ => None,
+            Type::Primitive(_) => None,
         }
     }
 
     /// Rebuild this type around a replacement primitive part,
-    /// preserving its composite or refinement structure. The
-    /// unifier uses this so a resolution that narrows membership
-    /// does not silently shed the rest of the type.
+    /// preserving its refinement structure. The unifier uses this
+    /// so a resolution that narrows membership does not silently
+    /// shed the rest of the type.
     pub(crate) fn with_primitive_part(&self, p: Primitive) -> Type {
         match self {
             Type::Primitive(_) => Type::Primitive(p),
-            Type::Composite(_, c) => Type::composite(p, c.clone()),
             Type::Refined(_, r) => Type::Refined(p, r.clone()),
         }
     }
 
-    /// Smart constructor. Collapses `Composite(p, empty)` to
-    /// `Primitive(p)`. Use this rather than building the
-    /// `Composite` variant directly.
-    pub fn composite(primitive: Primitive, composite: BTreeSet<Composite>) -> Type {
-        if composite.is_empty() {
-            Type::Primitive(primitive)
-        } else {
-            Type::Composite(primitive, composite)
-        }
-    }
-
-    /// Build a record type from named fields.
-    pub fn product(fields: BTreeMap<String, Type>) -> Type {
-        let mut set = BTreeSet::new();
-        set.insert(Composite::Product(fields));
-        Type::Composite(Primitive::EMPTY, set)
-    }
-
-    /// Build a singleton variant type from a label and payload.
-    pub fn variant(label: impl Into<String>, value: Type) -> Type {
-        let mut set = BTreeSet::new();
-        set.insert(Composite::Variant {
-            label: label.into(),
-            value,
-        });
-        Type::Composite(Primitive::EMPTY, set)
-    }
-
-    /// Set intersection over both primitive and composite parts.
-    /// Returns `None` when the result is empty: no admissible
-    /// shapes survive.
+    /// Set intersection: the meet of both memberships and both
+    /// refinements. Returns `None` when the result is empty: no
+    /// admissible shapes survive.
     ///
-    /// Composite shapes narrow structurally: two
-    /// `Composite::Product` values with the same field-name set
-    /// intersect their field types recursively (if any field
-    /// intersection is empty, the product is eliminated). Products
-    /// with disjoint field-name sets do not intersect; they
-    /// describe disjoint records. Variants intersect by matching
-    /// label, recursing into payload types.
+    /// Refinements are constraints: the meet carries the
+    /// conjunction. Two refined sides must have jointly
+    /// satisfiable refinements.
     pub fn intersect(&self, other: &Type) -> Option<Type> {
-        let p_self = self.primitive_part();
-        let p_other = other.primitive_part();
-        let p = Primitive {
-            bits: p_self.bits & p_other.bits,
-        };
-
-        // Refinements are constraints: the meet carries the
-        // conjunction. Two refined sides must have jointly
-        // satisfiable refinements; a refined side admits no
-        // composite shapes, so any composite part on the other
-        // side is dropped.
+        let p = self.primitive_part().intersect(other.primitive_part())?;
         let refinement = match (self.refinement(), other.refinement()) {
             (Some(a), Some(b)) => Some(a.meet(b)?),
             (Some(r), None) | (None, Some(r)) => Some(r.clone()),
             (None, None) => None,
         };
-        if let Some(refinement) = refinement {
-            return if p.is_empty() {
-                None
-            } else {
-                Some(Type::Refined(p, refinement))
-            };
-        }
-
-        let composite_intersection: BTreeSet<Composite> =
-            match (self.composite_part(), other.composite_part()) {
-                (Some(a), Some(b)) => intersect_composite_sets(a, b),
-                _ => BTreeSet::new(),
-            };
-
-        if p.is_empty() && composite_intersection.is_empty() {
-            None
-        } else {
-            Some(Type::composite(p, composite_intersection))
-        }
+        Some(match refinement {
+            Some(refinement) => Type::Refined(p, refinement),
+            None => Type::Primitive(p),
+        })
     }
 
-    /// Set union over both primitive and composite parts.
+    /// Set union of both memberships.
     ///
     /// Refinements weaken at a join: two refined sides keep their
     /// weakest common implication (the longest common prefix), a
@@ -601,55 +615,28 @@ impl Type {
     /// side admits.
     pub fn union(&self, other: &Type) -> Type {
         let p = self.primitive_part().union(other.primitive_part());
-
         if let (Some(a), Some(b)) = (self.refinement(), other.refinement())
             && let Some(joined) = a.join(b)
         {
             return Type::Refined(p, joined);
         }
-
-        let mut composites: BTreeSet<Composite> = BTreeSet::new();
-        if let Some(s) = self.composite_part() {
-            composites.extend(s.iter().cloned());
-        }
-        if let Some(s) = other.composite_part() {
-            composites.extend(s.iter().cloned());
-        }
-        Type::composite(p, composites)
+        Type::Primitive(p)
     }
 
     /// Subtype check. Returns `true` iff every shape `other`
     /// admits is also admitted by `self`.
-    ///
-    /// For composites: each shape in `other` must be included by
-    /// some shape in `self`. Inclusion is structural: a Product
-    /// `{x: T1, y: T2}` includes a Product `{x: T1', y: T2'}` when
-    /// the field-name sets match and each `Ti` includes `Ti'`. A
-    /// product with extra fields includes one with fewer fields
-    /// (width subtyping is not assumed; equal field sets only).
     pub fn includes(&self, other: &Type) -> bool {
         if !self.primitive_part().includes(other.primitive_part()) {
             return false;
         }
         // A refined type admits fewer values than its membership: it
         // includes `other` only if `other` is at least as
-        // constrained (other's prefix extends ours). An unrefined
+        // constrained (other's constraints imply ours). An unrefined
         // type over-approximates any refinement of its membership.
         match (self.refinement(), other.refinement()) {
-            (Some(a), Some(b)) => {
-                if !b.prefix.starts_with(&a.prefix) {
-                    return false;
-                }
-            }
-            (Some(_), None) => return false,
-            (None, _) => {}
-        }
-        match (self.composite_part(), other.composite_part()) {
-            (_, None) => true,
-            (None, Some(b)) => b.is_empty(),
-            (Some(a), Some(b)) => b
-                .iter()
-                .all(|b_shape| a.iter().any(|a_shape| composite_includes(a_shape, b_shape))),
+            (Some(a), Some(b)) => a.implied_by(b),
+            (Some(_), None) => false,
+            (None, _) => true,
         }
     }
 
@@ -662,129 +649,19 @@ impl Type {
     pub fn primitive_part(&self) -> Primitive {
         match self {
             Type::Primitive(p) => *p,
-            Type::Composite(p, _) => *p,
             Type::Refined(p, _) => *p,
         }
     }
 
-    /// The composite part of this type, or `None` if the type has
-    /// only a primitive part.
-    pub fn composite_part(&self) -> Option<&BTreeSet<Composite>> {
-        match self {
-            Type::Primitive(_) => None,
-            Type::Composite(_, c) => Some(c),
-            Type::Refined(_, _) => None,
-        }
-    }
-
     /// Legacy storage-codec view: if this type reduces to exactly
-    /// one [`ValueType`] (no `Nothing`, no composites), return it.
-    /// A refinement does not change the storage type, so a refined
-    /// singleton still reports its member.
+    /// one [`ValueType`] (no `Nothing`), return it. A refinement
+    /// does not change the storage type, so a refined singleton
+    /// still reports its member.
     pub fn as_value_type(&self) -> Option<ValueType> {
         match self {
             Type::Primitive(p) => p.as_singleton(),
-            Type::Composite(_, _) => None,
             Type::Refined(p, _) => p.as_singleton(),
         }
-    }
-}
-
-/// Structurally intersect two sets of [`Composite`] shapes.
-///
-/// For each `Composite::Product` in `a`, look for a same-field-set
-/// `Composite::Product` in `b` and intersect their field types
-/// pairwise; if any field intersection is empty, the product is
-/// eliminated. For each `Composite::Variant` in `a`, look for a
-/// same-label `Composite::Variant` in `b` and intersect their
-/// payload types. Anything in `a` or `b` without a structural
-/// counterpart on the other side is dropped: set intersection
-/// only keeps shapes admitted by both sides.
-fn intersect_composite_sets(
-    a: &BTreeSet<Composite>,
-    b: &BTreeSet<Composite>,
-) -> BTreeSet<Composite> {
-    let mut result = BTreeSet::new();
-    for a_shape in a {
-        for b_shape in b {
-            if let Some(merged) = intersect_composite(a_shape, b_shape) {
-                result.insert(merged);
-            }
-        }
-    }
-    result
-}
-
-/// Pairwise intersection of two [`Composite`] shapes. Two
-/// products intersect iff they share the same set of field names;
-/// two variants iff they share the same label.
-fn intersect_composite(a: &Composite, b: &Composite) -> Option<Composite> {
-    match (a, b) {
-        (Composite::Product(fa), Composite::Product(fb)) => {
-            if fa.len() != fb.len() {
-                return None;
-            }
-            let mut out = BTreeMap::new();
-            for (name, ta) in fa {
-                let tb = fb.get(name)?;
-                let merged = ta.intersect(tb)?;
-                out.insert(name.clone(), merged);
-            }
-            Some(Composite::Product(out))
-        }
-        (
-            Composite::Variant {
-                label: la,
-                value: va,
-            },
-            Composite::Variant {
-                label: lb,
-                value: vb,
-            },
-        ) => {
-            if la != lb {
-                return None;
-            }
-            let merged = va.intersect(vb)?;
-            Some(Composite::Variant {
-                label: la.clone(),
-                value: merged,
-            })
-        }
-        _ => None,
-    }
-}
-
-/// Structural inclusion check between two [`Composite`] shapes.
-/// `a` includes `b` iff they are the same shape kind, have matching
-/// keys/labels, and each of `a`'s recursive types includes `b`'s.
-fn composite_includes(a: &Composite, b: &Composite) -> bool {
-    match (a, b) {
-        (Composite::Product(fa), Composite::Product(fb)) => {
-            if fa.len() != fb.len() {
-                return false;
-            }
-            for (name, ta) in fa {
-                let Some(tb) = fb.get(name) else {
-                    return false;
-                };
-                if !ta.includes(tb) {
-                    return false;
-                }
-            }
-            true
-        }
-        (
-            Composite::Variant {
-                label: la,
-                value: va,
-            },
-            Composite::Variant {
-                label: lb,
-                value: vb,
-            },
-        ) => la == lb && va.includes(vb),
-        _ => false,
     }
 }
 
@@ -792,13 +669,7 @@ fn composite_includes(a: &Composite, b: &Composite) -> bool {
 mod tests {
     use super::*;
     use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hash as HashTrait, Hasher};
-
-    fn hash_of<T: HashTrait>(t: &T) -> u64 {
-        let mut h = DefaultHasher::new();
-        t.hash(&mut h);
-        h.finish()
-    }
+    use std::hash::{Hash, Hasher};
 
     fn p(vt: ValueType) -> Type {
         Type::from(vt)
@@ -925,185 +796,23 @@ mod tests {
         assert_eq!(a, b);
     }
 
+    /// Intersection and union reduce to primitive-part set algebra
+    /// when no refinements are involved.
     #[dialog_common::test]
-    fn product_constructor_round_trip() {
-        let mut fields = BTreeMap::new();
-        fields.insert("name".to_string(), Type::from(ValueType::String));
-        fields.insert("age".to_string(), Type::from(ValueType::UnsignedInt));
-        let a = Type::product(fields.clone());
-        let b = Type::product(fields);
-        assert_eq!(a, b);
-        let mut ha = DefaultHasher::new();
-        let mut hb = DefaultHasher::new();
-        a.hash(&mut ha);
-        b.hash(&mut hb);
-        assert_eq!(ha.finish(), hb.finish());
-    }
+    fn intersect_and_union_are_primitive_set_algebra() {
+        let numeric = Type::from(Primitive::NUMERIC);
+        let uint = Type::from(ValueType::UnsignedInt);
+        let met = numeric.intersect(&uint).expect("overlap");
+        assert_eq!(met.as_value_type(), Some(ValueType::UnsignedInt));
 
-    #[dialog_common::test]
-    fn variant_constructor_carries_label_and_payload() {
-        let some = Type::variant("Some", Type::from(ValueType::String));
-        let composites = some.composite_part().unwrap();
-        assert_eq!(composites.len(), 1);
-        let first = composites.iter().next().unwrap();
-        match first {
-            Composite::Variant { label, value } => {
-                assert_eq!(label, "Some");
-                assert_eq!(*value, Type::from(ValueType::String));
-            }
-            other => panic!("expected Variant, got {:?}", other),
-        }
-    }
+        let string = Type::from(ValueType::String);
+        assert!(uint.intersect(&string).is_none(), "disjoint memberships");
 
-    #[dialog_common::test]
-    fn intersect_two_records_same_fields() {
-        let mut fields = BTreeMap::new();
-        fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(fields.clone());
-        let b = Type::product(fields);
-        let c = a.intersect(&b).expect("intersection non-empty");
-        assert_eq!(a, c);
-    }
-
-    /// Two products with the same field names but different field
-    /// types narrow structurally: intersect each field's type
-    /// recursively. If every field intersection is non-empty, the
-    /// product survives with the narrowed fields.
-    #[dialog_common::test]
-    fn intersect_products_narrows_field_types() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(Primitive::NUMERIC));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("x".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
-
-        let merged = a.intersect(&b).expect("narrows to UnsignedInt");
-        let composite = merged.composite_part().expect("composite present");
-        let product = composite.iter().next().expect("one product");
-        match product {
-            Composite::Product(fields) => {
-                let x_type = fields.get("x").expect("x field");
-                assert_eq!(x_type.as_value_type(), Some(ValueType::UnsignedInt));
-            }
-            other => panic!("expected Product, got {other:?}"),
-        }
-    }
-
-    /// Two products with disjoint field types fail to intersect.
-    #[dialog_common::test]
-    fn intersect_products_disjoint_fields_eliminated() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("x".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
-
-        assert!(a.intersect(&b).is_none());
-    }
-
-    /// Two products with different field-name sets do not
-    /// intersect; they describe disjoint record shapes.
-    #[dialog_common::test]
-    fn intersect_products_different_keys_eliminated() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("y".to_string(), Type::from(ValueType::String));
-        let b = Type::product(b_fields);
-
-        assert!(a.intersect(&b).is_none());
-    }
-
-    /// Two variants with the same label intersect their payloads;
-    /// different labels do not intersect.
-    #[dialog_common::test]
-    fn intersect_variants_by_label() {
-        let a = Type::variant("Some", Type::from(Primitive::NUMERIC));
-        let b = Type::variant("Some", Type::from(ValueType::UnsignedInt));
-        let merged = a.intersect(&b).expect("same label narrows payload");
-        let composite = merged.composite_part().expect("composite present");
-        match composite.iter().next().expect("one variant") {
-            Composite::Variant { label, value } => {
-                assert_eq!(label, "Some");
-                assert_eq!(value.as_value_type(), Some(ValueType::UnsignedInt));
-            }
-            other => panic!("expected Variant, got {other:?}"),
-        }
-
-        let c = Type::variant("Other", Type::from(ValueType::UnsignedInt));
-        assert!(a.intersect(&c).is_none());
-    }
-
-    #[dialog_common::test]
-    fn intersect_primitive_and_composite_keeps_primitive_only() {
-        let mut fields = BTreeMap::new();
-        fields.insert("x".to_string(), Type::from(ValueType::String));
-        let composite = Type::product(fields);
-        let prim = Type::from(ValueType::String);
-        // primitive part of `composite` is EMPTY; composite part of `prim` is None.
-        // Intersection of primitive parts: EMPTY ∩ {String} = EMPTY.
-        // Intersection of composite parts: None ∩ {Product{...}} = empty.
-        // Overall: empty → None.
-        assert!(prim.intersect(&composite).is_none());
-
-        // But if the composite carries a Record primitive bit, the
-        // intersection has that bit alone.
-        let composite_with_record = Type::composite(
-            Primitive::singleton(ValueType::Record),
-            composite
-                .composite_part()
-                .cloned()
-                .unwrap_or_else(BTreeSet::new),
-        );
-        let record_prim = Type::from(ValueType::Record);
-        let intersected = record_prim.intersect(&composite_with_record).unwrap();
-        assert_eq!(
-            intersected.primitive_part().as_singleton(),
-            Some(ValueType::Record)
-        );
-        assert!(intersected.composite_part().is_none());
-    }
-
-    #[dialog_common::test]
-    fn includes_product_subtype_extra_fields_in_subject() {
-        // A type T "includes" U iff T admits every shape U admits.
-        // For our set semantics, T includes U requires every
-        // composite of U to be present in T's composite set. So
-        // larger composite sets in T are fine; an extra Product in
-        // U not in T breaks inclusion.
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields.clone());
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("x".to_string(), Type::from(ValueType::String));
-        b_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
-
-        // a and b are different products; neither includes the other.
-        assert!(!a.includes(&b));
-        assert!(!b.includes(&a));
-
-        // a includes itself.
-        assert!(a.includes(&a));
-
-        // Union of {a, b} includes both.
-        let union = a.union(&b);
-        assert!(union.includes(&a));
-        assert!(union.includes(&b));
-    }
-
-    #[dialog_common::test]
-    fn smart_constructor_collapses_empty_composite_set() {
-        let collapsed = Type::composite(Primitive::singleton(ValueType::String), BTreeSet::new());
-        assert!(matches!(collapsed, Type::Primitive(_)));
-        assert_eq!(collapsed.as_value_type(), Some(ValueType::String));
+        let joined = uint.union(&string);
+        assert!(joined.primitive_part().contains(ValueType::UnsignedInt));
+        assert!(joined.primitive_part().contains(ValueType::String));
+        assert!(joined.includes(&uint));
+        assert!(joined.includes(&string));
     }
 
     #[dialog_common::test]
@@ -1124,51 +833,6 @@ mod tests {
         assert_eq!(Type::from(Primitive::NUMERIC).as_value_type(), None);
     }
 
-    /// Insertion order of composite elements does not affect
-    /// equality or hash. The [`BTreeSet`] storage canonicalizes
-    /// the set, so different paths to the same set of shapes
-    /// produce equal `Type`s with equal hashes.
-    #[dialog_common::test]
-    fn composite_set_is_insertion_order_independent() {
-        let a = Type::variant("A", p(ValueType::String));
-        let b = Type::variant("B", p(ValueType::UnsignedInt));
-
-        // Build the same multi-element set two different ways:
-        // ({A, B}) via a.union(b), and ({B, A}) via b.union(a).
-        let ab = a.union(&b);
-        let ba = b.union(&a);
-
-        assert_eq!(ab, ba, "set equality is order-independent");
-        assert_eq!(hash_of(&ab), hash_of(&ba), "set hash is order-independent");
-    }
-
-    /// Field insertion order into a `BTreeMap<String, Type>` does
-    /// not affect product equality or hash: the BTreeMap sorts
-    /// by key. Same product built via `{x, y}` vs `{y, x}` insert
-    /// orders must compare equal and hash equal.
-    #[dialog_common::test]
-    fn product_field_insertion_order_independent() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        a_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        b_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let b = Type::product(b_fields);
-
-        assert_eq!(
-            a, b,
-            "product equality is field-insertion-order independent"
-        );
-        assert_eq!(
-            hash_of(&a),
-            hash_of(&b),
-            "product hash is field-insertion-order independent"
-        );
-    }
-
     /// `with_prefix` narrows membership to the TEXTUAL kinds and
     /// attaches the refinement; non-textual membership is an empty
     /// meet.
@@ -1178,7 +842,10 @@ mod tests {
             .with_prefix("did:")
             .expect("textual members remain");
         assert_eq!(refined.primitive_part(), Primitive::TEXTUAL);
-        assert_eq!(refined.refinement().expect("refined").prefix, "did:");
+        assert_eq!(
+            refined.refinement().expect("refined").prefix.as_deref(),
+            Some("did:")
+        );
 
         assert!(
             Type::from(Primitive::NUMERIC).with_prefix("did:").is_none(),
@@ -1200,7 +867,10 @@ mod tests {
             .with_prefix("did:key:")
             .unwrap();
         let met = did.intersect(&did_key).expect("compatible prefixes");
-        assert_eq!(met.refinement().unwrap().prefix, "did:key:");
+        assert_eq!(
+            met.refinement().unwrap().prefix.as_deref(),
+            Some("did:key:")
+        );
 
         let http = Type::from(ValueType::Entity).with_prefix("http:").unwrap();
         assert!(
@@ -1211,8 +881,8 @@ mod tests {
         let unrefined = Type::from(Primitive::TEXTUAL);
         let met = did.intersect(&unrefined).expect("memberships overlap");
         assert_eq!(
-            met.refinement().unwrap().prefix,
-            "did:",
+            met.refinement().unwrap().prefix.as_deref(),
+            Some("did:"),
             "the refinement survives a meet with an unrefined side"
         );
         assert_eq!(met.primitive_part().as_singleton(), Some(ValueType::Entity));
@@ -1229,7 +899,10 @@ mod tests {
             .with_prefix("user/guest")
             .unwrap();
         let joined = a.union(&b);
-        assert_eq!(joined.refinement().unwrap().prefix, "user/");
+        assert_eq!(
+            joined.refinement().unwrap().prefix.as_deref(),
+            Some("user/")
+        );
 
         let unrefined = Type::from(ValueType::String);
         assert_eq!(
@@ -1281,22 +954,138 @@ mod tests {
         assert_eq!(t, back);
     }
 
-    /// Combining two products via union also produces identical
-    /// hashes regardless of which product was unioned first.
+    fn concept(uri: &str) -> ConceptRef {
+        ConceptRef(uri.to_string())
+    }
+
+    /// `with_conformance` narrows membership to Entity (keeping the
+    /// `Nothing` bit for optional fields) and rejects memberships
+    /// with no entity in them.
     #[dialog_common::test]
-    fn product_union_is_order_independent() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields);
+    fn with_conformance_narrows_to_entity() {
+        let person = concept("concept:person");
+        let refined = Type::from(Primitive::ALL)
+            .with_conformance(person.clone())
+            .expect("Entity is a member");
+        assert_eq!(
+            refined.primitive_part().as_singleton(),
+            Some(ValueType::Entity)
+        );
+        assert!(refined.refinement().unwrap().conforms.contains(&person));
 
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
+        let optional = Type::from(ValueType::Entity)
+            .optional()
+            .with_conformance(person.clone())
+            .expect("optional entity remains inhabited");
+        assert!(
+            optional.primitive_part().contains_nothing(),
+            "the Nothing bit rides along"
+        );
 
-        let ab = a.union(&b);
-        let ba = b.union(&a);
+        assert!(
+            Type::from(Primitive::NUMERIC)
+                .with_conformance(person)
+                .is_none(),
+            "no numeric value is an entity"
+        );
+    }
 
-        assert_eq!(ab, ba);
-        assert_eq!(hash_of(&ab), hash_of(&ba));
+    /// The meet unions conformance sets (the value must satisfy both
+    /// sides); the join intersects them (only what both sides imply
+    /// survives).
+    #[dialog_common::test]
+    fn conformance_meet_unions_join_intersects() {
+        let person = concept("concept:person");
+        let employee = concept("concept:employee");
+        let a = Type::from(ValueType::Entity)
+            .with_conformance(person.clone())
+            .unwrap();
+        let b = Type::from(ValueType::Entity)
+            .with_conformance(employee.clone())
+            .unwrap();
+
+        let met = a.intersect(&b).expect("memberships overlap");
+        let conforms = &met.refinement().unwrap().conforms;
+        assert!(conforms.contains(&person) && conforms.contains(&employee));
+
+        assert!(
+            a.union(&b).refinement().is_none(),
+            "disjoint conformance sets imply nothing in common"
+        );
+        let both = a.clone().with_conformance(employee).unwrap();
+        assert_eq!(
+            both.union(&a),
+            a,
+            "the join keeps exactly the shared concepts"
+        );
+    }
+
+    /// Inclusion: a larger conformance set is more constrained, so
+    /// the superset side is the subtype.
+    #[dialog_common::test]
+    fn conformance_includes_is_subset_ordered() {
+        let person = concept("concept:person");
+        let a = Type::from(ValueType::Entity)
+            .with_conformance(person.clone())
+            .unwrap();
+        let both = a
+            .clone()
+            .with_conformance(concept("concept:employee"))
+            .unwrap();
+        let unrefined = Type::from(ValueType::Entity);
+
+        assert!(a.includes(&both), "more concepts is more constrained");
+        assert!(!both.includes(&a));
+        assert!(unrefined.includes(&a), "unrefined over-approximates");
+        assert!(!a.includes(&unrefined));
+
+        let prefixed = a.clone().with_prefix("did:").unwrap();
+        assert!(
+            a.includes(&prefixed) && !prefixed.includes(&a),
+            "both halves participate in the ordering"
+        );
+    }
+
+    /// Conformance is not row-checkable ("facts exist" is not a
+    /// property of the scalar): `admits` enforces only the prefix
+    /// half, enforcement of conformance is the desugared premises'
+    /// job.
+    #[dialog_common::test]
+    fn conformance_is_not_row_checked() {
+        let refined = Type::from(ValueType::Entity)
+            .with_conformance(concept("concept:person"))
+            .unwrap();
+        let entity = Value::Entity("did:key:z6Mk".parse().expect("valid entity"));
+        assert!(
+            refined.admits(&entity),
+            "any entity passes the row-local check"
+        );
+        assert!(
+            !refined.admits(&Value::UnsignedInt(7)),
+            "membership still applies"
+        );
+    }
+
+    /// Conformance survives serde, and the extended [`Refinement`]
+    /// still reads the prefix-only wire shape older peers produce.
+    #[dialog_common::test]
+    fn conformance_serde_round_trip_and_wire_compat() {
+        let t = Type::from(ValueType::Entity)
+            .with_conformance(concept("concept:person"))
+            .unwrap()
+            .with_prefix("did:")
+            .unwrap();
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
+
+        let old = Type::from(ValueType::Entity).with_prefix("did:").unwrap();
+        let old_wire = serde_json::to_string(&old).unwrap();
+        assert!(
+            !old_wire.contains("conforms"),
+            "an empty conformance set stays off the wire"
+        );
+        let read: Type = serde_json::from_str(&old_wire).unwrap();
+        assert_eq!(read, old);
     }
 }

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -62,7 +62,7 @@ pub enum UnifyError {
     },
     /// Occurs check: unifying a variable with a type that
     /// transitively contains the variable would produce an
-    /// infinite type. Reserved for future composite shapes.
+    /// infinite type. Reserved for future recursive types.
     #[error("occurs check failed for variable {var:?}")]
     OccursCheck {
         /// The offending variable.
@@ -189,8 +189,7 @@ impl Context {
     /// Returns `Err` on constraint conflict (an empty meet).
     ///
     /// Static types intersect via [`StaticType::intersect`], which
-    /// narrows both primitive and composite parts (products by
-    /// shared field-name set, variants by label). Variables carry
+    /// meets both memberships and refinements. Variables carry
     /// a [`Primitive`] constraint that's intersected with the
     /// primitive part of any concrete type they're unified with.
     pub fn unify(&mut self, a: &Type, b: &Type) -> Result<Type, UnifyError> {
@@ -253,8 +252,7 @@ impl Context {
                     .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
                 self.constraints.insert(x, merged);
                 // Rebuild around the merged membership without
-                // shedding the static's composite or refinement
-                // structure.
+                // shedding the static's refinement structure.
                 let resolved = narrowed_static.with_primitive_part(merged);
                 self.substitution.insert(x, Type::Static(resolved.clone()));
                 Ok(Type::Static(resolved))
@@ -479,7 +477,13 @@ mod tests {
         match resolved {
             Type::Static(s) => {
                 assert_eq!(s.primitive_part().as_singleton(), Some(ValueType::Entity));
-                assert_eq!(s.refinement().expect("refinement preserved").prefix, "did:");
+                assert_eq!(
+                    s.refinement()
+                        .expect("refinement preserved")
+                        .prefix
+                        .as_deref(),
+                    Some("did:")
+                );
             }
             other => panic!("expected static, got {other:?}"),
         }


### PR DESCRIPTION
Implements M3 (dialog-db-37): replaces the dormant `Composite::Product/Variant` type layer with conformance refinements on the entity atom, concept-typed fields enforced structurally, and spec-style ordered variants desugared to negation.

## Lattice: conformance refinements (replaces Composite)

`Composite::Product/Variant` (anonymous records / tagged unions with a non-idempotent meet) is deleted; composite structure is expressed by desugared premises, not by the scalar lattice. In its place, the value-level `Refinement` gains a second constraint alongside the (now optional) lexical prefix:

- `conforms: BTreeSet<ConceptRef>` — concepts the value's entity must conform to, where `ConceptRef` is the opaque `concept:{hash}` URI. Subsumption *between* concepts needs their descriptors, so the analyzer canonicalizes against descriptors; the lattice orders conformance sets by plain set inclusion.
- Meet unions conformance sets (both sides' constraints hold) and keeps the longer of two compatible prefixes; join intersects conformance and keeps the common prefix; `includes` orders by prefix-extension plus conforms-subset via `Refinement::implied_by`.
- `admits` checks only the prefix: conformance is "facts exist", not a property of the scalar, so it is deliberately not row-checked. An empty conformance set stays off the wire, so prefix-only refinements keep their previous serialized shape.

## Concept-typed fields

A concept field can be typed by another concept:

```rust
#[derive(Concept, Debug, Clone)]
pub struct Report {
    pub this: Entity,
    pub badge: org::Badge,
    #[dialog(conforms = BadgeHolder)]
    pub manager: org::Manager, // Manager(Entity)
}
```

- **Descriptor**: `ConceptFieldDescriptor.conforms` carries the full target descriptor on the wire (rule lowering needs no registry) while identity hashing uses only the target's URI, so plain and optional fields keep their existing encodings byte-for-byte.
- **Lowering**: the field's slot kind carries the conformance refinement, and enforcement is structural — the target concept is conjoined as a premise over the field's variable (projecting only `this`). A row survives only when the target entity satisfies the concept; verified end to end.
- **Derive**: `#[dialog(conforms = C)]` dispatches through the new `ConformingField` trait, implemented only for required entity-valued attribute newtypes — a non-entity or `Option<_>` field fails to compile (trait-marker dispatch, no syntactic type detection).
- **Invariants** hold on every construction path: non-entity conformance and optional conformance are rejected (`NonEntityConformance`, `OptionalConformance`) at construction and on the wire. Optional conformance is absence over a derived predicate, deferred until stratification (M4) owns it.

## Ordered variants and negative-edge validation

- `DeductiveRule::variants(conclusion, ordered)` compiles first-to-conform alternatives: variant *k*'s body is its own lowered premises plus one negated premise per earlier variant, joined on `this`, making the installed disjunction deterministic per entity. Verified end to end (email-else-phone contact resolution).
- Analysis rejects a rule that negates its own conclusion concept (`SelfNegation`) — the local, always-detectable case of recursion through negation — and surfaces `AnalyzedRule::negated_concepts()`, the negative IDB edges the global stratification pass (M4, dialog-db-38) consumes.

Full native suite: 1657 passed. `clippy --all --all-targets --all-features -D warnings` clean.