### PR TITLE
feat(dialog-repository): cover-scoped diff and DRed maintenance for subscriptions

### DIFF
--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -5,13 +5,13 @@ use crate::attribute::The;
 use crate::environment::Environment;
 use crate::negation::Negation;
 use crate::proposition::Proposition;
-use crate::query::Application;
 use crate::query::Output;
+use crate::query::{Application, Restriction};
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
 use crate::type_system::Type as Kind;
 use crate::types::{Any, Record};
-use crate::{Entity, EvaluationError, Parameters, Premise, Schema, Term};
+use crate::{Entity, EvaluationError, Parameters, Premise, Schema, Term, Value};
 use auto_enums::auto_enum;
 use dialog_artifacts::{Cause, Select};
 use dialog_capability::Provider;
@@ -205,6 +205,33 @@ impl Application for DynamicAttributeQuery {
         match self {
             DynamicAttributeQuery::All(q) => q.realize(input),
             DynamicAttributeQuery::Only(q) => q.realize(input),
+        }
+    }
+
+    fn restrict(&self, entity: &Entity) -> Restriction<Self> {
+        match self.of() {
+            Term::Constant(Value::Entity(this)) if this == entity => {
+                Restriction::Scoped(self.clone())
+            }
+            Term::Constant(_) => Restriction::Unaffected,
+            Term::Variable {
+                name: Some(name), ..
+            } if [self.the().name(), self.is().name(), self.cause().name()]
+                .into_iter()
+                .flatten()
+                .any(|other| other == name) =>
+            {
+                // `of` joins another slot through a shared variable
+                // name; pinning it would sever the join.
+                Restriction::Unsupported
+            }
+            _ => Restriction::Scoped(DynamicAttributeQuery::new(
+                self.the().clone(),
+                Term::Constant(Value::Entity(entity.clone())),
+                self.is().clone(),
+                self.cause().clone(),
+                Some(self.cardinality()),
+            )),
         }
     }
 }

--- a/rust/dialog-query/src/claim.rs
+++ b/rust/dialog-query/src/claim.rs
@@ -2,6 +2,7 @@
 
 pub use crate::artifact::{Artifact, ArtifactsAttribute, Cause, Entity, Value};
 use crate::attribute::The;
+use crate::concept::Conclusion;
 use serde::{Deserialize, Serialize};
 
 /// A claim represents a stored EAV datum with full metadata.
@@ -49,6 +50,15 @@ impl Claim {
     /// Get the cause (provenance hash) of this claim
     pub fn cause(&self) -> &Cause {
         &self.cause
+    }
+}
+
+impl Conclusion for Claim {
+    /// The claim's subject entity. Lets claim-valued query results
+    /// participate in subject-keyed machinery (e.g. per-entity
+    /// incremental maintenance) uniformly with concept conclusions.
+    fn this(&self) -> &Entity {
+        &self.of
     }
 }
 

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -9,7 +9,7 @@ use crate::attribute::{AttributeDescriptor, Attribution};
 use crate::concept::query::ConceptQuery;
 use crate::concept::{Concept, Conclusion};
 use crate::error::TypeError;
-use crate::query::Application;
+use crate::query::{Application, Restriction};
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
 use crate::statement::Retraction;
@@ -551,6 +551,42 @@ impl Application for ConceptQuery {
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
         ConceptQuery::evaluate(self, selection, env)
+    }
+
+    fn restrict(&self, entity: &Entity) -> Restriction<Self> {
+        match self.terms.get("this") {
+            Some(Term::Constant(Value::Entity(this))) if this == entity => {
+                Restriction::Scoped(self.clone())
+            }
+            Some(Term::Constant(_)) => Restriction::Unaffected,
+            Some(Term::Variable {
+                name: Some(name), ..
+            }) if self
+                .terms
+                .iter()
+                .any(|(param, term)| param != "this" && term.name() == Some(name)) =>
+            {
+                // `this` joins another field through a shared
+                // variable name; pinning it to a constant would
+                // sever the join.
+                Restriction::Unsupported
+            }
+            _ => {
+                let mut terms = self.terms.clone();
+                terms.insert(
+                    "this".to_string(),
+                    Term::Constant(Value::Entity(entity.clone())),
+                );
+                Restriction::Scoped(ConceptQuery {
+                    terms,
+                    predicate: self.predicate.clone(),
+                })
+            }
+        }
+    }
+
+    fn concept(&self) -> Option<&ConceptDescriptor> {
+        Some(&self.predicate)
     }
 
     fn realize(&self, source: Match) -> Result<Self::Conclusion, EvaluationError> {

--- a/rust/dialog-query/src/query/application.rs
+++ b/rust/dialog-query/src/query/application.rs
@@ -1,14 +1,34 @@
 use async_stream::try_stream;
-use dialog_artifacts::Select;
+use dialog_artifacts::{Entity, Select};
 use dialog_capability::Provider;
 use dialog_common::{ConditionalSend, ConditionalSync};
 
+use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::EvaluationError;
 use crate::selection;
 use crate::selection::Match;
 use crate::source::SelectRules;
 
 use super::Output;
+
+/// The outcome of restricting an [`Application`] to a single subject
+/// entity — the goal-directed unit incremental maintenance
+/// re-derives with (DRed's delete/re-derive step, scoped to one
+/// entity).
+#[derive(Clone, Debug)]
+pub enum Restriction<Q> {
+    /// The query restricted to the entity: evaluating it yields
+    /// exactly the original query's rows whose subject is the
+    /// entity.
+    Scoped(Q),
+    /// The original query can never produce rows for this entity
+    /// (its subject is pinned to a different one); nothing to
+    /// re-derive.
+    Unaffected,
+    /// The query cannot be scoped to one subject; the maintainer
+    /// falls back to full re-evaluation.
+    Unsupported,
+}
 
 /// A query pattern that can be evaluated against a provider to produce
 /// typed results.
@@ -37,6 +57,25 @@ pub trait Application: Clone + ConditionalSend + 'static {
 
     /// Convert a match into a concrete result value.
     fn realize(&self, input: selection::Match) -> Result<Self::Conclusion, EvaluationError>;
+
+    /// Restrict this query to a single subject entity, when the
+    /// query type supports it. The default is
+    /// [`Restriction::Unsupported`]: incremental maintainers fall
+    /// back to full re-evaluation.
+    fn restrict(&self, _entity: &Entity) -> Restriction<Self>
+    where
+        Self: Sized,
+    {
+        Restriction::Unsupported
+    }
+
+    /// The concept this query applies, when it is a concept query.
+    /// Incremental maintainers use it to resolve the rule set and
+    /// decide whether per-entity restriction is sound (every rule
+    /// entity-local, no recursion).
+    fn concept(&self) -> Option<&ConceptDescriptor> {
+        None
+    }
 
     /// Execute this query against an environment, returning a stream of typed results.
     fn perform<'a, Env>(self, env: &'a Env) -> impl Output<Self::Conclusion> + 'a

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -36,7 +36,7 @@ use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
-use crate::{Entity, Environment, Premise};
+use crate::{Entity, Environment, Premise, Term};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -229,6 +229,34 @@ impl AnalyzedRule {
         self.premises.iter().filter_map(|premise| match premise {
             Premise::Unless(Negation(Proposition::Concept(query))) => Some(query.predicate.this()),
             _ => None,
+        })
+    }
+
+    /// Whether every premise reads only the head entity's own facts:
+    /// each attribute premise (positive, optional, or negated) is a
+    /// lookup `of ?this`, and the remaining premises are row-local
+    /// transforms (formulas, constraints) over those bindings.
+    ///
+    /// For an entity-local rule, a base-fact change for entity `E`
+    /// can only affect the rule's rows whose subject is `E` — the
+    /// soundness condition for maintaining a subscription by
+    /// re-deriving just the touched entities instead of
+    /// re-evaluating the whole query. Concept premises are
+    /// cross-entity by construction (the target entity is a field
+    /// value, not the subject), so any rule carrying one is
+    /// non-local.
+    pub fn is_entity_local(&self) -> bool {
+        fn of_is_this(term: &Term<Entity>) -> bool {
+            matches!(term, Term::Variable { name: Some(name), .. } if name == "this")
+        }
+        self.premises.iter().all(|premise| match premise {
+            Premise::Assert(Proposition::Attribute(query)) => of_is_this(query.of()),
+            Premise::Assert(Proposition::OptionalAttribute(query)) => of_is_this(query.of()),
+            Premise::Assert(Proposition::Constraint(_)) => true,
+            Premise::Assert(Proposition::Formula(_)) => true,
+            Premise::Unless(Negation(Proposition::Attribute(query))) => of_is_this(query.of()),
+            Premise::Unless(Negation(Proposition::Constraint(_))) => true,
+            _ => false,
         })
     }
 }

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -935,6 +935,110 @@ mod tests {
         );
     }
 
+    /// Entity locality: the implicit rule of a plain concept reads
+    /// only `?this`'s facts; concept premises (conforming fields,
+    /// variant negations) make a rule non-local.
+    #[dialog_common::test]
+    fn it_classifies_entity_locality() {
+        let plain = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "nickname".to_string(),
+                ConceptFieldDescriptor::optional(AttributeDescriptor::new(
+                    the!("person/nickname"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+        ])
+        .unwrap();
+        assert!(
+            DeductiveRule::from(&plain).analysis().is_entity_local(),
+            "attribute and optional premises over ?this are local"
+        );
+
+        let target = ConceptDescriptor::try_from(vec![(
+            "badge",
+            AttributeDescriptor::new(
+                the!("employee/badge"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let conforming = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    AttributeDescriptor::new(
+                        the!("person/manager"),
+                        "",
+                        Cardinality::One,
+                        Some(Type::Entity),
+                    ),
+                    target.clone(),
+                )
+                .unwrap(),
+            ),
+        ])
+        .unwrap();
+        assert!(
+            !DeductiveRule::from(&conforming)
+                .analysis()
+                .is_entity_local(),
+            "a concept premise reads another entity's facts"
+        );
+
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let email = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/email"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let phone = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/phone"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let variants = DeductiveRule::variants(conclusion, vec![email, phone]).unwrap();
+        assert!(
+            variants[0].analysis().is_entity_local(),
+            "the first variant is plain attribute premises"
+        );
+        assert!(
+            !variants[1].analysis().is_entity_local(),
+            "a negated concept premise is non-local"
+        );
+    }
+
     /// A rule that negates its own conclusion concept is a negative
     /// self-loop: rejected at analysis.
     #[dialog_common::test]

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -397,8 +397,12 @@ where
     ) -> Result<Vec<Artifact>, DialogArtifactsError> {
         // Rule-discovery reads are demand too: a rule committed
         // later for a subscribed concept lands in this range and
-        // must re-trigger the subscription.
-        self.record_demand(&selector);
+        // must re-trigger the subscription. Recorded as *rule*
+        // demand: a hit here invalidates the whole result, not one
+        // entity's slice.
+        if let Some(demand) = &self.demand {
+            demand.record_rules(&selector);
+        }
         let stream = select_from_branch(branch, self.env, selector).await?;
         stream.try_collect().await
     }

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -44,7 +44,7 @@ use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output as _};
-use dialog_search_tree::{Change, ContentAddressedStorage};
+use dialog_search_tree::ContentAddressedStorage;
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
 
@@ -87,6 +87,12 @@ impl Demand {
             .expect("demand lock")
             .iter()
             .any(|range| range.contains(key))
+    }
+
+    /// A snapshot of the recorded ranges: the scope a cover-gated
+    /// tree diff walks.
+    pub(crate) fn ranges(&self) -> Vec<RangeInclusive<KeyBytes>> {
+        self.ranges.lock().expect("demand lock").clone()
     }
 
     /// Number of distinct recorded ranges.
@@ -235,8 +241,17 @@ where
     }
 
     /// Whether any change between the pinned root and `current`
-    /// falls inside the demand cover. Streams the tree diff and
-    /// stops at the first hit.
+    /// falls inside the demand cover.
+    ///
+    /// The diff itself is *scoped to the cover*
+    /// ([`differentiate_within`]): subtrees whose key span misses
+    /// every demanded range are dropped from the comparison without
+    /// being loaded, so on a partial replica the poll never fetches
+    /// subtrees the subscription didn't demand — the walk is bounded
+    /// by the changes *within the cover*, not the full delta between
+    /// the roots. The first in-scope change decides.
+    ///
+    /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
     async fn intersects<Env>(
         &self,
         env: &Env,
@@ -256,6 +271,10 @@ where
         if pinned == target {
             return Ok(false);
         }
+        let scope = self.demand.ranges();
+        if scope.is_empty() {
+            return Ok(false);
+        }
 
         let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
         let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
@@ -263,22 +282,13 @@ where
             Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
         let next = Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
 
-        let changes = previous.differentiate(&next, &storage, &storage);
+        let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
-        while let Some(change) = changes
+        Ok(changes
             .try_next()
             .await
             .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-        {
-            let entry = match change {
-                Change::Add(entry) => entry,
-                Change::Remove(entry) => entry,
-            };
-            if self.demand.covers(&entry.key) {
-                return Ok(true);
-            }
-        }
-        Ok(false)
+            .is_some())
     }
 
     /// Evaluate the query against the branch, recording every

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -12,29 +12,56 @@
 //! - root changed but no diff entry falls inside the cover → the
 //!   result cannot have changed; the pin advances without
 //!   re-evaluating (this is the point: unrelated writes are free);
-//! - a diff entry falls inside the cover → re-evaluate, emit the
-//!   result [`Delta`], re-record the cover, advance the pin.
+//! - a diff entry falls inside a *fact* range → maintain
+//!   incrementally when the query supports it (see below), emit the
+//!   result [`Delta`], advance the pin;
+//! - a diff entry falls inside a *rule-discovery* range → the rule
+//!   set may have changed, which can affect any row: full
+//!   re-evaluation, cover re-recorded.
 //!
 //! The cover is the *demanded* range, not the touched data: a scan
 //! that came back empty still recorded its range, so absence reads
 //! (a fact that wasn't there yet, a rule that wasn't installed yet)
-//! are invalidated by later writes into the demanded range. Rule
-//! discovery reads (`db.rule/*` scans) record the same way, so
-//! committing a new rule for a subscribed concept re-triggers too.
+//! are invalidated by later writes into the demanded range.
+//!
+//! # Incremental maintenance (DRed / FBF)
+//!
+//! For fact changes, the delta is derived without re-evaluating the
+//! whole query: the changed datums name their subject entities, and
+//! for each touched entity the retained rows are over-deleted and
+//! re-derived by evaluating the query *restricted to that entity*
+//! ([`Application::restrict`]) — DRed's delete / re-derive / insert,
+//! with the goal-directed re-evaluation playing both the re-derive
+//! and insert steps. A row with surviving alternate derivations is
+//! simply re-derived, which handles the multi-derivation retraction
+//! case (FBF's concern) exactly, without counting.
+//!
+//! Per-entity re-derivation is sound only when a change to entity
+//! `E` can only affect rows whose subject is `E`. Attribute queries
+//! have this by construction; concept queries are gated on their
+//! resolved rule set — every rule entity-local
+//! ([`AnalyzedRule::is_entity_local`]) and non-recursive — and
+//! anything else falls back to a full recompute, which is always
+//! sound. [`recomputes`](Subscription::recomputes) and
+//! [`maintenances`](Subscription::maintenances) expose which path
+//! each poll took.
 //!
 //! Deliberately pull-driven: nothing here retains operator state or
 //! integrated inputs. Demand transformation over the existing
 //! top-down engine is the architecture; the diff is the signal, the
-//! cover is the gate, and re-evaluation is the (current) recompute
-//! step. Per-delta DRed/FBF maintenance and dynamically maintained
-//! demand (cones that grow with data) build on this same surface.
+//! cover is the gate, and per-entity re-derivation is the
+//! maintenance step. Dynamically maintained demand (cones that grow
+//! with data) builds on this same surface.
+//!
+//! [`AnalyzedRule::is_entity_local`]: dialog_query::rule::analyzer::AnalyzedRule::is_entity_local
 
+use std::collections::BTreeSet;
 use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{ArtifactSelector, KeyBytes};
+use dialog_artifacts::{ArtifactSelector, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -42,9 +69,11 @@ use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
 use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
+use dialog_query::Conclusion;
 use dialog_query::error::EvaluationError;
-use dialog_query::query::{Application, Output as _};
-use dialog_search_tree::ContentAddressedStorage;
+use dialog_query::query::{Application, Output as _, Restriction};
+use dialog_query::source::SelectRules;
+use dialog_search_tree::{Change, ContentAddressedStorage};
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
 
@@ -60,7 +89,20 @@ use crate::{
 /// while the evaluation streams.
 #[derive(Clone, Debug, Default)]
 pub struct Demand {
-    ranges: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
+    /// Ranges read by fact scans: the query's data demand.
+    facts: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
+    /// Ranges read by rule-discovery scans (`db.rule/*`). Kept
+    /// apart because a change here can install a rule, which can
+    /// affect any row — it invalidates the whole result, not one
+    /// entity's slice.
+    rules: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
+}
+
+fn record_range(ranges: &Mutex<Vec<RangeInclusive<KeyBytes>>>, range: RangeInclusive<KeyBytes>) {
+    let mut ranges = ranges.lock().expect("demand lock");
+    if !ranges.contains(&range) {
+        ranges.push(range);
+    }
 }
 
 impl Demand {
@@ -69,35 +111,51 @@ impl Demand {
         Self::default()
     }
 
-    /// Record a selector's demanded range. The range covers
+    /// Record a fact scan's demanded range. The range covers
     /// everything the selector's scan would touch — including where
     /// no entries exist, so misses are demanded too.
     pub(crate) fn record(&self, selector: &ArtifactSelector<Constrained>) {
-        let range = selector_range(selector);
-        let mut ranges = self.ranges.lock().expect("demand lock");
-        if !ranges.contains(&range) {
-            ranges.push(range);
-        }
+        record_range(&self.facts, selector_range(selector));
+    }
+
+    /// Record a rule-discovery scan's demanded range.
+    pub(crate) fn record_rules(&self, selector: &ArtifactSelector<Constrained>) {
+        record_range(&self.rules, selector_range(selector));
     }
 
     /// Whether the key falls inside any recorded range.
     pub fn covers(&self, key: &KeyBytes) -> bool {
-        self.ranges
+        self.covers_facts(key) || self.covers_rules(key)
+    }
+
+    fn covers_facts(&self, key: &KeyBytes) -> bool {
+        self.facts
             .lock()
             .expect("demand lock")
             .iter()
             .any(|range| range.contains(key))
     }
 
-    /// A snapshot of the recorded ranges: the scope a cover-gated
-    /// tree diff walks.
+    fn covers_rules(&self, key: &KeyBytes) -> bool {
+        self.rules
+            .lock()
+            .expect("demand lock")
+            .iter()
+            .any(|range| range.contains(key))
+    }
+
+    /// A snapshot of every recorded range (facts and rules): the
+    /// scope a cover-gated tree diff walks.
     pub(crate) fn ranges(&self) -> Vec<RangeInclusive<KeyBytes>> {
-        self.ranges.lock().expect("demand lock").clone()
+        let mut ranges = self.facts.lock().expect("demand lock").clone();
+        ranges.extend(self.rules.lock().expect("demand lock").iter().cloned());
+        ranges
     }
 
     /// Number of distinct recorded ranges.
     pub fn len(&self) -> usize {
-        self.ranges.lock().expect("demand lock").len()
+        self.facts.lock().expect("demand lock").len()
+            + self.rules.lock().expect("demand lock").len()
     }
 
     /// Whether nothing was demanded.
@@ -136,6 +194,10 @@ pub struct Subscription<Q: Application> {
     /// next delta.
     results: Vec<Q::Conclusion>,
     initialized: bool,
+    /// Full evaluations performed (first poll + fallbacks).
+    recomputes: usize,
+    /// Polls maintained incrementally (per-entity re-derivation).
+    maintenances: usize,
 }
 
 impl Branch {
@@ -150,8 +212,23 @@ impl Branch {
             demand: Demand::new(),
             results: Vec::new(),
             initialized: false,
+            recomputes: 0,
+            maintenances: 0,
         }
     }
+}
+
+/// What the in-cover changes between two roots touched.
+enum Touched {
+    /// Nothing inside the cover changed (or the changes cannot
+    /// alter any read: tombstones over never-asserted keys).
+    Nothing,
+    /// A rule-discovery range changed: the rule set may differ, so
+    /// any row may be affected.
+    Rules,
+    /// Only fact ranges changed; the set of subject entities whose
+    /// facts changed.
+    Facts(BTreeSet<Entity>),
 }
 
 /// The index root a revision pins, or the empty tree for an
@@ -166,7 +243,7 @@ fn tree_hash(revision: &Option<Revision>) -> Blake3Hash {
 impl<Q> Subscription<Q>
 where
     Q: Application + Clone,
-    Q::Conclusion: PartialEq + Clone,
+    Q::Conclusion: Conclusion + PartialEq + Clone,
 {
     /// The retained result of the last evaluation.
     pub fn results(&self) -> &[Q::Conclusion] {
@@ -176,6 +253,20 @@ where
     /// The demand cover recorded by the last evaluation.
     pub fn demand(&self) -> &Demand {
         &self.demand
+    }
+
+    /// Full evaluations performed so far (the first poll plus every
+    /// fallback from incremental maintenance).
+    pub fn recomputes(&self) -> usize {
+        self.recomputes
+    }
+
+    /// Polls that were maintained incrementally: the delta was
+    /// derived by re-evaluating only the touched entities (DRed's
+    /// delete/re-derive, goal-directed per subject) instead of the
+    /// whole query.
+    pub fn maintenances(&self) -> usize {
+        self.maintenances
     }
 
     /// Poll the subscription against the branch's current state.
@@ -210,14 +301,29 @@ where
             if current == self.revision {
                 return Ok(None);
             }
-            if !self.intersects(env, &current).await? {
-                self.revision = current;
-                return Ok(None);
+            match self.touched(env, &current).await? {
+                Touched::Nothing => {
+                    self.revision = current;
+                    return Ok(None);
+                }
+                Touched::Facts(entities) => {
+                    if let Some(delta) = self.maintain(env, &entities).await? {
+                        self.maintenances += 1;
+                        self.revision = current;
+                        return Ok(Some(delta));
+                    }
+                    // Not maintainable for this query/rule shape:
+                    // fall through to a full recompute.
+                }
+                // A rule-range change can install or change a rule,
+                // which can affect any row: recompute.
+                Touched::Rules => {}
             }
         }
 
         let demand = Demand::new();
-        let results = self.evaluate(env, &demand).await?;
+        let results = self.evaluate(env, &demand, &self.query).await?;
+        self.recomputes += 1;
 
         let delta = Delta {
             asserted: results
@@ -240,23 +346,30 @@ where
         Ok(Some(delta))
     }
 
-    /// Whether any change between the pinned root and `current`
-    /// falls inside the demand cover.
+    /// Classify what the changes between the pinned root and
+    /// `current` touched within the demand cover.
     ///
-    /// The diff itself is *scoped to the cover*
+    /// The diff is *scoped to the cover*
     /// ([`differentiate_within`]): subtrees whose key span misses
     /// every demanded range are dropped from the comparison without
     /// being loaded, so on a partial replica the poll never fetches
     /// subtrees the subscription didn't demand — the walk is bounded
     /// by the changes *within the cover*, not the full delta between
-    /// the roots. The first in-scope change decides.
+    /// the roots.
+    ///
+    /// A change inside a rule-discovery range short-circuits to
+    /// [`Touched::Rules`]. Fact changes collect the subject entities
+    /// of the changed datums; changes with no datum on either side
+    /// (a tombstone written where nothing was asserted, or a
+    /// tombstone entry disappearing) never alter what a scan reads
+    /// and are skipped.
     ///
     /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
-    async fn intersects<Env>(
+    async fn touched<Env>(
         &self,
         env: &Env,
         current: &Option<Revision>,
-    ) -> Result<bool, EvaluationError>
+    ) -> Result<Touched, EvaluationError>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -269,11 +382,11 @@ where
         let pinned = tree_hash(&self.revision);
         let target = tree_hash(current);
         if pinned == target {
-            return Ok(false);
+            return Ok(Touched::Nothing);
         }
         let scope = self.demand.ranges();
         if scope.is_empty() {
-            return Ok(false);
+            return Ok(Touched::Nothing);
         }
 
         let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
@@ -284,11 +397,123 @@ where
 
         let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
-        Ok(changes
+        let mut entities = BTreeSet::new();
+        while let Some(change) = changes
             .try_next()
             .await
             .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-            .is_some())
+        {
+            let entry = match &change {
+                Change::Add(entry) => entry,
+                Change::Remove(entry) => entry,
+            };
+            if self.demand.covers_rules(&entry.key) {
+                return Ok(Touched::Rules);
+            }
+            if let State::Added(datum) = &entry.value {
+                let entity = datum.entity.parse().map_err(|error| {
+                    EvaluationError::Store(format!("changed datum entity: {error:?}"))
+                })?;
+                entities.insert(entity);
+            }
+        }
+
+        if entities.is_empty() {
+            Ok(Touched::Nothing)
+        } else {
+            Ok(Touched::Facts(entities))
+        }
+    }
+
+    /// Maintain the retained result incrementally: for each touched
+    /// entity, over-delete its retained rows and re-derive them with
+    /// the query restricted to that entity (DRed's delete /
+    /// re-derive / insert, with the goal-directed re-evaluation
+    /// playing both the re-derive and insert steps — a row with
+    /// surviving alternate derivations is simply re-derived, which
+    /// is what makes multi-derivation retractions exact without
+    /// counting).
+    ///
+    /// Returns `Ok(None)` when the query or its rule set cannot be
+    /// maintained per-entity — the query is not restrictable, a rule
+    /// reads other entities' facts (not entity-local), or the
+    /// concept is recursive — in which case the caller falls back to
+    /// a full recompute.
+    async fn maintain<Env>(
+        &mut self,
+        env: &Env,
+        entities: &BTreeSet<Entity>,
+    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        // Soundness gate for concept queries: every rule must be
+        // entity-local (reads only `?this`'s facts) and
+        // non-recursive, otherwise a change to entity E can affect
+        // other entities' rows and per-entity re-derivation would
+        // miss them.
+        if let Some(concept) = self.query.concept() {
+            let operator = Identify
+                .perform(env)
+                .await
+                .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+            let layer = QueryLayer::from(&self.branch);
+            let overlay = layer.overlay(&operator);
+            let tombstones = tombstones_from(&overlay);
+            let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+                .with_demand(self.demand.clone());
+            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
+            if rules.recursion().is_some() {
+                return Ok(None);
+            }
+            if !rules.rules().all(|rule| rule.analysis().is_entity_local()) {
+                return Ok(None);
+            }
+        }
+
+        let mut asserted = Vec::new();
+        let mut retracted = Vec::new();
+        for entity in entities {
+            let scoped = match self.query.restrict(entity) {
+                Restriction::Scoped(query) => query,
+                Restriction::Unaffected => continue,
+                Restriction::Unsupported => return Ok(None),
+            };
+            // Over-delete: every retained row for this entity...
+            let before: Vec<Q::Conclusion> = self
+                .results
+                .iter()
+                .filter(|row| row.this() == entity)
+                .cloned()
+                .collect();
+            // ...re-derive + insert: goal-directed re-evaluation,
+            // recording into the existing cover (the standing
+            // demand only ever grows between recomputes).
+            let after = self.evaluate(env, &self.demand.clone(), &scoped).await?;
+            for row in &after {
+                if !before.contains(row) {
+                    asserted.push(row.clone());
+                }
+            }
+            for row in &before {
+                if !after.contains(row) {
+                    retracted.push(row.clone());
+                }
+            }
+            self.results.retain(|row| row.this() != entity);
+            self.results.extend(after);
+        }
+        Ok(Some(Delta {
+            asserted,
+            retracted,
+        }))
     }
 
     /// Evaluate the query against the branch, recording every
@@ -299,6 +524,7 @@ where
         &self,
         env: &Env,
         demand: &Demand,
+        query: &Q,
     ) -> Result<Vec<Q::Conclusion>, EvaluationError>
     where
         Env: Provider<Get>
@@ -319,7 +545,7 @@ where
         let tombstones = tombstones_from(&overlay);
         let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
             .with_demand(demand.clone());
-        self.query.clone().perform(&query_env).try_vec().await
+        query.clone().perform(&query_env).try_vec().await
     }
 }
 
@@ -563,6 +789,187 @@ mod tests {
             names(&delta.asserted),
             vec![(alice.clone(), "Alice".to_string())]
         );
+        Ok(())
+    }
+
+    /// Covered writes are maintained incrementally: after the first
+    /// full evaluation, deltas come from per-entity re-derivation,
+    /// never a whole-query recompute.
+    #[dialog_common::test]
+    async fn it_maintains_covered_writes_without_recompute() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 0);
+
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("covered write");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the delta came from per-entity re-derivation, not a recompute"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+
+        branch
+            .transaction()
+            .retract(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        assert!(delta.asserted.is_empty());
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
+        assert_eq!(
+            names(subscription.results()),
+            vec![(bob, "Bob".to_string())],
+            "retained results track the maintained state"
+        );
+        Ok(())
+    }
+
+    /// The multi-derivation retraction case (what FBF solves without
+    /// counting): an entity carries two values for the same
+    /// attribute; retracting one must retract exactly that row and
+    /// keep the other, because the survivor re-derives during the
+    /// per-entity re-evaluation.
+    #[dialog_common::test]
+    async fn it_rederives_surviving_rows_on_partial_retraction() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("person/name").of(alice.clone()).is("Ali".to_string()))
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(initial.asserted.len(), 2, "both values surface");
+
+        branch
+            .transaction()
+            .retract(the!("person/name").of(alice.clone()).is("Ali".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(alice.clone(), "Ali".to_string())],
+            "only the retracted value goes"
+        );
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            names(subscription.results()),
+            vec![(alice.clone(), "Alice".to_string())],
+            "the surviving value re-derived"
+        );
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    /// A write touching only *other* entities' facts inside the
+    /// cover maintains just those entities: the untouched entity's
+    /// rows are never re-derived, and the delta is scoped to what
+    /// changed.
+    #[dialog_common::test]
+    async fn it_scopes_maintenance_to_touched_entities() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+
+        branch
+            .transaction()
+            .assert(the!("person/name").of(bob.clone()).is("Bobby".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("covered write");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(bob.clone(), "Bobby".to_string())]
+        );
+        assert!(
+            delta.retracted.is_empty(),
+            "cardinality-many: the prior value stays"
+        );
+        let mut retained = names(subscription.results());
+        retained.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+            (bob.clone(), "Bobby".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(retained, expected);
+        assert_eq!(subscription.maintenances(), 1);
         Ok(())
     }
 }

--- a/rust/dialog-search-tree/src/differential.rs
+++ b/rust/dialog-search-tree/src/differential.rs
@@ -224,6 +224,43 @@ where
         }
     }
 
+    /// Removes nodes whose key span cannot intersect any range in
+    /// `scope`, so out-of-scope subtrees are never expanded (and, on
+    /// a partial replica, never fetched).
+    ///
+    /// Links carry only upper bounds, so a node's span is bounded
+    /// conservatively: within the frontier (sorted by upper bound,
+    /// where pruning only ever *removes* nodes), a node's true span
+    /// is contained in `(predecessor's upper bound, own upper bound]`.
+    /// A node is dropped only when that conservative span misses
+    /// every scope range, which can only over-retain, never
+    /// over-drop — in-scope changes are always preserved. Dropping is
+    /// per-side, so the entry walk may surface spurious out-of-scope
+    /// changes where only one side dropped a shared region;
+    /// [`TreeDifference::changes_within`] filters those.
+    fn retain_scope(&mut self, scope: &[core::ops::RangeInclusive<Key>]) {
+        let mut lower: Option<Key> = None;
+        let mut kept = Vec::with_capacity(self.nodes.len());
+        for node in self.nodes.drain(..) {
+            let upper = node.upper_bound().clone();
+            let intersects = scope.iter().any(|range| {
+                // (lower, upper] ∩ [start, end] is non-empty iff
+                // upper >= start and lower < end (with lower = -∞
+                // for the first node).
+                *range.start() <= upper
+                    && match &lower {
+                        Some(lower) => lower < range.end(),
+                        None => true,
+                    }
+            });
+            if intersects {
+                kept.push(node);
+            }
+            lower = Some(upper);
+        }
+        self.nodes = kept;
+    }
+
     /// Removes nodes that are shared between `self` and `other`, keeping
     /// only nodes that differ.
     ///
@@ -397,6 +434,77 @@ where
     where
         D: Distribution,
     {
+        let mut difference = Self::compute_scoped(
+            source_tree,
+            target_tree,
+            source_storage,
+            target_storage,
+            None,
+        )
+        .await?;
+
+        // Expand any remaining target index nodes so novel_nodes() can
+        // enumerate every novel node, not just unexpanded subtree roots.
+        // These reads are not wasted: every remaining target node is novel
+        // by construction and must be visited to be reported.
+        loop {
+            let mut expanded = false;
+            for index in 0..difference.target.nodes.len() {
+                let bound = difference.target.nodes[index].upper_bound().clone();
+                if difference.target.expand_at(&bound).await? {
+                    expanded = true;
+                    break;
+                }
+            }
+            if !expanded {
+                break;
+            }
+        }
+
+        Ok(difference)
+    }
+
+    /// Computes the difference between two trees *restricted to
+    /// `scope`*: subtrees whose key span cannot intersect any scope
+    /// range are dropped from the comparison without being loaded,
+    /// so reads are proportional to the differing regions *within
+    /// the scope* rather than to the full difference. On a partial
+    /// replica this is what keeps a subscription's diff from
+    /// fetching subtrees it never demanded.
+    ///
+    /// Consume via [`changes_within`](Self::changes_within) (which
+    /// filters boundary spillover); [`novel_nodes`](Self::novel_nodes)
+    /// is not meaningful on a scoped difference.
+    pub async fn compute_within<D>(
+        source_tree: &PersistentTree<Key, Value, D>,
+        target_tree: &PersistentTree<Key, Value, D>,
+        source_storage: &'a ContentAddressedStorage<Backend>,
+        target_storage: &'a ContentAddressedStorage<Backend>,
+        scope: &[core::ops::RangeInclusive<Key>],
+    ) -> Result<TreeDifference<'a, Key, Value, Backend>, DialogSearchTreeError>
+    where
+        D: Distribution,
+    {
+        Self::compute_scoped(
+            source_tree,
+            target_tree,
+            source_storage,
+            target_storage,
+            Some(scope),
+        )
+        .await
+    }
+
+    async fn compute_scoped<D>(
+        source_tree: &PersistentTree<Key, Value, D>,
+        target_tree: &PersistentTree<Key, Value, D>,
+        source_storage: &'a ContentAddressedStorage<Backend>,
+        target_storage: &'a ContentAddressedStorage<Backend>,
+        scope: Option<&[core::ops::RangeInclusive<Key>]>,
+    ) -> Result<TreeDifference<'a, Key, Value, Backend>, DialogSearchTreeError>
+    where
+        D: Distribution,
+    {
         // Identical trees (including two empty trees) share their root
         // hash; nothing needs to be read at all.
         if source_tree.root() == target_tree.root() {
@@ -423,6 +531,10 @@ where
         // fixed point: only differing leaf segments (and unique-range
         // subtrees) remain.
         loop {
+            if let Some(scope) = scope {
+                source.retain_scope(scope);
+                target.retain_scope(scope);
+            }
             source.prune(&mut target);
 
             let mut expanded = false;
@@ -473,25 +585,34 @@ where
             }
         }
 
-        // Expand any remaining target index nodes so novel_nodes() can
-        // enumerate every novel node, not just unexpanded subtree roots.
-        // These reads are not wasted: every remaining target node is novel
-        // by construction and must be visited to be reported.
-        loop {
-            let mut expanded = false;
-            for index in 0..target.nodes.len() {
-                let bound = target.nodes[index].upper_bound().clone();
-                if target.expand_at(&bound).await? {
-                    expanded = true;
-                    break;
+        Ok(TreeDifference { source, target })
+    }
+
+    /// Returns a stream of the changes within `scope` that transform
+    /// the source tree into the target tree. Use on a difference
+    /// built by [`compute_within`](Self::compute_within): scope
+    /// pruning is per-side, so a shared region dropped from only one
+    /// frontier surfaces as spurious out-of-scope changes in the raw
+    /// entry walk — this filter removes them, leaving exactly the
+    /// in-scope changes.
+    pub fn changes_within(
+        &'a self,
+        scope: &'a [core::ops::RangeInclusive<Key>],
+    ) -> impl Differential<Key, Value> + 'a {
+        let changes = self.changes();
+        try_stream! {
+            futures_util::pin_mut!(changes);
+            for await change in changes {
+                let change = change?;
+                let key = match &change {
+                    Change::Add(entry) => &entry.key,
+                    Change::Remove(entry) => &entry.key,
+                };
+                if scope.iter().any(|range| range.contains(key)) {
+                    yield change;
                 }
             }
-            if !expanded {
-                break;
-            }
         }
-
-        Ok(TreeDifference { source, target })
     }
 
     /// Returns a stream of entry-level changes that transform the source
@@ -680,6 +801,127 @@ mod tests {
             }
         }
         Ok(tree)
+    }
+
+    async fn collect_scoped_changes(
+        source: &TestTree,
+        target: &TestTree,
+        scope: &[core::ops::RangeInclusive<[u8; 4]>],
+        storage: &ContentAddressedStorage<CountingBackend>,
+    ) -> Result<Vec<Change<[u8; 4], Vec<u8>>>> {
+        let stream = source.differentiate_within(target, scope, storage, storage);
+        futures_util::pin_mut!(stream);
+        let mut changes = vec![];
+        while let Some(change) = stream.next().await {
+            changes.push(change?);
+        }
+        Ok(changes)
+    }
+
+    /// A scoped diff yields exactly the full diff filtered to the
+    /// scope: in-scope changes are never dropped, boundary spillover
+    /// from one-sided pruning is filtered out.
+    ///
+    /// Keys stay below 256 so little-endian key bytes order the same
+    /// as the numbers they encode.
+    #[dialog_common::test]
+    async fn it_scopes_changes_to_the_given_ranges() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(CountingBackend::new());
+        let base = build((0..250u32).map(|i| (i, vec![0])), &mut storage).await?;
+
+        // Two changed regions far apart in key space.
+        let mut target = base.clone();
+        let mut delta = Delta::zero();
+        for i in (10..20u32).chain(200..210u32) {
+            target = target
+                .edit()
+                .insert(i.to_le_bytes(), vec![1], &storage)
+                .await?
+                .persist(&mut delta)?;
+            for (_, buffer) in delta.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
+            }
+        }
+
+        let scope = vec![0u32.to_le_bytes()..=50u32.to_le_bytes()];
+
+        let full = collect_changes(&base, &target, &storage).await?;
+        let scoped = collect_scoped_changes(&base, &target, &scope, &storage).await?;
+
+        let key = |change: &Change<[u8; 4], Vec<u8>>| match change {
+            Change::Add(entry) => entry.key,
+            Change::Remove(entry) => entry.key,
+        };
+        let expected: Vec<[u8; 4]> = full
+            .iter()
+            .filter(|change| scope.iter().any(|range| range.contains(&key(change))))
+            .map(&key)
+            .collect();
+        let actual: Vec<[u8; 4]> = scoped.iter().map(&key).collect();
+
+        assert_eq!(
+            actual, expected,
+            "scoped diff must equal the full diff filtered to scope"
+        );
+        assert_eq!(
+            scoped.len(),
+            20,
+            "ten modified keys in scope, one Remove + one Add each"
+        );
+        assert!(
+            scoped.iter().all(|change| {
+                key(change) >= 10u32.to_le_bytes() && key(change) < 20u32.to_le_bytes()
+            }),
+            "only the in-scope region's keys appear"
+        );
+        Ok(())
+    }
+
+    /// The point of scoping on a partial replica: subtrees whose key
+    /// span misses the scope are never read, so a scoped diff reads
+    /// strictly fewer blocks than the full diff when the
+    /// out-of-scope region changed heavily.
+    #[dialog_common::test]
+    async fn it_avoids_reading_out_of_scope_subtrees() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(CountingBackend::new());
+        let base = build((0..250u32).map(|i| (i, vec![0])), &mut storage).await?;
+
+        // A small in-scope change and a heavy out-of-scope change.
+        let mut target = base.clone();
+        let mut delta = Delta::zero();
+        for i in (10..12u32).chain(100..250u32) {
+            target = target
+                .edit()
+                .insert(i.to_le_bytes(), vec![1], &storage)
+                .await?
+                .persist(&mut delta)?;
+            for (_, buffer) in delta.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
+            }
+        }
+
+        let scope = vec![0u32.to_le_bytes()..=20u32.to_le_bytes()];
+
+        let before_full = storage.backend().reads();
+        let full = collect_changes(&base, &target, &storage).await?;
+        let full_reads = storage.backend().reads() - before_full;
+
+        let before_scoped = storage.backend().reads();
+        let scoped = collect_scoped_changes(&base, &target, &scope, &storage).await?;
+        let scoped_reads = storage.backend().reads() - before_scoped;
+
+        assert_eq!(scoped.len(), 4, "two in-scope keys, Remove + Add each");
+        assert!(full.len() > scoped.len());
+        assert!(
+            scoped_reads < full_reads,
+            "scoped diff must skip out-of-scope subtrees: \
+             scoped {scoped_reads} reads vs full {full_reads} reads"
+        );
+        Ok(())
     }
 
     async fn collect_changes(

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -263,6 +263,37 @@ where
         }
     }
 
+    /// Streams the changes *within `scope`* that transform this tree into
+    /// `other`.
+    ///
+    /// Like [`differentiate`](Self::differentiate), but subtrees whose key
+    /// span cannot intersect any scope range are dropped from the
+    /// comparison without being loaded: reads are proportional to the
+    /// differing regions within the scope, not to the full difference. On
+    /// a partial replica this keeps the diff from fetching subtrees the
+    /// caller never demanded.
+    pub fn differentiate_within<'a, Backend>(
+        &'a self,
+        other: &'a Self,
+        scope: &'a [core::ops::RangeInclusive<Key>],
+        self_storage: &'a ContentAddressedStorage<Backend>,
+        other_storage: &'a ContentAddressedStorage<Backend>,
+    ) -> impl Differential<Key, Value> + 'a
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+        Value: PartialEq,
+    {
+        async_stream::try_stream! {
+            let difference =
+                TreeDifference::compute_within(self, other, self_storage, other_storage, scope)
+                    .await?;
+            for await change in difference.changes_within(scope) {
+                yield change?;
+            }
+        }
+    }
+
     /// Builds a persistent tree from a sealed root hash and a node cache. Used
     /// by [`TransientTree::persist`] to turn a finished edit batch back into a
     /// [`PersistentTree`] while carrying its cache forward. The batch's new nodes


### PR DESCRIPTION
Stacked on #378. Two follow-ups from the subscriptions design, in dependency order:

## 1. Cover-scoped differentiation (partial-replica friendliness)

`differentiate` is hash-skipping but enumerates *every* change between two roots — a heavy change outside a subscription's cover still got descended into, and on a partial replica that descent lazy-fetches subtrees the subscription never demanded.

`dialog-search-tree` gains `differentiate_within(scope)` / `TreeDifference::compute_within` / `changes_within`: subtrees whose key span cannot intersect any scope range are dropped from the comparison **without being loaded**. Links carry only upper bounds, so a node's span is bounded conservatively by its frontier predecessor's upper bound — sound because pruning only ever removes nodes (the bound can over-retain, never over-drop), and boundary spillover from one-sided drops is filtered at the change stream, leaving exactly the in-scope changes.

`Subscription` polls now diff within the demand cover: reads are proportional to the changes *inside the cover*, not the full delta. Pinned by tests: scoped changes equal the full diff filtered to scope, and a heavy out-of-scope change costs the scoped diff strictly fewer block reads (`CountingBackend`).

## 2. DRed/FBF incremental maintenance

Covered fact changes no longer recompute the whole query.

- The demand cover splits into **fact ranges** and **rule-discovery ranges**. A rule-range hit can install a rule, which can affect any row → full re-evaluation (the only remaining recompute trigger besides unsupported shapes).
- Fact changes name their subject entities from the changed datums (datum-less changes — tombstones over never-asserted keys — cannot alter any read and are skipped). For each touched entity: over-delete its retained rows, re-derive by evaluating the query **restricted to that entity** (`Application::restrict`). The goal-directed re-evaluation is simultaneously DRed's re-derive and insert steps, and it resolves FBF's multi-derivation retraction concern exactly, without counting: a row with a surviving derivation simply re-derives.
- **Soundness gate**: per-entity re-derivation is sound only when a change to entity `E` affects only `E`'s rows. Attribute queries have that by construction; concept queries are gated on their resolved rule set — every rule entity-local (`AnalyzedRule::is_entity_local`: all attribute premises `of ?this`, remaining premises row-local; concept premises are cross-entity) and non-recursive. Everything else falls back to a full recompute, which is always sound. `restrict` also refuses to pin a subject variable that joins another slot.
- `recomputes()` / `maintenances()` counters expose which path each poll took; the tests assert covered asserts and retracts complete with **zero additional recomputes**.

New dialog-query surface: `Application::restrict` (`Restriction::{Scoped, Unaffected, Unsupported}`), `Application::concept`, `AnalyzedRule::is_entity_local`, and `Conclusion for Claim` (subject = `of`).

## Recorded follow-ups (dialog-db-39)

Derived `Query<C>` structs currently take the safe recompute fallback (needs derive-emitted `restrict` + `PartialEq` conclusions); non-entity-local rules need cross-entity delta-joins; then dynamically maintained demand (Dynamic Magic Sets), interval merging, pin GC.

Full native suite: 1682 passed. Clippy `-D warnings` clean.