### PR TITLE
feat(dialog-repository): dynamic demand maintenance (delta-join discovery)

### DIFF
--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -416,6 +416,51 @@ pub fn derive(input: TokenStream) -> TokenStream {
                     #(#realize_fields,)*
                 })
             }
+
+            // Restriction to one subject entity: the goal-directed
+            // unit incremental subscription maintenance re-derives
+            // with. Pinning is refused when the subject variable
+            // joins a field term through a shared name (the pin
+            // would sever the join).
+            fn restrict(&self, entity: &dialog_query::Entity) -> dialog_query::query::Restriction<Self> {
+                use dialog_query::query::Restriction;
+                match &self.this {
+                    dialog_query::Term::Constant(dialog_query::Value::Entity(this)) => {
+                        return if this == entity {
+                            Restriction::Scoped(self.clone())
+                        } else {
+                            Restriction::Unaffected
+                        };
+                    }
+                    dialog_query::Term::Constant(_) => return Restriction::Unaffected,
+                    dialog_query::Term::Variable { name: Some(name), .. } => {
+                        let shared = [ #( self.#field_names.name() ),* ]
+                            .into_iter()
+                            .flatten()
+                            .any(|other| other == name.as_str());
+                        if shared {
+                            return Restriction::Unsupported;
+                        }
+                    }
+                    dialog_query::Term::Variable { name: None, .. } => {}
+                }
+                let mut scoped = self.clone();
+                scoped.this = dialog_query::Term::Constant(
+                    dialog_query::Value::Entity(entity.clone()),
+                );
+                Restriction::Scoped(scoped)
+            }
+
+            // The concept this query applies; lets incremental
+            // maintainers resolve the rule set for the soundness
+            // gate.
+            fn concept(&self) -> std::option::Option<&dialog_query::ConceptDescriptor> {
+                std::option::Option::Some(
+                    <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor(),
+                )
+            }
         }
 
         // Add inherent perform method so users don't need to import Application trait

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -1,5 +1,7 @@
 /// Adornment types for parameter binding pattern caching.
 pub mod adornment;
+/// Affected-entity discovery for incremental maintenance.
+pub mod affected;
 /// Semi-naive fixpoint evaluation for recursive concepts.
 pub mod fixpoint;
 /// Shared, branch-owned plan cache keyed by (rule identity, adornment).

--- a/rust/dialog-query/src/concept/query/affected.rs
+++ b/rust/dialog-query/src/concept/query/affected.rs
@@ -1,0 +1,299 @@
+//! Affected-entity discovery: the delta-join step of incremental
+//! subscription maintenance.
+//!
+//! Given a set of changed base facts and a subscribed concept, which
+//! head entities can the changes affect? For an *entity-local* rule
+//! (every premise reads `of ?this`) the answer is just the changed
+//! facts' subjects. For a non-local rule — one whose body reads
+//! other entities' facts through a concept premise (a concept-typed
+//! field's conformance check, a variant's negation) — the answer is
+//! discovered by a *delta-join*: bind the changed fact into the
+//! premise it can match, evaluate the rule's remaining premises
+//! sideways with those bindings, and project the head variable.
+//! Each affected head is then re-derived goal-directedly by the
+//! caller (DRed's delete/re-derive, per entity).
+//!
+//! The discovery over-approximates but never misses: a fact bound
+//! into a premise it merely *could* match yields candidate heads,
+//! and re-derivation settles the truth per head. `None` means the
+//! discovery could not bound the affected set (recursion, a rule
+//! shape it does not handle, an unplannable sideways join) and the
+//! caller must fall back to full re-evaluation, which is always
+//! sound.
+
+use std::collections::BTreeSet;
+
+use dialog_capability::Provider;
+use dialog_common::ConditionalSync;
+use futures_util::TryStreamExt as _;
+
+use crate::artifact::{Artifact, Select};
+use crate::attribute::The;
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::concept::query::ConceptQuery;
+use crate::error::EvaluationError;
+use crate::negation::Negation;
+use crate::planner::Planner;
+use crate::premise::Premise;
+use crate::proposition::Proposition;
+use crate::rule::deductive::DeductiveRule;
+use crate::selection::{Binding, Match};
+use crate::source::SelectRules;
+use crate::term::Term;
+use crate::types::Any;
+use crate::{Entity, Environment, Value};
+
+/// The head entities of `concept` that the changed facts can
+/// affect, or `None` when the set cannot be bounded and the caller
+/// must re-evaluate in full.
+///
+/// Nesting is followed one level: a concept premise whose target's
+/// rules are all entity-local contributes its affected heads
+/// (over-approximated by the changed facts' subjects); a target
+/// with non-local rules of its own, or any recursion, returns
+/// `None`.
+pub async fn affected_entities<'a, Env>(
+    concept: &ConceptDescriptor,
+    facts: &[Artifact],
+    env: &'a Env,
+) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let bundle = Provider::<SelectRules>::execute(env, concept.clone()).await?;
+    if bundle.recursion().is_some() {
+        return Ok(None);
+    }
+
+    let subjects: BTreeSet<Entity> = facts.iter().map(|fact| fact.of.clone()).collect();
+    let mut affected = BTreeSet::new();
+
+    for rule in bundle.rules() {
+        if rule.analysis().is_entity_local() {
+            // A change to E's facts only affects E's rows.
+            affected.extend(subjects.iter().cloned());
+            continue;
+        }
+        match rule_heads(rule, facts, &subjects, env).await? {
+            Some(heads) => affected.extend(heads),
+            None => return Ok(None),
+        }
+    }
+
+    Ok(Some(affected))
+}
+
+/// The candidate head entities one non-local rule can produce or
+/// retract given the changed facts: per premise, bind what the
+/// change can match and join the remaining premises sideways.
+async fn rule_heads<'a, Env>(
+    rule: &DeductiveRule,
+    facts: &[Artifact],
+    subjects: &BTreeSet<Entity>,
+    env: &'a Env,
+) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let premises = &rule.analysis().premises;
+    let mut heads = BTreeSet::new();
+
+    for (index, premise) in premises.iter().enumerate() {
+        // Attribute premises (positive, optional, or negated) are
+        // matched directly by the changed facts.
+        let attribute_terms = match premise {
+            Premise::Assert(Proposition::Attribute(query)) => {
+                Some((query.the().clone(), query.of().clone(), query.is().clone()))
+            }
+            Premise::Assert(Proposition::OptionalAttribute(query)) => Some((
+                query.query().the().clone(),
+                query.of().clone(),
+                query.is().clone(),
+            )),
+            Premise::Unless(Negation(Proposition::Attribute(query))) => {
+                Some((query.the().clone(), query.of().clone(), query.is().clone()))
+            }
+            _ => None,
+        };
+        if let Some((the, of, is)) = attribute_terms {
+            for fact in facts {
+                let mut matched = Match::new();
+                let mut scope = Environment::new();
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    the.as_constant(),
+                    the.name(),
+                    Value::from(The::from(fact.the.clone())),
+                ) {
+                    continue;
+                }
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    of.as_constant(),
+                    of.name(),
+                    Value::Entity(fact.of.clone()),
+                ) {
+                    continue;
+                }
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    is.as_constant(),
+                    is.name(),
+                    fact.is.clone(),
+                ) {
+                    continue;
+                }
+                match sideways_heads(premises, index, matched, &scope, rule, env).await? {
+                    Some(found) => heads.extend(found),
+                    None => return Ok(None),
+                }
+            }
+            continue;
+        }
+
+        // Concept premises (positive or negated): the change affects
+        // the target's rows for some entities; each such entity,
+        // bound into the premise's `this` slot, joins sideways to
+        // candidate heads. One nesting level: the target's rules
+        // must all be entity-local, so its affected heads are the
+        // changed facts' subjects (over-approximated).
+        let concept_query = match premise {
+            Premise::Assert(Proposition::Concept(query)) => Some(query),
+            Premise::Unless(Negation(Proposition::Concept(query))) => Some(query),
+            _ => None,
+        };
+        if let Some(query) = concept_query {
+            match target_locality(query, env).await? {
+                Locality::Local => {}
+                Locality::NonLocal => return Ok(None),
+            }
+            let Some(this) = query.terms.get("this") else {
+                return Ok(None);
+            };
+            for entity in subjects {
+                let mut matched = Match::new();
+                let mut scope = Environment::new();
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    this.as_constant(),
+                    this.name(),
+                    Value::Entity(entity.clone()),
+                ) {
+                    continue;
+                }
+                match sideways_heads(premises, index, matched, &scope, rule, env).await? {
+                    Some(found) => heads.extend(found),
+                    None => return Ok(None),
+                }
+            }
+        }
+    }
+
+    Ok(Some(heads))
+}
+
+/// Whether a nested concept premise's target can contribute
+/// entity-local affected heads.
+enum Locality {
+    /// Every target rule is entity-local and non-recursive.
+    Local,
+    /// The target has non-local rules or recursion: fall back.
+    NonLocal,
+}
+
+async fn target_locality<'a, Env>(
+    query: &ConceptQuery,
+    env: &'a Env,
+) -> Result<Locality, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let bundle = Provider::<SelectRules>::execute(env, query.predicate.clone()).await?;
+    if bundle.recursion().is_some() {
+        return Ok(Locality::NonLocal);
+    }
+    if bundle.rules().all(|rule| rule.analysis().is_entity_local()) {
+        Ok(Locality::Local)
+    } else {
+        Ok(Locality::NonLocal)
+    }
+}
+
+/// Bind one premise slot from a changed value. A constant slot
+/// filters (the fact must match it); a named variable binds; a
+/// blank slot matches anything. Returns `false` when the fact
+/// cannot match the slot.
+fn bind_slot(
+    matched: &mut Match,
+    scope: &mut Environment,
+    constant: Option<&Value>,
+    name: Option<&str>,
+    value: Value,
+) -> bool {
+    if let Some(expected) = constant {
+        return *expected == value;
+    }
+    match name {
+        Some(name) => {
+            if matched.bind(&Term::<Any>::var(name), value).is_err() {
+                return false;
+            }
+            scope.add(name);
+            true
+        }
+        None => true,
+    }
+}
+
+/// Join the rule's remaining premises against the bound match and
+/// project the head (`?this`) of every result. `None` when the
+/// sideways join cannot be planned from these bindings or a result
+/// leaves the head unbound — the caller falls back.
+async fn sideways_heads<'a, Env>(
+    premises: &[Premise],
+    source: usize,
+    matched: Match,
+    scope: &Environment,
+    rule: &DeductiveRule,
+    env: &'a Env,
+) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    // The head may already be bound by the source premise itself.
+    if let Ok(Binding::Present(Value::Entity(entity))) = matched.lookup(&Term::<Any>::var("this")) {
+        return Ok(Some(BTreeSet::from([entity])));
+    }
+
+    let rest: Vec<Premise> = premises
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index != source)
+        .map(|(_, premise)| premise.clone())
+        .collect();
+    if rest.is_empty() {
+        // Only the source premise, and it does not bind the head:
+        // nothing to join through.
+        return Ok(None);
+    }
+
+    let Ok(plan) = Planner::with_types(rest, rule.analysis().types.clone()).plan(scope) else {
+        return Ok(None);
+    };
+
+    let mut heads = BTreeSet::new();
+    let results: Vec<Match> = plan.evaluate(matched.seed(), env).try_collect().await?;
+    for result in results {
+        match result.lookup(&Term::<Any>::var("this")) {
+            Ok(Binding::Present(Value::Entity(entity))) => {
+                heads.insert(entity);
+            }
+            _ => return Ok(None),
+        }
+    }
+    Ok(Some(heads))
+}

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -10,13 +10,15 @@ use dialog_common::ConditionalSync;
 use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::{Identify, Operator, OperatorExt as _};
 use dialog_effects::memory::Resolve;
-use dialog_query::DeductiveRule;
 use dialog_query::concept::descriptor::ConceptDescriptor;
-use dialog_query::concept::query::ConceptRules;
+use dialog_query::concept::query::{ConceptRules, PlanCache};
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output};
+use dialog_query::session::ProgramAnalysis;
 use dialog_query::source::SelectRules;
+use dialog_query::{DeductiveRule, Negation, Premise, Proposition};
 use futures_util::TryStreamExt as _;
+use std::sync::Arc;
 
 use crate::layer::{filter_tombstones, merge_grouped, tombstones_from};
 use crate::rules::{
@@ -477,6 +479,15 @@ where
     /// each branch is a durable layer (committed `db.rule/*`, head-cached),
     /// the overlay is a transient layer (uncommitted `db.rule/*`, fresh).
     /// The implicit per-descriptor rule is assembled once on top.
+    ///
+    /// The resolved rule set is checked against the program analysis
+    /// of its dependency closure: an ill-stratified closure fails
+    /// here (exactly like [`RuleRegistry::acquire`]), and a concept
+    /// on a (stratified) cycle gets the analysis attached so
+    /// evaluation runs the semi-naive fixpoint instead of recursing
+    /// top-down unboundedly.
+    ///
+    /// [`RuleRegistry::acquire`]: dialog_query::session::RuleRegistry::acquire
     async fn execute(&self, input: ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
         let concept = input.this();
         let mut rules: Vec<DeductiveRule> = Vec::new();
@@ -497,7 +508,81 @@ where
             .map(|branch| branch.plan_cache())
             .unwrap_or_default();
 
-        Ok(assemble(&input, rules, plan_cache))
+        let bundle = assemble(&input, rules, plan_cache);
+        let analysis = self.program_analysis(&input, &bundle).await?;
+        analysis.check(&input)?;
+        Ok(if analysis.is_recursive(&concept) {
+            bundle.with_recursion(analysis)
+        } else {
+            bundle
+        })
+    }
+}
+
+impl<'a, Env> QueryEnv<'a, Env>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    /// The program analysis over the rule set reachable from `root`:
+    /// every concept referenced (transitively) by a resolved rule's
+    /// concept premises contributes its own resolved rules, so
+    /// cycles that span concepts — including ones closed entirely by
+    /// durable rules — are visible.
+    ///
+    /// Per-concept rule discovery is head-cached
+    /// ([`durable_rules`](Self::durable_rules)), so the walk is
+    /// cheap after the first query at a given head.
+    async fn program_analysis(
+        &self,
+        root: &ConceptDescriptor,
+        root_bundle: &ConceptRules,
+    ) -> Result<Arc<ProgramAnalysis>, EvaluationError> {
+        fn referenced(bundle: &ConceptRules, queue: &mut Vec<ConceptDescriptor>) {
+            for rule in bundle.rules() {
+                for premise in rule.analysis().premises() {
+                    match premise {
+                        Premise::Assert(Proposition::Concept(query))
+                        | Premise::Unless(Negation(Proposition::Concept(query))) => {
+                            queue.push(query.predicate.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        let mut entries: Vec<(Entity, ConceptRules)> = Vec::new();
+        let mut seen = HashSet::new();
+        let mut queue = Vec::new();
+
+        seen.insert(root.this());
+        referenced(root_bundle, &mut queue);
+        entries.push((root.this(), root_bundle.clone()));
+
+        while let Some(descriptor) = queue.pop() {
+            let entity = descriptor.this();
+            if !seen.insert(entity.clone()) {
+                continue;
+            }
+            let mut rules: Vec<DeductiveRule> = Vec::new();
+            for branch in &self.branches {
+                rules.extend(self.durable_rules(branch, &entity).await?);
+            }
+            rules.extend(overlay_rules(&self.changes, &entity));
+            let bundle = assemble(&descriptor, rules, PlanCache::default());
+            referenced(&bundle, &mut queue);
+            entries.push((entity, bundle));
+        }
+
+        Ok(Arc::new(ProgramAnalysis::analyze(
+            entries.iter().map(|(entity, bundle)| (entity, bundle)),
+        )))
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -36,13 +36,18 @@
 //! simply re-derived, which handles the multi-derivation retraction
 //! case (FBF's concern) exactly, without counting.
 //!
-//! Per-entity re-derivation is sound only when a change to entity
-//! `E` can only affect rows whose subject is `E`. Attribute queries
-//! have this by construction; concept queries are gated on their
-//! resolved rule set — every rule entity-local
-//! ([`AnalyzedRule::is_entity_local`]) and non-recursive — and
-//! anything else falls back to a full recompute, which is always
-//! sound. [`recomputes`](Subscription::recomputes) and
+//! For attribute queries the affected entities are the changed
+//! facts' subjects. For concept queries they are discovered against
+//! the resolved rule set
+//! ([`affected_entities`]): entity-local rules
+//! ([`AnalyzedRule::is_entity_local`]) contribute the changed
+//! subjects, and non-local rules — concept premises reading *other*
+//! entities' facts (a conformance check, a variant's negation) —
+//! contribute delta-join heads: the changed fact bound into the
+//! premise it matches, the remaining premises joined sideways, the
+//! head variable projected. Recursion and shapes the discovery does
+//! not handle fall back to a full recompute, which is always sound.
+//! [`recomputes`](Subscription::recomputes) and
 //! [`maintenances`](Subscription::maintenances) expose which path
 //! each poll took.
 //!
@@ -61,7 +66,7 @@ use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{ArtifactSelector, Entity, KeyBytes, State};
+use dialog_artifacts::{Artifact, ArtifactSelector, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -70,9 +75,9 @@ use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
 use dialog_query::Conclusion;
+use dialog_query::concept::query::affected::affected_entities;
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output as _, Restriction};
-use dialog_query::source::SelectRules;
 use dialog_search_tree::{Change, ContentAddressedStorage};
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
@@ -226,9 +231,14 @@ enum Touched {
     /// A rule-discovery range changed: the rule set may differ, so
     /// any row may be affected.
     Rules,
-    /// Only fact ranges changed; the set of subject entities whose
-    /// facts changed.
-    Facts(BTreeSet<Entity>),
+    /// Only fact ranges changed: the changed facts (deduplicated
+    /// across the three index orders) and their subject entities.
+    Facts {
+        /// Subjects of the changed facts.
+        subjects: BTreeSet<Entity>,
+        /// The changed facts themselves, for delta-join discovery.
+        facts: Vec<Artifact>,
+    },
 }
 
 /// The index root a revision pins, or the empty tree for an
@@ -306,8 +316,8 @@ where
                     self.revision = current;
                     return Ok(None);
                 }
-                Touched::Facts(entities) => {
-                    if let Some(delta) = self.maintain(env, &entities).await? {
+                Touched::Facts { subjects, facts } => {
+                    if let Some(delta) = self.maintain(env, &subjects, &facts).await? {
                         self.maintenances += 1;
                         self.revision = current;
                         return Ok(Some(delta));
@@ -397,7 +407,11 @@ where
 
         let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
-        let mut entities = BTreeSet::new();
+        let mut subjects = BTreeSet::new();
+        let mut facts = Vec::new();
+        // A fact change surfaces once per index order; dedup on the
+        // datum triple.
+        let mut seen = BTreeSet::new();
         while let Some(change) = changes
             .try_next()
             .await
@@ -411,17 +425,24 @@ where
                 return Ok(Touched::Rules);
             }
             if let State::Added(datum) = &entry.value {
-                let entity = datum.entity.parse().map_err(|error| {
-                    EvaluationError::Store(format!("changed datum entity: {error:?}"))
-                })?;
-                entities.insert(entity);
+                if !seen.insert((
+                    datum.entity.clone(),
+                    datum.attribute.clone(),
+                    datum.value.clone(),
+                )) {
+                    continue;
+                }
+                let fact = Artifact::try_from(datum.clone())
+                    .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
+                subjects.insert(fact.of.clone());
+                facts.push(fact);
             }
         }
 
-        if entities.is_empty() {
+        if subjects.is_empty() {
             Ok(Touched::Nothing)
         } else {
-            Ok(Touched::Facts(entities))
+            Ok(Touched::Facts { subjects, facts })
         }
     }
 
@@ -434,15 +455,15 @@ where
     /// is what makes multi-derivation retractions exact without
     /// counting).
     ///
-    /// Returns `Ok(None)` when the query or its rule set cannot be
-    /// maintained per-entity — the query is not restrictable, a rule
-    /// reads other entities' facts (not entity-local), or the
-    /// concept is recursive — in which case the caller falls back to
-    /// a full recompute.
+    /// Returns `Ok(None)` when the affected set cannot be bounded —
+    /// the query is not restrictable, the concept is recursive, or
+    /// the delta-join discovery hit a shape it does not handle — in
+    /// which case the caller falls back to a full recompute.
     async fn maintain<Env>(
         &mut self,
         env: &Env,
-        entities: &BTreeSet<Entity>,
+        subjects: &BTreeSet<Entity>,
+        facts: &[Artifact],
     ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
@@ -454,12 +475,19 @@ where
             + ConditionalSync
             + 'static,
     {
-        // Soundness gate for concept queries: every rule must be
-        // entity-local (reads only `?this`'s facts) and
-        // non-recursive, otherwise a change to entity E can affect
-        // other entities' rows and per-entity re-derivation would
-        // miss them.
-        if let Some(concept) = self.query.concept() {
+        // For a concept query the affected heads are discovered
+        // against the resolved rule set: entity-local rules
+        // contribute the changed subjects, non-local rules (concept
+        // premises: conformance checks, variant negations)
+        // contribute delta-join heads — the changed fact bound into
+        // the premise it matches, remaining premises joined
+        // sideways, head projected. `None` (recursion, unhandled
+        // shape) falls back to full recompute. For a plain attribute
+        // query the affected heads are just the changed subjects.
+        //
+        // The discovery evaluates against the demand-recording
+        // environment, so the reads it depends on join the cover.
+        let entities: BTreeSet<Entity> = if let Some(concept) = self.query.concept() {
             let operator = Identify
                 .perform(env)
                 .await
@@ -469,18 +497,17 @@ where
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
                 .with_demand(self.demand.clone());
-            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
-            if rules.recursion().is_some() {
-                return Ok(None);
+            match affected_entities(concept, facts, &query_env).await? {
+                Some(entities) => entities,
+                None => return Ok(None),
             }
-            if !rules.rules().all(|rule| rule.analysis().is_entity_local()) {
-                return Ok(None);
-            }
-        }
+        } else {
+            subjects.clone()
+        };
 
         let mut asserted = Vec::new();
         let mut retracted = Vec::new();
-        for entity in entities {
+        for entity in &entities {
             let scoped = match self.query.restrict(entity) {
                 Restriction::Scoped(query) => query,
                 Restriction::Unaffected => continue,
@@ -557,6 +584,7 @@ mod tests {
     use crate::helpers::{test_operator_with_profile, test_repo};
     use dialog_artifacts::{Entity, Value};
     use dialog_query::attribute::The;
+    use dialog_query::types::Any;
     use dialog_query::{AttributeQuery, Claim, Term, the};
 
     /// A standing query over every `person/name` fact.
@@ -970,6 +998,517 @@ mod tests {
         expected.sort();
         assert_eq!(retained, expected);
         assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    mod concepts {
+        //! Derived concepts + attributes shared by the incremental
+        //! maintenance tests below.
+
+        use dialog_artifacts::Entity;
+        use dialog_query::{Attribute, Concept};
+
+        /// A badge number (`credential/badge`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("credential")]
+        pub struct Badge(pub String);
+
+        /// A report's display name (`report/name`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("report")]
+        pub struct Name(pub String);
+
+        /// The report's manager (`report/manager`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("report")]
+        pub struct Manager(pub Entity);
+
+        /// Someone holding a badge.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct BadgeHolder {
+            /// The badge holder entity.
+            pub this: Entity,
+            /// Their badge number.
+            pub badge: Badge,
+        }
+
+        /// Someone reporting to a badge holder.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct Report {
+            /// The report entity.
+            pub this: Entity,
+            /// Their display name.
+            pub name: Name,
+            /// Their manager, who must hold a badge.
+            #[dialog(conforms = BadgeHolder)]
+            pub manager: Manager,
+        }
+
+        /// An email handle (`comm/email`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("comm")]
+        pub struct Email(pub String);
+
+        /// A phone handle (`comm/phone`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("comm")]
+        pub struct Phone(pub String);
+
+        /// A contact handle (`contact/handle`) — the variant
+        /// conclusion.
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("contact")]
+        pub struct Handle(pub String);
+
+        /// A user with an email address.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct WithEmail {
+            /// The user entity.
+            pub this: Entity,
+            /// Their email handle.
+            pub handle: Email,
+        }
+
+        /// A user with a phone number.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct WithPhone {
+            /// The user entity.
+            pub this: Entity,
+            /// Their phone handle.
+            pub handle: Phone,
+        }
+
+        /// The preferred way to reach a user: email if they have
+        /// one, otherwise phone.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct Contact {
+            /// The user entity.
+            pub this: Entity,
+            /// The winning handle.
+            pub handle: Handle,
+        }
+
+        /// A parent edge (`family/parent`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("family")]
+        pub struct Parent(pub Entity);
+
+        /// An ancestor edge (`family/ancestor`) — the recursive
+        /// conclusion.
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("family")]
+        pub struct Ancestor(pub Entity);
+
+        /// Direct parenthood.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct HasParent {
+            /// The child entity.
+            pub this: Entity,
+            /// Their parent.
+            pub parent: Parent,
+        }
+
+        /// The transitive closure of parenthood.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct HasAncestor {
+            /// The descendant entity.
+            pub this: Entity,
+            /// One of their ancestors.
+            pub ancestor: Ancestor,
+        }
+    }
+
+    /// Stage the `db.rule/*` facts that persist a deductive rule
+    /// durably (the storage shape from `crate::rules`).
+    fn with_rule<'t>(
+        transaction: crate::Transaction<'t>,
+        rule: &dialog_query::DeductiveRule,
+    ) -> crate::Transaction<'t> {
+        let entity = rule.this();
+        transaction
+            .assert(
+                the!("db.rule/conclusion")
+                    .of(entity.clone())
+                    .is(rule.conclusion().this()),
+            )
+            .assert(the!("db.rule/source").of(entity).is(rule.encode()))
+    }
+
+    /// A rule `conclusion :- Concept(target, terms)` built from
+    /// derived concept descriptors, storable as a durable rule.
+    fn concept_rule(
+        conclusion: &dialog_query::ConceptDescriptor,
+        premises: Vec<dialog_query::Premise>,
+    ) -> dialog_query::DeductiveRule {
+        dialog_query::DeductiveRule::new(conclusion.clone(), premises).expect("rule compiles")
+    }
+
+    fn concept_premise(
+        target: &dialog_query::ConceptDescriptor,
+        bindings: &[(&str, &str)],
+    ) -> dialog_query::Premise {
+        let mut terms = dialog_query::Parameters::new();
+        for (param, variable) in bindings {
+            terms.insert((*param).to_string(), Term::<Any>::var(*variable));
+        }
+        dialog_query::Premise::Assert(dialog_query::Proposition::Concept(
+            dialog_query::ConceptQuery {
+                terms,
+                predicate: target.clone(),
+            },
+        ))
+    }
+
+    fn negated_concept_premise(
+        target: &dialog_query::ConceptDescriptor,
+        bindings: &[(&str, &str)],
+    ) -> dialog_query::Premise {
+        let mut terms = dialog_query::Parameters::new();
+        for (param, variable) in bindings {
+            terms.insert((*param).to_string(), Term::<Any>::var(*variable));
+        }
+        dialog_query::Premise::Unless(dialog_query::Negation(dialog_query::Proposition::Concept(
+            dialog_query::ConceptQuery {
+                terms,
+                predicate: target.clone(),
+            },
+        )))
+    }
+
+    /// Piece 1: a derived `Query<C>` subscription over an
+    /// entity-local concept is maintained incrementally.
+    #[dialog_common::test]
+    async fn it_maintains_derived_concept_subscriptions() -> anyhow::Result<()> {
+        use concepts::{Badge, BadgeHolder};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(Badge::of(alice.clone()).is("A-1"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<BadgeHolder>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            initial.asserted,
+            vec![BadgeHolder {
+                this: alice.clone(),
+                badge: Badge("A-1".into()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 1);
+
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(Badge::of(bob.clone()).is("B-2"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("covered write");
+        assert_eq!(
+            delta.asserted,
+            vec![BadgeHolder {
+                this: bob.clone(),
+                badge: Badge("B-2".into()),
+            }]
+        );
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the derived query restricted to the touched entity"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    /// Piece 2, conformance: a badge change for a *manager* affects
+    /// the *report* entity's rows (cross-entity), discovered by the
+    /// delta-join and maintained without a recompute.
+    #[dialog_common::test]
+    async fn it_maintains_cross_entity_conformance() -> anyhow::Result<()> {
+        use concepts::{Badge, Manager, Name, Report};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?; // manager WITH a badge
+        let carol = Entity::new()?; // manager WITHOUT a badge (yet)
+        let bob = Entity::new()?; // reports to alice
+        let mallory = Entity::new()?; // reports to carol
+
+        branch
+            .transaction()
+            .assert(Badge::of(alice.clone()).is("A-1"))
+            .assert(Name::of(bob.clone()).is("Bob"))
+            .assert(Manager::of(bob.clone()).is(alice.clone()))
+            .assert(Name::of(mallory.clone()).is("Mallory"))
+            .assert(Manager::of(mallory.clone()).is(carol.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<Report>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            initial.asserted,
+            vec![Report {
+                this: bob.clone(),
+                name: Name("Bob".into()),
+                manager: Manager(alice.clone()),
+            }],
+            "only the report whose manager holds a badge conforms"
+        );
+
+        // Carol gets a badge: mallory's row appears, though the
+        // changed fact's subject is carol, not mallory.
+        branch
+            .transaction()
+            .assert(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("cross-entity effect");
+        assert_eq!(
+            delta.asserted,
+            vec![Report {
+                this: mallory.clone(),
+                name: Name("Mallory".into()),
+                manager: Manager(carol.clone()),
+            }]
+        );
+        assert!(delta.retracted.is_empty());
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the affected report was discovered by the delta-join, not a recompute"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+
+        // And the retraction flows back the same way.
+        branch
+            .transaction()
+            .retract(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(
+            delta.retracted,
+            vec![Report {
+                this: mallory.clone(),
+                name: Name("Mallory".into()),
+                manager: Manager(carol.clone()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
+        Ok(())
+    }
+
+    /// Piece 2, variants: committing a rule re-triggers via the
+    /// rule-discovery range (full recompute — the rule set changed);
+    /// afterwards a fact write that flips a negated variant is
+    /// maintained incrementally through the delta-join.
+    #[dialog_common::test]
+    async fn it_maintains_variant_negation_flips() -> anyhow::Result<()> {
+        use concepts::{Contact, Email, Handle, Phone, WithEmail, WithPhone};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let contact = Contact::descriptor().clone();
+        let email = WithEmail::descriptor().clone();
+        let phone = WithPhone::descriptor().clone();
+
+        let email_rule = concept_rule(
+            &contact,
+            vec![concept_premise(
+                &email,
+                &[("this", "this"), ("handle", "handle")],
+            )],
+        );
+        let phone_rule = concept_rule(
+            &contact,
+            vec![
+                concept_premise(&phone, &[("this", "this"), ("handle", "handle")]),
+                negated_concept_premise(&email, &[("this", "this")]),
+            ],
+        );
+
+        let bob = Entity::new()?;
+        let transaction = branch
+            .transaction()
+            .assert(Phone::of(bob.clone()).is("555-0100"));
+        with_rule(transaction, &email_rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<Contact>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert!(
+            initial.asserted.is_empty(),
+            "only the email rule is installed and bob has no email"
+        );
+
+        // Installing the phone rule lands in the rule-discovery
+        // range: recompute.
+        with_rule(branch.transaction(), &phone_rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("rule installed");
+        assert_eq!(
+            delta.asserted,
+            vec![Contact {
+                this: bob.clone(),
+                handle: Handle("555-0100".into()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 2, "a rule-set change recomputes");
+
+        // An email for bob flips the negated variant: the phone row
+        // retracts and the email row asserts — maintained, not
+        // recomputed.
+        branch
+            .transaction()
+            .assert(Email::of(bob.clone()).is("bob@mail"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("variant flip");
+        assert_eq!(
+            delta.asserted,
+            vec![Contact {
+                this: bob.clone(),
+                handle: Handle("bob@mail".into()),
+            }]
+        );
+        assert_eq!(
+            delta.retracted,
+            vec![Contact {
+                this: bob.clone(),
+                handle: Handle("555-0100".into()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 2, "the flip was maintained");
+        assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    /// Piece 3, dynamic demand: a subscription over a recursive
+    /// concept keeps answering as its demand cone grows with the
+    /// data — each edge extending the chain re-triggers and derives
+    /// exactly the new closure pairs. (Recursive closures re-derive
+    /// via the fixpoint; incremental fixpoint continuation is a
+    /// recorded follow-up.)
+    #[dialog_common::test]
+    async fn it_grows_the_demand_cone_with_recursive_rules() -> anyhow::Result<()> {
+        use concepts::{Ancestor, HasAncestor, HasParent, Parent};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let ancestor = HasAncestor::descriptor().clone();
+        let parent = HasParent::descriptor().clone();
+
+        let base = concept_rule(
+            &ancestor,
+            vec![concept_premise(
+                &parent,
+                &[("this", "this"), ("parent", "ancestor")],
+            )],
+        );
+        let step = concept_rule(
+            &ancestor,
+            vec![
+                concept_premise(&parent, &[("this", "this"), ("parent", "p")]),
+                concept_premise(&ancestor, &[("this", "p"), ("ancestor", "ancestor")]),
+            ],
+        );
+
+        let a = Entity::new()?;
+        let b = Entity::new()?;
+        let c = Entity::new()?;
+        let d = Entity::new()?;
+        let transaction = branch
+            .transaction()
+            .assert(Parent::of(b.clone()).is(a.clone()));
+        with_rule(with_rule(transaction, &base), &step)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<HasAncestor>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            initial.asserted,
+            vec![HasAncestor {
+                this: b.clone(),
+                ancestor: Ancestor(a.clone()),
+            }]
+        );
+
+        // Extend the chain: the closure grows by two pairs.
+        branch
+            .transaction()
+            .assert(Parent::of(c.clone()).is(b.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("cone grows");
+        let mut asserted = delta.asserted.clone();
+        asserted.sort_by_key(|row| format!("{row:?}"));
+        let mut expected = vec![
+            HasAncestor {
+                this: c.clone(),
+                ancestor: Ancestor(b.clone()),
+            },
+            HasAncestor {
+                this: c.clone(),
+                ancestor: Ancestor(a.clone()),
+            },
+        ];
+        expected.sort_by_key(|row| format!("{row:?}"));
+        assert_eq!(asserted, expected);
+        assert!(delta.retracted.is_empty());
+
+        // And again: the frontier extended by the previous poll is
+        // itself demanded, so the next extension re-triggers too.
+        branch
+            .transaction()
+            .assert(Parent::of(d.clone()).is(c.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("cone grows again");
+        assert_eq!(delta.asserted.len(), 3, "(d,c), (d,b), (d,a)");
+        assert!(delta.retracted.is_empty());
         Ok(())
     }
 }


### PR DESCRIPTION
Stacked on #379. The remaining rungs toward Dynamic Magic Sets: derived concept subscriptions go incremental, non-entity-local rules are maintained through cross-entity delta-joins, and recursive rule sets resolved from durable storage evaluate soundly with a demand cone that grows with the data.

## Derived queries go incremental

`#[derive(Concept)]` query structs now emit `Application::restrict` (pinning `this` to one subject; refusing when the subject variable joins a field term, since the pin would sever the join) and `Application::concept`. A `Query<C>` subscription takes the maintenance path instead of the recompute fallback — pinned by test with the recompute counter frozen at 1.

## Cross-entity delta-joins (`dialog_query::concept::query::affected`)

For a non-entity-local rule — one whose body reads *other* entities' facts through a concept premise (a concept-typed field's conformance check, a variant's negation) — the affected heads are discovered by binding the changed fact into the premise it can match and joining the rule's remaining premises sideways, projecting the head variable. Nested concept premises are followed one level (entity-local targets, over-approximated by the changed subjects). The discovery over-approximates but never misses: the per-head goal-directed re-derivation settles the truth. `None` (recursion, unhandled shapes, unplannable sideways joins) falls back to full recompute, which is always sound.

Both motivating cases now maintain without recompute:
- **Conformance**: a manager's badge change asserts/retracts the *report's* row — the changed fact's subject is the manager, the affected head is the report.
- **Variant negation**: an email arriving flips the contact — the phone row retracts through the negation, the email row asserts, one maintenance pass.

## Recursive durable rules: soundness fix + growing cone

Found and fixed a pre-existing hang: the repository's `SelectRules` path (`QueryEnv`) assembled rules with **no recursion analysis** — rules committed as durable `db.rule/*` facts that formed a cycle would evaluate top-down and recurse unboundedly. `QueryEnv` now walks the rule set reachable from the queried concept (durable + overlay + implicit, per referenced concept, head-cached), checks stratification (ill-stratified closures error like `RuleRegistry::acquire`), and attaches the program analysis so recursive closures run the semi-naive fixpoint.

On top: the ancestor-subscription test pins the dynamic-demand behavior — each new `parent` edge re-triggers the subscription and derives exactly the new closure pairs, with the cover holding the extended frontier so the next extension triggers too.

## Recorded follow-up

Recursive cone growth currently re-runs the (demand-recorded) fixpoint per triggered poll — correct and cover-scoped, not yet delta-incremental. The remaining step is fixpoint *continuation*: retained per-subscription answer tables with semi-naive delta rounds seeded from the changed facts, slotting behind the same `maintain()` seam. Also: deeper concept-premise nesting in the discovery, merged interval covers, pin GC.

Full native suite: 1686 passed. Clippy `-D warnings` clean.