### PR TITLE
feat(dialog-query): DRed retraction, deep-nested discovery, merged covers

### DIFF
--- a/rust/dialog-query/src/concept/query/affected.rs
+++ b/rust/dialog-query/src/concept/query/affected.rs
@@ -21,7 +21,7 @@
 //! caller must fall back to full re-evaluation, which is always
 //! sound.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
@@ -47,11 +47,12 @@ use crate::{Entity, Environment, Value};
 /// affect, or `None` when the set cannot be bounded and the caller
 /// must re-evaluate in full.
 ///
-/// Nesting is followed one level: a concept premise whose target's
-/// rules are all entity-local contributes its affected heads
-/// (over-approximated by the changed facts' subjects); a target
-/// with non-local rules of its own, or any recursion, returns
-/// `None`.
+/// Nested concept premises are followed to arbitrary depth: the
+/// reachable concepts form an acyclic graph (recursion anywhere in
+/// it returns `None`), each is resolved once, and affected sets are
+/// computed bottom-up — a target's affected heads feed the premises
+/// that apply it, so a change can propagate through any number of
+/// derivation layers.
 pub async fn affected_entities<'a, Env>(
     concept: &ConceptDescriptor,
     facts: &[Artifact],
@@ -60,36 +61,94 @@ pub async fn affected_entities<'a, Env>(
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
-    let bundle = Provider::<SelectRules>::execute(env, concept.clone()).await?;
-    if bundle.recursion().is_some() {
-        return Ok(None);
-    }
+    let root = concept.this();
 
-    let subjects: BTreeSet<Entity> = facts.iter().map(|fact| fact.of.clone()).collect();
-    let mut affected = BTreeSet::new();
-
-    for rule in bundle.rules() {
-        if rule.analysis().is_entity_local() {
-            // A change to E's facts only affects E's rows.
-            affected.extend(subjects.iter().cloned());
+    // Collect the reachable concepts and their resolved rules.
+    let mut rules_of: HashMap<Entity, Vec<DeductiveRule>> = HashMap::new();
+    let mut targets_of: HashMap<Entity, BTreeSet<Entity>> = HashMap::new();
+    let mut queue = vec![concept.clone()];
+    while let Some(descriptor) = queue.pop() {
+        let entity = descriptor.this();
+        if rules_of.contains_key(&entity) {
             continue;
         }
-        match rule_heads(rule, facts, &subjects, env).await? {
-            Some(heads) => affected.extend(heads),
-            None => return Ok(None),
+        let bundle = Provider::<SelectRules>::execute(env, descriptor).await?;
+        if bundle.recursion().is_some() {
+            return Ok(None);
         }
+        let rules: Vec<DeductiveRule> = bundle.rules().cloned().collect();
+        let mut targets = BTreeSet::new();
+        for rule in &rules {
+            for premise in rule.analysis().premises() {
+                if let Some(query) = concept_premise(premise) {
+                    targets.insert(query.predicate.this());
+                    queue.push(query.predicate.clone());
+                }
+            }
+        }
+        targets_of.insert(entity.clone(), targets);
+        rules_of.insert(entity, rules);
     }
 
-    Ok(Some(affected))
+    // Bottom-up: a concept computes once every target it applies
+    // has. The graph is acyclic (recursion returned above), so this
+    // always makes progress.
+    let subjects: BTreeSet<Entity> = facts.iter().map(|fact| fact.of.clone()).collect();
+    let mut affected: HashMap<Entity, BTreeSet<Entity>> = HashMap::new();
+    let mut pending: Vec<Entity> = rules_of.keys().cloned().collect();
+    while !pending.is_empty() {
+        let ready: Vec<Entity> = pending
+            .iter()
+            .filter(|entity| {
+                targets_of[*entity]
+                    .iter()
+                    .all(|target| affected.contains_key(target))
+            })
+            .cloned()
+            .collect();
+        if ready.is_empty() {
+            // Unreachable for an acyclic graph; bail rather than spin.
+            return Ok(None);
+        }
+        for entity in &ready {
+            let mut heads = BTreeSet::new();
+            for rule in &rules_of[entity] {
+                if rule.analysis().is_entity_local() {
+                    // A change to E's facts only affects E's rows.
+                    heads.extend(subjects.iter().cloned());
+                    continue;
+                }
+                match rule_heads(rule, facts, &affected, env).await? {
+                    Some(found) => heads.extend(found),
+                    None => return Ok(None),
+                }
+            }
+            affected.insert(entity.clone(), heads);
+        }
+        pending.retain(|entity| !ready.contains(entity));
+    }
+
+    Ok(affected.remove(&root))
+}
+
+/// The concept application of a premise, positive or negated.
+fn concept_premise(premise: &Premise) -> Option<&ConceptQuery> {
+    match premise {
+        Premise::Assert(Proposition::Concept(query)) => Some(query),
+        Premise::Unless(Negation(Proposition::Concept(query))) => Some(query),
+        _ => None,
+    }
 }
 
 /// The candidate head entities one non-local rule can produce or
 /// retract given the changed facts: per premise, bind what the
 /// change can match and join the remaining premises sideways.
+/// Concept premises bind their `this` slot from the target's
+/// already-computed affected heads.
 async fn rule_heads<'a, Env>(
     rule: &DeductiveRule,
     facts: &[Artifact],
-    subjects: &BTreeSet<Entity>,
+    affected: &HashMap<Entity, BTreeSet<Entity>>,
     env: &'a Env,
 ) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
 where
@@ -154,26 +213,18 @@ where
             continue;
         }
 
-        // Concept premises (positive or negated): the change affects
-        // the target's rows for some entities; each such entity,
-        // bound into the premise's `this` slot, joins sideways to
-        // candidate heads. One nesting level: the target's rules
-        // must all be entity-local, so its affected heads are the
-        // changed facts' subjects (over-approximated).
-        let concept_query = match premise {
-            Premise::Assert(Proposition::Concept(query)) => Some(query),
-            Premise::Unless(Negation(Proposition::Concept(query))) => Some(query),
-            _ => None,
-        };
-        if let Some(query) = concept_query {
-            match target_locality(query, env).await? {
-                Locality::Local => {}
-                Locality::NonLocal => return Ok(None),
-            }
+        // Concept premises (positive or negated): the change's
+        // effect on the target is its already-computed affected
+        // set; each affected target head, bound into the premise's
+        // `this` slot, joins sideways to candidate heads.
+        if let Some(query) = concept_premise(premise) {
+            let Some(target_heads) = affected.get(&query.predicate.this()) else {
+                return Ok(None);
+            };
             let Some(this) = query.terms.get("this") else {
                 return Ok(None);
             };
-            for entity in subjects {
+            for entity in target_heads {
                 let mut matched = Match::new();
                 let mut scope = Environment::new();
                 if !bind_slot(
@@ -194,33 +245,6 @@ where
     }
 
     Ok(Some(heads))
-}
-
-/// Whether a nested concept premise's target can contribute
-/// entity-local affected heads.
-enum Locality {
-    /// Every target rule is entity-local and non-recursive.
-    Local,
-    /// The target has non-local rules or recursion: fall back.
-    NonLocal,
-}
-
-async fn target_locality<'a, Env>(
-    query: &ConceptQuery,
-    env: &'a Env,
-) -> Result<Locality, EvaluationError>
-where
-    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
-{
-    let bundle = Provider::<SelectRules>::execute(env, query.predicate.clone()).await?;
-    if bundle.recursion().is_some() {
-        return Ok(Locality::NonLocal);
-    }
-    if bundle.rules().all(|rule| rule.analysis().is_entity_local()) {
-        Ok(Locality::Local)
-    } else {
-        Ok(Locality::NonLocal)
-    }
 }
 
 /// Bind one premise slot from a changed value. A constant slot

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -47,7 +47,7 @@ use crate::selection::{Binding, Match};
 use crate::session::ProgramAnalysis;
 use crate::source::SelectRules;
 use crate::term::Term;
-use crate::types::Any;
+use crate::types::{Any, Typed};
 use crate::{Entity, Environment, Value};
 use core::fmt;
 use core::{iter, mem};
@@ -149,6 +149,17 @@ impl AnswerTable for InMemoryAnswerTable {
             .get(concept)
             .map(|rows| rows.values().cloned().collect())
             .unwrap_or_default()
+    }
+}
+
+impl InMemoryAnswerTable {
+    /// Remove a row from the total (DRed's over-delete step).
+    /// Between evaluations the delta and staging areas are drained,
+    /// so the total is the only place a retained row lives.
+    fn remove(&mut self, concept: &Entity, row: &Row) {
+        if let Some(rows) = self.total.get_mut(concept) {
+            rows.remove(&row_key(row));
+        }
     }
 }
 
@@ -359,17 +370,16 @@ where
 }
 
 /// Evaluate one rule with the given occurrence-and-source bindings:
-/// join the `rest` premises sideways and stage every projected
+/// join the `rest` premises sideways and return every projected
 /// conclusion row.
-async fn stage_rule_rows<'a, Env>(
+async fn collect_rule_rows<'a, Env>(
     member: &Member,
     split: &SplitRule,
     rest: Vec<Premise>,
     matched: Match,
     scope: &Environment,
-    table: &mut InMemoryAnswerTable,
     env: &'a Env,
-) -> Result<(), EvaluationError>
+) -> Result<Vec<Row>, EvaluationError>
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
@@ -383,11 +393,27 @@ where
             })?;
         plan.evaluate(matched.seed(), env).try_collect().await?
     };
-    for result in results {
-        table.insert(
-            &member.descriptor.this(),
-            project(&member.descriptor, &result),
-        );
+    Ok(results
+        .into_iter()
+        .map(|result| project(&member.descriptor, &result))
+        .collect())
+}
+
+/// [`collect_rule_rows`], staging every row into the table.
+async fn stage_rule_rows<'a, Env>(
+    member: &Member,
+    split: &SplitRule,
+    rest: Vec<Premise>,
+    matched: Match,
+    scope: &Environment,
+    table: &mut InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<(), EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    for row in collect_rule_rows(member, split, rest, matched, scope, env).await? {
+        table.insert(&member.descriptor.this(), row);
     }
     Ok(())
 }
@@ -649,6 +675,27 @@ fn bind_source_slot(
     }
 }
 
+/// Fold one term slot of a deleted-fact source into a suspicion
+/// pattern: a mismatching constant rejects the fact, a head-operand
+/// variable contributes a `(operand, value)` constraint, anything
+/// else constrains nothing. Returns `false` on rejection.
+fn pattern_slot<T: Typed>(
+    term: &Term<T>,
+    value: Value,
+    operands: &BTreeSet<&str>,
+    pattern: &mut Vec<(String, Value)>,
+) -> bool {
+    if let Some(expected) = term.as_constant() {
+        return *expected == value;
+    }
+    if let Some(name) = term.name()
+        && operands.contains(name)
+    {
+        pattern.push((name.to_string(), value));
+    }
+    true
+}
+
 /// Extend a previously computed fixpoint with newly added base
 /// facts: semi-naive continuation. For every rule, each new fact is
 /// bound into the base premise it can match (or, for an
@@ -789,6 +836,329 @@ where
     Ok(Some(table.total(&root_entity)))
 }
 
+/// Retract deleted base facts from a retained fixpoint: DRed.
+///
+/// 1. **Over-delete.** Every row forward-reachable from a deleted
+///    fact is suspected: deleted facts bind into the base premises
+///    they matched (occurrences reading the *pre-deletion* totals),
+///    and suspicion cascades through occurrence positions until
+///    closed. All suspects are removed.
+/// 2. **Re-derive.** Each suspect is checked for a surviving
+///    derivation: its head operands bind the rule body, occurrences
+///    read the *post-removal* table, base premises read the current
+///    store. Survivors re-insert; passes repeat until stable, so
+///    chains re-derive bottom-up.
+/// 3. **Insert.** The ordinary delta rounds propagate the
+///    re-insertions.
+///
+/// Sound only when no single rule body could have consumed more
+/// than one deleted thing at once — one body position is the delta,
+/// the rest are read from surviving state. The gate is
+/// conservative: if two or more of a rule's base premises match any
+/// deletion, or a deletion matches a negated or optional premise (a
+/// deletion there can make rows *appear*), `Ok(None)` is returned
+/// and the caller rebuilds.
+pub async fn retract<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+    table: &mut InMemoryAnswerTable,
+    deletions: &[Artifact],
+) -> Result<Option<()>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let root_entity = root.this();
+    let members = discover(root, analysis, env).await?;
+    let subjects: BTreeSet<Entity> = deletions.iter().map(|fact| fact.of.clone()).collect();
+
+    // Suspects per member, keyed like the table.
+    let mut suspects: HashMap<Entity, BTreeMap<Vec<u8>, Row>> = HashMap::new();
+
+    // Phase 1a: seed suspicion from the deleted facts. A deleted
+    // fact cannot be re-joined (it is gone from the store), so the
+    // rows it may have supported are found by *pattern-matching the
+    // retained table*: the head-operand bindings the fact imposes
+    // through the premise it matched select every consistent row.
+    // A source that binds no head operand suspects the member's
+    // whole table — conservative, settled by re-derivation.
+    for member in members.values() {
+        let operands: BTreeSet<&str> = iter::once("this")
+            .chain(member.descriptor.with().keys())
+            .collect();
+        for split in &member.rules {
+            let mut matchable = 0usize;
+            let mut patterns: Vec<Vec<(String, Value)>> = Vec::new();
+            for premise in &split.base {
+                match classify_base(premise, deletions, env).await? {
+                    BaseSource::Unsupported => return Ok(None),
+                    BaseSource::Inert => {}
+                    BaseSource::Attribute(slots) => {
+                        let (the, of, is) = slots.as_ref();
+                        let mut hit = false;
+                        for fact in deletions {
+                            let mut pattern = Vec::new();
+                            let matches =
+                                pattern_slot(
+                                    the,
+                                    Value::from(The::from(fact.the.clone())),
+                                    &operands,
+                                    &mut pattern,
+                                ) && pattern_slot(
+                                    of,
+                                    Value::Entity(fact.of.clone()),
+                                    &operands,
+                                    &mut pattern,
+                                ) && pattern_slot(is, fact.is.clone(), &operands, &mut pattern);
+                            if matches {
+                                hit = true;
+                                patterns.push(pattern);
+                            }
+                        }
+                        if hit {
+                            matchable += 1;
+                        }
+                    }
+                    BaseSource::LocalConcept { this } => {
+                        if !subjects.is_empty() {
+                            matchable += 1;
+                        }
+                        for entity in &subjects {
+                            let value = Value::Entity(entity.clone());
+                            match this.as_constant() {
+                                Some(expected) if *expected != value => {}
+                                Some(_) => patterns.push(Vec::new()),
+                                None => match this.name() {
+                                    Some(name) if operands.contains(name) => {
+                                        patterns.push(vec![(name.to_string(), value)]);
+                                    }
+                                    _ => patterns.push(Vec::new()),
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+            // Two matchable premises in one body: a derivation could
+            // have consumed two deleted things at once, and the
+            // one-position-at-a-time walk would miss it.
+            if matchable >= 2 {
+                return Ok(None);
+            }
+
+            if patterns.is_empty() {
+                continue;
+            }
+            let entity = member.descriptor.this();
+            for row in table.total(&entity) {
+                let suspect = patterns.iter().any(|pattern| {
+                    pattern
+                        .iter()
+                        .all(|(operand, value)| row.get(operand) == Some(value))
+                });
+                if suspect {
+                    suspects
+                        .entry(entity.clone())
+                        .or_default()
+                        .insert(row_key(&row), row);
+                }
+            }
+        }
+    }
+
+    // Phase 1b: cascade suspicion through occurrence positions,
+    // reading pre-removal totals.
+    let mut frontier = suspects.clone();
+    while !frontier.values().all(BTreeMap::is_empty) {
+        let mut next: HashMap<Entity, BTreeMap<Vec<u8>, Row>> = HashMap::new();
+        for member in members.values() {
+            for split in &member.rules {
+                if split.occurrences.is_empty() {
+                    continue;
+                }
+                for delta_index in 0..split.occurrences.len() {
+                    let choices: Vec<Vec<Row>> = split
+                        .occurrences
+                        .iter()
+                        .enumerate()
+                        .map(|(index, occurrence)| {
+                            let target = occurrence.predicate.this();
+                            if index == delta_index {
+                                frontier
+                                    .get(&target)
+                                    .map(|rows| rows.values().cloned().collect())
+                                    .unwrap_or_default()
+                            } else {
+                                table.total(&target)
+                            }
+                        })
+                        .collect();
+                    for combination in Combinations::new(choices.iter().map(Vec::len).collect()) {
+                        let mut matched = Match::new();
+                        let mut scope = Environment::new();
+                        let mut compatible = true;
+                        for (index, (occurrence, row_index)) in
+                            split.occurrences.iter().zip(&combination).enumerate()
+                        {
+                            let row = &choices[index][*row_index];
+                            if !bind_occurrence(&mut matched, occurrence, row) {
+                                compatible = false;
+                                break;
+                            }
+                            for (_, term) in occurrence.terms.iter() {
+                                if let Some(name) = term.name() {
+                                    scope.add(name);
+                                }
+                            }
+                        }
+                        if !compatible {
+                            continue;
+                        }
+                        let rows = collect_rule_rows(
+                            member,
+                            split,
+                            split.base.clone(),
+                            matched,
+                            &scope,
+                            env,
+                        )
+                        .await?;
+                        let entity = member.descriptor.this();
+                        for row in rows {
+                            let key = row_key(&row);
+                            let known = suspects
+                                .get(&entity)
+                                .is_some_and(|rows| rows.contains_key(&key));
+                            if !known {
+                                suspects
+                                    .entry(entity.clone())
+                                    .or_default()
+                                    .insert(key.clone(), row.clone());
+                                next.entry(entity.clone()).or_default().insert(key, row);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        frontier = next;
+    }
+
+    // Over-delete.
+    for (entity, rows) in &suspects {
+        for row in rows.values() {
+            table.remove(entity, row);
+        }
+    }
+
+    // Phase 2: re-derive survivors, bottom-up until stable.
+    loop {
+        let mut rederived = false;
+        for member in members.values() {
+            let entity = member.descriptor.this();
+            let Some(rows) = suspects.get(&entity) else {
+                continue;
+            };
+            let mut survived: Vec<Vec<u8>> = Vec::new();
+            for (key, row) in rows {
+                if derivable(member, row, table, env).await? {
+                    table.insert(&entity, row.clone());
+                    survived.push(key.clone());
+                    rederived = true;
+                }
+            }
+            if !survived.is_empty() {
+                // Promote the survivors immediately so this pass's
+                // later checks (and the next pass) see them.
+                table.advance();
+                let bucket = suspects.get_mut(&entity).expect("bucket exists");
+                for key in survived {
+                    bucket.remove(&key);
+                }
+            }
+        }
+        if !rederived {
+            break;
+        }
+    }
+
+    // Phase 3: propagate anything the re-insertions enable.
+    delta_rounds(&root_entity, &members, table, env).await?;
+    Ok(Some(()))
+}
+
+/// Whether a suspect row still has a derivation: bind its head
+/// operands into each rule body (occurrences read the current
+/// table, base premises the current store) and check whether any
+/// result projects back to the row.
+async fn derivable<'a, Env>(
+    member: &Member,
+    row: &Row,
+    table: &InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<bool, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    for split in &member.rules {
+        let mut seed = Match::new();
+        let mut seed_scope = Environment::new();
+        let mut consistent = true;
+        for (operand, value) in row {
+            if seed
+                .bind(&Term::<Any>::var(operand), value.clone())
+                .is_err()
+            {
+                consistent = false;
+                break;
+            }
+            seed_scope.add(operand);
+        }
+        if !consistent {
+            continue;
+        }
+
+        let choices: Vec<Vec<Row>> = split
+            .occurrences
+            .iter()
+            .map(|occurrence| table.total(&occurrence.predicate.this()))
+            .collect();
+        let combinations: Vec<Vec<usize>> = if split.occurrences.is_empty() {
+            vec![Vec::new()]
+        } else {
+            Combinations::new(choices.iter().map(Vec::len).collect()).collect()
+        };
+        for combination in combinations {
+            let mut matched = seed.clone();
+            let mut scope = seed_scope.clone();
+            let mut compatible = true;
+            for (index, (occurrence, row_index)) in
+                split.occurrences.iter().zip(&combination).enumerate()
+            {
+                let bound = &choices[index][*row_index];
+                if !bind_occurrence(&mut matched, occurrence, bound) {
+                    compatible = false;
+                    break;
+                }
+                for (_, term) in occurrence.terms.iter() {
+                    if let Some(name) = term.name() {
+                        scope.add(name);
+                    }
+                }
+            }
+            if !compatible {
+                continue;
+            }
+            let rows =
+                collect_rule_rows(member, split, split.base.clone(), matched, &scope, env).await?;
+            if rows.iter().any(|candidate| candidate == row) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
 /// A retained fixpoint carried across evaluations by a standing
 /// subscription: the answer table handle plus, when the poll's
 /// changes were additions only, the new facts to seed a semi-naive
@@ -798,31 +1168,42 @@ where
 #[derive(Clone, Default)]
 pub struct Continuation {
     table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
-    additions: Option<Arc<Vec<Artifact>>>,
+    additions: Arc<Vec<Artifact>>,
+    deletions: Arc<Vec<Artifact>>,
 }
 
 impl fmt::Debug for Continuation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Continuation")
-            .field(
-                "additions",
-                &self.additions.as_ref().map(|facts| facts.len()),
-            )
+            .field("additions", &self.additions.len())
+            .field("deletions", &self.deletions.len())
             .finish_non_exhaustive()
     }
 }
 
 impl Continuation {
-    /// A continuation over the subscription-held `table`. With
-    /// `additions`, evaluation extends the retained fixpoint
-    /// semi-naively (falling back to a rebuild when the rule set
-    /// cannot extend additively); without, it rebuilds into the
-    /// handle (the first evaluation, or after deletions).
-    pub fn new(
-        table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
-        additions: Option<Arc<Vec<Artifact>>>,
+    /// A continuation over the subscription-held `table`. Without
+    /// changes attached, evaluation rebuilds into the handle (the
+    /// first evaluation, or a recompute).
+    pub fn new(table: Arc<Mutex<Option<InMemoryAnswerTable>>>) -> Self {
+        Continuation {
+            table,
+            additions: Arc::new(Vec::new()),
+            deletions: Arc::new(Vec::new()),
+        }
+    }
+
+    /// Attach the poll's changed facts: deletions retract via DRed,
+    /// additions extend semi-naively, in that order. Either phase
+    /// declining (non-additive shapes) falls back to a rebuild.
+    pub fn with_changes(
+        mut self,
+        additions: Arc<Vec<Artifact>>,
+        deletions: Arc<Vec<Artifact>>,
     ) -> Self {
-        Continuation { table, additions }
+        self.additions = additions;
+        self.deletions = deletions;
+        self
     }
 
     /// The queried concept's fixpoint rows, reusing the retained
@@ -839,19 +1220,33 @@ impl Continuation {
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
         let prior = self.table.lock().expect("fixpoint table lock").take();
-        let (table, rows) = match (prior, &self.additions) {
-            (Some(mut table), Some(additions)) => {
-                match extend(root, analysis, env, &mut table, additions).await? {
-                    Some(rows) => (table, rows),
-                    None => {
-                        // Not additively extendable: rebuild.
-                        let mut table = InMemoryAnswerTable::default();
-                        let rows = evaluate_table(root, analysis, env, &mut table).await?;
-                        (table, rows)
+        let has_changes = !self.additions.is_empty() || !self.deletions.is_empty();
+        let maintained = match prior {
+            Some(mut table) if has_changes => {
+                let retracted = if self.deletions.is_empty() {
+                    Some(())
+                } else {
+                    retract(root, analysis, env, &mut table, &self.deletions).await?
+                };
+                match retracted {
+                    None => None,
+                    Some(()) => {
+                        if self.additions.is_empty() {
+                            let rows = table.total(&root.this());
+                            Some((table, rows))
+                        } else {
+                            extend(root, analysis, env, &mut table, &self.additions)
+                                .await?
+                                .map(|rows| (table, rows))
+                        }
                     }
                 }
             }
-            _ => {
+            _ => None,
+        };
+        let (table, rows) = match maintained {
+            Some(outcome) => outcome,
+            None => {
                 let mut table = InMemoryAnswerTable::default();
                 let rows = evaluate_table(root, analysis, env, &mut table).await?;
                 (table, rows)

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -105,11 +105,26 @@ pub struct Demand {
     rules: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
 }
 
+/// Insert a range into a cover, merging overlaps: the cover stays a
+/// sorted list of disjoint intervals, so it cannot grow beyond the
+/// number of genuinely distinct demanded regions no matter how many
+/// (nested, repeated) selectors record into it.
 fn record_range(ranges: &Mutex<Vec<RangeInclusive<KeyBytes>>>, range: RangeInclusive<KeyBytes>) {
     let mut ranges = ranges.lock().expect("demand lock");
-    if !ranges.contains(&range) {
-        ranges.push(range);
+    let (mut start, mut end) = range.into_inner();
+    // Absorb every existing interval the new one overlaps.
+    let mut merged = Vec::with_capacity(ranges.len() + 1);
+    for existing in ranges.drain(..) {
+        if *existing.start() > end || *existing.end() < start {
+            merged.push(existing);
+        } else {
+            start = start.min(*existing.start());
+            end = end.max(*existing.end());
+        }
     }
+    merged.push(start..=end);
+    merged.sort_by(|a, b| a.start().cmp(b.start()));
+    *ranges = merged;
 }
 
 impl Demand {
@@ -243,12 +258,13 @@ enum Touched {
     Facts {
         /// Subjects of the changed facts.
         subjects: BTreeSet<Entity>,
-        /// The changed facts themselves, for delta-join discovery.
+        /// Every changed fact (asserted and retracted alike), for
+        /// delta-join discovery.
         facts: Vec<Artifact>,
-        /// Whether every change was an addition (no fact left the
-        /// index and no tombstone was written): the precondition
-        /// for semi-naive fixpoint continuation.
-        additions_only: bool,
+        /// Facts that became readable.
+        asserted: Vec<Artifact>,
+        /// Facts that stopped being readable.
+        retracted: Vec<Artifact>,
     },
 }
 
@@ -330,10 +346,11 @@ where
                 Touched::Facts {
                     subjects,
                     facts,
-                    additions_only,
+                    asserted,
+                    retracted,
                 } => {
                     if let Some(delta) = self
-                        .maintain(env, &subjects, &facts, additions_only)
+                        .maintain(env, &subjects, &facts, &asserted, &retracted)
                         .await?
                     {
                         self.maintenances += 1;
@@ -426,10 +443,10 @@ where
         let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
         let mut subjects = BTreeSet::new();
-        let mut facts = Vec::new();
-        let mut additions_only = true;
+        let mut asserted = Vec::new();
+        let mut retracted = Vec::new();
         // A fact change surfaces once per index order; dedup on the
-        // datum triple.
+        // datum triple, per direction.
         let mut seen = BTreeSet::new();
         while let Some(change) = changes
             .try_next()
@@ -443,15 +460,15 @@ where
             if self.demand.covers_rules(&entry.key) {
                 return Ok(Touched::Rules);
             }
-            // An entry leaving the index, or a tombstone arriving,
-            // means a fact stopped being readable: not an addition.
-            match (&change, &entry.value) {
-                (Change::Remove(_), State::Added(_)) => additions_only = false,
-                (Change::Add(_), State::Removed) => additions_only = false,
-                _ => {}
-            }
+            // An entry arriving with a datum became readable; an
+            // entry leaving with a datum stopped being readable.
+            // Tombstone-valued entries carry no datum: their effect
+            // (if any) surfaces as the paired datum-bearing change
+            // at the same key.
+            let arriving = matches!(&change, Change::Add(_));
             if let State::Added(datum) = &entry.value {
                 if !seen.insert((
+                    arriving,
                     datum.entity.clone(),
                     datum.attribute.clone(),
                     datum.value.clone(),
@@ -461,17 +478,23 @@ where
                 let fact = Artifact::try_from(datum.clone())
                     .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
                 subjects.insert(fact.of.clone());
-                facts.push(fact);
+                if arriving {
+                    asserted.push(fact);
+                } else {
+                    retracted.push(fact);
+                }
             }
         }
 
         if subjects.is_empty() {
             Ok(Touched::Nothing)
         } else {
+            let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
             Ok(Touched::Facts {
                 subjects,
                 facts,
-                additions_only,
+                asserted,
+                retracted,
             })
         }
     }
@@ -494,7 +517,8 @@ where
         env: &Env,
         subjects: &BTreeSet<Entity>,
         facts: &[Artifact],
-        additions_only: bool,
+        asserted: &[Artifact],
+        retracted: &[Artifact],
     ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
@@ -530,17 +554,16 @@ where
                 .with_demand(self.demand.clone());
             let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
             if rules.recursion().is_some() {
-                // Fixpoint continuation: additions extend the
-                // retained answer table semi-naively (rebuilding
-                // when the rule set is not additively extendable);
-                // deletions fall back to a recompute, which rebuilds
-                // the table.
-                if !additions_only {
-                    return Ok(None);
-                }
+                // Fixpoint continuation: deletions retract via DRed,
+                // additions extend semi-naively — rebuilding into
+                // the retained table when either phase declines.
                 drop(query_env);
                 let results = self
-                    .evaluate_with_continuation(env, Some(Arc::new(facts.to_vec())))
+                    .evaluate_with_continuation(
+                        env,
+                        Arc::new(asserted.to_vec()),
+                        Arc::new(retracted.to_vec()),
+                    )
                     .await?;
                 let delta = Delta {
                     asserted: results
@@ -637,10 +660,8 @@ where
         // across polls: a recompute rebuilds into the retained
         // table so a later additions-only poll can extend it.
         if let Some(concept) = query.concept() {
-            query_env = query_env.with_fixpoint(
-                concept.this(),
-                Continuation::new(self.fixpoint.clone(), None),
-            );
+            query_env =
+                query_env.with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
         }
         query.clone().perform(&query_env).try_vec().await
     }
@@ -652,7 +673,8 @@ where
     async fn evaluate_with_continuation<Env>(
         &self,
         env: &Env,
-        additions: Option<Arc<Vec<Artifact>>>,
+        additions: Arc<Vec<Artifact>>,
+        deletions: Arc<Vec<Artifact>>,
     ) -> Result<Vec<Q::Conclusion>, EvaluationError>
     where
         Env: Provider<Get>
@@ -679,7 +701,7 @@ where
             .with_demand(self.demand.clone())
             .with_fixpoint(
                 concept.this(),
-                Continuation::new(self.fixpoint.clone(), additions),
+                Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
             );
         self.query.clone().perform(&query_env).try_vec().await
     }
@@ -1151,6 +1173,29 @@ mod tests {
             /// Their manager, who must hold a badge.
             #[dialog(conforms = BadgeHolder)]
             pub manager: Manager,
+        }
+
+        /// The chief's deputy (`chief/deputy`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("chief")]
+        pub struct Deputy(pub Entity);
+
+        /// The chief's title (`chief/title`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("chief")]
+        pub struct Title(pub String);
+
+        /// Someone whose deputy is a valid report — two conformance
+        /// layers deep (Chief -> Report -> BadgeHolder).
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct Chief {
+            /// The chief entity.
+            pub this: Entity,
+            /// Their title.
+            pub title: Title,
+            /// Their deputy, who must be a valid report.
+            #[dialog(conforms = Report)]
+            pub deputy: Deputy,
         }
 
         /// An email handle (`comm/email`).
@@ -1628,10 +1673,10 @@ mod tests {
         assert_eq!(subscription.recomputes(), 1);
         assert_eq!(subscription.maintenances(), 2);
 
-        // A deletion shrinks the closure: not additively
-        // extendable, so the poll rebuilds the fixpoint (and the
-        // retained table), retracting everything derived through
-        // the removed edge.
+        // A deletion shrinks the closure: DRed over the retained
+        // table — over-delete forward from the removed edge,
+        // re-derive survivors — retracting exactly what was
+        // derivable through it, still without a recompute.
         branch
             .transaction()
             .retract(Parent::of(c.clone()).is(b.clone()))
@@ -1646,9 +1691,14 @@ mod tests {
             "everything derived through the removed edge goes: \
              (c,b), (c,a), (d,b), (d,a); (d,c) survives"
         );
-        assert_eq!(subscription.recomputes(), 2, "deletions rebuild");
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the deletion was retracted via DRed, not a rebuild"
+        );
+        assert_eq!(subscription.maintenances(), 3);
 
-        // And the rebuilt table continues extending afterwards.
+        // And the retracted table continues extending afterwards.
         let e = Entity::new()?;
         branch
             .transaction()
@@ -1674,8 +1724,88 @@ mod tests {
             asserted, expected,
             "e's ancestors follow the surviving chain"
         );
-        assert_eq!(subscription.recomputes(), 2);
-        assert_eq!(subscription.maintenances(), 3);
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "never recomputed after the first poll"
+        );
+        assert_eq!(subscription.maintenances(), 4);
+        Ok(())
+    }
+
+    /// Deep nesting: a badge change three derivation layers away
+    /// (badge -> BadgeHolder -> Report -> Chief) propagates through
+    /// the bottom-up affected discovery and maintains without a
+    /// recompute.
+    #[dialog_common::test]
+    async fn it_maintains_deeply_nested_conformance() -> anyhow::Result<()> {
+        use concepts::{Badge, Chief, Deputy, Manager, Name, Title};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let carol = Entity::new()?; // manager, unbadged (yet)
+        let mallory = Entity::new()?; // reports to carol
+        let frank = Entity::new()?; // chief whose deputy is mallory
+
+        branch
+            .transaction()
+            .assert(Name::of(mallory.clone()).is("Mallory"))
+            .assert(Manager::of(mallory.clone()).is(carol.clone()))
+            .assert(Title::of(frank.clone()).is("Frank"))
+            .assert(Deputy::of(frank.clone()).is(mallory.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<Chief>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert!(
+            initial.asserted.is_empty(),
+            "mallory is not a valid report while carol is unbadged"
+        );
+
+        // Badge carol: mallory becomes a Report, so frank becomes a
+        // Chief — two layers above the changed fact's subject.
+        branch
+            .transaction()
+            .assert(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("deeply nested effect");
+        assert_eq!(
+            delta.asserted,
+            vec![Chief {
+                this: frank.clone(),
+                title: Title("Frank".into()),
+                deputy: Deputy(mallory.clone()),
+            }]
+        );
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "discovered through two conformance layers, not recomputed"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+
+        // And back out again.
+        branch
+            .transaction()
+            .retract(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(delta.retracted.len(), 1);
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
         Ok(())
     }
 }


### PR DESCRIPTION
Stacked on #381. The final maintenance rungs: recursive deletions go incremental, affected-entity discovery follows nesting to arbitrary depth, and demand covers stay bounded.

## DRed retraction for recursive cones (`fixpoint::retract`)

A deleted fact **cannot be re-joined** — it is gone from the store, so evaluating the source premise finds nothing (the naive approach silently misses every suspect; caught by test during development). Over-deletion suspects instead come from *pattern-matching the retained table*: the head-operand bindings the deleted fact imposes through the premise it matched select every consistent row, and a source binding no head operand suspects the member's whole table — conservative, settled by re-derivation.

The phases: suspicion cascades through occurrence positions against **pre-removal totals** until closed; suspects are removed; each is checked for a surviving derivation (head operands bound into the rule bodies, occurrences reading the **post-removal** table) with passes repeating until stable so chains re-derive bottom-up; the ordinary delta rounds propagate re-insertions.

Conservative gates returning `None` (caller rebuilds, always sound): two of one body's premises matching deletions — a derivation could have consumed two deleted things at once, and the one-position-at-a-time walk would miss it; or a deletion matching a negated/optional premise, where rows can *appear* rather than vanish.

`Continuation` now carries both directions; the poll routes asserted and retracted facts, and the recursive branch no longer requires additions-only. The ancestor lifecycle test now runs with **zero recomputes end to end**: extensions extend, the deletion retracts exactly the four pairs derivable through the removed edge, and the retracted table extends again.

## Deep nesting in affected discovery

`affected_entities` is restructured as a bottom-up worklist over the reachable (acyclic — recursion anywhere returns `None`) concept graph: each concept resolves once, targets compute before the premises that apply them, so a change propagates through any number of derivation layers. Pinned by test: a badge change three layers below (badge → `BadgeHolder` → `Report` → `Chief`, two `conforms` hops) asserts and retracts the chief's row without recompute.

## Merged interval covers

`Demand::record` coalesces overlapping intervals: the cover is a sorted list of disjoint ranges bounded by the number of genuinely distinct demanded regions, no matter how many nested or repeated selectors record into it.

## Pin GC: recorded as blocked, not built

There is no storage-layer garbage collector to pin roots against — content-addressed blocks are never reclaimed today. Recorded in dialog-db-39 as "design when GC lands" rather than speculative machinery.

Full native suite: 1687 passed. Clippy `-D warnings` clean.