### PR TITLE
feat(dialog-query): fixpoint continuation for recursive subscriptions

### DIFF
--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -287,7 +287,12 @@ impl ConceptQuery {
                     // component's semi-naive fixpoint is computed once
                     // and the caller's bindings join against the rows.
                     if let Some(analysis) = rules.recursion() {
-                        table = Some(fixpoint::evaluate(&app.predicate, analysis, env).await?);
+                        table = Some(match rules.continuation() {
+                            Some(continuation) => {
+                                continuation.rows(&app.predicate, analysis, env).await?
+                            }
+                            None => fixpoint::evaluate(&app.predicate, analysis, env).await?,
+                        });
                     } else {
                         plan = Some(rules.plan(&app.terms, &input));
                     }

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -33,6 +33,8 @@
 //! afterwards.
 
 use super::ConceptQuery;
+use crate::artifact::Artifact;
+use crate::attribute::The;
 use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::EvaluationError;
 use crate::negation::Negation;
@@ -47,12 +49,14 @@ use crate::source::SelectRules;
 use crate::term::Term;
 use crate::types::Any;
 use crate::{Entity, Environment, Value};
+use core::fmt;
 use core::{iter, mem};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
 use futures_util::TryStreamExt;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
 
 /// Upper bound on fixpoint rounds before the query fails loudly. A
 /// round derives at least one new row (otherwise the fixpoint has
@@ -309,22 +313,19 @@ impl Iterator for Combinations {
     }
 }
 
-/// Compute the full fixpoint of the queried concept's strongly
-/// connected component and return the rows derived for the queried
-/// concept itself.
-pub async fn evaluate<'a, Env>(
+/// Discover the queried concept's strongly connected component:
+/// starting from the root, follow in-component premises (each embeds
+/// its target's full descriptor) and collect every member's rules,
+/// split into recursive occurrences and base premises.
+async fn discover<'a, Env>(
     root: &ConceptDescriptor,
     analysis: &ProgramAnalysis,
     env: &'a Env,
-) -> Result<Vec<Row>, EvaluationError>
+) -> Result<HashMap<Entity, Member>, EvaluationError>
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
     let root_entity = root.this();
-
-    // Discover the component: starting from the queried concept,
-    // follow in-component premises (each embeds its target's full
-    // descriptor) and collect every member's rules.
     let mut members: HashMap<Entity, Member> = HashMap::new();
     let mut queue = vec![root.clone()];
     while let Some(descriptor) = queue.pop() {
@@ -354,38 +355,61 @@ where
         }
         members.insert(entity, Member { descriptor, rules });
     }
+    Ok(members)
+}
 
-    let mut table = InMemoryAnswerTable::default();
-
-    // Seed round: rules with no recursive occurrence evaluate fully
-    // top-down.
-    for member in members.values() {
-        for split in &member.rules {
-            if !split.occurrences.is_empty() {
-                continue;
-            }
-            let plan = split.rule.plan(&Environment::new());
-            let results: Vec<Match> = plan
-                .evaluate(Match::new().seed(), env)
-                .try_collect()
-                .await?;
-            for matched in results {
-                table.insert(
-                    &member.descriptor.this(),
-                    project(&member.descriptor, &matched),
-                );
-            }
-        }
+/// Evaluate one rule with the given occurrence-and-source bindings:
+/// join the `rest` premises sideways and stage every projected
+/// conclusion row.
+async fn stage_rule_rows<'a, Env>(
+    member: &Member,
+    split: &SplitRule,
+    rest: Vec<Premise>,
+    matched: Match,
+    scope: &Environment,
+    table: &mut InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<(), EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let results: Vec<Match> = if rest.is_empty() {
+        vec![matched]
+    } else {
+        let plan = Planner::with_types(rest, split.rule.analysis().types.clone())
+            .plan(scope)
+            .map_err(|error| EvaluationError::Planning {
+                message: error.to_string(),
+            })?;
+        plan.evaluate(matched.seed(), env).try_collect().await?
+    };
+    for result in results {
+        table.insert(
+            &member.descriptor.this(),
+            project(&member.descriptor, &result),
+        );
     }
+    Ok(())
+}
 
-    // Delta rounds: per rule and per recursive occurrence, that
-    // occurrence reads the delta while its siblings read the total.
+/// Run semi-naive delta rounds to convergence: per rule and per
+/// recursive occurrence, that occurrence reads the previous round's
+/// delta while its siblings read the running total.
+async fn delta_rounds<'a, Env>(
+    root: &Entity,
+    members: &HashMap<Entity, Member>,
+    table: &mut InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<(), EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
     let mut rounds = 0;
     while table.advance() {
         rounds += 1;
         if rounds > MAX_ROUNDS {
             return Err(EvaluationError::FixpointDivergence {
-                concept: root_entity.to_string(),
+                concept: root.to_string(),
                 rounds,
             });
         }
@@ -431,35 +455,411 @@ where
                         if !compatible {
                             continue;
                         }
+                        stage_rule_rows(
+                            member,
+                            split,
+                            split.base.clone(),
+                            matched,
+                            &scope,
+                            table,
+                            env,
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
-                        let results: Vec<Match> = if split.base.is_empty() {
-                            vec![matched]
-                        } else {
-                            let plan = Planner::with_types(
-                                split.base.clone(),
-                                split.rule.analysis().types.clone(),
-                            )
-                            .plan(&scope)
-                            .map_err(|error| {
-                                EvaluationError::Planning {
-                                    message: error.to_string(),
-                                }
-                            })?;
-                            plan.evaluate(matched.seed(), env).try_collect().await?
-                        };
-                        for result in results {
-                            table.insert(
-                                &member.descriptor.this(),
-                                project(&member.descriptor, &result),
-                            );
+/// Compute the full fixpoint of the queried concept's strongly
+/// connected component into `table` and return the rows derived for
+/// the queried concept itself.
+pub async fn evaluate_table<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+    table: &mut InMemoryAnswerTable,
+) -> Result<Vec<Row>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let root_entity = root.this();
+    let members = discover(root, analysis, env).await?;
+
+    // Seed round: rules with no recursive occurrence evaluate fully
+    // top-down.
+    for member in members.values() {
+        for split in &member.rules {
+            if !split.occurrences.is_empty() {
+                continue;
+            }
+            let plan = split.rule.plan(&Environment::new());
+            let results: Vec<Match> = plan
+                .evaluate(Match::new().seed(), env)
+                .try_collect()
+                .await?;
+            for matched in results {
+                table.insert(
+                    &member.descriptor.this(),
+                    project(&member.descriptor, &matched),
+                );
+            }
+        }
+    }
+
+    delta_rounds(&root_entity, &members, table, env).await?;
+    Ok(table.total(&root_entity))
+}
+
+/// Compute the full fixpoint of the queried concept's strongly
+/// connected component and return the rows derived for the queried
+/// concept itself.
+pub async fn evaluate<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+) -> Result<Vec<Row>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let mut table = InMemoryAnswerTable::default();
+    evaluate_table(root, analysis, env, &mut table).await
+}
+
+/// How a base premise participates in addition-seeding.
+enum BaseSource {
+    /// A positive attribute premise: a matching new fact binds its
+    /// slots directly. Boxed to keep the variant sizes even.
+    Attribute(Box<(Term<The>, Term<Entity>, Term<Any>)>),
+    /// A positive out-of-component concept premise over an
+    /// entity-local target: a new fact's subject binds its `this`
+    /// slot (over-approximated; re-derivation settles truth).
+    LocalConcept { this: Term<Any> },
+    /// Never sourced by a fact (constraints, formulas).
+    Inert,
+    /// A shape additive seeding cannot handle soundly: a negated or
+    /// optional premise a new fact matches can *retract* derived
+    /// rows, and a non-local nested concept cannot bound its heads.
+    Unsupported,
+}
+
+/// Classify a base premise for addition-seeding, given the changed
+/// facts. Negated and optional premises are only `Unsupported` when
+/// an addition can actually match them.
+async fn classify_base<'a, Env>(
+    premise: &Premise,
+    additions: &[Artifact],
+    env: &'a Env,
+) -> Result<BaseSource, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    fn slots(query: &crate::AttributeQuery) -> (Term<The>, Term<Entity>, Term<Any>) {
+        (query.the().clone(), query.of().clone(), query.is().clone())
+    }
+    fn any_match(the: &Term<The>, of: &Term<Entity>, is: &Term<Any>, facts: &[Artifact]) -> bool {
+        facts.iter().any(|fact| {
+            constant_admits(the.as_constant(), &Value::from(The::from(fact.the.clone())))
+                && constant_admits(of.as_constant(), &Value::Entity(fact.of.clone()))
+                && constant_admits(is.as_constant(), &fact.is)
+        })
+    }
+
+    Ok(match premise {
+        Premise::Assert(Proposition::Attribute(query)) => {
+            BaseSource::Attribute(Box::new(slots(query)))
+        }
+        Premise::Assert(Proposition::OptionalAttribute(query)) => {
+            // A new fact turning an Absent slot Present replaces the
+            // row rather than adding one: not additively seedable.
+            let (the, of, is) = (
+                query.query().the().clone(),
+                query.of().clone(),
+                query.is().clone(),
+            );
+            if any_match(&the, &of, &is, additions) {
+                BaseSource::Unsupported
+            } else {
+                BaseSource::Inert
+            }
+        }
+        Premise::Unless(Negation(Proposition::Attribute(query))) => {
+            let (the, of, is) = slots(query);
+            if any_match(&the, &of, &is, additions) {
+                BaseSource::Unsupported
+            } else {
+                BaseSource::Inert
+            }
+        }
+        Premise::Assert(Proposition::Concept(query)) => {
+            let bundle = Provider::<SelectRules>::execute(env, query.predicate.clone()).await?;
+            let local = bundle.recursion().is_none()
+                && bundle.rules().all(|rule| rule.analysis().is_entity_local());
+            let Some(this) = query.terms.get("this") else {
+                return Ok(BaseSource::Unsupported);
+            };
+            if local {
+                BaseSource::LocalConcept { this: this.clone() }
+            } else {
+                BaseSource::Unsupported
+            }
+        }
+        Premise::Unless(Negation(Proposition::Concept(_))) => {
+            if additions.is_empty() {
+                BaseSource::Inert
+            } else {
+                // An addition can grow the negated set and retract
+                // derived rows: not additively seedable.
+                BaseSource::Unsupported
+            }
+        }
+        _ => BaseSource::Inert,
+    })
+}
+
+/// Whether a constant slot admits the value (a variable or blank
+/// slot admits anything).
+fn constant_admits(constant: Option<&Value>, value: &Value) -> bool {
+    constant.map(|expected| expected == value).unwrap_or(true)
+}
+
+/// Bind one slot of a source premise from a changed value: a
+/// constant filters, a named variable binds, a blank matches.
+fn bind_source_slot(
+    matched: &mut Match,
+    scope: &mut Environment,
+    constant: Option<&Value>,
+    name: Option<&str>,
+    value: Value,
+) -> bool {
+    if let Some(expected) = constant {
+        return *expected == value;
+    }
+    match name {
+        Some(name) => {
+            if matched.bind(&Term::<Any>::var(name), value).is_err() {
+                return false;
+            }
+            scope.add(name);
+            true
+        }
+        None => true,
+    }
+}
+
+/// Extend a previously computed fixpoint with newly added base
+/// facts: semi-naive continuation. For every rule, each new fact is
+/// bound into the base premise it can match (or, for an
+/// out-of-component entity-local concept premise, the fact's
+/// subject binds the premise's `this` slot); recursive occurrences
+/// read the *retained totals*; the remaining base premises join
+/// sideways top-down. Newly staged rows then drive the ordinary
+/// delta rounds to convergence.
+///
+/// Returns `Ok(None)` when the rule set cannot be extended
+/// additively — a negated or optional premise a new fact matches
+/// (the addition could *retract* rows), or a non-local nested
+/// concept — in which case the caller rebuilds from scratch, which
+/// is always sound. Deletions must never reach this function; the
+/// caller rebuilds for those.
+pub async fn extend<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+    table: &mut InMemoryAnswerTable,
+    additions: &[Artifact],
+) -> Result<Option<Vec<Row>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let root_entity = root.this();
+    let members = discover(root, analysis, env).await?;
+    let subjects: BTreeSet<Entity> = additions.iter().map(|fact| fact.of.clone()).collect();
+
+    for member in members.values() {
+        for split in &member.rules {
+            // Classify every base premise first: any unsupported
+            // shape aborts the extension before rows are staged.
+            let mut classified = Vec::with_capacity(split.base.len());
+            for premise in &split.base {
+                match classify_base(premise, additions, env).await? {
+                    BaseSource::Unsupported => return Ok(None),
+                    source => classified.push(source),
+                }
+            }
+
+            for source in classified.iter() {
+                // The bindings each new fact contributes through
+                // this source premise.
+                let mut seeds: Vec<(Match, Environment)> = Vec::new();
+                match source {
+                    BaseSource::Attribute(slots) => {
+                        let (the, of, is) = slots.as_ref();
+                        for fact in additions {
+                            let mut matched = Match::new();
+                            let mut scope = Environment::new();
+                            if bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                the.as_constant(),
+                                the.name(),
+                                Value::from(The::from(fact.the.clone())),
+                            ) && bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                of.as_constant(),
+                                of.name(),
+                                Value::Entity(fact.of.clone()),
+                            ) && bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                is.as_constant(),
+                                is.name(),
+                                fact.is.clone(),
+                            ) {
+                                seeds.push((matched, scope));
+                            }
                         }
+                    }
+                    BaseSource::LocalConcept { this } => {
+                        for entity in &subjects {
+                            let mut matched = Match::new();
+                            let mut scope = Environment::new();
+                            if bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                this.as_constant(),
+                                this.name(),
+                                Value::Entity(entity.clone()),
+                            ) {
+                                seeds.push((matched, scope));
+                            }
+                        }
+                    }
+                    BaseSource::Inert | BaseSource::Unsupported => continue,
+                }
+
+                // The source premise stays in the sideways join: with
+                // its slots bound it re-verifies as a point lookup
+                // (preserving cardinality-one winner semantics), and
+                // a concept source's remaining fields bind from its
+                // goal-directed evaluation.
+                let rest: Vec<Premise> = split.base.clone();
+
+                for (seed_match, seed_scope) in seeds {
+                    // Occurrences read the retained totals: the new
+                    // fact is the delta position.
+                    let choices: Vec<Vec<Row>> = split
+                        .occurrences
+                        .iter()
+                        .map(|occurrence| table.total(&occurrence.predicate.this()))
+                        .collect();
+                    for combination in Combinations::new(choices.iter().map(Vec::len).collect()) {
+                        let mut matched = seed_match.clone();
+                        let mut scope = seed_scope.clone();
+                        let mut compatible = true;
+                        for (index, (occurrence, row_index)) in
+                            split.occurrences.iter().zip(&combination).enumerate()
+                        {
+                            let row = &choices[index][*row_index];
+                            if !bind_occurrence(&mut matched, occurrence, row) {
+                                compatible = false;
+                                break;
+                            }
+                            for (_, term) in occurrence.terms.iter() {
+                                if let Some(name) = term.name() {
+                                    scope.add(name);
+                                }
+                            }
+                        }
+                        if !compatible {
+                            continue;
+                        }
+                        stage_rule_rows(member, split, rest.clone(), matched, &scope, table, env)
+                            .await?;
                     }
                 }
             }
         }
     }
 
-    Ok(table.total(&root_entity))
+    delta_rounds(&root_entity, &members, table, env).await?;
+    Ok(Some(table.total(&root_entity)))
+}
+
+/// A retained fixpoint carried across evaluations by a standing
+/// subscription: the answer table handle plus, when the poll's
+/// changes were additions only, the new facts to seed a semi-naive
+/// continuation from. Attached to a concept's
+/// [`ConceptRules`](crate::ConceptRules) by the query environment;
+/// consumed by `ConceptQuery::evaluate`'s fixpoint branch.
+#[derive(Clone, Default)]
+pub struct Continuation {
+    table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
+    additions: Option<Arc<Vec<Artifact>>>,
+}
+
+impl fmt::Debug for Continuation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Continuation")
+            .field(
+                "additions",
+                &self.additions.as_ref().map(|facts| facts.len()),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl Continuation {
+    /// A continuation over the subscription-held `table`. With
+    /// `additions`, evaluation extends the retained fixpoint
+    /// semi-naively (falling back to a rebuild when the rule set
+    /// cannot extend additively); without, it rebuilds into the
+    /// handle (the first evaluation, or after deletions).
+    pub fn new(
+        table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
+        additions: Option<Arc<Vec<Artifact>>>,
+    ) -> Self {
+        Continuation { table, additions }
+    }
+
+    /// The queried concept's fixpoint rows, reusing the retained
+    /// table when possible. The table is taken out of the handle
+    /// for the duration (an error mid-evaluation leaves the handle
+    /// empty, so the next evaluation rebuilds).
+    pub(crate) async fn rows<'a, Env>(
+        &self,
+        root: &ConceptDescriptor,
+        analysis: &ProgramAnalysis,
+        env: &'a Env,
+    ) -> Result<Vec<Row>, EvaluationError>
+    where
+        Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+    {
+        let prior = self.table.lock().expect("fixpoint table lock").take();
+        let (table, rows) = match (prior, &self.additions) {
+            (Some(mut table), Some(additions)) => {
+                match extend(root, analysis, env, &mut table, additions).await? {
+                    Some(rows) => (table, rows),
+                    None => {
+                        // Not additively extendable: rebuild.
+                        let mut table = InMemoryAnswerTable::default();
+                        let rows = evaluate_table(root, analysis, env, &mut table).await?;
+                        (table, rows)
+                    }
+                }
+            }
+            _ => {
+                let mut table = InMemoryAnswerTable::default();
+                let rows = evaluate_table(root, analysis, env, &mut table).await?;
+                (table, rows)
+            }
+        };
+        *self.table.lock().expect("fixpoint table lock") = Some(table);
+        Ok(rows)
+    }
 }
 
 #[cfg(test)]

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -11,6 +11,7 @@
 use std::iter;
 
 use super::adornment::Adornment;
+use super::fixpoint::Continuation;
 use super::plan_cache::PlanCache;
 use crate::DeductiveRule;
 use crate::concept::descriptor::ConceptDescriptor;
@@ -43,6 +44,11 @@ pub struct ConceptRules {
     /// [`RuleRegistry::acquire`](crate::session::RuleRegistry) and
     /// read by `ConceptQuery::evaluate`.
     recursion: Option<Arc<ProgramAnalysis>>,
+    /// A standing subscription's retained fixpoint, when one is
+    /// polling this concept: evaluation continues the retained
+    /// answer table (or rebuilds into it) instead of computing a
+    /// throwaway fixpoint.
+    continuation: Option<Continuation>,
 }
 
 impl ConceptRules {
@@ -65,6 +71,7 @@ impl ConceptRules {
             plans: Arc::new(RwLock::new(HashMap::new())),
             plan_cache,
             recursion: None,
+            continuation: None,
         }
     }
 
@@ -79,6 +86,19 @@ impl ConceptRules {
     /// in a dependency cycle; `None` for ordinary concepts.
     pub fn recursion(&self) -> Option<&Arc<ProgramAnalysis>> {
         self.recursion.as_ref()
+    }
+
+    /// Attach a standing subscription's retained fixpoint. Only
+    /// consulted when the concept is recursive.
+    pub fn with_continuation(mut self, continuation: Continuation) -> Self {
+        self.continuation = Some(continuation);
+        self
+    }
+
+    /// The retained fixpoint attached by a polling subscription, if
+    /// any.
+    pub fn continuation(&self) -> Option<&Continuation> {
+        self.continuation.as_ref()
     }
 
     /// Install a deductive rule, deduplicating by equality.

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -11,6 +11,7 @@ use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::{Identify, Operator, OperatorExt as _};
 use dialog_effects::memory::Resolve;
 use dialog_query::concept::descriptor::ConceptDescriptor;
+use dialog_query::concept::query::fixpoint::Continuation;
 use dialog_query::concept::query::{ConceptRules, PlanCache};
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output};
@@ -255,6 +256,11 @@ pub(crate) struct QueryEnv<'a, Env> {
     /// demanded range here. Subscriptions use the recorded cover to
     /// gate re-evaluation.
     demand: Option<crate::Demand>,
+    /// A polling subscription's retained fixpoint for one concept:
+    /// attached to that concept's resolved rules so a recursive
+    /// evaluation continues (or rebuilds into) the retained answer
+    /// table instead of computing a throwaway one.
+    fixpoint: Option<(Entity, Continuation)>,
     env: &'a Env,
 }
 
@@ -279,6 +285,7 @@ impl<'a, Env> QueryEnv<'a, Env> {
             changes,
             tombstones,
             demand: None,
+            fixpoint: None,
             env,
         }
     }
@@ -288,6 +295,14 @@ impl<'a, Env> QueryEnv<'a, Env> {
     /// demand cover.
     pub(crate) fn with_demand(mut self, demand: crate::Demand) -> Self {
         self.demand = Some(demand);
+        self
+    }
+
+    /// Attach a subscription's retained fixpoint for `concept`:
+    /// when that concept's rules resolve recursive, evaluation
+    /// continues the retained answer table instead of recomputing.
+    pub(crate) fn with_fixpoint(mut self, concept: Entity, continuation: Continuation) -> Self {
+        self.fixpoint = Some((concept, continuation));
         self
     }
 
@@ -306,6 +321,7 @@ impl<Env> Clone for QueryEnv<'_, Env> {
             changes: self.changes.clone(),
             tombstones: self.tombstones.clone(),
             demand: self.demand.clone(),
+            fixpoint: self.fixpoint.clone(),
             env: self.env,
         }
     }
@@ -512,7 +528,13 @@ where
         let analysis = self.program_analysis(&input, &bundle).await?;
         analysis.check(&input)?;
         Ok(if analysis.is_recursive(&concept) {
-            bundle.with_recursion(analysis)
+            let bundle = bundle.with_recursion(analysis);
+            match &self.fixpoint {
+                Some((entity, continuation)) if *entity == concept => {
+                    bundle.with_continuation(continuation.clone())
+                }
+                _ => bundle,
+            }
         } else {
             bundle
         })

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -76,8 +76,10 @@ use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
 use dialog_query::Conclusion;
 use dialog_query::concept::query::affected::affected_entities;
+use dialog_query::concept::query::fixpoint::{Continuation, InMemoryAnswerTable};
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output as _, Restriction};
+use dialog_query::source::SelectRules;
 use dialog_search_tree::{Change, ContentAddressedStorage};
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
@@ -198,6 +200,10 @@ pub struct Subscription<Q: Application> {
     /// The last evaluation's full result, retained to compute the
     /// next delta.
     results: Vec<Q::Conclusion>,
+    /// The retained fixpoint answer table when the subscribed
+    /// concept is recursive: additions extend it semi-naively;
+    /// recomputes rebuild into it.
+    fixpoint: Arc<Mutex<Option<InMemoryAnswerTable>>>,
     initialized: bool,
     /// Full evaluations performed (first poll + fallbacks).
     recomputes: usize,
@@ -216,6 +222,7 @@ impl Branch {
             revision: None,
             demand: Demand::new(),
             results: Vec::new(),
+            fixpoint: Arc::new(Mutex::new(None)),
             initialized: false,
             recomputes: 0,
             maintenances: 0,
@@ -238,6 +245,10 @@ enum Touched {
         subjects: BTreeSet<Entity>,
         /// The changed facts themselves, for delta-join discovery.
         facts: Vec<Artifact>,
+        /// Whether every change was an addition (no fact left the
+        /// index and no tombstone was written): the precondition
+        /// for semi-naive fixpoint continuation.
+        additions_only: bool,
     },
 }
 
@@ -316,8 +327,15 @@ where
                     self.revision = current;
                     return Ok(None);
                 }
-                Touched::Facts { subjects, facts } => {
-                    if let Some(delta) = self.maintain(env, &subjects, &facts).await? {
+                Touched::Facts {
+                    subjects,
+                    facts,
+                    additions_only,
+                } => {
+                    if let Some(delta) = self
+                        .maintain(env, &subjects, &facts, additions_only)
+                        .await?
+                    {
                         self.maintenances += 1;
                         self.revision = current;
                         return Ok(Some(delta));
@@ -409,6 +427,7 @@ where
         let mut changes = Box::pin(changes);
         let mut subjects = BTreeSet::new();
         let mut facts = Vec::new();
+        let mut additions_only = true;
         // A fact change surfaces once per index order; dedup on the
         // datum triple.
         let mut seen = BTreeSet::new();
@@ -423,6 +442,13 @@ where
             };
             if self.demand.covers_rules(&entry.key) {
                 return Ok(Touched::Rules);
+            }
+            // An entry leaving the index, or a tombstone arriving,
+            // means a fact stopped being readable: not an addition.
+            match (&change, &entry.value) {
+                (Change::Remove(_), State::Added(_)) => additions_only = false,
+                (Change::Add(_), State::Removed) => additions_only = false,
+                _ => {}
             }
             if let State::Added(datum) = &entry.value {
                 if !seen.insert((
@@ -442,7 +468,11 @@ where
         if subjects.is_empty() {
             Ok(Touched::Nothing)
         } else {
-            Ok(Touched::Facts { subjects, facts })
+            Ok(Touched::Facts {
+                subjects,
+                facts,
+                additions_only,
+            })
         }
     }
 
@@ -464,6 +494,7 @@ where
         env: &Env,
         subjects: &BTreeSet<Entity>,
         facts: &[Artifact],
+        additions_only: bool,
     ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
@@ -497,6 +528,36 @@ where
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
                 .with_demand(self.demand.clone());
+            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
+            if rules.recursion().is_some() {
+                // Fixpoint continuation: additions extend the
+                // retained answer table semi-naively (rebuilding
+                // when the rule set is not additively extendable);
+                // deletions fall back to a recompute, which rebuilds
+                // the table.
+                if !additions_only {
+                    return Ok(None);
+                }
+                drop(query_env);
+                let results = self
+                    .evaluate_with_continuation(env, Some(Arc::new(facts.to_vec())))
+                    .await?;
+                let delta = Delta {
+                    asserted: results
+                        .iter()
+                        .filter(|row| !self.results.contains(row))
+                        .cloned()
+                        .collect(),
+                    retracted: self
+                        .results
+                        .iter()
+                        .filter(|row| !results.contains(row))
+                        .cloned()
+                        .collect(),
+                };
+                self.results = results;
+                return Ok(Some(delta));
+            }
             match affected_entities(concept, facts, &query_env).await? {
                 Some(entities) => entities,
                 None => return Ok(None),
@@ -570,9 +631,57 @@ where
         let layer = QueryLayer::from(&self.branch);
         let overlay = layer.overlay(&operator);
         let tombstones = tombstones_from(&overlay);
-        let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+        let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
             .with_demand(demand.clone());
+        // Recursive concept subscriptions retain their fixpoint
+        // across polls: a recompute rebuilds into the retained
+        // table so a later additions-only poll can extend it.
+        if let Some(concept) = query.concept() {
+            query_env = query_env.with_fixpoint(
+                concept.this(),
+                Continuation::new(self.fixpoint.clone(), None),
+            );
+        }
         query.clone().perform(&query_env).try_vec().await
+    }
+
+    /// Evaluate the standing query with the retained fixpoint
+    /// attached, seeding a semi-naive continuation from `additions`
+    /// when present. Demand keeps recording into the standing
+    /// cover.
+    async fn evaluate_with_continuation<Env>(
+        &self,
+        env: &Env,
+        additions: Option<Arc<Vec<Artifact>>>,
+    ) -> Result<Vec<Q::Conclusion>, EvaluationError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let concept = self
+            .query
+            .concept()
+            .expect("continuation evaluation requires a concept query");
+        let operator = Identify
+            .perform(env)
+            .await
+            .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+        let layer = QueryLayer::from(&self.branch);
+        let overlay = layer.overlay(&operator);
+        let tombstones = tombstones_from(&overlay);
+        let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+            .with_demand(self.demand.clone())
+            .with_fixpoint(
+                concept.this(),
+                Continuation::new(self.fixpoint.clone(), additions),
+            );
+        self.query.clone().perform(&query_env).try_vec().await
     }
 }
 
@@ -1478,7 +1587,14 @@ mod tests {
             .commit()
             .perform(&operator)
             .await?;
+        assert_eq!(subscription.recomputes(), 1);
         let delta = subscription.poll(&operator).await?.expect("cone grows");
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the closure extended via fixpoint continuation, not a re-fixpoint"
+        );
+        assert_eq!(subscription.maintenances(), 1);
         let mut asserted = delta.asserted.clone();
         asserted.sort_by_key(|row| format!("{row:?}"));
         let mut expected = vec![
@@ -1509,6 +1625,57 @@ mod tests {
             .expect("cone grows again");
         assert_eq!(delta.asserted.len(), 3, "(d,c), (d,b), (d,a)");
         assert!(delta.retracted.is_empty());
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
+
+        // A deletion shrinks the closure: not additively
+        // extendable, so the poll rebuilds the fixpoint (and the
+        // retained table), retracting everything derived through
+        // the removed edge.
+        branch
+            .transaction()
+            .retract(Parent::of(c.clone()).is(b.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("cone shrinks");
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            delta.retracted.len(),
+            4,
+            "everything derived through the removed edge goes: \
+             (c,b), (c,a), (d,b), (d,a); (d,c) survives"
+        );
+        assert_eq!(subscription.recomputes(), 2, "deletions rebuild");
+
+        // And the rebuilt table continues extending afterwards.
+        let e = Entity::new()?;
+        branch
+            .transaction()
+            .assert(Parent::of(e.clone()).is(d.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("extends again");
+        let mut asserted = delta.asserted.clone();
+        asserted.sort_by_key(|row| format!("{row:?}"));
+        let mut expected = vec![
+            HasAncestor {
+                this: e.clone(),
+                ancestor: Ancestor(d.clone()),
+            },
+            HasAncestor {
+                this: e.clone(),
+                ancestor: Ancestor(c.clone()),
+            },
+        ];
+        expected.sort_by_key(|row| format!("{row:?}"));
+        assert_eq!(
+            asserted, expected,
+            "e's ancestors follow the surviving chain"
+        );
+        assert_eq!(subscription.recomputes(), 2);
+        assert_eq!(subscription.maintenances(), 3);
         Ok(())
     }
 }


### PR DESCRIPTION
Stacked on #380. Recursive cones go incremental: a subscription over a recursive concept retains its strongly connected component's answer table across polls, and additions extend it semi-naively instead of re-running the fixpoint.

## The continuation channel

`fixpoint::Continuation` — the subscription-held table handle plus optional addition seeds — attaches to `ConceptRules` via `QueryEnv::with_fixpoint`, the same channel the recursion analysis travels. `ConceptQuery::evaluate`'s fixpoint branch continues into the retained table, or rebuilds into it on recompute paths, so the table is always current for the next poll. The table is taken out of the handle for the duration of an evaluation: an error mid-flight leaves it empty and the next poll rebuilds — a corrupt table cannot survive.

## Additive extension (`fixpoint::extend`)

New facts seed a semi-naive continuation: per rule, each addition binds into the base premise it can match (attribute premises directly; out-of-component entity-local concept premises through the fact's subject), recursive occurrences read the **retained totals** (the new fact is the delta position), and the base joins sideways. Newly staged rows then drive the ordinary delta rounds to convergence — `evaluate` is now a thin wrapper over the extracted `discover` / seed / `delta_rounds` phases shared with `extend`.

One correctness subtlety, caught by test during development: the source premise **stays in the sideways join** rather than being excluded — with its slots bound it re-verifies as a point lookup, which preserves cardinality-one winner semantics and lets a concept-premise source bind its remaining fields.

## Soundness boundaries — everything else rebuilds

- An addition matching a **negated or optional premise** could retract rows: not expressible additively, `extend` returns `None`, caller rebuilds.
- **Deletions** never reach `extend`: the poll classifies changes (an entry leaving the index, or a tombstone arriving, is not an addition) and routes to the recompute path, which rebuilds the retained table.
- Non-local nested concept premises in the base: heads can't be bounded, rebuild.

## Pinned lifecycle

The ancestor subscription test covers the full arc: two chain extensions maintained with the recompute counter frozen at 1, an edge deletion rebuilding the closure (exactly the four pairs derivable through the removed edge retract; `(d,c)` survives), and the rebuilt table extending again on the next addition.

## Recorded follow-up

Incremental deletions for recursive concepts (DRed over the SCC: over-delete reachable derivations, re-derive survivors bounded by the over-deleted set) — the last recompute trigger for recursion, slotting behind the same `Continuation` seam.

Full native suite: 1686 passed. Clippy `-D warnings` clean.