### PR TITLE
feat(dialog-repository): transient overlays for subscriptions, Send-general polls

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -221,7 +221,8 @@ where
     /// [`Artifacts::export`]
     pub async fn import<Read>(&mut self, read: &mut Read) -> Result<(), DialogArtifactsError>
     where
-        Read: AsyncRead + Unpin + ConditionalSend,
+        // bare-send-ok: csv_async bounds its readers on real Send on every target
+        Read: AsyncRead + Unpin + Send,
     {
         let instructions = stream! {
             let mut reader = csv_async::AsyncReaderBuilder::new()

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -221,7 +221,7 @@ where
     /// [`Artifacts::export`]
     pub async fn import<Read>(&mut self, read: &mut Read) -> Result<(), DialogArtifactsError>
     where
-        Read: AsyncRead + Unpin + Send,
+        Read: AsyncRead + Unpin + ConditionalSend,
     {
         let instructions = stream! {
             let mut reader = csv_async::AsyncReaderBuilder::new()

--- a/rust/dialog-common/src/async.rs
+++ b/rust/dialog-common/src/async.rs
@@ -92,7 +92,7 @@ pub enum DialogAsyncError {
 pub async fn spawn<F>(future: F) -> Result<F::Output, DialogAsyncError>
 where
     F: Future + ConditionalSend + 'static,
-    F::Output: Send + 'static,
+    F::Output: ConditionalSend + 'static,
 {
     #[cfg(target_arch = "wasm32")]
     {

--- a/rust/dialog-common/tests/conventions.rs
+++ b/rust/dialog-common/tests/conventions.rs
@@ -77,15 +77,40 @@ mod native {
         false
     }
 
+    /// The rust/ workspace directory, resolved at *runtime*: at
+    /// compile time `CARGO_MANIFEST_DIR` names the build sandbox,
+    /// which no longer exists when an archived test runs (the nix
+    /// gate re-runs nextest archives with `--workspace-remap`). The
+    /// runner sets each test's working directory to the (remapped)
+    /// crate root, so ascend from there to the directory holding the
+    /// workspace crates; fall back to the compile-time path for
+    /// plain `cargo` invocations with an unusual working directory.
+    fn workspace_dir() -> PathBuf {
+        if let Ok(mut dir) = std::env::current_dir() {
+            loop {
+                if dir.join("dialog-common").is_dir() && dir.join("dialog-query").is_dir() {
+                    return dir;
+                }
+                if !dir.pop() {
+                    break;
+                }
+            }
+        }
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("dialog-common lives under the rust/ workspace dir")
+            .to_path_buf()
+    }
+
     /// Hand-written `Send` / `Sync` bounds must be `ConditionalSend`
     /// / `ConditionalSync`; see the module doc for the rationale and
     /// the exemptions.
-    #[dialog_common::test]
+    // dialog_macros directly (a dev-dependency): the dialog_common::test
+    // re-export lives behind the `helpers` feature, which the crate's own
+    // integration tests build without.
+    #[dialog_macros::test]
     async fn it_bounds_on_conditional_send_and_sync() {
-        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .expect("dialog-common lives under the rust/ workspace dir")
-            .to_path_buf();
+        let workspace = workspace_dir();
         let mut sources = Vec::new();
         rust_sources(&workspace, &mut sources);
         assert!(

--- a/rust/dialog-common/tests/conventions.rs
+++ b/rust/dialog-common/tests/conventions.rs
@@ -1,0 +1,132 @@
+//! Workspace source conventions, enforced as a test.
+//!
+//! Async code in this workspace targets both native and
+//! `wasm32-unknown-unknown`, so hand-written bounds must use
+//! [`dialog_common::ConditionalSend`] / [`ConditionalSync`] (which
+//! are `Send` / `Sync` on native and nothing on wasm) instead of the
+//! bare marker traits. Bare `Send` / `Sync` remain correct in
+//! exactly two places:
+//!
+//! - `dyn` bounds (`Box<dyn Future + Send>`): auto traits cannot be
+//!   substituted there, so the type gets a cfg'd pair of aliases —
+//!   one per target — like `ArtifactStream`.
+//! - Native-only code (a `#[cfg(not(target_arch = "wasm32"))]` fn
+//!   feeding `tokio::spawn`, a deliberately `Send` variant of a
+//!   local/sendable pair).
+//!
+//! Lines using `dyn` are exempt automatically. Anything else must
+//! carry a `bare-send-ok: <reason>` comment, which exempts lines
+//! from the marker to the next blank line.
+//!
+//! This is a source-level scan rather than a clippy
+//! `disallowed-types` rule because clippy attributes the `Send`
+//! tokens that `async_trait` and the provider macros *expand to*
+//! back to the local attribute line, flagging every macro use in the
+//! workspace; the convention is about what humans write.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    /// The single file allowed to name the bare traits freely: the
+    /// definition site of the conditional ones.
+    const DEFINITION_SITE: &str = "dialog-common/src/sync.rs";
+
+    /// Marker comment that exempts lines up to the next blank line.
+    const EXEMPT_MARKER: &str = "bare-send-ok";
+
+    fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "target") {
+                    continue;
+                }
+                rust_sources(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Whether `line` (comments stripped) uses bare `Send` or `Sync`
+    /// in bound position (preceded by `:` or `+`).
+    fn uses_bare_marker(line: &str) -> bool {
+        for word in ["Send", "Sync"] {
+            let mut from = 0;
+            while let Some(at) = line[from..].find(word) {
+                let start = from + at;
+                let end = start + word.len();
+                from = end;
+                let word_char = |c: char| c.is_ascii_alphanumeric() || c == '_';
+                if line[..start].chars().next_back().is_some_and(word_char)
+                    || line[end..].chars().next().is_some_and(word_char)
+                {
+                    continue;
+                }
+                let before = line[..start].trim_end();
+                if before.ends_with(':') || before.ends_with('+') {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Hand-written `Send` / `Sync` bounds must be `ConditionalSend`
+    /// / `ConditionalSync`; see the module doc for the rationale and
+    /// the exemptions.
+    #[dialog_common::test]
+    async fn it_bounds_on_conditional_send_and_sync() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("dialog-common lives under the rust/ workspace dir")
+            .to_path_buf();
+        let mut sources = Vec::new();
+        rust_sources(&workspace, &mut sources);
+        assert!(
+            sources.len() > 100,
+            "the scan should see the whole workspace, found {} files",
+            sources.len()
+        );
+
+        let mut violations = Vec::new();
+        for path in sources {
+            if path.ends_with(DEFINITION_SITE) {
+                continue;
+            }
+            let Ok(source) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let mut exempt = false;
+            for (index, line) in source.lines().enumerate() {
+                if line.trim().is_empty() {
+                    exempt = false;
+                    continue;
+                }
+                if line.contains(EXEMPT_MARKER) {
+                    exempt = true;
+                    continue;
+                }
+                if exempt || line.contains("dyn ") {
+                    continue;
+                }
+                let code = line.split("//").next().unwrap_or(line);
+                if uses_bare_marker(code) {
+                    violations.push(format!("{}:{}: {}", path.display(), index + 1, line.trim()));
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "bare Send/Sync bounds found; use ConditionalSend/ConditionalSync \
+             (or mark deliberate native-only/dyn uses with `{EXEMPT_MARKER}: <reason>`):\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/rust/dialog-csv/Cargo.toml
+++ b/rust/dialog-csv/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 dialog-artifacts = { workspace = true }
-dialog-common = { workspace = true }
 async-trait = { workspace = true }
 base58 = { workspace = true }
 csv-async = { workspace = true, features = ["tokio"] }

--- a/rust/dialog-csv/Cargo.toml
+++ b/rust/dialog-csv/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 dialog-artifacts = { workspace = true }
+dialog-common = { workspace = true }
 async-trait = { workspace = true }
 base58 = { workspace = true }
 csv-async = { workspace = true, features = ["tokio"] }

--- a/rust/dialog-csv/src/exporter.rs
+++ b/rust/dialog-csv/src/exporter.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use dialog_artifacts::Exporter;
 use dialog_artifacts::{Artifact, DialogArtifactsError};
+use dialog_common::ConditionalSend;
 use tokio::io::AsyncWrite;
 
 use crate::row::CsvRow;
@@ -29,7 +30,7 @@ impl<W: AsyncWrite + Unpin> From<W> for CsvExporter<W> {
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<W: AsyncWrite + Unpin + Send> Exporter for CsvExporter<W> {
+impl<W: AsyncWrite + Unpin + ConditionalSend> Exporter for CsvExporter<W> {
     async fn write(&mut self, artifact: &Artifact) -> Result<(), DialogArtifactsError> {
         let row = CsvRow::from(artifact);
         self.writer

--- a/rust/dialog-csv/src/exporter.rs
+++ b/rust/dialog-csv/src/exporter.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use dialog_artifacts::Exporter;
 use dialog_artifacts::{Artifact, DialogArtifactsError};
-use dialog_common::ConditionalSend;
 use tokio::io::AsyncWrite;
 
 use crate::row::CsvRow;
@@ -30,7 +29,8 @@ impl<W: AsyncWrite + Unpin> From<W> for CsvExporter<W> {
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<W: AsyncWrite + Unpin + ConditionalSend> Exporter for CsvExporter<W> {
+// bare-send-ok: csv_async bounds its writers on real Send on every target
+impl<W: AsyncWrite + Unpin + Send> Exporter for CsvExporter<W> {
     async fn write(&mut self, artifact: &Artifact) -> Result<(), DialogArtifactsError> {
         let row = CsvRow::from(artifact);
         self.writer

--- a/rust/dialog-csv/src/importer.rs
+++ b/rust/dialog-csv/src/importer.rs
@@ -1,5 +1,4 @@
 use dialog_artifacts::{Artifact, DialogArtifactsError};
-use dialog_common::ConditionalSend;
 use futures_util::{Stream, StreamExt};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -7,28 +6,23 @@ use tokio::io::AsyncRead;
 
 use crate::row::CsvRow;
 
-/// The imported row stream: boxed `Send` on native so the importer
-/// can cross threads, unboxed of that requirement on wasm.
-#[cfg(not(target_arch = "wasm32"))]
-// bare-send-ok: dyn bounds cannot carry ConditionalSend; this is the cfg'd native alias
-type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>;
-
-/// The imported row stream (see the native alias).
-#[cfg(target_arch = "wasm32")]
-type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>>>>;
-
 /// Imports artifacts from CSV rows.
 ///
 /// Expects columns: `the`, `of`, `as` (value type), `is`, `cause`.
 ///
 /// Implements [`Stream`] yielding one [`Artifact`] per CSV row.
+///
+/// Readers are bounded on real `Send` (not `ConditionalSend`)
+/// because `csv_async` requires it on every target.
 pub struct CsvImporter {
-    inner: ArtifactRows,
+    // bare-send-ok: dyn bound over a csv_async stream, which is Send on every target
+    inner: Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>,
 }
 
 impl CsvImporter {
     /// Create a new CSV importer reading from the given reader.
-    pub fn new<R: AsyncRead + Unpin + ConditionalSend + 'static>(reader: R) -> Self {
+    // bare-send-ok: csv_async bounds its readers on real Send on every target
+    pub fn new<R: AsyncRead + Unpin + Send + 'static>(reader: R) -> Self {
         let deserializer = csv_async::AsyncReaderBuilder::new().create_deserializer(reader);
         let stream = deserializer
             .into_deserialize::<CsvRow>()
@@ -42,7 +36,8 @@ impl CsvImporter {
     }
 }
 
-impl<R: AsyncRead + Unpin + ConditionalSend + 'static> From<R> for CsvImporter {
+// bare-send-ok: csv_async bounds its readers on real Send on every target
+impl<R: AsyncRead + Unpin + Send + 'static> From<R> for CsvImporter {
     fn from(reader: R) -> Self {
         Self::new(reader)
     }

--- a/rust/dialog-csv/src/importer.rs
+++ b/rust/dialog-csv/src/importer.rs
@@ -1,4 +1,5 @@
 use dialog_artifacts::{Artifact, DialogArtifactsError};
+use dialog_common::ConditionalSend;
 use futures_util::{Stream, StreamExt};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -6,18 +7,28 @@ use tokio::io::AsyncRead;
 
 use crate::row::CsvRow;
 
+/// The imported row stream: boxed `Send` on native so the importer
+/// can cross threads, unboxed of that requirement on wasm.
+#[cfg(not(target_arch = "wasm32"))]
+// bare-send-ok: dyn bounds cannot carry ConditionalSend; this is the cfg'd native alias
+type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>;
+
+/// The imported row stream (see the native alias).
+#[cfg(target_arch = "wasm32")]
+type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>>>>;
+
 /// Imports artifacts from CSV rows.
 ///
 /// Expects columns: `the`, `of`, `as` (value type), `is`, `cause`.
 ///
 /// Implements [`Stream`] yielding one [`Artifact`] per CSV row.
 pub struct CsvImporter {
-    inner: Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>,
+    inner: ArtifactRows,
 }
 
 impl CsvImporter {
     /// Create a new CSV importer reading from the given reader.
-    pub fn new<R: AsyncRead + Unpin + Send + 'static>(reader: R) -> Self {
+    pub fn new<R: AsyncRead + Unpin + ConditionalSend + 'static>(reader: R) -> Self {
         let deserializer = csv_async::AsyncReaderBuilder::new().create_deserializer(reader);
         let stream = deserializer
             .into_deserialize::<CsvRow>()
@@ -31,7 +42,7 @@ impl CsvImporter {
     }
 }
 
-impl<R: AsyncRead + Unpin + Send + 'static> From<R> for CsvImporter {
+impl<R: AsyncRead + Unpin + ConditionalSend + 'static> From<R> for CsvImporter {
     fn from(reader: R) -> Self {
         Self::new(reader)
     }

--- a/rust/dialog-query/src/attribute/query/typed.rs
+++ b/rust/dialog-query/src/attribute/query/typed.rs
@@ -14,7 +14,7 @@ use crate::types::Scalar;
 use crate::{Entity, EvaluationError, Premise, Proposition, Term, Value};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
-use dialog_common::ConditionalSync;
+use dialog_common::{ConditionalSend, ConditionalSync};
 
 /// A typed attribute query with named fields for entity and value.
 ///
@@ -77,7 +77,7 @@ where
 
 impl<A> Application for StaticAttributeQuery<A>
 where
-    A: Attribute + Descriptor<AttributeDescriptor> + Clone + Send + 'static,
+    A: Attribute + Descriptor<AttributeDescriptor> + Clone + ConditionalSend + 'static,
     A: From<A::Type>,
     A::Type: Scalar + TryFrom<Value>,
 {

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -473,7 +473,7 @@ impl<'a> Builder<'a> {
 /// Field values are accessed by the term bindings from the query.
 /// The `terms` map provides the mapping from field names to variable terms
 /// used in the match.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ConceptConclusion {
     this: Entity,
     terms: Parameters,

--- a/rust/dialog-query/src/stream.rs
+++ b/rust/dialog-query/src/stream.rs
@@ -33,6 +33,7 @@ where
 #[cfg(not(target_arch = "wasm32"))]
 fn spawn<F>(future: F)
 where
+    // bare-send-ok: native-only fn feeding tokio::spawn, which requires real Send
     F: Future<Output = ()> + Send + 'static,
 {
     tokio::spawn(future);

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -19,7 +19,7 @@
 
 use crate::type_system;
 use crate::type_system::Type as Kind;
-use dialog_common::ConditionalSend;
+use dialog_common::{ConditionalSend, ConditionalSync};
 use std::fmt;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -34,7 +34,7 @@ use crate::attribute::The;
 /// [`Self::kind`] returning `Option<type_system::Type>`. `None`
 /// means "unknown; the unifier decides at rule-compile time."
 pub trait TypeDescriptor:
-    Clone + fmt::Debug + Default + PartialEq + Eq + Hash + Send + Sync + 'static
+    Clone + fmt::Debug + Default + PartialEq + Eq + Hash + ConditionalSend + ConditionalSync + 'static
 {
     /// The legacy storage tag, if statically known. `None` means
     /// "any type."

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -40,6 +40,9 @@ mod metadata;
 mod open;
 pub use open::*;
 
+mod overlay;
+pub use overlay::*;
+
 mod pull;
 pub use pull::*;
 
@@ -95,6 +98,11 @@ pub struct Branch {
     /// every query's durable rule resolution, so the `db.rule/*` scan is
     /// paid once per (concept, head) rather than per query.
     rule_cache: SharedRuleCache,
+    /// Transient session overlay: ephemeral facts folded into every
+    /// read of this branch, never committed. Shared across clones
+    /// like the caches; mutations bump an epoch subscriptions gate
+    /// on. See [`Overlay`].
+    overlay: Overlay,
     /// Shared plan cache for the deductive rules resolved on this branch,
     /// keyed by content-addressed `(rule, adornment)`. Handed to each
     /// per-query `ConceptRules` assembly so a re-assembled rule set reuses

--- a/rust/dialog-repository/src/repository/branch/open.rs
+++ b/rust/dialog-repository/src/repository/branch/open.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::rules::RuleCache;
-use crate::{Branch, BranchReference, ResolveError};
+use crate::{Branch, BranchReference, Overlay, ResolveError};
 use dialog_capability::Provider;
 use dialog_effects::memory::Resolve;
 use dialog_query::concept::query::PlanCache;
@@ -38,6 +38,7 @@ impl OpenBranch {
             node_cache: dialog_search_tree::Cache::new(),
             rule_cache: Arc::new(RuleCache::new()),
             plan_cache: PlanCache::default(),
+            overlay: Overlay::default(),
         })
     }
 }

--- a/rust/dialog-repository/src/repository/branch/overlay.rs
+++ b/rust/dialog-repository/src/repository/branch/overlay.rs
@@ -1,0 +1,83 @@
+//! Branch-scoped transient overlay.
+
+use std::sync::{Arc, Mutex};
+
+use dialog_artifacts::{Changes, Statement};
+
+use crate::Branch;
+
+/// Ephemeral session facts folded into every read of the branch —
+/// queries, transaction queries, and standing subscriptions — but
+/// never committed to the tree. Obtained via
+/// [`Branch::overlay`]; shared across branch clones, so a fact
+/// asserted through any clone is visible to readers of all of them.
+///
+/// Asserts surface alongside branch facts; retracts tombstone
+/// matching branch facts for readers without touching the tree.
+/// Every mutation bumps an epoch that subscriptions snapshot at each
+/// poll: a poll re-evaluates when the epoch moved even though the
+/// tree did not, which is how overlay changes propagate to the
+/// branch's subscriptions.
+#[derive(Debug, Clone, Default)]
+pub struct Overlay {
+    state: Arc<Mutex<State>>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    /// Bumped on every mutation. Subscriptions pin the epoch they
+    /// last evaluated at; an off-tree change is invisible to the
+    /// poll's tree-diff gate, so the epoch is what re-triggers.
+    epoch: u64,
+    changes: Changes,
+}
+
+impl Overlay {
+    /// Assert an ephemeral statement into the session overlay.
+    pub fn assert<S: Statement>(&self, statement: S) -> &Self {
+        let mut state = self.state.lock().expect("overlay lock");
+        statement.assert(&mut state.changes);
+        state.epoch += 1;
+        self
+    }
+
+    /// Retract a statement for the session: matching branch facts
+    /// are tombstoned for readers; the tree is untouched.
+    pub fn retract<S: Statement>(&self, statement: S) -> &Self {
+        let mut state = self.state.lock().expect("overlay lock");
+        statement.retract(&mut state.changes);
+        state.epoch += 1;
+        self
+    }
+
+    /// Drop every session fact.
+    pub fn clear(&self) -> &Self {
+        let mut state = self.state.lock().expect("overlay lock");
+        state.changes = Changes::new();
+        state.epoch += 1;
+        self
+    }
+
+    /// The current session changes, folded into a [`QueryLayer`] at
+    /// construction so every read path sees them.
+    ///
+    /// [`QueryLayer`]: crate::QueryLayer
+    pub(crate) fn changes(&self) -> Changes {
+        self.state.lock().expect("overlay lock").changes.clone()
+    }
+
+    /// The current epoch: subscriptions compare it against the one
+    /// they pinned to decide whether the overlay moved.
+    pub(crate) fn epoch(&self) -> u64 {
+        self.state.lock().expect("overlay lock").epoch
+    }
+}
+
+impl Branch {
+    /// The branch's transient session overlay: assert or retract
+    /// ephemeral facts that every read of this branch observes but
+    /// no commit persists. See [`Overlay`].
+    pub fn overlay(&self) -> &Overlay {
+        &self.overlay
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -361,8 +361,17 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<'a, Env> Provider<Select<'a>> for QueryEnv<'a, Env>
+// The `Select` lifetime `'s` is decoupled from the env lifetime `'a`
+// (`'a: 'a` bounds it below `'a`): a `QueryEnv<'a>` provides
+// `Select<'s>` for *any* `'s` outlived by `'a`, not only `'s == 'a`.
+// This is what lets a subscription poll hold `&query_env` across an
+// `await` and stay Send-general — the caller's higher-ranked
+// `for<'s> Provider<Select<'s>>` demand is now satisfiable. The
+// returned stream still borrows `'a` data, which outlives `'s`, so
+// the shorter `ArtifactStream<'s>` is sound.
+impl<'a, 's, Env> Provider<Select<'s>> for QueryEnv<'a, Env>
 where
+    'a: 's,
     Env: Provider<Get>
         + Provider<Put>
         + Provider<Resolve>
@@ -374,20 +383,22 @@ where
     async fn execute(
         &self,
         input: ArtifactSelector<Constrained>,
-    ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
+    ) -> Result<ArtifactStream<'s>, DialogArtifactsError> {
         self.record_demand(&input);
-        let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.branches.len() + 1);
+        let mut streams: Vec<ArtifactStream<'s>> = Vec::with_capacity(self.branches.len() + 1);
 
         // Branch streams — each filtered by tombstones from the
         // overlay's retracts so a `tx.retract(x)` (or any user-asserted
-        // retract in `with(..)`) suppresses matching source facts.
+        // retract in `with(..)`) suppresses matching source facts. Each
+        // borrows `'a` data, which outlives `'s`, so it coerces to
+        // `ArtifactStream<'s>`.
         for branch in &self.branches {
             let raw = select_from_branch(branch, self.env, input.clone()).await?;
             streams.push(filter_tombstones(raw, self.tombstones.clone()));
         }
 
         // Overlay stream — Changes itself is a Provider<Select>.
-        streams.push(Provider::<Select<'a>>::execute(&self.changes, input).await?);
+        streams.push(Provider::<Select<'s>>::execute(&self.changes, input).await?);
 
         Ok(merge_grouped(streams))
     }

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -227,8 +227,8 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
 
-            let query_env =
-                QueryEnv::new(layer.branches, overlay, tombstones, env);
+            let branches = layer.branches.iter().map(|&branch| branch.clone()).collect();
+            let query_env = QueryEnv::new(branches, overlay, tombstones, env);
             let results = Box::pin(query.perform(&query_env));
             for await result in results {
                 yield result?;
@@ -243,7 +243,14 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
 /// Built fresh on each `.perform(env)`; the environment reference
 /// is never captured on the layer itself.
 pub(crate) struct QueryEnv<'a, Env> {
-    branches: Vec<&'a Branch>,
+    /// Owned (cheaply cloned: shared caches) so the env's only
+    /// lifetime is the underlying `env` reference. A poll/evaluation
+    /// can then type its `QueryEnv` with the *named* env lifetime
+    /// instead of a generator-local borrow — which is what keeps the
+    /// enclosing future `Send`-general on native (two independent
+    /// erased lifetimes in `QueryEnv<'0>: Provider<Select<'1>>` hit
+    /// rustc's #100013 limitation; a named lifetime does not).
+    branches: Vec<Branch>,
     /// All overlay facts — caller-asserted + auto-injected metadata —
     /// merged into one batch. Queried via `Provider<Select> for Changes`.
     changes: Changes,
@@ -275,7 +282,7 @@ impl<'a, Env> QueryEnv<'a, Env> {
     /// resolution is built in (a durable layer per branch + the overlay
     /// as a transient layer), so the two paths can never diverge on it.
     pub(crate) fn new(
-        branches: Vec<&'a Branch>,
+        branches: Vec<Branch>,
         changes: Changes,
         tombstones: HashSet<SortKey>,
         env: &'a Env,
@@ -331,11 +338,15 @@ impl<Env> Clone for QueryEnv<'_, Env> {
 /// the branch's remote upstream when configured. Extracted as a freestanding
 /// helper so every branch in a [`QueryEnv`] shares the exact same branch-read
 /// path (a transaction query is itself a single-branch `QueryEnv`).
-pub(crate) async fn select_from_branch<'a, Env>(
-    branch: &'a Branch,
+///
+/// Takes the branch by value (a cheap clone: shared caches) and moves
+/// it into the returned stream, so the stream borrows only the env —
+/// errors surface as the stream's first item.
+pub(crate) fn select_from_branch<'a, Env>(
+    branch: Branch,
     env: &'a Env,
     input: ArtifactSelector<Constrained>,
-) -> Result<ArtifactStream<'a>, DialogArtifactsError>
+) -> ArtifactStream<'a>
 where
     Env: Provider<Get>
         + Provider<Put>
@@ -345,33 +356,41 @@ where
         + ConditionalSync
         + 'static,
 {
-    let select = branch.claims().select(input);
+    Box::pin(async_stream::try_stream! {
+        let select = branch.claims().select(input);
 
-    let remote = match branch.upstream() {
-        Some(Upstream::Remote { remote: name, .. }) => {
-            branch.subject().remote(name).load().perform(env).await.ok()
+        let remote = match branch.upstream() {
+            Some(Upstream::Remote { remote: name, .. }) => {
+                branch.subject().remote(name).load().perform(env).await.ok()
+            }
+            _ => None,
+        };
+
+        let store = NetworkedIndex::new(env, select.catalog(), remote);
+        let stream = select.execute(store).await?;
+        for await artifact in stream {
+            yield artifact?;
         }
-        _ => None,
-    };
-
-    let store = NetworkedIndex::new(env, select.catalog(), remote);
-    let stream = select.execute(store).await?;
-    Ok(Box::pin(stream))
+    })
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-// The `Select` lifetime `'s` is decoupled from the env lifetime `'a`
-// (`'a: 'a` bounds it below `'a`): a `QueryEnv<'a>` provides
-// `Select<'s>` for *any* `'s` outlived by `'a`, not only `'s == 'a`.
-// This is what lets a subscription poll hold `&query_env` across an
-// `await` and stay Send-general — the caller's higher-ranked
-// `for<'s> Provider<Select<'s>>` demand is now satisfiable. The
-// returned stream still borrows `'a` data, which outlives `'s`, so
-// the shorter `ArtifactStream<'s>` is sound.
-impl<'a, 's, Env> Provider<Select<'s>> for QueryEnv<'a, Env>
+// Deliberately implemented for the *same* lifetime on both sides
+// (`QueryEnv<'a>: Provider<Select<'a>>`), never a decoupled pair
+// (`impl<'a, 's> ... where 'a: 's`). Auto-trait (`Send`) checking of
+// a future that holds `&query_env` across an `await` erases every
+// region, so the obligation resurfaces higher-ranked: a single
+// erased lifetime (`for<'0> QueryEnv<'0>: Provider<Select<'0>>`)
+// is provable by this impl, while a decoupled pair
+// (`for<'0, '1> QueryEnv<'0>: Provider<Select<'1>>`) hits rustc's
+// #100013 limitation and the poll future stops being `Send` on
+// native. `QueryEnv` is covariant in `'a`, so call sites shrink
+// `&QueryEnv<'a>` to `&QueryEnv<'s>` implicitly — the strict impl
+// is what forces region inference to unify the two into one
+// variable.
+impl<'a, Env> Provider<Select<'a>> for QueryEnv<'a, Env>
 where
-    'a: 's,
     Env: Provider<Get>
         + Provider<Put>
         + Provider<Resolve>
@@ -383,22 +402,21 @@ where
     async fn execute(
         &self,
         input: ArtifactSelector<Constrained>,
-    ) -> Result<ArtifactStream<'s>, DialogArtifactsError> {
+    ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
         self.record_demand(&input);
-        let mut streams: Vec<ArtifactStream<'s>> = Vec::with_capacity(self.branches.len() + 1);
+        let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.branches.len() + 1);
 
         // Branch streams — each filtered by tombstones from the
         // overlay's retracts so a `tx.retract(x)` (or any user-asserted
         // retract in `with(..)`) suppresses matching source facts. Each
-        // borrows `'a` data, which outlives `'s`, so it coerces to
-        // `ArtifactStream<'s>`.
+        // owns its branch clone and borrows only `self.env`.
         for branch in &self.branches {
-            let raw = select_from_branch(branch, self.env, input.clone()).await?;
+            let raw = select_from_branch(branch.clone(), self.env, input.clone());
             streams.push(filter_tombstones(raw, self.tombstones.clone()));
         }
 
         // Overlay stream — Changes itself is a Provider<Select>.
-        streams.push(Provider::<Select<'s>>::execute(&self.changes, input).await?);
+        streams.push(Provider::<Select<'a>>::execute(&self.changes, input).await?);
 
         Ok(merge_grouped(streams))
     }
@@ -421,7 +439,7 @@ where
     /// separately, fresh, by the transient layer.
     async fn select_tree(
         &self,
-        branch: &'a Branch,
+        branch: &Branch,
         selector: ArtifactSelector<Constrained>,
     ) -> Result<Vec<Artifact>, DialogArtifactsError> {
         // Rule-discovery reads are demand too: a rule committed
@@ -432,8 +450,9 @@ where
         if let Some(demand) = &self.demand {
             demand.record_rules(&selector);
         }
-        let stream = select_from_branch(branch, self.env, selector).await?;
-        stream.try_collect().await
+        select_from_branch(branch.clone(), self.env, selector)
+            .try_collect()
+            .await
     }
 
     /// The durable rules concluding `concept` on `branch`: the committed
@@ -442,7 +461,7 @@ where
     /// cached by content-addressed rule entity.
     async fn durable_rules(
         &self,
-        branch: &'a Branch,
+        branch: &Branch,
         concept: &Entity,
     ) -> Result<Vec<DeductiveRule>, EvaluationError> {
         let cache = branch.rule_cache();

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -165,11 +165,16 @@ impl<'a> QueryLayer<'a> {
     }
 }
 
+// Folds the branch's transient session overlay
+// ([`Branch::overlay`]): every read path — `branch.select`,
+// `branch.query`, transaction queries, subscription evaluations —
+// constructs through here, so session facts participate in all of
+// them with no per-path wiring.
 impl<'a> From<&'a Branch> for QueryLayer<'a> {
     fn from(branch: &'a Branch) -> Self {
         Self {
             branches: vec![branch],
-            changes: Changes::new(),
+            changes: branch.overlay().changes(),
         }
     }
 }

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -61,6 +61,7 @@
 //! [`AnalyzedRule::is_entity_local`]: dialog_query::rule::analyzer::AnalyzedRule::is_entity_local
 
 use std::collections::BTreeSet;
+use std::future::Future;
 use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 
@@ -316,13 +317,21 @@ where
         &self.demand
     }
 
-    /// Replace the transient overlay folded into evaluations. The
-    /// overlay is off-tree, so this alone changes nothing: the caller
-    /// must follow with a [`poll`](Subscription::poll), which then
-    /// recomputes (the overlay delta can't be derived from the tree
-    /// diff) and reports the result change as a delta.
+    /// Replace the transient overlay folded into evaluations and
+    /// invalidate the pinned revision so the next
+    /// [`poll`](Subscription::poll) recomputes.
+    ///
+    /// The overlay is off-tree, so a change to it never appears in
+    /// the tree diff the poll gates on; without invalidating the pin
+    /// the next poll would short-circuit (`current == revision`) and
+    /// miss the overlay change. Invalidation routes the next poll
+    /// through a full evaluation (the overlay delta cannot be derived
+    /// incrementally from the tree), which reports the result change
+    /// as a delta against the retained results.
     pub fn set_overlay(&mut self, overlay: Changes) {
         self.overlay = overlay;
+        self.revision = None;
+        self.initialized = false;
     }
 
     /// Full evaluations performed so far (the first poll plus every
@@ -352,10 +361,10 @@ where
     /// lands mid-evaluation re-triggers on the next poll (the diff
     /// from the pinned root is a superset), so changes are never
     /// missed, at worst re-checked.
-    pub async fn poll<Env>(
-        &mut self,
-        env: &Env,
-    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
+    pub fn poll<'a, Env>(
+        &'a mut self,
+        env: &'a Env,
+    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -366,62 +375,71 @@ where
             + ConditionalSync
             + 'static,
     {
-        let current = self.branch.revision();
-        if self.initialized {
-            if current == self.revision {
-                return Ok(None);
-            }
-            match self.touched(env, &current).await? {
-                Touched::Nothing => {
-                    self.revision = current;
+        // Returned as an explicit `impl Future + 'a` (not an `async
+        // fn`) so the env lifetime is named rather than higher-ranked.
+        // An `async fn poll<Env>(&mut self, env: &Env)` desugars to a
+        // future whose `&Env` capture is `for<'e>`, which defeats
+        // Send-generality inference in a caller that must be `Send`
+        // (an axum handler draining subscription polls) — the same
+        // reason `SelectQuery::perform` is written this way.
+        async move {
+            let current = self.branch.revision();
+            if self.initialized {
+                if current == self.revision {
                     return Ok(None);
                 }
-                Touched::Facts {
-                    subjects,
-                    facts,
-                    asserted,
-                    retracted,
-                } => {
-                    if let Some(delta) = self
-                        .maintain(env, &subjects, &facts, &asserted, &retracted)
-                        .await?
-                    {
-                        self.maintenances += 1;
+                match self.touched(env, &current).await? {
+                    Touched::Nothing => {
                         self.revision = current;
-                        return Ok(Some(delta));
+                        return Ok(None);
                     }
-                    // Not maintainable for this query/rule shape:
-                    // fall through to a full recompute.
+                    Touched::Facts {
+                        subjects,
+                        facts,
+                        asserted,
+                        retracted,
+                    } => {
+                        if let Some(delta) = self
+                            .maintain(env, &subjects, &facts, &asserted, &retracted)
+                            .await?
+                        {
+                            self.maintenances += 1;
+                            self.revision = current;
+                            return Ok(Some(delta));
+                        }
+                        // Not maintainable for this query/rule shape:
+                        // fall through to a full recompute.
+                    }
+                    // A rule-range change can install or change a rule,
+                    // which can affect any row: recompute.
+                    Touched::Rules => {}
                 }
-                // A rule-range change can install or change a rule,
-                // which can affect any row: recompute.
-                Touched::Rules => {}
             }
+
+            let demand = Demand::new();
+            let results = self.evaluate(env, &demand, &self.query).await?;
+            self.recomputes += 1;
+
+            let delta = Delta {
+                asserted: results
+                    .iter()
+                    .filter(|row| !self.results.contains(row))
+                    .cloned()
+                    .collect(),
+                retracted: self
+                    .results
+                    .iter()
+                    .filter(|row| !results.contains(row))
+                    .cloned()
+                    .collect(),
+            };
+
+            self.results = results;
+            self.demand = demand;
+            self.revision = current;
+            self.initialized = true;
+            Ok(Some(delta))
         }
-
-        let demand = Demand::new();
-        let results = self.evaluate(env, &demand, &self.query).await?;
-        self.recomputes += 1;
-
-        let delta = Delta {
-            asserted: results
-                .iter()
-                .filter(|row| !self.results.contains(row))
-                .cloned()
-                .collect(),
-            retracted: self
-                .results
-                .iter()
-                .filter(|row| !results.contains(row))
-                .cloned()
-                .collect(),
-        };
-
-        self.results = results;
-        self.demand = demand;
-        self.revision = current;
-        self.initialized = true;
-        Ok(Some(delta))
     }
 
     /// Classify what the changes between the pinned root and
@@ -443,11 +461,11 @@ where
     /// and are skipped.
     ///
     /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
-    async fn touched<Env>(
-        &self,
-        env: &Env,
-        current: &Option<Revision>,
-    ) -> Result<Touched, EvaluationError>
+    fn touched<'a, Env>(
+        &'a self,
+        env: &'a Env,
+        current: &'a Option<Revision>,
+    ) -> impl Future<Output = Result<Touched, EvaluationError>> + 'a
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -457,78 +475,82 @@ where
             + ConditionalSync
             + 'static,
     {
-        let pinned = tree_hash(&self.revision);
-        let target = tree_hash(current);
-        if pinned == target {
-            return Ok(Touched::Nothing);
-        }
-        let scope = self.demand.ranges();
-        if scope.is_empty() {
-            return Ok(Touched::Nothing);
-        }
-
-        let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
-        let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
-        let previous =
-            Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
-        let next = Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
-
-        let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
-        let mut changes = Box::pin(changes);
-        let mut subjects = BTreeSet::new();
-        let mut asserted = Vec::new();
-        let mut retracted = Vec::new();
-        // A fact change surfaces once per index order; dedup on the
-        // datum triple, per direction.
-        let mut seen = BTreeSet::new();
-        while let Some(change) = changes
-            .try_next()
-            .await
-            .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-        {
-            let entry = match &change {
-                Change::Add(entry) => entry,
-                Change::Remove(entry) => entry,
-            };
-            if self.demand.covers_rules(&entry.key) {
-                return Ok(Touched::Rules);
+        async move {
+            let pinned = tree_hash(&self.revision);
+            let target = tree_hash(current);
+            if pinned == target {
+                return Ok(Touched::Nothing);
             }
-            // An entry arriving with a datum became readable; an
-            // entry leaving with a datum stopped being readable.
-            // Tombstone-valued entries carry no datum: their effect
-            // (if any) surfaces as the paired datum-bearing change
-            // at the same key.
-            let arriving = matches!(&change, Change::Add(_));
-            if let State::Added(datum) = &entry.value {
-                if !seen.insert((
-                    arriving,
-                    datum.entity.clone(),
-                    datum.attribute.clone(),
-                    datum.value.clone(),
-                )) {
-                    continue;
+            let scope = self.demand.ranges();
+            if scope.is_empty() {
+                return Ok(Touched::Nothing);
+            }
+
+            let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
+            let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
+            let previous =
+                Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
+            let next =
+                Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
+
+            let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
+            let mut changes = Box::pin(changes);
+            let mut subjects = BTreeSet::new();
+            let mut asserted = Vec::new();
+            let mut retracted = Vec::new();
+            // A fact change surfaces once per index order; dedup on the
+            // datum triple, per direction.
+            let mut seen = BTreeSet::new();
+            while let Some(change) = changes
+                .try_next()
+                .await
+                .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
+            {
+                let entry = match &change {
+                    Change::Add(entry) => entry,
+                    Change::Remove(entry) => entry,
+                };
+                if self.demand.covers_rules(&entry.key) {
+                    return Ok(Touched::Rules);
                 }
-                let fact = Artifact::try_from(datum.clone())
-                    .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
-                subjects.insert(fact.of.clone());
-                if arriving {
-                    asserted.push(fact);
-                } else {
-                    retracted.push(fact);
+                // An entry arriving with a datum became readable; an
+                // entry leaving with a datum stopped being readable.
+                // Tombstone-valued entries carry no datum: their effect
+                // (if any) surfaces as the paired datum-bearing change
+                // at the same key.
+                let arriving = matches!(&change, Change::Add(_));
+                if let State::Added(datum) = &entry.value {
+                    if !seen.insert((
+                        arriving,
+                        datum.entity.clone(),
+                        datum.attribute.clone(),
+                        datum.value.clone(),
+                    )) {
+                        continue;
+                    }
+                    let fact = Artifact::try_from(datum.clone()).map_err(|error| {
+                        EvaluationError::Store(format!("changed datum: {error:?}"))
+                    })?;
+                    subjects.insert(fact.of.clone());
+                    if arriving {
+                        asserted.push(fact);
+                    } else {
+                        retracted.push(fact);
+                    }
                 }
             }
-        }
 
-        if subjects.is_empty() {
-            Ok(Touched::Nothing)
-        } else {
-            let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
-            Ok(Touched::Facts {
-                subjects,
-                facts,
-                asserted,
-                retracted,
-            })
+            if subjects.is_empty() {
+                Ok(Touched::Nothing)
+            } else {
+                let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
+                Ok(Touched::Facts {
+                    subjects,
+                    facts,
+                    asserted,
+                    retracted,
+                })
+            }
         }
     }
 
@@ -545,14 +567,14 @@ where
     /// the query is not restrictable, the concept is recursive, or
     /// the delta-join discovery hit a shape it does not handle — in
     /// which case the caller falls back to a full recompute.
-    async fn maintain<Env>(
-        &mut self,
-        env: &Env,
-        subjects: &BTreeSet<Entity>,
-        facts: &[Artifact],
-        asserted: &[Artifact],
-        retracted: &[Artifact],
-    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
+    fn maintain<'a, Env>(
+        &'a mut self,
+        env: &'a Env,
+        subjects: &'a BTreeSet<Entity>,
+        facts: &'a [Artifact],
+        asserted: &'a [Artifact],
+        retracted: &'a [Artifact],
+    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -563,19 +585,174 @@ where
             + ConditionalSync
             + 'static,
     {
-        // For a concept query the affected heads are discovered
-        // against the resolved rule set: entity-local rules
-        // contribute the changed subjects, non-local rules (concept
-        // premises: conformance checks, variant negations)
-        // contribute delta-join heads — the changed fact bound into
-        // the premise it matches, remaining premises joined
-        // sideways, head projected. `None` (recursion, unhandled
-        // shape) falls back to full recompute. For a plain attribute
-        // query the affected heads are just the changed subjects.
-        //
-        // The discovery evaluates against the demand-recording
-        // environment, so the reads it depends on join the cover.
-        let entities: BTreeSet<Entity> = if let Some(concept) = self.query.concept() {
+        async move {
+            // For a concept query the affected heads are discovered
+            // against the resolved rule set: entity-local rules
+            // contribute the changed subjects, non-local rules (concept
+            // premises: conformance checks, variant negations)
+            // contribute delta-join heads — the changed fact bound into
+            // the premise it matches, remaining premises joined
+            // sideways, head projected. `None` (recursion, unhandled
+            // shape) falls back to full recompute. For a plain attribute
+            // query the affected heads are just the changed subjects.
+            //
+            // The discovery evaluates against the demand-recording
+            // environment, so the reads it depends on join the cover.
+            let entities: BTreeSet<Entity> = if let Some(concept) = self.query.concept() {
+                let operator = Identify
+                    .perform(env)
+                    .await
+                    .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+                let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+                let overlay = layer.overlay(&operator);
+                let tombstones = tombstones_from(&overlay);
+                let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+                    .with_demand(self.demand.clone());
+                let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
+                if rules.recursion().is_some() {
+                    // Fixpoint continuation: deletions retract via DRed,
+                    // additions extend semi-naively — rebuilding into
+                    // the retained table when either phase declines.
+                    drop(query_env);
+                    let results = self
+                        .evaluate_with_continuation(
+                            env,
+                            Arc::new(asserted.to_vec()),
+                            Arc::new(retracted.to_vec()),
+                        )
+                        .await?;
+                    let delta = Delta {
+                        asserted: results
+                            .iter()
+                            .filter(|row| !self.results.contains(row))
+                            .cloned()
+                            .collect(),
+                        retracted: self
+                            .results
+                            .iter()
+                            .filter(|row| !results.contains(row))
+                            .cloned()
+                            .collect(),
+                    };
+                    self.results = results;
+                    return Ok(Some(delta));
+                }
+                match affected_entities(concept, facts, &query_env).await? {
+                    Some(entities) => entities,
+                    None => return Ok(None),
+                }
+            } else {
+                subjects.clone()
+            };
+
+            let mut asserted = Vec::new();
+            let mut retracted = Vec::new();
+            for entity in &entities {
+                let scoped = match self.query.restrict(entity) {
+                    Restriction::Scoped(query) => query,
+                    Restriction::Unaffected => continue,
+                    Restriction::Unsupported => return Ok(None),
+                };
+                // Over-delete: every retained row for this entity...
+                let before: Vec<Q::Conclusion> = self
+                    .results
+                    .iter()
+                    .filter(|row| row.this() == entity)
+                    .cloned()
+                    .collect();
+                // ...re-derive + insert: goal-directed re-evaluation,
+                // recording into the existing cover (the standing
+                // demand only ever grows between recomputes).
+                let after = self.evaluate(env, &self.demand.clone(), &scoped).await?;
+                for row in &after {
+                    if !before.contains(row) {
+                        asserted.push(row.clone());
+                    }
+                }
+                for row in &before {
+                    if !after.contains(row) {
+                        retracted.push(row.clone());
+                    }
+                }
+                self.results.retain(|row| row.this() != entity);
+                self.results.extend(after);
+            }
+            Ok(Some(Delta {
+                asserted,
+                retracted,
+            }))
+        }
+    }
+
+    /// Evaluate the query against the branch, recording every
+    /// demanded range into `demand`. Mirrors the ordinary
+    /// `branch.select(query).perform(env)` path with a
+    /// demand-recording environment.
+    // `impl Future + 'a` (not `async fn`) so the env lifetime is
+    // named, keeping the enclosing `poll` future Send-general on
+    // native — see the note on `poll`.
+    fn evaluate<'a, Env>(
+        &'a self,
+        env: &'a Env,
+        demand: &'a Demand,
+        query: &'a Q,
+    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        async move {
+            let operator = Identify
+                .perform(env)
+                .await
+                .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+            let overlay = layer.overlay(&operator);
+            let tombstones = tombstones_from(&overlay);
+            let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+                .with_demand(demand.clone());
+            // Recursive concept subscriptions retain their fixpoint
+            // across polls: a recompute rebuilds into the retained
+            // table so a later additions-only poll can extend it.
+            if let Some(concept) = query.concept() {
+                query_env = query_env
+                    .with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
+            }
+            query.clone().perform(&query_env).try_vec().await
+        }
+    }
+
+    /// Evaluate the standing query with the retained fixpoint
+    /// attached, seeding a semi-naive continuation from `additions`
+    /// when present. Demand keeps recording into the standing
+    /// cover.
+    fn evaluate_with_continuation<'a, Env>(
+        &'a self,
+        env: &'a Env,
+        additions: Arc<Vec<Artifact>>,
+        deletions: Arc<Vec<Artifact>>,
+    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        async move {
+            let concept = self
+                .query
+                .concept()
+                .expect("continuation evaluation requires a concept query");
             let operator = Identify
                 .perform(env)
                 .await
@@ -584,159 +761,13 @@ where
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                .with_demand(self.demand.clone());
-            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
-            if rules.recursion().is_some() {
-                // Fixpoint continuation: deletions retract via DRed,
-                // additions extend semi-naively — rebuilding into
-                // the retained table when either phase declines.
-                drop(query_env);
-                let results = self
-                    .evaluate_with_continuation(
-                        env,
-                        Arc::new(asserted.to_vec()),
-                        Arc::new(retracted.to_vec()),
-                    )
-                    .await?;
-                let delta = Delta {
-                    asserted: results
-                        .iter()
-                        .filter(|row| !self.results.contains(row))
-                        .cloned()
-                        .collect(),
-                    retracted: self
-                        .results
-                        .iter()
-                        .filter(|row| !results.contains(row))
-                        .cloned()
-                        .collect(),
-                };
-                self.results = results;
-                return Ok(Some(delta));
-            }
-            match affected_entities(concept, facts, &query_env).await? {
-                Some(entities) => entities,
-                None => return Ok(None),
-            }
-        } else {
-            subjects.clone()
-        };
-
-        let mut asserted = Vec::new();
-        let mut retracted = Vec::new();
-        for entity in &entities {
-            let scoped = match self.query.restrict(entity) {
-                Restriction::Scoped(query) => query,
-                Restriction::Unaffected => continue,
-                Restriction::Unsupported => return Ok(None),
-            };
-            // Over-delete: every retained row for this entity...
-            let before: Vec<Q::Conclusion> = self
-                .results
-                .iter()
-                .filter(|row| row.this() == entity)
-                .cloned()
-                .collect();
-            // ...re-derive + insert: goal-directed re-evaluation,
-            // recording into the existing cover (the standing
-            // demand only ever grows between recomputes).
-            let after = self.evaluate(env, &self.demand.clone(), &scoped).await?;
-            for row in &after {
-                if !before.contains(row) {
-                    asserted.push(row.clone());
-                }
-            }
-            for row in &before {
-                if !after.contains(row) {
-                    retracted.push(row.clone());
-                }
-            }
-            self.results.retain(|row| row.this() != entity);
-            self.results.extend(after);
+                .with_demand(self.demand.clone())
+                .with_fixpoint(
+                    concept.this(),
+                    Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
+                );
+            self.query.clone().perform(&query_env).try_vec().await
         }
-        Ok(Some(Delta {
-            asserted,
-            retracted,
-        }))
-    }
-
-    /// Evaluate the query against the branch, recording every
-    /// demanded range into `demand`. Mirrors the ordinary
-    /// `branch.select(query).perform(env)` path with a
-    /// demand-recording environment.
-    async fn evaluate<Env>(
-        &self,
-        env: &Env,
-        demand: &Demand,
-        query: &Q,
-    ) -> Result<Vec<Q::Conclusion>, EvaluationError>
-    where
-        Env: Provider<Get>
-            + Provider<Put>
-            + Provider<Resolve>
-            + Provider<Identify>
-            + Provider<Fork<RemoteSite, Get>>
-            + Provider<Fork<RemoteSite, Resolve>>
-            + ConditionalSync
-            + 'static,
-    {
-        let operator = Identify
-            .perform(env)
-            .await
-            .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
-        let overlay = layer.overlay(&operator);
-        let tombstones = tombstones_from(&overlay);
-        let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-            .with_demand(demand.clone());
-        // Recursive concept subscriptions retain their fixpoint
-        // across polls: a recompute rebuilds into the retained
-        // table so a later additions-only poll can extend it.
-        if let Some(concept) = query.concept() {
-            query_env =
-                query_env.with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
-        }
-        query.clone().perform(&query_env).try_vec().await
-    }
-
-    /// Evaluate the standing query with the retained fixpoint
-    /// attached, seeding a semi-naive continuation from `additions`
-    /// when present. Demand keeps recording into the standing
-    /// cover.
-    async fn evaluate_with_continuation<Env>(
-        &self,
-        env: &Env,
-        additions: Arc<Vec<Artifact>>,
-        deletions: Arc<Vec<Artifact>>,
-    ) -> Result<Vec<Q::Conclusion>, EvaluationError>
-    where
-        Env: Provider<Get>
-            + Provider<Put>
-            + Provider<Resolve>
-            + Provider<Identify>
-            + Provider<Fork<RemoteSite, Get>>
-            + Provider<Fork<RemoteSite, Resolve>>
-            + ConditionalSync
-            + 'static,
-    {
-        let concept = self
-            .query
-            .concept()
-            .expect("continuation evaluation requires a concept query");
-        let operator = Identify
-            .perform(env)
-            .await
-            .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
-        let overlay = layer.overlay(&operator);
-        let tombstones = tombstones_from(&overlay);
-        let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-            .with_demand(self.demand.clone())
-            .with_fixpoint(
-                concept.this(),
-                Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
-            );
-        self.query.clone().perform(&query_env).try_vec().await
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -68,7 +68,7 @@ use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{Artifact, ArtifactSelector, Changes, Entity, KeyBytes, State};
+use dialog_artifacts::{Artifact, ArtifactSelector, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -209,21 +209,17 @@ impl<T> Delta<T> {
 pub struct Subscription<Q: Application> {
     branch: Branch,
     query: Q,
-    /// A caller-supplied transient overlay folded into every
-    /// evaluation alongside the branch facts — the same role
-    /// [`QueryLayer::with`] plays for a one-shot query. Ephemeral:
-    /// off-tree, never committed, so the tree-diff gate in
-    /// [`touched`](Subscription::touched) can't observe a change to
-    /// it. The owner must therefore call
-    /// [`set_overlay`](Subscription::set_overlay) and force a poll
-    /// when the overlay mutates; a poll then recomputes (the overlay
-    /// delta is not derivable from the tree). Empty by default
-    /// ([`subscribe`](Branch::subscribe)); populated via
-    /// [`subscribe_with`](Branch::subscribe_with).
-    overlay: Changes,
     /// The revision the retained results were evaluated at. `None`
     /// until the first poll.
     revision: Option<Revision>,
+    /// The [`Overlay`](crate::Overlay) epoch the retained results
+    /// were evaluated at. The branch's session overlay is off-tree,
+    /// so a change to it is invisible to the poll's tree-diff gate;
+    /// the epoch is the signal that re-triggers evaluation (the
+    /// overlay delta is not derivable from the tree, so an epoch
+    /// move recomputes, reporting the change as a delta against the
+    /// retained results).
+    overlay_epoch: u64,
     /// The demand cover recorded during the last evaluation.
     demand: Demand,
     /// The last evaluation's full result, retained to compute the
@@ -244,23 +240,18 @@ impl Branch {
     /// Register a standing query over this branch. The subscription
     /// evaluates on its first [`poll`](Subscription::poll) and is
     /// incrementally gated afterwards.
+    ///
+    /// Reads observe the branch's transient session overlay
+    /// ([`Branch::overlay`]) like every other read path, and a poll
+    /// picks up overlay changes: asserting an ephemeral fact into
+    /// the overlay propagates to the branch's subscriptions as a
+    /// result delta on their next poll.
     pub fn subscribe<Q: Application>(&self, query: Q) -> Subscription<Q> {
-        self.subscribe_with(query, Changes::new())
-    }
-
-    /// Register a standing query with a transient `overlay` folded
-    /// into every evaluation — ephemeral facts (an invite seed, a
-    /// UI status stamp) that participate in reads and in the demand
-    /// cover but are never committed. Because the overlay is
-    /// off-tree, a change to it is invisible to the poll's tree-diff
-    /// gate: after mutating it via [`Subscription::set_overlay`], the
-    /// owner must force a poll to pick the change up.
-    pub fn subscribe_with<Q: Application>(&self, query: Q, overlay: Changes) -> Subscription<Q> {
         Subscription {
             branch: self.clone(),
             query,
-            overlay,
             revision: None,
+            overlay_epoch: 0,
             demand: Demand::new(),
             results: Vec::new(),
             fixpoint: Arc::new(Mutex::new(None)),
@@ -335,23 +326,6 @@ where
         &self.demand
     }
 
-    /// Replace the transient overlay folded into evaluations and
-    /// invalidate the pinned revision so the next
-    /// [`poll`](Subscription::poll) recomputes.
-    ///
-    /// The overlay is off-tree, so a change to it never appears in
-    /// the tree diff the poll gates on; without invalidating the pin
-    /// the next poll would short-circuit (`current == revision`) and
-    /// miss the overlay change. Invalidation routes the next poll
-    /// through a full evaluation (the overlay delta cannot be derived
-    /// incrementally from the tree), which reports the result change
-    /// as a delta against the retained results.
-    pub fn set_overlay(&mut self, overlay: Changes) {
-        self.overlay = overlay;
-        self.revision = None;
-        self.initialized = false;
-    }
-
     /// Full evaluations performed so far (the first poll plus every
     /// fallback from incremental maintenance).
     pub fn recomputes(&self) -> usize {
@@ -369,16 +343,17 @@ where
     /// Poll the subscription against the branch's current state.
     ///
     /// Returns `Ok(None)` when the result is known unchanged: the
-    /// branch is at the pinned revision, or it moved but no change
-    /// intersects the demand cover (the pin advances silently).
-    /// Returns `Ok(Some(delta))` after a (re-)evaluation — the first
-    /// poll always evaluates, reporting the initial result as
-    /// `asserted` rows.
+    /// branch is at the pinned revision with the session overlay at
+    /// the pinned epoch, or the tree moved but no change intersects
+    /// the demand cover (the pin advances silently). Returns
+    /// `Ok(Some(delta))` after a (re-)evaluation — the first poll
+    /// always evaluates, reporting the initial result as `asserted`
+    /// rows.
     ///
-    /// The revision is snapshotted before evaluating; a commit that
-    /// lands mid-evaluation re-triggers on the next poll (the diff
-    /// from the pinned root is a superset), so changes are never
-    /// missed, at worst re-checked.
+    /// The revision and overlay epoch are snapshotted before
+    /// evaluating; a commit or overlay mutation that lands
+    /// mid-evaluation re-triggers on the next poll, so changes are
+    /// never missed, at worst re-checked.
     // The `self` and `env` lifetimes are deliberately unified into
     // one named `'a`: the poll future must stay `Send` on native (an
     // axum handler drains subscription polls), and its inner
@@ -398,7 +373,13 @@ where
             + 'static,
     {
         let current = self.branch.revision();
-        if self.initialized {
+        let epoch = self.branch.overlay().epoch();
+        // The session overlay is off-tree: an epoch move is invisible
+        // to the tree-diff gate below and its delta is not derivable
+        // from the tree, so it routes straight to a re-evaluation
+        // (reported against the retained results). The incremental
+        // path only serves polls where the tree alone moved.
+        if self.initialized && epoch == self.overlay_epoch {
             if current == self.revision {
                 return Ok(None);
             }
@@ -451,6 +432,7 @@ where
         self.results = results;
         self.demand = demand;
         self.revision = current;
+        self.overlay_epoch = epoch;
         self.initialized = true;
         Ok(Some(delta))
     }
@@ -612,7 +594,7 @@ where
                     .perform(env)
                     .await
                     .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-                let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+                let layer = QueryLayer::from(&self.branch);
                 let overlay = layer.overlay(&operator);
                 let tombstones = tombstones_from(&overlay);
                 // Typed with the *named* env lifetime (owned branch
@@ -723,7 +705,7 @@ where
                 .perform(env)
                 .await
                 .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+            let layer = QueryLayer::from(&self.branch);
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             // Named env lifetime: keeps the poll future Send-general
@@ -771,7 +753,7 @@ where
                 .perform(env)
                 .await
                 .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+            let layer = QueryLayer::from(&self.branch);
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             // Named env lifetime: keeps the poll future Send-general
@@ -885,6 +867,267 @@ mod tests {
                 (claim.of.clone(), name)
             })
             .collect()
+    }
+
+    /// The branch's session overlay participates in subscription
+    /// results: ephemeral facts surface alongside tree facts from
+    /// the first poll, without ever being committed.
+    #[dialog_common::test]
+    async fn it_folds_the_overlay_into_subscription_results() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // An ephemeral fact: participates in reads, never committed.
+        let bob = Entity::new()?;
+        branch
+            .overlay()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()));
+
+        let mut subscription = branch.subscribe(names_query());
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("first poll evaluates");
+        let mut asserted = names(&delta.asserted);
+        asserted.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(
+            asserted, expected,
+            "overlay facts surface alongside tree facts"
+        );
+        Ok(())
+    }
+
+    /// Asserting into the branch overlay propagates to the branch's
+    /// subscriptions: every standing query the ephemeral fact
+    /// affects reports it as a delta on its next poll, with no tree
+    /// movement at all — and clearing the overlay retracts exactly
+    /// the ephemeral rows.
+    #[dialog_common::test]
+    async fn it_propagates_overlay_updates_to_subscriptions() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        let mut sibling = branch.subscribe(names_query());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            names(&initial.asserted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        sibling.poll(&operator).await?.expect("sibling initial");
+
+        // An ephemeral fact lands in the branch overlay: both
+        // standing queries report it against their retained results.
+        let bob = Entity::new()?;
+        branch
+            .overlay()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()));
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("overlay change propagates");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        assert!(delta.retracted.is_empty());
+        let sibling_delta = sibling
+            .poll(&operator)
+            .await?
+            .expect("every subscription on the branch observes the overlay");
+        assert_eq!(
+            names(&sibling_delta.asserted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+
+        let mut retained = names(subscription.results());
+        retained.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(retained, expected);
+
+        // Clearing the overlay retracts exactly the ephemeral rows.
+        branch.overlay().clear();
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("overlay removal propagates");
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        assert_eq!(
+            names(subscription.results()),
+            vec![(alice.clone(), "Alice".to_string())],
+            "tree facts persist through overlay changes"
+        );
+
+        // With the overlay quiet the gates still hold: polling again
+        // is a revision + epoch no-op.
+        assert!(subscription.poll(&operator).await?.is_none());
+        Ok(())
+    }
+
+    /// Retracting into the branch overlay tombstones matching tree
+    /// facts for readers — the subscription retracts the row on its
+    /// next poll while the tree keeps the fact.
+    #[dialog_common::test]
+    async fn it_tombstones_tree_facts_retracted_in_the_overlay() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+
+        branch.overlay().retract(
+            the!("person/name")
+                .of(alice.clone())
+                .is("Alice".to_string()),
+        );
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("overlay retract propagates");
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        assert!(subscription.results().is_empty());
+
+        // The tree is untouched: dropping the session retract brings
+        // the fact back.
+        branch.overlay().clear();
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("clearing the session retract restores the row");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        Ok(())
+    }
+
+    /// One-shot reads see the session overlay too: `branch.select`
+    /// and a transaction's as-if-committed view both fold it, so
+    /// every read path of the branch agrees on what exists.
+    #[dialog_common::test]
+    async fn it_folds_the_overlay_into_queries_and_transactions() -> anyhow::Result<()> {
+        use dialog_query::query::Output as _;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let bob = Entity::new()?;
+        branch
+            .overlay()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()));
+
+        let mut read = names(
+            &branch
+                .select(names_query())
+                .perform(&operator)
+                .try_vec()
+                .await?,
+        );
+        read.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(read, expected, "plain queries fold the session overlay");
+
+        let carol = Entity::new()?;
+        let transaction = branch.transaction().assert(
+            the!("person/name")
+                .of(carol.clone())
+                .is("Carol".to_string()),
+        );
+        let mut staged = names(
+            &transaction
+                .query()
+                .select(names_query())
+                .perform(&operator)
+                .try_vec()
+                .await?,
+        );
+        staged.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+            (carol.clone(), "Carol".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(
+            staged, expected,
+            "a transaction's view folds the session overlay under its pending changes"
+        );
+        Ok(())
     }
 
     /// The first poll evaluates and reports the initial result;

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -63,6 +63,7 @@
 use std::collections::BTreeSet;
 use std::future::Future;
 use std::ops::RangeInclusive;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
@@ -293,6 +294,23 @@ enum Touched {
     },
 }
 
+/// A boxed evaluation future. The poll chain's inner evaluations are
+/// boxed (rather than returned as `impl Future`) deliberately: an
+/// opaque future carries its defining function's `Env:
+/// Provider<Select<'s>>` where-clauses, and re-proving those during
+/// the *caller's* `Send` check erases every lifetime into
+/// independent placeholders — rustc's #100013 limitation, which
+/// would make the poll future `!Send` on native. Boxing to `dyn
+/// Future + Send` proves `Send` eagerly at the definition site,
+/// where the lifetime relations are still known.
+#[cfg(not(target_arch = "wasm32"))]
+type EvaluationFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, EvaluationError>> + Send + 'a>>;
+
+/// A boxed evaluation future (see the native alias for why).
+#[cfg(target_arch = "wasm32")]
+type EvaluationFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, EvaluationError>> + 'a>>;
+
 /// The index root a revision pins, or the empty tree for an
 /// unborn branch.
 fn tree_hash(revision: &Option<Revision>) -> Blake3Hash {
@@ -304,8 +322,8 @@ fn tree_hash(revision: &Option<Revision>) -> Blake3Hash {
 
 impl<Q> Subscription<Q>
 where
-    Q: Application + Clone,
-    Q::Conclusion: Conclusion + PartialEq + Clone,
+    Q: Application + Clone + ConditionalSync,
+    Q::Conclusion: Conclusion + PartialEq + Clone + ConditionalSync,
 {
     /// The retained result of the last evaluation.
     pub fn results(&self) -> &[Q::Conclusion] {
@@ -361,10 +379,14 @@ where
     /// lands mid-evaluation re-triggers on the next poll (the diff
     /// from the pinned root is a superset), so changes are never
     /// missed, at worst re-checked.
-    pub fn poll<'a, Env>(
+    // The `self` and `env` lifetimes are deliberately unified into
+    // one named `'a`: the poll future must stay `Send` on native (an
+    // axum handler drains subscription polls), and its inner
+    // evaluations are boxed `EvaluationFuture`s for the same reason.
+    pub async fn poll<'a, Env>(
         &'a mut self,
         env: &'a Env,
-    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
+    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -375,71 +397,62 @@ where
             + ConditionalSync
             + 'static,
     {
-        // Returned as an explicit `impl Future + 'a` (not an `async
-        // fn`) so the env lifetime is named rather than higher-ranked.
-        // An `async fn poll<Env>(&mut self, env: &Env)` desugars to a
-        // future whose `&Env` capture is `for<'e>`, which defeats
-        // Send-generality inference in a caller that must be `Send`
-        // (an axum handler draining subscription polls) — the same
-        // reason `SelectQuery::perform` is written this way.
-        async move {
-            let current = self.branch.revision();
-            if self.initialized {
-                if current == self.revision {
+        let current = self.branch.revision();
+        if self.initialized {
+            if current == self.revision {
+                return Ok(None);
+            }
+            match self.touched(env, &current).await? {
+                Touched::Nothing => {
+                    self.revision = current;
                     return Ok(None);
                 }
-                match self.touched(env, &current).await? {
-                    Touched::Nothing => {
+                Touched::Facts {
+                    subjects,
+                    facts,
+                    asserted,
+                    retracted,
+                } => {
+                    if let Some(delta) = self
+                        .maintain(env, &subjects, &facts, &asserted, &retracted)
+                        .await?
+                    {
+                        self.maintenances += 1;
                         self.revision = current;
-                        return Ok(None);
+                        return Ok(Some(delta));
                     }
-                    Touched::Facts {
-                        subjects,
-                        facts,
-                        asserted,
-                        retracted,
-                    } => {
-                        if let Some(delta) = self
-                            .maintain(env, &subjects, &facts, &asserted, &retracted)
-                            .await?
-                        {
-                            self.maintenances += 1;
-                            self.revision = current;
-                            return Ok(Some(delta));
-                        }
-                        // Not maintainable for this query/rule shape:
-                        // fall through to a full recompute.
-                    }
-                    // A rule-range change can install or change a rule,
-                    // which can affect any row: recompute.
-                    Touched::Rules => {}
+                    // Not maintainable for this query/rule shape:
+                    // fall through to a full recompute.
                 }
+                // A rule-range change can install or change a rule,
+                // which can affect any row: recompute.
+                Touched::Rules => {}
             }
-
-            let demand = Demand::new();
-            let results = self.evaluate(env, &demand, &self.query).await?;
-            self.recomputes += 1;
-
-            let delta = Delta {
-                asserted: results
-                    .iter()
-                    .filter(|row| !self.results.contains(row))
-                    .cloned()
-                    .collect(),
-                retracted: self
-                    .results
-                    .iter()
-                    .filter(|row| !results.contains(row))
-                    .cloned()
-                    .collect(),
-            };
-
-            self.results = results;
-            self.demand = demand;
-            self.revision = current;
-            self.initialized = true;
-            Ok(Some(delta))
         }
+
+        let demand = Demand::new();
+        let results = self.evaluate(env, &demand, &self.query).await?;
+        self.recomputes += 1;
+
+        let delta = Delta {
+            asserted: results
+                .iter()
+                .filter(|row| !self.results.contains(row))
+                .cloned()
+                .collect(),
+            retracted: self
+                .results
+                .iter()
+                .filter(|row| !results.contains(row))
+                .cloned()
+                .collect(),
+        };
+
+        self.results = results;
+        self.demand = demand;
+        self.revision = current;
+        self.initialized = true;
+        Ok(Some(delta))
     }
 
     /// Classify what the changes between the pinned root and
@@ -461,11 +474,11 @@ where
     /// and are skipped.
     ///
     /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
-    fn touched<'a, Env>(
+    async fn touched<'a, Env>(
         &'a self,
         env: &'a Env,
         current: &'a Option<Revision>,
-    ) -> impl Future<Output = Result<Touched, EvaluationError>> + 'a
+    ) -> Result<Touched, EvaluationError>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -475,82 +488,78 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
-            let pinned = tree_hash(&self.revision);
-            let target = tree_hash(current);
-            if pinned == target {
-                return Ok(Touched::Nothing);
-            }
-            let scope = self.demand.ranges();
-            if scope.is_empty() {
-                return Ok(Touched::Nothing);
-            }
+        let pinned = tree_hash(&self.revision);
+        let target = tree_hash(current);
+        if pinned == target {
+            return Ok(Touched::Nothing);
+        }
+        let scope = self.demand.ranges();
+        if scope.is_empty() {
+            return Ok(Touched::Nothing);
+        }
 
-            let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
-            let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
-            let previous =
-                Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
-            let next =
-                Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
+        let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
+        let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
+        let previous =
+            Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
+        let next = Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
 
-            let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
-            let mut changes = Box::pin(changes);
-            let mut subjects = BTreeSet::new();
-            let mut asserted = Vec::new();
-            let mut retracted = Vec::new();
-            // A fact change surfaces once per index order; dedup on the
-            // datum triple, per direction.
-            let mut seen = BTreeSet::new();
-            while let Some(change) = changes
-                .try_next()
-                .await
-                .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-            {
-                let entry = match &change {
-                    Change::Add(entry) => entry,
-                    Change::Remove(entry) => entry,
-                };
-                if self.demand.covers_rules(&entry.key) {
-                    return Ok(Touched::Rules);
+        let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
+        let mut changes = Box::pin(changes);
+        let mut subjects = BTreeSet::new();
+        let mut asserted = Vec::new();
+        let mut retracted = Vec::new();
+        // A fact change surfaces once per index order; dedup on the
+        // datum triple, per direction.
+        let mut seen = BTreeSet::new();
+        while let Some(change) = changes
+            .try_next()
+            .await
+            .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
+        {
+            let entry = match &change {
+                Change::Add(entry) => entry,
+                Change::Remove(entry) => entry,
+            };
+            if self.demand.covers_rules(&entry.key) {
+                return Ok(Touched::Rules);
+            }
+            // An entry arriving with a datum became readable; an
+            // entry leaving with a datum stopped being readable.
+            // Tombstone-valued entries carry no datum: their effect
+            // (if any) surfaces as the paired datum-bearing change
+            // at the same key.
+            let arriving = matches!(&change, Change::Add(_));
+            if let State::Added(datum) = &entry.value {
+                if !seen.insert((
+                    arriving,
+                    datum.entity.clone(),
+                    datum.attribute.clone(),
+                    datum.value.clone(),
+                )) {
+                    continue;
                 }
-                // An entry arriving with a datum became readable; an
-                // entry leaving with a datum stopped being readable.
-                // Tombstone-valued entries carry no datum: their effect
-                // (if any) surfaces as the paired datum-bearing change
-                // at the same key.
-                let arriving = matches!(&change, Change::Add(_));
-                if let State::Added(datum) = &entry.value {
-                    if !seen.insert((
-                        arriving,
-                        datum.entity.clone(),
-                        datum.attribute.clone(),
-                        datum.value.clone(),
-                    )) {
-                        continue;
-                    }
-                    let fact = Artifact::try_from(datum.clone()).map_err(|error| {
-                        EvaluationError::Store(format!("changed datum: {error:?}"))
-                    })?;
-                    subjects.insert(fact.of.clone());
-                    if arriving {
-                        asserted.push(fact);
-                    } else {
-                        retracted.push(fact);
-                    }
+                let fact = Artifact::try_from(datum.clone())
+                    .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
+                subjects.insert(fact.of.clone());
+                if arriving {
+                    asserted.push(fact);
+                } else {
+                    retracted.push(fact);
                 }
             }
+        }
 
-            if subjects.is_empty() {
-                Ok(Touched::Nothing)
-            } else {
-                let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
-                Ok(Touched::Facts {
-                    subjects,
-                    facts,
-                    asserted,
-                    retracted,
-                })
-            }
+        if subjects.is_empty() {
+            Ok(Touched::Nothing)
+        } else {
+            let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
+            Ok(Touched::Facts {
+                subjects,
+                facts,
+                asserted,
+                retracted,
+            })
         }
     }
 
@@ -574,7 +583,7 @@ where
         facts: &'a [Artifact],
         asserted: &'a [Artifact],
         retracted: &'a [Artifact],
-    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
+    ) -> EvaluationFuture<'a, Option<Delta<Q::Conclusion>>>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -585,7 +594,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
+        Box::pin(async move {
             // For a concept query the affected heads are discovered
             // against the resolved rule set: entity-local rules
             // contribute the changed subjects, non-local rules (concept
@@ -606,8 +615,13 @@ where
                 let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
                 let overlay = layer.overlay(&operator);
                 let tombstones = tombstones_from(&overlay);
-                let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                    .with_demand(self.demand.clone());
+                // Typed with the *named* env lifetime (owned branch
+                // clone, no generator-local borrows) so the poll
+                // future stays Send-general on native — see the note
+                // on `QueryEnv::branches`.
+                let query_env: QueryEnv<'a, Env> =
+                    QueryEnv::new(vec![self.branch.clone()], overlay, tombstones, env)
+                        .with_demand(self.demand.clone());
                 let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
                 if rules.recursion().is_some() {
                     // Fixpoint continuation: deletions retract via DRed,
@@ -681,22 +695,19 @@ where
                 asserted,
                 retracted,
             }))
-        }
+        })
     }
 
     /// Evaluate the query against the branch, recording every
     /// demanded range into `demand`. Mirrors the ordinary
     /// `branch.select(query).perform(env)` path with a
     /// demand-recording environment.
-    // `impl Future + 'a` (not `async fn`) so the env lifetime is
-    // named, keeping the enclosing `poll` future Send-general on
-    // native — see the note on `poll`.
     fn evaluate<'a, Env>(
         &'a self,
         env: &'a Env,
         demand: &'a Demand,
         query: &'a Q,
-    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    ) -> EvaluationFuture<'a, Vec<Q::Conclusion>>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -707,7 +718,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
+        Box::pin(async move {
             let operator = Identify
                 .perform(env)
                 .await
@@ -715,8 +726,11 @@ where
             let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
-            let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                .with_demand(demand.clone());
+            // Named env lifetime: keeps the poll future Send-general
+            // on native — see the note on `QueryEnv::branches`.
+            let mut query_env: QueryEnv<'a, Env> =
+                QueryEnv::new(vec![self.branch.clone()], overlay, tombstones, env)
+                    .with_demand(demand.clone());
             // Recursive concept subscriptions retain their fixpoint
             // across polls: a recompute rebuilds into the retained
             // table so a later additions-only poll can extend it.
@@ -725,7 +739,7 @@ where
                     .with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
             }
             query.clone().perform(&query_env).try_vec().await
-        }
+        })
     }
 
     /// Evaluate the standing query with the retained fixpoint
@@ -737,7 +751,7 @@ where
         env: &'a Env,
         additions: Arc<Vec<Artifact>>,
         deletions: Arc<Vec<Artifact>>,
-    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    ) -> EvaluationFuture<'a, Vec<Q::Conclusion>>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -748,7 +762,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
+        Box::pin(async move {
             let concept = self
                 .query
                 .concept()
@@ -760,14 +774,17 @@ where
             let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
-            let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                .with_demand(self.demand.clone())
-                .with_fixpoint(
-                    concept.this(),
-                    Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
-                );
+            // Named env lifetime: keeps the poll future Send-general
+            // on native — see the note on `QueryEnv::branches`.
+            let query_env: QueryEnv<'a, Env> =
+                QueryEnv::new(vec![self.branch.clone()], overlay, tombstones, env)
+                    .with_demand(self.demand.clone())
+                    .with_fixpoint(
+                        concept.this(),
+                        Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
+                    );
             self.query.clone().perform(&query_env).try_vec().await
-        }
+        })
     }
 }
 
@@ -776,11 +793,75 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+    use crate::RemoteSite;
     use crate::helpers::{test_operator_with_profile, test_repo};
     use dialog_artifacts::{Entity, Value};
+    use dialog_capability::{Fork, Provider};
+    use dialog_common::{ConditionalSend, ConditionalSync};
+    use dialog_effects::archive::{Get, Put};
+    use dialog_effects::authority::Identify;
+    use dialog_effects::memory::Resolve;
     use dialog_query::attribute::The;
     use dialog_query::types::Any;
     use dialog_query::{AttributeQuery, Claim, Term, the};
+
+    /// Compile-time proof that the poll future is `Send` on native
+    /// (`ConditionalSend` = `Send` there, nothing on wasm): the
+    /// consumer drains subscription polls from axum handlers, whose
+    /// futures must be `Send`. Generic over the env so the guarantee
+    /// holds for any consumer's environment, not just the test
+    /// operator. Exercised by
+    /// [`it_keeps_the_poll_future_send_general`].
+    fn require_send_poll<Env>(subscription: &mut super::Subscription<AttributeQuery>, env: &Env)
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSend
+            + ConditionalSync
+            + 'static,
+    {
+        fn assert_send<T: ConditionalSend>(_: T) {}
+        assert_send(subscription.poll(env));
+    }
+
+    /// The poll future stays `Send`-general: the reactor's native
+    /// build drives polls from axum handlers, so a regression here
+    /// is a compile error in [`require_send_poll`], and the
+    /// subscription still evaluates normally afterwards.
+    #[dialog_common::test]
+    async fn it_keeps_the_poll_future_send_general() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        // Builds (and drops) a poll future through the Send-requiring
+        // bound; the compile is the assertion.
+        require_send_poll(&mut subscription, &operator);
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("first poll evaluates");
+        assert_eq!(names(&delta.asserted), vec![(alice, "Alice".to_string())]);
+        Ok(())
+    }
 
     /// A standing query over every `person/name` fact.
     fn names_query() -> AttributeQuery {

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -66,7 +66,7 @@ use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{Artifact, ArtifactSelector, Entity, KeyBytes, State};
+use dialog_artifacts::{Artifact, ArtifactSelector, Changes, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -207,6 +207,18 @@ impl<T> Delta<T> {
 pub struct Subscription<Q: Application> {
     branch: Branch,
     query: Q,
+    /// A caller-supplied transient overlay folded into every
+    /// evaluation alongside the branch facts — the same role
+    /// [`QueryLayer::with`] plays for a one-shot query. Ephemeral:
+    /// off-tree, never committed, so the tree-diff gate in
+    /// [`touched`](Subscription::touched) can't observe a change to
+    /// it. The owner must therefore call
+    /// [`set_overlay`](Subscription::set_overlay) and force a poll
+    /// when the overlay mutates; a poll then recomputes (the overlay
+    /// delta is not derivable from the tree). Empty by default
+    /// ([`subscribe`](Branch::subscribe)); populated via
+    /// [`subscribe_with`](Branch::subscribe_with).
+    overlay: Changes,
     /// The revision the retained results were evaluated at. `None`
     /// until the first poll.
     revision: Option<Revision>,
@@ -231,9 +243,21 @@ impl Branch {
     /// evaluates on its first [`poll`](Subscription::poll) and is
     /// incrementally gated afterwards.
     pub fn subscribe<Q: Application>(&self, query: Q) -> Subscription<Q> {
+        self.subscribe_with(query, Changes::new())
+    }
+
+    /// Register a standing query with a transient `overlay` folded
+    /// into every evaluation — ephemeral facts (an invite seed, a
+    /// UI status stamp) that participate in reads and in the demand
+    /// cover but are never committed. Because the overlay is
+    /// off-tree, a change to it is invisible to the poll's tree-diff
+    /// gate: after mutating it via [`Subscription::set_overlay`], the
+    /// owner must force a poll to pick the change up.
+    pub fn subscribe_with<Q: Application>(&self, query: Q, overlay: Changes) -> Subscription<Q> {
         Subscription {
             branch: self.clone(),
             query,
+            overlay,
             revision: None,
             demand: Demand::new(),
             results: Vec::new(),
@@ -290,6 +314,15 @@ where
     /// The demand cover recorded by the last evaluation.
     pub fn demand(&self) -> &Demand {
         &self.demand
+    }
+
+    /// Replace the transient overlay folded into evaluations. The
+    /// overlay is off-tree, so this alone changes nothing: the caller
+    /// must follow with a [`poll`](Subscription::poll), which then
+    /// recomputes (the overlay delta can't be derived from the tree
+    /// diff) and reports the result change as a delta.
+    pub fn set_overlay(&mut self, overlay: Changes) {
+        self.overlay = overlay;
     }
 
     /// Full evaluations performed so far (the first poll plus every
@@ -547,7 +580,7 @@ where
                 .perform(env)
                 .await
                 .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-            let layer = QueryLayer::from(&self.branch);
+            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
@@ -651,7 +684,7 @@ where
             .perform(env)
             .await
             .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch);
+        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
         let overlay = layer.overlay(&operator);
         let tombstones = tombstones_from(&overlay);
         let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
@@ -694,7 +727,7 @@ where
             .perform(env)
             .await
             .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch);
+        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
         let overlay = layer.overlay(&operator);
         let tombstones = tombstones_from(&overlay);
         let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)

--- a/rust/dialog-repository/src/repository/branch/transaction/query.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/query.rs
@@ -152,7 +152,7 @@ impl<'a, Q: Application> TransactionSelectQuery<'a, Q> {
             // uses is what guarantees identical behavior — fact reads,
             // tombstones, schema metadata, and deductive-rule
             // resolution all share one implementation.
-            let query_env = QueryEnv::new(vec![branch], overlay, tombstones, env);
+            let query_env = QueryEnv::new(vec![branch.clone()], overlay, tombstones, env);
             let results = Box::pin(query.perform(&query_env));
             for await result in results {
                 yield result?;

--- a/rust/dialog-repository/src/transaction_query.rs
+++ b/rust/dialog-repository/src/transaction_query.rs
@@ -165,7 +165,7 @@ where
         // retracts. Tombstones touch only the branch source; the
         // overlay's facts (below) pass through unfiltered so a
         // `retract(x).assert(x)` pattern surfaces `x` correctly.
-        let raw = select_from_branch(self.branch, self.env, input.clone()).await?;
+        let raw = select_from_branch(self.branch.clone(), self.env, input.clone());
         let filtered_branch = filter_tombstones(raw, self.tombstones.clone());
 
         // Pending changes overlay — Changes itself is a Provider<Select>.

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -278,11 +278,20 @@ where
         scope: &'a [core::ops::RangeInclusive<Key>],
         self_storage: &'a ContentAddressedStorage<Backend>,
         other_storage: &'a ContentAddressedStorage<Backend>,
-    ) -> impl Differential<Key, Value> + 'a
+    ) -> impl Differential<Key, Value> + ConditionalSend + 'a
     where
         Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
             + ConditionalSync,
-        Value: PartialEq,
+        // `Key`/`Value` bound `ConditionalSync` (not just the trait's
+        // `ConditionalSend`) so that `&PersistentTree` — which the
+        // returned `async_stream` captures — is `Send` on native.
+        // `PersistentTree` holds `PhantomData<Key>`/`PhantomData<Value>`,
+        // so its `Sync` (hence `&_: Send`) needs `Key: Sync`/`Value: Sync`.
+        // Subscriptions poll this diff inside an axum handler future that
+        // must be `Send`; without the bound the whole handler is `!Send`.
+        Key: ConditionalSync,
+        Value: PartialEq + ConditionalSync,
+        D: ConditionalSync,
     {
         async_stream::try_stream! {
             let difference =

--- a/rust/dialog-storage/src/storage/provider/fs/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/certificate.rs
@@ -7,6 +7,7 @@ use dialog_capability::access::{
     AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
 };
 use dialog_capability::{Capability, Policy, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_varsig::Did;
 
 use super::{FileSystem, FileSystemError, FileSystemHandle};
@@ -20,10 +21,11 @@ impl FileSystem {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<P: Protocol> CertificateStore<P> for FileSystem
 where
-    P::Certificate: Send + Sync,
+    P::Certificate: ConditionalSend + ConditionalSync,
 {
     /// List certificates where `audience` is the recipient and `subject`
     /// is either the specific subject DID or, when `None`, a
@@ -95,13 +97,14 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<P> Provider<Prove<P>> for FileSystem
 where
     P: Protocol,
-    P::Access: Clone + Send + Sync,
-    P::Certificate: Clone + Send + Sync,
-    P::Proof: Send,
+    P::Access: Clone + ConditionalSend + ConditionalSync,
+    P::Certificate: Clone + ConditionalSend + ConditionalSync,
+    P::Proof: ConditionalSend,
 {
     async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
         let auth = Prove::<P>::of(&input);
@@ -111,11 +114,12 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<P> Provider<Retain<P>> for FileSystem
 where
     P: Protocol,
-    P::Delegation: Send + Sync,
+    P::Delegation: ConditionalSend + ConditionalSync,
 {
     async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
         let delegation = &Retain::<P>::of(&input).delegation;

--- a/rust/dialog-ucan-core/src/delegation/store.rs
+++ b/rust/dialog-ucan-core/src/delegation/store.rs
@@ -139,6 +139,8 @@ impl<S: Signature, H: BuildHasher> DelegationStore<Local, S, Arc<Delegation<S>>>
     }
 }
 
+// bare-send-ok: the Sendable future-kind variant deliberately requires real
+// Send/Sync to produce BoxFuture; the Local variant above is its counterpart
 impl<S: Signature + Send + Sync, H: BuildHasher + Send>
     DelegationStore<Sendable, S, Arc<Delegation<S>>>
     for Arc<Mutex<HashMap<Cid, Arc<Delegation<S>>, H>>>


### PR DESCRIPTION
## Why

Tonk's reactor wraps dialog subscriptions with an SSE fan-out and, crucially, folds a **transient session overlay** into every read: ephemeral facts that must participate in query results but never touch the tree (an invite's private seed, a UI sync-status stamp). Today that works for one-shot queries via `QueryLayer::with`, but nothing retains an overlay on the branch, and the incremental `Subscription` (from `feat/incremental-retraction`) gates on the tree diff — which an off-tree overlay never moves.

The reactor's native build also drives subscription polls from axum handlers, which require `Send` futures — and the poll future was `!Send` on native.

This PR gives the branch a session overlay that every read path (including standing subscriptions) observes, and makes the poll future `Send`-general. Stacks on `feat/incremental-retraction`.

## What

1. **Branch-scoped session overlay.** `branch.overlay()` returns a shared handle (one store across branch clones, like the node/rule caches) with `assert` / `retract` / `clear` for ephemeral facts. It folds in at `QueryLayer::from(&Branch)` — the single construction point every read path goes through — so `branch.select`, `branch.query`, a transaction's as-if-committed view, and subscription evaluations all observe session facts with no per-path wiring. Retracts tombstone matching tree facts for readers via the existing tombstone lift. Every mutation bumps an **epoch**; `Subscription::poll` gates on `(revision, epoch)`, so asserting into the overlay propagates to all of the branch's subscriptions as result deltas on their next poll. An epoch move routes to re-evaluation (the overlay delta is not derivable from the tree diff); the incremental maintenance path serves polls where only the tree moved. Tests cover first-poll folding, propagation to multiple subscriptions, clear retracting exactly the ephemeral rows, session retracts tombstoning tree facts (and restoring on clear), and query/transaction inheritance.

2. **`ConceptConclusion: PartialEq`** — `Subscription::poll` bounds `Q::Conclusion: PartialEq` to compute result deltas; `ConceptConclusion` (what the reactor subscribes with) only derived `Clone`. Just the derive.

3. **The poll future is `Send` on native.** Root cause: auto-trait checking erases every lifetime in a future's held types and re-proves their trait obligations with *independent* placeholders, so any awaited call whose type carries an `Env: Provider<Select<'s>>` where-clause with the env lifetime distinct from `'s` resurfaces as `for<'0, '1> QueryEnv<'0>: Provider<Select<'1>>` — rustc's [#100013](https://github.com/rust-lang/rust/issues/100013) limitation. Only the single-placeholder form is provable. Three-part fix:
   - `Provider<Select<'a>> for QueryEnv<'a>` is **strict** (one lifetime, both sides); covariance shrinks call sites and forces region inference to unify the pair. A decoupled `impl<'a, 's> ... where 'a: 's` makes it worse — documented on the impl.
   - `QueryEnv` **owns its branches** (cheap clones), so its only lifetime is the env reference and the poll chain types it with the named method lifetime instead of a generator-local borrow.
   - The inner evaluations return boxed `EvaluationFuture`s (cfg'd `dyn Future + Send`, like `ArtifactStream`): `dyn` carries no where-clauses, so `Send` is proven eagerly at the definition site.

   One honest new bound surfaced: the futures capture `&self`, so `Subscription` requires `Q: ConditionalSync` and `Q::Conclusion: ConditionalSync`. Pinned by `it_keeps_the_poll_future_send_general`, which demands `ConditionalSend` polls for *any* conforming env — a regression is a compile error.

4. **`ConditionalSend`/`ConditionalSync` convention, enforced.** A workspace convention test (`dialog-common/tests/conventions.rs`) scans every source file for hand-written bare `Send`/`Sync` in bound position (source-level rather than clippy `disallowed-types`, which attributes macro-expanded `Send` tokens to every `async_trait` use). `dyn` bounds are exempt automatically; deliberate exemptions carry a `bare-send-ok: <reason>` marker. The sweep converts the genuine violations (`TypeDescriptor`, `StaticAttributeQuery`, dialog-common `spawn`, the fs `CertificateStore` impls — which also gain the cfg_attr `(?Send)` async_trait pairs their trait declaration uses) and marks the deliberate ones (`csv_async` requires real `Send` on every target; the native-only `tokio::spawn` helper; ucan-core's `Sendable`-variant `DelegationStore`).
