### PR TITLE
fix(dialog-repository): skip push when nothing new to push

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "tower-http",
  "url",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-time",
 ]

--- a/notes/claim-based-serialization.md
+++ b/notes/claim-based-serialization.md
@@ -1,0 +1,104 @@
+# Claim-Based Serialization: Remove Serialize from Capabilities
+
+## Status
+
+The `Claim` trait and `#[derive(Claim)]` macro are implemented. What remains is removing the `Serialize + DeserializeOwned` requirement from `Caveat` and switching the UCAN parameter collection to use claim projections instead of direct serialization.
+
+## Problem
+
+Every capability type (attenuations, policies, effects) must implement `Serialize + DeserializeOwned` because `Caveat` requires it. This was needed before the `Claim` system existed, as effects were serialized directly for UCAN authorization.
+
+Now that `Claim` generates separate serializable claim types, the requirement on the effects themselves is vestigial. It prevents effects from carrying non-serializable runtime types like `Ed25519Signer` or `CryptoKeyPair`.
+
+## Current State
+
+```
+Effect: Sized + Caveat + Claim
+Caveat: Serialize + DeserializeOwned       <-- forces effects to be serializable
+Claim { type Claim: Serialize + DeserializeOwned }  <-- the actual serializable form
+
+Attenuation: Sized + Caveat                <-- forces attenuations to be serializable
+Policy: Sized + Caveat                     <-- forces policies to be serializable
+Ability: Sized + Serialize + DeserializeOwned
+```
+
+The UCAN path: `parameters(capability)` calls `capability.constrain(&mut builder)` which walks the chain. Each node calls `builder.push(self)` which does `to_ipld(self)`, requiring `Serialize`.
+
+## Proposed Change
+
+Move serialization from the types themselves to their claim representations.
+
+### Step 1: Change `Caveat` to use claims
+
+```rust
+// Before (current)
+pub trait Caveat: Serialize + DeserializeOwned {
+    fn constrain(&self, builder: &mut impl PolicyBuilder);
+}
+
+impl<T: Serialize + DeserializeOwned> Caveat for T {
+    fn constrain(&self, builder: &mut impl PolicyBuilder) {
+        builder.push(self);
+    }
+}
+
+// After
+pub trait Caveat {
+    fn constrain(&self, builder: &mut impl PolicyBuilder);
+}
+```
+
+No blanket impl. Each type implements `constrain()` by pushing its claim representation.
+
+### Step 2: Make `Claim` provide `constrain()`
+
+Merge `Caveat` into `Claim`:
+
+```rust
+pub trait Claim {
+    type Claim: Serialize + DeserializeOwned;
+    fn claim(self) -> Self::Claim;
+    fn constrain(&self, builder: &mut impl PolicyBuilder);
+}
+```
+
+For types where `Claim = Self`, `constrain` just pushes `self`. For types with non-serializable fields, `constrain` pushes the claim type.
+
+### Step 3: Drop `Serialize + DeserializeOwned` from trait bounds
+
+```rust
+pub trait Effect: Sized + Claim { ... }
+pub trait Attenuation: Sized + Claim { ... }
+pub trait Policy: Sized + Claim { ... }
+pub trait Ability: Sized { ... }
+```
+
+### Step 4: Make `Constrained` and `Capability` conditionally serializable
+
+Only implement `Serialize`/`Deserialize` when all parts are serializable, rather than deriving unconditionally.
+
+### Step 5: Update `parameters()` to use claim projection
+
+Use `Claim::constrain()` instead of `Caveat::constrain()` for UCAN parameter collection.
+
+## Impact
+
+- Most types unaffected: where `Claim::Claim = Self`, behavior is identical
+- Types with projections (`Put`, `Set`, `Publish`) already have derive macros that work
+- `access::Prove<P>` can carry `by: P::Issuer`, projected to `Did`
+- Eliminates the two-step Proof/claim(signer) flow
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `dialog-capability/src/settings.rs` | Remove `Serialize + DeserializeOwned` from `Caveat`, or merge into `Claim` |
+| `dialog-capability/src/claim.rs` | Add `constrain()` method |
+| `dialog-capability/src/effect.rs` | Drop `Caveat` from `Effect` bounds |
+| `dialog-capability/src/attenuation.rs` | `Caveat` to `Claim` |
+| `dialog-capability/src/policy.rs` | `Caveat` to `Claim` |
+| `dialog-capability/src/ability.rs` | Drop `Serialize + DeserializeOwned` |
+| `dialog-capability/src/constrained.rs` | Conditional `Serialize`/`Deserialize` impl |
+| `dialog-capability/src/capability.rs` | Conditional `Serialize`/`Deserialize` impl |
+| `dialog-macros/src/lib.rs` | Update `Claim` derive to generate `constrain()` |
+| `dialog-ucan/src/scope.rs` | Use `Claim::constrain` instead of `Caveat::constrain` |

--- a/notes/memory-layout.md
+++ b/notes/memory-layout.md
@@ -1,0 +1,59 @@
+# Repository Memory Layout
+
+Each repository scoped to a subject DID uses the following memory cell layout:
+
+## Local Branches
+
+```
+branch/{name}/revision          Cell<Revision>
+branch/{name}/upstream          Cell<Option<UpstreamState>>
+```
+
+- **revision** -- the local branch head (latest committed tree + metadata)
+- **upstream** -- what this branch tracks (`UpstreamState::Remote { name, branch, tree }`)
+
+## Remote Sites
+
+```
+remote/{name}/address                     Cell<RemoteAddress>
+remote/{name}/branch/{branch}/revision    Cell<Revision>
+```
+
+- **address** -- connection info wrapped in `RemoteAddress { address: SiteAddress, subject: Did }`
+- **branch revision** -- last fetched revision for a remote branch (updated by fetch, not by pull)
+
+## Operations
+
+### fetch
+
+1. Read `branch/{name}/upstream` to get the remote `{ name, branch }`
+2. Load `remote/{remote}/address` to get connection info and subject DID
+3. Resolve remote revision using the address + subject
+4. Write result to `remote/{remote}/branch/{branch}/revision`
+5. Local `branch/{name}/revision` and `branch/{name}/upstream` are unchanged
+
+### pull
+
+1. Fetch (as above)
+2. Read `remote/{remote}/branch/{branch}/revision` -- the upstream revision
+3. Read `branch/{name}/upstream` tree -- the last sync point
+4. Three-way merge: upstream vs base vs local
+5. Update `branch/{name}/revision` with merged result
+6. Update `branch/{name}/upstream` tree to match upstream revision
+
+### push
+
+1. Read `branch/{name}/revision` -- local head
+2. Read `branch/{name}/upstream` tree -- last sync point (base for novelty)
+3. Compute novel blocks (diff between base and local)
+4. Upload blocks to remote via `remote/{remote}/address`
+5. Publish local revision to remote
+6. Update `branch/{name}/upstream` tree to match pushed revision
+7. Update `remote/{remote}/branch/{branch}/revision` to match
+
+## Type Notes
+
+- `SiteAddress` -- enum: `S3(Address)` | `Ucan(UcanAddress)`. Connection info only.
+- `RemoteAddress` -- wraps `SiteAddress` with a `subject: Did` identifying which repository at the site.
+- `UpstreamState` -- enum: `Local { branch, tree }` | `Remote { name, branch, tree }`. The `subject` DID lives on the `RemoteAddress`, not on `UpstreamState`.
+- `Revision` -- `{ subject, issuer, authority, tree, cause, period, moment }`. The `tree` is a `NodeReference` (blake3 hash of the prolly tree root).

--- a/notes/query-cost-model.md
+++ b/notes/query-cost-model.md
@@ -1,0 +1,157 @@
+# Query Cost Model
+
+## Problem
+
+A datalog query decomposes into premises, each resolved by a range scan over a prolly tree index. The tree is sparsely replicated on demand. Every node traversal during a scan may incur a network roundtrip. The order in which premises execute determines which variables are bound when subsequent premises run, which determines how tight their scans are. A good ordering can be the difference between a handful of point lookups and a full index walk. The query planner needs a cost model to estimate the expense of each premise given currently bound variables, so it can choose an execution order that minimizes total traversal.
+
+## Index Structure
+
+All claims are stored in a search tree index with three key layouts distinguished by a tag byte. Every key is 162 bytes:
+
+
+```
+Key size: 162 bytes
+
+EAV
+|1B |-----------64B-----------|-----------64B-----------|1B |------32B------|
++---+-------------------------+-------------------------+---+---------------+
+|tag|         entity          |        attribute        |typ|   value_ref   |
++---+-------------------------+-------------------------+---+---------------+
+
+AEV
+|1B |-----------64B-----------|-----------64B-----------|1B |------32B------|
++---+-------------------------+-------------------------+---+---------------+
+|tag|        attribute        |          entity         |typ|   value_ref   |
++---+-------------------------+-------------------------+---+---------------+
+
+VAE
+|1B |1B |------32B------|-----------64B-----------|-----------64B-----------|
++---+---+---------------+-------------------------+-------------------------+
+|tag|typ|   value_ref   |        attribute        |          entity         |
++---+---+---------------+-------------------------+-------------------------+
+```
+
+A range scan constructs a `(start_key, end_key)` pair. Known fields are set to their actual value in both keys. Unknown fields are `0x00..` in the start and `0xFF..` in the end. Only fields that form a contiguous prefix from the start of the key constrain the tree traversal.
+
+```
+Example: {the, is} on AEV
+
+  AEV key:  [tag][attribute][entity][value_type][value_ref]
+  Known:          ^^^^^^^^^^                    ^^^^^^^^^^
+  Prefix:         65 bytes   ← attribute constrains the prefix
+  Gap:                       ← entity unknown, 64 bytes of 0x00..0xFF
+  Tail:                                        ← value known but after gap, post-filtered
+
+Example: {the, is} on VAE
+
+  VAE key:  [tag][value_type][value_ref][attribute][entity]
+  Known:          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Prefix:         97 bytes   ← value + attribute form contiguous prefix
+
+  Same two known fields, but VAE yields a 97-byte prefix vs AEV's 65.
+```
+
+The cost model selects the index that produces the longest contiguous prefix for the known fields:
+
+```
+entity known         → EAV  (entity leads, 64B+)
+attribute + value    → VAE  (value + attribute contiguous, 97B)
+attribute only       → AEV  (attribute leads, 65B)
+value only           → VAE  (value leads, 34B)
+```
+
+When entity is known, EAV always wins — entity is 64 bytes and leads the key. If attribute is also known the prefix extends to 129 bytes. If value is known instead, it sits at the end of the EAV key and gets post-filtered, but no index places entity and value adjacent so EAV is still best.
+
+When entity is unknown but both attribute and value are known, VAE produces a 97-byte prefix while AEV produces 65 bytes with value post-filtered.
+
+## Decision
+
+Use a greedy algorithm with an index-aware cost function. At each step, estimate the cost of every remaining premise given currently bound variables, pick the cheapest, execute it, extend the bindings, and repeat.
+
+### Cost function
+
+For a given premise, determine which of `{the, of, is}` are bound, select the best index by longest contiguous prefix, and assign a cost from the following tiers:
+
+```
+LOOKUP     = 100      1-2 tree nodes, near point-lookup
+RANGE_READ = 200      small bounded range, a few nodes
+RANGE_SCAN = 1000     broader range, multiple segments
+INDEX_SCAN = 5000     large portion of an index
+VERIFY     = 100      per-match secondary lookup for cardinality-one verification
+```
+
+These are relative weights for ordering, not latency predictions. The full cost table:
+
+```
+Known       Index   Prefix    ONE                    MANY
+---------   -----   ------    -------------------    ---------------
+{the,of,is} EAV     162B      LOOKUP        (100)    LOOKUP     (100)
+{of,the}    EAV     129B      LOOKUP        (100)    RANGE_READ (200)
+{the,is}    VAE      97B      RANGE_READ+V  (300)    RANGE_READ (200)
+{of}        EAV      65B      RANGE_READ    (200)    RANGE_SCAN (1000)
+{of,is}     EAV      65B      RANGE_READ    (200)    RANGE_SCAN (1000)
+{the}       AEV      65B      RANGE_SCAN    (1000)   INDEX_SCAN (5000)
+{is}        VAE      34B      INDEX_SCAN+V  (5100)   INDEX_SCAN (5000)
+```
+
+Notable details:
+
+- `{of, is}` costs the same as `{of}` alone. No index places entity and value adjacent, so the value constraint is post-filtered and does not reduce tree traversal.
+- `{the, is}` with `Cardinality::One` incurs a VERIFY cost. The VAE index does not group results by (entity, attribute), so each candidate needs a secondary EAV lookup to confirm it is the write-race winner.
+- `{the}` is expensive despite having one field bound because attributes are shared across many entities ("person/name" applies to every person).
+
+### Cardinality-one winner verification
+
+When an attribute has `Cardinality::One`, only the write-race winner for each (entity, attribute) pair should be yielded. The verification strategy depends on whether the scan index groups results by (entity, attribute):
+
+**Sliding window** — when results are grouped by (entity, attribute) in key order, buffer the group and emit the winner at the boundary. Applies to EAV scans and AEV scans with attribute known.
+
+**Secondary lookup** — when results are not grouped, verify each candidate individually by scanning EAV with the `[entity][attribute]` prefix (129 bytes) and checking whether the winner's value matches. Applies to VAE scans.
+
+```
+sliding_window = entity_known OR (attribute_known AND NOT value_known)
+```
+
+### Greedy ordering
+
+The greedy algorithm runs in O(N^2) for N premises. At each of N steps it scans remaining premises for the cheapest viable one. This is simple to implement, easy to reason about, and produces optimal or near-optimal orderings when the cheapest next step is clearly distinguished — which the index-aware cost tiers ensure in most cases.
+
+### Rationale
+
+The cost function is keyed on *which* components are bound, not merely *how many*. This matters because two premises with the same number of known components can have very different scan costs depending on index layout. `{the, of}` (129-byte EAV prefix) is fundamentally cheaper than `{the, is}` (97-byte VAE prefix with possible verification overhead).
+
+Greedy is the right starting point because most real queries have a handful of premises where the cost differences between orderings are large enough that the locally cheapest choice at each step is globally optimal. The index-aware tiers amplify these differences (SEGMENT vs SCAN is a 10x gap), so ties that would force greedy into an arbitrary (possibly wrong) choice are expected to be rare.
+
+## Alternatives
+
+### Exhaustive search (Held-Karp DP)
+
+Find the minimum-cost ordering over all N! permutations using dynamic programming over subsets. State is a bitmask of evaluated premises; complexity is O(2^N * N^2).
+
+```
+cost(S) = min over Pi in S: cost(S \ {Pi}) + estimate(Pi, bound(S \ {Pi}))
+```
+
+This is optimal and DP overhead is small in absolute terms, but adds significant implementation complexity for what is expected to be a margin gain in the common case where (N < 10) greedy algorithm can often find near optimal order, because cost tiers create clear winners at each step.
+
+## Future Improvements
+
+### Hybrid greedy + Held-Karp for tie-breaking
+
+Greedy fails to determine most optimal order when multiple premises tie on cost, because it picks arbitrarily without considering how each choice's bindings cascade to downstream premises:
+
+```
+P1: (person/name, ?person, ?name)       {the} only → SCAN (1000)
+P2: (dept/members, ?dept, ?person)       {the} only → SCAN (1000)
+P3: (dept/budget, ?dept, ?budget)        {the} only → SCAN (1000)
+
+Greedy picks P1 (arbitrary). Binds ?person.
+  P2 → {the, is} READ (200). P3 still {the} → SCAN (1000).
+  Total: 1000 + 200 + 1000 = 2200.
+
+P2 first. Binds ?dept and ?person.
+  P1 → {the, is} READ (200). P3 → {the, is} READ (200).
+  Total: 1000 + 200 + 200 = 1400.
+```
+
+When greedy encounters a tie, apply Held-Karp over the tied subset and remaining premises to break it optimally. This gives O(N^2) in the common case and O(2^N * N^2) only when it matters. Planning runs once per adornment and is cached, so planning overhead is negligible against a single network roundtrip.

--- a/notes/repository.md
+++ b/notes/repository.md
@@ -1,0 +1,168 @@
+# Credentials
+
+Credentials enable authorization of operations on a repository through a three-layer identity model: **account**, **profile**, and **operator**.
+
+## Identity Layers
+
+### Account
+
+An optional persistent identity backed by a passkey, hardware key, or paper key. It has no storage of its own; it exists purely as a recovery point and delegation target. You may have multiple accounts for different purposes (e.g. work, personal). When recovering access on a new device, you authenticate to the account and selectively delegate from it to that device's profile, choosing which capabilities to grant rather than delegating everything. Account creation can be deferred until you need to sync or share across devices.
+
+In the type system, Account is represented as an `Option<Did>` field on the `Profile` attenuation, not as a standalone type.
+
+### Profile
+
+A named user identity on a specific device. A device may have multiple profiles (e.g. "work" and "personal"), each with its own ed25519 keypair generated on first use. Profiles persist for the lifetime of the device. On first run, a default profile is created automatically.
+
+The profile is represented in the capability chain as:
+
+```
+Subject -> Profile { profile: Did, account: Option<Did> } -> Operator { operator: Did }
+```
+
+### Operator
+
+An ephemeral key representing the immediate invoker of a capability in a specific session or process context. Derived from the profile key using a context byte string (same profile + context always yields the same operator key).
+
+## Authorization Chain
+
+Invoking a capability on a repository requires a delegation chain from the subject back to the operator. The chain always includes the profile layer; the account layer is optional:
+
+### Local
+
+No account is configured. The subject delegates directly to the profile:
+
+```
+subject -> profile -> operator
+```
+
+Access is tied to this device. If the device is lost, access cannot be recovered.
+
+### Recovered
+
+An account is present, meaning access has been delegated through a persistent identity that survives device loss:
+
+```
+subject -> account -> profile -> operator
+```
+
+Or directly, if the repository was created after the account already existed on the device:
+
+```
+subject -> account -> operator
+```
+
+The profile is the stable identity on each device. The account, when present, is the anchor for recovery and cross-device delegation.
+
+## Capability Domains
+
+The system is organized into these effect domains (defined in `dialog-effects`):
+
+- **`authority::Identify`** -- returns the current delegation chain as `Capability<Operator>`
+- **`archive`** -- content-addressed storage (`Get`, `Put`)
+- **`memory`** -- CAS memory cells (`Resolve`, `Publish`, `Retract`)
+- **`credential`** -- credential storage (`Save<T>`, `Load<T>`)
+- **`space`** -- named space discovery (`Load`, `Create`)
+- **`storage`** -- location-based bootstrap (`Load`, `Create`)
+- **`access`** -- authorization via protocols (`Prove`, `Retain`, `Authorize`)
+
+## Named Spaces
+
+Profiles and repositories are both named spaces identified by a human-readable name, each containing an ed25519 identity (the "credential").
+
+### Credential
+
+A credential is either:
+- **Signer** (`SignerCredential`) -- full keypair available (owner of the space)
+- **Verifier** (`VerifierCredential`) -- public key only (delegate of the space)
+
+### Storage Format
+
+Credentials are stored using multicodec-tagged key material:
+
+- **Signer** (68 bytes): `[0x80 0x26 | secret(32) | 0xed 0x01 | public_key(32)]`
+- **Verifier** (34 bytes): `[0xed 0x01 | public_key(32)]`
+
+Where `0x80 0x26` is varint-encoded `0x1300` (ed25519-priv multicodec) and `0xed 0x01` is varint-encoded `0xed` (ed25519-pub multicodec).
+
+On web (IndexedDB), signer credentials are stored as `CryptoKeyPair` objects (non-extractable). Verifier credentials are stored as `Uint8Array`.
+
+### Storage Layout
+
+- **Native (FileSystem)**: `{name}/credentials/self`
+- **Web (IndexedDB)**: database `{name}`, store `credentials`, key `self`
+
+The `name` scopes the storage on both platforms. Each named space gets its own directory (native) or database (web).
+
+## Opening a Repository
+
+Opening a repository is a two-step process using `space::Load` and `space::Create` capabilities:
+
+1. **Load**: attempts to load an existing credential for the named space
+   - If `Some(Credential::Signer(signer))` -- owner access, can delegate
+   - If `Some(Credential::Verifier(verifier))` -- delegate access, read-only unless invited
+   - If `None` -- repository doesn't exist
+
+2. **Create** (if None):
+   1. Generate an ed25519 keypair
+   2. Save the credential via `space::Create`
+   3. Delegate subject -> profile (powerline UCAN delegation)
+   4. The repository is created with the new `did:key` as its subject
+
+Higher-level `Repository::open()` combines these steps. Three modes:
+- `.open()` -- loads existing or creates new
+- `.load()` -- loads existing, fails if not found
+- `.create()` -- creates new, fails if exists
+
+## Environment Setup
+
+The operator is built from a profile:
+
+```rust
+let storage = Storage::default();
+
+let profile = Profile::open("alice")
+    .perform(&storage)
+    .await?;
+
+let operator = profile
+    .derive(b"my-app")
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+```
+
+The builder chain:
+1. `Profile::open(name)` opens or creates the profile keypair from storage
+2. `.derive(context)` starts building an operator with a deterministic key
+3. `.allow(capability)` configures the UCAN delegation scope
+4. `.network(network)` optionally adds remote network capability
+5. `.build(storage)` takes ownership of storage and produces the `Operator`
+
+Profile keys are stored at the platform data directory:
+- **Native**: `~/Library/Application Support/dialog/profile/{name}/key` (32-byte seed)
+- **Web**: IndexedDB database `dialog`, store `credentials`, key `profile/{name}` (CryptoKeyPair)
+
+## Authorization
+
+Invoking any capability requires authorization. The operator resolves delegation chains using the `access::Prove` capability.
+
+**Input:** the capability the caller wishes to invoke, identified by its subject `did:key` and ability.
+**Output on success:** a signed invocation ready to be dispatched.
+
+The authorization flow:
+1. The operator's `CertificateStore` is searched for delegation chains from the subject to the operator
+2. If a valid chain is found, the operator signs an invocation carrying the proof chain
+3. If no chain exists but the subject credential is a `Signer`, a delegation can be issued on the spot
+
+## Delegation Import
+
+Delegations are imported via `profile.access().save(chain).perform(&operator)`. This stores the UCAN delegation chain in the profile's certificate store, making it available for future authorization lookups.
+
+## Identification
+
+Invoking `authority::Identify` returns the current delegation chain as `Capability<Operator>`, which encodes:
+
+- The **subject** DID (from the chain root)
+- The **profile** DID and optional **account** DID (from `Profile` in the chain)
+- The **operator** DID (from `Operator` in the chain)

--- a/notes/scope-and-delegation.md
+++ b/notes/scope-and-delegation.md
@@ -1,0 +1,121 @@
+# Capability Scoping and Delegation Design
+
+## Status
+
+This describes future work. Currently `Subject::any()` creates a wildcard subject with `did:_:_`, and the UCAN layer uses `UcanSubject::Any`. The type-level parameterization described below has not been implemented.
+
+## Problem
+
+Capabilities are always rooted in a `Subject(Did)`. This means you can't express "access to archive/catalog/index" without knowing the repository DID upfront. But delegation scoping needs exactly that: describing *what kind* of access without naming *which resource*.
+
+## Current State
+
+Every capability chain starts with `Subject`:
+
+```
+Subject(repo_did) -> Archive -> Catalog("index") -> Get { key }
+```
+
+`Attenuation::Of` walks up to `Subject`:
+```rust
+impl Attenuation for Archive { type Of = Subject; }
+impl Attenuation for Catalog { type Of = Archive; }
+```
+
+`Constraint` computes the full chain type from the leaf:
+```rust
+type Capability<Fx> = <Fx as Constraint>::Capability;
+// Capability<Get> = Constrained<Get, Constrained<Catalog, Constrained<Archive, Subject>>>
+```
+
+`Ability` trait requires `fn subject(&self) -> &Did`. For wildcards, `Subject::any()` returns a subject with `did:_:_`.
+
+## Proposed Design
+
+### `Any` as Wildcard Root
+
+Introduce `Any` as an alternative chain root alongside `Subject`:
+
+```rust
+pub struct Any;  // wildcard: represents any subject
+```
+
+### Parameterize `Constraint` by Root
+
+```rust
+impl<T: Policy, Root> Constraint<Root> for T {
+    type Capability = Constrained<T, <T::Of as Constraint<Root>>::Capability>;
+}
+
+impl<Root> Constraint<Root> for Subject {
+    type Capability = Root;  // terminates with whatever root was given
+}
+```
+
+### Convenience Alias
+
+```rust
+pub type Scope<T> = Capability<T, Any>;
+```
+
+- `Capability<Catalog>` -- subject-rooted, invocable (backward compatible)
+- `Scope<Catalog>` -- wildcard-rooted, delegation scope only
+
+### Compile-Time Safety
+
+`invoke`/`perform`/`fork` only available on subject-rooted chains:
+
+```rust
+impl<Fx, Of> Constrained<Fx, Of>
+where
+    Fx: Effect,
+    Of: Ability<Root = Subject>,  // only Subject-rooted chains
+{
+    pub fn invoke(...) { ... }
+    pub async fn perform(...) { ... }
+}
+```
+
+`Any`-rooted chains compile for building and reading but cannot be invoked.
+
+### `Ability` Changes
+
+```rust
+pub trait Ability {
+    type Root;  // Subject or Any, propagated from chain root
+    fn subject(&self) -> Option<&Did>;  // None for Any-rooted
+    fn ability(&self) -> String;
+}
+```
+
+## Usage
+
+### Building Delegation Scopes
+
+```rust
+let scope: Scope<Catalog> = Any
+    .attenuate(Archive)
+    .attenuate(Catalog::new("index"));
+
+// Use in builder
+profile.derive(b"alice")
+    .allow(scope)
+    .build(storage)
+    .await?;
+```
+
+### Powerline Delegation (current)
+
+```rust
+profile.derive(b"alice")
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+```
+
+## UCAN Mapping
+
+- `Any` root maps to UCAN `Subject::Any` (powerline delegation)
+- `Subject(did)` root maps to UCAN `Subject::Specific(did)`
+- Ability path maps to UCAN command (e.g., `["archive", "catalog"]`)
+- Policy constraints map to UCAN policy predicates

--- a/notes/space-and-storage.md
+++ b/notes/space-and-storage.md
@@ -1,0 +1,151 @@
+# Space and Storage Design
+
+## Overview
+
+Storage is the runtime environment that routes capability effects to the correct backend providers. It uses a two-level dispatch: first by subject DID (which space), then by capability (which provider within that space).
+
+## Core Types
+
+### Location
+
+A struct combining a directory kind with a name:
+
+```rust
+pub struct Location {
+    pub directory: Directory,
+    pub name: String,
+}
+```
+
+`Directory` is an enum of logical address categories:
+
+```rust
+pub enum Directory {
+    Profile,   // platform profile directory (~/Library/.../dialog/ on macOS)
+    Current,   // working directory (.dialog/)
+    Temp,      // temporary directory
+    At(String) // custom path
+}
+```
+
+Each backend resolves a `Location` to its platform-specific path. The `StorageFx` sugar creates locations:
+
+```rust
+StorageFx::profile("alice")   // Location { directory: Profile, name: "alice" }
+StorageFx::temp("scratch")    // Location { directory: Temp, name: "scratch" }
+```
+
+### Space
+
+A composed product of providers that routes capabilities to the correct backend:
+
+```rust
+#[derive(Provider)]
+pub struct Space<A, M, C, D> {
+    #[provide(archive::Get, archive::Put)]
+    archive: A,
+
+    #[provide(memory::Resolve, memory::Publish, memory::Retract)]
+    memory: M,
+
+    #[provide(credential::Load<Credential>, credential::Save<Credential>)]
+    credential: C,
+
+    #[provide(access::Prove<P>, access::Retain<P>)]
+    certificate: D,
+}
+```
+
+`#[derive(Provider)]` generates capability dispatch: `archive::Get` goes to `archive`, `memory::Resolve` goes to `memory`, etc.
+
+### Storage
+
+Composes a `Loader` (for space bootstrap via `storage::Load`/`storage::Create`) and a `Router` (DID-based dispatch for all other effects):
+
+```rust
+#[derive(Provider)]
+pub struct Storage<S: SpaceProvider> {
+    #[provide(storage::Load, storage::Create)]
+    loader: Loader<S>,
+
+    #[provide(archive::Get, archive::Put, memory::Resolve, ...)]
+    router: Router<S>,
+}
+```
+
+Platform defaults:
+- **Native**: `NativeSpace` backed by `FileSystem` providers
+- **Web**: `WebSpace` backed by `IndexedDb` providers
+
+`Storage::default()` creates the platform-appropriate configuration.
+
+## Mounting Flow
+
+When `storage::Load` or `storage::Create` is performed:
+
+1. The `Loader` resolves the `Location` to platform-specific addresses
+2. Creates provider instances for each capability domain
+3. Reads the credential directly from the credential provider (no DID needed yet)
+4. Registers the space under its DID in the `Router`
+5. Returns the `Credential` (signer or verifier)
+
+No bootstrap DID hack. The credential is read directly from the provider before registering in the router.
+
+## Two Levels of Dispatch
+
+```
+Effect arrives with Subject DID
+  |
+  v
+Router looks up DID -> Space
+  |
+  v
+Space routes by capability -> Provider
+  |
+  v
+Provider executes the effect
+```
+
+## On-Disk Layout (FileSystem)
+
+```
+~/Library/.../dialog/alice/        <-- Location { Profile, "alice" }
+  credentials/self                 <-- credential provider
+  archive/                         <-- archive provider (index + blob)
+  memory/                          <-- memory provider
+  certificates/                    <-- certificate store
+```
+
+## On-Web Layout (IndexedDB)
+
+```
+Database: "alice"
+Object stores:
+  "credentials"                    <-- credential provider
+  "archive"                        <-- archive provider
+  "memory"                         <-- memory provider
+  "certificates"                   <-- certificate store
+```
+
+## Setup Flow
+
+```rust
+let storage = Storage::default();
+
+let profile = Profile::open("alice")
+    .perform(&storage)
+    .await?;
+
+let operator = profile
+    .derive(b"my-app")
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+
+let repo = profile.repository("contacts")
+    .open()
+    .perform(&operator)
+    .await?;
+```
+
+`Profile::open` triggers `storage::Load` internally. `Repository::open` does the same for the repo's space. The `Operator` holds the assembled `Storage` and routes all subsequent effects through it.

--- a/notes/subject-routing-options.md
+++ b/notes/subject-routing-options.md
@@ -1,0 +1,36 @@
+# Subject Routing: How Effects Find Their Storage
+
+Historical decision record. The system implemented a hybrid of Options B and C (routing table with layout conventions).
+
+## Problem
+
+When a capability effect arrives (e.g. `archive::Get` with subject `did:key:zRepo`), the system needs to know *where* to read/write data for that subject. The subject DID identifies *who*, but not *where*.
+
+Two things must happen:
+1. **Name to DID**: Resolve a human name ("home", "personal") to a subject DID by loading a keypair.
+2. **DID to Storage**: Route effects on that DID to the right storage location.
+
+## Option A: Location in Subject
+
+Extend `Subject` to carry an optional storage location alongside the DID.
+
+**Pros:** No secondary lookups; each Subject is self-contained.
+**Cons:** If someone constructs a Subject from just a DID, the location is missing and effects fail. The location is runtime-only metadata that doesn't serialize.
+
+## Option B: Routing Table in the Environment
+
+The environment maintains a `Did -> Provider` mapping. When a profile or repository is opened, the DID gets registered with its storage provider.
+
+**Pros:** Doesn't matter how the Subject was constructed. Supports mixed providers.
+**Cons:** Shared mutable state (interior mutability). Effects on unregistered DIDs fail.
+
+## Option C: Routing by Layout Convention
+
+Use filesystem layout conventions. All subjects live under a shared root, organized by DID.
+
+**Pros:** Simplest; one provider, no dispatch logic.
+**Cons:** All subjects must use the same provider type. Can't spread repos across different directories.
+
+## Decision
+
+The current implementation uses Option B (`Router` in `Storage<S>`) for DID-based dispatch, combined with Option C's convention for layout within each space. The `Loader` creates providers using platform-specific address resolution from a `Location`, then registers them in the `Router` under the space's DID.

--- a/notes/version-control.md
+++ b/notes/version-control.md
@@ -1,0 +1,307 @@
+# Version Control
+
+## Context
+
+The [divergence clock] design encodes causal position as `{ since, at, drift }` where `since` increments at synchronization points, enabling cheap concurrency detection: two changes with the same `since` and different `at` values are concurrent by inspection, no traversal required.
+
+This works well for a single collaborative repository. The limitation surfaces when two repositories with independent histories need to interact. The `since` counter is local to a repo's synchronization history. There is no meaningful way to compare `since: 3` from repo A with `since: 3` from repo B. They count different sync events. A cross-repo merge would require either renumbering one history (losing provenance) or accepting that the clock values are simply incommensurable.
+
+A desired property of Dialog's collaboration model is that forks and follows work as first-class operations across independent repositories. This document describes a causal encoding grounded in the revision DAG that aims to preserve the divergence clock's fast concurrency detection while composing correctly across repo boundaries.
+
+## Idea
+
+Instead of deriving causal position from a logical counter, derive it from the structure of the revision DAG directly. Every revision has a natural position: the count of revisions in the causal chain leading to it. This is its `Edition`. An author increments their edition with each local revision and advances it to `max(seen) + 1` on sync. This is isomorphic to a Lamport timestamp, which gives it a useful property: a higher edition has seen at least as much causal history as any lower one, regardless of which repository it came from.
+
+`Edition` alone is not enough to identify a revision globally, because two authors could independently reach the same edition count. It is therefore paired with `Origin`, a repository-scoped identity derived as `Blake3(issuer + subject)`. Deriving origin from both the signing key and the repository DID ensures that the same principal acting on two different repositories produces two distinct origins. Without this, a principal whose histories in two separate repositories later merge could produce colliding identifiers.
+
+Together, `Origin` and `Edition` form a `Version`: a compact revision identifier that sorts naturally by causal depth and uniquely addresses any revision across all repositories.
+
+## Core Types
+
+```rust
+/// Root of the search tree at a given revision
+#[derive(Attribute, Debug, Clone)]
+#[domain("dialog.revision")]
+pub struct Tree(Blake3Hash);
+
+/// Count of revisions in the causal chain leading to this one.
+/// Increments locally on each revision; advances to max(seen) + 1 on sync.
+/// Isomorphic to a Lamport timestamp.
+#[derive(Attribute, Debug, Clone)]
+#[domain("dialog.revision")]
+pub struct Edition(u64);
+
+/// Repository membership identifier derived as Blake3(issuer + subject).
+/// Deriving from both signing key and repository DID ensures that the same
+/// principal acting on two different repositories produces two distinct origins,
+/// preventing collisions when independent repositories later merge.
+#[derive(Attribute, Debug, Clone)]
+#[domain("dialog.revision")]
+pub struct Origin(Blake3Hash);
+
+/// Ed25519 authority responsible for the revision
+#[derive(Attribute, Debug, Clone)]
+#[domain("dialog.revision")]
+pub struct Authority([u8; 32]);
+
+/// Ed25519 principal committing the revision
+#[derive(Attribute, Debug, Clone)]
+#[domain("dialog.revision")]
+pub struct Issuer([u8; 32]);
+
+/// Cryptographic signature for the revision
+#[derive(Attribute, Debug, Clone)]
+#[domain("dialog.revision")]
+pub struct Signature(Vec<u8>);
+
+/// Uniquely identifies a specific revision by a specific origin.
+/// Sorts naturally by causal depth via edition.
+/// Two versions with the same edition but different origins are concurrent.
+pub struct Version {
+    pub origin:  Origin,
+    pub edition: Edition,
+}
+
+/// A set of versions identifying prior claims superseded by this one.
+pub struct Cause(Vec<Version>);
+```
+
+## Revision
+
+A revision is a Dialog concept stored as a claim in the EAV index under the repository DID as the entity, making revision history queryable via Datalog like any other data.
+
+```rust
+#[derive(Concept, Debug, Clone)]
+pub struct Revision {
+    pub this:      Entity,     // content-addressed hash of this Revision object
+    pub tree:      Tree,
+    pub edition:   Edition,
+    pub subject:   Did,        // DID of the repository
+    pub issuer:    Issuer,
+    pub authority: Authority,
+    pub signature: Signature,
+    pub cause:     Cause,      // parent revision versions (one normally, multiple on merge)
+}
+
+impl Revision {
+    /// Derives the origin from issuer and repository DID.
+    /// Stored nowhere; always computed on demand.
+    pub fn origin(&self) -> Origin {
+        Origin(blake3::hash(&[self.issuer.0.as_ref(), self.subject.as_bytes()].concat()))
+    }
+
+    /// Returns the Version identifying this revision.
+    pub fn version(&self) -> Version {
+        Version {
+            origin:  self.origin(),
+            edition: self.edition.clone(),
+        }
+    }
+}
+```
+
+A revision is content-addressed: `this` is the hash of the Revision object itself, serving as its stable entity identifier. When stored as claims in the EAV index, `of` is the repository DID and `is` is the revision's entity hash rather than the full Revision object:
+
+```
+Claim {
+    the:   "dialog.db/revision",
+    of:    repository_did,
+    is:    version_hash,  // hash(edition + origin), the Version identifying this revision
+    cause: Cause(vec![...]),      // parent revision version(s)
+}
+```
+
+The repository DID as `of` means querying the current revision is a simple lookup, and the full revision history is all claims on that entity ordered by edition. The `Version` hash serves as a stable, content-addressed identifier for the revision. Multiple repositories each maintain their own independent lineage under their respective DIDs.
+
+**Edition rule:** on each local revision, `edition = last_edition + 1`. On sync, `edition = max(local_edition, received_edition) + 1`. A higher edition has seen more causal history regardless of which repository it came from.
+
+**Offline construction:** a new revision requires only the previous revision. No fetches needed. The new version is derived from the previous revision's edition and origin, and `cause` points to the previous revision's version.
+
+**Merge revisions:** when incorporating changes from another revision lineage, `cause` lists the versions of all parent revisions. This is the only case where `cause` contains more than one entry.
+
+## Claim Structure
+
+Claims carry a `cause` field identifying the prior claims on the same `(entity, attribute)` that this claim supersedes. This is analogous to how a git commit records which commits it builds on, but scoped to individual fact lineages rather than the full repository state.
+
+```rust
+pub struct Claim {
+    pub the:   The,
+    pub of:    Entity,
+    pub is:    Value,
+    pub cause: Cause,
+}
+```
+
+`cause` is empty on first write to an attribute. It contains one entry in the normal sequential case. It contains multiple entries when explicitly resolving concurrent claims from different authors, recording that the author saw and deliberately superseded all of them.
+
+This enables conflict detection scoped to individual attribute lineages rather than requiring full revision DAG traversal.
+
+## History Index
+
+Revisions and claims share a unified history index:
+
+```
+/edition/origin/entity/attribute/value_hash -> Claim
+```
+
+This key structure serves two purposes.
+
+**Revision DAG traversal:** revision claims are stored under `entity = repository_did`. Scanning by edition gives revision history in causal order. Finding a common ancestor between two revision lineages is done by following `cause` pointers backward from each head.
+
+**Claim conflict resolution:** when two conflicting claims on the same `(entity, attribute)` are encountered, the index allows efficient traversal of the attribute's causal lineage. Given a conflicting claim's `Version`, the key `/edition/origin/entity/attribute` locates it directly and its `cause` chain can be followed backward.
+
+## Conflict Detection
+
+When two claims A and B conflict on the same `(entity, attribute)`, resolution proceeds in tiers.
+
+**Tier 1: Direct cause check, O(1):**
+- If B's version is in A's `cause`, A supersedes B
+- If A's version is in B's `cause`, B supersedes A
+- If neither, proceed to tier 2
+
+**Tier 2: Cause chain traversal, O(k):**
+
+Follow the higher-edition claim's `cause` chain backward through the history index, looking for the lower-edition claim's version. Edition comparison bounds and guides the traversal:
+
+- Found the other claim's version in the chain: superseded
+- Reached a claim whose edition is less than the other claim's edition: concurrent, stop
+- Chain exhausted: concurrent
+
+The traversal is bounded by k, the number of writes to that specific `(entity, attribute)`, not the total revision history. In practice k is small since most attributes are written infrequently.
+
+**Incomplete replication:**
+
+If the cause chain is incomplete due to missing claims, causal ordering cannot be determined locally. Resolution blocks until the missing claims have been replicated. This is expected behavior: a partial replica does not have enough information to resolve conflicts it has not fully received yet.
+
+### Conflict Detection Illustrated
+
+Two authors work independently from the same revision then sync. Alice makes two revisions, Bob makes one, then Bob pulls Alice's work before committing again:
+
+```mermaid
+%%{init: { 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'shared', 'parallelCommits': true}} }%%
+gitGraph TB:
+   commit id: "genesis" tag: "edition:0"
+   branch alice
+   branch bob
+   checkout alice
+   commit id: "A:1"
+   commit id: "A:2"
+   checkout bob
+   commit id: "B:1"
+   checkout shared
+   merge alice tag: "edition:2"
+   checkout bob
+   merge shared
+   commit id: "B:3"
+   checkout shared
+   merge bob tag: "edition:3"
+```
+
+| Author | Action | Edition |
+|--------|--------|---------|
+| Alice | commit | 1 |
+| Alice | commit | 2 |
+| Bob | commit | 1 |
+| Alice | push | 2 |
+| Bob | pull | max(2, 1) + 1 = 3, counter advances |
+| Bob | commit | 3 |
+| Bob | push | 3 |
+
+When Alice's `A:2` and Bob's `B:1` meet during sync, neither version appears in the other's `cause`. Following Tier 2, we traverse `A:2`'s cause chain backward. We check the higher edition because it may have seen the lower one, while the lower edition cannot have seen something with a higher edition. The chain contains only `A:1` at edition 1, which matches `B:1`'s edition but has a different origin. Neither is an ancestor of the other: concurrent.
+
+After Bob pulls and commits `B:3`, his `cause` contains `A:2`'s version. Any subsequent claim from Bob on an attribute Alice also wrote supersedes hers via Tier 1 direct check, O(1).
+
+```mermaid
+stateDiagram-v2
+    shared: edition 0 shared base
+    alice: A edition 2 writes name
+    bob: B edition 1 writes name
+    concurrent: concurrent neither in others cause
+    bobafter: B edition 3 after pulling A
+    resolved: B edition 3 supersedes both
+
+    shared --> alice
+    shared --> bob
+    alice --> concurrent
+    bob --> concurrent
+    alice --> bobafter
+    bob --> bobafter
+    bobafter --> resolved
+```
+
+## Cross-Repo Merges and Forks
+
+Each repository maintains its own revision lineage identified by its DID. Because `Edition` is a Lamport timestamp, editions from different repositories are directly comparable: a higher edition has seen more causal history regardless of which repository produced it.
+
+**Forking:** Alice creates her own repository DID and writes her first revision with `cause` pointing to Bob's current head version. Her edition takes `max(Bob's edition) + 1`. All subsequent edition comparisons are meaningful relative to Bob's history.
+
+**Merging upstream:** Alice finds the common ancestor by traversing both revision lineages via `cause` pointers. Conflicting claims are resolved using the two-tier conflict detection above.
+
+**Collaborator joining with no prior history:** Carol initializes a fresh repository (edition 0, no claims), accepts Bob's invite, and pulls his history. Her counter advances to `max(Bob's edition) + 1` on pull. She then makes her first commit at that edition.
+
+```mermaid
+%%{init: { 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'bob', 'parallelCommits': true}} }%%
+gitGraph TB:
+   commit id: "B:1"
+   commit id: "B:2"
+   branch carol
+   checkout carol
+   commit id: "C:3"
+```
+
+Carol has no prior claims. She pulls Bob's history, her counter advances to 3 (max(2, 0) + 1), and her first commit lands at edition 3. No reconciliation needed.
+
+**Collaborator joining with prior history:** Carol has been working independently and has reached edition 2 with her own claims. She accepts Bob's invite and pulls his history. Her editions were incommensurable with Bob's since both reached edition 2 via independent histories. On pulling, her counter advances to `max(Bob's edition, Carol's edition) + 1`. Her prior claims are preserved in the revision DAG and her cause chain re-anchors from the merge point.
+
+```mermaid
+%%{init: { 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'bob', 'parallelCommits': true}} }%%
+gitGraph TB:
+   branch carol
+   checkout carol
+   commit id: "C:1"
+   commit id: "C:2"
+   checkout bob
+   commit id: "B:1"
+   commit id: "B:2"
+   checkout carol
+   merge bob
+   commit id: "C:3"
+```
+
+Carol's pre-join claims at C:1 and C:2 are preserved with their original editions. Her first new revision after joining is edition 3 (max(2, 2) + 1).
+
+### Fork and Merge Illustrated
+
+Alice forks Bob's repository at edition 2. Both continue writing independently, then Alice merges Bob's updates:
+
+```mermaid
+%%{init: { 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'bob', 'parallelCommits': true}} }%%
+gitGraph TB:
+   commit id: "genesis" tag: "edition:0"
+   commit id: "B:1"
+   commit id: "B:2"
+   branch alice
+   checkout alice
+   commit id: "A:3"
+   commit id: "A:4"
+   checkout bob
+   commit id: "B:3"
+   commit id: "B:4"
+   checkout alice
+   merge bob
+   commit id: "A:5"
+```
+
+Alice forks at Bob's `edition: 2`. Her first revision is `edition: 3` (max(2) + 1). When she merges Bob's `B:3` and `B:4`, the common ancestor at `edition: 2` is found by traversing the revision DAG via `cause` pointers. Conflicting claims are resolved using the two-tier conflict detection. After the merge, Alice's `A:5` has `edition: 5` and her `cause` references both lineages.
+
+## Concurrent Claim Resolution
+
+When two claims on the same `(entity, attribute)` are genuinely concurrent (neither appears in the other's cause chain), both are valid. A last-write-wins query resolves this deterministically by sorting on claim hash, producing a stable winner without requiring user intervention. Applications that need to surface the conflict explicitly can do so by requesting all concurrent values.
+
+## Cross-Repository Collaboration
+
+The [divergence clock] `since` counter is local to a repository's synchronization history. Two independent repositories that later merge have incommensurable counters: `since: 3` from repo A and `since: 3` from repo B count different sync events. Reconciling them requires either renumbering one history, losing provenance, or treating the merge as a special case outside the normal conflict detection machinery.
+
+This design addresses that limitation directly. Because `Edition` is a Lamport timestamp and `Origin` is derived from `Blake3(issuer + subject)`, both are meaningful across repository boundaries without coordination. Two revisions from independent repositories can be compared, their common ancestor can be found by following `cause` pointers, and conflicting claims can be resolved using the same two-tier detection that works within a single repository. Forks, merges, and collaborators joining with prior history all follow naturally from the same primitives.
+
+[divergence clock]:./divergence-clock.md

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -221,7 +221,8 @@ where
     /// [`Artifacts::export`]
     pub async fn import<Read>(&mut self, read: &mut Read) -> Result<(), DialogArtifactsError>
     where
-        Read: AsyncRead + Unpin + ConditionalSend,
+        // bare-send-ok: csv_async bounds its readers on real Send on every target
+        Read: AsyncRead + Unpin + Send,
     {
         let instructions = stream! {
             let mut reader = csv_async::AsyncReaderBuilder::new()

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -221,7 +221,7 @@ where
     /// [`Artifacts::export`]
     pub async fn import<Read>(&mut self, read: &mut Read) -> Result<(), DialogArtifactsError>
     where
-        Read: AsyncRead + Unpin + Send,
+        Read: AsyncRead + Unpin + ConditionalSend,
     {
         let instructions = stream! {
             let mut reader = csv_async::AsyncReaderBuilder::new()

--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -31,6 +31,7 @@ use dialog_search_tree::{
 };
 use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
 use futures_util::{Stream, StreamExt};
+use std::ops::RangeInclusive;
 
 use crate::{
     ATTRIBUTE_LENGTH, Artifact, ArtifactSelector, AttributeKey, AttributeKeyPart, Datum,
@@ -337,46 +338,7 @@ impl ArtifactTreeExt for ArtifactTree {
         let tree = self;
         let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
         try_stream! {
-            // Index choice: exact fields take priority (entity /
-            // value / attribute, as before); prefix bounds pick the
-            // index whose leading dimension they constrain when no
-            // exact field does. Every branch additionally tightens
-            // its key range with whatever prefix bounds the selector
-            // carries (sound on any dimension, tight on leading ones)
-            // via `apply_prefix_bounds`, and `matches_selector`
-            // re-checks per entry. The lower/upper bounds collapse to
-            // the same exact key when every component is constrained,
-            // and the inclusive range still selects it.
-            let range = if selector.entity().is_some()
-                || (selector.entity_prefix().is_some()
-                    && selector.value().is_none()
-                    && selector.attribute().is_none()
-                    && selector.attribute_prefix().is_none())
-            {
-                let (start, end) = apply_prefix_bounds(
-                    <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(&selector),
-                    <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(&selector),
-                    &selector,
-                );
-                KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
-            } else if selector.value().is_some() {
-                let (start, end) = apply_prefix_bounds(
-                    <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(&selector),
-                    <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(&selector),
-                    &selector,
-                );
-                KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
-            } else if selector.attribute().is_some() || selector.attribute_prefix().is_some() {
-                let (start, end) = apply_prefix_bounds(
-                    <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(&selector),
-                    <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(&selector),
-                    &selector,
-                );
-                KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
-            } else {
-                // `Constrained` guarantees at least one field is set.
-                unreachable!("ArtifactSelector will always have at least one field specified")
-            };
+            let range = selector_range(&selector);
 
             let stream = tree.stream_range(range, &storage);
             tokio::pin!(stream);
@@ -393,5 +355,55 @@ impl ArtifactTreeExt for ArtifactTree {
                 }
             }
         }
+    }
+}
+
+/// The inclusive key range a selector's scan reads.
+///
+/// Index choice: exact fields take priority (entity / value /
+/// attribute); prefix bounds pick the index whose leading dimension
+/// they constrain when no exact field does. The range is additionally
+/// tightened with whatever prefix bounds the selector carries (sound
+/// on any dimension, tight on leading ones) via
+/// [`apply_prefix_bounds`]; per-entry re-checking against the full
+/// selector happens during the scan, not here. The lower/upper bounds
+/// collapse to the same exact key when every component is
+/// constrained, and the inclusive range still selects it.
+///
+/// This is the selector's *demanded range*: everything a scan for it
+/// would touch, whether or not entries exist there. Subscriptions use
+/// it as the unit of a demand cover — a range that came back empty is
+/// still demanded (the emptiness was read), so a later write into it
+/// must invalidate the reader.
+pub fn selector_range(selector: &ArtifactSelector<Constrained>) -> RangeInclusive<KeyBytes> {
+    if selector.entity().is_some()
+        || (selector.entity_prefix().is_some()
+            && selector.value().is_none()
+            && selector.attribute().is_none()
+            && selector.attribute_prefix().is_none())
+    {
+        let (start, end) = apply_prefix_bounds(
+            <EntityKey<Key> as KeyViewConstruct>::min().apply_selector(selector),
+            <EntityKey<Key> as KeyViewConstruct>::max().apply_selector(selector),
+            selector,
+        );
+        KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
+    } else if selector.value().is_some() {
+        let (start, end) = apply_prefix_bounds(
+            <ValueKey<Key> as KeyViewConstruct>::min().apply_selector(selector),
+            <ValueKey<Key> as KeyViewConstruct>::max().apply_selector(selector),
+            selector,
+        );
+        KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
+    } else if selector.attribute().is_some() || selector.attribute_prefix().is_some() {
+        let (start, end) = apply_prefix_bounds(
+            <AttributeKey<Key> as KeyViewConstruct>::min().apply_selector(selector),
+            <AttributeKey<Key> as KeyViewConstruct>::max().apply_selector(selector),
+            selector,
+        );
+        KeyBytes::from(start.into_key())..=KeyBytes::from(end.into_key())
+    } else {
+        // `Constrained` guarantees at least one field is set.
+        unreachable!("ArtifactSelector will always have at least one field specified")
     }
 }

--- a/rust/dialog-common/src/async.rs
+++ b/rust/dialog-common/src/async.rs
@@ -92,7 +92,7 @@ pub enum DialogAsyncError {
 pub async fn spawn<F>(future: F) -> Result<F::Output, DialogAsyncError>
 where
     F: Future + ConditionalSend + 'static,
-    F::Output: Send + 'static,
+    F::Output: ConditionalSend + 'static,
 {
     #[cfg(target_arch = "wasm32")]
     {

--- a/rust/dialog-common/tests/conventions.rs
+++ b/rust/dialog-common/tests/conventions.rs
@@ -77,15 +77,40 @@ mod native {
         false
     }
 
+    /// The rust/ workspace directory, resolved at *runtime*: at
+    /// compile time `CARGO_MANIFEST_DIR` names the build sandbox,
+    /// which no longer exists when an archived test runs (the nix
+    /// gate re-runs nextest archives with `--workspace-remap`). The
+    /// runner sets each test's working directory to the (remapped)
+    /// crate root, so ascend from there to the directory holding the
+    /// workspace crates; fall back to the compile-time path for
+    /// plain `cargo` invocations with an unusual working directory.
+    fn workspace_dir() -> PathBuf {
+        if let Ok(mut dir) = std::env::current_dir() {
+            loop {
+                if dir.join("dialog-common").is_dir() && dir.join("dialog-query").is_dir() {
+                    return dir;
+                }
+                if !dir.pop() {
+                    break;
+                }
+            }
+        }
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("dialog-common lives under the rust/ workspace dir")
+            .to_path_buf()
+    }
+
     /// Hand-written `Send` / `Sync` bounds must be `ConditionalSend`
     /// / `ConditionalSync`; see the module doc for the rationale and
     /// the exemptions.
-    #[dialog_common::test]
+    // dialog_macros directly (a dev-dependency): the dialog_common::test
+    // re-export lives behind the `helpers` feature, which the crate's own
+    // integration tests build without.
+    #[dialog_macros::test]
     async fn it_bounds_on_conditional_send_and_sync() {
-        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .expect("dialog-common lives under the rust/ workspace dir")
-            .to_path_buf();
+        let workspace = workspace_dir();
         let mut sources = Vec::new();
         rust_sources(&workspace, &mut sources);
         assert!(

--- a/rust/dialog-common/tests/conventions.rs
+++ b/rust/dialog-common/tests/conventions.rs
@@ -1,0 +1,132 @@
+//! Workspace source conventions, enforced as a test.
+//!
+//! Async code in this workspace targets both native and
+//! `wasm32-unknown-unknown`, so hand-written bounds must use
+//! [`dialog_common::ConditionalSend`] / [`ConditionalSync`] (which
+//! are `Send` / `Sync` on native and nothing on wasm) instead of the
+//! bare marker traits. Bare `Send` / `Sync` remain correct in
+//! exactly two places:
+//!
+//! - `dyn` bounds (`Box<dyn Future + Send>`): auto traits cannot be
+//!   substituted there, so the type gets a cfg'd pair of aliases —
+//!   one per target — like `ArtifactStream`.
+//! - Native-only code (a `#[cfg(not(target_arch = "wasm32"))]` fn
+//!   feeding `tokio::spawn`, a deliberately `Send` variant of a
+//!   local/sendable pair).
+//!
+//! Lines using `dyn` are exempt automatically. Anything else must
+//! carry a `bare-send-ok: <reason>` comment, which exempts lines
+//! from the marker to the next blank line.
+//!
+//! This is a source-level scan rather than a clippy
+//! `disallowed-types` rule because clippy attributes the `Send`
+//! tokens that `async_trait` and the provider macros *expand to*
+//! back to the local attribute line, flagging every macro use in the
+//! workspace; the convention is about what humans write.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    /// The single file allowed to name the bare traits freely: the
+    /// definition site of the conditional ones.
+    const DEFINITION_SITE: &str = "dialog-common/src/sync.rs";
+
+    /// Marker comment that exempts lines up to the next blank line.
+    const EXEMPT_MARKER: &str = "bare-send-ok";
+
+    fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "target") {
+                    continue;
+                }
+                rust_sources(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Whether `line` (comments stripped) uses bare `Send` or `Sync`
+    /// in bound position (preceded by `:` or `+`).
+    fn uses_bare_marker(line: &str) -> bool {
+        for word in ["Send", "Sync"] {
+            let mut from = 0;
+            while let Some(at) = line[from..].find(word) {
+                let start = from + at;
+                let end = start + word.len();
+                from = end;
+                let word_char = |c: char| c.is_ascii_alphanumeric() || c == '_';
+                if line[..start].chars().next_back().is_some_and(word_char)
+                    || line[end..].chars().next().is_some_and(word_char)
+                {
+                    continue;
+                }
+                let before = line[..start].trim_end();
+                if before.ends_with(':') || before.ends_with('+') {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Hand-written `Send` / `Sync` bounds must be `ConditionalSend`
+    /// / `ConditionalSync`; see the module doc for the rationale and
+    /// the exemptions.
+    #[dialog_common::test]
+    async fn it_bounds_on_conditional_send_and_sync() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("dialog-common lives under the rust/ workspace dir")
+            .to_path_buf();
+        let mut sources = Vec::new();
+        rust_sources(&workspace, &mut sources);
+        assert!(
+            sources.len() > 100,
+            "the scan should see the whole workspace, found {} files",
+            sources.len()
+        );
+
+        let mut violations = Vec::new();
+        for path in sources {
+            if path.ends_with(DEFINITION_SITE) {
+                continue;
+            }
+            let Ok(source) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let mut exempt = false;
+            for (index, line) in source.lines().enumerate() {
+                if line.trim().is_empty() {
+                    exempt = false;
+                    continue;
+                }
+                if line.contains(EXEMPT_MARKER) {
+                    exempt = true;
+                    continue;
+                }
+                if exempt || line.contains("dyn ") {
+                    continue;
+                }
+                let code = line.split("//").next().unwrap_or(line);
+                if uses_bare_marker(code) {
+                    violations.push(format!("{}:{}: {}", path.display(), index + 1, line.trim()));
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "bare Send/Sync bounds found; use ConditionalSend/ConditionalSync \
+             (or mark deliberate native-only/dyn uses with `{EXEMPT_MARKER}: <reason>`):\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/rust/dialog-csv/Cargo.toml
+++ b/rust/dialog-csv/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 dialog-artifacts = { workspace = true }
-dialog-common = { workspace = true }
 async-trait = { workspace = true }
 base58 = { workspace = true }
 csv-async = { workspace = true, features = ["tokio"] }

--- a/rust/dialog-csv/Cargo.toml
+++ b/rust/dialog-csv/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 dialog-artifacts = { workspace = true }
+dialog-common = { workspace = true }
 async-trait = { workspace = true }
 base58 = { workspace = true }
 csv-async = { workspace = true, features = ["tokio"] }

--- a/rust/dialog-csv/src/exporter.rs
+++ b/rust/dialog-csv/src/exporter.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use dialog_artifacts::Exporter;
 use dialog_artifacts::{Artifact, DialogArtifactsError};
+use dialog_common::ConditionalSend;
 use tokio::io::AsyncWrite;
 
 use crate::row::CsvRow;
@@ -29,7 +30,7 @@ impl<W: AsyncWrite + Unpin> From<W> for CsvExporter<W> {
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<W: AsyncWrite + Unpin + Send> Exporter for CsvExporter<W> {
+impl<W: AsyncWrite + Unpin + ConditionalSend> Exporter for CsvExporter<W> {
     async fn write(&mut self, artifact: &Artifact) -> Result<(), DialogArtifactsError> {
         let row = CsvRow::from(artifact);
         self.writer

--- a/rust/dialog-csv/src/exporter.rs
+++ b/rust/dialog-csv/src/exporter.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use dialog_artifacts::Exporter;
 use dialog_artifacts::{Artifact, DialogArtifactsError};
-use dialog_common::ConditionalSend;
 use tokio::io::AsyncWrite;
 
 use crate::row::CsvRow;
@@ -30,7 +29,8 @@ impl<W: AsyncWrite + Unpin> From<W> for CsvExporter<W> {
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<W: AsyncWrite + Unpin + ConditionalSend> Exporter for CsvExporter<W> {
+// bare-send-ok: csv_async bounds its writers on real Send on every target
+impl<W: AsyncWrite + Unpin + Send> Exporter for CsvExporter<W> {
     async fn write(&mut self, artifact: &Artifact) -> Result<(), DialogArtifactsError> {
         let row = CsvRow::from(artifact);
         self.writer

--- a/rust/dialog-csv/src/importer.rs
+++ b/rust/dialog-csv/src/importer.rs
@@ -1,5 +1,4 @@
 use dialog_artifacts::{Artifact, DialogArtifactsError};
-use dialog_common::ConditionalSend;
 use futures_util::{Stream, StreamExt};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -7,28 +6,23 @@ use tokio::io::AsyncRead;
 
 use crate::row::CsvRow;
 
-/// The imported row stream: boxed `Send` on native so the importer
-/// can cross threads, unboxed of that requirement on wasm.
-#[cfg(not(target_arch = "wasm32"))]
-// bare-send-ok: dyn bounds cannot carry ConditionalSend; this is the cfg'd native alias
-type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>;
-
-/// The imported row stream (see the native alias).
-#[cfg(target_arch = "wasm32")]
-type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>>>>;
-
 /// Imports artifacts from CSV rows.
 ///
 /// Expects columns: `the`, `of`, `as` (value type), `is`, `cause`.
 ///
 /// Implements [`Stream`] yielding one [`Artifact`] per CSV row.
+///
+/// Readers are bounded on real `Send` (not `ConditionalSend`)
+/// because `csv_async` requires it on every target.
 pub struct CsvImporter {
-    inner: ArtifactRows,
+    // bare-send-ok: dyn bound over a csv_async stream, which is Send on every target
+    inner: Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>,
 }
 
 impl CsvImporter {
     /// Create a new CSV importer reading from the given reader.
-    pub fn new<R: AsyncRead + Unpin + ConditionalSend + 'static>(reader: R) -> Self {
+    // bare-send-ok: csv_async bounds its readers on real Send on every target
+    pub fn new<R: AsyncRead + Unpin + Send + 'static>(reader: R) -> Self {
         let deserializer = csv_async::AsyncReaderBuilder::new().create_deserializer(reader);
         let stream = deserializer
             .into_deserialize::<CsvRow>()
@@ -42,7 +36,8 @@ impl CsvImporter {
     }
 }
 
-impl<R: AsyncRead + Unpin + ConditionalSend + 'static> From<R> for CsvImporter {
+// bare-send-ok: csv_async bounds its readers on real Send on every target
+impl<R: AsyncRead + Unpin + Send + 'static> From<R> for CsvImporter {
     fn from(reader: R) -> Self {
         Self::new(reader)
     }

--- a/rust/dialog-csv/src/importer.rs
+++ b/rust/dialog-csv/src/importer.rs
@@ -1,4 +1,5 @@
 use dialog_artifacts::{Artifact, DialogArtifactsError};
+use dialog_common::ConditionalSend;
 use futures_util::{Stream, StreamExt};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -6,18 +7,28 @@ use tokio::io::AsyncRead;
 
 use crate::row::CsvRow;
 
+/// The imported row stream: boxed `Send` on native so the importer
+/// can cross threads, unboxed of that requirement on wasm.
+#[cfg(not(target_arch = "wasm32"))]
+// bare-send-ok: dyn bounds cannot carry ConditionalSend; this is the cfg'd native alias
+type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>;
+
+/// The imported row stream (see the native alias).
+#[cfg(target_arch = "wasm32")]
+type ArtifactRows = Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>>>>;
+
 /// Imports artifacts from CSV rows.
 ///
 /// Expects columns: `the`, `of`, `as` (value type), `is`, `cause`.
 ///
 /// Implements [`Stream`] yielding one [`Artifact`] per CSV row.
 pub struct CsvImporter {
-    inner: Pin<Box<dyn Stream<Item = Result<Artifact, DialogArtifactsError>> + Send>>,
+    inner: ArtifactRows,
 }
 
 impl CsvImporter {
     /// Create a new CSV importer reading from the given reader.
-    pub fn new<R: AsyncRead + Unpin + Send + 'static>(reader: R) -> Self {
+    pub fn new<R: AsyncRead + Unpin + ConditionalSend + 'static>(reader: R) -> Self {
         let deserializer = csv_async::AsyncReaderBuilder::new().create_deserializer(reader);
         let stream = deserializer
             .into_deserialize::<CsvRow>()
@@ -31,7 +42,7 @@ impl CsvImporter {
     }
 }
 
-impl<R: AsyncRead + Unpin + Send + 'static> From<R> for CsvImporter {
+impl<R: AsyncRead + Unpin + ConditionalSend + 'static> From<R> for CsvImporter {
     fn from(reader: R) -> Self {
         Self::new(reader)
     }

--- a/rust/dialog-macros/src/lib.rs
+++ b/rust/dialog-macros/src/lib.rs
@@ -175,7 +175,7 @@ pub fn provider(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     role: Term::var("role"),
 /// };
 /// ```
-#[proc_macro_derive(Concept)]
+#[proc_macro_derive(Concept, attributes(dialog))]
 pub fn derive_concept(input: TokenStream) -> TokenStream {
     query::concept::derive(input)
 }

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -77,7 +77,7 @@ use quote::quote;
 use syn::ext::IdentExt;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
-use super::helpers::extract_doc_comments;
+use super::helpers::{extract_doc_comments, parse_dialog_rename_attribute};
 
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -170,7 +170,13 @@ pub fn derive(input: TokenStream) -> TokenStream {
         }
 
         let field_type = &field.ty;
-        let field_name_lit = syn::LitStr::new(&field_name_str, proc_macro2::Span::call_site());
+
+        // Check for #[dialog(rename = "...")] to override the string key
+        let effective_name_str = match parse_dialog_rename_attribute(&field.attrs) {
+            Ok(rename) => rename.unwrap_or_else(|| field_name_str.clone()),
+            Err(e) => return e.to_compile_error().into(),
+        };
+        let field_name_lit = syn::LitStr::new(&effective_name_str, proc_macro2::Span::call_site());
 
         // Forward the user's field doc when present, otherwise synthesize a
         // fallback so `#![deny(missing_docs)]` in consumer crates is happy.

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -416,6 +416,51 @@ pub fn derive(input: TokenStream) -> TokenStream {
                     #(#realize_fields,)*
                 })
             }
+
+            // Restriction to one subject entity: the goal-directed
+            // unit incremental subscription maintenance re-derives
+            // with. Pinning is refused when the subject variable
+            // joins a field term through a shared name (the pin
+            // would sever the join).
+            fn restrict(&self, entity: &dialog_query::Entity) -> dialog_query::query::Restriction<Self> {
+                use dialog_query::query::Restriction;
+                match &self.this {
+                    dialog_query::Term::Constant(dialog_query::Value::Entity(this)) => {
+                        return if this == entity {
+                            Restriction::Scoped(self.clone())
+                        } else {
+                            Restriction::Unaffected
+                        };
+                    }
+                    dialog_query::Term::Constant(_) => return Restriction::Unaffected,
+                    dialog_query::Term::Variable { name: Some(name), .. } => {
+                        let shared = [ #( self.#field_names.name() ),* ]
+                            .into_iter()
+                            .flatten()
+                            .any(|other| other == name.as_str());
+                        if shared {
+                            return Restriction::Unsupported;
+                        }
+                    }
+                    dialog_query::Term::Variable { name: None, .. } => {}
+                }
+                let mut scoped = self.clone();
+                scoped.this = dialog_query::Term::Constant(
+                    dialog_query::Value::Entity(entity.clone()),
+                );
+                Restriction::Scoped(scoped)
+            }
+
+            // The concept this query applies; lets incremental
+            // maintainers resolve the rule set for the soundness
+            // gate.
+            fn concept(&self) -> std::option::Option<&dialog_query::ConceptDescriptor> {
+                std::option::Option::Some(
+                    <#struct_name as dialog_query::Descriptor<
+                        dialog_query::ConceptDescriptor,
+                    >>::descriptor(),
+                )
+            }
         }
 
         // Add inherent perform method so users don't need to import Application trait

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -77,7 +77,7 @@ use quote::quote;
 use syn::ext::IdentExt;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
-use super::helpers::{extract_doc_comments, parse_dialog_rename_attribute};
+use super::helpers::{extract_doc_comments, parse_dialog_field_attributes};
 
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -171,11 +171,15 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
         let field_type = &field.ty;
 
-        // Check for #[dialog(rename = "...")] to override the string key
-        let effective_name_str = match parse_dialog_rename_attribute(&field.attrs) {
-            Ok(rename) => rename.unwrap_or_else(|| field_name_str.clone()),
+        // Field-level #[dialog(...)] parameters: rename overrides
+        // the string key; conforms marks a concept-typed field.
+        let dialog_attrs = match parse_dialog_field_attributes(&field.attrs) {
+            Ok(parsed) => parsed,
             Err(e) => return e.to_compile_error().into(),
         };
+        let effective_name_str = dialog_attrs
+            .rename
+            .unwrap_or_else(|| field_name_str.clone());
         let field_name_lit = syn::LitStr::new(&effective_name_str, proc_macro2::Span::call_site());
 
         // Forward the user's field doc when present, otherwise synthesize a
@@ -234,12 +238,32 @@ pub fn derive(input: TokenStream) -> TokenStream {
         // attribute's descriptor with this field's optionality
         // (tagged from the `OPTIONAL` const, never by syntactic
         // `Option<_>` inspection).
-        descriptor_pair_pushes.push(quote! {
-            __fields.push((
-                #field_name_lit.to_string(),
-                <#field_type as dialog_query::ConceptField>::field_descriptor(),
-            ));
-        });
+        //
+        // A `#[dialog(conforms = C)]` field goes through
+        // `ConformingField::conforming_descriptor` instead, which
+        // tags the descriptor with the target concept. The trait is
+        // implemented only for required, entity-valued attribute
+        // newtypes, so a non-entity or `Option<_>` field fails to
+        // compile rather than producing an invalid descriptor.
+        match &dialog_attrs.conforms {
+            Some(target) => descriptor_pair_pushes.push(quote! {
+                __fields.push((
+                    #field_name_lit.to_string(),
+                    <#field_type as dialog_query::ConformingField>::conforming_descriptor(
+                        <#target as dialog_query::Descriptor<
+                            dialog_query::ConceptDescriptor,
+                        >>::descriptor()
+                        .clone(),
+                    ),
+                ));
+            }),
+            None => descriptor_pair_pushes.push(quote! {
+                __fields.push((
+                    #field_name_lit.to_string(),
+                    <#field_type as dialog_query::ConceptField>::field_descriptor(),
+                ));
+            }),
+        }
 
         // Statement emission via the trait method. The concept's
         // `this` field is an `Entity` (concept structs always have

--- a/rust/dialog-macros/src/query/helpers.rs
+++ b/rust/dialog-macros/src/query/helpers.rs
@@ -154,38 +154,55 @@ pub fn parse_domain_attribute(attrs: &[Attribute]) -> Option<String> {
     None
 }
 
-/// Parse the `#[dialog(rename = "...")]` attribute.
-///
-/// Allows overriding the generated name for an attribute or concept field.
+/// Field-level `#[dialog(...)]` parameters on a `#[derive(Concept)]`
+/// field.
+#[derive(Default)]
+pub struct DialogFieldAttributes {
+    /// `rename = "..."`: overrides the generated field key.
+    pub rename: Option<String>,
+    /// `conforms = SomeConcept`: marks a concept-typed field; the
+    /// path names the target concept type.
+    pub conforms: Option<syn::Path>,
+}
+
+/// Parse the field-level `#[dialog(...)]` attribute.
 ///
 /// Supports:
-/// - `#[dialog(rename = "type")]` - rename to a specific string
+/// - `#[dialog(rename = "type")]` - rename the field key to a
+///   specific string
+/// - `#[dialog(conforms = Employee)]` - concept-typed field whose
+///   target entity must conform to the named concept
 ///
-/// Returns `Ok(Some(name))` if rename is specified, `Ok(None)` to use default.
-pub fn parse_dialog_rename_attribute(attrs: &[Attribute]) -> Result<Option<String>, syn::Error> {
+/// Both parameters may appear together.
+pub fn parse_dialog_field_attributes(
+    attrs: &[Attribute],
+) -> Result<DialogFieldAttributes, syn::Error> {
+    let mut parsed = DialogFieldAttributes::default();
     for attr in attrs {
         if attr.path().is_ident("dialog") {
-            let mut rename_value = None;
-
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("rename") {
                     let value = meta.value()?;
                     let lit: Lit = value.parse()?;
                     if let Lit::Str(lit_str) = lit {
-                        rename_value = Some(lit_str.value());
+                        parsed.rename = Some(lit_str.value());
                         Ok(())
                     } else {
                         Err(meta.error("rename value must be a string literal"))
                     }
+                } else if meta.path.is_ident("conforms") {
+                    let value = meta.value()?;
+                    parsed.conforms = Some(value.parse::<syn::Path>()?);
+                    Ok(())
                 } else {
-                    Err(meta.error("unknown dialog attribute parameter; expected `rename`"))
+                    Err(meta.error(
+                        "unknown dialog attribute parameter; expected `rename` or `conforms`",
+                    ))
                 }
             })?;
-
-            return Ok(rename_value);
         }
     }
-    Ok(None)
+    Ok(parsed)
 }
 
 /// Parse the `#[cardinality(one)]` or `#[cardinality(many)]` attribute.

--- a/rust/dialog-macros/src/query/helpers.rs
+++ b/rust/dialog-macros/src/query/helpers.rs
@@ -154,6 +154,40 @@ pub fn parse_domain_attribute(attrs: &[Attribute]) -> Option<String> {
     None
 }
 
+/// Parse the `#[dialog(rename = "...")]` attribute.
+///
+/// Allows overriding the generated name for an attribute or concept field.
+///
+/// Supports:
+/// - `#[dialog(rename = "type")]` - rename to a specific string
+///
+/// Returns `Ok(Some(name))` if rename is specified, `Ok(None)` to use default.
+pub fn parse_dialog_rename_attribute(attrs: &[Attribute]) -> Result<Option<String>, syn::Error> {
+    for attr in attrs {
+        if attr.path().is_ident("dialog") {
+            let mut rename_value = None;
+
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("rename") {
+                    let value = meta.value()?;
+                    let lit: Lit = value.parse()?;
+                    if let Lit::Str(lit_str) = lit {
+                        rename_value = Some(lit_str.value());
+                        Ok(())
+                    } else {
+                        Err(meta.error("rename value must be a string literal"))
+                    }
+                } else {
+                    Err(meta.error("unknown dialog attribute parameter; expected `rename`"))
+                }
+            })?;
+
+            return Ok(rename_value);
+        }
+    }
+    Ok(None)
+}
+
 /// Parse the `#[cardinality(one)]` or `#[cardinality(many)]` attribute.
 /// Returns the appropriate Cardinality token stream, defaulting to `One`.
 pub fn parse_cardinality_attribute(attrs: &[Attribute]) -> Result<TokenStream, syn::Error> {

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -360,8 +360,15 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
             Term::Variable { .. } => {
                 // A prefix refinement the planner stamped onto the
                 // attribute variable becomes an AEV range bound.
-                if let Some(refinement) = from.the.kind().as_ref().and_then(Kind::refinement) {
-                    let prefix = refinement.prefix.clone();
+                // Conformance-only refinements carry no prefix and
+                // produce no range bound.
+                if let Some(prefix) = from
+                    .the
+                    .kind()
+                    .as_ref()
+                    .and_then(Kind::refinement)
+                    .and_then(|refinement| refinement.prefix.clone())
+                {
                     selector = Some(match selector {
                         None => ArtifactSelector::new().the_starting_with(prefix),
                         Some(s) => s.the_starting_with(prefix),
@@ -383,8 +390,15 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
             Term::Variable { .. } => {
                 // A prefix refinement on the entity variable becomes
                 // an EAV range bound over the URI's raw head.
-                if let Some(refinement) = from.of.kind().as_ref().and_then(Kind::refinement) {
-                    let prefix = refinement.prefix.clone();
+                // Conformance-only refinements carry no prefix and
+                // produce no range bound.
+                if let Some(prefix) = from
+                    .of
+                    .kind()
+                    .as_ref()
+                    .and_then(Kind::refinement)
+                    .and_then(|refinement| refinement.prefix.clone())
+                {
                     selector = Some(match selector {
                         None => ArtifactSelector::new().of_starting_with(prefix),
                         Some(s) => s.of_starting_with(prefix),

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -5,13 +5,13 @@ use crate::attribute::The;
 use crate::environment::Environment;
 use crate::negation::Negation;
 use crate::proposition::Proposition;
-use crate::query::Application;
 use crate::query::Output;
+use crate::query::{Application, Restriction};
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
 use crate::type_system::Type as Kind;
 use crate::types::{Any, Record};
-use crate::{Entity, EvaluationError, Parameters, Premise, Schema, Term};
+use crate::{Entity, EvaluationError, Parameters, Premise, Schema, Term, Value};
 use auto_enums::auto_enum;
 use dialog_artifacts::{Cause, Select};
 use dialog_capability::Provider;
@@ -205,6 +205,33 @@ impl Application for DynamicAttributeQuery {
         match self {
             DynamicAttributeQuery::All(q) => q.realize(input),
             DynamicAttributeQuery::Only(q) => q.realize(input),
+        }
+    }
+
+    fn restrict(&self, entity: &Entity) -> Restriction<Self> {
+        match self.of() {
+            Term::Constant(Value::Entity(this)) if this == entity => {
+                Restriction::Scoped(self.clone())
+            }
+            Term::Constant(_) => Restriction::Unaffected,
+            Term::Variable {
+                name: Some(name), ..
+            } if [self.the().name(), self.is().name(), self.cause().name()]
+                .into_iter()
+                .flatten()
+                .any(|other| other == name) =>
+            {
+                // `of` joins another slot through a shared variable
+                // name; pinning it would sever the join.
+                Restriction::Unsupported
+            }
+            _ => Restriction::Scoped(DynamicAttributeQuery::new(
+                self.the().clone(),
+                Term::Constant(Value::Entity(entity.clone())),
+                self.is().clone(),
+                self.cause().clone(),
+                Some(self.cardinality()),
+            )),
         }
     }
 }

--- a/rust/dialog-query/src/attribute/query/typed.rs
+++ b/rust/dialog-query/src/attribute/query/typed.rs
@@ -14,7 +14,7 @@ use crate::types::Scalar;
 use crate::{Entity, EvaluationError, Premise, Proposition, Term, Value};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
-use dialog_common::ConditionalSync;
+use dialog_common::{ConditionalSend, ConditionalSync};
 
 /// A typed attribute query with named fields for entity and value.
 ///
@@ -77,7 +77,7 @@ where
 
 impl<A> Application for StaticAttributeQuery<A>
 where
-    A: Attribute + Descriptor<AttributeDescriptor> + Clone + Send + 'static,
+    A: Attribute + Descriptor<AttributeDescriptor> + Clone + ConditionalSend + 'static,
     A: From<A::Type>,
     A::Type: Scalar + TryFrom<Value>,
 {

--- a/rust/dialog-query/src/claim.rs
+++ b/rust/dialog-query/src/claim.rs
@@ -2,6 +2,7 @@
 
 pub use crate::artifact::{Artifact, ArtifactsAttribute, Cause, Entity, Value};
 use crate::attribute::The;
+use crate::concept::Conclusion;
 use serde::{Deserialize, Serialize};
 
 /// A claim represents a stored EAV datum with full metadata.
@@ -49,6 +50,15 @@ impl Claim {
     /// Get the cause (provenance hash) of this claim
     pub fn cause(&self) -> &Cause {
         &self.cause
+    }
+}
+
+impl Conclusion for Claim {
+    /// The claim's subject entity. Lets claim-valued query results
+    /// participate in subject-keyed machinery (e.g. per-entity
+    /// incremental maintenance) uniformly with concept conclusions.
+    fn this(&self) -> &Entity {
+        &self.of
     }
 }
 

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -1496,4 +1496,186 @@ mod tests {
 
         Ok(())
     }
+
+    // -- Tests migrated from tests/dialog_rename_test.rs --
+
+    mod item {
+        use crate::Attribute;
+
+        /// The type of item
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Kind(pub String);
+
+        /// Name of the item
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Name(pub String);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_attribute_name_as_kebab_case() {
+        // Kind struct should derive name from struct name via kebab-case
+        assert_eq!(item::Kind::descriptor().name(), "kind");
+    }
+
+    #[dialog_common::test]
+    fn it_preserves_attribute_metadata() {
+        assert_eq!(item::Kind::descriptor().domain(), "item");
+        assert_eq!(item::Kind::descriptor().description(), "The type of item");
+        assert_eq!(
+            item::Kind::descriptor().cardinality(),
+            crate::Cardinality::One
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_formats_attribute_selector() {
+        assert_eq!(item::Kind::the().to_string(), "item/kind");
+    }
+
+    #[dialog_common::test]
+    fn it_leaves_unrenamed_attribute_unchanged() {
+        // Name without rename should behave normally
+        assert_eq!(item::Name::descriptor().name(), "name");
+        assert_eq!(item::Name::descriptor().domain(), "item");
+    }
+
+    // -- Concept field rename tests --
+
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct Item {
+        pub this: Entity,
+
+        /// Name of the item
+        pub name: item::Name,
+
+        /// Type of the item
+        #[dialog(rename = "type")]
+        pub kind: item::Kind,
+    }
+
+    #[dialog_common::test]
+    fn it_renames_concept_field_in_descriptor() {
+        let descriptor = Item::descriptor();
+        let attrs: Vec<_> = descriptor.with().iter().collect();
+
+        assert_eq!(attrs.len(), 2);
+
+        // Find the attributes by key — concept field rename maps "kind" field to "type" key
+        let name_attr = attrs.iter().find(|(k, _)| *k == "name");
+        let type_attr = attrs.iter().find(|(k, _)| *k == "type");
+
+        assert!(name_attr.is_some(), "Should have 'name' key in descriptor");
+        assert!(
+            type_attr.is_some(),
+            "Should have 'type' key (from renamed field) in descriptor",
+        );
+
+        // The 'type' key should point to the item/kind attribute (attribute name is "kind")
+        assert_eq!(type_attr.unwrap().1.name(), "kind");
+        assert_eq!(type_attr.unwrap().1.domain(), "item");
+    }
+
+    #[dialog_common::test]
+    fn it_renames_concept_field_in_query_struct() {
+        // Query struct should still use the Rust field name
+        let query = ItemQuery {
+            this: Term::var("item"),
+            name: Term::var("item_name"),
+            kind: Term::var("item_kind"),
+        };
+
+        // But when converted to Parameters, the key should be the renamed value
+        let params: Parameters = query.into();
+        assert!(
+            params.get("type").is_some(),
+            "Parameters should have 'type' key from renamed field",
+        );
+        assert!(
+            params.get("kind").is_none(),
+            "Parameters should NOT have 'kind' key (the Rust field name)",
+        );
+        assert!(
+            params.get("name").is_some(),
+            "Parameters should have 'name' key for unrenamed field",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_uses_renamed_value_in_default_query() {
+        // Default Query should create Term::var with the renamed string
+        let query = ItemQuery::default();
+
+        // The 'kind' field should have a variable named "type"
+        match &query.kind {
+            Term::Variable { name, .. } => {
+                assert_eq!(
+                    name.as_deref(),
+                    Some("type"),
+                    "Default variable name should use renamed value",
+                );
+            }
+            _ => panic!("Expected variable term"),
+        }
+
+        // The 'name' field should have a variable named "name" (unrenamed)
+        match &query.name {
+            Term::Variable { name, .. } => {
+                assert_eq!(name.as_deref(), Some("name"));
+            }
+            _ => panic!("Expected variable term"),
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_uses_renamed_value_in_terms() {
+        // Terms method should still use Rust field name but produce renamed variable
+        let term = ItemTerms::kind();
+        match &term {
+            Term::Variable { name, .. } => {
+                assert_eq!(
+                    name.as_deref(),
+                    Some("type"),
+                    "Terms method should produce variable with renamed name",
+                );
+            }
+            _ => panic!("Expected variable term"),
+        }
+    }
+
+    // -- Combined: concept field rename with normal attribute --
+
+    mod task {
+        use crate::Attribute;
+
+        /// The reference identifier
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Reference(pub String);
+
+        /// Task title
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Title(pub String);
+    }
+
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct Task {
+        pub this: Entity,
+        pub title: task::Title,
+        #[dialog(rename = "ref")]
+        pub reference: task::Reference,
+    }
+
+    #[dialog_common::test]
+    fn it_combines_concept_rename_with_attribute() {
+        // Attribute name is derived from struct name (no rename on attributes)
+        assert_eq!(task::Reference::descriptor().name(), "reference");
+        assert_eq!(task::Reference::the().to_string(), "task/reference");
+
+        // Concept descriptor should have "ref" key (concept field rename)
+        let descriptor = Task::descriptor();
+        let attrs: Vec<_> = descriptor.with().iter().collect();
+        let ref_attr = attrs.iter().find(|(k, _)| *k == "ref");
+        assert!(ref_attr.is_some(), "Should have 'ref' key in descriptor");
+        // The attribute descriptor's name is still "reference" (no attribute rename)
+        assert_eq!(ref_attr.unwrap().1.name(), "reference");
+    }
 }

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -1361,6 +1361,100 @@ mod tests {
         Ok(())
     }
 
+    // Ordered variants: first-to-conform via desugared negation.
+    mod contact {
+        use crate::Attribute;
+
+        /// Preferred way to reach the user.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Handle(pub String);
+    }
+
+    /// How to reach a user: their email when they have one,
+    /// otherwise their phone number.
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct Contact {
+        pub this: Entity,
+        pub handle: contact::Handle,
+    }
+
+    #[dialog_common::test]
+    async fn it_evaluates_ordered_variants_first_to_conform() -> Result<()> {
+        use crate::attribute::{AttributeDescriptor, The};
+        use crate::rule::deductive::DeductiveRule;
+        use crate::{Cardinality, ConceptDescriptor};
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let variant = |the: The| {
+            ConceptDescriptor::try_from(vec![(
+                "handle",
+                AttributeDescriptor::new(the, "", Cardinality::One, Some(ValueType::String)),
+            )])
+            .unwrap()
+        };
+        let email = variant(the!("user/email"));
+        let phone = variant(the!("user/phone"));
+
+        let rules = DeductiveRule::variants(Contact::descriptor().clone(), vec![email, phone])
+            .expect("variants compile");
+
+        let mut registry = RuleRegistry::new();
+        for rule in rules {
+            registry.register(rule).expect("rule registers");
+        }
+
+        let alice = Entity::new()?; // email AND phone: email wins
+        let bob = Entity::new()?; // phone only: phone row
+
+        branch
+            .transaction()
+            .assert(
+                the!("user/email")
+                    .of(alice.clone())
+                    .is("alice@mail".to_string()),
+            )
+            .assert(
+                the!("user/phone")
+                    .of(alice.clone())
+                    .is("555-0100".to_string()),
+            )
+            .assert(
+                the!("user/phone")
+                    .of(bob.clone())
+                    .is("555-0199".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, registry);
+        let mut contacts: Vec<Contact> = Query::<Contact>::default()
+            .perform(&source)
+            .try_collect()
+            .await?;
+        contacts.sort_by(|a, b| a.handle.value().cmp(b.handle.value()));
+
+        assert_eq!(
+            contacts,
+            vec![
+                Contact {
+                    this: bob,
+                    handle: contact::Handle("555-0199".into()),
+                },
+                Contact {
+                    this: alice,
+                    handle: contact::Handle("alice@mail".into()),
+                },
+            ],
+            "the first conforming variant wins; later variants fill the rest"
+        );
+
+        Ok(())
+    }
+
     // Tests migrated from tests/concept_query_shortcut_test.rs
     mod shortcut_employee {
         use crate::Attribute;

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -249,6 +249,35 @@ where
     }
 }
 
+/// Marker + constructor for *concept-typed* fields: a required,
+/// entity-valued attribute whose target entity must conform to a
+/// concept. `#[dialog(conforms = C)]` in `#[derive(Concept)]`
+/// dispatches through this trait, so both constraints are enforced
+/// at compile time rather than syntactically:
+///
+/// - a non-entity attribute fails the `Attribute<Type = Entity>`
+///   bound of the single blanket impl;
+/// - an `Option<_>` field has no impl at all — optional conformance
+///   is absence over a derived predicate, which stratification has
+///   to own before it can be evaluated soundly.
+pub trait ConformingField: ConceptField {
+    /// The [`ConceptFieldDescriptor`] for this field conforming to
+    /// `target`: the underlying attribute's descriptor tagged with
+    /// the target concept.
+    fn conforming_descriptor(target: ConceptDescriptor) -> ConceptFieldDescriptor {
+        ConceptFieldDescriptor::conforming(
+            <Self::Attribute as Descriptor<AttributeDescriptor>>::descriptor().clone(),
+            target,
+        )
+        .expect("the ConformingField bound guarantees an entity-valued attribute")
+    }
+}
+
+impl<N> ConformingField for N where
+    N: Attribute<Type = Entity> + Descriptor<AttributeDescriptor> + Clone + From<Entity>
+{
+}
+
 // Blanket impl for &T -> Parameters that uses the generated From<T> impl
 impl<T> From<&T> for Parameters
 where
@@ -1227,6 +1256,107 @@ mod tests {
 
         assert_eq!(name_facts.len(), 0);
         assert_eq!(birthday_facts.len(), 0);
+
+        Ok(())
+    }
+
+    // Concept-typed fields: `#[dialog(conforms = C)]`.
+    mod org {
+        use crate::Attribute;
+        use crate::Entity;
+
+        /// Employee badge number.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Badge(pub String);
+
+        /// The person's manager.
+        #[derive(Attribute, Clone, PartialEq)]
+        pub struct Manager(pub Entity);
+    }
+
+    /// Someone with a badge.
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct BadgeHolder {
+        pub this: Entity,
+        pub badge: org::Badge,
+    }
+
+    /// Someone reporting to a badge holder.
+    #[derive(Concept, Debug, Clone, PartialEq)]
+    pub struct Report {
+        pub this: Entity,
+        pub badge: org::Badge,
+        /// The report's manager, who must hold a badge.
+        #[dialog(conforms = BadgeHolder)]
+        pub manager: org::Manager,
+    }
+
+    #[dialog_common::test]
+    fn it_tags_conforming_field_in_descriptor() {
+        let descriptor = Report::descriptor();
+        let manager = descriptor
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "manager")
+            .map(|(_, field)| field)
+            .expect("manager field present");
+        assert_eq!(
+            manager.conforms().map(|target| target.this()),
+            Some(BadgeHolder::descriptor().this()),
+            "the descriptor names the target concept"
+        );
+        assert_eq!(
+            manager.content_type(),
+            Some(ValueType::Entity),
+            "the conforming field is entity-valued"
+        );
+
+        let badge = descriptor
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "badge")
+            .map(|(_, field)| field)
+            .expect("badge field present");
+        assert!(badge.conforms().is_none(), "plain fields stay untagged");
+    }
+
+    /// End to end: a concept-typed field filters rows whose target
+    /// entity does not satisfy the target concept.
+    #[dialog_common::test]
+    async fn it_enforces_conformance_structurally() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?; // manager WITH a badge
+        let carol = Entity::new()?; // manager WITHOUT a badge
+        let bob = Entity::new()?; // reports to alice: conforms
+        let mallory = Entity::new()?; // reports to carol: does not
+
+        branch
+            .transaction()
+            .assert(org::Badge::of(alice.clone()).is("A-1"))
+            .assert(org::Badge::of(bob.clone()).is("B-2"))
+            .assert(org::Manager::of(bob.clone()).is(alice.clone()))
+            .assert(org::Badge::of(mallory.clone()).is("M-3"))
+            .assert(org::Manager::of(mallory.clone()).is(carol.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let reports: Vec<Report> = Query::<Report>::default()
+            .perform(&source)
+            .try_collect()
+            .await?;
+
+        assert_eq!(
+            reports.len(),
+            1,
+            "only the report whose manager holds a badge conforms, got {reports:?}"
+        );
+        assert_eq!(reports[0].this, bob);
+        assert_eq!(reports[0].manager.value(), &alice);
 
         Ok(())
     }

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -473,7 +473,7 @@ impl<'a> Builder<'a> {
 /// Field values are accessed by the term bindings from the query.
 /// The `terms` map provides the mapping from field names to variable terms
 /// used in the match.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ConceptConclusion {
     this: Entity,
     terms: Parameters,

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -14,7 +14,7 @@ use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
 use crate::statement::Retraction;
 use crate::term::Term;
-use crate::type_system::{Primitive, Type as Kind};
+use crate::type_system::{ConceptRef, Primitive, Type as Kind};
 use crate::types::Scalar;
 use crate::{
     Cardinality, Entity, EvaluationError, Field, Parameters, Proposition, Requirement, Schema,
@@ -136,21 +136,29 @@ impl ConceptDescriptor {
     /// - The value for a **required** attribute is an empty map `{}`.
     /// - The value for an **optional** attribute is `{ "optional":
     ///   true }`.
+    /// - The value for a **concept-typed** attribute carries the
+    ///   target's URI: `{ "conforms": "concept:{hash}" }`. The
+    ///   target participates by identity, not by embedding, so a
+    ///   conforming field adds one URI to the encoding rather than
+    ///   the target's whole attribute set.
     ///
-    /// A concept with no optional attributes therefore hashes
-    /// exactly as it did before optionality existed (every value is
-    /// `{}`), so existing concept identities are preserved. Marking
-    /// an attribute optional changes its value object, and thus the
-    /// concept's identity.
+    /// A concept with no optional or conforming attributes therefore
+    /// hashes exactly as it did before either existed (every value
+    /// is `{}`), so existing concept identities are preserved.
+    /// Marking an attribute optional or conforming changes its value
+    /// object, and thus the concept's identity.
     pub fn to_cbor_bytes(&self) -> Vec<u8> {
         /// Per-attribute hash value: `{}` for required,
-        /// `{ "optional": true }` for optional. `optional` is omitted
-        /// when false, so a required attribute encodes as an empty
-        /// map, byte-identical to the pre-optionality encoding.
+        /// `{ "optional": true }` for optional, `{ "conforms":
+        /// "concept:.." }` for concept-typed. Both keys are omitted
+        /// when absent, so a plain required attribute encodes as an
+        /// empty map, byte-identical to the earlier encodings.
         #[derive(Serialize)]
         struct AttributeIdentity {
             #[serde(skip_serializing_if = "Not::not")]
             optional: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            conforms: Option<String>,
         }
 
         let mut attr_map: BTreeMap<String, AttributeIdentity> = BTreeMap::new();
@@ -161,6 +169,7 @@ impl ConceptDescriptor {
                 uri,
                 AttributeIdentity {
                     optional: schema.is_optional(),
+                    conforms: schema.conforms().map(|target| target.this().to_string()),
                 },
             );
         }
@@ -322,6 +331,18 @@ impl From<&ConceptDescriptor> for Schema {
                 (Some(ty), true) => Some(Kind::from(ty).optional()),
                 (None, true) => Some(Kind::from(Primitive::ALL).optional()),
                 (None, false) => None,
+            };
+            // A concept-typed field's slot carries the conformance
+            // refinement, so a consuming rule's TypeEnv sees which
+            // concept the entity must satisfy. The field is
+            // entity-valued by construction, so the meet is never
+            // empty.
+            let content_type = match (content_type, field.conforms()) {
+                (Some(kind), Some(target)) => Some(
+                    kind.with_conformance(ConceptRef(target.this().to_string()))
+                        .expect("a conforming field is entity-valued by construction"),
+                ),
+                (kind, _) => kind,
             };
             schema.insert(
                 name.into(),
@@ -1614,6 +1635,190 @@ mod tests {
         );
     }
 
+    /// Helpers shared by the conformance tests below.
+    fn badge_target() -> ConceptDescriptor {
+        ConceptDescriptor::try_from(vec![(
+            "badge",
+            AttributeDescriptor::new(
+                the!("employee/badge"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap()
+    }
+
+    fn manager_attr(content: Option<Type>) -> AttributeDescriptor {
+        AttributeDescriptor::new(the!("person/manager"), "", Cardinality::One, content)
+    }
+
+    /// Only entity-valued attributes can conform to a concept.
+    #[dialog_common::test]
+    fn it_rejects_non_entity_conformance() {
+        let result =
+            ConceptFieldDescriptor::conforming(manager_attr(Some(Type::String)), badge_target());
+        match result {
+            Err(crate::TypeError::NonEntityConformance { the, .. }) => {
+                assert_eq!(the, "person/manager");
+            }
+            other => panic!("expected NonEntityConformance, got {other:?}"),
+        }
+
+        let untyped = ConceptFieldDescriptor::conforming(manager_attr(None), badge_target());
+        assert!(
+            untyped.is_err(),
+            "an attribute without a declared value type cannot conform"
+        );
+    }
+
+    /// The wire path enforces the same invariants: a conforming
+    /// field that is optional, or not entity-valued, fails to parse.
+    #[dialog_common::test]
+    fn it_validates_conformance_on_the_wire() {
+        let target = serde_json::to_value(badge_target()).unwrap();
+
+        let optional = serde_json::json!({
+            "with": {
+                "name": { "the": "person/name", "as": "Text" },
+                "manager": {
+                    "the": "person/manager",
+                    "as": "Entity",
+                    "optional": true,
+                    "conforms": target,
+                }
+            }
+        });
+        assert!(
+            serde_json::from_value::<ConceptDescriptor>(optional).is_err(),
+            "optional conformance is absence-over-IDB; rejected until stratification"
+        );
+
+        let non_entity = serde_json::json!({
+            "with": {
+                "name": { "the": "person/name", "as": "Text" },
+                "manager": {
+                    "the": "person/manager",
+                    "as": "Text",
+                    "conforms": target,
+                }
+            }
+        });
+        assert!(
+            serde_json::from_value::<ConceptDescriptor>(non_entity).is_err(),
+            "a conforming field must be entity-valued"
+        );
+    }
+
+    /// A conforming field round-trips through JSON, carrying the
+    /// full target descriptor under `conforms`; plain fields stay
+    /// free of the key.
+    #[dialog_common::test]
+    fn it_round_trips_a_conforming_field() {
+        let target = badge_target();
+        let concept = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    manager_attr(Some(Type::Entity)),
+                    target.clone(),
+                )
+                .unwrap(),
+            ),
+        ])
+        .unwrap();
+
+        let json = serde_json::to_value(&concept).expect("serialize");
+        let with = json["with"].as_object().expect("with map");
+        assert!(
+            with["manager"]["conforms"].is_object(),
+            "conforming field carries the target descriptor"
+        );
+        assert!(
+            with["name"].as_object().unwrap().get("conforms").is_none(),
+            "plain field omits the key"
+        );
+
+        let back: ConceptDescriptor = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back.this(), concept.this());
+        let manager = back
+            .with()
+            .iter()
+            .find(|(name, _)| *name == "manager")
+            .map(|(_, field)| field)
+            .expect("manager present");
+        assert_eq!(
+            manager.conforms().map(|c| c.this()),
+            Some(target.this()),
+            "the target survives the round-trip"
+        );
+    }
+
+    /// Conformance participates in the concept's identity by the
+    /// target's URI: tagging a field changes the hash, and the hash
+    /// depends on the target's identity rather than its embedding.
+    #[dialog_common::test]
+    fn it_hashes_conformance_into_identity() {
+        let plain = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::required(manager_attr(Some(Type::Entity))),
+            ),
+        ])
+        .unwrap();
+
+        let conforming = |target: ConceptDescriptor| {
+            ConceptDescriptor::try_from(vec![
+                (
+                    "name".to_string(),
+                    ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                        the!("person/name"),
+                        "",
+                        Cardinality::One,
+                        Some(Type::String),
+                    )),
+                ),
+                (
+                    "manager".to_string(),
+                    ConceptFieldDescriptor::conforming(manager_attr(Some(Type::Entity)), target)
+                        .unwrap(),
+                ),
+            ])
+            .unwrap()
+        };
+
+        let a = conforming(badge_target());
+        assert_ne!(
+            plain.hash(),
+            a.hash(),
+            "tagging a field with conformance changes the identity"
+        );
+
+        // The same target built independently hashes identically, so
+        // the concept identity is a function of the target's URI.
+        let b = conforming(badge_target());
+        assert_eq!(a.hash(), b.hash());
+        assert_eq!(a.this(), b.this());
+    }
+
     /// `From<&ConceptDescriptor> for Schema` lifts a typed
     /// attribute's content_type into the unified `type_system::Type`.
     #[dialog_common::test]
@@ -1708,6 +1913,48 @@ mod tests {
         assert!(
             tag.content_type().expect("tag kind").is_optional(),
             "an untyped optional field widens the full value set"
+        );
+    }
+
+    /// A conforming field's schema slot carries the conformance
+    /// refinement, so consuming rules see which concept the entity
+    /// must satisfy.
+    #[dialog_common::test]
+    fn schema_from_concept_stamps_conformance() {
+        use crate::type_system::ConceptRef;
+
+        let target = badge_target();
+        let descriptor = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    manager_attr(Some(Type::Entity)),
+                    target.clone(),
+                )
+                .unwrap(),
+            ),
+        ])
+        .unwrap();
+
+        let schema = Schema::from(&descriptor);
+        let manager = schema.get("manager").expect("manager field present");
+        let kind = manager.content_type().expect("typed slot");
+        assert_eq!(kind.primitive_part().as_singleton(), Some(Type::Entity));
+        assert!(
+            kind.refinement()
+                .expect("refined")
+                .conforms
+                .contains(&ConceptRef(target.this().to_string())),
+            "the slot kind names the target concept"
         );
     }
 

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -9,7 +9,7 @@ use crate::attribute::{AttributeDescriptor, Attribution};
 use crate::concept::query::ConceptQuery;
 use crate::concept::{Concept, Conclusion};
 use crate::error::TypeError;
-use crate::query::Application;
+use crate::query::{Application, Restriction};
 use crate::selection::{Match, Selection};
 use crate::source::SelectRules;
 use crate::statement::Retraction;
@@ -551,6 +551,42 @@ impl Application for ConceptQuery {
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
         ConceptQuery::evaluate(self, selection, env)
+    }
+
+    fn restrict(&self, entity: &Entity) -> Restriction<Self> {
+        match self.terms.get("this") {
+            Some(Term::Constant(Value::Entity(this))) if this == entity => {
+                Restriction::Scoped(self.clone())
+            }
+            Some(Term::Constant(_)) => Restriction::Unaffected,
+            Some(Term::Variable {
+                name: Some(name), ..
+            }) if self
+                .terms
+                .iter()
+                .any(|(param, term)| param != "this" && term.name() == Some(name)) =>
+            {
+                // `this` joins another field through a shared
+                // variable name; pinning it to a constant would
+                // sever the join.
+                Restriction::Unsupported
+            }
+            _ => {
+                let mut terms = self.terms.clone();
+                terms.insert(
+                    "this".to_string(),
+                    Term::Constant(Value::Entity(entity.clone())),
+                );
+                Restriction::Scoped(ConceptQuery {
+                    terms,
+                    predicate: self.predicate.clone(),
+                })
+            }
+        }
+    }
+
+    fn concept(&self) -> Option<&ConceptDescriptor> {
+        Some(&self.predicate)
     }
 
     fn realize(&self, source: Match) -> Result<Self::Conclusion, EvaluationError> {

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -1,6 +1,7 @@
 use crate::Cardinality;
 use crate::artifact::Type;
 use crate::attribute::{AttributeDescriptor, The};
+use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::TypeError;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
@@ -34,7 +35,7 @@ fn is_not_optional(optional: &bool) -> bool {
 ///
 /// A required field omits `optional`, so it is byte-identical to the
 /// pre-optionality encoding.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ConceptFieldDescriptor {
     #[serde(flatten)]
     descriptor: AttributeDescriptor,
@@ -44,6 +45,18 @@ pub struct ConceptFieldDescriptor {
     /// the wire.
     #[serde(default, skip_serializing_if = "is_not_optional")]
     optional: bool,
+    /// The concept the field's target entity must conform to — a
+    /// *concept-typed* field. Only entity-valued attributes can
+    /// conform (validated at every construction path), and a
+    /// conforming field cannot be optional: the left-join over
+    /// "edge exists AND target conforms" is absence-over-IDB, which
+    /// stratification (M4) has to own first.
+    ///
+    /// Carried as the full target descriptor so rule lowering can
+    /// conjoin the target's premises without a registry; identity
+    /// hashing uses only the target's `concept:{hash}` URI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    conforms: Option<Box<ConceptDescriptor>>,
 }
 
 impl ConceptFieldDescriptor {
@@ -52,6 +65,7 @@ impl ConceptFieldDescriptor {
         Self {
             descriptor,
             optional: false,
+            conforms: None,
         }
     }
 
@@ -61,7 +75,30 @@ impl ConceptFieldDescriptor {
         Self {
             descriptor,
             optional: true,
+            conforms: None,
         }
+    }
+
+    /// A *concept-typed* field: a required, entity-valued attribute
+    /// whose target entity must conform to `target`. Errors when the
+    /// attribute's value type is not `Entity` — only entities can
+    /// conform to a concept.
+    pub fn conforming(
+        descriptor: AttributeDescriptor,
+        target: ConceptDescriptor,
+    ) -> Result<Self, TypeError> {
+        if descriptor.content_type() != Some(Type::Entity) {
+            return Err(TypeError::NonEntityConformance {
+                the: descriptor.the().to_string(),
+                concept: target.this().to_string(),
+                actual: descriptor.content_type(),
+            });
+        }
+        Ok(Self {
+            descriptor,
+            optional: false,
+            conforms: Some(Box::new(target)),
+        })
     }
 
     /// The underlying attribute descriptor.
@@ -72,6 +109,12 @@ impl ConceptFieldDescriptor {
     /// Returns `true` iff this field is optional (set-widened).
     pub fn is_optional(&self) -> bool {
         self.optional
+    }
+
+    /// The concept this field's target entity must conform to, if
+    /// the field is concept-typed.
+    pub fn conforms(&self) -> Option<&ConceptDescriptor> {
+        self.conforms.as_deref()
     }
 
     /// Convenience: the attribute's relation identifier.
@@ -155,10 +198,29 @@ impl NamedAttributes {
 
     /// Fallible builder shared by the [`TryFrom`] impls: rejects an
     /// empty set, or a set with no required field, with
-    /// [`TypeError::EmptyConcept`].
+    /// [`TypeError::EmptyConcept`]; rejects malformed concept-typed
+    /// fields (non-entity value type, or optional conformance) so
+    /// the wire path enforces the same invariants
+    /// [`ConceptFieldDescriptor::conforming`] does.
     fn try_new(map: BTreeMap<String, ConceptFieldDescriptor>) -> Result<Self, TypeError> {
         if map.is_empty() || map.values().all(|field| field.is_optional()) {
             return Err(TypeError::EmptyConcept);
+        }
+        for field in map.values() {
+            if let Some(target) = field.conforms() {
+                if field.content_type() != Some(Type::Entity) {
+                    return Err(TypeError::NonEntityConformance {
+                        the: field.the().to_string(),
+                        concept: target.this().to_string(),
+                        actual: field.content_type(),
+                    });
+                }
+                if field.is_optional() {
+                    return Err(TypeError::OptionalConformance {
+                        the: field.the().to_string(),
+                    });
+                }
+            }
         }
         Ok(NamedAttributes(map))
     }

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -287,7 +287,12 @@ impl ConceptQuery {
                     // component's semi-naive fixpoint is computed once
                     // and the caller's bindings join against the rows.
                     if let Some(analysis) = rules.recursion() {
-                        table = Some(fixpoint::evaluate(&app.predicate, analysis, env).await?);
+                        table = Some(match rules.continuation() {
+                            Some(continuation) => {
+                                continuation.rows(&app.predicate, analysis, env).await?
+                            }
+                            None => fixpoint::evaluate(&app.predicate, analysis, env).await?,
+                        });
                     } else {
                         plan = Some(rules.plan(&app.terms, &input));
                     }

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -1,5 +1,7 @@
 /// Adornment types for parameter binding pattern caching.
 pub mod adornment;
+/// Affected-entity discovery for incremental maintenance.
+pub mod affected;
 /// Semi-naive fixpoint evaluation for recursive concepts.
 pub mod fixpoint;
 /// Shared, branch-owned plan cache keyed by (rule identity, adornment).

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -1,5 +1,7 @@
 /// Adornment types for parameter binding pattern caching.
 pub mod adornment;
+/// Semi-naive fixpoint evaluation for recursive concepts.
+pub mod fixpoint;
 /// Shared, branch-owned plan cache keyed by (rule identity, adornment).
 mod plan_cache;
 /// Per-concept rule management with adornment-keyed plan caching.
@@ -268,6 +270,7 @@ impl ConceptQuery {
 
         try_stream! {
             let mut plan = None;
+            let mut table: Option<Vec<fixpoint::Row>> = None;
 
             for await each in selection {
                 let input = each?;
@@ -275,9 +278,26 @@ impl ConceptQuery {
                 // Derive the binding pattern from the first match and cache the
                 // plan. All matches in the selection share the same binding pattern
                 // (same variables bound), only the values differ.
-                if plan.is_none() {
+                if plan.is_none() && table.is_none() {
                     let rules = Provider::<SelectRules>::execute(env, app.predicate.clone()).await?;
-                    plan = Some(rules.plan(&app.terms, &input));
+                    // A concept on a dependency cycle cannot evaluate
+                    // top-down (it would recurse unboundedly): its
+                    // component's semi-naive fixpoint is computed once
+                    // and the caller's bindings join against the rows.
+                    if let Some(analysis) = rules.recursion() {
+                        table = Some(fixpoint::evaluate(&app.predicate, analysis, env).await?);
+                    } else {
+                        plan = Some(rules.plan(&app.terms, &input));
+                    }
+                }
+
+                if let Some(rows) = table.as_ref() {
+                    for row in rows {
+                        if let Some(merged) = fixpoint::join(&input, &app.terms, row)? {
+                            yield merged;
+                        }
+                    }
+                    continue;
                 }
                 let plan = plan.as_ref().unwrap();
 

--- a/rust/dialog-query/src/concept/query/affected.rs
+++ b/rust/dialog-query/src/concept/query/affected.rs
@@ -1,0 +1,299 @@
+//! Affected-entity discovery: the delta-join step of incremental
+//! subscription maintenance.
+//!
+//! Given a set of changed base facts and a subscribed concept, which
+//! head entities can the changes affect? For an *entity-local* rule
+//! (every premise reads `of ?this`) the answer is just the changed
+//! facts' subjects. For a non-local rule — one whose body reads
+//! other entities' facts through a concept premise (a concept-typed
+//! field's conformance check, a variant's negation) — the answer is
+//! discovered by a *delta-join*: bind the changed fact into the
+//! premise it can match, evaluate the rule's remaining premises
+//! sideways with those bindings, and project the head variable.
+//! Each affected head is then re-derived goal-directedly by the
+//! caller (DRed's delete/re-derive, per entity).
+//!
+//! The discovery over-approximates but never misses: a fact bound
+//! into a premise it merely *could* match yields candidate heads,
+//! and re-derivation settles the truth per head. `None` means the
+//! discovery could not bound the affected set (recursion, a rule
+//! shape it does not handle, an unplannable sideways join) and the
+//! caller must fall back to full re-evaluation, which is always
+//! sound.
+
+use std::collections::BTreeSet;
+
+use dialog_capability::Provider;
+use dialog_common::ConditionalSync;
+use futures_util::TryStreamExt as _;
+
+use crate::artifact::{Artifact, Select};
+use crate::attribute::The;
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::concept::query::ConceptQuery;
+use crate::error::EvaluationError;
+use crate::negation::Negation;
+use crate::planner::Planner;
+use crate::premise::Premise;
+use crate::proposition::Proposition;
+use crate::rule::deductive::DeductiveRule;
+use crate::selection::{Binding, Match};
+use crate::source::SelectRules;
+use crate::term::Term;
+use crate::types::Any;
+use crate::{Entity, Environment, Value};
+
+/// The head entities of `concept` that the changed facts can
+/// affect, or `None` when the set cannot be bounded and the caller
+/// must re-evaluate in full.
+///
+/// Nesting is followed one level: a concept premise whose target's
+/// rules are all entity-local contributes its affected heads
+/// (over-approximated by the changed facts' subjects); a target
+/// with non-local rules of its own, or any recursion, returns
+/// `None`.
+pub async fn affected_entities<'a, Env>(
+    concept: &ConceptDescriptor,
+    facts: &[Artifact],
+    env: &'a Env,
+) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let bundle = Provider::<SelectRules>::execute(env, concept.clone()).await?;
+    if bundle.recursion().is_some() {
+        return Ok(None);
+    }
+
+    let subjects: BTreeSet<Entity> = facts.iter().map(|fact| fact.of.clone()).collect();
+    let mut affected = BTreeSet::new();
+
+    for rule in bundle.rules() {
+        if rule.analysis().is_entity_local() {
+            // A change to E's facts only affects E's rows.
+            affected.extend(subjects.iter().cloned());
+            continue;
+        }
+        match rule_heads(rule, facts, &subjects, env).await? {
+            Some(heads) => affected.extend(heads),
+            None => return Ok(None),
+        }
+    }
+
+    Ok(Some(affected))
+}
+
+/// The candidate head entities one non-local rule can produce or
+/// retract given the changed facts: per premise, bind what the
+/// change can match and join the remaining premises sideways.
+async fn rule_heads<'a, Env>(
+    rule: &DeductiveRule,
+    facts: &[Artifact],
+    subjects: &BTreeSet<Entity>,
+    env: &'a Env,
+) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let premises = &rule.analysis().premises;
+    let mut heads = BTreeSet::new();
+
+    for (index, premise) in premises.iter().enumerate() {
+        // Attribute premises (positive, optional, or negated) are
+        // matched directly by the changed facts.
+        let attribute_terms = match premise {
+            Premise::Assert(Proposition::Attribute(query)) => {
+                Some((query.the().clone(), query.of().clone(), query.is().clone()))
+            }
+            Premise::Assert(Proposition::OptionalAttribute(query)) => Some((
+                query.query().the().clone(),
+                query.of().clone(),
+                query.is().clone(),
+            )),
+            Premise::Unless(Negation(Proposition::Attribute(query))) => {
+                Some((query.the().clone(), query.of().clone(), query.is().clone()))
+            }
+            _ => None,
+        };
+        if let Some((the, of, is)) = attribute_terms {
+            for fact in facts {
+                let mut matched = Match::new();
+                let mut scope = Environment::new();
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    the.as_constant(),
+                    the.name(),
+                    Value::from(The::from(fact.the.clone())),
+                ) {
+                    continue;
+                }
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    of.as_constant(),
+                    of.name(),
+                    Value::Entity(fact.of.clone()),
+                ) {
+                    continue;
+                }
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    is.as_constant(),
+                    is.name(),
+                    fact.is.clone(),
+                ) {
+                    continue;
+                }
+                match sideways_heads(premises, index, matched, &scope, rule, env).await? {
+                    Some(found) => heads.extend(found),
+                    None => return Ok(None),
+                }
+            }
+            continue;
+        }
+
+        // Concept premises (positive or negated): the change affects
+        // the target's rows for some entities; each such entity,
+        // bound into the premise's `this` slot, joins sideways to
+        // candidate heads. One nesting level: the target's rules
+        // must all be entity-local, so its affected heads are the
+        // changed facts' subjects (over-approximated).
+        let concept_query = match premise {
+            Premise::Assert(Proposition::Concept(query)) => Some(query),
+            Premise::Unless(Negation(Proposition::Concept(query))) => Some(query),
+            _ => None,
+        };
+        if let Some(query) = concept_query {
+            match target_locality(query, env).await? {
+                Locality::Local => {}
+                Locality::NonLocal => return Ok(None),
+            }
+            let Some(this) = query.terms.get("this") else {
+                return Ok(None);
+            };
+            for entity in subjects {
+                let mut matched = Match::new();
+                let mut scope = Environment::new();
+                if !bind_slot(
+                    &mut matched,
+                    &mut scope,
+                    this.as_constant(),
+                    this.name(),
+                    Value::Entity(entity.clone()),
+                ) {
+                    continue;
+                }
+                match sideways_heads(premises, index, matched, &scope, rule, env).await? {
+                    Some(found) => heads.extend(found),
+                    None => return Ok(None),
+                }
+            }
+        }
+    }
+
+    Ok(Some(heads))
+}
+
+/// Whether a nested concept premise's target can contribute
+/// entity-local affected heads.
+enum Locality {
+    /// Every target rule is entity-local and non-recursive.
+    Local,
+    /// The target has non-local rules or recursion: fall back.
+    NonLocal,
+}
+
+async fn target_locality<'a, Env>(
+    query: &ConceptQuery,
+    env: &'a Env,
+) -> Result<Locality, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let bundle = Provider::<SelectRules>::execute(env, query.predicate.clone()).await?;
+    if bundle.recursion().is_some() {
+        return Ok(Locality::NonLocal);
+    }
+    if bundle.rules().all(|rule| rule.analysis().is_entity_local()) {
+        Ok(Locality::Local)
+    } else {
+        Ok(Locality::NonLocal)
+    }
+}
+
+/// Bind one premise slot from a changed value. A constant slot
+/// filters (the fact must match it); a named variable binds; a
+/// blank slot matches anything. Returns `false` when the fact
+/// cannot match the slot.
+fn bind_slot(
+    matched: &mut Match,
+    scope: &mut Environment,
+    constant: Option<&Value>,
+    name: Option<&str>,
+    value: Value,
+) -> bool {
+    if let Some(expected) = constant {
+        return *expected == value;
+    }
+    match name {
+        Some(name) => {
+            if matched.bind(&Term::<Any>::var(name), value).is_err() {
+                return false;
+            }
+            scope.add(name);
+            true
+        }
+        None => true,
+    }
+}
+
+/// Join the rule's remaining premises against the bound match and
+/// project the head (`?this`) of every result. `None` when the
+/// sideways join cannot be planned from these bindings or a result
+/// leaves the head unbound — the caller falls back.
+async fn sideways_heads<'a, Env>(
+    premises: &[Premise],
+    source: usize,
+    matched: Match,
+    scope: &Environment,
+    rule: &DeductiveRule,
+    env: &'a Env,
+) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    // The head may already be bound by the source premise itself.
+    if let Ok(Binding::Present(Value::Entity(entity))) = matched.lookup(&Term::<Any>::var("this")) {
+        return Ok(Some(BTreeSet::from([entity])));
+    }
+
+    let rest: Vec<Premise> = premises
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index != source)
+        .map(|(_, premise)| premise.clone())
+        .collect();
+    if rest.is_empty() {
+        // Only the source premise, and it does not bind the head:
+        // nothing to join through.
+        return Ok(None);
+    }
+
+    let Ok(plan) = Planner::with_types(rest, rule.analysis().types.clone()).plan(scope) else {
+        return Ok(None);
+    };
+
+    let mut heads = BTreeSet::new();
+    let results: Vec<Match> = plan.evaluate(matched.seed(), env).try_collect().await?;
+    for result in results {
+        match result.lookup(&Term::<Any>::var("this")) {
+            Ok(Binding::Present(Value::Entity(entity))) => {
+                heads.insert(entity);
+            }
+            _ => return Ok(None),
+        }
+    }
+    Ok(Some(heads))
+}

--- a/rust/dialog-query/src/concept/query/affected.rs
+++ b/rust/dialog-query/src/concept/query/affected.rs
@@ -21,7 +21,7 @@
 //! caller must fall back to full re-evaluation, which is always
 //! sound.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
@@ -47,11 +47,12 @@ use crate::{Entity, Environment, Value};
 /// affect, or `None` when the set cannot be bounded and the caller
 /// must re-evaluate in full.
 ///
-/// Nesting is followed one level: a concept premise whose target's
-/// rules are all entity-local contributes its affected heads
-/// (over-approximated by the changed facts' subjects); a target
-/// with non-local rules of its own, or any recursion, returns
-/// `None`.
+/// Nested concept premises are followed to arbitrary depth: the
+/// reachable concepts form an acyclic graph (recursion anywhere in
+/// it returns `None`), each is resolved once, and affected sets are
+/// computed bottom-up — a target's affected heads feed the premises
+/// that apply it, so a change can propagate through any number of
+/// derivation layers.
 pub async fn affected_entities<'a, Env>(
     concept: &ConceptDescriptor,
     facts: &[Artifact],
@@ -60,36 +61,94 @@ pub async fn affected_entities<'a, Env>(
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
-    let bundle = Provider::<SelectRules>::execute(env, concept.clone()).await?;
-    if bundle.recursion().is_some() {
-        return Ok(None);
-    }
+    let root = concept.this();
 
-    let subjects: BTreeSet<Entity> = facts.iter().map(|fact| fact.of.clone()).collect();
-    let mut affected = BTreeSet::new();
-
-    for rule in bundle.rules() {
-        if rule.analysis().is_entity_local() {
-            // A change to E's facts only affects E's rows.
-            affected.extend(subjects.iter().cloned());
+    // Collect the reachable concepts and their resolved rules.
+    let mut rules_of: HashMap<Entity, Vec<DeductiveRule>> = HashMap::new();
+    let mut targets_of: HashMap<Entity, BTreeSet<Entity>> = HashMap::new();
+    let mut queue = vec![concept.clone()];
+    while let Some(descriptor) = queue.pop() {
+        let entity = descriptor.this();
+        if rules_of.contains_key(&entity) {
             continue;
         }
-        match rule_heads(rule, facts, &subjects, env).await? {
-            Some(heads) => affected.extend(heads),
-            None => return Ok(None),
+        let bundle = Provider::<SelectRules>::execute(env, descriptor).await?;
+        if bundle.recursion().is_some() {
+            return Ok(None);
         }
+        let rules: Vec<DeductiveRule> = bundle.rules().cloned().collect();
+        let mut targets = BTreeSet::new();
+        for rule in &rules {
+            for premise in rule.analysis().premises() {
+                if let Some(query) = concept_premise(premise) {
+                    targets.insert(query.predicate.this());
+                    queue.push(query.predicate.clone());
+                }
+            }
+        }
+        targets_of.insert(entity.clone(), targets);
+        rules_of.insert(entity, rules);
     }
 
-    Ok(Some(affected))
+    // Bottom-up: a concept computes once every target it applies
+    // has. The graph is acyclic (recursion returned above), so this
+    // always makes progress.
+    let subjects: BTreeSet<Entity> = facts.iter().map(|fact| fact.of.clone()).collect();
+    let mut affected: HashMap<Entity, BTreeSet<Entity>> = HashMap::new();
+    let mut pending: Vec<Entity> = rules_of.keys().cloned().collect();
+    while !pending.is_empty() {
+        let ready: Vec<Entity> = pending
+            .iter()
+            .filter(|entity| {
+                targets_of[*entity]
+                    .iter()
+                    .all(|target| affected.contains_key(target))
+            })
+            .cloned()
+            .collect();
+        if ready.is_empty() {
+            // Unreachable for an acyclic graph; bail rather than spin.
+            return Ok(None);
+        }
+        for entity in &ready {
+            let mut heads = BTreeSet::new();
+            for rule in &rules_of[entity] {
+                if rule.analysis().is_entity_local() {
+                    // A change to E's facts only affects E's rows.
+                    heads.extend(subjects.iter().cloned());
+                    continue;
+                }
+                match rule_heads(rule, facts, &affected, env).await? {
+                    Some(found) => heads.extend(found),
+                    None => return Ok(None),
+                }
+            }
+            affected.insert(entity.clone(), heads);
+        }
+        pending.retain(|entity| !ready.contains(entity));
+    }
+
+    Ok(affected.remove(&root))
+}
+
+/// The concept application of a premise, positive or negated.
+fn concept_premise(premise: &Premise) -> Option<&ConceptQuery> {
+    match premise {
+        Premise::Assert(Proposition::Concept(query)) => Some(query),
+        Premise::Unless(Negation(Proposition::Concept(query))) => Some(query),
+        _ => None,
+    }
 }
 
 /// The candidate head entities one non-local rule can produce or
 /// retract given the changed facts: per premise, bind what the
 /// change can match and join the remaining premises sideways.
+/// Concept premises bind their `this` slot from the target's
+/// already-computed affected heads.
 async fn rule_heads<'a, Env>(
     rule: &DeductiveRule,
     facts: &[Artifact],
-    subjects: &BTreeSet<Entity>,
+    affected: &HashMap<Entity, BTreeSet<Entity>>,
     env: &'a Env,
 ) -> Result<Option<BTreeSet<Entity>>, EvaluationError>
 where
@@ -154,26 +213,18 @@ where
             continue;
         }
 
-        // Concept premises (positive or negated): the change affects
-        // the target's rows for some entities; each such entity,
-        // bound into the premise's `this` slot, joins sideways to
-        // candidate heads. One nesting level: the target's rules
-        // must all be entity-local, so its affected heads are the
-        // changed facts' subjects (over-approximated).
-        let concept_query = match premise {
-            Premise::Assert(Proposition::Concept(query)) => Some(query),
-            Premise::Unless(Negation(Proposition::Concept(query))) => Some(query),
-            _ => None,
-        };
-        if let Some(query) = concept_query {
-            match target_locality(query, env).await? {
-                Locality::Local => {}
-                Locality::NonLocal => return Ok(None),
-            }
+        // Concept premises (positive or negated): the change's
+        // effect on the target is its already-computed affected
+        // set; each affected target head, bound into the premise's
+        // `this` slot, joins sideways to candidate heads.
+        if let Some(query) = concept_premise(premise) {
+            let Some(target_heads) = affected.get(&query.predicate.this()) else {
+                return Ok(None);
+            };
             let Some(this) = query.terms.get("this") else {
                 return Ok(None);
             };
-            for entity in subjects {
+            for entity in target_heads {
                 let mut matched = Match::new();
                 let mut scope = Environment::new();
                 if !bind_slot(
@@ -194,33 +245,6 @@ where
     }
 
     Ok(Some(heads))
-}
-
-/// Whether a nested concept premise's target can contribute
-/// entity-local affected heads.
-enum Locality {
-    /// Every target rule is entity-local and non-recursive.
-    Local,
-    /// The target has non-local rules or recursion: fall back.
-    NonLocal,
-}
-
-async fn target_locality<'a, Env>(
-    query: &ConceptQuery,
-    env: &'a Env,
-) -> Result<Locality, EvaluationError>
-where
-    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
-{
-    let bundle = Provider::<SelectRules>::execute(env, query.predicate.clone()).await?;
-    if bundle.recursion().is_some() {
-        return Ok(Locality::NonLocal);
-    }
-    if bundle.rules().all(|rule| rule.analysis().is_entity_local()) {
-        Ok(Locality::Local)
-    } else {
-        Ok(Locality::NonLocal)
-    }
 }
 
 /// Bind one premise slot from a changed value. A constant slot

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -561,8 +561,9 @@ mod tests {
             let ancestor = matched.lookup(&Term::<Any>::var("relative"))?.content()?;
             pairs.push((who, ancestor));
         }
+        // Deliberately no dedup: the fixpoint must emit exactly one
+        // row per distinct pair, so a duplicate is a test failure.
         pairs.sort_by_key(|pair| format!("{pair:?}"));
-        pairs.dedup();
         Ok(pairs)
     }
 
@@ -708,6 +709,675 @@ mod tests {
             Value::Entity(alice),
             "the caller's binding filtered the fixpoint rows"
         );
+        Ok(())
+    }
+
+    /// Ported from `query/test/loop.spec.js` "test ancestor": a
+    /// six-person linear chain (Eve is the root ancestor) derives
+    /// all fifteen ancestor pairs.
+    #[dialog_common::test]
+    async fn it_derives_all_pairs_over_a_deep_chain() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        // alice -> bob -> mallory -> jack -> adam -> eve
+        let chain: Vec<Entity> = (0..6).map(|_| Entity::new()).collect::<Result<_, _>>()?;
+        let mut transaction = branch.transaction();
+        for pair in chain.windows(2) {
+            transaction = transaction.assert(
+                the!("family/parent")
+                    .of(pair[0].clone())
+                    .is(pair[1].clone()),
+            );
+        }
+        transaction.commit().perform(&operator).await?;
+
+        let concept = ancestor_concept();
+        let mut registry = RuleRegistry::new();
+        for rule in ancestor_rules(&concept) {
+            registry.register(rule)?;
+        }
+
+        let source = TestEnv::new(&branch, &operator, registry);
+        let pairs = ancestor_pairs(&source, query_terms()).await?;
+
+        // Every strictly-later chain member is an ancestor of every
+        // earlier one: 5 + 4 + 3 + 2 + 1 = 15 pairs.
+        let mut expected = Vec::new();
+        for (child_index, child) in chain.iter().enumerate() {
+            for ancestor in chain.iter().skip(child_index + 1) {
+                expected.push((
+                    Value::Entity(child.clone()),
+                    Value::Entity(ancestor.clone()),
+                ));
+            }
+        }
+        expected.sort_by_key(|pair| format!("{pair:?}"));
+        assert_eq!(pairs.len(), 15, "fifteen distinct pairs, no duplicates");
+        assert_eq!(pairs, expected);
+        Ok(())
+    }
+
+    /// Ported from `query/test/loop.spec.js` "complex ancestor
+    /// test": a family tree with multiple paths to the same nodes
+    /// derives exactly 29 unique ancestor relationships (10 direct,
+    /// 19 transitive), with every multi-path derivation collapsed
+    /// to one row.
+    #[dialog_common::test]
+    async fn it_derives_the_multi_path_family_tree() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+        let charlie = Entity::new()?;
+        let david = Entity::new()?;
+        let mallory = Entity::new()?;
+        let jack = Entity::new()?;
+        let adam = Entity::new()?;
+        let eve = Entity::new()?;
+        let dave = Entity::new()?;
+
+        // Three branches from alice converging on jack, then a
+        // common tail jack -> adam -> eve. Both bob and david have
+        // mallory as parent; both mallory and dave have jack.
+        let edges = [
+            (&alice, &bob),
+            (&bob, &mallory),
+            (&mallory, &jack),
+            (&alice, &charlie),
+            (&charlie, &dave),
+            (&dave, &jack),
+            (&alice, &david),
+            (&david, &mallory),
+            (&jack, &adam),
+            (&adam, &eve),
+        ];
+        let mut transaction = branch.transaction();
+        for (child, parent) in edges {
+            transaction = transaction.assert(
+                the!("family/parent")
+                    .of((*child).clone())
+                    .is((*parent).clone()),
+            );
+        }
+        transaction.commit().perform(&operator).await?;
+
+        let concept = ancestor_concept();
+        let mut registry = RuleRegistry::new();
+        for rule in ancestor_rules(&concept) {
+            registry.register(rule)?;
+        }
+
+        let source = TestEnv::new(&branch, &operator, registry);
+        let pairs = ancestor_pairs(&source, query_terms()).await?;
+
+        assert_eq!(
+            pairs.len(),
+            29,
+            "10 direct + 19 transitive unique relationships, multi-path \
+             derivations deduplicated"
+        );
+        let expect = |child: &Entity, ancestor: &Entity| {
+            let pair = (
+                Value::Entity(child.clone()),
+                Value::Entity(ancestor.clone()),
+            );
+            assert!(pairs.contains(&pair), "missing pair {pair:?}");
+        };
+        // The multi-path derivations called out in the original test.
+        expect(&alice, &mallory); // via bob or via david
+        expect(&alice, &jack); // via bob/mallory, david/mallory, or charlie/dave
+        expect(&alice, &adam); // via any path to jack
+        expect(&alice, &eve); // via any path to adam
+        expect(&bob, &eve); // via mallory/jack/adam
+        expect(&charlie, &eve); // via dave/jack/adam
+        Ok(())
+    }
+
+    /// Ported from `query/test/loop.spec.js` "test recursion": a
+    /// non-recursive concept consumes a recursive one. `List` is the
+    /// transitive closure of `list/next`; `Connection` joins each
+    /// derived link with the target's `meta/name`. The outer concept
+    /// evaluates top-down and enters the fixpoint at the `List`
+    /// boundary.
+    #[dialog_common::test]
+    async fn it_consumes_a_recursive_concept_from_a_plain_rule() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let n0 = Entity::new()?;
+        let n1 = Entity::new()?;
+        let n2 = Entity::new()?;
+        let n3 = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("list/next").of(n0.clone()).is(n1.clone()))
+            .assert(the!("list/next").of(n1.clone()).is(n2.clone()))
+            .assert(the!("list/next").of(n2.clone()).is(n3.clone()))
+            .assert(the!("meta/name").of(n1.clone()).is("a".to_string()))
+            .assert(the!("meta/name").of(n2.clone()).is("b".to_string()))
+            .assert(the!("meta/name").of(n3.clone()).is("c".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // List { this, next }: transitive closure of list/next.
+        let list = ConceptDescriptor::try_from(vec![(
+            "next",
+            AttributeDescriptor::new(the!("list/link"), "", Cardinality::Many, Some(Type::Entity)),
+        )])?;
+        let direct = DeductiveRule::new(
+            list.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("list/next")),
+                    Term::<Entity>::var("this"),
+                    Term::var("next"),
+                    Term::blank(),
+                    Some(Cardinality::Many),
+                )
+                .into(),
+            ],
+        )?;
+        let mut step_terms = Parameters::new();
+        step_terms.insert("this".to_string(), Term::<Any>::var("hop"));
+        step_terms.insert("next".to_string(), Term::<Any>::var("next"));
+        let transitive = DeductiveRule::new(
+            list.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("list/next")),
+                    Term::<Entity>::var("this"),
+                    Term::var("hop"),
+                    Term::blank(),
+                    Some(Cardinality::Many),
+                )
+                .into(),
+                Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms: step_terms,
+                    predicate: list.clone(),
+                })),
+            ],
+        )?;
+
+        // Connection { this, to, name }: every reachable node with
+        // its name. Not itself recursive.
+        let connection = ConceptDescriptor::try_from(vec![
+            (
+                "to",
+                AttributeDescriptor::new(
+                    the!("conn/to"),
+                    "",
+                    Cardinality::Many,
+                    Some(Type::Entity),
+                ),
+            ),
+            (
+                "name",
+                AttributeDescriptor::new(
+                    the!("conn/name"),
+                    "",
+                    Cardinality::Many,
+                    Some(Type::String),
+                ),
+            ),
+        ])?;
+        let mut link_terms = Parameters::new();
+        link_terms.insert("this".to_string(), Term::<Any>::var("this"));
+        link_terms.insert("next".to_string(), Term::<Any>::var("to"));
+        let connection_rule = DeductiveRule::new(
+            connection.clone(),
+            vec![
+                Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms: link_terms,
+                    predicate: list.clone(),
+                })),
+                AttributeQuery::new(
+                    Term::from(the!("meta/name")),
+                    Term::<Entity>::var("to"),
+                    Term::var("name"),
+                    Term::blank(),
+                    Some(Cardinality::One),
+                )
+                .into(),
+            ],
+        )?;
+
+        let mut registry = RuleRegistry::new();
+        registry.register(direct)?;
+        registry.register(transitive)?;
+        registry.register(connection_rule)?;
+        assert!(registry.is_recursive(&list.this())?);
+        assert!(
+            !registry.is_recursive(&connection.this())?,
+            "the consuming concept is outside the cycle"
+        );
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("from"));
+        terms.insert("to".to_string(), Term::<Any>::var("to"));
+        terms.insert("name".to_string(), Term::<Any>::var("name"));
+        let source = TestEnv::new(&branch, &operator, registry);
+        let plan = Planner::from(vec![Premise::Assert(Proposition::Concept(ConceptQuery {
+            terms,
+            predicate: connection,
+        }))])
+        .plan(&Environment::new())
+        .expect("plans");
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+
+        let mut connections = Vec::new();
+        for matched in results {
+            connections.push((
+                matched.lookup(&Term::<Any>::var("from"))?.content()?,
+                matched.lookup(&Term::<Any>::var("to"))?.content()?,
+                matched.lookup(&Term::<Any>::var("name"))?.content()?,
+            ));
+        }
+        connections.sort_by_key(|row| format!("{row:?}"));
+        let mut expected = vec![
+            (
+                Value::Entity(n0.clone()),
+                Value::Entity(n1.clone()),
+                Value::String("a".into()),
+            ),
+            (
+                Value::Entity(n1.clone()),
+                Value::Entity(n2.clone()),
+                Value::String("b".into()),
+            ),
+            (
+                Value::Entity(n0.clone()),
+                Value::Entity(n2.clone()),
+                Value::String("b".into()),
+            ),
+            (
+                Value::Entity(n2.clone()),
+                Value::Entity(n3.clone()),
+                Value::String("c".into()),
+            ),
+            (
+                Value::Entity(n1.clone()),
+                Value::Entity(n3.clone()),
+                Value::String("c".into()),
+            ),
+            (
+                Value::Entity(n0.clone()),
+                Value::Entity(n3.clone()),
+                Value::String("c".into()),
+            ),
+        ];
+        expected.sort_by_key(|row| format!("{row:?}"));
+        assert_eq!(connections, expected, "every reachable node, named");
+        Ok(())
+    }
+
+    /// Ported from `query/test/loop.spec.js` "test not really
+    /// recursive": a concept with a base rule plus a rule that
+    /// re-derives the concept from itself. The recursive rule adds
+    /// nothing new, so the fixpoint converges to exactly the base
+    /// rows.
+    #[dialog_common::test]
+    async fn it_converges_when_the_recursive_rule_adds_nothing() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let x = Entity::new()?;
+        let y = Entity::new()?;
+        let z = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("meta/name").of(x.clone()).is("a".to_string()))
+            .assert(the!("meta/name").of(y.clone()).is("b".to_string()))
+            .assert(the!("meta/name").of(z.clone()).is("c".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let person = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(the!("query/name"), "", Cardinality::One, Some(Type::String)),
+        )])?;
+        let base = DeductiveRule::new(
+            person.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("meta/name")),
+                    Term::<Entity>::var("this"),
+                    Term::var("name"),
+                    Term::blank(),
+                    Some(Cardinality::One),
+                )
+                .into(),
+            ],
+        )?;
+        let mut self_terms = Parameters::new();
+        self_terms.insert("this".to_string(), Term::<Any>::var("this"));
+        self_terms.insert("name".to_string(), Term::<Any>::var("name"));
+        let recur = DeductiveRule::new(
+            person.clone(),
+            vec![Premise::Assert(Proposition::Concept(ConceptQuery {
+                terms: self_terms,
+                predicate: person.clone(),
+            }))],
+        )?;
+
+        let mut registry = RuleRegistry::new();
+        registry.register(base)?;
+        registry.register(recur)?;
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("who"));
+        terms.insert("name".to_string(), Term::<Any>::var("name"));
+        let source = TestEnv::new(&branch, &operator, registry);
+        let plan = Planner::from(vec![Premise::Assert(Proposition::Concept(ConceptQuery {
+            terms,
+            predicate: person,
+        }))])
+        .plan(&Environment::new())
+        .expect("plans");
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+
+        let mut names = Vec::new();
+        for matched in &results {
+            names.push(matched.lookup(&Term::<Any>::var("name"))?.content()?);
+        }
+        names.sort_by_key(|name| format!("{name:?}"));
+        assert_eq!(
+            names,
+            vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+                Value::String("c".into()),
+            ],
+            "exactly the base rows, once each"
+        );
+        Ok(())
+    }
+
+    /// Ported from `query/test/loop.spec.js` "test tautology", with
+    /// least-fixpoint semantics: a single rule that conjoins the
+    /// base scan with the concept itself has no non-recursive rule
+    /// to seed the table, so nothing is ever derivable and the
+    /// fixpoint converges to the empty set. (The legacy JS engine
+    /// returned the base rows here; classical Datalog says empty,
+    /// and that is what this engine implements.) The implicit rule
+    /// scans the conclusion attribute's own facts, of which there
+    /// are none.
+    #[dialog_common::test]
+    async fn it_derives_nothing_for_a_tautology() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let x = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("meta/name").of(x.clone()).is("a".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let tautology = ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                the!("tautology/name"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])?;
+        let mut self_terms = Parameters::new();
+        self_terms.insert("this".to_string(), Term::<Any>::var("this"));
+        self_terms.insert("name".to_string(), Term::<Any>::var("name"));
+        let rule = DeductiveRule::new(
+            tautology.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("meta/name")),
+                    Term::<Entity>::var("this"),
+                    Term::var("name"),
+                    Term::blank(),
+                    Some(Cardinality::One),
+                )
+                .into(),
+                Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms: self_terms,
+                    predicate: tautology.clone(),
+                })),
+            ],
+        )?;
+
+        let mut registry = RuleRegistry::new();
+        registry.register(rule)?;
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("who"));
+        terms.insert("name".to_string(), Term::<Any>::var("name"));
+        let source = TestEnv::new(&branch, &operator, registry);
+        let plan = Planner::from(vec![Premise::Assert(Proposition::Concept(ConceptQuery {
+            terms,
+            predicate: tautology,
+        }))])
+        .plan(&Environment::new())
+        .expect("plans");
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+
+        assert!(
+            results.is_empty(),
+            "no base case, no derivations; and the query terminates"
+        );
+        Ok(())
+    }
+
+    /// The nl-datalog demo program (alexwarth.github.io/projects/
+    /// nl-datalog): Simpsons facts with derived `parent` and
+    /// `grandfather` rules, extended with the recursive `ancestor`.
+    /// "Homer is Bart's father. Homer is Lisa's father. Abe is
+    /// Homer's father." Abe is the grandfather of Bart and Lisa,
+    /// and the ancestor closure has exactly five pairs.
+    #[dialog_common::test]
+    async fn it_derives_the_simpsons_program() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let homer = Entity::new()?;
+        let bart = Entity::new()?;
+        let lisa = Entity::new()?;
+        let abe = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("family/father").of(bart.clone()).is(homer.clone()))
+            .assert(the!("family/father").of(lisa.clone()).is(homer.clone()))
+            .assert(the!("family/father").of(homer.clone()).is(abe.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // parent(this, parent) :- father(this, parent).
+        let parent = ConceptDescriptor::try_from(vec![(
+            "parent",
+            AttributeDescriptor::new(
+                the!("family/derived-parent"),
+                "",
+                Cardinality::Many,
+                Some(Type::Entity),
+            ),
+        )])?;
+        let parent_rule = DeductiveRule::new(
+            parent.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("family/father")),
+                    Term::<Entity>::var("this"),
+                    Term::var("parent"),
+                    Term::blank(),
+                    Some(Cardinality::One),
+                )
+                .into(),
+            ],
+        )?;
+
+        // grandfather(this, g) :- father(z, g), parent(this, z).
+        let grandfather = ConceptDescriptor::try_from(vec![(
+            "grandfather",
+            AttributeDescriptor::new(
+                the!("family/grandfather"),
+                "",
+                Cardinality::Many,
+                Some(Type::Entity),
+            ),
+        )])?;
+        let mut parent_terms = Parameters::new();
+        parent_terms.insert("this".to_string(), Term::<Any>::var("this"));
+        parent_terms.insert("parent".to_string(), Term::<Any>::var("z"));
+        let grandfather_rule = DeductiveRule::new(
+            grandfather.clone(),
+            vec![
+                Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms: parent_terms,
+                    predicate: parent.clone(),
+                })),
+                AttributeQuery::new(
+                    Term::from(the!("family/father")),
+                    Term::<Entity>::var("z"),
+                    Term::var("grandfather"),
+                    Term::blank(),
+                    Some(Cardinality::One),
+                )
+                .into(),
+            ],
+        )?;
+
+        // ancestor: the recursive extension over the same facts.
+        let ancestor = ConceptDescriptor::try_from(vec![(
+            "ancestor",
+            AttributeDescriptor::new(
+                the!("family/forebear"),
+                "",
+                Cardinality::Many,
+                Some(Type::Entity),
+            ),
+        )])?;
+        let ancestor_base = DeductiveRule::new(
+            ancestor.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("family/father")),
+                    Term::<Entity>::var("this"),
+                    Term::var("ancestor"),
+                    Term::blank(),
+                    Some(Cardinality::One),
+                )
+                .into(),
+            ],
+        )?;
+        let mut step_terms = Parameters::new();
+        step_terms.insert("this".to_string(), Term::<Any>::var("f"));
+        step_terms.insert("ancestor".to_string(), Term::<Any>::var("ancestor"));
+        let ancestor_step = DeductiveRule::new(
+            ancestor.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("family/father")),
+                    Term::<Entity>::var("this"),
+                    Term::var("f"),
+                    Term::blank(),
+                    Some(Cardinality::One),
+                )
+                .into(),
+                Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms: step_terms,
+                    predicate: ancestor.clone(),
+                })),
+            ],
+        )?;
+
+        let mut registry = RuleRegistry::new();
+        registry.register(parent_rule)?;
+        registry.register(grandfather_rule)?;
+        registry.register(ancestor_base)?;
+        registry.register(ancestor_step)?;
+
+        let source = TestEnv::new(&branch, &operator, registry);
+
+        // Who is whose grandfather?
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("grandchild"));
+        terms.insert("grandfather".to_string(), Term::<Any>::var("grandfather"));
+        let plan = Planner::from(vec![Premise::Assert(Proposition::Concept(ConceptQuery {
+            terms,
+            predicate: grandfather,
+        }))])
+        .plan(&Environment::new())
+        .expect("plans");
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+        let mut grandchildren = Vec::new();
+        for matched in &results {
+            let grandchild = matched.lookup(&Term::<Any>::var("grandchild"))?.content()?;
+            assert_eq!(
+                matched
+                    .lookup(&Term::<Any>::var("grandfather"))?
+                    .content()?,
+                Value::Entity(abe.clone()),
+                "Abe is the only grandfather"
+            );
+            grandchildren.push(grandchild);
+        }
+        grandchildren.sort_by_key(|value| format!("{value:?}"));
+        let mut expected = vec![Value::Entity(bart.clone()), Value::Entity(lisa.clone())];
+        expected.sort_by_key(|value| format!("{value:?}"));
+        assert_eq!(grandchildren, expected, "Abe has two grandchildren");
+
+        // The full ancestor closure: five pairs.
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("who"));
+        terms.insert("ancestor".to_string(), Term::<Any>::var("relative"));
+        let plan = Planner::from(vec![Premise::Assert(Proposition::Concept(ConceptQuery {
+            terms,
+            predicate: ancestor,
+        }))])
+        .plan(&Environment::new())
+        .expect("plans");
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+        let mut pairs = Vec::new();
+        for matched in &results {
+            pairs.push((
+                matched.lookup(&Term::<Any>::var("who"))?.content()?,
+                matched.lookup(&Term::<Any>::var("relative"))?.content()?,
+            ));
+        }
+        pairs.sort_by_key(|pair| format!("{pair:?}"));
+        let mut expected = vec![
+            (Value::Entity(bart.clone()), Value::Entity(homer.clone())),
+            (Value::Entity(lisa.clone()), Value::Entity(homer.clone())),
+            (Value::Entity(homer.clone()), Value::Entity(abe.clone())),
+            (Value::Entity(bart.clone()), Value::Entity(abe.clone())),
+            (Value::Entity(lisa.clone()), Value::Entity(abe.clone())),
+        ];
+        expected.sort_by_key(|pair| format!("{pair:?}"));
+        assert_eq!(pairs, expected);
         Ok(())
     }
 }

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -1,0 +1,713 @@
+//! Semi-naive fixpoint evaluation for recursive concepts.
+//!
+//! When the queried concept participates in a dependency cycle (a
+//! non-trivial SCC in the [`ProgramAnalysis`] graph), top-down
+//! evaluation would recurse unboundedly. This module evaluates the
+//! whole strongly connected component bottom-up instead:
+//!
+//! 1. **Seed round.** Every rule of every component member with no
+//!    in-component concept premise evaluates on the ordinary
+//!    top-down path; its rows seed the [`AnswerTable`].
+//! 2. **Delta rounds.** Each round re-derives every rule with
+//!    in-component premises, semi-naive style: per rule and per
+//!    recursive occurrence, that occurrence reads the previous
+//!    round's *delta* while the other occurrences read the running
+//!    *total*, so only derivations involving at least one new row
+//!    are recomputed. The occurrences bind their rows into a
+//!    [`Match`]; the remaining (non-recursive) premises are planned
+//!    against that binding scope and evaluated on the ordinary
+//!    top-down path.
+//! 3. **Termination.** The fixpoint is reached when a round stages
+//!    nothing new. [`MAX_ROUNDS`] is the loud-failure safety valve
+//!    for rule sets that generate unboundedly (e.g. through
+//!    formulas).
+//!
+//! The stratification contract makes this sound: negation inside a
+//! component is rejected before evaluation (see
+//! [`ProgramAnalysis::check`]), so every premise a component member
+//! negates is fully derivable before the component's fixpoint runs.
+//!
+//! Goal-directed (magic-set) filtering of the component's answer
+//! space is future work: this evaluator computes the component's
+//! full fixpoint and joins the caller's bindings against the result
+//! afterwards.
+
+use super::ConceptQuery;
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::error::EvaluationError;
+use crate::negation::Negation;
+use crate::parameters::Parameters;
+use crate::planner::Planner;
+use crate::premise::Premise;
+use crate::proposition::Proposition;
+use crate::rule::deductive::DeductiveRule;
+use crate::selection::{Binding, Match};
+use crate::session::ProgramAnalysis;
+use crate::source::SelectRules;
+use crate::term::Term;
+use crate::types::Any;
+use crate::{Entity, Environment, Value};
+use core::{iter, mem};
+use dialog_artifacts::Select;
+use dialog_capability::Provider;
+use dialog_common::ConditionalSync;
+use futures_util::TryStreamExt;
+use std::collections::{BTreeMap, HashMap};
+
+/// Upper bound on fixpoint rounds before the query fails loudly. A
+/// round derives at least one new row (otherwise the fixpoint has
+/// converged), so purely fact-driven recursion terminates well under
+/// this; hitting it means the rule set generates fresh values every
+/// round (e.g. through a formula) and would spin forever.
+pub const MAX_ROUNDS: usize = 1000;
+
+/// One derived conclusion: operand name to value. Operands resolved
+/// to `Absent` (optional fields) are omitted.
+pub type Row = BTreeMap<String, Value>;
+
+/// Storage for the answers accumulated during a fixpoint run. The
+/// trait is the swap point for bounded-memory (disk-backed)
+/// implementations; the evaluator only ever appends, advances, and
+/// scans.
+pub trait AnswerTable {
+    /// Stage a freshly derived row. Returns `false` when the row is
+    /// already known (in the total or already staged), `true` when
+    /// it is new.
+    fn insert(&mut self, concept: &Entity, row: Row) -> bool;
+
+    /// End the round: staged rows become the new delta and join the
+    /// total. Returns `true` when the new delta is non-empty (the
+    /// fixpoint has not converged).
+    fn advance(&mut self) -> bool;
+
+    /// Every row derived for the concept so far, including the
+    /// current delta.
+    fn total(&self, concept: &Entity) -> Vec<Row>;
+
+    /// The rows first derived in the previous round.
+    fn delta(&self, concept: &Entity) -> Vec<Row>;
+}
+
+/// In-memory [`AnswerTable`]. [`Value`] has no total order (floats),
+/// so rows are deduplicated by their canonical dag-cbor encoding and
+/// stored in sorted maps for deterministic iteration.
+#[derive(Debug, Default)]
+pub struct InMemoryAnswerTable {
+    total: HashMap<Entity, BTreeMap<Vec<u8>, Row>>,
+    delta: HashMap<Entity, BTreeMap<Vec<u8>, Row>>,
+    staged: HashMap<Entity, BTreeMap<Vec<u8>, Row>>,
+}
+
+/// The canonical identity of a row: its dag-cbor bytes. dag-cbor
+/// sorts map keys per spec, so the encoding is a pure function of
+/// the row's contents.
+fn row_key(row: &Row) -> Vec<u8> {
+    serde_ipld_dagcbor::to_vec(row).expect("a row of values encodes")
+}
+
+impl AnswerTable for InMemoryAnswerTable {
+    fn insert(&mut self, concept: &Entity, row: Row) -> bool {
+        let key = row_key(&row);
+        if self
+            .total
+            .get(concept)
+            .is_some_and(|rows| rows.contains_key(&key))
+        {
+            return false;
+        }
+        self.staged
+            .entry(concept.clone())
+            .or_default()
+            .insert(key, row)
+            .is_none()
+    }
+
+    fn advance(&mut self) -> bool {
+        self.delta = mem::take(&mut self.staged);
+        for (concept, rows) in &self.delta {
+            self.total
+                .entry(concept.clone())
+                .or_default()
+                .extend(rows.iter().map(|(key, row)| (key.clone(), row.clone())));
+        }
+        self.delta.values().any(|rows| !rows.is_empty())
+    }
+
+    fn total(&self, concept: &Entity) -> Vec<Row> {
+        self.total
+            .get(concept)
+            .map(|rows| rows.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn delta(&self, concept: &Entity) -> Vec<Row> {
+        self.delta
+            .get(concept)
+            .map(|rows| rows.values().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+/// Join one caller row against one derived row: bind the caller's
+/// terms to the row's operand values, treating conflicts (a term
+/// already bound to a different value, or a constant that doesn't
+/// match) as a non-match. Operands the row resolved to `Absent`
+/// bind absent, so optional concept fields keep their left-join
+/// semantics.
+pub fn join(
+    input: &Match,
+    terms: &Parameters,
+    row: &Row,
+) -> Result<Option<Match>, EvaluationError> {
+    let mut merged = input.clone();
+    for (param, term) in terms.iter() {
+        match (row.get(param), term) {
+            (Some(value), Term::Variable { name: Some(_), .. }) => {
+                if merged.bind(term, value.clone()).is_err() {
+                    return Ok(None);
+                }
+            }
+            (Some(value), Term::Constant(expected)) => {
+                if expected != value {
+                    return Ok(None);
+                }
+            }
+            (None, Term::Variable { name: Some(_), .. }) => {
+                if merged.bind_absent(term).is_err() {
+                    return Ok(None);
+                }
+            }
+            (None, Term::Constant(_)) => return Ok(None),
+            (_, Term::Variable { name: None, .. }) => {}
+        }
+    }
+    Ok(Some(merged))
+}
+
+/// A component member's rule split into its in-component concept
+/// premises (the *recursive occurrences*, evaluated from the answer
+/// table) and everything else (the *base premises*, evaluated
+/// top-down).
+struct SplitRule {
+    rule: DeductiveRule,
+    occurrences: Vec<ConceptQuery>,
+    base: Vec<Premise>,
+}
+
+/// A component member: its descriptor (for row projection) and its
+/// split rules.
+struct Member {
+    descriptor: ConceptDescriptor,
+    rules: Vec<SplitRule>,
+}
+
+/// Whether the premise applies a concept in the same cycle as
+/// `root`, returning the application when so.
+fn in_component<'p>(
+    premise: &'p Premise,
+    analysis: &ProgramAnalysis,
+    root: &Entity,
+) -> Option<&'p ConceptQuery> {
+    let query = match premise {
+        Premise::Assert(Proposition::Concept(query)) => query,
+        // Negation into the component is rejected by the
+        // stratification check before evaluation begins.
+        Premise::Unless(Negation(Proposition::Concept(query))) => query,
+        _ => return None,
+    };
+    analysis
+        .in_same_cycle(root, &query.predicate.this())
+        .then_some(query)
+}
+
+/// Bind one recursive occurrence's terms from a table row. Returns
+/// `false` when the row conflicts with the bindings accumulated so
+/// far (the combination is a non-match).
+fn bind_occurrence(matched: &mut Match, occurrence: &ConceptQuery, row: &Row) -> bool {
+    for (param, term) in occurrence.terms.iter() {
+        let Some(value) = row.get(param) else {
+            // The row resolved this operand to Absent (an optional
+            // field); nothing to bind.
+            continue;
+        };
+        match term {
+            Term::Variable { name: Some(_), .. } => {
+                if matched.bind(term, value.clone()).is_err() {
+                    return false;
+                }
+            }
+            Term::Constant(expected) => {
+                if expected != value {
+                    return false;
+                }
+            }
+            Term::Variable { name: None, .. } => {}
+        }
+    }
+    true
+}
+
+/// Project a rule's result match into a conclusion [`Row`]: one
+/// entry per conclusion operand bound to a present value; operands
+/// resolved to `Absent` (or never bound) are omitted.
+fn project(descriptor: &ConceptDescriptor, matched: &Match) -> Row {
+    let mut row = Row::new();
+    let operands = iter::once("this").chain(descriptor.with().keys());
+    for operand in operands {
+        if let Ok(Binding::Present(value)) = matched.lookup(&Term::<Any>::var(operand)) {
+            row.insert(operand.to_string(), value);
+        }
+    }
+    row
+}
+
+/// Enumerate the cartesian product of per-occurrence row choices as
+/// index vectors. An empty choice list for any occurrence yields no
+/// combinations.
+struct Combinations {
+    sizes: Vec<usize>,
+    cursor: Vec<usize>,
+    done: bool,
+}
+
+impl Combinations {
+    fn new(sizes: Vec<usize>) -> Self {
+        let done = sizes.contains(&0);
+        let cursor = vec![0; sizes.len()];
+        Combinations {
+            sizes,
+            cursor,
+            done,
+        }
+    }
+}
+
+impl Iterator for Combinations {
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Vec<usize>> {
+        if self.done {
+            return None;
+        }
+        let current = self.cursor.clone();
+        // Odometer increment; overflow past the last position ends
+        // the iteration.
+        self.done = true;
+        for position in (0..self.cursor.len()).rev() {
+            self.cursor[position] += 1;
+            if self.cursor[position] < self.sizes[position] {
+                self.done = false;
+                break;
+            }
+            self.cursor[position] = 0;
+        }
+        // A zero-occurrence rule has exactly one (empty) combination.
+        if self.cursor.is_empty() {
+            self.done = true;
+        }
+        Some(current)
+    }
+}
+
+/// Compute the full fixpoint of the queried concept's strongly
+/// connected component and return the rows derived for the queried
+/// concept itself.
+pub async fn evaluate<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+) -> Result<Vec<Row>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let root_entity = root.this();
+
+    // Discover the component: starting from the queried concept,
+    // follow in-component premises (each embeds its target's full
+    // descriptor) and collect every member's rules.
+    let mut members: HashMap<Entity, Member> = HashMap::new();
+    let mut queue = vec![root.clone()];
+    while let Some(descriptor) = queue.pop() {
+        let entity = descriptor.this();
+        if members.contains_key(&entity) || !analysis.in_same_cycle(&root_entity, &entity) {
+            continue;
+        }
+        let bundle = Provider::<SelectRules>::execute(env, descriptor.clone()).await?;
+        let mut rules = Vec::new();
+        for rule in bundle.rules() {
+            let mut occurrences = Vec::new();
+            let mut base = Vec::new();
+            for premise in rule.analysis().premises() {
+                match in_component(premise, analysis, &root_entity) {
+                    Some(query) => {
+                        queue.push(query.predicate.clone());
+                        occurrences.push(query.clone());
+                    }
+                    None => base.push(premise.clone()),
+                }
+            }
+            rules.push(SplitRule {
+                rule: rule.clone(),
+                occurrences,
+                base,
+            });
+        }
+        members.insert(entity, Member { descriptor, rules });
+    }
+
+    let mut table = InMemoryAnswerTable::default();
+
+    // Seed round: rules with no recursive occurrence evaluate fully
+    // top-down.
+    for member in members.values() {
+        for split in &member.rules {
+            if !split.occurrences.is_empty() {
+                continue;
+            }
+            let plan = split.rule.plan(&Environment::new());
+            let results: Vec<Match> = plan
+                .evaluate(Match::new().seed(), env)
+                .try_collect()
+                .await?;
+            for matched in results {
+                table.insert(
+                    &member.descriptor.this(),
+                    project(&member.descriptor, &matched),
+                );
+            }
+        }
+    }
+
+    // Delta rounds: per rule and per recursive occurrence, that
+    // occurrence reads the delta while its siblings read the total.
+    let mut rounds = 0;
+    while table.advance() {
+        rounds += 1;
+        if rounds > MAX_ROUNDS {
+            return Err(EvaluationError::FixpointDivergence {
+                concept: root_entity.to_string(),
+                rounds,
+            });
+        }
+
+        for member in members.values() {
+            for split in &member.rules {
+                if split.occurrences.is_empty() {
+                    continue;
+                }
+                for delta_index in 0..split.occurrences.len() {
+                    let choices: Vec<Vec<Row>> = split
+                        .occurrences
+                        .iter()
+                        .enumerate()
+                        .map(|(index, occurrence)| {
+                            let target = occurrence.predicate.this();
+                            if index == delta_index {
+                                table.delta(&target)
+                            } else {
+                                table.total(&target)
+                            }
+                        })
+                        .collect();
+
+                    for combination in Combinations::new(choices.iter().map(Vec::len).collect()) {
+                        let mut matched = Match::new();
+                        let mut scope = Environment::new();
+                        let mut compatible = true;
+                        for (index, (occurrence, row_index)) in
+                            split.occurrences.iter().zip(&combination).enumerate()
+                        {
+                            let row = &choices[index][*row_index];
+                            if !bind_occurrence(&mut matched, occurrence, row) {
+                                compatible = false;
+                                break;
+                            }
+                            for (_, term) in occurrence.terms.iter() {
+                                if let Some(name) = term.name() {
+                                    scope.add(name);
+                                }
+                            }
+                        }
+                        if !compatible {
+                            continue;
+                        }
+
+                        let results: Vec<Match> = if split.base.is_empty() {
+                            vec![matched]
+                        } else {
+                            let plan = Planner::with_types(
+                                split.base.clone(),
+                                split.rule.analysis().types.clone(),
+                            )
+                            .plan(&scope)
+                            .map_err(|error| {
+                                EvaluationError::Planning {
+                                    message: error.to_string(),
+                                }
+                            })?;
+                            plan.evaluate(matched.seed(), env).try_collect().await?
+                        };
+                        for result in results {
+                            table.insert(
+                                &member.descriptor.this(),
+                                project(&member.descriptor, &result),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(table.total(&root_entity))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::attribute::query::AttributeQuery;
+    use crate::attribute::{AttributeDescriptor, Cardinality, Type};
+    use crate::session::RuleRegistry;
+    use crate::source::test::TestEnv;
+    use crate::the;
+    use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+    use futures_util::TryStreamExt;
+
+    /// The `ancestor` concept: `this` plus one entity-valued
+    /// `ancestor` field.
+    fn ancestor_concept() -> ConceptDescriptor {
+        ConceptDescriptor::try_from(vec![(
+            "ancestor",
+            AttributeDescriptor::new(
+                the!("family/ancestor"),
+                "",
+                Cardinality::Many,
+                Some(Type::Entity),
+            ),
+        )])
+        .unwrap()
+    }
+
+    /// The classic pair of rules:
+    ///
+    /// ```text
+    /// ancestor(this, a) :- parent(this, a).
+    /// ancestor(this, a) :- parent(this, p), ancestor(p, a).
+    /// ```
+    fn ancestor_rules(concept: &ConceptDescriptor) -> Vec<DeductiveRule> {
+        let base = DeductiveRule::new(
+            concept.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("family/parent")),
+                    Term::<Entity>::var("this"),
+                    Term::var("ancestor"),
+                    Term::blank(),
+                    Some(Cardinality::Many),
+                )
+                .into(),
+            ],
+        )
+        .expect("base rule compiles");
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("p"));
+        terms.insert("ancestor".to_string(), Term::<Any>::var("ancestor"));
+        let step = DeductiveRule::new(
+            concept.clone(),
+            vec![
+                AttributeQuery::new(
+                    Term::from(the!("family/parent")),
+                    Term::<Entity>::var("this"),
+                    Term::var("p"),
+                    Term::blank(),
+                    Some(Cardinality::Many),
+                )
+                .into(),
+                Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms,
+                    predicate: concept.clone(),
+                })),
+            ],
+        )
+        .expect("recursive rule compiles");
+
+        vec![base, step]
+    }
+
+    /// Evaluate the ancestor concept against the source and return
+    /// the derived `(this, ancestor)` pairs.
+    async fn ancestor_pairs(
+        source: &TestEnv<'_>,
+        terms: Parameters,
+    ) -> anyhow::Result<Vec<(Value, Value)>> {
+        let premise = Premise::Assert(Proposition::Concept(ConceptQuery {
+            terms,
+            predicate: ancestor_concept(),
+        }));
+        let plan = Planner::from(vec![premise])
+            .plan(&Environment::new())
+            .expect("plans");
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), source)
+            .try_collect()
+            .await?;
+        let mut pairs = Vec::new();
+        for matched in results {
+            let who = matched.lookup(&Term::<Any>::var("who"))?.content()?;
+            let ancestor = matched.lookup(&Term::<Any>::var("relative"))?.content()?;
+            pairs.push((who, ancestor));
+        }
+        pairs.sort_by_key(|pair| format!("{pair:?}"));
+        pairs.dedup();
+        Ok(pairs)
+    }
+
+    fn query_terms() -> Parameters {
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("who"));
+        terms.insert("ancestor".to_string(), Term::<Any>::var("relative"));
+        terms
+    }
+
+    /// Transitive closure over a linear chain: carol -> bob -> alice
+    /// derives all three ancestor pairs.
+    #[dialog_common::test]
+    async fn it_derives_transitive_closure_over_a_chain() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+        let carol = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("family/parent").of(carol.clone()).is(bob.clone()))
+            .assert(the!("family/parent").of(bob.clone()).is(alice.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let concept = ancestor_concept();
+        let mut registry = RuleRegistry::new();
+        for rule in ancestor_rules(&concept) {
+            registry.register(rule)?;
+        }
+        assert!(registry.is_recursive(&concept.this())?);
+
+        let source = TestEnv::new(&branch, &operator, registry);
+        let pairs = ancestor_pairs(&source, query_terms()).await?;
+        let mut expected = vec![
+            (Value::Entity(carol.clone()), Value::Entity(bob.clone())),
+            (Value::Entity(bob.clone()), Value::Entity(alice.clone())),
+            (Value::Entity(carol.clone()), Value::Entity(alice.clone())),
+        ];
+        expected.sort_by_key(|pair| format!("{pair:?}"));
+        assert_eq!(pairs, expected, "the closure includes the transitive pair");
+        Ok(())
+    }
+
+    /// A diamond family tree: d's ancestors are b, c, and a, with
+    /// the two derivations of (d, a) deduplicated to one row.
+    #[dialog_common::test]
+    async fn it_deduplicates_diamond_derivations() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let a = Entity::new()?;
+        let b = Entity::new()?;
+        let c = Entity::new()?;
+        let d = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("family/parent").of(d.clone()).is(b.clone()))
+            .assert(the!("family/parent").of(d.clone()).is(c.clone()))
+            .assert(the!("family/parent").of(b.clone()).is(a.clone()))
+            .assert(the!("family/parent").of(c.clone()).is(a.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let concept = ancestor_concept();
+        let mut registry = RuleRegistry::new();
+        for rule in ancestor_rules(&concept) {
+            registry.register(rule)?;
+        }
+
+        let source = TestEnv::new(&branch, &operator, registry);
+        let pairs = ancestor_pairs(&source, query_terms()).await?;
+        let mut expected = vec![
+            (Value::Entity(d.clone()), Value::Entity(b.clone())),
+            (Value::Entity(d.clone()), Value::Entity(c.clone())),
+            (Value::Entity(b.clone()), Value::Entity(a.clone())),
+            (Value::Entity(c.clone()), Value::Entity(a.clone())),
+            (Value::Entity(d.clone()), Value::Entity(a.clone())),
+        ];
+        expected.sort_by_key(|pair| format!("{pair:?}"));
+        assert_eq!(
+            pairs, expected,
+            "one row per distinct pair; the diamond's two paths to (d, a) collapse"
+        );
+        Ok(())
+    }
+
+    /// A caller binding `this` joins against the fixpoint rows: only
+    /// the bound entity's ancestors come back.
+    #[dialog_common::test]
+    async fn it_joins_caller_bindings_against_the_fixpoint() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+        let carol = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("family/parent").of(carol.clone()).is(bob.clone()))
+            .assert(the!("family/parent").of(bob.clone()).is(alice.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let concept = ancestor_concept();
+        let mut registry = RuleRegistry::new();
+        for rule in ancestor_rules(&concept) {
+            registry.register(rule)?;
+        }
+
+        let mut terms = Parameters::new();
+        terms.insert(
+            "this".to_string(),
+            Term::Constant(Value::Entity(bob.clone())),
+        );
+        terms.insert("ancestor".to_string(), Term::<Any>::var("relative"));
+        let source = TestEnv::new(&branch, &operator, registry);
+        let premise = Premise::Assert(Proposition::Concept(ConceptQuery {
+            terms,
+            predicate: concept,
+        }));
+        let plan = Planner::from(vec![premise])
+            .plan(&Environment::new())
+            .expect("plans");
+        let results: Vec<Match> = plan
+            .evaluate(Match::new().seed(), &source)
+            .try_collect()
+            .await?;
+
+        assert_eq!(results.len(), 1, "bob has exactly one ancestor");
+        assert_eq!(
+            results[0]
+                .lookup(&Term::<Any>::var("relative"))?
+                .content()?,
+            Value::Entity(alice),
+            "the caller's binding filtered the fixpoint rows"
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -47,7 +47,7 @@ use crate::selection::{Binding, Match};
 use crate::session::ProgramAnalysis;
 use crate::source::SelectRules;
 use crate::term::Term;
-use crate::types::Any;
+use crate::types::{Any, Typed};
 use crate::{Entity, Environment, Value};
 use core::fmt;
 use core::{iter, mem};
@@ -149,6 +149,17 @@ impl AnswerTable for InMemoryAnswerTable {
             .get(concept)
             .map(|rows| rows.values().cloned().collect())
             .unwrap_or_default()
+    }
+}
+
+impl InMemoryAnswerTable {
+    /// Remove a row from the total (DRed's over-delete step).
+    /// Between evaluations the delta and staging areas are drained,
+    /// so the total is the only place a retained row lives.
+    fn remove(&mut self, concept: &Entity, row: &Row) {
+        if let Some(rows) = self.total.get_mut(concept) {
+            rows.remove(&row_key(row));
+        }
     }
 }
 
@@ -359,17 +370,16 @@ where
 }
 
 /// Evaluate one rule with the given occurrence-and-source bindings:
-/// join the `rest` premises sideways and stage every projected
+/// join the `rest` premises sideways and return every projected
 /// conclusion row.
-async fn stage_rule_rows<'a, Env>(
+async fn collect_rule_rows<'a, Env>(
     member: &Member,
     split: &SplitRule,
     rest: Vec<Premise>,
     matched: Match,
     scope: &Environment,
-    table: &mut InMemoryAnswerTable,
     env: &'a Env,
-) -> Result<(), EvaluationError>
+) -> Result<Vec<Row>, EvaluationError>
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
@@ -383,11 +393,27 @@ where
             })?;
         plan.evaluate(matched.seed(), env).try_collect().await?
     };
-    for result in results {
-        table.insert(
-            &member.descriptor.this(),
-            project(&member.descriptor, &result),
-        );
+    Ok(results
+        .into_iter()
+        .map(|result| project(&member.descriptor, &result))
+        .collect())
+}
+
+/// [`collect_rule_rows`], staging every row into the table.
+async fn stage_rule_rows<'a, Env>(
+    member: &Member,
+    split: &SplitRule,
+    rest: Vec<Premise>,
+    matched: Match,
+    scope: &Environment,
+    table: &mut InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<(), EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    for row in collect_rule_rows(member, split, rest, matched, scope, env).await? {
+        table.insert(&member.descriptor.this(), row);
     }
     Ok(())
 }
@@ -649,6 +675,27 @@ fn bind_source_slot(
     }
 }
 
+/// Fold one term slot of a deleted-fact source into a suspicion
+/// pattern: a mismatching constant rejects the fact, a head-operand
+/// variable contributes a `(operand, value)` constraint, anything
+/// else constrains nothing. Returns `false` on rejection.
+fn pattern_slot<T: Typed>(
+    term: &Term<T>,
+    value: Value,
+    operands: &BTreeSet<&str>,
+    pattern: &mut Vec<(String, Value)>,
+) -> bool {
+    if let Some(expected) = term.as_constant() {
+        return *expected == value;
+    }
+    if let Some(name) = term.name()
+        && operands.contains(name)
+    {
+        pattern.push((name.to_string(), value));
+    }
+    true
+}
+
 /// Extend a previously computed fixpoint with newly added base
 /// facts: semi-naive continuation. For every rule, each new fact is
 /// bound into the base premise it can match (or, for an
@@ -789,6 +836,329 @@ where
     Ok(Some(table.total(&root_entity)))
 }
 
+/// Retract deleted base facts from a retained fixpoint: DRed.
+///
+/// 1. **Over-delete.** Every row forward-reachable from a deleted
+///    fact is suspected: deleted facts bind into the base premises
+///    they matched (occurrences reading the *pre-deletion* totals),
+///    and suspicion cascades through occurrence positions until
+///    closed. All suspects are removed.
+/// 2. **Re-derive.** Each suspect is checked for a surviving
+///    derivation: its head operands bind the rule body, occurrences
+///    read the *post-removal* table, base premises read the current
+///    store. Survivors re-insert; passes repeat until stable, so
+///    chains re-derive bottom-up.
+/// 3. **Insert.** The ordinary delta rounds propagate the
+///    re-insertions.
+///
+/// Sound only when no single rule body could have consumed more
+/// than one deleted thing at once — one body position is the delta,
+/// the rest are read from surviving state. The gate is
+/// conservative: if two or more of a rule's base premises match any
+/// deletion, or a deletion matches a negated or optional premise (a
+/// deletion there can make rows *appear*), `Ok(None)` is returned
+/// and the caller rebuilds.
+pub async fn retract<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+    table: &mut InMemoryAnswerTable,
+    deletions: &[Artifact],
+) -> Result<Option<()>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let root_entity = root.this();
+    let members = discover(root, analysis, env).await?;
+    let subjects: BTreeSet<Entity> = deletions.iter().map(|fact| fact.of.clone()).collect();
+
+    // Suspects per member, keyed like the table.
+    let mut suspects: HashMap<Entity, BTreeMap<Vec<u8>, Row>> = HashMap::new();
+
+    // Phase 1a: seed suspicion from the deleted facts. A deleted
+    // fact cannot be re-joined (it is gone from the store), so the
+    // rows it may have supported are found by *pattern-matching the
+    // retained table*: the head-operand bindings the fact imposes
+    // through the premise it matched select every consistent row.
+    // A source that binds no head operand suspects the member's
+    // whole table — conservative, settled by re-derivation.
+    for member in members.values() {
+        let operands: BTreeSet<&str> = iter::once("this")
+            .chain(member.descriptor.with().keys())
+            .collect();
+        for split in &member.rules {
+            let mut matchable = 0usize;
+            let mut patterns: Vec<Vec<(String, Value)>> = Vec::new();
+            for premise in &split.base {
+                match classify_base(premise, deletions, env).await? {
+                    BaseSource::Unsupported => return Ok(None),
+                    BaseSource::Inert => {}
+                    BaseSource::Attribute(slots) => {
+                        let (the, of, is) = slots.as_ref();
+                        let mut hit = false;
+                        for fact in deletions {
+                            let mut pattern = Vec::new();
+                            let matches =
+                                pattern_slot(
+                                    the,
+                                    Value::from(The::from(fact.the.clone())),
+                                    &operands,
+                                    &mut pattern,
+                                ) && pattern_slot(
+                                    of,
+                                    Value::Entity(fact.of.clone()),
+                                    &operands,
+                                    &mut pattern,
+                                ) && pattern_slot(is, fact.is.clone(), &operands, &mut pattern);
+                            if matches {
+                                hit = true;
+                                patterns.push(pattern);
+                            }
+                        }
+                        if hit {
+                            matchable += 1;
+                        }
+                    }
+                    BaseSource::LocalConcept { this } => {
+                        if !subjects.is_empty() {
+                            matchable += 1;
+                        }
+                        for entity in &subjects {
+                            let value = Value::Entity(entity.clone());
+                            match this.as_constant() {
+                                Some(expected) if *expected != value => {}
+                                Some(_) => patterns.push(Vec::new()),
+                                None => match this.name() {
+                                    Some(name) if operands.contains(name) => {
+                                        patterns.push(vec![(name.to_string(), value)]);
+                                    }
+                                    _ => patterns.push(Vec::new()),
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+            // Two matchable premises in one body: a derivation could
+            // have consumed two deleted things at once, and the
+            // one-position-at-a-time walk would miss it.
+            if matchable >= 2 {
+                return Ok(None);
+            }
+
+            if patterns.is_empty() {
+                continue;
+            }
+            let entity = member.descriptor.this();
+            for row in table.total(&entity) {
+                let suspect = patterns.iter().any(|pattern| {
+                    pattern
+                        .iter()
+                        .all(|(operand, value)| row.get(operand) == Some(value))
+                });
+                if suspect {
+                    suspects
+                        .entry(entity.clone())
+                        .or_default()
+                        .insert(row_key(&row), row);
+                }
+            }
+        }
+    }
+
+    // Phase 1b: cascade suspicion through occurrence positions,
+    // reading pre-removal totals.
+    let mut frontier = suspects.clone();
+    while !frontier.values().all(BTreeMap::is_empty) {
+        let mut next: HashMap<Entity, BTreeMap<Vec<u8>, Row>> = HashMap::new();
+        for member in members.values() {
+            for split in &member.rules {
+                if split.occurrences.is_empty() {
+                    continue;
+                }
+                for delta_index in 0..split.occurrences.len() {
+                    let choices: Vec<Vec<Row>> = split
+                        .occurrences
+                        .iter()
+                        .enumerate()
+                        .map(|(index, occurrence)| {
+                            let target = occurrence.predicate.this();
+                            if index == delta_index {
+                                frontier
+                                    .get(&target)
+                                    .map(|rows| rows.values().cloned().collect())
+                                    .unwrap_or_default()
+                            } else {
+                                table.total(&target)
+                            }
+                        })
+                        .collect();
+                    for combination in Combinations::new(choices.iter().map(Vec::len).collect()) {
+                        let mut matched = Match::new();
+                        let mut scope = Environment::new();
+                        let mut compatible = true;
+                        for (index, (occurrence, row_index)) in
+                            split.occurrences.iter().zip(&combination).enumerate()
+                        {
+                            let row = &choices[index][*row_index];
+                            if !bind_occurrence(&mut matched, occurrence, row) {
+                                compatible = false;
+                                break;
+                            }
+                            for (_, term) in occurrence.terms.iter() {
+                                if let Some(name) = term.name() {
+                                    scope.add(name);
+                                }
+                            }
+                        }
+                        if !compatible {
+                            continue;
+                        }
+                        let rows = collect_rule_rows(
+                            member,
+                            split,
+                            split.base.clone(),
+                            matched,
+                            &scope,
+                            env,
+                        )
+                        .await?;
+                        let entity = member.descriptor.this();
+                        for row in rows {
+                            let key = row_key(&row);
+                            let known = suspects
+                                .get(&entity)
+                                .is_some_and(|rows| rows.contains_key(&key));
+                            if !known {
+                                suspects
+                                    .entry(entity.clone())
+                                    .or_default()
+                                    .insert(key.clone(), row.clone());
+                                next.entry(entity.clone()).or_default().insert(key, row);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        frontier = next;
+    }
+
+    // Over-delete.
+    for (entity, rows) in &suspects {
+        for row in rows.values() {
+            table.remove(entity, row);
+        }
+    }
+
+    // Phase 2: re-derive survivors, bottom-up until stable.
+    loop {
+        let mut rederived = false;
+        for member in members.values() {
+            let entity = member.descriptor.this();
+            let Some(rows) = suspects.get(&entity) else {
+                continue;
+            };
+            let mut survived: Vec<Vec<u8>> = Vec::new();
+            for (key, row) in rows {
+                if derivable(member, row, table, env).await? {
+                    table.insert(&entity, row.clone());
+                    survived.push(key.clone());
+                    rederived = true;
+                }
+            }
+            if !survived.is_empty() {
+                // Promote the survivors immediately so this pass's
+                // later checks (and the next pass) see them.
+                table.advance();
+                let bucket = suspects.get_mut(&entity).expect("bucket exists");
+                for key in survived {
+                    bucket.remove(&key);
+                }
+            }
+        }
+        if !rederived {
+            break;
+        }
+    }
+
+    // Phase 3: propagate anything the re-insertions enable.
+    delta_rounds(&root_entity, &members, table, env).await?;
+    Ok(Some(()))
+}
+
+/// Whether a suspect row still has a derivation: bind its head
+/// operands into each rule body (occurrences read the current
+/// table, base premises the current store) and check whether any
+/// result projects back to the row.
+async fn derivable<'a, Env>(
+    member: &Member,
+    row: &Row,
+    table: &InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<bool, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    for split in &member.rules {
+        let mut seed = Match::new();
+        let mut seed_scope = Environment::new();
+        let mut consistent = true;
+        for (operand, value) in row {
+            if seed
+                .bind(&Term::<Any>::var(operand), value.clone())
+                .is_err()
+            {
+                consistent = false;
+                break;
+            }
+            seed_scope.add(operand);
+        }
+        if !consistent {
+            continue;
+        }
+
+        let choices: Vec<Vec<Row>> = split
+            .occurrences
+            .iter()
+            .map(|occurrence| table.total(&occurrence.predicate.this()))
+            .collect();
+        let combinations: Vec<Vec<usize>> = if split.occurrences.is_empty() {
+            vec![Vec::new()]
+        } else {
+            Combinations::new(choices.iter().map(Vec::len).collect()).collect()
+        };
+        for combination in combinations {
+            let mut matched = seed.clone();
+            let mut scope = seed_scope.clone();
+            let mut compatible = true;
+            for (index, (occurrence, row_index)) in
+                split.occurrences.iter().zip(&combination).enumerate()
+            {
+                let bound = &choices[index][*row_index];
+                if !bind_occurrence(&mut matched, occurrence, bound) {
+                    compatible = false;
+                    break;
+                }
+                for (_, term) in occurrence.terms.iter() {
+                    if let Some(name) = term.name() {
+                        scope.add(name);
+                    }
+                }
+            }
+            if !compatible {
+                continue;
+            }
+            let rows =
+                collect_rule_rows(member, split, split.base.clone(), matched, &scope, env).await?;
+            if rows.iter().any(|candidate| candidate == row) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
 /// A retained fixpoint carried across evaluations by a standing
 /// subscription: the answer table handle plus, when the poll's
 /// changes were additions only, the new facts to seed a semi-naive
@@ -798,31 +1168,42 @@ where
 #[derive(Clone, Default)]
 pub struct Continuation {
     table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
-    additions: Option<Arc<Vec<Artifact>>>,
+    additions: Arc<Vec<Artifact>>,
+    deletions: Arc<Vec<Artifact>>,
 }
 
 impl fmt::Debug for Continuation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Continuation")
-            .field(
-                "additions",
-                &self.additions.as_ref().map(|facts| facts.len()),
-            )
+            .field("additions", &self.additions.len())
+            .field("deletions", &self.deletions.len())
             .finish_non_exhaustive()
     }
 }
 
 impl Continuation {
-    /// A continuation over the subscription-held `table`. With
-    /// `additions`, evaluation extends the retained fixpoint
-    /// semi-naively (falling back to a rebuild when the rule set
-    /// cannot extend additively); without, it rebuilds into the
-    /// handle (the first evaluation, or after deletions).
-    pub fn new(
-        table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
-        additions: Option<Arc<Vec<Artifact>>>,
+    /// A continuation over the subscription-held `table`. Without
+    /// changes attached, evaluation rebuilds into the handle (the
+    /// first evaluation, or a recompute).
+    pub fn new(table: Arc<Mutex<Option<InMemoryAnswerTable>>>) -> Self {
+        Continuation {
+            table,
+            additions: Arc::new(Vec::new()),
+            deletions: Arc::new(Vec::new()),
+        }
+    }
+
+    /// Attach the poll's changed facts: deletions retract via DRed,
+    /// additions extend semi-naively, in that order. Either phase
+    /// declining (non-additive shapes) falls back to a rebuild.
+    pub fn with_changes(
+        mut self,
+        additions: Arc<Vec<Artifact>>,
+        deletions: Arc<Vec<Artifact>>,
     ) -> Self {
-        Continuation { table, additions }
+        self.additions = additions;
+        self.deletions = deletions;
+        self
     }
 
     /// The queried concept's fixpoint rows, reusing the retained
@@ -839,19 +1220,33 @@ impl Continuation {
         Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
     {
         let prior = self.table.lock().expect("fixpoint table lock").take();
-        let (table, rows) = match (prior, &self.additions) {
-            (Some(mut table), Some(additions)) => {
-                match extend(root, analysis, env, &mut table, additions).await? {
-                    Some(rows) => (table, rows),
-                    None => {
-                        // Not additively extendable: rebuild.
-                        let mut table = InMemoryAnswerTable::default();
-                        let rows = evaluate_table(root, analysis, env, &mut table).await?;
-                        (table, rows)
+        let has_changes = !self.additions.is_empty() || !self.deletions.is_empty();
+        let maintained = match prior {
+            Some(mut table) if has_changes => {
+                let retracted = if self.deletions.is_empty() {
+                    Some(())
+                } else {
+                    retract(root, analysis, env, &mut table, &self.deletions).await?
+                };
+                match retracted {
+                    None => None,
+                    Some(()) => {
+                        if self.additions.is_empty() {
+                            let rows = table.total(&root.this());
+                            Some((table, rows))
+                        } else {
+                            extend(root, analysis, env, &mut table, &self.additions)
+                                .await?
+                                .map(|rows| (table, rows))
+                        }
                     }
                 }
             }
-            _ => {
+            _ => None,
+        };
+        let (table, rows) = match maintained {
+            Some(outcome) => outcome,
+            None => {
                 let mut table = InMemoryAnswerTable::default();
                 let rows = evaluate_table(root, analysis, env, &mut table).await?;
                 (table, rows)

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -33,6 +33,8 @@
 //! afterwards.
 
 use super::ConceptQuery;
+use crate::artifact::Artifact;
+use crate::attribute::The;
 use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::EvaluationError;
 use crate::negation::Negation;
@@ -47,12 +49,14 @@ use crate::source::SelectRules;
 use crate::term::Term;
 use crate::types::Any;
 use crate::{Entity, Environment, Value};
+use core::fmt;
 use core::{iter, mem};
 use dialog_artifacts::Select;
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
 use futures_util::TryStreamExt;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
 
 /// Upper bound on fixpoint rounds before the query fails loudly. A
 /// round derives at least one new row (otherwise the fixpoint has
@@ -309,22 +313,19 @@ impl Iterator for Combinations {
     }
 }
 
-/// Compute the full fixpoint of the queried concept's strongly
-/// connected component and return the rows derived for the queried
-/// concept itself.
-pub async fn evaluate<'a, Env>(
+/// Discover the queried concept's strongly connected component:
+/// starting from the root, follow in-component premises (each embeds
+/// its target's full descriptor) and collect every member's rules,
+/// split into recursive occurrences and base premises.
+async fn discover<'a, Env>(
     root: &ConceptDescriptor,
     analysis: &ProgramAnalysis,
     env: &'a Env,
-) -> Result<Vec<Row>, EvaluationError>
+) -> Result<HashMap<Entity, Member>, EvaluationError>
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
     let root_entity = root.this();
-
-    // Discover the component: starting from the queried concept,
-    // follow in-component premises (each embeds its target's full
-    // descriptor) and collect every member's rules.
     let mut members: HashMap<Entity, Member> = HashMap::new();
     let mut queue = vec![root.clone()];
     while let Some(descriptor) = queue.pop() {
@@ -354,38 +355,61 @@ where
         }
         members.insert(entity, Member { descriptor, rules });
     }
+    Ok(members)
+}
 
-    let mut table = InMemoryAnswerTable::default();
-
-    // Seed round: rules with no recursive occurrence evaluate fully
-    // top-down.
-    for member in members.values() {
-        for split in &member.rules {
-            if !split.occurrences.is_empty() {
-                continue;
-            }
-            let plan = split.rule.plan(&Environment::new());
-            let results: Vec<Match> = plan
-                .evaluate(Match::new().seed(), env)
-                .try_collect()
-                .await?;
-            for matched in results {
-                table.insert(
-                    &member.descriptor.this(),
-                    project(&member.descriptor, &matched),
-                );
-            }
-        }
+/// Evaluate one rule with the given occurrence-and-source bindings:
+/// join the `rest` premises sideways and stage every projected
+/// conclusion row.
+async fn stage_rule_rows<'a, Env>(
+    member: &Member,
+    split: &SplitRule,
+    rest: Vec<Premise>,
+    matched: Match,
+    scope: &Environment,
+    table: &mut InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<(), EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let results: Vec<Match> = if rest.is_empty() {
+        vec![matched]
+    } else {
+        let plan = Planner::with_types(rest, split.rule.analysis().types.clone())
+            .plan(scope)
+            .map_err(|error| EvaluationError::Planning {
+                message: error.to_string(),
+            })?;
+        plan.evaluate(matched.seed(), env).try_collect().await?
+    };
+    for result in results {
+        table.insert(
+            &member.descriptor.this(),
+            project(&member.descriptor, &result),
+        );
     }
+    Ok(())
+}
 
-    // Delta rounds: per rule and per recursive occurrence, that
-    // occurrence reads the delta while its siblings read the total.
+/// Run semi-naive delta rounds to convergence: per rule and per
+/// recursive occurrence, that occurrence reads the previous round's
+/// delta while its siblings read the running total.
+async fn delta_rounds<'a, Env>(
+    root: &Entity,
+    members: &HashMap<Entity, Member>,
+    table: &mut InMemoryAnswerTable,
+    env: &'a Env,
+) -> Result<(), EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
     let mut rounds = 0;
     while table.advance() {
         rounds += 1;
         if rounds > MAX_ROUNDS {
             return Err(EvaluationError::FixpointDivergence {
-                concept: root_entity.to_string(),
+                concept: root.to_string(),
                 rounds,
             });
         }
@@ -431,35 +455,411 @@ where
                         if !compatible {
                             continue;
                         }
+                        stage_rule_rows(
+                            member,
+                            split,
+                            split.base.clone(),
+                            matched,
+                            &scope,
+                            table,
+                            env,
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
-                        let results: Vec<Match> = if split.base.is_empty() {
-                            vec![matched]
-                        } else {
-                            let plan = Planner::with_types(
-                                split.base.clone(),
-                                split.rule.analysis().types.clone(),
-                            )
-                            .plan(&scope)
-                            .map_err(|error| {
-                                EvaluationError::Planning {
-                                    message: error.to_string(),
-                                }
-                            })?;
-                            plan.evaluate(matched.seed(), env).try_collect().await?
-                        };
-                        for result in results {
-                            table.insert(
-                                &member.descriptor.this(),
-                                project(&member.descriptor, &result),
-                            );
+/// Compute the full fixpoint of the queried concept's strongly
+/// connected component into `table` and return the rows derived for
+/// the queried concept itself.
+pub async fn evaluate_table<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+    table: &mut InMemoryAnswerTable,
+) -> Result<Vec<Row>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let root_entity = root.this();
+    let members = discover(root, analysis, env).await?;
+
+    // Seed round: rules with no recursive occurrence evaluate fully
+    // top-down.
+    for member in members.values() {
+        for split in &member.rules {
+            if !split.occurrences.is_empty() {
+                continue;
+            }
+            let plan = split.rule.plan(&Environment::new());
+            let results: Vec<Match> = plan
+                .evaluate(Match::new().seed(), env)
+                .try_collect()
+                .await?;
+            for matched in results {
+                table.insert(
+                    &member.descriptor.this(),
+                    project(&member.descriptor, &matched),
+                );
+            }
+        }
+    }
+
+    delta_rounds(&root_entity, &members, table, env).await?;
+    Ok(table.total(&root_entity))
+}
+
+/// Compute the full fixpoint of the queried concept's strongly
+/// connected component and return the rows derived for the queried
+/// concept itself.
+pub async fn evaluate<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+) -> Result<Vec<Row>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let mut table = InMemoryAnswerTable::default();
+    evaluate_table(root, analysis, env, &mut table).await
+}
+
+/// How a base premise participates in addition-seeding.
+enum BaseSource {
+    /// A positive attribute premise: a matching new fact binds its
+    /// slots directly. Boxed to keep the variant sizes even.
+    Attribute(Box<(Term<The>, Term<Entity>, Term<Any>)>),
+    /// A positive out-of-component concept premise over an
+    /// entity-local target: a new fact's subject binds its `this`
+    /// slot (over-approximated; re-derivation settles truth).
+    LocalConcept { this: Term<Any> },
+    /// Never sourced by a fact (constraints, formulas).
+    Inert,
+    /// A shape additive seeding cannot handle soundly: a negated or
+    /// optional premise a new fact matches can *retract* derived
+    /// rows, and a non-local nested concept cannot bound its heads.
+    Unsupported,
+}
+
+/// Classify a base premise for addition-seeding, given the changed
+/// facts. Negated and optional premises are only `Unsupported` when
+/// an addition can actually match them.
+async fn classify_base<'a, Env>(
+    premise: &Premise,
+    additions: &[Artifact],
+    env: &'a Env,
+) -> Result<BaseSource, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    fn slots(query: &crate::AttributeQuery) -> (Term<The>, Term<Entity>, Term<Any>) {
+        (query.the().clone(), query.of().clone(), query.is().clone())
+    }
+    fn any_match(the: &Term<The>, of: &Term<Entity>, is: &Term<Any>, facts: &[Artifact]) -> bool {
+        facts.iter().any(|fact| {
+            constant_admits(the.as_constant(), &Value::from(The::from(fact.the.clone())))
+                && constant_admits(of.as_constant(), &Value::Entity(fact.of.clone()))
+                && constant_admits(is.as_constant(), &fact.is)
+        })
+    }
+
+    Ok(match premise {
+        Premise::Assert(Proposition::Attribute(query)) => {
+            BaseSource::Attribute(Box::new(slots(query)))
+        }
+        Premise::Assert(Proposition::OptionalAttribute(query)) => {
+            // A new fact turning an Absent slot Present replaces the
+            // row rather than adding one: not additively seedable.
+            let (the, of, is) = (
+                query.query().the().clone(),
+                query.of().clone(),
+                query.is().clone(),
+            );
+            if any_match(&the, &of, &is, additions) {
+                BaseSource::Unsupported
+            } else {
+                BaseSource::Inert
+            }
+        }
+        Premise::Unless(Negation(Proposition::Attribute(query))) => {
+            let (the, of, is) = slots(query);
+            if any_match(&the, &of, &is, additions) {
+                BaseSource::Unsupported
+            } else {
+                BaseSource::Inert
+            }
+        }
+        Premise::Assert(Proposition::Concept(query)) => {
+            let bundle = Provider::<SelectRules>::execute(env, query.predicate.clone()).await?;
+            let local = bundle.recursion().is_none()
+                && bundle.rules().all(|rule| rule.analysis().is_entity_local());
+            let Some(this) = query.terms.get("this") else {
+                return Ok(BaseSource::Unsupported);
+            };
+            if local {
+                BaseSource::LocalConcept { this: this.clone() }
+            } else {
+                BaseSource::Unsupported
+            }
+        }
+        Premise::Unless(Negation(Proposition::Concept(_))) => {
+            if additions.is_empty() {
+                BaseSource::Inert
+            } else {
+                // An addition can grow the negated set and retract
+                // derived rows: not additively seedable.
+                BaseSource::Unsupported
+            }
+        }
+        _ => BaseSource::Inert,
+    })
+}
+
+/// Whether a constant slot admits the value (a variable or blank
+/// slot admits anything).
+fn constant_admits(constant: Option<&Value>, value: &Value) -> bool {
+    constant.map(|expected| expected == value).unwrap_or(true)
+}
+
+/// Bind one slot of a source premise from a changed value: a
+/// constant filters, a named variable binds, a blank matches.
+fn bind_source_slot(
+    matched: &mut Match,
+    scope: &mut Environment,
+    constant: Option<&Value>,
+    name: Option<&str>,
+    value: Value,
+) -> bool {
+    if let Some(expected) = constant {
+        return *expected == value;
+    }
+    match name {
+        Some(name) => {
+            if matched.bind(&Term::<Any>::var(name), value).is_err() {
+                return false;
+            }
+            scope.add(name);
+            true
+        }
+        None => true,
+    }
+}
+
+/// Extend a previously computed fixpoint with newly added base
+/// facts: semi-naive continuation. For every rule, each new fact is
+/// bound into the base premise it can match (or, for an
+/// out-of-component entity-local concept premise, the fact's
+/// subject binds the premise's `this` slot); recursive occurrences
+/// read the *retained totals*; the remaining base premises join
+/// sideways top-down. Newly staged rows then drive the ordinary
+/// delta rounds to convergence.
+///
+/// Returns `Ok(None)` when the rule set cannot be extended
+/// additively — a negated or optional premise a new fact matches
+/// (the addition could *retract* rows), or a non-local nested
+/// concept — in which case the caller rebuilds from scratch, which
+/// is always sound. Deletions must never reach this function; the
+/// caller rebuilds for those.
+pub async fn extend<'a, Env>(
+    root: &ConceptDescriptor,
+    analysis: &ProgramAnalysis,
+    env: &'a Env,
+    table: &mut InMemoryAnswerTable,
+    additions: &[Artifact],
+) -> Result<Option<Vec<Row>>, EvaluationError>
+where
+    Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+{
+    let root_entity = root.this();
+    let members = discover(root, analysis, env).await?;
+    let subjects: BTreeSet<Entity> = additions.iter().map(|fact| fact.of.clone()).collect();
+
+    for member in members.values() {
+        for split in &member.rules {
+            // Classify every base premise first: any unsupported
+            // shape aborts the extension before rows are staged.
+            let mut classified = Vec::with_capacity(split.base.len());
+            for premise in &split.base {
+                match classify_base(premise, additions, env).await? {
+                    BaseSource::Unsupported => return Ok(None),
+                    source => classified.push(source),
+                }
+            }
+
+            for source in classified.iter() {
+                // The bindings each new fact contributes through
+                // this source premise.
+                let mut seeds: Vec<(Match, Environment)> = Vec::new();
+                match source {
+                    BaseSource::Attribute(slots) => {
+                        let (the, of, is) = slots.as_ref();
+                        for fact in additions {
+                            let mut matched = Match::new();
+                            let mut scope = Environment::new();
+                            if bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                the.as_constant(),
+                                the.name(),
+                                Value::from(The::from(fact.the.clone())),
+                            ) && bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                of.as_constant(),
+                                of.name(),
+                                Value::Entity(fact.of.clone()),
+                            ) && bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                is.as_constant(),
+                                is.name(),
+                                fact.is.clone(),
+                            ) {
+                                seeds.push((matched, scope));
+                            }
                         }
+                    }
+                    BaseSource::LocalConcept { this } => {
+                        for entity in &subjects {
+                            let mut matched = Match::new();
+                            let mut scope = Environment::new();
+                            if bind_source_slot(
+                                &mut matched,
+                                &mut scope,
+                                this.as_constant(),
+                                this.name(),
+                                Value::Entity(entity.clone()),
+                            ) {
+                                seeds.push((matched, scope));
+                            }
+                        }
+                    }
+                    BaseSource::Inert | BaseSource::Unsupported => continue,
+                }
+
+                // The source premise stays in the sideways join: with
+                // its slots bound it re-verifies as a point lookup
+                // (preserving cardinality-one winner semantics), and
+                // a concept source's remaining fields bind from its
+                // goal-directed evaluation.
+                let rest: Vec<Premise> = split.base.clone();
+
+                for (seed_match, seed_scope) in seeds {
+                    // Occurrences read the retained totals: the new
+                    // fact is the delta position.
+                    let choices: Vec<Vec<Row>> = split
+                        .occurrences
+                        .iter()
+                        .map(|occurrence| table.total(&occurrence.predicate.this()))
+                        .collect();
+                    for combination in Combinations::new(choices.iter().map(Vec::len).collect()) {
+                        let mut matched = seed_match.clone();
+                        let mut scope = seed_scope.clone();
+                        let mut compatible = true;
+                        for (index, (occurrence, row_index)) in
+                            split.occurrences.iter().zip(&combination).enumerate()
+                        {
+                            let row = &choices[index][*row_index];
+                            if !bind_occurrence(&mut matched, occurrence, row) {
+                                compatible = false;
+                                break;
+                            }
+                            for (_, term) in occurrence.terms.iter() {
+                                if let Some(name) = term.name() {
+                                    scope.add(name);
+                                }
+                            }
+                        }
+                        if !compatible {
+                            continue;
+                        }
+                        stage_rule_rows(member, split, rest.clone(), matched, &scope, table, env)
+                            .await?;
                     }
                 }
             }
         }
     }
 
-    Ok(table.total(&root_entity))
+    delta_rounds(&root_entity, &members, table, env).await?;
+    Ok(Some(table.total(&root_entity)))
+}
+
+/// A retained fixpoint carried across evaluations by a standing
+/// subscription: the answer table handle plus, when the poll's
+/// changes were additions only, the new facts to seed a semi-naive
+/// continuation from. Attached to a concept's
+/// [`ConceptRules`](crate::ConceptRules) by the query environment;
+/// consumed by `ConceptQuery::evaluate`'s fixpoint branch.
+#[derive(Clone, Default)]
+pub struct Continuation {
+    table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
+    additions: Option<Arc<Vec<Artifact>>>,
+}
+
+impl fmt::Debug for Continuation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Continuation")
+            .field(
+                "additions",
+                &self.additions.as_ref().map(|facts| facts.len()),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl Continuation {
+    /// A continuation over the subscription-held `table`. With
+    /// `additions`, evaluation extends the retained fixpoint
+    /// semi-naively (falling back to a rebuild when the rule set
+    /// cannot extend additively); without, it rebuilds into the
+    /// handle (the first evaluation, or after deletions).
+    pub fn new(
+        table: Arc<Mutex<Option<InMemoryAnswerTable>>>,
+        additions: Option<Arc<Vec<Artifact>>>,
+    ) -> Self {
+        Continuation { table, additions }
+    }
+
+    /// The queried concept's fixpoint rows, reusing the retained
+    /// table when possible. The table is taken out of the handle
+    /// for the duration (an error mid-evaluation leaves the handle
+    /// empty, so the next evaluation rebuilds).
+    pub(crate) async fn rows<'a, Env>(
+        &self,
+        root: &ConceptDescriptor,
+        analysis: &ProgramAnalysis,
+        env: &'a Env,
+    ) -> Result<Vec<Row>, EvaluationError>
+    where
+        Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
+    {
+        let prior = self.table.lock().expect("fixpoint table lock").take();
+        let (table, rows) = match (prior, &self.additions) {
+            (Some(mut table), Some(additions)) => {
+                match extend(root, analysis, env, &mut table, additions).await? {
+                    Some(rows) => (table, rows),
+                    None => {
+                        // Not additively extendable: rebuild.
+                        let mut table = InMemoryAnswerTable::default();
+                        let rows = evaluate_table(root, analysis, env, &mut table).await?;
+                        (table, rows)
+                    }
+                }
+            }
+            _ => {
+                let mut table = InMemoryAnswerTable::default();
+                let rows = evaluate_table(root, analysis, env, &mut table).await?;
+                (table, rows)
+            }
+        };
+        *self.table.lock().expect("fixpoint table lock") = Some(table);
+        Ok(rows)
+    }
 }
 
 #[cfg(test)]

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -17,6 +17,7 @@ use crate::concept::descriptor::ConceptDescriptor;
 use crate::parameters::Parameters;
 use crate::planner::Disjunction;
 use crate::selection::Match;
+use crate::session::ProgramAnalysis;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -36,6 +37,12 @@ pub struct ConceptRules {
     /// plans the previous query computed. A standalone instance gets a
     /// private one via [`PlanCache::default`].
     plan_cache: PlanCache,
+    /// Present when this concept participates in a dependency
+    /// cycle: the program analysis the fixpoint evaluator needs to
+    /// tell in-component premises from base ones. Attached by
+    /// [`RuleRegistry::acquire`](crate::session::RuleRegistry) and
+    /// read by `ConceptQuery::evaluate`.
+    recursion: Option<Arc<ProgramAnalysis>>,
 }
 
 impl ConceptRules {
@@ -57,7 +64,21 @@ impl ConceptRules {
             installed: Vec::new(),
             plans: Arc::new(RwLock::new(HashMap::new())),
             plan_cache,
+            recursion: None,
         }
+    }
+
+    /// Attach the program analysis marking this concept recursive.
+    /// Evaluation switches to the semi-naive fixpoint when present.
+    pub fn with_recursion(mut self, analysis: Arc<ProgramAnalysis>) -> Self {
+        self.recursion = Some(analysis);
+        self
+    }
+
+    /// The program analysis attached when this concept participates
+    /// in a dependency cycle; `None` for ordinary concepts.
+    pub fn recursion(&self) -> Option<&Arc<ProgramAnalysis>> {
+        self.recursion.as_ref()
     }
 
     /// Install a deductive rule, deduplicating by equality.

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -74,6 +74,13 @@ impl ConceptRules {
         &self.installed
     }
 
+    /// Every rule for this concept: the implicit rule (derived from
+    /// the descriptor) followed by the installed ones. This is the
+    /// rule set the program-level dependency analysis walks.
+    pub fn rules(&self) -> impl Iterator<Item = &DeductiveRule> {
+        iter::once(&self.implicit).chain(self.installed.iter())
+    }
+
     /// Install every rule from `other` into this `ConceptRules`.
     ///
     /// Used when combining two rule sources (e.g. a primary registry and an

--- a/rust/dialog-query/src/concept/query/rules.rs
+++ b/rust/dialog-query/src/concept/query/rules.rs
@@ -11,6 +11,7 @@
 use std::iter;
 
 use super::adornment::Adornment;
+use super::fixpoint::Continuation;
 use super::plan_cache::PlanCache;
 use crate::DeductiveRule;
 use crate::concept::descriptor::ConceptDescriptor;
@@ -43,6 +44,11 @@ pub struct ConceptRules {
     /// [`RuleRegistry::acquire`](crate::session::RuleRegistry) and
     /// read by `ConceptQuery::evaluate`.
     recursion: Option<Arc<ProgramAnalysis>>,
+    /// A standing subscription's retained fixpoint, when one is
+    /// polling this concept: evaluation continues the retained
+    /// answer table (or rebuilds into it) instead of computing a
+    /// throwaway fixpoint.
+    continuation: Option<Continuation>,
 }
 
 impl ConceptRules {
@@ -65,6 +71,7 @@ impl ConceptRules {
             plans: Arc::new(RwLock::new(HashMap::new())),
             plan_cache,
             recursion: None,
+            continuation: None,
         }
     }
 
@@ -79,6 +86,19 @@ impl ConceptRules {
     /// in a dependency cycle; `None` for ordinary concepts.
     pub fn recursion(&self) -> Option<&Arc<ProgramAnalysis>> {
         self.recursion.as_ref()
+    }
+
+    /// Attach a standing subscription's retained fixpoint. Only
+    /// consulted when the concept is recursive.
+    pub fn with_continuation(mut self, continuation: Continuation) -> Self {
+        self.continuation = Some(continuation);
+        self
+    }
+
+    /// The retained fixpoint attached by a polling subscription, if
+    /// any.
+    pub fn continuation(&self) -> Option<&Continuation> {
+        self.continuation.as_ref()
     }
 
     /// Install a deductive rule, deduplicating by equality.

--- a/rust/dialog-query/src/constraint/starts_with.rs
+++ b/rust/dialog-query/src/constraint/starts_with.rs
@@ -429,8 +429,11 @@ mod tests {
             "a prefix with a space excludes entities"
         );
         assert_eq!(
-            kind.refinement().expect("the prefix travels").prefix,
-            "has space",
+            kind.refinement()
+                .expect("the prefix travels")
+                .prefix
+                .as_deref(),
+            Some("has space"),
             "the inferred kind carries the prefix refinement"
         );
         Ok(())

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -68,6 +68,37 @@ pub enum TypeError {
     #[error("Concept declares no required attributes; at least one `with` attribute is required")]
     EmptyConcept,
 
+    /// A concept-typed field's attribute is not entity-valued. Only
+    /// an entity can conform to a concept, so a field that declares
+    /// `conforms` must have `Entity` as its value type.
+    #[error(
+        "Attribute \"{the}\" declares conformance to {concept} but its value type is \
+         {actual:?}; a concept-typed field must be entity-valued"
+    )]
+    NonEntityConformance {
+        /// The offending attribute selector.
+        the: String,
+        /// The target concept's URI.
+        concept: String,
+        /// The attribute's declared value type.
+        actual: Option<Type>,
+    },
+
+    /// A concept-typed field is marked optional. An optional
+    /// concept-typed field is a left-join over "edge exists AND the
+    /// target conforms" — absence over a rule-derived (IDB)
+    /// predicate — which requires stratification to evaluate
+    /// soundly. Not supported yet; make the field required or drop
+    /// the conformance.
+    #[error(
+        "Attribute \"{the}\" is both optional and concept-typed; optional conformance \
+         (absence over a derived predicate) is not supported yet"
+    )]
+    OptionalConformance {
+        /// The offending attribute selector.
+        the: String,
+    },
+
     /// A rule declares a parameter that none of its premises use.
     #[error("Rule {rule} does not use parameter \"{parameter}\"")]
     UnusedParameter {

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -509,14 +509,17 @@ pub enum EvaluationError {
         negated: String,
     },
 
-    /// The queried concept's dependency closure is recursive. The
-    /// program is well-stratified, but the fixpoint evaluator is
-    /// not implemented yet, so recursive closures are rejected
-    /// rather than evaluated unboundedly.
-    #[error("Concept {concept} is recursive; recursive evaluation is not supported yet")]
-    UnsupportedRecursion {
-        /// A concept on the dependency cycle.
+    /// A recursive concept's semi-naive fixpoint did not converge
+    /// within the round cap. A round derives at least one new row,
+    /// so purely fact-driven recursion terminates well under the
+    /// cap; hitting it means the rule set generates fresh values
+    /// every round (e.g. through a formula) and would spin forever.
+    #[error("Fixpoint for {concept} did not converge after {rounds} rounds")]
+    FixpointDivergence {
+        /// The queried recursive concept.
         concept: String,
+        /// Rounds evaluated before giving up.
+        rounds: usize,
     },
 }
 

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -159,6 +159,19 @@ pub enum TypeError {
         rule: Box<Rule>,
     },
 
+    /// A rule negates its own conclusion concept: a negative
+    /// self-loop no stratification can order (the rule would derive
+    /// a row exactly when it doesn't). Cycles through negation that
+    /// span multiple rules are the global stratification pass's
+    /// job; this is the local, always detectable case.
+    #[error("Rule {rule} negates its own conclusion {concept}")]
+    SelfNegation {
+        /// The offending rule.
+        rule: Box<Rule>,
+        /// The conclusion concept's URI.
+        concept: String,
+    },
+
     /// Type inference over a rule's premises produced a
     /// contradiction (a variable appears in slots with conflicting
     /// kinds). The planner cannot proceed because the rule has no
@@ -685,4 +698,14 @@ pub enum AnalysisError {
     /// be vacuously false.
     #[error("negation over an optional (maybe) premise is always false")]
     NegatedOptional,
+    /// A rule negates its own conclusion concept: a negative
+    /// self-loop no stratification can order. The local, always
+    /// detectable case of recursion through negation; cycles
+    /// spanning multiple rules are the global stratification
+    /// pass's job.
+    #[error("rule negates its own conclusion {concept}")]
+    SelfNegation {
+        /// The conclusion concept's URI.
+        concept: String,
+    },
 }

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -489,6 +489,35 @@ pub enum EvaluationError {
         /// Description of the planning error.
         message: String,
     },
+
+    /// The queried concept's dependency closure contains a cycle
+    /// through negation: some rule concluding `concept` negates
+    /// `negated` inside the same dependency cycle, so the negation
+    /// reads a set the cycle itself is still deriving. No
+    /// stratified semantics exists for such a program. Rules are
+    /// installed unconditionally (replicas must converge on the
+    /// merged rule set), so this surfaces at query time, on exactly
+    /// the queries whose closure is ill-stratified.
+    #[error(
+        "Negation through recursion: rules for {concept} negate {negated} \
+         inside the same dependency cycle; no stratified semantics exists"
+    )]
+    NegationThroughRecursion {
+        /// The concluding concept whose rule negates into its cycle.
+        concept: String,
+        /// The negated concept inside the same cycle.
+        negated: String,
+    },
+
+    /// The queried concept's dependency closure is recursive. The
+    /// program is well-stratified, but the fixpoint evaluator is
+    /// not implemented yet, so recursive closures are rejected
+    /// rather than evaluated unboundedly.
+    #[error("Concept {concept} is recursive; recursive evaluation is not supported yet")]
+    UnsupportedRecursion {
+        /// A concept on the dependency cycle.
+        concept: String,
+    },
 }
 
 /// Result type for query operations

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -77,7 +77,7 @@ pub mod stream;
 /// Term types for pattern matching with variables and constants.
 pub mod term;
 /// Unified schema-layer type system (`Type`, `Primitive`,
-/// `Composite`, set-operations).
+/// `Refinement`, set-operations).
 pub mod type_system;
 /// Type system utilities bridging Rust types to dialog-artifacts types.
 pub mod types;

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -88,7 +88,7 @@ pub use attribute::*;
 pub use claim::Claim;
 pub use concept::descriptor::{ConceptConclusion, ConceptDescriptor, ConceptFieldDescriptor};
 pub use concept::query::{ConceptQuery, ConceptRules};
-pub use concept::{Concept, ConceptField, Conclusion};
+pub use concept::{Concept, ConceptField, Conclusion, ConformingField};
 pub use constraint::Constraint;
 pub use descriptor::Descriptor;
 pub use environment::*;

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -399,8 +399,8 @@ mod tests {
         });
         let kind = stamped.expect("the scan's entity term carries a kind");
         assert_eq!(
-            kind.refinement().expect("refined").prefix,
-            "did:key:",
+            kind.refinement().expect("refined").prefix.as_deref(),
+            Some("did:key:"),
             "the proved prefix reaches the scan boundary"
         );
     }

--- a/rust/dialog-query/src/query/application.rs
+++ b/rust/dialog-query/src/query/application.rs
@@ -1,14 +1,34 @@
 use async_stream::try_stream;
-use dialog_artifacts::Select;
+use dialog_artifacts::{Entity, Select};
 use dialog_capability::Provider;
 use dialog_common::{ConditionalSend, ConditionalSync};
 
+use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::EvaluationError;
 use crate::selection;
 use crate::selection::Match;
 use crate::source::SelectRules;
 
 use super::Output;
+
+/// The outcome of restricting an [`Application`] to a single subject
+/// entity — the goal-directed unit incremental maintenance
+/// re-derives with (DRed's delete/re-derive step, scoped to one
+/// entity).
+#[derive(Clone, Debug)]
+pub enum Restriction<Q> {
+    /// The query restricted to the entity: evaluating it yields
+    /// exactly the original query's rows whose subject is the
+    /// entity.
+    Scoped(Q),
+    /// The original query can never produce rows for this entity
+    /// (its subject is pinned to a different one); nothing to
+    /// re-derive.
+    Unaffected,
+    /// The query cannot be scoped to one subject; the maintainer
+    /// falls back to full re-evaluation.
+    Unsupported,
+}
 
 /// A query pattern that can be evaluated against a provider to produce
 /// typed results.
@@ -37,6 +57,25 @@ pub trait Application: Clone + ConditionalSend + 'static {
 
     /// Convert a match into a concrete result value.
     fn realize(&self, input: selection::Match) -> Result<Self::Conclusion, EvaluationError>;
+
+    /// Restrict this query to a single subject entity, when the
+    /// query type supports it. The default is
+    /// [`Restriction::Unsupported`]: incremental maintainers fall
+    /// back to full re-evaluation.
+    fn restrict(&self, _entity: &Entity) -> Restriction<Self>
+    where
+        Self: Sized,
+    {
+        Restriction::Unsupported
+    }
+
+    /// The concept this query applies, when it is a concept query.
+    /// Incremental maintainers use it to resolve the rule set and
+    /// decide whether per-entity restriction is sound (every rule
+    /// entity-local, no recursion).
+    fn concept(&self) -> Option<&ConceptDescriptor> {
+        None
+    }
 
     /// Execute this query against an environment, returning a stream of typed results.
     fn perform<'a, Env>(self, env: &'a Env) -> impl Output<Self::Conclusion> + 'a

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -90,6 +90,27 @@ impl From<InductiveRule> for Rule {
     }
 }
 
+/// Which of the two rule kinds is being compiled — equivalently,
+/// *when* the conclusion takes effect relative to the state the body
+/// reads.
+///
+/// A deductive rule concludes at the same instant its body is
+/// evaluated: the head is a derived view of the current state. An
+/// inductive rule's body (including its `unless` premises) reads the
+/// current state while its head is *asserted into the next one* — a
+/// committed transaction, since facts persist in the store until
+/// retracted (there are no Dedalus-style frame rules to encode).
+/// From the deductive program's perspective an inductive head is
+/// base data, not a derived predicate, which is why the two kinds
+/// stratify differently (see [`analyze`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleKind {
+    /// Concludes at the same instant: a derived view.
+    Deductive,
+    /// Concludes at the next state: a transaction generator.
+    Inductive,
+}
+
 /// Common construction surface for both rule kinds.
 ///
 /// Implementors are constructible from a head + planned body via
@@ -98,6 +119,14 @@ impl From<InductiveRule> for Rule {
 /// uniformly. The default [`compile`](Compile::compile) runs the
 /// shared analysis pipeline (planner + unbound-variable check).
 pub trait Compile: Sized + Into<Rule> {
+    /// Which rule kind this type compiles as. Analysis is shared
+    /// except where the kinds genuinely differ: a deductive rule may
+    /// not negate its own conclusion (a same-instant paradox), while
+    /// for an inductive rule that same shape is the standard
+    /// idempotence guard ("create one unless one exists") because the
+    /// negation reads the pre-transition state.
+    const KIND: RuleKind;
+
     /// Build the rule from its analysis. Called by
     /// [`analyze`](Self::analyze) once analysis passes: the
     /// [`AnalyzedRule`] holds the narrowed premises, dependency graph
@@ -112,9 +141,10 @@ pub trait Compile: Sized + Into<Rule> {
     fn in_progress(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Self;
 
     /// Analyze a rule's conclusion and premises into a verified,
-    /// plannable rule. Default impl is identical for deductive and
-    /// inductive rules; the only difference between the kinds lives at
-    /// evaluation time, not compile time.
+    /// plannable rule. The default impl is shared by both kinds;
+    /// [`Self::KIND`] parameterizes the one structural check where
+    /// they differ (self-negation), and evaluation semantics differ
+    /// at runtime.
     ///
     /// Runs type inference + narrowing, the required-head and Coalesce
     /// contract checks, and the dependency-graph build (all in
@@ -134,7 +164,7 @@ pub trait Compile: Sized + Into<Rule> {
         // before any execution order is chosen. The original premises
         // are kept for the error-path display rule.
         let display_premises = premises.clone();
-        let analysis = match analyzer::analyze(conclusion.clone(), premises) {
+        let analysis = match analyzer::analyze(conclusion.clone(), premises, Self::KIND) {
             Ok(analysis) => analysis,
             Err(err) => {
                 let rule = Self::in_progress(conclusion, display_premises);

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -155,6 +155,10 @@ pub trait Compile: Sized + Into<Rule> {
                     AnalysisError::NegatedOptional => TypeError::NegatedOptional {
                         rule: Box::new(rule.into()),
                     },
+                    AnalysisError::SelfNegation { concept } => TypeError::SelfNegation {
+                        rule: Box::new(rule.into()),
+                        concept,
+                    },
                 });
             }
         };

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -36,7 +36,7 @@ use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
-use crate::{Entity, Environment, Premise};
+use crate::{Entity, Environment, Premise, Term};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -229,6 +229,34 @@ impl AnalyzedRule {
         self.premises.iter().filter_map(|premise| match premise {
             Premise::Unless(Negation(Proposition::Concept(query))) => Some(query.predicate.this()),
             _ => None,
+        })
+    }
+
+    /// Whether every premise reads only the head entity's own facts:
+    /// each attribute premise (positive, optional, or negated) is a
+    /// lookup `of ?this`, and the remaining premises are row-local
+    /// transforms (formulas, constraints) over those bindings.
+    ///
+    /// For an entity-local rule, a base-fact change for entity `E`
+    /// can only affect the rule's rows whose subject is `E` — the
+    /// soundness condition for maintaining a subscription by
+    /// re-deriving just the touched entities instead of
+    /// re-evaluating the whole query. Concept premises are
+    /// cross-entity by construction (the target entity is a field
+    /// value, not the subject), so any rule carrying one is
+    /// non-local.
+    pub fn is_entity_local(&self) -> bool {
+        fn of_is_this(term: &Term<Entity>) -> bool {
+            matches!(term, Term::Variable { name: Some(name), .. } if name == "this")
+        }
+        self.premises.iter().all(|premise| match premise {
+            Premise::Assert(Proposition::Attribute(query)) => of_is_this(query.of()),
+            Premise::Assert(Proposition::OptionalAttribute(query)) => of_is_this(query.of()),
+            Premise::Assert(Proposition::Constraint(_)) => true,
+            Premise::Assert(Proposition::Formula(_)) => true,
+            Premise::Unless(Negation(Proposition::Attribute(query))) => of_is_this(query.of()),
+            Premise::Unless(Negation(Proposition::Constraint(_))) => true,
+            _ => false,
         })
     }
 }

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -33,6 +33,7 @@ use crate::error::AnalysisError;
 use crate::planner::categorize;
 use crate::premise::Negation;
 use crate::proposition::Proposition;
+use crate::rule::RuleKind;
 use crate::rule::types::TypeEnv;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
@@ -221,10 +222,13 @@ impl AnalyzedRule {
 
     /// The concepts this rule negates: its *negative IDB edges*.
     /// One entry per `unless` premise over a concept, identified by
-    /// the concept's content-addressed URI. Self-negation is
-    /// rejected at analysis, so none of these is the rule's own
-    /// conclusion; the global stratification pass consumes these
-    /// edges to order (or reject) cycles that span multiple rules.
+    /// the concept's content-addressed URI. Deductive self-negation
+    /// is rejected at analysis, so for a deductive rule none of
+    /// these is its own conclusion; the global stratification pass
+    /// consumes these edges to order (or reject) cycles that span
+    /// multiple rules. (An inductive rule may negate its own
+    /// conclusion — the idempotence guard — but inductive rules
+    /// never feed that pass.)
     pub fn negated_concepts(&self) -> impl Iterator<Item = Entity> + '_ {
         self.premises.iter().filter_map(|premise| match premise {
             Premise::Unless(Negation(Proposition::Concept(query))) => Some(query.predicate.this()),
@@ -276,6 +280,7 @@ impl AnalyzedRule {
 pub fn analyze(
     conclusion: ConceptDescriptor,
     premises: Vec<Premise>,
+    kind: RuleKind,
 ) -> Result<AnalyzedRule, AnalysisError> {
     let types = Arc::new(
         TypeEnv::infer(&premises).map_err(|err| AnalysisError::Inference {
@@ -319,20 +324,30 @@ pub fn analyze(
         }
     }
 
-    // A rule that negates its own conclusion is a negative
-    // self-loop: it would derive a row exactly when it doesn't, and
-    // no stratification can order it. This is the local, always
-    // detectable case; negation over *other* derived concepts is a
-    // negative IDB edge, surfaced per rule by
+    // A *deductive* rule that negates its own conclusion is a
+    // negative self-loop: it would derive a row exactly when it
+    // doesn't, and no stratification can order it. This is the
+    // local, always detectable case; negation over *other* derived
+    // concepts is a negative IDB edge, surfaced per rule by
     // [`AnalyzedRule::negated_concepts`] for the global
     // stratification pass to consume.
-    for premise in &premises {
-        if let Premise::Unless(Negation(Proposition::Concept(query))) = premise
-            && query.predicate.this() == conclusion.this()
-        {
-            return Err(AnalysisError::SelfNegation {
-                concept: conclusion.this().to_string(),
-            });
+    //
+    // An *inductive* rule is exempt: its `unless` reads the
+    // pre-transition state while its head asserts into the next one,
+    // so "assert P unless P exists" is the standard idempotence
+    // guard (Dedalus `P@next :- body, not P@now`), stratified by the
+    // time step rather than paradoxical. Inductive rules never join
+    // deductive resolution, so the head is base data to the same-
+    // instant program and no global negative edge arises either.
+    if kind == RuleKind::Deductive {
+        for premise in &premises {
+            if let Premise::Unless(Negation(Proposition::Concept(query))) = premise
+                && query.predicate.this() == conclusion.this()
+            {
+                return Err(AnalysisError::SelfNegation {
+                    concept: conclusion.this().to_string(),
+                });
+            }
         }
     }
 
@@ -389,7 +404,7 @@ mod tests {
             )
             .into(),
         ];
-        let analyzed = analyze(person_with_name(), premises).unwrap();
+        let analyzed = analyze(person_with_name(), premises, RuleKind::Deductive).unwrap();
 
         assert_eq!(analyzed.premises.len(), 1);
         let name_kind = analyzed.type_of("name").expect("name has an inferred type");
@@ -417,7 +432,7 @@ mod tests {
             Some(Cardinality::One),
         );
         let premises = vec![q1.into(), q2.into()];
-        let analyzed = analyze(person_with_name(), premises).unwrap();
+        let analyzed = analyze(person_with_name(), premises, RuleKind::Deductive).unwrap();
 
         assert_eq!(analyzed.graph.len(), 2);
 
@@ -451,7 +466,7 @@ mod tests {
         let length = Length::apply(params).unwrap();
 
         let premises: Vec<Premise> = vec![attr.into(), Premise::from(length)];
-        let analyzed = analyze(person_with_name(), premises).unwrap();
+        let analyzed = analyze(person_with_name(), premises, RuleKind::Deductive).unwrap();
 
         assert_eq!(analyzed.graph.len(), 2);
 
@@ -501,7 +516,7 @@ mod tests {
             )
             .into(),
         ];
-        let err = analyze(person_with_name(), premises).unwrap_err();
+        let err = analyze(person_with_name(), premises, RuleKind::Deductive).unwrap_err();
         match err {
             AnalysisError::RequiredHeadFromOptional { variable } => {
                 assert_eq!(variable, "name");
@@ -534,7 +549,7 @@ mod tests {
             Premise::Unless(Negation(Proposition::OptionalAttribute(Box::new(maybe)))),
         ];
 
-        let err = analyze(person_with_name(), premises).unwrap_err();
+        let err = analyze(person_with_name(), premises, RuleKind::Deductive).unwrap_err();
         assert!(
             matches!(err, AnalysisError::NegatedOptional),
             "negating a maybe premise is vacuously false, got {err:?}"

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -36,7 +36,7 @@ use crate::proposition::Proposition;
 use crate::rule::types::TypeEnv;
 use crate::type_system::Type as Kind;
 use crate::type_system::unifier::Context;
-use crate::{Environment, Premise};
+use crate::{Entity, Environment, Premise};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -218,6 +218,19 @@ impl AnalyzedRule {
     pub fn type_of(&self, name: &str) -> Option<&Kind> {
         self.types.get(name)
     }
+
+    /// The concepts this rule negates: its *negative IDB edges*.
+    /// One entry per `unless` premise over a concept, identified by
+    /// the concept's content-addressed URI. Self-negation is
+    /// rejected at analysis, so none of these is the rule's own
+    /// conclusion; the global stratification pass consumes these
+    /// edges to order (or reject) cycles that span multiple rules.
+    pub fn negated_concepts(&self) -> impl Iterator<Item = Entity> + '_ {
+        self.premises.iter().filter_map(|premise| match premise {
+            Premise::Unless(Negation(Proposition::Concept(query))) => Some(query.predicate.this()),
+            _ => None,
+        })
+    }
 }
 
 /// Run analysis over the rule's premises:
@@ -275,6 +288,23 @@ pub fn analyze(
     for premise in &premises {
         if let Premise::Unless(Negation(Proposition::OptionalAttribute(_))) = premise {
             return Err(AnalysisError::NegatedOptional);
+        }
+    }
+
+    // A rule that negates its own conclusion is a negative
+    // self-loop: it would derive a row exactly when it doesn't, and
+    // no stratification can order it. This is the local, always
+    // detectable case; negation over *other* derived concepts is a
+    // negative IDB edge, surfaced per rule by
+    // [`AnalyzedRule::negated_concepts`] for the global
+    // stratification pass to consume.
+    for premise in &premises {
+        if let Premise::Unless(Negation(Proposition::Concept(query))) = premise
+            && query.predicate.this() == conclusion.this()
+        {
+            return Err(AnalysisError::SelfNegation {
+                concept: conclusion.this().to_string(),
+            });
         }
     }
 

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -195,79 +195,130 @@ impl Display for DeductiveRule {
     }
 }
 
+impl DeductiveRule {
+    /// Compile *ordered variants* of a concept: spec-style
+    /// first-to-conform alternatives, each an alternative body for
+    /// the same conclusion.
+    ///
+    /// Variant `k` desugars to a rule whose body is the variant's
+    /// own premises plus one negated premise per *earlier* variant:
+    /// the entity yields variant `k`'s row only when no earlier
+    /// variant matched it. Order is semantic; the returned rules are
+    /// installed together (e.g. via
+    /// [`ConceptRules::install`](crate::ConceptRules)) and their
+    /// disjunction is deterministic per entity because the
+    /// negations make the variants pairwise disjoint.
+    ///
+    /// Every variant must ground the conclusion's required operands
+    /// with its own fields (the ordinary head-grounding contract);
+    /// a variant that doesn't fails compilation like any other rule.
+    pub fn variants(
+        conclusion: ConceptDescriptor,
+        ordered: Vec<ConceptDescriptor>,
+    ) -> Result<Vec<DeductiveRule>, TypeError> {
+        use crate::concept::query::ConceptQuery;
+
+        let mut rules = Vec::new();
+        for (position, variant) in ordered.iter().enumerate() {
+            let mut premises = concept_premises(variant);
+            for earlier in &ordered[..position] {
+                let mut terms = Parameters::new();
+                terms.insert("this".to_string(), Term::<Entity>::var("this").into());
+                premises.push(Premise::Unless(Negation(Proposition::Concept(
+                    ConceptQuery {
+                        terms,
+                        predicate: earlier.clone(),
+                    },
+                ))));
+            }
+            rules.push(DeductiveRule::new(conclusion.clone(), premises)?);
+        }
+        Ok(rules)
+    }
+}
+
+/// Lower a concept's fields into the body premises of its implicit
+/// rule: one scan (or left-join) per field, plus a conjoined target
+/// premise per concept-typed field. Shared by
+/// `From<&ConceptDescriptor>` and [`DeductiveRule::variants`].
+fn concept_premises(concept: &ConceptDescriptor) -> Vec<Premise> {
+    use crate::concept::query::ConceptQuery;
+    use crate::type_system::ConceptRef;
+
+    let mut premises = Vec::new();
+
+    let this = Term::<Entity>::var("this");
+
+    for (name, field) in concept.with().iter() {
+        // The value term stays scalar in both cases; the
+        // associative layer never carries optionality. A
+        // required field lowers to a plain scan (a missing fact
+        // filters the row out); an optional field lowers to a
+        // `OptionalAttributeQuery` left-join, which set-widens at the
+        // projection: `this` is bound by the required fields, so
+        // a miss yields one row with the slot bound to
+        // `Binding::Absent`.
+        //
+        // A concept-typed field's slot additionally carries the
+        // conformance refinement, and the constraint itself is
+        // enforced structurally: the target concept is conjoined
+        // as a premise over the field's variable below.
+        let kind = match (field.content_type().map(Kind::from), field.conforms()) {
+            (Some(kind), Some(target)) => Some(
+                kind.with_conformance(ConceptRef(target.this().to_string()))
+                    .expect("a conforming field is entity-valued by construction"),
+            ),
+            (kind, _) => kind,
+        };
+        let value = match kind {
+            Some(kind) => Term::<Any>::typed_var(name, kind),
+            None => Term::var(name),
+        };
+
+        let premise: Premise = if field.is_optional() {
+            OptionalAttributeQuery::new(
+                Term::Constant(Value::from(field.the().clone())),
+                this.clone(),
+                value.clone(),
+                Term::blank(),
+                Some(field.cardinality()),
+            )
+            .into()
+        } else {
+            AttributeQuery::new(
+                Term::Constant(Value::from(field.the().clone())),
+                this.clone(),
+                value.clone(),
+                Term::blank(),
+                Some(field.cardinality()),
+            )
+            .into()
+        };
+        premises.push(premise);
+
+        // Conformance is "facts exist", not a property of the
+        // scalar, so it desugars to the target concept applied
+        // to the field's entity: the row survives only when the
+        // target entity satisfies the concept. Only `this` is
+        // projected; the target's own fields stay internal to
+        // the premise.
+        if let Some(target) = field.conforms() {
+            let mut terms = Parameters::new();
+            terms.insert("this".to_string(), value);
+            premises.push(Premise::Assert(Proposition::Concept(ConceptQuery {
+                terms,
+                predicate: target.clone(),
+            })));
+        }
+    }
+
+    premises
+}
+
 impl From<&ConceptDescriptor> for DeductiveRule {
     fn from(concept: &ConceptDescriptor) -> Self {
-        use crate::concept::query::ConceptQuery;
-        use crate::type_system::ConceptRef;
-
-        let mut premises = Vec::new();
-
-        let this = Term::<Entity>::var("this");
-
-        for (name, field) in concept.with().iter() {
-            // The value term stays scalar in both cases; the
-            // associative layer never carries optionality. A
-            // required field lowers to a plain scan (a missing fact
-            // filters the row out); an optional field lowers to a
-            // `OptionalAttributeQuery` left-join, which set-widens at the
-            // projection: `this` is bound by the required fields, so
-            // a miss yields one row with the slot bound to
-            // `Binding::Absent`.
-            //
-            // A concept-typed field's slot additionally carries the
-            // conformance refinement, and the constraint itself is
-            // enforced structurally: the target concept is conjoined
-            // as a premise over the field's variable below.
-            let kind = match (field.content_type().map(Kind::from), field.conforms()) {
-                (Some(kind), Some(target)) => Some(
-                    kind.with_conformance(ConceptRef(target.this().to_string()))
-                        .expect("a conforming field is entity-valued by construction"),
-                ),
-                (kind, _) => kind,
-            };
-            let value = match kind {
-                Some(kind) => Term::<Any>::typed_var(name, kind),
-                None => Term::var(name),
-            };
-
-            let premise: Premise = if field.is_optional() {
-                OptionalAttributeQuery::new(
-                    Term::Constant(Value::from(field.the().clone())),
-                    this.clone(),
-                    value.clone(),
-                    Term::blank(),
-                    Some(field.cardinality()),
-                )
-                .into()
-            } else {
-                AttributeQuery::new(
-                    Term::Constant(Value::from(field.the().clone())),
-                    this.clone(),
-                    value.clone(),
-                    Term::blank(),
-                    Some(field.cardinality()),
-                )
-                .into()
-            };
-            premises.push(premise);
-
-            // Conformance is "facts exist", not a property of the
-            // scalar, so it desugars to the target concept applied
-            // to the field's entity: the row survives only when the
-            // target entity satisfies the concept. Only `this` is
-            // projected; the target's own fields stay internal to
-            // the premise.
-            if let Some(target) = field.conforms() {
-                let mut terms = Parameters::new();
-                terms.insert("this".to_string(), value);
-                premises.push(Premise::Assert(Proposition::Concept(ConceptQuery {
-                    terms,
-                    predicate: target.clone(),
-                })));
-            }
-        }
-
-        DeductiveRule::new(concept.clone(), premises).expect("Concept should compile")
+        DeductiveRule::new(concept.clone(), concept_premises(concept))
+            .expect("Concept should compile")
     }
 }
 
@@ -818,6 +869,153 @@ mod tests {
         }
         assert_eq!(scans, 1, "expected one scalar scan (name)");
         assert_eq!(maybes, 1, "expected one Maybe left-join (nickname)");
+    }
+
+    /// Ordered variants desugar to negated premises: variant `k`
+    /// carries one `Unless` per earlier variant, joined on `this`,
+    /// so the first conforming variant wins.
+    #[dialog_common::test]
+    fn variants_desugar_to_ordered_negations() {
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let email = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/email"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let phone = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/phone"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+
+        let rules = DeductiveRule::variants(conclusion, vec![email.clone(), phone.clone()])
+            .expect("variants compile");
+        assert_eq!(rules.len(), 2);
+
+        let negations = |rule: &DeductiveRule| {
+            rule.analysis()
+                .premises
+                .iter()
+                .filter_map(|premise| match premise {
+                    Premise::Unless(Negation(Proposition::Concept(query))) => Some(query.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert!(
+            negations(&rules[0]).is_empty(),
+            "the first variant negates nothing"
+        );
+
+        let unless = negations(&rules[1]);
+        assert_eq!(unless.len(), 1, "one negation per earlier variant");
+        assert_eq!(
+            unless[0].predicate.this(),
+            email.this(),
+            "the later variant excludes the earlier one"
+        );
+        assert_eq!(
+            unless[0].terms.iter().count(),
+            1,
+            "the negation joins on `this` alone"
+        );
+        assert_eq!(
+            unless[0].terms.get("this").and_then(|term| term.name()),
+            Some("this")
+        );
+    }
+
+    /// A rule that negates its own conclusion concept is a negative
+    /// self-loop: rejected at analysis.
+    #[dialog_common::test]
+    fn it_rejects_self_negating_rule() {
+        use crate::concept::query::ConceptQuery;
+        use crate::negation::Negation;
+
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Entity>::var("this").into());
+        let premises = vec![
+            AttributeQuery::new(
+                Term::from(the!("user/email")),
+                Term::<Entity>::var("this"),
+                Term::var("handle"),
+                Term::blank(),
+                Some(Cardinality::One),
+            )
+            .into(),
+            Premise::Unless(Negation(Proposition::Concept(ConceptQuery {
+                terms,
+                predicate: conclusion.clone(),
+            }))),
+        ];
+
+        match DeductiveRule::new(conclusion, premises) {
+            Err(TypeError::SelfNegation { concept, .. }) => {
+                assert!(concept.starts_with("concept:"));
+            }
+            other => panic!("expected SelfNegation, got {other:?}"),
+        }
+    }
+
+    /// Negation over *another* concept is a negative IDB edge,
+    /// surfaced by the analysis for the stratification pass.
+    #[dialog_common::test]
+    fn analysis_surfaces_negative_idb_edges() {
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let email = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/email"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let phone = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/phone"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+
+        let rules =
+            DeductiveRule::variants(conclusion, vec![email.clone(), phone]).expect("compiles");
+
+        assert_eq!(
+            rules[0].analysis().negated_concepts().count(),
+            0,
+            "the first variant carries no negative edges"
+        );
+        assert_eq!(
+            rules[1].analysis().negated_concepts().collect::<Vec<_>>(),
+            vec![email.this()],
+            "the later variant's negative edge names the earlier variant"
+        );
     }
 
     /// A concept-typed field conjoins the target concept as a

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -197,6 +197,9 @@ impl Display for DeductiveRule {
 
 impl From<&ConceptDescriptor> for DeductiveRule {
     fn from(concept: &ConceptDescriptor) -> Self {
+        use crate::concept::query::ConceptQuery;
+        use crate::type_system::ConceptRef;
+
         let mut premises = Vec::new();
 
         let this = Term::<Entity>::var("this");
@@ -210,8 +213,20 @@ impl From<&ConceptDescriptor> for DeductiveRule {
             // projection: `this` is bound by the required fields, so
             // a miss yields one row with the slot bound to
             // `Binding::Absent`.
-            let value = match field.content_type() {
-                Some(ty) => Term::<Any>::typed_var(name, Kind::from(ty)),
+            //
+            // A concept-typed field's slot additionally carries the
+            // conformance refinement, and the constraint itself is
+            // enforced structurally: the target concept is conjoined
+            // as a premise over the field's variable below.
+            let kind = match (field.content_type().map(Kind::from), field.conforms()) {
+                (Some(kind), Some(target)) => Some(
+                    kind.with_conformance(ConceptRef(target.this().to_string()))
+                        .expect("a conforming field is entity-valued by construction"),
+                ),
+                (kind, _) => kind,
+            };
+            let value = match kind {
+                Some(kind) => Term::<Any>::typed_var(name, kind),
                 None => Term::var(name),
             };
 
@@ -219,7 +234,7 @@ impl From<&ConceptDescriptor> for DeductiveRule {
                 OptionalAttributeQuery::new(
                     Term::Constant(Value::from(field.the().clone())),
                     this.clone(),
-                    value,
+                    value.clone(),
                     Term::blank(),
                     Some(field.cardinality()),
                 )
@@ -228,13 +243,28 @@ impl From<&ConceptDescriptor> for DeductiveRule {
                 AttributeQuery::new(
                     Term::Constant(Value::from(field.the().clone())),
                     this.clone(),
-                    value,
+                    value.clone(),
                     Term::blank(),
                     Some(field.cardinality()),
                 )
                 .into()
             };
             premises.push(premise);
+
+            // Conformance is "facts exist", not a property of the
+            // scalar, so it desugars to the target concept applied
+            // to the field's entity: the row survives only when the
+            // target entity satisfies the concept. Only `this` is
+            // projected; the target's own fields stay internal to
+            // the premise.
+            if let Some(target) = field.conforms() {
+                let mut terms = Parameters::new();
+                terms.insert("this".to_string(), value);
+                premises.push(Premise::Assert(Proposition::Concept(ConceptQuery {
+                    terms,
+                    predicate: target.clone(),
+                })));
+            }
         }
 
         DeductiveRule::new(concept.clone(), premises).expect("Concept should compile")
@@ -788,6 +818,92 @@ mod tests {
         }
         assert_eq!(scans, 1, "expected one scalar scan (name)");
         assert_eq!(maybes, 1, "expected one Maybe left-join (nickname)");
+    }
+
+    /// A concept-typed field conjoins the target concept as a
+    /// premise over the field's variable, and the field's slot kind
+    /// carries the conformance refinement.
+    #[dialog_common::test]
+    fn from_concept_with_conforming_field_conjoins_target_premise() {
+        use crate::type_system::ConceptRef;
+
+        let target = ConceptDescriptor::try_from(vec![(
+            "badge",
+            AttributeDescriptor::new(
+                the!("employee/badge"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+
+        let concept = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    AttributeDescriptor::new(
+                        the!("person/manager"),
+                        "",
+                        Cardinality::One,
+                        Some(Type::Entity),
+                    ),
+                    target.clone(),
+                )
+                .expect("entity-valued attribute conforms"),
+            ),
+        ])
+        .unwrap();
+
+        let rule = DeductiveRule::from(&concept);
+
+        let mut scans = Vec::new();
+        let mut concepts = Vec::new();
+        for premise in rule.analysis().premises.iter() {
+            match premise {
+                Premise::Assert(Proposition::Attribute(query)) => scans.push(query),
+                Premise::Assert(Proposition::Concept(query)) => concepts.push(query),
+                other => panic!("unexpected premise {other:?}"),
+            }
+        }
+        assert_eq!(scans.len(), 2, "one scan per attribute");
+        assert_eq!(concepts.len(), 1, "one conjoined target premise");
+
+        let conformance = &concepts[0];
+        assert_eq!(
+            conformance.predicate.this(),
+            target.this(),
+            "the conjoined premise applies the target concept"
+        );
+        assert_eq!(
+            conformance.terms.iter().count(),
+            1,
+            "only `this` is projected into the target"
+        );
+        let this = conformance.terms.get("this").expect("this bound");
+        assert_eq!(this.name(), Some("manager"), "joins on the field variable");
+
+        let manager_scan = scans
+            .iter()
+            .find(|scan| scan.is().name() == Some("manager"))
+            .expect("manager scan present");
+        let kind = manager_scan.is().kind().expect("typed slot");
+        assert!(
+            kind.refinement()
+                .expect("conformance refinement stamped")
+                .conforms
+                .contains(&ConceptRef(target.this().to_string())),
+            "the slot kind names the target concept"
+        );
     }
 
     /// The degenerate "rule body binds only optionals" shape, at the

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -935,6 +935,110 @@ mod tests {
         );
     }
 
+    /// Entity locality: the implicit rule of a plain concept reads
+    /// only `?this`'s facts; concept premises (conforming fields,
+    /// variant negations) make a rule non-local.
+    #[dialog_common::test]
+    fn it_classifies_entity_locality() {
+        let plain = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "nickname".to_string(),
+                ConceptFieldDescriptor::optional(AttributeDescriptor::new(
+                    the!("person/nickname"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+        ])
+        .unwrap();
+        assert!(
+            DeductiveRule::from(&plain).analysis().is_entity_local(),
+            "attribute and optional premises over ?this are local"
+        );
+
+        let target = ConceptDescriptor::try_from(vec![(
+            "badge",
+            AttributeDescriptor::new(
+                the!("employee/badge"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let conforming = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    the!("person/name"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "manager".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    AttributeDescriptor::new(
+                        the!("person/manager"),
+                        "",
+                        Cardinality::One,
+                        Some(Type::Entity),
+                    ),
+                    target.clone(),
+                )
+                .unwrap(),
+            ),
+        ])
+        .unwrap();
+        assert!(
+            !DeductiveRule::from(&conforming)
+                .analysis()
+                .is_entity_local(),
+            "a concept premise reads another entity's facts"
+        );
+
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(
+                the!("contact/handle"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .unwrap();
+        let email = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/email"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let phone = ConceptDescriptor::try_from(vec![(
+            "handle",
+            AttributeDescriptor::new(the!("user/phone"), "", Cardinality::One, Some(Type::String)),
+        )])
+        .unwrap();
+        let variants = DeductiveRule::variants(conclusion, vec![email, phone]).unwrap();
+        assert!(
+            variants[0].analysis().is_entity_local(),
+            "the first variant is plain attribute premises"
+        );
+        assert!(
+            !variants[1].analysis().is_entity_local(),
+            "a negated concept premise is non-local"
+        );
+    }
+
     /// A rule that negates its own conclusion concept is a negative
     /// self-loop: rejected at analysis.
     #[dialog_common::test]

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -11,7 +11,7 @@ pub use crate::planner::Plan;
 pub use crate::planner::{Conjunction, Planner};
 pub use crate::premise::Premise;
 use crate::rule::analyzer::AnalyzedRule;
-use crate::rule::{Compile, fmt_rule_schema};
+use crate::rule::{Compile, RuleKind, fmt_rule_schema};
 use crate::type_system::Type as Kind;
 use crate::types::Any;
 pub use crate::{Attribute, Cardinality, Parameters, Proposition, Requirement, Value};
@@ -34,6 +34,8 @@ pub struct DeductiveRule {
     analysis: AnalyzedRule,
 }
 impl Compile for DeductiveRule {
+    const KIND: RuleKind = RuleKind::Deductive;
+
     fn from_analysis(analysis: AnalyzedRule) -> Self {
         DeductiveRule { analysis }
     }

--- a/rust/dialog-query/src/rule/inductive.rs
+++ b/rust/dialog-query/src/rule/inductive.rs
@@ -23,7 +23,7 @@ use crate::negation::Negation;
 use crate::planner::{Conjunction, Planner};
 use crate::premise::Premise;
 use crate::rule::analyzer::AnalyzedRule;
-use crate::rule::{Compile, fmt_rule_schema};
+use crate::rule::{Compile, RuleKind, fmt_rule_schema};
 use crate::{Environment, Parameters, Proposition};
 use descriptor::InductiveRuleDescriptor;
 use serde::de::Error as _;
@@ -41,6 +41,8 @@ pub struct InductiveRule {
 }
 
 impl Compile for InductiveRule {
+    const KIND: RuleKind = RuleKind::Inductive;
+
     fn from_analysis(analysis: AnalyzedRule) -> Self {
         InductiveRule { analysis }
     }
@@ -195,6 +197,43 @@ mod tests {
     fn it_compiles_with_valid_premises() {
         let result = InductiveRule::new(counter_head(), increment_body());
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+    }
+
+    /// The create-once shape: `assert! P when body unless P`. For an
+    /// inductive rule the `unless` reads the pre-transition state
+    /// while the head asserts into the next one, so negating the
+    /// rule's own conclusion is the standard idempotence guard
+    /// (Dedalus `P@next :- body, not P@now`), not a paradox — it
+    /// must compile, and the negation premise must survive analysis
+    /// so evaluation applies the guard. The same shape on a
+    /// deductive rule stays rejected
+    /// (`deductive::tests::it_rejects_self_negating_rule`).
+    #[dialog_common::test]
+    fn it_permits_negating_its_own_conclusion() {
+        use crate::concept::query::ConceptQuery;
+        use crate::negation::Negation;
+        use crate::proposition::Proposition;
+        use crate::types::Any;
+
+        let head = counter_head();
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("this"));
+        let mut premises = increment_body();
+        premises.push(Premise::Unless(Negation(Proposition::Concept(
+            ConceptQuery {
+                terms,
+                predicate: head.clone(),
+            },
+        ))));
+
+        let rule = InductiveRule::new(head.clone(), premises)
+            .expect("an inductive rule may negate its own conclusion");
+        let negated: Vec<Entity> = rule.analysis().negated_concepts().collect();
+        assert_eq!(
+            negated,
+            vec![head.this()],
+            "the idempotence guard survives analysis"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/session.rs
+++ b/rust/dialog-query/src/session.rs
@@ -1,7 +1,10 @@
 //! Rule registry for deductive inference.
 
+/// Program-level dependency analysis: recursion and stratification.
+pub mod dependencies;
 /// Registry for deductive rules, indexed by conclusion entity.
 pub mod rule_registry;
+pub use dependencies::{NegationViolation, Polarity, ProgramAnalysis};
 pub use rule_registry::*;
 
 #[cfg(test)]

--- a/rust/dialog-query/src/session.rs
+++ b/rust/dialog-query/src/session.rs
@@ -4,7 +4,7 @@
 pub mod dependencies;
 /// Registry for deductive rules, indexed by conclusion entity.
 pub mod rule_registry;
-pub use dependencies::{NegationViolation, Polarity, ProgramAnalysis};
+pub use dependencies::{Closure, NegationViolation, Polarity, ProgramAnalysis};
 pub use rule_registry::*;
 
 #[cfg(test)]

--- a/rust/dialog-query/src/session/dependencies.rs
+++ b/rust/dialog-query/src/session/dependencies.rs
@@ -1,0 +1,603 @@
+//! Program-level dependency analysis over the installed rule set.
+//!
+//! Rules live in the database and can be installed concurrently on
+//! multiple replicas, each install fully valid in isolation, so
+//! stratification is a *whole-set* property, not an install-time
+//! one: [`RuleRegistry::register`](super::rule_registry::RuleRegistry::register)
+//! accepts every rule unconditionally (replicas must converge on the
+//! merged rule set regardless of stratifiability) and the merged set
+//! is analyzed here, after the fact.
+//!
+//! The analysis builds the Apt-Blair-Walker dependency graph over
+//! concepts: one node per concept, an edge from a rule's conclusion
+//! to each concept its body references, tagged with the polarity of
+//! the reference (`unless` premises are negative). Tarjan's
+//! algorithm computes the strongly connected components; a concept
+//! is *recursive* when its component is non-trivial, and a negative
+//! edge inside a component is a stratification violation (no
+//! stratified semantics exists for the program).
+//!
+//! Callers consume the analysis two ways:
+//!
+//! - [`RuleRegistry::validate`](super::rule_registry::RuleRegistry::validate)
+//!   returns every [`NegationViolation`] in the program, for callers
+//!   that want immediate feedback after an install or a merge.
+//! - [`RuleRegistry::acquire`](super::rule_registry::RuleRegistry::acquire)
+//!   runs the targeted [`ProgramAnalysis::check`] over the queried
+//!   concept's dependency closure, so an ill-stratified or recursive
+//!   region of the program fails the queries that touch it (and only
+//!   those) with a structured error.
+
+use crate::Entity;
+use crate::concept::descriptor::ConceptDescriptor;
+use crate::concept::query::ConceptRules;
+use crate::error::EvaluationError;
+use crate::negation::Negation;
+use crate::premise::Premise;
+use crate::proposition::Proposition;
+use crate::rule::deductive::DeductiveRule;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::iter;
+
+/// Polarity of a dependency edge: whether the rule body references
+/// the concept positively (an ordinary premise) or under `unless`.
+/// Negative edges inside a dependency cycle are stratification
+/// violations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Polarity {
+    /// The body asserts the concept.
+    Positive,
+    /// The body negates the concept (`unless`).
+    Negative,
+}
+
+/// A stratification violation: some rule concluding `concept`
+/// negates `negated`, and both live in the same dependency cycle,
+/// so the negation reads a set the cycle itself is still deriving.
+/// No stratified semantics exists for such a program.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NegationViolation {
+    /// The concluding concept whose rule negates into its own cycle.
+    pub concept: Entity,
+    /// The negated concept inside the same cycle.
+    pub negated: Entity,
+}
+
+/// The dependency edges a rule's body contributes: one per concept
+/// premise, negative when the premise sits under `unless`. The
+/// target's full descriptor rides along so concepts that never got
+/// a registry entry still contribute their structural edges.
+fn rule_edges(rule: &DeductiveRule) -> Vec<(ConceptDescriptor, Polarity)> {
+    rule.analysis()
+        .premises()
+        .filter_map(|premise| match premise {
+            Premise::Assert(Proposition::Concept(query)) => {
+                Some((query.predicate.clone(), Polarity::Positive))
+            }
+            Premise::Unless(Negation(Proposition::Concept(query))) => {
+                Some((query.predicate.clone(), Polarity::Negative))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// The dependency edges a concept contributes with no rules
+/// installed: its implicit rule applies the target concept of every
+/// concept-typed field, so each `conforms` target is a positive
+/// edge.
+fn structural_edges(descriptor: &ConceptDescriptor) -> Vec<(ConceptDescriptor, Polarity)> {
+    descriptor
+        .with()
+        .iter()
+        .filter_map(|(_, field)| field.conforms().map(|t| (t.clone(), Polarity::Positive)))
+        .collect()
+}
+
+/// A snapshot of the program's dependency structure: edges,
+/// strongly connected components, the recursive concept set, and
+/// every stratification violation. Computed by
+/// [`ProgramAnalysis::analyze`] from a registry's rule map and
+/// cached until the next install.
+#[derive(Clone, Debug, Default)]
+pub struct ProgramAnalysis {
+    /// Adjacency: concept -> the concepts its rules reference.
+    edges: HashMap<Entity, Vec<(Entity, Polarity)>>,
+    /// Concepts whose strongly connected component is non-trivial
+    /// (more than one member, or a self-edge).
+    recursive: HashSet<Entity>,
+    /// Every negative edge that lands inside its own component.
+    violations: Vec<NegationViolation>,
+}
+
+impl ProgramAnalysis {
+    /// Analyze the program formed by the given per-concept rule
+    /// sets: every implicit and installed rule contributes edges,
+    /// and concepts referenced by premises without a registry entry
+    /// of their own contribute their structural (`conforms`) edges.
+    pub fn analyze<'a>(entries: impl IntoIterator<Item = (&'a Entity, &'a ConceptRules)>) -> Self {
+        let mut edges: HashMap<Entity, Vec<(Entity, Polarity)>> = HashMap::new();
+        let mut pending: VecDeque<ConceptDescriptor> = VecDeque::new();
+
+        for (entity, rules) in entries {
+            let mut out = Vec::new();
+            for rule in rules.rules() {
+                for (target, polarity) in rule_edges(rule) {
+                    out.push((target.this(), polarity));
+                    pending.push_back(target);
+                }
+            }
+            edges.insert(entity.clone(), out);
+        }
+
+        // Concepts referenced by premises but never registered still
+        // constrain the graph through their embedded descriptors.
+        while let Some(descriptor) = pending.pop_front() {
+            let entity = descriptor.this();
+            if edges.contains_key(&entity) {
+                continue;
+            }
+            let mut out = Vec::new();
+            for (target, polarity) in structural_edges(&descriptor) {
+                out.push((target.this(), polarity));
+                pending.push_back(target);
+            }
+            edges.insert(entity, out);
+        }
+
+        // Index the node set (keys plus any edge target) for Tarjan.
+        // Sorted so component numbering and violation order are
+        // deterministic regardless of hash-map iteration order.
+        let mut nodes: Vec<Entity> = edges
+            .iter()
+            .flat_map(|(node, out)| {
+                iter::once(node.clone()).chain(out.iter().map(|(target, _)| target.clone()))
+            })
+            .collect();
+        nodes.sort();
+        nodes.dedup();
+        let index_of: HashMap<&Entity, usize> =
+            nodes.iter().enumerate().map(|(i, e)| (e, i)).collect();
+        let adjacency: Vec<Vec<usize>> = nodes
+            .iter()
+            .map(|node| {
+                edges
+                    .get(node)
+                    .map(|out| out.iter().map(|(target, _)| index_of[target]).collect())
+                    .unwrap_or_default()
+            })
+            .collect();
+
+        let component = components(&adjacency);
+
+        // A concept is recursive when its component has more than
+        // one member, or when it has a self-edge.
+        let mut component_size = vec![0usize; nodes.len()];
+        for &c in &component {
+            component_size[c] += 1;
+        }
+        let mut recursive = HashSet::new();
+        for (i, node) in nodes.iter().enumerate() {
+            let self_edge = adjacency[i].contains(&i);
+            if component_size[component[i]] > 1 || self_edge {
+                recursive.insert(node.clone());
+            }
+        }
+
+        // A negative edge whose endpoints share a component negates
+        // a set the cycle is still deriving.
+        let mut violations = Vec::new();
+        for node in &nodes {
+            let Some(out) = edges.get(node) else { continue };
+            for (target, polarity) in out {
+                if *polarity == Polarity::Negative
+                    && component[index_of[node]] == component[index_of[target]]
+                {
+                    violations.push(NegationViolation {
+                        concept: node.clone(),
+                        negated: target.clone(),
+                    });
+                }
+            }
+        }
+
+        ProgramAnalysis {
+            edges,
+            recursive,
+            violations,
+        }
+    }
+
+    /// Every stratification violation in the program, in
+    /// deterministic (concept-sorted) order.
+    pub fn violations(&self) -> &[NegationViolation] {
+        &self.violations
+    }
+
+    /// Whether the concept participates in a dependency cycle.
+    pub fn is_recursive(&self, concept: &Entity) -> bool {
+        self.recursive.contains(concept)
+    }
+
+    /// Check the queried concept's dependency closure: an
+    /// ill-stratified closure fails with
+    /// [`EvaluationError::NegationThroughRecursion`], and a
+    /// recursive (but stratified) closure fails with
+    /// [`EvaluationError::UnsupportedRecursion`] until the fixpoint
+    /// evaluator lands. Well-stratified, non-recursive closures (the
+    /// vast majority) pass.
+    ///
+    /// Takes the descriptor rather than the entity because the
+    /// queried concept may be unknown to the analysis (never
+    /// registered); its embedded `conforms` targets seed the walk.
+    pub fn check(&self, descriptor: &ConceptDescriptor) -> Result<(), EvaluationError> {
+        // Closure over the analysis edges, seeded with the queried
+        // concept's structural closure for the unregistered case.
+        let mut order = Vec::new();
+        let mut seen = HashSet::new();
+        let mut structural = VecDeque::from([descriptor.clone()]);
+        while let Some(descriptor) = structural.pop_front() {
+            let entity = descriptor.this();
+            if !seen.insert(entity.clone()) {
+                continue;
+            }
+            order.push(entity.clone());
+            if !self.edges.contains_key(&entity) {
+                for (target, _) in structural_edges(&descriptor) {
+                    structural.push_back(target);
+                }
+            }
+        }
+        let mut queue: VecDeque<Entity> = order.iter().cloned().collect();
+        while let Some(entity) = queue.pop_front() {
+            for (target, _) in self.edges.get(&entity).map(Vec::as_slice).unwrap_or(&[]) {
+                if seen.insert(target.clone()) {
+                    order.push(target.clone());
+                    queue.push_back(target.clone());
+                }
+            }
+        }
+
+        for violation in &self.violations {
+            if seen.contains(&violation.concept) {
+                return Err(EvaluationError::NegationThroughRecursion {
+                    concept: violation.concept.to_string(),
+                    negated: violation.negated.to_string(),
+                });
+            }
+        }
+        if let Some(concept) = order.iter().find(|entity| self.recursive.contains(*entity)) {
+            return Err(EvaluationError::UnsupportedRecursion {
+                concept: concept.to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Iterative Tarjan: returns the component id per node index.
+fn components(adjacency: &[Vec<usize>]) -> Vec<usize> {
+    struct Frame {
+        node: usize,
+        edge: usize,
+    }
+
+    let n = adjacency.len();
+    let mut index = vec![usize::MAX; n];
+    let mut lowlink = vec![0usize; n];
+    let mut on_stack = vec![false; n];
+    let mut stack = Vec::new();
+    let mut component = vec![usize::MAX; n];
+    let mut next_index = 0;
+    let mut next_component = 0;
+
+    for start in 0..n {
+        if index[start] != usize::MAX {
+            continue;
+        }
+        index[start] = next_index;
+        lowlink[start] = next_index;
+        next_index += 1;
+        stack.push(start);
+        on_stack[start] = true;
+        let mut frames = vec![Frame {
+            node: start,
+            edge: 0,
+        }];
+
+        while let Some(frame) = frames.last_mut() {
+            let v = frame.node;
+            if frame.edge < adjacency[v].len() {
+                let w = adjacency[v][frame.edge];
+                frame.edge += 1;
+                if index[w] == usize::MAX {
+                    index[w] = next_index;
+                    lowlink[w] = next_index;
+                    next_index += 1;
+                    stack.push(w);
+                    on_stack[w] = true;
+                    frames.push(Frame { node: w, edge: 0 });
+                } else if on_stack[w] {
+                    lowlink[v] = lowlink[v].min(index[w]);
+                }
+            } else {
+                frames.pop();
+                if let Some(parent) = frames.last() {
+                    lowlink[parent.node] = lowlink[parent.node].min(lowlink[v]);
+                }
+                if lowlink[v] == index[v] {
+                    while let Some(w) = stack.pop() {
+                        on_stack[w] = false;
+                        component[w] = next_component;
+                        if w == v {
+                            break;
+                        }
+                    }
+                    next_component += 1;
+                }
+            }
+        }
+    }
+
+    component
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::attribute::{AttributeDescriptor, Cardinality, Type};
+    use crate::concept::query::ConceptQuery;
+    use crate::session::RuleRegistry;
+    use crate::types::Any;
+    use crate::{ConceptFieldDescriptor, Parameters, Term};
+
+    /// A one-field concept in the given domain: `{domain}/name` as
+    /// text. Distinct domains produce distinct concept identities.
+    fn concept(domain: &str) -> ConceptDescriptor {
+        ConceptDescriptor::try_from(vec![(
+            "name",
+            AttributeDescriptor::new(
+                format!("{domain}/name").parse().expect("valid selector"),
+                "",
+                Cardinality::One,
+                Some(Type::String),
+            ),
+        )])
+        .expect("concept builds")
+    }
+
+    /// A rule concluding `conclusion` whose body asserts each
+    /// `positive` concept (binding `this` and `name`) and negates
+    /// each `negative` one (joined on `this`).
+    fn rule(
+        conclusion: &ConceptDescriptor,
+        positive: &[&ConceptDescriptor],
+        negative: &[&ConceptDescriptor],
+    ) -> DeductiveRule {
+        let mut premises: Vec<Premise> = Vec::new();
+        for target in positive {
+            let mut terms = Parameters::new();
+            terms.insert("this".to_string(), Term::<Entity>::var("this").into());
+            terms.insert("name".to_string(), Term::<Any>::var("name"));
+            premises.push(Premise::Assert(Proposition::Concept(ConceptQuery {
+                terms,
+                predicate: (*target).clone(),
+            })));
+        }
+        for target in negative {
+            let mut terms = Parameters::new();
+            terms.insert("this".to_string(), Term::<Entity>::var("this").into());
+            premises.push(Premise::Unless(Negation(Proposition::Concept(
+                ConceptQuery {
+                    terms,
+                    predicate: (*target).clone(),
+                },
+            ))));
+        }
+        DeductiveRule::new(conclusion.clone(), premises).expect("rule compiles")
+    }
+
+    /// The replica-merge scenario: `safe :- person, !blocked` and
+    /// `blocked :- safe, banned` are each valid alone; together they
+    /// form a cycle through negation. Both installs are accepted,
+    /// validate() reports the violation, and only queries touching
+    /// the cycle fail.
+    #[dialog_common::test]
+    fn it_accepts_and_reports_negation_through_recursion() {
+        let person = concept("person");
+        let banned = concept("banned");
+        let safe = concept("safe");
+        let blocked = concept("blocked");
+
+        let mut registry = RuleRegistry::new();
+        registry
+            .register(rule(&safe, &[&person], &[&blocked]))
+            .expect("install is unconditional");
+        registry
+            .register(rule(&blocked, &[&safe, &banned], &[]))
+            .expect("install is unconditional");
+
+        let violations = registry.validate().expect("validate");
+        assert_eq!(
+            violations,
+            vec![NegationViolation {
+                concept: safe.this(),
+                negated: blocked.this(),
+            }]
+        );
+
+        assert!(registry.is_recursive(&safe.this()).unwrap());
+        assert!(registry.is_recursive(&blocked.this()).unwrap());
+        assert!(!registry.is_recursive(&person.this()).unwrap());
+
+        match registry.acquire(&safe) {
+            Err(EvaluationError::NegationThroughRecursion { concept, negated }) => {
+                assert_eq!(concept, safe.this().to_string());
+                assert_eq!(negated, blocked.this().to_string());
+            }
+            other => panic!("expected NegationThroughRecursion, got {other:?}"),
+        }
+        assert!(
+            matches!(
+                registry.acquire(&blocked),
+                Err(EvaluationError::NegationThroughRecursion { .. })
+            ),
+            "the whole cycle is poisoned"
+        );
+        assert!(
+            registry.acquire(&person).is_ok(),
+            "concepts outside the ill-stratified region still answer"
+        );
+    }
+
+    /// A well-stratified recursive closure is rejected with a
+    /// structured error until the fixpoint evaluator lands, rather
+    /// than evaluated unboundedly.
+    #[dialog_common::test]
+    fn it_rejects_recursive_closures_until_fixpoint() {
+        let same = concept("same");
+        let mut registry = RuleRegistry::new();
+        registry.register(rule(&same, &[&same], &[])).unwrap();
+
+        assert!(registry.validate().unwrap().is_empty(), "stratified");
+        assert!(registry.is_recursive(&same.this()).unwrap());
+        match registry.acquire(&same) {
+            Err(EvaluationError::UnsupportedRecursion { concept }) => {
+                assert_eq!(concept, same.this().to_string());
+            }
+            other => panic!("expected UnsupportedRecursion, got {other:?}"),
+        }
+    }
+
+    /// Mutual recursion across two concepts and a transitive
+    /// three-concept cycle are both detected.
+    #[dialog_common::test]
+    fn it_detects_mutual_and_transitive_recursion() {
+        let a = concept("aaa");
+        let b = concept("bbb");
+        let c = concept("ccc");
+
+        let mut mutual = RuleRegistry::new();
+        mutual.register(rule(&a, &[&b], &[])).unwrap();
+        mutual.register(rule(&b, &[&a], &[])).unwrap();
+        assert!(mutual.is_recursive(&a.this()).unwrap());
+        assert!(mutual.is_recursive(&b.this()).unwrap());
+        assert!(matches!(
+            mutual.acquire(&a),
+            Err(EvaluationError::UnsupportedRecursion { .. })
+        ));
+
+        let mut transitive = RuleRegistry::new();
+        transitive.register(rule(&a, &[&b], &[])).unwrap();
+        transitive.register(rule(&b, &[&c], &[])).unwrap();
+        transitive.register(rule(&c, &[&a], &[])).unwrap();
+        for concept in [&a, &b, &c] {
+            assert!(transitive.is_recursive(&concept.this()).unwrap());
+            assert!(matches!(
+                transitive.acquire(concept),
+                Err(EvaluationError::UnsupportedRecursion { .. })
+            ));
+        }
+    }
+
+    /// Ordered-variant style negation over acyclic concepts is
+    /// well-stratified: no violations, queries proceed.
+    #[dialog_common::test]
+    fn it_passes_well_stratified_negation() {
+        let contact = concept("contact");
+        let email = concept("email");
+        let phone = concept("phone");
+
+        let mut registry = RuleRegistry::new();
+        registry.register(rule(&contact, &[&email], &[])).unwrap();
+        registry
+            .register(rule(&contact, &[&phone], &[&email]))
+            .unwrap();
+
+        assert!(registry.validate().unwrap().is_empty());
+        assert!(!registry.is_recursive(&contact.this()).unwrap());
+        assert!(registry.acquire(&contact).is_ok());
+    }
+
+    /// The post-merge case: each registry is valid alone; extending
+    /// one with the other closes a cycle through negation, and the
+    /// merged analysis reports it.
+    #[dialog_common::test]
+    fn it_reports_violation_closed_by_merge() {
+        let person = concept("person");
+        let banned = concept("banned");
+        let safe = concept("safe");
+        let blocked = concept("blocked");
+
+        let mut replica_a = RuleRegistry::new();
+        replica_a
+            .register(rule(&safe, &[&person], &[&blocked]))
+            .unwrap();
+        assert!(replica_a.validate().unwrap().is_empty());
+        assert!(replica_a.acquire(&safe).is_ok(), "valid before the merge");
+
+        let mut replica_b = RuleRegistry::new();
+        replica_b
+            .register(rule(&blocked, &[&safe, &banned], &[]))
+            .unwrap();
+        assert!(replica_b.validate().unwrap().is_empty());
+
+        replica_a.extend(&replica_b).unwrap();
+        assert_eq!(replica_a.validate().unwrap().len(), 1);
+        assert!(matches!(
+            replica_a.acquire(&safe),
+            Err(EvaluationError::NegationThroughRecursion { .. })
+        ));
+    }
+
+    /// Concept-typed fields contribute structural edges: a concept
+    /// whose field conforms to a target participates in cycles the
+    /// target's rules close, even when the outer concept itself has
+    /// no registry entry.
+    #[dialog_common::test]
+    fn it_walks_conformance_edges_structurally() {
+        let inner = concept("inner");
+        let outer = ConceptDescriptor::try_from(vec![
+            (
+                "name".to_string(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::new(
+                    "outer/name".parse().expect("valid selector"),
+                    "",
+                    Cardinality::One,
+                    Some(Type::String),
+                )),
+            ),
+            (
+                "peer".to_string(),
+                ConceptFieldDescriptor::conforming(
+                    AttributeDescriptor::new(
+                        "outer/peer".parse().expect("valid selector"),
+                        "",
+                        Cardinality::One,
+                        Some(Type::Entity),
+                    ),
+                    inner.clone(),
+                )
+                .expect("entity-valued"),
+            ),
+        ])
+        .unwrap();
+
+        // inner's installed rule references outer, closing the
+        // cycle outer -> inner -> outer.
+        let mut registry = RuleRegistry::new();
+        registry.register(rule(&inner, &[&outer], &[])).unwrap();
+
+        assert!(matches!(
+            registry.acquire(&outer),
+            Err(EvaluationError::UnsupportedRecursion { .. })
+        ));
+        assert!(
+            registry.acquire(&inner).is_err(),
+            "the cycle is visible from both ends"
+        );
+    }
+}

--- a/rust/dialog-query/src/session/dependencies.rs
+++ b/rust/dialog-query/src/session/dependencies.rs
@@ -106,8 +106,24 @@ pub struct ProgramAnalysis {
     /// Concepts whose strongly connected component is non-trivial
     /// (more than one member, or a self-edge).
     recursive: HashSet<Entity>,
+    /// Strongly connected component id per concept. Two recursive
+    /// concepts with the same id are on the same cycle.
+    component: HashMap<Entity, usize>,
     /// Every negative edge that lands inside its own component.
     violations: Vec<NegationViolation>,
+}
+
+/// The shape of a queried concept's dependency closure, as
+/// classified by [`ProgramAnalysis::check`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Closure {
+    /// No dependency cycle anywhere in the closure: ordinary
+    /// top-down evaluation applies.
+    Acyclic,
+    /// The closure contains at least one cycle (all of them
+    /// stratified): recursive concepts in it evaluate via the
+    /// semi-naive fixpoint.
+    Recursive,
 }
 
 impl ProgramAnalysis {
@@ -201,9 +217,16 @@ impl ProgramAnalysis {
             }
         }
 
+        let component = nodes
+            .iter()
+            .enumerate()
+            .map(|(i, node)| (node.clone(), component[i]))
+            .collect();
+
         ProgramAnalysis {
             edges,
             recursive,
+            component,
             violations,
         }
     }
@@ -219,18 +242,31 @@ impl ProgramAnalysis {
         self.recursive.contains(concept)
     }
 
+    /// Whether the two concepts sit on the *same* dependency cycle:
+    /// both recursive and in the same strongly connected component.
+    /// This is the membership test the fixpoint evaluator uses to
+    /// tell recursive occurrences (evaluated from the answer table)
+    /// from base premises (evaluated top-down).
+    pub fn in_same_cycle(&self, a: &Entity, b: &Entity) -> bool {
+        self.recursive.contains(a)
+            && self.recursive.contains(b)
+            && match (self.component.get(a), self.component.get(b)) {
+                (Some(x), Some(y)) => x == y,
+                _ => false,
+            }
+    }
+
     /// Check the queried concept's dependency closure: an
     /// ill-stratified closure fails with
-    /// [`EvaluationError::NegationThroughRecursion`], and a
-    /// recursive (but stratified) closure fails with
-    /// [`EvaluationError::UnsupportedRecursion`] until the fixpoint
-    /// evaluator lands. Well-stratified, non-recursive closures (the
-    /// vast majority) pass.
+    /// [`EvaluationError::NegationThroughRecursion`]; otherwise the
+    /// closure is classified [`Closure::Recursive`] when it contains
+    /// a cycle (the fixpoint evaluator's cue) or [`Closure::Acyclic`]
+    /// for ordinary top-down evaluation.
     ///
     /// Takes the descriptor rather than the entity because the
     /// queried concept may be unknown to the analysis (never
     /// registered); its embedded `conforms` targets seed the walk.
-    pub fn check(&self, descriptor: &ConceptDescriptor) -> Result<(), EvaluationError> {
+    pub fn check(&self, descriptor: &ConceptDescriptor) -> Result<Closure, EvaluationError> {
         // Closure over the analysis edges, seeded with the queried
         // concept's structural closure for the unregistered case.
         let mut order = Vec::new();
@@ -266,12 +302,11 @@ impl ProgramAnalysis {
                 });
             }
         }
-        if let Some(concept) = order.iter().find(|entity| self.recursive.contains(*entity)) {
-            return Err(EvaluationError::UnsupportedRecursion {
-                concept: concept.to_string(),
-            });
+        if order.iter().any(|entity| self.recursive.contains(entity)) {
+            Ok(Closure::Recursive)
+        } else {
+            Ok(Closure::Acyclic)
         }
-        Ok(())
     }
 }
 
@@ -457,23 +492,23 @@ mod tests {
     /// structured error until the fixpoint evaluator lands, rather
     /// than evaluated unboundedly.
     #[dialog_common::test]
-    fn it_rejects_recursive_closures_until_fixpoint() {
+    fn it_marks_recursive_closures_for_fixpoint_evaluation() {
         let same = concept("same");
         let mut registry = RuleRegistry::new();
         registry.register(rule(&same, &[&same], &[])).unwrap();
 
         assert!(registry.validate().unwrap().is_empty(), "stratified");
         assert!(registry.is_recursive(&same.this()).unwrap());
-        match registry.acquire(&same) {
-            Err(EvaluationError::UnsupportedRecursion { concept }) => {
-                assert_eq!(concept, same.this().to_string());
-            }
-            other => panic!("expected UnsupportedRecursion, got {other:?}"),
-        }
+        let rules = registry.acquire(&same).expect("recursive concepts answer");
+        assert!(
+            rules.recursion().is_some(),
+            "the rules carry the analysis so evaluation runs the fixpoint"
+        );
     }
 
     /// Mutual recursion across two concepts and a transitive
-    /// three-concept cycle are both detected.
+    /// three-concept cycle are both detected, and each member's
+    /// rules carry the recursion context.
     #[dialog_common::test]
     fn it_detects_mutual_and_transitive_recursion() {
         let a = concept("aaa");
@@ -485,10 +520,9 @@ mod tests {
         mutual.register(rule(&b, &[&a], &[])).unwrap();
         assert!(mutual.is_recursive(&a.this()).unwrap());
         assert!(mutual.is_recursive(&b.this()).unwrap());
-        assert!(matches!(
-            mutual.acquire(&a),
-            Err(EvaluationError::UnsupportedRecursion { .. })
-        ));
+        assert!(mutual.acquire(&a).unwrap().recursion().is_some());
+        let analysis = mutual.analysis().unwrap();
+        assert!(analysis.in_same_cycle(&a.this(), &b.this()));
 
         let mut transitive = RuleRegistry::new();
         transitive.register(rule(&a, &[&b], &[])).unwrap();
@@ -496,11 +530,14 @@ mod tests {
         transitive.register(rule(&c, &[&a], &[])).unwrap();
         for concept in [&a, &b, &c] {
             assert!(transitive.is_recursive(&concept.this()).unwrap());
-            assert!(matches!(
-                transitive.acquire(concept),
-                Err(EvaluationError::UnsupportedRecursion { .. })
-            ));
+            assert!(transitive.acquire(concept).unwrap().recursion().is_some());
         }
+        let analysis = transitive.analysis().unwrap();
+        assert!(analysis.in_same_cycle(&a.this(), &c.this()));
+        assert!(
+            !analysis.in_same_cycle(&a.this(), &concept("ddd").this()),
+            "concepts outside the cycle are not members"
+        );
     }
 
     /// Ordered-variant style negation over acyclic concepts is
@@ -591,12 +628,20 @@ mod tests {
         let mut registry = RuleRegistry::new();
         registry.register(rule(&inner, &[&outer], &[])).unwrap();
 
-        assert!(matches!(
-            registry.acquire(&outer),
-            Err(EvaluationError::UnsupportedRecursion { .. })
-        ));
         assert!(
-            registry.acquire(&inner).is_err(),
+            registry
+                .acquire(&outer)
+                .expect("recursive concepts answer")
+                .recursion()
+                .is_some(),
+            "the conformance cycle is visible from the unregistered end"
+        );
+        assert!(
+            registry
+                .acquire(&inner)
+                .expect("recursive concepts answer")
+                .recursion()
+                .is_some(),
             "the cycle is visible from both ends"
         );
     }

--- a/rust/dialog-query/src/session/rule_registry.rs
+++ b/rust/dialog-query/src/session/rule_registry.rs
@@ -1,3 +1,4 @@
+use super::dependencies::{NegationViolation, ProgramAnalysis};
 use crate::Entity;
 use crate::EvaluationError;
 use crate::concept::descriptor::ConceptDescriptor;
@@ -27,6 +28,10 @@ use std::sync::{Arc, RwLock};
 #[derive(Debug, Clone, Default)]
 pub struct RuleRegistry {
     rules: Arc<RwLock<HashMap<Entity, ConceptRules>>>,
+    /// Lazily computed program-level dependency analysis (recursion
+    /// and stratification), shared across clones and invalidated by
+    /// [`register`](Self::register) / [`extend`](Self::extend).
+    analysis: Arc<RwLock<Option<Arc<ProgramAnalysis>>>>,
 }
 
 impl RuleRegistry {
@@ -37,6 +42,13 @@ impl RuleRegistry {
 
     /// Register a deductive rule, deduplicating by equality.
     /// Invalidates cached plans for the affected concept entity.
+    ///
+    /// Registration is *unconditional* with respect to
+    /// stratification: rules can be installed concurrently on
+    /// multiple replicas and the merged set must converge, so
+    /// whole-set properties (recursion, negation through recursion)
+    /// are checked by [`validate`](Self::validate) and at query
+    /// time, never here. Only lock poisoning errors.
     pub fn register(&mut self, rule: DeductiveRule) -> Result<(), EvaluationError> {
         let entity = rule.conclusion().this();
         self.rules
@@ -45,13 +57,22 @@ impl RuleRegistry {
             .entry(entity)
             .or_insert_with(|| ConceptRules::new(rule.conclusion()))
             .install(rule);
+        self.invalidate_analysis()?;
         Ok(())
     }
 
     /// Acquire rules for the given concept. Creates the default rule from
     /// the predicate's attributes on first access, so this always returns
     /// a ConceptRules regardless of whether any rules were explicitly installed.
+    ///
+    /// Runs the query-time dependency check over the concept's
+    /// closure first: an ill-stratified closure fails with
+    /// [`EvaluationError::NegationThroughRecursion`], a recursive
+    /// one with [`EvaluationError::UnsupportedRecursion`] (until the
+    /// fixpoint evaluator lands). Ill-stratified regions of the
+    /// program fail exactly the queries that touch them.
     pub fn acquire(&self, predicate: &ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
+        self.analysis()?.check(predicate)?;
         let entity = predicate.this();
         Ok(self
             .rules
@@ -66,6 +87,9 @@ impl RuleRegistry {
     ///
     /// Entries that exist on both sides are folded together via
     /// [`ConceptRules::extend`] so installed rules from both contribute.
+    /// Like [`register`](Self::register), merging is unconditional:
+    /// the merged set may be ill-stratified, which
+    /// [`validate`](Self::validate) reports and queries surface.
     pub fn extend(&mut self, other: &RuleRegistry) -> Result<(), EvaluationError> {
         let other_rules = other
             .rules
@@ -81,6 +105,54 @@ impl RuleRegistry {
                 .and_modify(|existing| existing.extend(rules))
                 .or_insert_with(|| rules.clone());
         }
+        drop(self_rules);
+        self.invalidate_analysis()?;
+        Ok(())
+    }
+
+    /// The current program analysis snapshot, computing it if the
+    /// rule set changed since the last one.
+    pub fn analysis(&self) -> Result<Arc<ProgramAnalysis>, EvaluationError> {
+        if let Some(analysis) = self
+            .analysis
+            .read()
+            .map_err(|e| EvaluationError::Store(e.to_string()))?
+            .as_ref()
+        {
+            return Ok(analysis.clone());
+        }
+        let rules = self
+            .rules
+            .read()
+            .map_err(|e| EvaluationError::Store(e.to_string()))?;
+        let analysis = Arc::new(ProgramAnalysis::analyze(rules.iter()));
+        drop(rules);
+        *self
+            .analysis
+            .write()
+            .map_err(|e| EvaluationError::Store(e.to_string()))? = Some(analysis.clone());
+        Ok(analysis)
+    }
+
+    /// Every stratification violation in the current rule set.
+    /// Callers decide what to do: surface as a warning after an
+    /// install, refuse to proceed after a merge, or ignore and let
+    /// queries fail individually.
+    pub fn validate(&self) -> Result<Vec<NegationViolation>, EvaluationError> {
+        Ok(self.analysis()?.violations().to_vec())
+    }
+
+    /// Whether the concept participates in a dependency cycle in
+    /// the current rule set.
+    pub fn is_recursive(&self, concept: &Entity) -> Result<bool, EvaluationError> {
+        Ok(self.analysis()?.is_recursive(concept))
+    }
+
+    fn invalidate_analysis(&self) -> Result<(), EvaluationError> {
+        *self
+            .analysis
+            .write()
+            .map_err(|e| EvaluationError::Store(e.to_string()))? = None;
         Ok(())
     }
 }

--- a/rust/dialog-query/src/session/rule_registry.rs
+++ b/rust/dialog-query/src/session/rule_registry.rs
@@ -67,20 +67,28 @@ impl RuleRegistry {
     ///
     /// Runs the query-time dependency check over the concept's
     /// closure first: an ill-stratified closure fails with
-    /// [`EvaluationError::NegationThroughRecursion`], a recursive
-    /// one with [`EvaluationError::UnsupportedRecursion`] (until the
-    /// fixpoint evaluator lands). Ill-stratified regions of the
-    /// program fail exactly the queries that touch them.
+    /// [`EvaluationError::NegationThroughRecursion`], so
+    /// ill-stratified regions of the program fail exactly the
+    /// queries that touch them. When the concept itself sits on a
+    /// (stratified) dependency cycle, the returned rules carry the
+    /// program analysis so evaluation switches to the semi-naive
+    /// fixpoint.
     pub fn acquire(&self, predicate: &ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
-        self.analysis()?.check(predicate)?;
+        let analysis = self.analysis()?;
+        analysis.check(predicate)?;
         let entity = predicate.this();
-        Ok(self
+        let rules = self
             .rules
             .write()
             .map_err(|e| EvaluationError::Store(e.to_string()))?
-            .entry(entity)
+            .entry(entity.clone())
             .or_insert_with(|| ConceptRules::new(predicate))
-            .clone())
+            .clone();
+        Ok(if analysis.is_recursive(&entity) {
+            rules.with_recursion(analysis)
+        } else {
+            rules
+        })
     }
 
     /// Merge every per-concept rule set from `other` into this registry.

--- a/rust/dialog-query/src/stream.rs
+++ b/rust/dialog-query/src/stream.rs
@@ -33,6 +33,7 @@ where
 #[cfg(not(target_arch = "wasm32"))]
 fn spawn<F>(future: F)
 where
+    // bare-send-ok: native-only fn feeding tokio::spawn, which requires real Send
     F: Future<Output = ()> + Send + 'static,
 {
     tokio::spawn(future);

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -7,12 +7,11 @@
 //! and the schema layer.
 //!
 //! A [`Type`] is the set of admissible value shapes a slot may
-//! bind. It is built from a [`Primitive`] bitfield (the atomic
-//! shapes, plus a `Nothing` bit for set-widened optionality) and an
-//! optional set of [`Composite`] shapes (Product records, Variant
-//! tags). The two parts compose by set-union: a value satisfies
-//! [`Type`] iff it inhabits at least one of the primitive bits or
-//! one of the composite shapes.
+//! bind: a [`Primitive`] bitfield (the atomic shapes, plus a
+//! `Nothing` bit for set-widened optionality), optionally narrowed
+//! by a value-level [`Refinement`]. A value satisfies [`Type`] iff
+//! its data type is a member of the primitive set and the
+//! refinement (if any) admits the value itself.
 //!
 //! Type variables (used for compile-time unification of rules)
 //! live in the [`unifier`] submodule, never in the user-facing
@@ -26,7 +25,7 @@ pub mod unifier;
 use crate::artifact::Type as ValueType;
 use crate::artifact::Value;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// A bitfield over [`ValueType`] variants plus a `Nothing` bit:
@@ -271,49 +270,21 @@ impl From<Primitive> for Type {
     }
 }
 
-/// Schema-layer type: the set of admissible value shapes a slot
-/// can bind.
-///
-/// A [`Type`] is the union of two parts:
-///
-/// - A [`Primitive`] bitfield carrying atomic [`ValueType`] bits
-///   plus an optional `Nothing` atom (row-level absence).
-/// - An optional non-empty set of [`Composite`] shapes for
-///   structured values (records, variants).
-///
-/// Smart constructors enforce the invariant that
-/// `Composite(_, set)` always has `!set.is_empty()`; a request to
-/// build a composite with an empty set collapses to a plain
-/// `Primitive`.
-///
-/// Composites live in a [`BTreeSet`] rather than a [`HashSet`].
-/// Two reasons:
-///
 impl Display for Type {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Type::Primitive(p) => write!(f, "{p}"),
-            Type::Composite(p, c) => write!(f, "{p}+{} composite", c.len()),
-            Type::Refined(p, r) => write!(f, "{p}[starts-with {:?}]", r.prefix),
+            Type::Refined(p, r) => write!(f, "{p}[{r}]"),
         }
     }
 }
 
-/// 1. `Type` derives [`Hash`]. `BTreeSet` iterates in a stable
-///    `Ord`-based order, so the derived hash is canonical:
-///    `Type::Composite(p, {a, b})` and `Type::Composite(p, {b, a})`
-///    have identical hashes. `HashSet` does not implement `Hash`
-///    in std, and any hand-rolled order-independent hash would
-///    have to sort internally anyway, and `BTreeSet` is that already.
+/// Schema-layer type: the set of admissible value shapes a slot
+/// can bind.
 ///
-/// 2. Insertion order at construction never affects equality.
-///    Building the same set via different paths (different unions,
-///    different insert orders) yields equal [`Type`]s.
-///
-/// The cost is requiring [`Ord`] on [`Composite`], [`Type`], and
-/// [`Primitive`]. The ordering is structural plumbing; it has no
-/// semantic meaning (no claim that `u32 < String`); it exists only
-/// to keep the set canonical.
+/// A [`Type`] is a [`Primitive`] bitfield carrying atomic
+/// [`ValueType`] bits plus an optional `Nothing` atom (row-level
+/// absence), optionally narrowed by a value-level [`Refinement`].
 ///
 /// `Type` is fully static: no type variables, no allocation
 /// state. Deriving [`PartialEq`]/[`Eq`]/[`Hash`] is safe and
@@ -321,23 +292,32 @@ impl Display for Type {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
-    /// Pure primitive set (no composite shapes admitted).
+    /// Pure primitive membership set.
     Primitive(Primitive),
-    /// The union of a primitive set and a non-empty set of composite
-    /// shapes: a value satisfies it if it inhabits one of the
-    /// primitive bits OR matches one of the composite shapes (not
-    /// the intersection of the two). The primitive set may be empty,
-    /// giving a pure composite type. Invariant: the composite set is
-    /// never empty (an empty one collapses to `Primitive`).
-    Composite(Primitive, BTreeSet<Composite>),
     /// Primitive set narrowed by a [`Refinement`] on the *values*
     /// of the member types — not just which types are admitted, but
     /// which of their inhabitants. Produced by refinement
     /// predicates (`starts-with`); consumed by scan-range pushdown
     /// and, like every kind, by [`Type::admits`] at the data
-    /// boundary. Admits no composite shapes (refinements constrain
-    /// lexical forms, which composites do not have).
+    /// boundary.
     Refined(Primitive, Refinement),
+}
+
+/// Opaque identity of a concept an entity must conform to — the
+/// concept's content-derived entity URI (`concept:{hash}`).
+///
+/// Deliberately opaque on the lattice: subsumption *between*
+/// concepts (attribute-set inclusion) needs their descriptors,
+/// which the lattice does not carry. The analyzer canonicalizes
+/// conformance sets against the registry before refinements enter
+/// unification; the lattice orders them by plain set inclusion.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ConceptRef(pub String);
+
+impl Display for ConceptRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", self.0)
+    }
 }
 
 /// A value-level constraint layered onto a primitive membership
@@ -345,53 +325,142 @@ pub enum Type {
 /// constraints), the join their weakest common implication — see
 /// [`Refinement::meet`] and [`Refinement::join`].
 ///
-/// Today one refinement exists: a lexical prefix over the TEXTUAL
-/// kinds. Numeric intervals and Entity concept-membership (M3)
-/// extend this struct rather than adding lattice variants.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+/// Two constraints exist: a lexical prefix over the TEXTUAL kinds,
+/// and a conformance set over Entity — the value must satisfy a
+/// concept-typed field's target concepts. Numeric intervals extend
+/// this struct the same way rather than adding lattice variants.
+///
+/// Invariant: never empty (no prefix and no conformance is no
+/// refinement; the constructors collapse it to an unrefined type).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Refinement {
     /// Lexical prefix every admitted value must begin with.
-    /// Invariant: non-empty (an empty prefix is no refinement; the
-    /// constructors collapse it).
-    pub prefix: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+    /// Concepts the value's entity must conform to — all of them
+    /// (the meet unions this set). Carried as *information*: an
+    /// entity's conformance is not a property of the scalar (it is
+    /// "facts exist"), so enforcement is structural — the analyzer
+    /// conjoins the target concept's premises on the field — while
+    /// this set feeds inclusion ordering, demand covers, and
+    /// diagnostics.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub conforms: BTreeSet<ConceptRef>,
 }
 
 impl Refinement {
-    /// Meet: the conjunction of both constraints. Two prefixes are
-    /// jointly satisfiable iff one extends the other, and the meet
-    /// is the longer; disjoint prefixes admit nothing.
-    fn meet(&self, other: &Refinement) -> Option<Refinement> {
-        if self.prefix.starts_with(&other.prefix) {
-            Some(self.clone())
-        } else if other.prefix.starts_with(&self.prefix) {
-            Some(other.clone())
-        } else {
-            None
+    /// A prefix-only refinement.
+    fn prefix(prefix: String) -> Refinement {
+        Refinement {
+            prefix: Some(prefix),
+            conforms: BTreeSet::new(),
         }
+    }
+
+    /// True when the refinement constrains nothing — the shape the
+    /// constructors collapse to an unrefined type.
+    fn is_empty(&self) -> bool {
+        self.prefix.is_none() && self.conforms.is_empty()
+    }
+
+    /// Meet: the conjunction of both constraints. Two prefixes are
+    /// jointly satisfiable iff one extends the other (the meet is
+    /// the longer; disjoint prefixes admit nothing); conformance
+    /// sets union — the value must satisfy both sides' concepts.
+    fn meet(&self, other: &Refinement) -> Option<Refinement> {
+        let prefix = match (&self.prefix, &other.prefix) {
+            (Some(a), Some(b)) => {
+                if a.starts_with(b.as_str()) {
+                    Some(a.clone())
+                } else if b.starts_with(a.as_str()) {
+                    Some(b.clone())
+                } else {
+                    return None;
+                }
+            }
+            (Some(p), None) | (None, Some(p)) => Some(p.clone()),
+            (None, None) => None,
+        };
+        let conforms = self.conforms.union(&other.conforms).cloned().collect();
+        Some(Refinement { prefix, conforms })
     }
 
     /// Join: the weakest constraint both sides imply — the longest
-    /// common prefix. `None` when nothing is common (the join
-    /// carries no refinement).
+    /// common prefix (a side without one implies none) and the
+    /// intersection of the conformance sets. `None` when nothing
+    /// remains (the join carries no refinement).
     fn join(&self, other: &Refinement) -> Option<Refinement> {
-        let common: String = self
-            .prefix
-            .chars()
-            .zip(other.prefix.chars())
-            .take_while(|(a, b)| a == b)
-            .map(|(a, _)| a)
+        let prefix = match (&self.prefix, &other.prefix) {
+            (Some(a), Some(b)) => {
+                let common: String = a
+                    .chars()
+                    .zip(b.chars())
+                    .take_while(|(x, y)| x == y)
+                    .map(|(x, _)| x)
+                    .collect();
+                if common.is_empty() {
+                    None
+                } else {
+                    Some(common)
+                }
+            }
+            _ => None,
+        };
+        let conforms: BTreeSet<ConceptRef> = self
+            .conforms
+            .intersection(&other.conforms)
+            .cloned()
             .collect();
-        if common.is_empty() {
+        let joined = Refinement { prefix, conforms };
+        if joined.is_empty() {
             None
         } else {
-            Some(Refinement { prefix: common })
+            Some(joined)
         }
     }
 
-    /// True when the value's lexical form satisfies the refinement.
-    /// Values without a lexical form satisfy no prefix.
+    /// True when `other` is at least as constrained as `self` —
+    /// every value satisfying `other` satisfies `self`. The
+    /// inclusion check behind [`Type::includes`].
+    fn implied_by(&self, other: &Refinement) -> bool {
+        let prefix_implied = match (&self.prefix, &other.prefix) {
+            (Some(a), Some(b)) => b.starts_with(a.as_str()),
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        prefix_implied && self.conforms.is_subset(&other.conforms)
+    }
+
+    /// True when the value satisfies the row-locally checkable half
+    /// of the refinement: the lexical prefix. Values without a
+    /// lexical form satisfy no prefix. Conformance is deliberately
+    /// not checked here — see the field doc; its enforcement is the
+    /// desugared premises' job.
     pub fn admits(&self, value: &Value) -> bool {
-        lexical_form(value).is_some_and(|form| form.starts_with(&self.prefix))
+        match &self.prefix {
+            Some(prefix) => {
+                lexical_form(value).is_some_and(|form| form.starts_with(prefix.as_str()))
+            }
+            None => true,
+        }
+    }
+}
+
+impl Display for Refinement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let mut separate = false;
+        if let Some(prefix) = &self.prefix {
+            write!(f, "starts-with {prefix:?}")?;
+            separate = true;
+        }
+        for concept in &self.conforms {
+            if separate {
+                write!(f, " & ")?;
+            }
+            write!(f, "conforms-to {concept}")?;
+            separate = true;
+        }
+        Ok(())
     }
 }
 
@@ -408,23 +477,6 @@ pub fn lexical_form(value: &Value) -> Option<String> {
     }
 }
 
-/// A composite (structured) value shape. Ordered by derived
-/// [`Ord`] for stable iteration and hashing inside a [`BTreeSet`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Composite {
-    /// Product (record) type with named fields. Field names ordered
-    /// by [`BTreeMap`] for stable equality and hashing.
-    Product(BTreeMap<String, Type>),
-    /// Sum-type variant carrying a single label and its payload.
-    Variant {
-        /// The discriminator label.
-        label: String,
-        /// The payload type for this label.
-        value: Type,
-    },
-}
-
 impl Type {
     /// The type whose only inhabitant is the `Nothing` atom: the
     /// "absent" row-layer value.
@@ -437,7 +489,6 @@ impl Type {
     pub fn optional(self) -> Type {
         match self {
             Type::Primitive(p) => Type::Primitive(p.union(Primitive::NOTHING)),
-            Type::Composite(p, c) => Type::Composite(p.union(Primitive::NOTHING), c),
             Type::Refined(p, r) => Type::Refined(p.union(Primitive::NOTHING), r),
         }
     }
@@ -445,15 +496,13 @@ impl Type {
     /// True when the given runtime value inhabits this type: the
     /// value's data type is a member of the primitive part, and the
     /// refinement (if any) admits the value itself.
-    /// Composite refinements are not yet checked; no composite
-    /// values flow through evaluation today.
     pub fn admits(&self, value: &Value) -> bool {
         if !self.primitive_part().contains(value.data_type()) {
             return false;
         }
         match self {
             Type::Refined(_, r) => r.admits(value),
-            _ => true,
+            Type::Primitive(_) => true,
         }
     }
 
@@ -463,7 +512,6 @@ impl Type {
     pub fn required(self) -> Type {
         match self {
             Type::Primitive(p) => Type::Primitive(p.required()),
-            Type::Composite(p, c) => Type::Composite(p.required(), c),
             Type::Refined(p, r) => Type::Refined(p.required(), r),
         }
     }
@@ -489,9 +537,33 @@ impl Type {
             return None;
         }
         let refinement = match &self {
-            Type::Refined(_, existing) => existing.meet(&Refinement { prefix })?,
-            _ => Refinement { prefix },
+            Type::Refined(_, existing) => existing.meet(&Refinement::prefix(prefix))?,
+            _ => Refinement::prefix(prefix),
         };
+        Some(Type::Refined(membership, refinement))
+    }
+
+    /// Constrain this type's values to entities conforming to the
+    /// given concept — the lattice form of a concept-typed field.
+    ///
+    /// The membership narrows to Entity (the `Nothing` bit, if
+    /// present, rides along — an optional concept-typed field is
+    /// still optional). Returns `None` when no entity could inhabit
+    /// the type — an empty meet, the ordinary
+    /// known-types-misalign conflict. Conformance accumulates: an
+    /// existing refinement gains the concept.
+    pub fn with_conformance(self, concept: ConceptRef) -> Option<Type> {
+        let membership = self
+            .primitive_part()
+            .intersect(Primitive::from(ValueType::Entity).union(Primitive::NOTHING))?;
+        if membership.required().is_empty() {
+            return None;
+        }
+        let mut refinement = match self {
+            Type::Refined(_, r) => r,
+            Type::Primitive(_) => Refinement::default(),
+        };
+        refinement.conforms.insert(concept);
         Some(Type::Refined(membership, refinement))
     }
 
@@ -499,100 +571,42 @@ impl Type {
     pub fn refinement(&self) -> Option<&Refinement> {
         match self {
             Type::Refined(_, r) => Some(r),
-            _ => None,
+            Type::Primitive(_) => None,
         }
     }
 
     /// Rebuild this type around a replacement primitive part,
-    /// preserving its composite or refinement structure. The
-    /// unifier uses this so a resolution that narrows membership
-    /// does not silently shed the rest of the type.
+    /// preserving its refinement structure. The unifier uses this
+    /// so a resolution that narrows membership does not silently
+    /// shed the rest of the type.
     pub(crate) fn with_primitive_part(&self, p: Primitive) -> Type {
         match self {
             Type::Primitive(_) => Type::Primitive(p),
-            Type::Composite(_, c) => Type::composite(p, c.clone()),
             Type::Refined(_, r) => Type::Refined(p, r.clone()),
         }
     }
 
-    /// Smart constructor. Collapses `Composite(p, empty)` to
-    /// `Primitive(p)`. Use this rather than building the
-    /// `Composite` variant directly.
-    pub fn composite(primitive: Primitive, composite: BTreeSet<Composite>) -> Type {
-        if composite.is_empty() {
-            Type::Primitive(primitive)
-        } else {
-            Type::Composite(primitive, composite)
-        }
-    }
-
-    /// Build a record type from named fields.
-    pub fn product(fields: BTreeMap<String, Type>) -> Type {
-        let mut set = BTreeSet::new();
-        set.insert(Composite::Product(fields));
-        Type::Composite(Primitive::EMPTY, set)
-    }
-
-    /// Build a singleton variant type from a label and payload.
-    pub fn variant(label: impl Into<String>, value: Type) -> Type {
-        let mut set = BTreeSet::new();
-        set.insert(Composite::Variant {
-            label: label.into(),
-            value,
-        });
-        Type::Composite(Primitive::EMPTY, set)
-    }
-
-    /// Set intersection over both primitive and composite parts.
-    /// Returns `None` when the result is empty: no admissible
-    /// shapes survive.
+    /// Set intersection: the meet of both memberships and both
+    /// refinements. Returns `None` when the result is empty: no
+    /// admissible shapes survive.
     ///
-    /// Composite shapes narrow structurally: two
-    /// `Composite::Product` values with the same field-name set
-    /// intersect their field types recursively (if any field
-    /// intersection is empty, the product is eliminated). Products
-    /// with disjoint field-name sets do not intersect; they
-    /// describe disjoint records. Variants intersect by matching
-    /// label, recursing into payload types.
+    /// Refinements are constraints: the meet carries the
+    /// conjunction. Two refined sides must have jointly
+    /// satisfiable refinements.
     pub fn intersect(&self, other: &Type) -> Option<Type> {
-        let p_self = self.primitive_part();
-        let p_other = other.primitive_part();
-        let p = Primitive {
-            bits: p_self.bits & p_other.bits,
-        };
-
-        // Refinements are constraints: the meet carries the
-        // conjunction. Two refined sides must have jointly
-        // satisfiable refinements; a refined side admits no
-        // composite shapes, so any composite part on the other
-        // side is dropped.
+        let p = self.primitive_part().intersect(other.primitive_part())?;
         let refinement = match (self.refinement(), other.refinement()) {
             (Some(a), Some(b)) => Some(a.meet(b)?),
             (Some(r), None) | (None, Some(r)) => Some(r.clone()),
             (None, None) => None,
         };
-        if let Some(refinement) = refinement {
-            return if p.is_empty() {
-                None
-            } else {
-                Some(Type::Refined(p, refinement))
-            };
-        }
-
-        let composite_intersection: BTreeSet<Composite> =
-            match (self.composite_part(), other.composite_part()) {
-                (Some(a), Some(b)) => intersect_composite_sets(a, b),
-                _ => BTreeSet::new(),
-            };
-
-        if p.is_empty() && composite_intersection.is_empty() {
-            None
-        } else {
-            Some(Type::composite(p, composite_intersection))
-        }
+        Some(match refinement {
+            Some(refinement) => Type::Refined(p, refinement),
+            None => Type::Primitive(p),
+        })
     }
 
-    /// Set union over both primitive and composite parts.
+    /// Set union of both memberships.
     ///
     /// Refinements weaken at a join: two refined sides keep their
     /// weakest common implication (the longest common prefix), a
@@ -601,55 +615,28 @@ impl Type {
     /// side admits.
     pub fn union(&self, other: &Type) -> Type {
         let p = self.primitive_part().union(other.primitive_part());
-
         if let (Some(a), Some(b)) = (self.refinement(), other.refinement())
             && let Some(joined) = a.join(b)
         {
             return Type::Refined(p, joined);
         }
-
-        let mut composites: BTreeSet<Composite> = BTreeSet::new();
-        if let Some(s) = self.composite_part() {
-            composites.extend(s.iter().cloned());
-        }
-        if let Some(s) = other.composite_part() {
-            composites.extend(s.iter().cloned());
-        }
-        Type::composite(p, composites)
+        Type::Primitive(p)
     }
 
     /// Subtype check. Returns `true` iff every shape `other`
     /// admits is also admitted by `self`.
-    ///
-    /// For composites: each shape in `other` must be included by
-    /// some shape in `self`. Inclusion is structural: a Product
-    /// `{x: T1, y: T2}` includes a Product `{x: T1', y: T2'}` when
-    /// the field-name sets match and each `Ti` includes `Ti'`. A
-    /// product with extra fields includes one with fewer fields
-    /// (width subtyping is not assumed; equal field sets only).
     pub fn includes(&self, other: &Type) -> bool {
         if !self.primitive_part().includes(other.primitive_part()) {
             return false;
         }
         // A refined type admits fewer values than its membership: it
         // includes `other` only if `other` is at least as
-        // constrained (other's prefix extends ours). An unrefined
+        // constrained (other's constraints imply ours). An unrefined
         // type over-approximates any refinement of its membership.
         match (self.refinement(), other.refinement()) {
-            (Some(a), Some(b)) => {
-                if !b.prefix.starts_with(&a.prefix) {
-                    return false;
-                }
-            }
-            (Some(_), None) => return false,
-            (None, _) => {}
-        }
-        match (self.composite_part(), other.composite_part()) {
-            (_, None) => true,
-            (None, Some(b)) => b.is_empty(),
-            (Some(a), Some(b)) => b
-                .iter()
-                .all(|b_shape| a.iter().any(|a_shape| composite_includes(a_shape, b_shape))),
+            (Some(a), Some(b)) => a.implied_by(b),
+            (Some(_), None) => false,
+            (None, _) => true,
         }
     }
 
@@ -662,129 +649,19 @@ impl Type {
     pub fn primitive_part(&self) -> Primitive {
         match self {
             Type::Primitive(p) => *p,
-            Type::Composite(p, _) => *p,
             Type::Refined(p, _) => *p,
         }
     }
 
-    /// The composite part of this type, or `None` if the type has
-    /// only a primitive part.
-    pub fn composite_part(&self) -> Option<&BTreeSet<Composite>> {
-        match self {
-            Type::Primitive(_) => None,
-            Type::Composite(_, c) => Some(c),
-            Type::Refined(_, _) => None,
-        }
-    }
-
     /// Legacy storage-codec view: if this type reduces to exactly
-    /// one [`ValueType`] (no `Nothing`, no composites), return it.
-    /// A refinement does not change the storage type, so a refined
-    /// singleton still reports its member.
+    /// one [`ValueType`] (no `Nothing`), return it. A refinement
+    /// does not change the storage type, so a refined singleton
+    /// still reports its member.
     pub fn as_value_type(&self) -> Option<ValueType> {
         match self {
             Type::Primitive(p) => p.as_singleton(),
-            Type::Composite(_, _) => None,
             Type::Refined(p, _) => p.as_singleton(),
         }
-    }
-}
-
-/// Structurally intersect two sets of [`Composite`] shapes.
-///
-/// For each `Composite::Product` in `a`, look for a same-field-set
-/// `Composite::Product` in `b` and intersect their field types
-/// pairwise; if any field intersection is empty, the product is
-/// eliminated. For each `Composite::Variant` in `a`, look for a
-/// same-label `Composite::Variant` in `b` and intersect their
-/// payload types. Anything in `a` or `b` without a structural
-/// counterpart on the other side is dropped: set intersection
-/// only keeps shapes admitted by both sides.
-fn intersect_composite_sets(
-    a: &BTreeSet<Composite>,
-    b: &BTreeSet<Composite>,
-) -> BTreeSet<Composite> {
-    let mut result = BTreeSet::new();
-    for a_shape in a {
-        for b_shape in b {
-            if let Some(merged) = intersect_composite(a_shape, b_shape) {
-                result.insert(merged);
-            }
-        }
-    }
-    result
-}
-
-/// Pairwise intersection of two [`Composite`] shapes. Two
-/// products intersect iff they share the same set of field names;
-/// two variants iff they share the same label.
-fn intersect_composite(a: &Composite, b: &Composite) -> Option<Composite> {
-    match (a, b) {
-        (Composite::Product(fa), Composite::Product(fb)) => {
-            if fa.len() != fb.len() {
-                return None;
-            }
-            let mut out = BTreeMap::new();
-            for (name, ta) in fa {
-                let tb = fb.get(name)?;
-                let merged = ta.intersect(tb)?;
-                out.insert(name.clone(), merged);
-            }
-            Some(Composite::Product(out))
-        }
-        (
-            Composite::Variant {
-                label: la,
-                value: va,
-            },
-            Composite::Variant {
-                label: lb,
-                value: vb,
-            },
-        ) => {
-            if la != lb {
-                return None;
-            }
-            let merged = va.intersect(vb)?;
-            Some(Composite::Variant {
-                label: la.clone(),
-                value: merged,
-            })
-        }
-        _ => None,
-    }
-}
-
-/// Structural inclusion check between two [`Composite`] shapes.
-/// `a` includes `b` iff they are the same shape kind, have matching
-/// keys/labels, and each of `a`'s recursive types includes `b`'s.
-fn composite_includes(a: &Composite, b: &Composite) -> bool {
-    match (a, b) {
-        (Composite::Product(fa), Composite::Product(fb)) => {
-            if fa.len() != fb.len() {
-                return false;
-            }
-            for (name, ta) in fa {
-                let Some(tb) = fb.get(name) else {
-                    return false;
-                };
-                if !ta.includes(tb) {
-                    return false;
-                }
-            }
-            true
-        }
-        (
-            Composite::Variant {
-                label: la,
-                value: va,
-            },
-            Composite::Variant {
-                label: lb,
-                value: vb,
-            },
-        ) => la == lb && va.includes(vb),
-        _ => false,
     }
 }
 
@@ -792,13 +669,7 @@ fn composite_includes(a: &Composite, b: &Composite) -> bool {
 mod tests {
     use super::*;
     use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hash as HashTrait, Hasher};
-
-    fn hash_of<T: HashTrait>(t: &T) -> u64 {
-        let mut h = DefaultHasher::new();
-        t.hash(&mut h);
-        h.finish()
-    }
+    use std::hash::{Hash, Hasher};
 
     fn p(vt: ValueType) -> Type {
         Type::from(vt)
@@ -925,185 +796,23 @@ mod tests {
         assert_eq!(a, b);
     }
 
+    /// Intersection and union reduce to primitive-part set algebra
+    /// when no refinements are involved.
     #[dialog_common::test]
-    fn product_constructor_round_trip() {
-        let mut fields = BTreeMap::new();
-        fields.insert("name".to_string(), Type::from(ValueType::String));
-        fields.insert("age".to_string(), Type::from(ValueType::UnsignedInt));
-        let a = Type::product(fields.clone());
-        let b = Type::product(fields);
-        assert_eq!(a, b);
-        let mut ha = DefaultHasher::new();
-        let mut hb = DefaultHasher::new();
-        a.hash(&mut ha);
-        b.hash(&mut hb);
-        assert_eq!(ha.finish(), hb.finish());
-    }
+    fn intersect_and_union_are_primitive_set_algebra() {
+        let numeric = Type::from(Primitive::NUMERIC);
+        let uint = Type::from(ValueType::UnsignedInt);
+        let met = numeric.intersect(&uint).expect("overlap");
+        assert_eq!(met.as_value_type(), Some(ValueType::UnsignedInt));
 
-    #[dialog_common::test]
-    fn variant_constructor_carries_label_and_payload() {
-        let some = Type::variant("Some", Type::from(ValueType::String));
-        let composites = some.composite_part().unwrap();
-        assert_eq!(composites.len(), 1);
-        let first = composites.iter().next().unwrap();
-        match first {
-            Composite::Variant { label, value } => {
-                assert_eq!(label, "Some");
-                assert_eq!(*value, Type::from(ValueType::String));
-            }
-            other => panic!("expected Variant, got {:?}", other),
-        }
-    }
+        let string = Type::from(ValueType::String);
+        assert!(uint.intersect(&string).is_none(), "disjoint memberships");
 
-    #[dialog_common::test]
-    fn intersect_two_records_same_fields() {
-        let mut fields = BTreeMap::new();
-        fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(fields.clone());
-        let b = Type::product(fields);
-        let c = a.intersect(&b).expect("intersection non-empty");
-        assert_eq!(a, c);
-    }
-
-    /// Two products with the same field names but different field
-    /// types narrow structurally: intersect each field's type
-    /// recursively. If every field intersection is non-empty, the
-    /// product survives with the narrowed fields.
-    #[dialog_common::test]
-    fn intersect_products_narrows_field_types() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(Primitive::NUMERIC));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("x".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
-
-        let merged = a.intersect(&b).expect("narrows to UnsignedInt");
-        let composite = merged.composite_part().expect("composite present");
-        let product = composite.iter().next().expect("one product");
-        match product {
-            Composite::Product(fields) => {
-                let x_type = fields.get("x").expect("x field");
-                assert_eq!(x_type.as_value_type(), Some(ValueType::UnsignedInt));
-            }
-            other => panic!("expected Product, got {other:?}"),
-        }
-    }
-
-    /// Two products with disjoint field types fail to intersect.
-    #[dialog_common::test]
-    fn intersect_products_disjoint_fields_eliminated() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("x".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
-
-        assert!(a.intersect(&b).is_none());
-    }
-
-    /// Two products with different field-name sets do not
-    /// intersect; they describe disjoint record shapes.
-    #[dialog_common::test]
-    fn intersect_products_different_keys_eliminated() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("y".to_string(), Type::from(ValueType::String));
-        let b = Type::product(b_fields);
-
-        assert!(a.intersect(&b).is_none());
-    }
-
-    /// Two variants with the same label intersect their payloads;
-    /// different labels do not intersect.
-    #[dialog_common::test]
-    fn intersect_variants_by_label() {
-        let a = Type::variant("Some", Type::from(Primitive::NUMERIC));
-        let b = Type::variant("Some", Type::from(ValueType::UnsignedInt));
-        let merged = a.intersect(&b).expect("same label narrows payload");
-        let composite = merged.composite_part().expect("composite present");
-        match composite.iter().next().expect("one variant") {
-            Composite::Variant { label, value } => {
-                assert_eq!(label, "Some");
-                assert_eq!(value.as_value_type(), Some(ValueType::UnsignedInt));
-            }
-            other => panic!("expected Variant, got {other:?}"),
-        }
-
-        let c = Type::variant("Other", Type::from(ValueType::UnsignedInt));
-        assert!(a.intersect(&c).is_none());
-    }
-
-    #[dialog_common::test]
-    fn intersect_primitive_and_composite_keeps_primitive_only() {
-        let mut fields = BTreeMap::new();
-        fields.insert("x".to_string(), Type::from(ValueType::String));
-        let composite = Type::product(fields);
-        let prim = Type::from(ValueType::String);
-        // primitive part of `composite` is EMPTY; composite part of `prim` is None.
-        // Intersection of primitive parts: EMPTY ∩ {String} = EMPTY.
-        // Intersection of composite parts: None ∩ {Product{...}} = empty.
-        // Overall: empty → None.
-        assert!(prim.intersect(&composite).is_none());
-
-        // But if the composite carries a Record primitive bit, the
-        // intersection has that bit alone.
-        let composite_with_record = Type::composite(
-            Primitive::singleton(ValueType::Record),
-            composite
-                .composite_part()
-                .cloned()
-                .unwrap_or_else(BTreeSet::new),
-        );
-        let record_prim = Type::from(ValueType::Record);
-        let intersected = record_prim.intersect(&composite_with_record).unwrap();
-        assert_eq!(
-            intersected.primitive_part().as_singleton(),
-            Some(ValueType::Record)
-        );
-        assert!(intersected.composite_part().is_none());
-    }
-
-    #[dialog_common::test]
-    fn includes_product_subtype_extra_fields_in_subject() {
-        // A type T "includes" U iff T admits every shape U admits.
-        // For our set semantics, T includes U requires every
-        // composite of U to be present in T's composite set. So
-        // larger composite sets in T are fine; an extra Product in
-        // U not in T breaks inclusion.
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields.clone());
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("x".to_string(), Type::from(ValueType::String));
-        b_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
-
-        // a and b are different products; neither includes the other.
-        assert!(!a.includes(&b));
-        assert!(!b.includes(&a));
-
-        // a includes itself.
-        assert!(a.includes(&a));
-
-        // Union of {a, b} includes both.
-        let union = a.union(&b);
-        assert!(union.includes(&a));
-        assert!(union.includes(&b));
-    }
-
-    #[dialog_common::test]
-    fn smart_constructor_collapses_empty_composite_set() {
-        let collapsed = Type::composite(Primitive::singleton(ValueType::String), BTreeSet::new());
-        assert!(matches!(collapsed, Type::Primitive(_)));
-        assert_eq!(collapsed.as_value_type(), Some(ValueType::String));
+        let joined = uint.union(&string);
+        assert!(joined.primitive_part().contains(ValueType::UnsignedInt));
+        assert!(joined.primitive_part().contains(ValueType::String));
+        assert!(joined.includes(&uint));
+        assert!(joined.includes(&string));
     }
 
     #[dialog_common::test]
@@ -1124,51 +833,6 @@ mod tests {
         assert_eq!(Type::from(Primitive::NUMERIC).as_value_type(), None);
     }
 
-    /// Insertion order of composite elements does not affect
-    /// equality or hash. The [`BTreeSet`] storage canonicalizes
-    /// the set, so different paths to the same set of shapes
-    /// produce equal `Type`s with equal hashes.
-    #[dialog_common::test]
-    fn composite_set_is_insertion_order_independent() {
-        let a = Type::variant("A", p(ValueType::String));
-        let b = Type::variant("B", p(ValueType::UnsignedInt));
-
-        // Build the same multi-element set two different ways:
-        // ({A, B}) via a.union(b), and ({B, A}) via b.union(a).
-        let ab = a.union(&b);
-        let ba = b.union(&a);
-
-        assert_eq!(ab, ba, "set equality is order-independent");
-        assert_eq!(hash_of(&ab), hash_of(&ba), "set hash is order-independent");
-    }
-
-    /// Field insertion order into a `BTreeMap<String, Type>` does
-    /// not affect product equality or hash: the BTreeMap sorts
-    /// by key. Same product built via `{x, y}` vs `{y, x}` insert
-    /// orders must compare equal and hash equal.
-    #[dialog_common::test]
-    fn product_field_insertion_order_independent() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        a_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        let a = Type::product(a_fields);
-
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        b_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let b = Type::product(b_fields);
-
-        assert_eq!(
-            a, b,
-            "product equality is field-insertion-order independent"
-        );
-        assert_eq!(
-            hash_of(&a),
-            hash_of(&b),
-            "product hash is field-insertion-order independent"
-        );
-    }
-
     /// `with_prefix` narrows membership to the TEXTUAL kinds and
     /// attaches the refinement; non-textual membership is an empty
     /// meet.
@@ -1178,7 +842,10 @@ mod tests {
             .with_prefix("did:")
             .expect("textual members remain");
         assert_eq!(refined.primitive_part(), Primitive::TEXTUAL);
-        assert_eq!(refined.refinement().expect("refined").prefix, "did:");
+        assert_eq!(
+            refined.refinement().expect("refined").prefix.as_deref(),
+            Some("did:")
+        );
 
         assert!(
             Type::from(Primitive::NUMERIC).with_prefix("did:").is_none(),
@@ -1200,7 +867,10 @@ mod tests {
             .with_prefix("did:key:")
             .unwrap();
         let met = did.intersect(&did_key).expect("compatible prefixes");
-        assert_eq!(met.refinement().unwrap().prefix, "did:key:");
+        assert_eq!(
+            met.refinement().unwrap().prefix.as_deref(),
+            Some("did:key:")
+        );
 
         let http = Type::from(ValueType::Entity).with_prefix("http:").unwrap();
         assert!(
@@ -1211,8 +881,8 @@ mod tests {
         let unrefined = Type::from(Primitive::TEXTUAL);
         let met = did.intersect(&unrefined).expect("memberships overlap");
         assert_eq!(
-            met.refinement().unwrap().prefix,
-            "did:",
+            met.refinement().unwrap().prefix.as_deref(),
+            Some("did:"),
             "the refinement survives a meet with an unrefined side"
         );
         assert_eq!(met.primitive_part().as_singleton(), Some(ValueType::Entity));
@@ -1229,7 +899,10 @@ mod tests {
             .with_prefix("user/guest")
             .unwrap();
         let joined = a.union(&b);
-        assert_eq!(joined.refinement().unwrap().prefix, "user/");
+        assert_eq!(
+            joined.refinement().unwrap().prefix.as_deref(),
+            Some("user/")
+        );
 
         let unrefined = Type::from(ValueType::String);
         assert_eq!(
@@ -1281,22 +954,138 @@ mod tests {
         assert_eq!(t, back);
     }
 
-    /// Combining two products via union also produces identical
-    /// hashes regardless of which product was unioned first.
+    fn concept(uri: &str) -> ConceptRef {
+        ConceptRef(uri.to_string())
+    }
+
+    /// `with_conformance` narrows membership to Entity (keeping the
+    /// `Nothing` bit for optional fields) and rejects memberships
+    /// with no entity in them.
     #[dialog_common::test]
-    fn product_union_is_order_independent() {
-        let mut a_fields = BTreeMap::new();
-        a_fields.insert("x".to_string(), Type::from(ValueType::String));
-        let a = Type::product(a_fields);
+    fn with_conformance_narrows_to_entity() {
+        let person = concept("concept:person");
+        let refined = Type::from(Primitive::ALL)
+            .with_conformance(person.clone())
+            .expect("Entity is a member");
+        assert_eq!(
+            refined.primitive_part().as_singleton(),
+            Some(ValueType::Entity)
+        );
+        assert!(refined.refinement().unwrap().conforms.contains(&person));
 
-        let mut b_fields = BTreeMap::new();
-        b_fields.insert("y".to_string(), Type::from(ValueType::UnsignedInt));
-        let b = Type::product(b_fields);
+        let optional = Type::from(ValueType::Entity)
+            .optional()
+            .with_conformance(person.clone())
+            .expect("optional entity remains inhabited");
+        assert!(
+            optional.primitive_part().contains_nothing(),
+            "the Nothing bit rides along"
+        );
 
-        let ab = a.union(&b);
-        let ba = b.union(&a);
+        assert!(
+            Type::from(Primitive::NUMERIC)
+                .with_conformance(person)
+                .is_none(),
+            "no numeric value is an entity"
+        );
+    }
 
-        assert_eq!(ab, ba);
-        assert_eq!(hash_of(&ab), hash_of(&ba));
+    /// The meet unions conformance sets (the value must satisfy both
+    /// sides); the join intersects them (only what both sides imply
+    /// survives).
+    #[dialog_common::test]
+    fn conformance_meet_unions_join_intersects() {
+        let person = concept("concept:person");
+        let employee = concept("concept:employee");
+        let a = Type::from(ValueType::Entity)
+            .with_conformance(person.clone())
+            .unwrap();
+        let b = Type::from(ValueType::Entity)
+            .with_conformance(employee.clone())
+            .unwrap();
+
+        let met = a.intersect(&b).expect("memberships overlap");
+        let conforms = &met.refinement().unwrap().conforms;
+        assert!(conforms.contains(&person) && conforms.contains(&employee));
+
+        assert!(
+            a.union(&b).refinement().is_none(),
+            "disjoint conformance sets imply nothing in common"
+        );
+        let both = a.clone().with_conformance(employee).unwrap();
+        assert_eq!(
+            both.union(&a),
+            a,
+            "the join keeps exactly the shared concepts"
+        );
+    }
+
+    /// Inclusion: a larger conformance set is more constrained, so
+    /// the superset side is the subtype.
+    #[dialog_common::test]
+    fn conformance_includes_is_subset_ordered() {
+        let person = concept("concept:person");
+        let a = Type::from(ValueType::Entity)
+            .with_conformance(person.clone())
+            .unwrap();
+        let both = a
+            .clone()
+            .with_conformance(concept("concept:employee"))
+            .unwrap();
+        let unrefined = Type::from(ValueType::Entity);
+
+        assert!(a.includes(&both), "more concepts is more constrained");
+        assert!(!both.includes(&a));
+        assert!(unrefined.includes(&a), "unrefined over-approximates");
+        assert!(!a.includes(&unrefined));
+
+        let prefixed = a.clone().with_prefix("did:").unwrap();
+        assert!(
+            a.includes(&prefixed) && !prefixed.includes(&a),
+            "both halves participate in the ordering"
+        );
+    }
+
+    /// Conformance is not row-checkable ("facts exist" is not a
+    /// property of the scalar): `admits` enforces only the prefix
+    /// half, enforcement of conformance is the desugared premises'
+    /// job.
+    #[dialog_common::test]
+    fn conformance_is_not_row_checked() {
+        let refined = Type::from(ValueType::Entity)
+            .with_conformance(concept("concept:person"))
+            .unwrap();
+        let entity = Value::Entity("did:key:z6Mk".parse().expect("valid entity"));
+        assert!(
+            refined.admits(&entity),
+            "any entity passes the row-local check"
+        );
+        assert!(
+            !refined.admits(&Value::UnsignedInt(7)),
+            "membership still applies"
+        );
+    }
+
+    /// Conformance survives serde, and the extended [`Refinement`]
+    /// still reads the prefix-only wire shape older peers produce.
+    #[dialog_common::test]
+    fn conformance_serde_round_trip_and_wire_compat() {
+        let t = Type::from(ValueType::Entity)
+            .with_conformance(concept("concept:person"))
+            .unwrap()
+            .with_prefix("did:")
+            .unwrap();
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
+
+        let old = Type::from(ValueType::Entity).with_prefix("did:").unwrap();
+        let old_wire = serde_json::to_string(&old).unwrap();
+        assert!(
+            !old_wire.contains("conforms"),
+            "an empty conformance set stays off the wire"
+        );
+        let read: Type = serde_json::from_str(&old_wire).unwrap();
+        assert_eq!(read, old);
     }
 }

--- a/rust/dialog-query/src/type_system/unifier.rs
+++ b/rust/dialog-query/src/type_system/unifier.rs
@@ -62,7 +62,7 @@ pub enum UnifyError {
     },
     /// Occurs check: unifying a variable with a type that
     /// transitively contains the variable would produce an
-    /// infinite type. Reserved for future composite shapes.
+    /// infinite type. Reserved for future recursive types.
     #[error("occurs check failed for variable {var:?}")]
     OccursCheck {
         /// The offending variable.
@@ -189,8 +189,7 @@ impl Context {
     /// Returns `Err` on constraint conflict (an empty meet).
     ///
     /// Static types intersect via [`StaticType::intersect`], which
-    /// narrows both primitive and composite parts (products by
-    /// shared field-name set, variants by label). Variables carry
+    /// meets both memberships and refinements. Variables carry
     /// a [`Primitive`] constraint that's intersected with the
     /// primitive part of any concrete type they're unified with.
     pub fn unify(&mut self, a: &Type, b: &Type) -> Result<Type, UnifyError> {
@@ -253,8 +252,7 @@ impl Context {
                     .ok_or(UnifyError::ConstraintConflict { left: cx, right: p })?;
                 self.constraints.insert(x, merged);
                 // Rebuild around the merged membership without
-                // shedding the static's composite or refinement
-                // structure.
+                // shedding the static's refinement structure.
                 let resolved = narrowed_static.with_primitive_part(merged);
                 self.substitution.insert(x, Type::Static(resolved.clone()));
                 Ok(Type::Static(resolved))
@@ -479,7 +477,13 @@ mod tests {
         match resolved {
             Type::Static(s) => {
                 assert_eq!(s.primitive_part().as_singleton(), Some(ValueType::Entity));
-                assert_eq!(s.refinement().expect("refinement preserved").prefix, "did:");
+                assert_eq!(
+                    s.refinement()
+                        .expect("refinement preserved")
+                        .prefix
+                        .as_deref(),
+                    Some("did:")
+                );
             }
             other => panic!("expected static, got {other:?}"),
         }

--- a/rust/dialog-query/src/types.rs
+++ b/rust/dialog-query/src/types.rs
@@ -19,7 +19,7 @@
 
 use crate::type_system;
 use crate::type_system::Type as Kind;
-use dialog_common::ConditionalSend;
+use dialog_common::{ConditionalSend, ConditionalSync};
 use std::fmt;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -34,7 +34,7 @@ use crate::attribute::The;
 /// [`Self::kind`] returning `Option<type_system::Type>`. `None`
 /// means "unknown; the unifier decides at rule-compile time."
 pub trait TypeDescriptor:
-    Clone + fmt::Debug + Default + PartialEq + Eq + Hash + Send + Sync + 'static
+    Clone + fmt::Debug + Default + PartialEq + Eq + Hash + ConditionalSend + ConditionalSync + 'static
 {
     /// The legacy storage tag, if statically known. `None` means
     /// "any type."

--- a/rust/dialog-repository/Guide.md
+++ b/rust/dialog-repository/Guide.md
@@ -1,0 +1,273 @@
+# Dialog
+
+Dialog is a local-first database with built-in identity, replication, and delegated access control.
+
+## Identity
+
+Three Ed25519 keypairs, each identified by a `did:key`:
+
+- **Profile**: a named identity on a device. Created on first use, persists for the device lifetime.
+- **Operator**: a session key derived from the profile. Same profile + context always yields the same key. Ephemeral, revocable.
+- **Account** *(optional)*: a passkey or hardware key for cross-device recovery. Can be deferred.
+
+Every capability invocation carries a delegation chain: `subject -> profile -> operator`.
+
+## Setup
+
+```rs
+let storage = Storage::default();
+
+let profile = Profile::open("alice")
+    .perform(&storage)
+    .await?;
+
+let operator = profile
+    .derive(b"my-app")
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+```
+
+The operator's base directory defaults to `Directory::Current`. Override it with `.base()`:
+
+```rs
+let operator = profile
+    .derive(b"my-app")
+    .base(Directory::Temp)
+    .allow(Subject::any())
+    .build(storage)
+    .await?;
+```
+
+Note: `.build(storage)` takes ownership of the storage value.
+
+## Repository
+
+A repository has its own keypair, branches, and remotes. Same name under the same profile always yields the same identity.
+
+Repositories are opened through the profile, which provides the correct subject DID. The operator resolves the name against its base directory and verifies access.
+
+```rs
+let repo = profile.repository("contacts")
+    .open()
+    .perform(&operator)
+    .await?;
+
+let main = repo
+    .branch("main")
+    .open()
+    .perform(&operator)
+    .await?;
+```
+
+Repository modes:
+
+- `.open()` loads existing or creates new. Returns `Repository<Credential>`.
+- `.load()` loads existing, fails if not found. Returns `Repository<Credential>`.
+- `.create()` creates new, fails if exists. Returns `Repository<SignerCredential>`.
+
+Branch modes:
+
+- `.open()` loads existing or creates new.
+- `.load()` loads existing, fails if not found.
+
+## Writing
+
+Data is stored as semantic triples: *the `attribute` of `entity` is `value`*.
+
+Typed writes use `branch.transaction()`:
+
+```rs
+main.transaction()
+    .assert(Name::of(alice).is("Alice"))
+    .assert(Age::of(alice).is(30u32))
+    .commit()
+    .perform(&operator)
+    .await?;
+```
+
+## Querying
+
+Typed queries use concepts defined with derive macros:
+
+```rs
+#[derive(Concept)]
+struct Employee {
+    this: Entity,
+    name: employee::Name,
+    role: employee::Role,
+}
+
+let results: Vec<Employee> = main
+    .select(Query::<Employee> {
+        this: Term::var("this"),
+        name: Term::var("name"),
+        role: Term::var("role"),
+    })
+    .perform(&operator)
+    .try_vec()
+    .await?;
+```
+
+For queries with deductive rules:
+
+```rs
+let results: Vec<Employee> = main
+    .query()
+    .install(my_rule)?
+    .select(Query::<Employee> { ... })
+    .perform(&operator)
+    .try_vec()
+    .await?;
+```
+
+Raw artifact selection (with automatic remote fallback):
+
+```rs
+let artifacts = main
+    .claims()
+    .select(ArtifactSelector::new().the("user/name".parse()?))
+    .perform(&operator)
+    .await?
+    .collect::<Vec<_>>()
+    .await;
+```
+
+## Syncing
+
+Register a remote and set the branch's upstream, then push and pull:
+
+```rs
+// Create remote with a UCAN access service
+let origin = repo.remote("origin")
+    .create(SiteAddress::Ucan(UcanAddress::new("https://access.example.com")))
+    .perform(&operator).await?;
+
+// Open remote branch and set as upstream
+let remote_main = origin.branch("main").open().perform(&operator).await?;
+main.set_upstream(remote_main).perform(&operator).await?;
+
+main.push().perform(&operator).await?;
+main.pull().perform(&operator).await?;
+```
+
+To point at a different repository (e.g., pulling from someone else's repo):
+
+```rs
+let origin = bob_repo.remote("origin")
+    .create(SiteAddress::Ucan(UcanAddress::new("https://access.example.com")))
+    .subject(alice_repo.did())  // target Alice's repo, not Bob's
+    .perform(&bob_operator).await?;
+```
+
+When a branch has a remote upstream, queries automatically replicate missing blocks on demand.
+
+## Collaboration
+
+Access is shared through UCAN delegation: signed tokens forming a chain of trust.
+
+The access API follows a fluent pattern: `.access().claim(&capability).delegate(audience)`.
+
+- `repo.access()` and `profile.access()` return an `Access` handle
+- `.claim()` takes anything that converts into a `Capability` (a `&repo`, `&profile`, or capability chain)
+- `.delegate(audience_did)` produces a delegation chain on `.perform()`
+- `.save(chain)` stores a received delegation under the profile
+
+### Alice sets up a shared repo
+
+```rs
+let repo = alice_profile.repository("shared")
+    .create()
+    .perform(&alice_operator).await?;
+
+// Repo delegates to Alice's profile
+let chain = repo.access()
+    .claim(&repo)
+    .delegate(alice_profile.did())
+    .perform(&alice_operator)
+    .await?;
+
+// Alice saves the delegation under her profile
+alice_profile
+    .access()
+    .save(chain)
+    .perform(&alice_operator)
+    .await?;
+
+let origin = repo.remote("origin")
+    .create(SiteAddress::Ucan(UcanAddress::new("https://access.example.com")))
+    .perform(&alice_operator).await?;
+
+let main = repo.branch("main").open().perform(&alice_operator).await?;
+let remote_main = origin.branch("main").open().perform(&alice_operator).await?;
+main.set_upstream(remote_main).perform(&alice_operator).await?;
+
+main.transaction()
+    .assert(Name::of(alice).is("Alice"))
+    .commit()
+    .perform(&alice_operator)
+    .await?;
+
+main.push().perform(&alice_operator).await?;
+```
+
+### Alice invites Bob
+
+Alice claims her authority over the repo and re-delegates to Bob. The resulting chain includes the full proof path from the repo subject through Alice to Bob.
+
+```rs
+let chain = alice_profile.access()
+    .claim(&repo)
+    .delegate(bob_profile.did())
+    .perform(&alice_operator).await?;
+```
+
+Optional time bounds can constrain the delegation:
+
+```rs
+let chain = alice_profile.access()
+    .claim(&repo)
+    .not_before(start)
+    .expires(end)
+    .delegate(bob_profile.did())
+    .perform(&alice_operator).await?;
+```
+
+### Bob joins
+
+Bob saves the delegation under his profile. This is what authorizes his operator to act on Alice's repo.
+
+```rs
+bob_profile.access().save(chain).perform(&bob_operator).await?;
+
+let bob_repo = bob_profile.repository("bob-copy")
+    .open()
+    .perform(&bob_operator)
+    .await?;
+
+let origin = bob_repo.remote("origin")
+    .create(SiteAddress::Ucan(UcanAddress::new("https://access.example.com")))
+    .subject(alice_repo_did)  // point at Alice's repo
+    .perform(&bob_operator).await?;
+
+let main = bob_repo.branch("main").open().perform(&bob_operator).await?;
+let remote_main = origin.branch("main").open().perform(&bob_operator).await?;
+main.set_upstream(remote_main).perform(&bob_operator).await?;
+
+// Pull, edit, push
+main.pull().perform(&bob_operator).await?;
+
+main.transaction()
+    .assert(Name::of(bob).is("Bob"))
+    .commit()
+    .perform(&bob_operator)
+    .await?;
+
+main.push().perform(&bob_operator).await?;
+```
+
+Alice pulls to get Bob's changes:
+
+```rs
+main.pull().perform(&operator).await?;
+```

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -37,6 +37,9 @@ mod metadata;
 mod open;
 pub use open::*;
 
+mod overlay;
+pub use overlay::*;
+
 mod pull;
 pub use pull::*;
 
@@ -92,6 +95,11 @@ pub struct Branch {
     /// every query's durable rule resolution, so the `db.rule/*` scan is
     /// paid once per (concept, head) rather than per query.
     rule_cache: SharedRuleCache,
+    /// Transient session overlay: ephemeral facts folded into every
+    /// read of this branch, never committed. Shared across clones
+    /// like the caches; mutations bump an epoch subscriptions gate
+    /// on. See [`Overlay`].
+    overlay: Overlay,
     /// Shared plan cache for the deductive rules resolved on this branch,
     /// keyed by content-addressed `(rule, adornment)`. Handed to each
     /// per-query `ConceptRules` assembly so a re-assembled rule set reuses

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -55,6 +55,9 @@ pub use select::*;
 mod session;
 pub use session::*;
 
+mod subscription;
+pub use subscription::*;
+
 mod set_upstream;
 pub use set_upstream::*;
 

--- a/rust/dialog-repository/src/repository/branch/open.rs
+++ b/rust/dialog-repository/src/repository/branch/open.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::rules::RuleCache;
-use crate::{Branch, BranchReference, ResolveError};
+use crate::{Branch, BranchReference, Overlay, ResolveError};
 use dialog_capability::Provider;
 use dialog_effects::memory::Resolve;
 use dialog_query::concept::query::PlanCache;
@@ -38,6 +38,7 @@ impl OpenBranch {
             node_cache: dialog_search_tree::Cache::new(),
             rule_cache: Arc::new(RuleCache::new()),
             plan_cache: PlanCache::default(),
+            overlay: Overlay::default(),
         })
     }
 }

--- a/rust/dialog-repository/src/repository/branch/overlay.rs
+++ b/rust/dialog-repository/src/repository/branch/overlay.rs
@@ -1,0 +1,83 @@
+//! Branch-scoped transient overlay.
+
+use std::sync::{Arc, Mutex};
+
+use dialog_artifacts::{Changes, Statement};
+
+use crate::Branch;
+
+/// Ephemeral session facts folded into every read of the branch —
+/// queries, transaction queries, and standing subscriptions — but
+/// never committed to the tree. Obtained via
+/// [`Branch::overlay`]; shared across branch clones, so a fact
+/// asserted through any clone is visible to readers of all of them.
+///
+/// Asserts surface alongside branch facts; retracts tombstone
+/// matching branch facts for readers without touching the tree.
+/// Every mutation bumps an epoch that subscriptions snapshot at each
+/// poll: a poll re-evaluates when the epoch moved even though the
+/// tree did not, which is how overlay changes propagate to the
+/// branch's subscriptions.
+#[derive(Debug, Clone, Default)]
+pub struct Overlay {
+    state: Arc<Mutex<State>>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    /// Bumped on every mutation. Subscriptions pin the epoch they
+    /// last evaluated at; an off-tree change is invisible to the
+    /// poll's tree-diff gate, so the epoch is what re-triggers.
+    epoch: u64,
+    changes: Changes,
+}
+
+impl Overlay {
+    /// Assert an ephemeral statement into the session overlay.
+    pub fn assert<S: Statement>(&self, statement: S) -> &Self {
+        let mut state = self.state.lock().expect("overlay lock");
+        statement.assert(&mut state.changes);
+        state.epoch += 1;
+        self
+    }
+
+    /// Retract a statement for the session: matching branch facts
+    /// are tombstoned for readers; the tree is untouched.
+    pub fn retract<S: Statement>(&self, statement: S) -> &Self {
+        let mut state = self.state.lock().expect("overlay lock");
+        statement.retract(&mut state.changes);
+        state.epoch += 1;
+        self
+    }
+
+    /// Drop every session fact.
+    pub fn clear(&self) -> &Self {
+        let mut state = self.state.lock().expect("overlay lock");
+        state.changes = Changes::new();
+        state.epoch += 1;
+        self
+    }
+
+    /// The current session changes, folded into a [`QueryLayer`] at
+    /// construction so every read path sees them.
+    ///
+    /// [`QueryLayer`]: crate::QueryLayer
+    pub(crate) fn changes(&self) -> Changes {
+        self.state.lock().expect("overlay lock").changes.clone()
+    }
+
+    /// The current epoch: subscriptions compare it against the one
+    /// they pinned to decide whether the overlay moved.
+    pub(crate) fn epoch(&self) -> u64 {
+        self.state.lock().expect("overlay lock").epoch
+    }
+}
+
+impl Branch {
+    /// The branch's transient session overlay: assert or retract
+    /// ephemeral facts that every read of this branch observes but
+    /// no commit persists. See [`Overlay`].
+    pub fn overlay(&self) -> &Overlay {
+        &self.overlay
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/push.rs
+++ b/rust/dialog-repository/src/repository/branch/push.rs
@@ -74,6 +74,16 @@ impl Push<'_> {
         };
         let base = upstream_state.tree().clone();
 
+        // Nothing new to push: the local head already equals the recorded
+        // upstream sync point. Without this guard every sync tick re-publishes
+        // the revision pointer to the remote (an ongoing `branch/*/revision`
+        // PUT) and re-fetches + diffs the upstream for an empty novelty set,
+        // even when no commit has landed since the last push. Short-circuit so
+        // an idle branch does no push I/O.
+        if revision.tree == base {
+            return Ok(Some(revision));
+        }
+
         match &upstream_state {
             Upstream::Local {
                 branch: upstream_name,
@@ -206,6 +216,51 @@ mod tests {
             .revision()
             .expect("main should have a revision after push");
         assert_eq!(main_rev.tree, feature_revision.tree);
+
+        Ok(())
+    }
+
+    /// A second push with no intervening commit is a no-op: the local head
+    /// already equals the recorded upstream sync point, so it returns the
+    /// current revision without re-publishing. Guards the ongoing-`revision`-PUT
+    /// regression where an idle sync tick re-pushed on every drain.
+    #[dialog_common::test]
+    async fn it_is_a_noop_when_nothing_new_to_push() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        feature.set_upstream(&main).perform(&operator).await?;
+
+        feature
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:123".parse()?,
+                is: Value::String("Alice".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+
+        let revision = feature.revision().expect("feature should have a revision");
+
+        // First push lands the commit.
+        let first = feature.push().perform(&operator).await?;
+        assert_eq!(
+            first.map(|r| r.tree),
+            Some(revision.tree.clone()),
+            "first push lands the local head"
+        );
+
+        // Second push, with no new commit, is a no-op that still reports the
+        // current revision.
+        let second = feature.push().perform(&operator).await?;
+        assert_eq!(
+            second.map(|r| r.tree),
+            Some(revision.tree),
+            "second push with nothing new returns the current revision as a no-op"
+        );
 
         Ok(())
     }

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -361,8 +361,17 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<'a, Env> Provider<Select<'a>> for QueryEnv<'a, Env>
+// The `Select` lifetime `'s` is decoupled from the env lifetime `'a`
+// (`'a: 'a` bounds it below `'a`): a `QueryEnv<'a>` provides
+// `Select<'s>` for *any* `'s` outlived by `'a`, not only `'s == 'a`.
+// This is what lets a subscription poll hold `&query_env` across an
+// `await` and stay Send-general — the caller's higher-ranked
+// `for<'s> Provider<Select<'s>>` demand is now satisfiable. The
+// returned stream still borrows `'a` data, which outlives `'s`, so
+// the shorter `ArtifactStream<'s>` is sound.
+impl<'a, 's, Env> Provider<Select<'s>> for QueryEnv<'a, Env>
 where
+    'a: 's,
     Env: Provider<Get>
         + Provider<Put>
         + Provider<Resolve>
@@ -374,20 +383,22 @@ where
     async fn execute(
         &self,
         input: ArtifactSelector<Constrained>,
-    ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
+    ) -> Result<ArtifactStream<'s>, DialogArtifactsError> {
         self.record_demand(&input);
-        let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.branches.len() + 1);
+        let mut streams: Vec<ArtifactStream<'s>> = Vec::with_capacity(self.branches.len() + 1);
 
         // Branch streams — each filtered by tombstones from the
         // overlay's retracts so a `tx.retract(x)` (or any user-asserted
-        // retract in `with(..)`) suppresses matching source facts.
+        // retract in `with(..)`) suppresses matching source facts. Each
+        // borrows `'a` data, which outlives `'s`, so it coerces to
+        // `ArtifactStream<'s>`.
         for branch in &self.branches {
             let raw = select_from_branch(branch, self.env, input.clone()).await?;
             streams.push(filter_tombstones(raw, self.tombstones.clone()));
         }
 
         // Overlay stream — Changes itself is a Provider<Select>.
-        streams.push(Provider::<Select<'a>>::execute(&self.changes, input).await?);
+        streams.push(Provider::<Select<'s>>::execute(&self.changes, input).await?);
 
         Ok(merge_grouped(streams))
     }

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -248,6 +248,11 @@ pub(crate) struct QueryEnv<'a, Env> {
     /// stream is filtered against these before the merge so retracts
     /// in the overlay suppress matching facts in the source.
     tombstones: HashSet<SortKey>,
+    /// When present, every selector this environment executes —
+    /// fact scans and rule-discovery reads alike — records its
+    /// demanded range here. Subscriptions use the recorded cover to
+    /// gate re-evaluation.
+    demand: Option<crate::Demand>,
     env: &'a Env,
 }
 
@@ -271,7 +276,23 @@ impl<'a, Env> QueryEnv<'a, Env> {
             branches,
             changes,
             tombstones,
+            demand: None,
             env,
+        }
+    }
+
+    /// Record every selector this environment executes into
+    /// `demand`. Used by subscriptions to capture the evaluation's
+    /// demand cover.
+    pub(crate) fn with_demand(mut self, demand: crate::Demand) -> Self {
+        self.demand = Some(demand);
+        self
+    }
+
+    /// Record a selector's demanded range, when recording is on.
+    fn record_demand(&self, selector: &ArtifactSelector<Constrained>) {
+        if let Some(demand) = &self.demand {
+            demand.record(selector);
         }
     }
 }
@@ -282,6 +303,7 @@ impl<Env> Clone for QueryEnv<'_, Env> {
             branches: self.branches.clone(),
             changes: self.changes.clone(),
             tombstones: self.tombstones.clone(),
+            demand: self.demand.clone(),
             env: self.env,
         }
     }
@@ -335,6 +357,7 @@ where
         &self,
         input: ArtifactSelector<Constrained>,
     ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
+        self.record_demand(&input);
         let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.branches.len() + 1);
 
         // Branch streams — each filtered by tombstones from the
@@ -372,6 +395,10 @@ where
         branch: &'a Branch,
         selector: ArtifactSelector<Constrained>,
     ) -> Result<Vec<Artifact>, DialogArtifactsError> {
+        // Rule-discovery reads are demand too: a rule committed
+        // later for a subscribed concept lands in this range and
+        // must re-trigger the subscription.
+        self.record_demand(&selector);
         let stream = select_from_branch(branch, self.env, selector).await?;
         stream.try_collect().await
     }

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -227,8 +227,8 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
 
-            let query_env =
-                QueryEnv::new(layer.branches, overlay, tombstones, env);
+            let branches = layer.branches.iter().map(|&branch| branch.clone()).collect();
+            let query_env = QueryEnv::new(branches, overlay, tombstones, env);
             let results = Box::pin(query.perform(&query_env));
             for await result in results {
                 yield result?;
@@ -243,7 +243,14 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
 /// Built fresh on each `.perform(env)`; the environment reference
 /// is never captured on the layer itself.
 pub(crate) struct QueryEnv<'a, Env> {
-    branches: Vec<&'a Branch>,
+    /// Owned (cheaply cloned: shared caches) so the env's only
+    /// lifetime is the underlying `env` reference. A poll/evaluation
+    /// can then type its `QueryEnv` with the *named* env lifetime
+    /// instead of a generator-local borrow — which is what keeps the
+    /// enclosing future `Send`-general on native (two independent
+    /// erased lifetimes in `QueryEnv<'0>: Provider<Select<'1>>` hit
+    /// rustc's #100013 limitation; a named lifetime does not).
+    branches: Vec<Branch>,
     /// All overlay facts — caller-asserted + auto-injected metadata —
     /// merged into one batch. Queried via `Provider<Select> for Changes`.
     changes: Changes,
@@ -275,7 +282,7 @@ impl<'a, Env> QueryEnv<'a, Env> {
     /// resolution is built in (a durable layer per branch + the overlay
     /// as a transient layer), so the two paths can never diverge on it.
     pub(crate) fn new(
-        branches: Vec<&'a Branch>,
+        branches: Vec<Branch>,
         changes: Changes,
         tombstones: HashSet<SortKey>,
         env: &'a Env,
@@ -331,11 +338,15 @@ impl<Env> Clone for QueryEnv<'_, Env> {
 /// the branch's remote upstream when configured. Extracted as a freestanding
 /// helper so every branch in a [`QueryEnv`] shares the exact same branch-read
 /// path (a transaction query is itself a single-branch `QueryEnv`).
-pub(crate) async fn select_from_branch<'a, Env>(
-    branch: &'a Branch,
+///
+/// Takes the branch by value (a cheap clone: shared caches) and moves
+/// it into the returned stream, so the stream borrows only the env —
+/// errors surface as the stream's first item.
+pub(crate) fn select_from_branch<'a, Env>(
+    branch: Branch,
     env: &'a Env,
     input: ArtifactSelector<Constrained>,
-) -> Result<ArtifactStream<'a>, DialogArtifactsError>
+) -> ArtifactStream<'a>
 where
     Env: Provider<Get>
         + Provider<Put>
@@ -345,33 +356,41 @@ where
         + ConditionalSync
         + 'static,
 {
-    let select = branch.claims().select(input);
+    Box::pin(async_stream::try_stream! {
+        let select = branch.claims().select(input);
 
-    let remote = match branch.upstream() {
-        Some(Upstream::Remote { remote: name, .. }) => {
-            branch.subject().remote(name).load().perform(env).await.ok()
+        let remote = match branch.upstream() {
+            Some(Upstream::Remote { remote: name, .. }) => {
+                branch.subject().remote(name).load().perform(env).await.ok()
+            }
+            _ => None,
+        };
+
+        let store = NetworkedIndex::new(env, select.catalog(), remote);
+        let stream = select.execute(store).await?;
+        for await artifact in stream {
+            yield artifact?;
         }
-        _ => None,
-    };
-
-    let store = NetworkedIndex::new(env, select.catalog(), remote);
-    let stream = select.execute(store).await?;
-    Ok(Box::pin(stream))
+    })
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-// The `Select` lifetime `'s` is decoupled from the env lifetime `'a`
-// (`'a: 'a` bounds it below `'a`): a `QueryEnv<'a>` provides
-// `Select<'s>` for *any* `'s` outlived by `'a`, not only `'s == 'a`.
-// This is what lets a subscription poll hold `&query_env` across an
-// `await` and stay Send-general — the caller's higher-ranked
-// `for<'s> Provider<Select<'s>>` demand is now satisfiable. The
-// returned stream still borrows `'a` data, which outlives `'s`, so
-// the shorter `ArtifactStream<'s>` is sound.
-impl<'a, 's, Env> Provider<Select<'s>> for QueryEnv<'a, Env>
+// Deliberately implemented for the *same* lifetime on both sides
+// (`QueryEnv<'a>: Provider<Select<'a>>`), never a decoupled pair
+// (`impl<'a, 's> ... where 'a: 's`). Auto-trait (`Send`) checking of
+// a future that holds `&query_env` across an `await` erases every
+// region, so the obligation resurfaces higher-ranked: a single
+// erased lifetime (`for<'0> QueryEnv<'0>: Provider<Select<'0>>`)
+// is provable by this impl, while a decoupled pair
+// (`for<'0, '1> QueryEnv<'0>: Provider<Select<'1>>`) hits rustc's
+// #100013 limitation and the poll future stops being `Send` on
+// native. `QueryEnv` is covariant in `'a`, so call sites shrink
+// `&QueryEnv<'a>` to `&QueryEnv<'s>` implicitly — the strict impl
+// is what forces region inference to unify the two into one
+// variable.
+impl<'a, Env> Provider<Select<'a>> for QueryEnv<'a, Env>
 where
-    'a: 's,
     Env: Provider<Get>
         + Provider<Put>
         + Provider<Resolve>
@@ -383,22 +402,21 @@ where
     async fn execute(
         &self,
         input: ArtifactSelector<Constrained>,
-    ) -> Result<ArtifactStream<'s>, DialogArtifactsError> {
+    ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
         self.record_demand(&input);
-        let mut streams: Vec<ArtifactStream<'s>> = Vec::with_capacity(self.branches.len() + 1);
+        let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.branches.len() + 1);
 
         // Branch streams — each filtered by tombstones from the
         // overlay's retracts so a `tx.retract(x)` (or any user-asserted
         // retract in `with(..)`) suppresses matching source facts. Each
-        // borrows `'a` data, which outlives `'s`, so it coerces to
-        // `ArtifactStream<'s>`.
+        // owns its branch clone and borrows only `self.env`.
         for branch in &self.branches {
-            let raw = select_from_branch(branch, self.env, input.clone()).await?;
+            let raw = select_from_branch(branch.clone(), self.env, input.clone());
             streams.push(filter_tombstones(raw, self.tombstones.clone()));
         }
 
         // Overlay stream — Changes itself is a Provider<Select>.
-        streams.push(Provider::<Select<'s>>::execute(&self.changes, input).await?);
+        streams.push(Provider::<Select<'a>>::execute(&self.changes, input).await?);
 
         Ok(merge_grouped(streams))
     }
@@ -421,7 +439,7 @@ where
     /// separately, fresh, by the transient layer.
     async fn select_tree(
         &self,
-        branch: &'a Branch,
+        branch: &Branch,
         selector: ArtifactSelector<Constrained>,
     ) -> Result<Vec<Artifact>, DialogArtifactsError> {
         // Rule-discovery reads are demand too: a rule committed
@@ -432,8 +450,9 @@ where
         if let Some(demand) = &self.demand {
             demand.record_rules(&selector);
         }
-        let stream = select_from_branch(branch, self.env, selector).await?;
-        stream.try_collect().await
+        select_from_branch(branch.clone(), self.env, selector)
+            .try_collect()
+            .await
     }
 
     /// The durable rules concluding `concept` on `branch`: the committed
@@ -442,7 +461,7 @@ where
     /// cached by content-addressed rule entity.
     async fn durable_rules(
         &self,
-        branch: &'a Branch,
+        branch: &Branch,
         concept: &Entity,
     ) -> Result<Vec<DeductiveRule>, EvaluationError> {
         let cache = branch.rule_cache();

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -11,6 +11,7 @@ use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::{Identify, Operator, OperatorExt as _};
 use dialog_effects::memory::Resolve;
 use dialog_query::concept::descriptor::ConceptDescriptor;
+use dialog_query::concept::query::fixpoint::Continuation;
 use dialog_query::concept::query::{ConceptRules, PlanCache};
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output};
@@ -255,6 +256,11 @@ pub(crate) struct QueryEnv<'a, Env> {
     /// demanded range here. Subscriptions use the recorded cover to
     /// gate re-evaluation.
     demand: Option<crate::Demand>,
+    /// A polling subscription's retained fixpoint for one concept:
+    /// attached to that concept's resolved rules so a recursive
+    /// evaluation continues (or rebuilds into) the retained answer
+    /// table instead of computing a throwaway one.
+    fixpoint: Option<(Entity, Continuation)>,
     env: &'a Env,
 }
 
@@ -279,6 +285,7 @@ impl<'a, Env> QueryEnv<'a, Env> {
             changes,
             tombstones,
             demand: None,
+            fixpoint: None,
             env,
         }
     }
@@ -288,6 +295,14 @@ impl<'a, Env> QueryEnv<'a, Env> {
     /// demand cover.
     pub(crate) fn with_demand(mut self, demand: crate::Demand) -> Self {
         self.demand = Some(demand);
+        self
+    }
+
+    /// Attach a subscription's retained fixpoint for `concept`:
+    /// when that concept's rules resolve recursive, evaluation
+    /// continues the retained answer table instead of recomputing.
+    pub(crate) fn with_fixpoint(mut self, concept: Entity, continuation: Continuation) -> Self {
+        self.fixpoint = Some((concept, continuation));
         self
     }
 
@@ -306,6 +321,7 @@ impl<Env> Clone for QueryEnv<'_, Env> {
             changes: self.changes.clone(),
             tombstones: self.tombstones.clone(),
             demand: self.demand.clone(),
+            fixpoint: self.fixpoint.clone(),
             env: self.env,
         }
     }
@@ -512,7 +528,13 @@ where
         let analysis = self.program_analysis(&input, &bundle).await?;
         analysis.check(&input)?;
         Ok(if analysis.is_recursive(&concept) {
-            bundle.with_recursion(analysis)
+            let bundle = bundle.with_recursion(analysis);
+            match &self.fixpoint {
+                Some((entity, continuation)) if *entity == concept => {
+                    bundle.with_continuation(continuation.clone())
+                }
+                _ => bundle,
+            }
         } else {
             bundle
         })

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -397,8 +397,12 @@ where
     ) -> Result<Vec<Artifact>, DialogArtifactsError> {
         // Rule-discovery reads are demand too: a rule committed
         // later for a subscribed concept lands in this range and
-        // must re-trigger the subscription.
-        self.record_demand(&selector);
+        // must re-trigger the subscription. Recorded as *rule*
+        // demand: a hit here invalidates the whole result, not one
+        // entity's slice.
+        if let Some(demand) = &self.demand {
+            demand.record_rules(&selector);
+        }
         let stream = select_from_branch(branch, self.env, selector).await?;
         stream.try_collect().await
     }

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -10,13 +10,15 @@ use dialog_common::ConditionalSync;
 use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::{Identify, Operator, OperatorExt as _};
 use dialog_effects::memory::Resolve;
-use dialog_query::DeductiveRule;
 use dialog_query::concept::descriptor::ConceptDescriptor;
-use dialog_query::concept::query::ConceptRules;
+use dialog_query::concept::query::{ConceptRules, PlanCache};
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output};
+use dialog_query::session::ProgramAnalysis;
 use dialog_query::source::SelectRules;
+use dialog_query::{DeductiveRule, Negation, Premise, Proposition};
 use futures_util::TryStreamExt as _;
+use std::sync::Arc;
 
 use crate::layer::{filter_tombstones, merge_grouped, tombstones_from};
 use crate::rules::{
@@ -477,6 +479,15 @@ where
     /// each branch is a durable layer (committed `db.rule/*`, head-cached),
     /// the overlay is a transient layer (uncommitted `db.rule/*`, fresh).
     /// The implicit per-descriptor rule is assembled once on top.
+    ///
+    /// The resolved rule set is checked against the program analysis
+    /// of its dependency closure: an ill-stratified closure fails
+    /// here (exactly like [`RuleRegistry::acquire`]), and a concept
+    /// on a (stratified) cycle gets the analysis attached so
+    /// evaluation runs the semi-naive fixpoint instead of recursing
+    /// top-down unboundedly.
+    ///
+    /// [`RuleRegistry::acquire`]: dialog_query::session::RuleRegistry::acquire
     async fn execute(&self, input: ConceptDescriptor) -> Result<ConceptRules, EvaluationError> {
         let concept = input.this();
         let mut rules: Vec<DeductiveRule> = Vec::new();
@@ -497,7 +508,81 @@ where
             .map(|branch| branch.plan_cache())
             .unwrap_or_default();
 
-        Ok(assemble(&input, rules, plan_cache))
+        let bundle = assemble(&input, rules, plan_cache);
+        let analysis = self.program_analysis(&input, &bundle).await?;
+        analysis.check(&input)?;
+        Ok(if analysis.is_recursive(&concept) {
+            bundle.with_recursion(analysis)
+        } else {
+            bundle
+        })
+    }
+}
+
+impl<'a, Env> QueryEnv<'a, Env>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    /// The program analysis over the rule set reachable from `root`:
+    /// every concept referenced (transitively) by a resolved rule's
+    /// concept premises contributes its own resolved rules, so
+    /// cycles that span concepts — including ones closed entirely by
+    /// durable rules — are visible.
+    ///
+    /// Per-concept rule discovery is head-cached
+    /// ([`durable_rules`](Self::durable_rules)), so the walk is
+    /// cheap after the first query at a given head.
+    async fn program_analysis(
+        &self,
+        root: &ConceptDescriptor,
+        root_bundle: &ConceptRules,
+    ) -> Result<Arc<ProgramAnalysis>, EvaluationError> {
+        fn referenced(bundle: &ConceptRules, queue: &mut Vec<ConceptDescriptor>) {
+            for rule in bundle.rules() {
+                for premise in rule.analysis().premises() {
+                    match premise {
+                        Premise::Assert(Proposition::Concept(query))
+                        | Premise::Unless(Negation(Proposition::Concept(query))) => {
+                            queue.push(query.predicate.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        let mut entries: Vec<(Entity, ConceptRules)> = Vec::new();
+        let mut seen = HashSet::new();
+        let mut queue = Vec::new();
+
+        seen.insert(root.this());
+        referenced(root_bundle, &mut queue);
+        entries.push((root.this(), root_bundle.clone()));
+
+        while let Some(descriptor) = queue.pop() {
+            let entity = descriptor.this();
+            if !seen.insert(entity.clone()) {
+                continue;
+            }
+            let mut rules: Vec<DeductiveRule> = Vec::new();
+            for branch in &self.branches {
+                rules.extend(self.durable_rules(branch, &entity).await?);
+            }
+            rules.extend(overlay_rules(&self.changes, &entity));
+            let bundle = assemble(&descriptor, rules, PlanCache::default());
+            referenced(&bundle, &mut queue);
+            entries.push((entity, bundle));
+        }
+
+        Ok(Arc::new(ProgramAnalysis::analyze(
+            entries.iter().map(|(entity, bundle)| (entity, bundle)),
+        )))
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -165,11 +165,16 @@ impl<'a> QueryLayer<'a> {
     }
 }
 
+// Folds the branch's transient session overlay
+// ([`Branch::overlay`]): every read path — `branch.select`,
+// `branch.query`, transaction queries, subscription evaluations —
+// constructs through here, so session facts participate in all of
+// them with no per-path wiring.
 impl<'a> From<&'a Branch> for QueryLayer<'a> {
     fn from(branch: &'a Branch) -> Self {
         Self {
             branches: vec![branch],
-            changes: Changes::new(),
+            changes: branch.overlay().changes(),
         }
     }
 }

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -61,6 +61,7 @@
 //! [`AnalyzedRule::is_entity_local`]: dialog_query::rule::analyzer::AnalyzedRule::is_entity_local
 
 use std::collections::BTreeSet;
+use std::future::Future;
 use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 
@@ -316,13 +317,21 @@ where
         &self.demand
     }
 
-    /// Replace the transient overlay folded into evaluations. The
-    /// overlay is off-tree, so this alone changes nothing: the caller
-    /// must follow with a [`poll`](Subscription::poll), which then
-    /// recomputes (the overlay delta can't be derived from the tree
-    /// diff) and reports the result change as a delta.
+    /// Replace the transient overlay folded into evaluations and
+    /// invalidate the pinned revision so the next
+    /// [`poll`](Subscription::poll) recomputes.
+    ///
+    /// The overlay is off-tree, so a change to it never appears in
+    /// the tree diff the poll gates on; without invalidating the pin
+    /// the next poll would short-circuit (`current == revision`) and
+    /// miss the overlay change. Invalidation routes the next poll
+    /// through a full evaluation (the overlay delta cannot be derived
+    /// incrementally from the tree), which reports the result change
+    /// as a delta against the retained results.
     pub fn set_overlay(&mut self, overlay: Changes) {
         self.overlay = overlay;
+        self.revision = None;
+        self.initialized = false;
     }
 
     /// Full evaluations performed so far (the first poll plus every
@@ -352,10 +361,10 @@ where
     /// lands mid-evaluation re-triggers on the next poll (the diff
     /// from the pinned root is a superset), so changes are never
     /// missed, at worst re-checked.
-    pub async fn poll<Env>(
-        &mut self,
-        env: &Env,
-    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
+    pub fn poll<'a, Env>(
+        &'a mut self,
+        env: &'a Env,
+    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -366,62 +375,71 @@ where
             + ConditionalSync
             + 'static,
     {
-        let current = self.branch.revision();
-        if self.initialized {
-            if current == self.revision {
-                return Ok(None);
-            }
-            match self.touched(env, &current).await? {
-                Touched::Nothing => {
-                    self.revision = current;
+        // Returned as an explicit `impl Future + 'a` (not an `async
+        // fn`) so the env lifetime is named rather than higher-ranked.
+        // An `async fn poll<Env>(&mut self, env: &Env)` desugars to a
+        // future whose `&Env` capture is `for<'e>`, which defeats
+        // Send-generality inference in a caller that must be `Send`
+        // (an axum handler draining subscription polls) — the same
+        // reason `SelectQuery::perform` is written this way.
+        async move {
+            let current = self.branch.revision();
+            if self.initialized {
+                if current == self.revision {
                     return Ok(None);
                 }
-                Touched::Facts {
-                    subjects,
-                    facts,
-                    asserted,
-                    retracted,
-                } => {
-                    if let Some(delta) = self
-                        .maintain(env, &subjects, &facts, &asserted, &retracted)
-                        .await?
-                    {
-                        self.maintenances += 1;
+                match self.touched(env, &current).await? {
+                    Touched::Nothing => {
                         self.revision = current;
-                        return Ok(Some(delta));
+                        return Ok(None);
                     }
-                    // Not maintainable for this query/rule shape:
-                    // fall through to a full recompute.
+                    Touched::Facts {
+                        subjects,
+                        facts,
+                        asserted,
+                        retracted,
+                    } => {
+                        if let Some(delta) = self
+                            .maintain(env, &subjects, &facts, &asserted, &retracted)
+                            .await?
+                        {
+                            self.maintenances += 1;
+                            self.revision = current;
+                            return Ok(Some(delta));
+                        }
+                        // Not maintainable for this query/rule shape:
+                        // fall through to a full recompute.
+                    }
+                    // A rule-range change can install or change a rule,
+                    // which can affect any row: recompute.
+                    Touched::Rules => {}
                 }
-                // A rule-range change can install or change a rule,
-                // which can affect any row: recompute.
-                Touched::Rules => {}
             }
+
+            let demand = Demand::new();
+            let results = self.evaluate(env, &demand, &self.query).await?;
+            self.recomputes += 1;
+
+            let delta = Delta {
+                asserted: results
+                    .iter()
+                    .filter(|row| !self.results.contains(row))
+                    .cloned()
+                    .collect(),
+                retracted: self
+                    .results
+                    .iter()
+                    .filter(|row| !results.contains(row))
+                    .cloned()
+                    .collect(),
+            };
+
+            self.results = results;
+            self.demand = demand;
+            self.revision = current;
+            self.initialized = true;
+            Ok(Some(delta))
         }
-
-        let demand = Demand::new();
-        let results = self.evaluate(env, &demand, &self.query).await?;
-        self.recomputes += 1;
-
-        let delta = Delta {
-            asserted: results
-                .iter()
-                .filter(|row| !self.results.contains(row))
-                .cloned()
-                .collect(),
-            retracted: self
-                .results
-                .iter()
-                .filter(|row| !results.contains(row))
-                .cloned()
-                .collect(),
-        };
-
-        self.results = results;
-        self.demand = demand;
-        self.revision = current;
-        self.initialized = true;
-        Ok(Some(delta))
     }
 
     /// Classify what the changes between the pinned root and
@@ -443,11 +461,11 @@ where
     /// and are skipped.
     ///
     /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
-    async fn touched<Env>(
-        &self,
-        env: &Env,
-        current: &Option<Revision>,
-    ) -> Result<Touched, EvaluationError>
+    fn touched<'a, Env>(
+        &'a self,
+        env: &'a Env,
+        current: &'a Option<Revision>,
+    ) -> impl Future<Output = Result<Touched, EvaluationError>> + 'a
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -457,78 +475,82 @@ where
             + ConditionalSync
             + 'static,
     {
-        let pinned = tree_hash(&self.revision);
-        let target = tree_hash(current);
-        if pinned == target {
-            return Ok(Touched::Nothing);
-        }
-        let scope = self.demand.ranges();
-        if scope.is_empty() {
-            return Ok(Touched::Nothing);
-        }
-
-        let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
-        let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
-        let previous =
-            Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
-        let next = Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
-
-        let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
-        let mut changes = Box::pin(changes);
-        let mut subjects = BTreeSet::new();
-        let mut asserted = Vec::new();
-        let mut retracted = Vec::new();
-        // A fact change surfaces once per index order; dedup on the
-        // datum triple, per direction.
-        let mut seen = BTreeSet::new();
-        while let Some(change) = changes
-            .try_next()
-            .await
-            .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-        {
-            let entry = match &change {
-                Change::Add(entry) => entry,
-                Change::Remove(entry) => entry,
-            };
-            if self.demand.covers_rules(&entry.key) {
-                return Ok(Touched::Rules);
+        async move {
+            let pinned = tree_hash(&self.revision);
+            let target = tree_hash(current);
+            if pinned == target {
+                return Ok(Touched::Nothing);
             }
-            // An entry arriving with a datum became readable; an
-            // entry leaving with a datum stopped being readable.
-            // Tombstone-valued entries carry no datum: their effect
-            // (if any) surfaces as the paired datum-bearing change
-            // at the same key.
-            let arriving = matches!(&change, Change::Add(_));
-            if let State::Added(datum) = &entry.value {
-                if !seen.insert((
-                    arriving,
-                    datum.entity.clone(),
-                    datum.attribute.clone(),
-                    datum.value.clone(),
-                )) {
-                    continue;
+            let scope = self.demand.ranges();
+            if scope.is_empty() {
+                return Ok(Touched::Nothing);
+            }
+
+            let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
+            let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
+            let previous =
+                Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
+            let next =
+                Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
+
+            let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
+            let mut changes = Box::pin(changes);
+            let mut subjects = BTreeSet::new();
+            let mut asserted = Vec::new();
+            let mut retracted = Vec::new();
+            // A fact change surfaces once per index order; dedup on the
+            // datum triple, per direction.
+            let mut seen = BTreeSet::new();
+            while let Some(change) = changes
+                .try_next()
+                .await
+                .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
+            {
+                let entry = match &change {
+                    Change::Add(entry) => entry,
+                    Change::Remove(entry) => entry,
+                };
+                if self.demand.covers_rules(&entry.key) {
+                    return Ok(Touched::Rules);
                 }
-                let fact = Artifact::try_from(datum.clone())
-                    .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
-                subjects.insert(fact.of.clone());
-                if arriving {
-                    asserted.push(fact);
-                } else {
-                    retracted.push(fact);
+                // An entry arriving with a datum became readable; an
+                // entry leaving with a datum stopped being readable.
+                // Tombstone-valued entries carry no datum: their effect
+                // (if any) surfaces as the paired datum-bearing change
+                // at the same key.
+                let arriving = matches!(&change, Change::Add(_));
+                if let State::Added(datum) = &entry.value {
+                    if !seen.insert((
+                        arriving,
+                        datum.entity.clone(),
+                        datum.attribute.clone(),
+                        datum.value.clone(),
+                    )) {
+                        continue;
+                    }
+                    let fact = Artifact::try_from(datum.clone()).map_err(|error| {
+                        EvaluationError::Store(format!("changed datum: {error:?}"))
+                    })?;
+                    subjects.insert(fact.of.clone());
+                    if arriving {
+                        asserted.push(fact);
+                    } else {
+                        retracted.push(fact);
+                    }
                 }
             }
-        }
 
-        if subjects.is_empty() {
-            Ok(Touched::Nothing)
-        } else {
-            let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
-            Ok(Touched::Facts {
-                subjects,
-                facts,
-                asserted,
-                retracted,
-            })
+            if subjects.is_empty() {
+                Ok(Touched::Nothing)
+            } else {
+                let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
+                Ok(Touched::Facts {
+                    subjects,
+                    facts,
+                    asserted,
+                    retracted,
+                })
+            }
         }
     }
 
@@ -545,14 +567,14 @@ where
     /// the query is not restrictable, the concept is recursive, or
     /// the delta-join discovery hit a shape it does not handle — in
     /// which case the caller falls back to a full recompute.
-    async fn maintain<Env>(
-        &mut self,
-        env: &Env,
-        subjects: &BTreeSet<Entity>,
-        facts: &[Artifact],
-        asserted: &[Artifact],
-        retracted: &[Artifact],
-    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
+    fn maintain<'a, Env>(
+        &'a mut self,
+        env: &'a Env,
+        subjects: &'a BTreeSet<Entity>,
+        facts: &'a [Artifact],
+        asserted: &'a [Artifact],
+        retracted: &'a [Artifact],
+    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -563,19 +585,174 @@ where
             + ConditionalSync
             + 'static,
     {
-        // For a concept query the affected heads are discovered
-        // against the resolved rule set: entity-local rules
-        // contribute the changed subjects, non-local rules (concept
-        // premises: conformance checks, variant negations)
-        // contribute delta-join heads — the changed fact bound into
-        // the premise it matches, remaining premises joined
-        // sideways, head projected. `None` (recursion, unhandled
-        // shape) falls back to full recompute. For a plain attribute
-        // query the affected heads are just the changed subjects.
-        //
-        // The discovery evaluates against the demand-recording
-        // environment, so the reads it depends on join the cover.
-        let entities: BTreeSet<Entity> = if let Some(concept) = self.query.concept() {
+        async move {
+            // For a concept query the affected heads are discovered
+            // against the resolved rule set: entity-local rules
+            // contribute the changed subjects, non-local rules (concept
+            // premises: conformance checks, variant negations)
+            // contribute delta-join heads — the changed fact bound into
+            // the premise it matches, remaining premises joined
+            // sideways, head projected. `None` (recursion, unhandled
+            // shape) falls back to full recompute. For a plain attribute
+            // query the affected heads are just the changed subjects.
+            //
+            // The discovery evaluates against the demand-recording
+            // environment, so the reads it depends on join the cover.
+            let entities: BTreeSet<Entity> = if let Some(concept) = self.query.concept() {
+                let operator = Identify
+                    .perform(env)
+                    .await
+                    .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+                let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+                let overlay = layer.overlay(&operator);
+                let tombstones = tombstones_from(&overlay);
+                let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+                    .with_demand(self.demand.clone());
+                let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
+                if rules.recursion().is_some() {
+                    // Fixpoint continuation: deletions retract via DRed,
+                    // additions extend semi-naively — rebuilding into
+                    // the retained table when either phase declines.
+                    drop(query_env);
+                    let results = self
+                        .evaluate_with_continuation(
+                            env,
+                            Arc::new(asserted.to_vec()),
+                            Arc::new(retracted.to_vec()),
+                        )
+                        .await?;
+                    let delta = Delta {
+                        asserted: results
+                            .iter()
+                            .filter(|row| !self.results.contains(row))
+                            .cloned()
+                            .collect(),
+                        retracted: self
+                            .results
+                            .iter()
+                            .filter(|row| !results.contains(row))
+                            .cloned()
+                            .collect(),
+                    };
+                    self.results = results;
+                    return Ok(Some(delta));
+                }
+                match affected_entities(concept, facts, &query_env).await? {
+                    Some(entities) => entities,
+                    None => return Ok(None),
+                }
+            } else {
+                subjects.clone()
+            };
+
+            let mut asserted = Vec::new();
+            let mut retracted = Vec::new();
+            for entity in &entities {
+                let scoped = match self.query.restrict(entity) {
+                    Restriction::Scoped(query) => query,
+                    Restriction::Unaffected => continue,
+                    Restriction::Unsupported => return Ok(None),
+                };
+                // Over-delete: every retained row for this entity...
+                let before: Vec<Q::Conclusion> = self
+                    .results
+                    .iter()
+                    .filter(|row| row.this() == entity)
+                    .cloned()
+                    .collect();
+                // ...re-derive + insert: goal-directed re-evaluation,
+                // recording into the existing cover (the standing
+                // demand only ever grows between recomputes).
+                let after = self.evaluate(env, &self.demand.clone(), &scoped).await?;
+                for row in &after {
+                    if !before.contains(row) {
+                        asserted.push(row.clone());
+                    }
+                }
+                for row in &before {
+                    if !after.contains(row) {
+                        retracted.push(row.clone());
+                    }
+                }
+                self.results.retain(|row| row.this() != entity);
+                self.results.extend(after);
+            }
+            Ok(Some(Delta {
+                asserted,
+                retracted,
+            }))
+        }
+    }
+
+    /// Evaluate the query against the branch, recording every
+    /// demanded range into `demand`. Mirrors the ordinary
+    /// `branch.select(query).perform(env)` path with a
+    /// demand-recording environment.
+    // `impl Future + 'a` (not `async fn`) so the env lifetime is
+    // named, keeping the enclosing `poll` future Send-general on
+    // native — see the note on `poll`.
+    fn evaluate<'a, Env>(
+        &'a self,
+        env: &'a Env,
+        demand: &'a Demand,
+        query: &'a Q,
+    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        async move {
+            let operator = Identify
+                .perform(env)
+                .await
+                .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+            let overlay = layer.overlay(&operator);
+            let tombstones = tombstones_from(&overlay);
+            let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+                .with_demand(demand.clone());
+            // Recursive concept subscriptions retain their fixpoint
+            // across polls: a recompute rebuilds into the retained
+            // table so a later additions-only poll can extend it.
+            if let Some(concept) = query.concept() {
+                query_env = query_env
+                    .with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
+            }
+            query.clone().perform(&query_env).try_vec().await
+        }
+    }
+
+    /// Evaluate the standing query with the retained fixpoint
+    /// attached, seeding a semi-naive continuation from `additions`
+    /// when present. Demand keeps recording into the standing
+    /// cover.
+    fn evaluate_with_continuation<'a, Env>(
+        &'a self,
+        env: &'a Env,
+        additions: Arc<Vec<Artifact>>,
+        deletions: Arc<Vec<Artifact>>,
+    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        async move {
+            let concept = self
+                .query
+                .concept()
+                .expect("continuation evaluation requires a concept query");
             let operator = Identify
                 .perform(env)
                 .await
@@ -584,159 +761,13 @@ where
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                .with_demand(self.demand.clone());
-            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
-            if rules.recursion().is_some() {
-                // Fixpoint continuation: deletions retract via DRed,
-                // additions extend semi-naively — rebuilding into
-                // the retained table when either phase declines.
-                drop(query_env);
-                let results = self
-                    .evaluate_with_continuation(
-                        env,
-                        Arc::new(asserted.to_vec()),
-                        Arc::new(retracted.to_vec()),
-                    )
-                    .await?;
-                let delta = Delta {
-                    asserted: results
-                        .iter()
-                        .filter(|row| !self.results.contains(row))
-                        .cloned()
-                        .collect(),
-                    retracted: self
-                        .results
-                        .iter()
-                        .filter(|row| !results.contains(row))
-                        .cloned()
-                        .collect(),
-                };
-                self.results = results;
-                return Ok(Some(delta));
-            }
-            match affected_entities(concept, facts, &query_env).await? {
-                Some(entities) => entities,
-                None => return Ok(None),
-            }
-        } else {
-            subjects.clone()
-        };
-
-        let mut asserted = Vec::new();
-        let mut retracted = Vec::new();
-        for entity in &entities {
-            let scoped = match self.query.restrict(entity) {
-                Restriction::Scoped(query) => query,
-                Restriction::Unaffected => continue,
-                Restriction::Unsupported => return Ok(None),
-            };
-            // Over-delete: every retained row for this entity...
-            let before: Vec<Q::Conclusion> = self
-                .results
-                .iter()
-                .filter(|row| row.this() == entity)
-                .cloned()
-                .collect();
-            // ...re-derive + insert: goal-directed re-evaluation,
-            // recording into the existing cover (the standing
-            // demand only ever grows between recomputes).
-            let after = self.evaluate(env, &self.demand.clone(), &scoped).await?;
-            for row in &after {
-                if !before.contains(row) {
-                    asserted.push(row.clone());
-                }
-            }
-            for row in &before {
-                if !after.contains(row) {
-                    retracted.push(row.clone());
-                }
-            }
-            self.results.retain(|row| row.this() != entity);
-            self.results.extend(after);
+                .with_demand(self.demand.clone())
+                .with_fixpoint(
+                    concept.this(),
+                    Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
+                );
+            self.query.clone().perform(&query_env).try_vec().await
         }
-        Ok(Some(Delta {
-            asserted,
-            retracted,
-        }))
-    }
-
-    /// Evaluate the query against the branch, recording every
-    /// demanded range into `demand`. Mirrors the ordinary
-    /// `branch.select(query).perform(env)` path with a
-    /// demand-recording environment.
-    async fn evaluate<Env>(
-        &self,
-        env: &Env,
-        demand: &Demand,
-        query: &Q,
-    ) -> Result<Vec<Q::Conclusion>, EvaluationError>
-    where
-        Env: Provider<Get>
-            + Provider<Put>
-            + Provider<Resolve>
-            + Provider<Identify>
-            + Provider<Fork<RemoteSite, Get>>
-            + Provider<Fork<RemoteSite, Resolve>>
-            + ConditionalSync
-            + 'static,
-    {
-        let operator = Identify
-            .perform(env)
-            .await
-            .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
-        let overlay = layer.overlay(&operator);
-        let tombstones = tombstones_from(&overlay);
-        let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-            .with_demand(demand.clone());
-        // Recursive concept subscriptions retain their fixpoint
-        // across polls: a recompute rebuilds into the retained
-        // table so a later additions-only poll can extend it.
-        if let Some(concept) = query.concept() {
-            query_env =
-                query_env.with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
-        }
-        query.clone().perform(&query_env).try_vec().await
-    }
-
-    /// Evaluate the standing query with the retained fixpoint
-    /// attached, seeding a semi-naive continuation from `additions`
-    /// when present. Demand keeps recording into the standing
-    /// cover.
-    async fn evaluate_with_continuation<Env>(
-        &self,
-        env: &Env,
-        additions: Arc<Vec<Artifact>>,
-        deletions: Arc<Vec<Artifact>>,
-    ) -> Result<Vec<Q::Conclusion>, EvaluationError>
-    where
-        Env: Provider<Get>
-            + Provider<Put>
-            + Provider<Resolve>
-            + Provider<Identify>
-            + Provider<Fork<RemoteSite, Get>>
-            + Provider<Fork<RemoteSite, Resolve>>
-            + ConditionalSync
-            + 'static,
-    {
-        let concept = self
-            .query
-            .concept()
-            .expect("continuation evaluation requires a concept query");
-        let operator = Identify
-            .perform(env)
-            .await
-            .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
-        let overlay = layer.overlay(&operator);
-        let tombstones = tombstones_from(&overlay);
-        let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-            .with_demand(self.demand.clone())
-            .with_fixpoint(
-                concept.this(),
-                Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
-            );
-        self.query.clone().perform(&query_env).try_vec().await
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -76,8 +76,10 @@ use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
 use dialog_query::Conclusion;
 use dialog_query::concept::query::affected::affected_entities;
+use dialog_query::concept::query::fixpoint::{Continuation, InMemoryAnswerTable};
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output as _, Restriction};
+use dialog_query::source::SelectRules;
 use dialog_search_tree::{Change, ContentAddressedStorage};
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
@@ -198,6 +200,10 @@ pub struct Subscription<Q: Application> {
     /// The last evaluation's full result, retained to compute the
     /// next delta.
     results: Vec<Q::Conclusion>,
+    /// The retained fixpoint answer table when the subscribed
+    /// concept is recursive: additions extend it semi-naively;
+    /// recomputes rebuild into it.
+    fixpoint: Arc<Mutex<Option<InMemoryAnswerTable>>>,
     initialized: bool,
     /// Full evaluations performed (first poll + fallbacks).
     recomputes: usize,
@@ -216,6 +222,7 @@ impl Branch {
             revision: None,
             demand: Demand::new(),
             results: Vec::new(),
+            fixpoint: Arc::new(Mutex::new(None)),
             initialized: false,
             recomputes: 0,
             maintenances: 0,
@@ -238,6 +245,10 @@ enum Touched {
         subjects: BTreeSet<Entity>,
         /// The changed facts themselves, for delta-join discovery.
         facts: Vec<Artifact>,
+        /// Whether every change was an addition (no fact left the
+        /// index and no tombstone was written): the precondition
+        /// for semi-naive fixpoint continuation.
+        additions_only: bool,
     },
 }
 
@@ -316,8 +327,15 @@ where
                     self.revision = current;
                     return Ok(None);
                 }
-                Touched::Facts { subjects, facts } => {
-                    if let Some(delta) = self.maintain(env, &subjects, &facts).await? {
+                Touched::Facts {
+                    subjects,
+                    facts,
+                    additions_only,
+                } => {
+                    if let Some(delta) = self
+                        .maintain(env, &subjects, &facts, additions_only)
+                        .await?
+                    {
                         self.maintenances += 1;
                         self.revision = current;
                         return Ok(Some(delta));
@@ -409,6 +427,7 @@ where
         let mut changes = Box::pin(changes);
         let mut subjects = BTreeSet::new();
         let mut facts = Vec::new();
+        let mut additions_only = true;
         // A fact change surfaces once per index order; dedup on the
         // datum triple.
         let mut seen = BTreeSet::new();
@@ -423,6 +442,13 @@ where
             };
             if self.demand.covers_rules(&entry.key) {
                 return Ok(Touched::Rules);
+            }
+            // An entry leaving the index, or a tombstone arriving,
+            // means a fact stopped being readable: not an addition.
+            match (&change, &entry.value) {
+                (Change::Remove(_), State::Added(_)) => additions_only = false,
+                (Change::Add(_), State::Removed) => additions_only = false,
+                _ => {}
             }
             if let State::Added(datum) = &entry.value {
                 if !seen.insert((
@@ -442,7 +468,11 @@ where
         if subjects.is_empty() {
             Ok(Touched::Nothing)
         } else {
-            Ok(Touched::Facts { subjects, facts })
+            Ok(Touched::Facts {
+                subjects,
+                facts,
+                additions_only,
+            })
         }
     }
 
@@ -464,6 +494,7 @@ where
         env: &Env,
         subjects: &BTreeSet<Entity>,
         facts: &[Artifact],
+        additions_only: bool,
     ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
@@ -497,6 +528,36 @@ where
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
                 .with_demand(self.demand.clone());
+            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
+            if rules.recursion().is_some() {
+                // Fixpoint continuation: additions extend the
+                // retained answer table semi-naively (rebuilding
+                // when the rule set is not additively extendable);
+                // deletions fall back to a recompute, which rebuilds
+                // the table.
+                if !additions_only {
+                    return Ok(None);
+                }
+                drop(query_env);
+                let results = self
+                    .evaluate_with_continuation(env, Some(Arc::new(facts.to_vec())))
+                    .await?;
+                let delta = Delta {
+                    asserted: results
+                        .iter()
+                        .filter(|row| !self.results.contains(row))
+                        .cloned()
+                        .collect(),
+                    retracted: self
+                        .results
+                        .iter()
+                        .filter(|row| !results.contains(row))
+                        .cloned()
+                        .collect(),
+                };
+                self.results = results;
+                return Ok(Some(delta));
+            }
             match affected_entities(concept, facts, &query_env).await? {
                 Some(entities) => entities,
                 None => return Ok(None),
@@ -570,9 +631,57 @@ where
         let layer = QueryLayer::from(&self.branch);
         let overlay = layer.overlay(&operator);
         let tombstones = tombstones_from(&overlay);
-        let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+        let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
             .with_demand(demand.clone());
+        // Recursive concept subscriptions retain their fixpoint
+        // across polls: a recompute rebuilds into the retained
+        // table so a later additions-only poll can extend it.
+        if let Some(concept) = query.concept() {
+            query_env = query_env.with_fixpoint(
+                concept.this(),
+                Continuation::new(self.fixpoint.clone(), None),
+            );
+        }
         query.clone().perform(&query_env).try_vec().await
+    }
+
+    /// Evaluate the standing query with the retained fixpoint
+    /// attached, seeding a semi-naive continuation from `additions`
+    /// when present. Demand keeps recording into the standing
+    /// cover.
+    async fn evaluate_with_continuation<Env>(
+        &self,
+        env: &Env,
+        additions: Option<Arc<Vec<Artifact>>>,
+    ) -> Result<Vec<Q::Conclusion>, EvaluationError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let concept = self
+            .query
+            .concept()
+            .expect("continuation evaluation requires a concept query");
+        let operator = Identify
+            .perform(env)
+            .await
+            .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+        let layer = QueryLayer::from(&self.branch);
+        let overlay = layer.overlay(&operator);
+        let tombstones = tombstones_from(&overlay);
+        let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+            .with_demand(self.demand.clone())
+            .with_fixpoint(
+                concept.this(),
+                Continuation::new(self.fixpoint.clone(), additions),
+            );
+        self.query.clone().perform(&query_env).try_vec().await
     }
 }
 
@@ -1478,7 +1587,14 @@ mod tests {
             .commit()
             .perform(&operator)
             .await?;
+        assert_eq!(subscription.recomputes(), 1);
         let delta = subscription.poll(&operator).await?.expect("cone grows");
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the closure extended via fixpoint continuation, not a re-fixpoint"
+        );
+        assert_eq!(subscription.maintenances(), 1);
         let mut asserted = delta.asserted.clone();
         asserted.sort_by_key(|row| format!("{row:?}"));
         let mut expected = vec![
@@ -1509,6 +1625,57 @@ mod tests {
             .expect("cone grows again");
         assert_eq!(delta.asserted.len(), 3, "(d,c), (d,b), (d,a)");
         assert!(delta.retracted.is_empty());
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
+
+        // A deletion shrinks the closure: not additively
+        // extendable, so the poll rebuilds the fixpoint (and the
+        // retained table), retracting everything derived through
+        // the removed edge.
+        branch
+            .transaction()
+            .retract(Parent::of(c.clone()).is(b.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("cone shrinks");
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            delta.retracted.len(),
+            4,
+            "everything derived through the removed edge goes: \
+             (c,b), (c,a), (d,b), (d,a); (d,c) survives"
+        );
+        assert_eq!(subscription.recomputes(), 2, "deletions rebuild");
+
+        // And the rebuilt table continues extending afterwards.
+        let e = Entity::new()?;
+        branch
+            .transaction()
+            .assert(Parent::of(e.clone()).is(d.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("extends again");
+        let mut asserted = delta.asserted.clone();
+        asserted.sort_by_key(|row| format!("{row:?}"));
+        let mut expected = vec![
+            HasAncestor {
+                this: e.clone(),
+                ancestor: Ancestor(d.clone()),
+            },
+            HasAncestor {
+                this: e.clone(),
+                ancestor: Ancestor(c.clone()),
+            },
+        ];
+        expected.sort_by_key(|row| format!("{row:?}"));
+        assert_eq!(
+            asserted, expected,
+            "e's ancestors follow the surviving chain"
+        );
+        assert_eq!(subscription.recomputes(), 2);
+        assert_eq!(subscription.maintenances(), 3);
         Ok(())
     }
 }

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -1,0 +1,558 @@
+//! Standing query subscriptions, incrementally gated by demand.
+//!
+//! A [`Subscription`] registers a query once and is then *polled*:
+//! each poll compares the branch's current revision against the
+//! revision the subscription last evaluated at. Re-evaluation is
+//! gated by the subscription's **demand cover** — the set of index
+//! key ranges the previous evaluation read, recorded at the `Select`
+//! boundary — intersected with the tree diff between the pinned root
+//! and the new one:
+//!
+//! - no root change → nothing to do;
+//! - root changed but no diff entry falls inside the cover → the
+//!   result cannot have changed; the pin advances without
+//!   re-evaluating (this is the point: unrelated writes are free);
+//! - a diff entry falls inside the cover → re-evaluate, emit the
+//!   result [`Delta`], re-record the cover, advance the pin.
+//!
+//! The cover is the *demanded* range, not the touched data: a scan
+//! that came back empty still recorded its range, so absence reads
+//! (a fact that wasn't there yet, a rule that wasn't installed yet)
+//! are invalidated by later writes into the demanded range. Rule
+//! discovery reads (`db.rule/*` scans) record the same way, so
+//! committing a new rule for a subscribed concept re-triggers too.
+//!
+//! Deliberately pull-driven: nothing here retains operator state or
+//! integrated inputs. Demand transformation over the existing
+//! top-down engine is the architecture; the diff is the signal, the
+//! cover is the gate, and re-evaluation is the (current) recompute
+//! step. Per-delta DRed/FBF maintenance and dynamically maintained
+//! demand (cones that grow with data) build on this same surface.
+
+use std::ops::RangeInclusive;
+use std::sync::{Arc, Mutex};
+
+use dialog_artifacts::selector::Constrained;
+use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
+use dialog_artifacts::{ArtifactSelector, KeyBytes};
+use dialog_capability::{Fork, Provider};
+use dialog_common::Blake3Hash as NodeHash;
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::authority::Identify;
+use dialog_effects::memory::Resolve;
+use dialog_query::error::EvaluationError;
+use dialog_query::query::{Application, Output as _};
+use dialog_search_tree::{Change, ContentAddressedStorage};
+use dialog_storage::Blake3Hash;
+use futures_util::TryStreamExt as _;
+
+use super::session::{QueryEnv, QueryLayer};
+use crate::layer::tombstones_from;
+use crate::{
+    Branch, EMPTY_TREE_HASH, Index, NetworkedIndex, RemoteSite, RepositoryArchiveExt as _, Revision,
+};
+
+/// The demand cover of one evaluation: every index key range the
+/// evaluation's selects read, recorded at the `Select` boundary.
+/// Shared (cheaply clonable) so the query environment can append
+/// while the evaluation streams.
+#[derive(Clone, Debug, Default)]
+pub struct Demand {
+    ranges: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
+}
+
+impl Demand {
+    /// An empty cover.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a selector's demanded range. The range covers
+    /// everything the selector's scan would touch — including where
+    /// no entries exist, so misses are demanded too.
+    pub(crate) fn record(&self, selector: &ArtifactSelector<Constrained>) {
+        let range = selector_range(selector);
+        let mut ranges = self.ranges.lock().expect("demand lock");
+        if !ranges.contains(&range) {
+            ranges.push(range);
+        }
+    }
+
+    /// Whether the key falls inside any recorded range.
+    pub fn covers(&self, key: &KeyBytes) -> bool {
+        self.ranges
+            .lock()
+            .expect("demand lock")
+            .iter()
+            .any(|range| range.contains(key))
+    }
+
+    /// Number of distinct recorded ranges.
+    pub fn len(&self) -> usize {
+        self.ranges.lock().expect("demand lock").len()
+    }
+
+    /// Whether nothing was demanded.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// The change to a subscription's result set between two polls.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Delta<T> {
+    /// Rows in the new result that were not in the previous one.
+    pub asserted: Vec<T>,
+    /// Rows of the previous result that are gone from the new one.
+    pub retracted: Vec<T>,
+}
+
+impl<T> Delta<T> {
+    /// Whether the result set did not change.
+    pub fn is_empty(&self) -> bool {
+        self.asserted.is_empty() && self.retracted.is_empty()
+    }
+}
+
+/// A standing query over a branch. Created by
+/// [`Branch::subscribe`]; driven by [`poll`](Subscription::poll).
+pub struct Subscription<Q: Application> {
+    branch: Branch,
+    query: Q,
+    /// The revision the retained results were evaluated at. `None`
+    /// until the first poll.
+    revision: Option<Revision>,
+    /// The demand cover recorded during the last evaluation.
+    demand: Demand,
+    /// The last evaluation's full result, retained to compute the
+    /// next delta.
+    results: Vec<Q::Conclusion>,
+    initialized: bool,
+}
+
+impl Branch {
+    /// Register a standing query over this branch. The subscription
+    /// evaluates on its first [`poll`](Subscription::poll) and is
+    /// incrementally gated afterwards.
+    pub fn subscribe<Q: Application>(&self, query: Q) -> Subscription<Q> {
+        Subscription {
+            branch: self.clone(),
+            query,
+            revision: None,
+            demand: Demand::new(),
+            results: Vec::new(),
+            initialized: false,
+        }
+    }
+}
+
+/// The index root a revision pins, or the empty tree for an
+/// unborn branch.
+fn tree_hash(revision: &Option<Revision>) -> Blake3Hash {
+    revision
+        .as_ref()
+        .map(|revision| *revision.tree.hash())
+        .unwrap_or(EMPTY_TREE_HASH)
+}
+
+impl<Q> Subscription<Q>
+where
+    Q: Application + Clone,
+    Q::Conclusion: PartialEq + Clone,
+{
+    /// The retained result of the last evaluation.
+    pub fn results(&self) -> &[Q::Conclusion] {
+        &self.results
+    }
+
+    /// The demand cover recorded by the last evaluation.
+    pub fn demand(&self) -> &Demand {
+        &self.demand
+    }
+
+    /// Poll the subscription against the branch's current state.
+    ///
+    /// Returns `Ok(None)` when the result is known unchanged: the
+    /// branch is at the pinned revision, or it moved but no change
+    /// intersects the demand cover (the pin advances silently).
+    /// Returns `Ok(Some(delta))` after a (re-)evaluation — the first
+    /// poll always evaluates, reporting the initial result as
+    /// `asserted` rows.
+    ///
+    /// The revision is snapshotted before evaluating; a commit that
+    /// lands mid-evaluation re-triggers on the next poll (the diff
+    /// from the pinned root is a superset), so changes are never
+    /// missed, at worst re-checked.
+    pub async fn poll<Env>(
+        &mut self,
+        env: &Env,
+    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let current = self.branch.revision();
+        if self.initialized {
+            if current == self.revision {
+                return Ok(None);
+            }
+            if !self.intersects(env, &current).await? {
+                self.revision = current;
+                return Ok(None);
+            }
+        }
+
+        let demand = Demand::new();
+        let results = self.evaluate(env, &demand).await?;
+
+        let delta = Delta {
+            asserted: results
+                .iter()
+                .filter(|row| !self.results.contains(row))
+                .cloned()
+                .collect(),
+            retracted: self
+                .results
+                .iter()
+                .filter(|row| !results.contains(row))
+                .cloned()
+                .collect(),
+        };
+
+        self.results = results;
+        self.demand = demand;
+        self.revision = current;
+        self.initialized = true;
+        Ok(Some(delta))
+    }
+
+    /// Whether any change between the pinned root and `current`
+    /// falls inside the demand cover. Streams the tree diff and
+    /// stops at the first hit.
+    async fn intersects<Env>(
+        &self,
+        env: &Env,
+        current: &Option<Revision>,
+    ) -> Result<bool, EvaluationError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let pinned = tree_hash(&self.revision);
+        let target = tree_hash(current);
+        if pinned == target {
+            return Ok(false);
+        }
+
+        let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
+        let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
+        let previous =
+            Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
+        let next = Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
+
+        let changes = previous.differentiate(&next, &storage, &storage);
+        let mut changes = Box::pin(changes);
+        while let Some(change) = changes
+            .try_next()
+            .await
+            .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
+        {
+            let entry = match change {
+                Change::Add(entry) => entry,
+                Change::Remove(entry) => entry,
+            };
+            if self.demand.covers(&entry.key) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Evaluate the query against the branch, recording every
+    /// demanded range into `demand`. Mirrors the ordinary
+    /// `branch.select(query).perform(env)` path with a
+    /// demand-recording environment.
+    async fn evaluate<Env>(
+        &self,
+        env: &Env,
+        demand: &Demand,
+    ) -> Result<Vec<Q::Conclusion>, EvaluationError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let operator = Identify
+            .perform(env)
+            .await
+            .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+        let layer = QueryLayer::from(&self.branch);
+        let overlay = layer.overlay(&operator);
+        let tombstones = tombstones_from(&overlay);
+        let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+            .with_demand(demand.clone());
+        self.query.clone().perform(&query_env).try_vec().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::{test_operator_with_profile, test_repo};
+    use dialog_artifacts::{Entity, Value};
+    use dialog_query::attribute::The;
+    use dialog_query::{AttributeQuery, Claim, Term, the};
+
+    /// A standing query over every `person/name` fact.
+    fn names_query() -> AttributeQuery {
+        AttributeQuery::from(
+            Term::<The>::from(the!("person/name"))
+                .of(Term::<Entity>::var("e"))
+                .is(Term::<String>::var("v")),
+        )
+    }
+
+    /// Project claims to comparable `(entity, name)` pairs; the
+    /// `cause` provenance hash is commit-dependent and irrelevant
+    /// to what the subscription observed.
+    fn names(claims: &[Claim]) -> Vec<(Entity, String)> {
+        claims
+            .iter()
+            .map(|claim| {
+                let Value::String(name) = claim.is.clone() else {
+                    panic!("expected a string value, got {:?}", claim.is)
+                };
+                (claim.of.clone(), name)
+            })
+            .collect()
+    }
+
+    /// The first poll evaluates and reports the initial result;
+    /// polling again without a commit is a no-op.
+    #[dialog_common::test]
+    async fn it_evaluates_on_first_poll_and_idles_after() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("first poll evaluates");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        assert!(delta.retracted.is_empty());
+        assert!(
+            !subscription.demand().is_empty(),
+            "the evaluation recorded its demand cover"
+        );
+
+        assert!(
+            subscription.poll(&operator).await?.is_none(),
+            "no commit, no work"
+        );
+        Ok(())
+    }
+
+    /// A commit outside the demand cover advances the pin without
+    /// re-evaluating: unrelated writes are free.
+    #[dialog_common::test]
+    async fn it_ignores_writes_outside_the_demand_cover() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+
+        // An unrelated attribute: outside the person/name cover.
+        branch
+            .transaction()
+            .assert(
+                the!("misc/tag")
+                    .of(Entity::new()?)
+                    .is("unrelated".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        assert!(
+            subscription.poll(&operator).await?.is_none(),
+            "a write outside the cover must not re-evaluate"
+        );
+        assert_eq!(
+            names(subscription.results()),
+            vec![(alice.clone(), "Alice".to_string())],
+            "results retained across the gated poll"
+        );
+
+        // The pin advanced: polling again is a revision-equality
+        // no-op, not another diff.
+        assert!(subscription.poll(&operator).await?.is_none());
+        Ok(())
+    }
+
+    /// A commit inside the cover re-evaluates and emits the delta:
+    /// asserted rows on assert, retracted rows on retract.
+    #[dialog_common::test]
+    async fn it_emits_deltas_for_writes_inside_the_cover() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("covered write re-evaluates");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        assert!(delta.retracted.is_empty());
+
+        branch
+            .transaction()
+            .retract(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("retraction re-evaluates");
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        assert_eq!(
+            names(subscription.results()),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        Ok(())
+    }
+
+    /// The cover is the *demanded* range, not the touched data: a
+    /// subscription whose query currently matches nothing still
+    /// re-triggers when a fact lands in the demanded range.
+    #[dialog_common::test]
+    async fn it_invalidates_absence_reads() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        // Something unrelated so the branch has a first commit.
+        branch
+            .transaction()
+            .assert(the!("misc/tag").of(Entity::new()?).is("seed".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        let delta = subscription.poll(&operator).await?.expect("initial");
+        assert!(delta.is_empty(), "nothing matches yet");
+        assert!(
+            !subscription.demand().is_empty(),
+            "the miss was still demanded"
+        );
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("a write into the demanded (empty) range re-triggers");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -68,7 +68,7 @@ use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{Artifact, ArtifactSelector, Changes, Entity, KeyBytes, State};
+use dialog_artifacts::{Artifact, ArtifactSelector, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -209,21 +209,17 @@ impl<T> Delta<T> {
 pub struct Subscription<Q: Application> {
     branch: Branch,
     query: Q,
-    /// A caller-supplied transient overlay folded into every
-    /// evaluation alongside the branch facts — the same role
-    /// [`QueryLayer::with`] plays for a one-shot query. Ephemeral:
-    /// off-tree, never committed, so the tree-diff gate in
-    /// [`touched`](Subscription::touched) can't observe a change to
-    /// it. The owner must therefore call
-    /// [`set_overlay`](Subscription::set_overlay) and force a poll
-    /// when the overlay mutates; a poll then recomputes (the overlay
-    /// delta is not derivable from the tree). Empty by default
-    /// ([`subscribe`](Branch::subscribe)); populated via
-    /// [`subscribe_with`](Branch::subscribe_with).
-    overlay: Changes,
     /// The revision the retained results were evaluated at. `None`
     /// until the first poll.
     revision: Option<Revision>,
+    /// The [`Overlay`](crate::Overlay) epoch the retained results
+    /// were evaluated at. The branch's session overlay is off-tree,
+    /// so a change to it is invisible to the poll's tree-diff gate;
+    /// the epoch is the signal that re-triggers evaluation (the
+    /// overlay delta is not derivable from the tree, so an epoch
+    /// move recomputes, reporting the change as a delta against the
+    /// retained results).
+    overlay_epoch: u64,
     /// The demand cover recorded during the last evaluation.
     demand: Demand,
     /// The last evaluation's full result, retained to compute the
@@ -244,23 +240,18 @@ impl Branch {
     /// Register a standing query over this branch. The subscription
     /// evaluates on its first [`poll`](Subscription::poll) and is
     /// incrementally gated afterwards.
+    ///
+    /// Reads observe the branch's transient session overlay
+    /// ([`Branch::overlay`]) like every other read path, and a poll
+    /// picks up overlay changes: asserting an ephemeral fact into
+    /// the overlay propagates to the branch's subscriptions as a
+    /// result delta on their next poll.
     pub fn subscribe<Q: Application>(&self, query: Q) -> Subscription<Q> {
-        self.subscribe_with(query, Changes::new())
-    }
-
-    /// Register a standing query with a transient `overlay` folded
-    /// into every evaluation — ephemeral facts (an invite seed, a
-    /// UI status stamp) that participate in reads and in the demand
-    /// cover but are never committed. Because the overlay is
-    /// off-tree, a change to it is invisible to the poll's tree-diff
-    /// gate: after mutating it via [`Subscription::set_overlay`], the
-    /// owner must force a poll to pick the change up.
-    pub fn subscribe_with<Q: Application>(&self, query: Q, overlay: Changes) -> Subscription<Q> {
         Subscription {
             branch: self.clone(),
             query,
-            overlay,
             revision: None,
+            overlay_epoch: 0,
             demand: Demand::new(),
             results: Vec::new(),
             fixpoint: Arc::new(Mutex::new(None)),
@@ -335,23 +326,6 @@ where
         &self.demand
     }
 
-    /// Replace the transient overlay folded into evaluations and
-    /// invalidate the pinned revision so the next
-    /// [`poll`](Subscription::poll) recomputes.
-    ///
-    /// The overlay is off-tree, so a change to it never appears in
-    /// the tree diff the poll gates on; without invalidating the pin
-    /// the next poll would short-circuit (`current == revision`) and
-    /// miss the overlay change. Invalidation routes the next poll
-    /// through a full evaluation (the overlay delta cannot be derived
-    /// incrementally from the tree), which reports the result change
-    /// as a delta against the retained results.
-    pub fn set_overlay(&mut self, overlay: Changes) {
-        self.overlay = overlay;
-        self.revision = None;
-        self.initialized = false;
-    }
-
     /// Full evaluations performed so far (the first poll plus every
     /// fallback from incremental maintenance).
     pub fn recomputes(&self) -> usize {
@@ -369,16 +343,17 @@ where
     /// Poll the subscription against the branch's current state.
     ///
     /// Returns `Ok(None)` when the result is known unchanged: the
-    /// branch is at the pinned revision, or it moved but no change
-    /// intersects the demand cover (the pin advances silently).
-    /// Returns `Ok(Some(delta))` after a (re-)evaluation — the first
-    /// poll always evaluates, reporting the initial result as
-    /// `asserted` rows.
+    /// branch is at the pinned revision with the session overlay at
+    /// the pinned epoch, or the tree moved but no change intersects
+    /// the demand cover (the pin advances silently). Returns
+    /// `Ok(Some(delta))` after a (re-)evaluation — the first poll
+    /// always evaluates, reporting the initial result as `asserted`
+    /// rows.
     ///
-    /// The revision is snapshotted before evaluating; a commit that
-    /// lands mid-evaluation re-triggers on the next poll (the diff
-    /// from the pinned root is a superset), so changes are never
-    /// missed, at worst re-checked.
+    /// The revision and overlay epoch are snapshotted before
+    /// evaluating; a commit or overlay mutation that lands
+    /// mid-evaluation re-triggers on the next poll, so changes are
+    /// never missed, at worst re-checked.
     // The `self` and `env` lifetimes are deliberately unified into
     // one named `'a`: the poll future must stay `Send` on native (an
     // axum handler drains subscription polls), and its inner
@@ -398,7 +373,13 @@ where
             + 'static,
     {
         let current = self.branch.revision();
-        if self.initialized {
+        let epoch = self.branch.overlay().epoch();
+        // The session overlay is off-tree: an epoch move is invisible
+        // to the tree-diff gate below and its delta is not derivable
+        // from the tree, so it routes straight to a re-evaluation
+        // (reported against the retained results). The incremental
+        // path only serves polls where the tree alone moved.
+        if self.initialized && epoch == self.overlay_epoch {
             if current == self.revision {
                 return Ok(None);
             }
@@ -451,6 +432,7 @@ where
         self.results = results;
         self.demand = demand;
         self.revision = current;
+        self.overlay_epoch = epoch;
         self.initialized = true;
         Ok(Some(delta))
     }
@@ -612,7 +594,7 @@ where
                     .perform(env)
                     .await
                     .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-                let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+                let layer = QueryLayer::from(&self.branch);
                 let overlay = layer.overlay(&operator);
                 let tombstones = tombstones_from(&overlay);
                 // Typed with the *named* env lifetime (owned branch
@@ -723,7 +705,7 @@ where
                 .perform(env)
                 .await
                 .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+            let layer = QueryLayer::from(&self.branch);
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             // Named env lifetime: keeps the poll future Send-general
@@ -771,7 +753,7 @@ where
                 .perform(env)
                 .await
                 .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
+            let layer = QueryLayer::from(&self.branch);
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             // Named env lifetime: keeps the poll future Send-general
@@ -885,6 +867,267 @@ mod tests {
                 (claim.of.clone(), name)
             })
             .collect()
+    }
+
+    /// The branch's session overlay participates in subscription
+    /// results: ephemeral facts surface alongside tree facts from
+    /// the first poll, without ever being committed.
+    #[dialog_common::test]
+    async fn it_folds_the_overlay_into_subscription_results() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // An ephemeral fact: participates in reads, never committed.
+        let bob = Entity::new()?;
+        branch
+            .overlay()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()));
+
+        let mut subscription = branch.subscribe(names_query());
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("first poll evaluates");
+        let mut asserted = names(&delta.asserted);
+        asserted.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(
+            asserted, expected,
+            "overlay facts surface alongside tree facts"
+        );
+        Ok(())
+    }
+
+    /// Asserting into the branch overlay propagates to the branch's
+    /// subscriptions: every standing query the ephemeral fact
+    /// affects reports it as a delta on its next poll, with no tree
+    /// movement at all — and clearing the overlay retracts exactly
+    /// the ephemeral rows.
+    #[dialog_common::test]
+    async fn it_propagates_overlay_updates_to_subscriptions() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        let mut sibling = branch.subscribe(names_query());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            names(&initial.asserted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        sibling.poll(&operator).await?.expect("sibling initial");
+
+        // An ephemeral fact lands in the branch overlay: both
+        // standing queries report it against their retained results.
+        let bob = Entity::new()?;
+        branch
+            .overlay()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()));
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("overlay change propagates");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        assert!(delta.retracted.is_empty());
+        let sibling_delta = sibling
+            .poll(&operator)
+            .await?
+            .expect("every subscription on the branch observes the overlay");
+        assert_eq!(
+            names(&sibling_delta.asserted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+
+        let mut retained = names(subscription.results());
+        retained.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(retained, expected);
+
+        // Clearing the overlay retracts exactly the ephemeral rows.
+        branch.overlay().clear();
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("overlay removal propagates");
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        assert_eq!(
+            names(subscription.results()),
+            vec![(alice.clone(), "Alice".to_string())],
+            "tree facts persist through overlay changes"
+        );
+
+        // With the overlay quiet the gates still hold: polling again
+        // is a revision + epoch no-op.
+        assert!(subscription.poll(&operator).await?.is_none());
+        Ok(())
+    }
+
+    /// Retracting into the branch overlay tombstones matching tree
+    /// facts for readers — the subscription retracts the row on its
+    /// next poll while the tree keeps the fact.
+    #[dialog_common::test]
+    async fn it_tombstones_tree_facts_retracted_in_the_overlay() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+
+        branch.overlay().retract(
+            the!("person/name")
+                .of(alice.clone())
+                .is("Alice".to_string()),
+        );
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("overlay retract propagates");
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        assert!(subscription.results().is_empty());
+
+        // The tree is untouched: dropping the session retract brings
+        // the fact back.
+        branch.overlay().clear();
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("clearing the session retract restores the row");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        Ok(())
+    }
+
+    /// One-shot reads see the session overlay too: `branch.select`
+    /// and a transaction's as-if-committed view both fold it, so
+    /// every read path of the branch agrees on what exists.
+    #[dialog_common::test]
+    async fn it_folds_the_overlay_into_queries_and_transactions() -> anyhow::Result<()> {
+        use dialog_query::query::Output as _;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let bob = Entity::new()?;
+        branch
+            .overlay()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()));
+
+        let mut read = names(
+            &branch
+                .select(names_query())
+                .perform(&operator)
+                .try_vec()
+                .await?,
+        );
+        read.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(read, expected, "plain queries fold the session overlay");
+
+        let carol = Entity::new()?;
+        let transaction = branch.transaction().assert(
+            the!("person/name")
+                .of(carol.clone())
+                .is("Carol".to_string()),
+        );
+        let mut staged = names(
+            &transaction
+                .query()
+                .select(names_query())
+                .perform(&operator)
+                .try_vec()
+                .await?,
+        );
+        staged.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+            (carol.clone(), "Carol".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(
+            staged, expected,
+            "a transaction's view folds the session overlay under its pending changes"
+        );
+        Ok(())
     }
 
     /// The first poll evaluates and reports the initial result;

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -36,13 +36,18 @@
 //! simply re-derived, which handles the multi-derivation retraction
 //! case (FBF's concern) exactly, without counting.
 //!
-//! Per-entity re-derivation is sound only when a change to entity
-//! `E` can only affect rows whose subject is `E`. Attribute queries
-//! have this by construction; concept queries are gated on their
-//! resolved rule set — every rule entity-local
-//! ([`AnalyzedRule::is_entity_local`]) and non-recursive — and
-//! anything else falls back to a full recompute, which is always
-//! sound. [`recomputes`](Subscription::recomputes) and
+//! For attribute queries the affected entities are the changed
+//! facts' subjects. For concept queries they are discovered against
+//! the resolved rule set
+//! ([`affected_entities`]): entity-local rules
+//! ([`AnalyzedRule::is_entity_local`]) contribute the changed
+//! subjects, and non-local rules — concept premises reading *other*
+//! entities' facts (a conformance check, a variant's negation) —
+//! contribute delta-join heads: the changed fact bound into the
+//! premise it matches, the remaining premises joined sideways, the
+//! head variable projected. Recursion and shapes the discovery does
+//! not handle fall back to a full recompute, which is always sound.
+//! [`recomputes`](Subscription::recomputes) and
 //! [`maintenances`](Subscription::maintenances) expose which path
 //! each poll took.
 //!
@@ -61,7 +66,7 @@ use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{ArtifactSelector, Entity, KeyBytes, State};
+use dialog_artifacts::{Artifact, ArtifactSelector, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -70,9 +75,9 @@ use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
 use dialog_query::Conclusion;
+use dialog_query::concept::query::affected::affected_entities;
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output as _, Restriction};
-use dialog_query::source::SelectRules;
 use dialog_search_tree::{Change, ContentAddressedStorage};
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
@@ -226,9 +231,14 @@ enum Touched {
     /// A rule-discovery range changed: the rule set may differ, so
     /// any row may be affected.
     Rules,
-    /// Only fact ranges changed; the set of subject entities whose
-    /// facts changed.
-    Facts(BTreeSet<Entity>),
+    /// Only fact ranges changed: the changed facts (deduplicated
+    /// across the three index orders) and their subject entities.
+    Facts {
+        /// Subjects of the changed facts.
+        subjects: BTreeSet<Entity>,
+        /// The changed facts themselves, for delta-join discovery.
+        facts: Vec<Artifact>,
+    },
 }
 
 /// The index root a revision pins, or the empty tree for an
@@ -306,8 +316,8 @@ where
                     self.revision = current;
                     return Ok(None);
                 }
-                Touched::Facts(entities) => {
-                    if let Some(delta) = self.maintain(env, &entities).await? {
+                Touched::Facts { subjects, facts } => {
+                    if let Some(delta) = self.maintain(env, &subjects, &facts).await? {
                         self.maintenances += 1;
                         self.revision = current;
                         return Ok(Some(delta));
@@ -397,7 +407,11 @@ where
 
         let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
-        let mut entities = BTreeSet::new();
+        let mut subjects = BTreeSet::new();
+        let mut facts = Vec::new();
+        // A fact change surfaces once per index order; dedup on the
+        // datum triple.
+        let mut seen = BTreeSet::new();
         while let Some(change) = changes
             .try_next()
             .await
@@ -411,17 +425,24 @@ where
                 return Ok(Touched::Rules);
             }
             if let State::Added(datum) = &entry.value {
-                let entity = datum.entity.parse().map_err(|error| {
-                    EvaluationError::Store(format!("changed datum entity: {error:?}"))
-                })?;
-                entities.insert(entity);
+                if !seen.insert((
+                    datum.entity.clone(),
+                    datum.attribute.clone(),
+                    datum.value.clone(),
+                )) {
+                    continue;
+                }
+                let fact = Artifact::try_from(datum.clone())
+                    .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
+                subjects.insert(fact.of.clone());
+                facts.push(fact);
             }
         }
 
-        if entities.is_empty() {
+        if subjects.is_empty() {
             Ok(Touched::Nothing)
         } else {
-            Ok(Touched::Facts(entities))
+            Ok(Touched::Facts { subjects, facts })
         }
     }
 
@@ -434,15 +455,15 @@ where
     /// is what makes multi-derivation retractions exact without
     /// counting).
     ///
-    /// Returns `Ok(None)` when the query or its rule set cannot be
-    /// maintained per-entity — the query is not restrictable, a rule
-    /// reads other entities' facts (not entity-local), or the
-    /// concept is recursive — in which case the caller falls back to
-    /// a full recompute.
+    /// Returns `Ok(None)` when the affected set cannot be bounded —
+    /// the query is not restrictable, the concept is recursive, or
+    /// the delta-join discovery hit a shape it does not handle — in
+    /// which case the caller falls back to a full recompute.
     async fn maintain<Env>(
         &mut self,
         env: &Env,
-        entities: &BTreeSet<Entity>,
+        subjects: &BTreeSet<Entity>,
+        facts: &[Artifact],
     ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
@@ -454,12 +475,19 @@ where
             + ConditionalSync
             + 'static,
     {
-        // Soundness gate for concept queries: every rule must be
-        // entity-local (reads only `?this`'s facts) and
-        // non-recursive, otherwise a change to entity E can affect
-        // other entities' rows and per-entity re-derivation would
-        // miss them.
-        if let Some(concept) = self.query.concept() {
+        // For a concept query the affected heads are discovered
+        // against the resolved rule set: entity-local rules
+        // contribute the changed subjects, non-local rules (concept
+        // premises: conformance checks, variant negations)
+        // contribute delta-join heads — the changed fact bound into
+        // the premise it matches, remaining premises joined
+        // sideways, head projected. `None` (recursion, unhandled
+        // shape) falls back to full recompute. For a plain attribute
+        // query the affected heads are just the changed subjects.
+        //
+        // The discovery evaluates against the demand-recording
+        // environment, so the reads it depends on join the cover.
+        let entities: BTreeSet<Entity> = if let Some(concept) = self.query.concept() {
             let operator = Identify
                 .perform(env)
                 .await
@@ -469,18 +497,17 @@ where
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
                 .with_demand(self.demand.clone());
-            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
-            if rules.recursion().is_some() {
-                return Ok(None);
+            match affected_entities(concept, facts, &query_env).await? {
+                Some(entities) => entities,
+                None => return Ok(None),
             }
-            if !rules.rules().all(|rule| rule.analysis().is_entity_local()) {
-                return Ok(None);
-            }
-        }
+        } else {
+            subjects.clone()
+        };
 
         let mut asserted = Vec::new();
         let mut retracted = Vec::new();
-        for entity in entities {
+        for entity in &entities {
             let scoped = match self.query.restrict(entity) {
                 Restriction::Scoped(query) => query,
                 Restriction::Unaffected => continue,
@@ -557,6 +584,7 @@ mod tests {
     use crate::helpers::{test_operator_with_profile, test_repo};
     use dialog_artifacts::{Entity, Value};
     use dialog_query::attribute::The;
+    use dialog_query::types::Any;
     use dialog_query::{AttributeQuery, Claim, Term, the};
 
     /// A standing query over every `person/name` fact.
@@ -970,6 +998,517 @@ mod tests {
         expected.sort();
         assert_eq!(retained, expected);
         assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    mod concepts {
+        //! Derived concepts + attributes shared by the incremental
+        //! maintenance tests below.
+
+        use dialog_artifacts::Entity;
+        use dialog_query::{Attribute, Concept};
+
+        /// A badge number (`credential/badge`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("credential")]
+        pub struct Badge(pub String);
+
+        /// A report's display name (`report/name`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("report")]
+        pub struct Name(pub String);
+
+        /// The report's manager (`report/manager`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("report")]
+        pub struct Manager(pub Entity);
+
+        /// Someone holding a badge.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct BadgeHolder {
+            /// The badge holder entity.
+            pub this: Entity,
+            /// Their badge number.
+            pub badge: Badge,
+        }
+
+        /// Someone reporting to a badge holder.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct Report {
+            /// The report entity.
+            pub this: Entity,
+            /// Their display name.
+            pub name: Name,
+            /// Their manager, who must hold a badge.
+            #[dialog(conforms = BadgeHolder)]
+            pub manager: Manager,
+        }
+
+        /// An email handle (`comm/email`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("comm")]
+        pub struct Email(pub String);
+
+        /// A phone handle (`comm/phone`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("comm")]
+        pub struct Phone(pub String);
+
+        /// A contact handle (`contact/handle`) — the variant
+        /// conclusion.
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("contact")]
+        pub struct Handle(pub String);
+
+        /// A user with an email address.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct WithEmail {
+            /// The user entity.
+            pub this: Entity,
+            /// Their email handle.
+            pub handle: Email,
+        }
+
+        /// A user with a phone number.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct WithPhone {
+            /// The user entity.
+            pub this: Entity,
+            /// Their phone handle.
+            pub handle: Phone,
+        }
+
+        /// The preferred way to reach a user: email if they have
+        /// one, otherwise phone.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct Contact {
+            /// The user entity.
+            pub this: Entity,
+            /// The winning handle.
+            pub handle: Handle,
+        }
+
+        /// A parent edge (`family/parent`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("family")]
+        pub struct Parent(pub Entity);
+
+        /// An ancestor edge (`family/ancestor`) — the recursive
+        /// conclusion.
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("family")]
+        pub struct Ancestor(pub Entity);
+
+        /// Direct parenthood.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct HasParent {
+            /// The child entity.
+            pub this: Entity,
+            /// Their parent.
+            pub parent: Parent,
+        }
+
+        /// The transitive closure of parenthood.
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct HasAncestor {
+            /// The descendant entity.
+            pub this: Entity,
+            /// One of their ancestors.
+            pub ancestor: Ancestor,
+        }
+    }
+
+    /// Stage the `db.rule/*` facts that persist a deductive rule
+    /// durably (the storage shape from `crate::rules`).
+    fn with_rule<'t>(
+        transaction: crate::Transaction<'t>,
+        rule: &dialog_query::DeductiveRule,
+    ) -> crate::Transaction<'t> {
+        let entity = rule.this();
+        transaction
+            .assert(
+                the!("db.rule/conclusion")
+                    .of(entity.clone())
+                    .is(rule.conclusion().this()),
+            )
+            .assert(the!("db.rule/source").of(entity).is(rule.encode()))
+    }
+
+    /// A rule `conclusion :- Concept(target, terms)` built from
+    /// derived concept descriptors, storable as a durable rule.
+    fn concept_rule(
+        conclusion: &dialog_query::ConceptDescriptor,
+        premises: Vec<dialog_query::Premise>,
+    ) -> dialog_query::DeductiveRule {
+        dialog_query::DeductiveRule::new(conclusion.clone(), premises).expect("rule compiles")
+    }
+
+    fn concept_premise(
+        target: &dialog_query::ConceptDescriptor,
+        bindings: &[(&str, &str)],
+    ) -> dialog_query::Premise {
+        let mut terms = dialog_query::Parameters::new();
+        for (param, variable) in bindings {
+            terms.insert((*param).to_string(), Term::<Any>::var(*variable));
+        }
+        dialog_query::Premise::Assert(dialog_query::Proposition::Concept(
+            dialog_query::ConceptQuery {
+                terms,
+                predicate: target.clone(),
+            },
+        ))
+    }
+
+    fn negated_concept_premise(
+        target: &dialog_query::ConceptDescriptor,
+        bindings: &[(&str, &str)],
+    ) -> dialog_query::Premise {
+        let mut terms = dialog_query::Parameters::new();
+        for (param, variable) in bindings {
+            terms.insert((*param).to_string(), Term::<Any>::var(*variable));
+        }
+        dialog_query::Premise::Unless(dialog_query::Negation(dialog_query::Proposition::Concept(
+            dialog_query::ConceptQuery {
+                terms,
+                predicate: target.clone(),
+            },
+        )))
+    }
+
+    /// Piece 1: a derived `Query<C>` subscription over an
+    /// entity-local concept is maintained incrementally.
+    #[dialog_common::test]
+    async fn it_maintains_derived_concept_subscriptions() -> anyhow::Result<()> {
+        use concepts::{Badge, BadgeHolder};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(Badge::of(alice.clone()).is("A-1"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<BadgeHolder>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            initial.asserted,
+            vec![BadgeHolder {
+                this: alice.clone(),
+                badge: Badge("A-1".into()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 1);
+
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(Badge::of(bob.clone()).is("B-2"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("covered write");
+        assert_eq!(
+            delta.asserted,
+            vec![BadgeHolder {
+                this: bob.clone(),
+                badge: Badge("B-2".into()),
+            }]
+        );
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the derived query restricted to the touched entity"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    /// Piece 2, conformance: a badge change for a *manager* affects
+    /// the *report* entity's rows (cross-entity), discovered by the
+    /// delta-join and maintained without a recompute.
+    #[dialog_common::test]
+    async fn it_maintains_cross_entity_conformance() -> anyhow::Result<()> {
+        use concepts::{Badge, Manager, Name, Report};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?; // manager WITH a badge
+        let carol = Entity::new()?; // manager WITHOUT a badge (yet)
+        let bob = Entity::new()?; // reports to alice
+        let mallory = Entity::new()?; // reports to carol
+
+        branch
+            .transaction()
+            .assert(Badge::of(alice.clone()).is("A-1"))
+            .assert(Name::of(bob.clone()).is("Bob"))
+            .assert(Manager::of(bob.clone()).is(alice.clone()))
+            .assert(Name::of(mallory.clone()).is("Mallory"))
+            .assert(Manager::of(mallory.clone()).is(carol.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<Report>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            initial.asserted,
+            vec![Report {
+                this: bob.clone(),
+                name: Name("Bob".into()),
+                manager: Manager(alice.clone()),
+            }],
+            "only the report whose manager holds a badge conforms"
+        );
+
+        // Carol gets a badge: mallory's row appears, though the
+        // changed fact's subject is carol, not mallory.
+        branch
+            .transaction()
+            .assert(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("cross-entity effect");
+        assert_eq!(
+            delta.asserted,
+            vec![Report {
+                this: mallory.clone(),
+                name: Name("Mallory".into()),
+                manager: Manager(carol.clone()),
+            }]
+        );
+        assert!(delta.retracted.is_empty());
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the affected report was discovered by the delta-join, not a recompute"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+
+        // And the retraction flows back the same way.
+        branch
+            .transaction()
+            .retract(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(
+            delta.retracted,
+            vec![Report {
+                this: mallory.clone(),
+                name: Name("Mallory".into()),
+                manager: Manager(carol.clone()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
+        Ok(())
+    }
+
+    /// Piece 2, variants: committing a rule re-triggers via the
+    /// rule-discovery range (full recompute — the rule set changed);
+    /// afterwards a fact write that flips a negated variant is
+    /// maintained incrementally through the delta-join.
+    #[dialog_common::test]
+    async fn it_maintains_variant_negation_flips() -> anyhow::Result<()> {
+        use concepts::{Contact, Email, Handle, Phone, WithEmail, WithPhone};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let contact = Contact::descriptor().clone();
+        let email = WithEmail::descriptor().clone();
+        let phone = WithPhone::descriptor().clone();
+
+        let email_rule = concept_rule(
+            &contact,
+            vec![concept_premise(
+                &email,
+                &[("this", "this"), ("handle", "handle")],
+            )],
+        );
+        let phone_rule = concept_rule(
+            &contact,
+            vec![
+                concept_premise(&phone, &[("this", "this"), ("handle", "handle")]),
+                negated_concept_premise(&email, &[("this", "this")]),
+            ],
+        );
+
+        let bob = Entity::new()?;
+        let transaction = branch
+            .transaction()
+            .assert(Phone::of(bob.clone()).is("555-0100"));
+        with_rule(transaction, &email_rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<Contact>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert!(
+            initial.asserted.is_empty(),
+            "only the email rule is installed and bob has no email"
+        );
+
+        // Installing the phone rule lands in the rule-discovery
+        // range: recompute.
+        with_rule(branch.transaction(), &phone_rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("rule installed");
+        assert_eq!(
+            delta.asserted,
+            vec![Contact {
+                this: bob.clone(),
+                handle: Handle("555-0100".into()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 2, "a rule-set change recomputes");
+
+        // An email for bob flips the negated variant: the phone row
+        // retracts and the email row asserts — maintained, not
+        // recomputed.
+        branch
+            .transaction()
+            .assert(Email::of(bob.clone()).is("bob@mail"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("variant flip");
+        assert_eq!(
+            delta.asserted,
+            vec![Contact {
+                this: bob.clone(),
+                handle: Handle("bob@mail".into()),
+            }]
+        );
+        assert_eq!(
+            delta.retracted,
+            vec![Contact {
+                this: bob.clone(),
+                handle: Handle("555-0100".into()),
+            }]
+        );
+        assert_eq!(subscription.recomputes(), 2, "the flip was maintained");
+        assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    /// Piece 3, dynamic demand: a subscription over a recursive
+    /// concept keeps answering as its demand cone grows with the
+    /// data — each edge extending the chain re-triggers and derives
+    /// exactly the new closure pairs. (Recursive closures re-derive
+    /// via the fixpoint; incremental fixpoint continuation is a
+    /// recorded follow-up.)
+    #[dialog_common::test]
+    async fn it_grows_the_demand_cone_with_recursive_rules() -> anyhow::Result<()> {
+        use concepts::{Ancestor, HasAncestor, HasParent, Parent};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let ancestor = HasAncestor::descriptor().clone();
+        let parent = HasParent::descriptor().clone();
+
+        let base = concept_rule(
+            &ancestor,
+            vec![concept_premise(
+                &parent,
+                &[("this", "this"), ("parent", "ancestor")],
+            )],
+        );
+        let step = concept_rule(
+            &ancestor,
+            vec![
+                concept_premise(&parent, &[("this", "this"), ("parent", "p")]),
+                concept_premise(&ancestor, &[("this", "p"), ("ancestor", "ancestor")]),
+            ],
+        );
+
+        let a = Entity::new()?;
+        let b = Entity::new()?;
+        let c = Entity::new()?;
+        let d = Entity::new()?;
+        let transaction = branch
+            .transaction()
+            .assert(Parent::of(b.clone()).is(a.clone()));
+        with_rule(with_rule(transaction, &base), &step)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<HasAncestor>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            initial.asserted,
+            vec![HasAncestor {
+                this: b.clone(),
+                ancestor: Ancestor(a.clone()),
+            }]
+        );
+
+        // Extend the chain: the closure grows by two pairs.
+        branch
+            .transaction()
+            .assert(Parent::of(c.clone()).is(b.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("cone grows");
+        let mut asserted = delta.asserted.clone();
+        asserted.sort_by_key(|row| format!("{row:?}"));
+        let mut expected = vec![
+            HasAncestor {
+                this: c.clone(),
+                ancestor: Ancestor(b.clone()),
+            },
+            HasAncestor {
+                this: c.clone(),
+                ancestor: Ancestor(a.clone()),
+            },
+        ];
+        expected.sort_by_key(|row| format!("{row:?}"));
+        assert_eq!(asserted, expected);
+        assert!(delta.retracted.is_empty());
+
+        // And again: the frontier extended by the previous poll is
+        // itself demanded, so the next extension re-triggers too.
+        branch
+            .transaction()
+            .assert(Parent::of(d.clone()).is(c.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("cone grows again");
+        assert_eq!(delta.asserted.len(), 3, "(d,c), (d,b), (d,a)");
+        assert!(delta.retracted.is_empty());
         Ok(())
     }
 }

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -63,6 +63,7 @@
 use std::collections::BTreeSet;
 use std::future::Future;
 use std::ops::RangeInclusive;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
@@ -293,6 +294,23 @@ enum Touched {
     },
 }
 
+/// A boxed evaluation future. The poll chain's inner evaluations are
+/// boxed (rather than returned as `impl Future`) deliberately: an
+/// opaque future carries its defining function's `Env:
+/// Provider<Select<'s>>` where-clauses, and re-proving those during
+/// the *caller's* `Send` check erases every lifetime into
+/// independent placeholders — rustc's #100013 limitation, which
+/// would make the poll future `!Send` on native. Boxing to `dyn
+/// Future + Send` proves `Send` eagerly at the definition site,
+/// where the lifetime relations are still known.
+#[cfg(not(target_arch = "wasm32"))]
+type EvaluationFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, EvaluationError>> + Send + 'a>>;
+
+/// A boxed evaluation future (see the native alias for why).
+#[cfg(target_arch = "wasm32")]
+type EvaluationFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, EvaluationError>> + 'a>>;
+
 /// The index root a revision pins, or the empty tree for an
 /// unborn branch.
 fn tree_hash(revision: &Option<Revision>) -> Blake3Hash {
@@ -304,8 +322,8 @@ fn tree_hash(revision: &Option<Revision>) -> Blake3Hash {
 
 impl<Q> Subscription<Q>
 where
-    Q: Application + Clone,
-    Q::Conclusion: Conclusion + PartialEq + Clone,
+    Q: Application + Clone + ConditionalSync,
+    Q::Conclusion: Conclusion + PartialEq + Clone + ConditionalSync,
 {
     /// The retained result of the last evaluation.
     pub fn results(&self) -> &[Q::Conclusion] {
@@ -361,10 +379,14 @@ where
     /// lands mid-evaluation re-triggers on the next poll (the diff
     /// from the pinned root is a superset), so changes are never
     /// missed, at worst re-checked.
-    pub fn poll<'a, Env>(
+    // The `self` and `env` lifetimes are deliberately unified into
+    // one named `'a`: the poll future must stay `Send` on native (an
+    // axum handler drains subscription polls), and its inner
+    // evaluations are boxed `EvaluationFuture`s for the same reason.
+    pub async fn poll<'a, Env>(
         &'a mut self,
         env: &'a Env,
-    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
+    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -375,71 +397,62 @@ where
             + ConditionalSync
             + 'static,
     {
-        // Returned as an explicit `impl Future + 'a` (not an `async
-        // fn`) so the env lifetime is named rather than higher-ranked.
-        // An `async fn poll<Env>(&mut self, env: &Env)` desugars to a
-        // future whose `&Env` capture is `for<'e>`, which defeats
-        // Send-generality inference in a caller that must be `Send`
-        // (an axum handler draining subscription polls) — the same
-        // reason `SelectQuery::perform` is written this way.
-        async move {
-            let current = self.branch.revision();
-            if self.initialized {
-                if current == self.revision {
+        let current = self.branch.revision();
+        if self.initialized {
+            if current == self.revision {
+                return Ok(None);
+            }
+            match self.touched(env, &current).await? {
+                Touched::Nothing => {
+                    self.revision = current;
                     return Ok(None);
                 }
-                match self.touched(env, &current).await? {
-                    Touched::Nothing => {
+                Touched::Facts {
+                    subjects,
+                    facts,
+                    asserted,
+                    retracted,
+                } => {
+                    if let Some(delta) = self
+                        .maintain(env, &subjects, &facts, &asserted, &retracted)
+                        .await?
+                    {
+                        self.maintenances += 1;
                         self.revision = current;
-                        return Ok(None);
+                        return Ok(Some(delta));
                     }
-                    Touched::Facts {
-                        subjects,
-                        facts,
-                        asserted,
-                        retracted,
-                    } => {
-                        if let Some(delta) = self
-                            .maintain(env, &subjects, &facts, &asserted, &retracted)
-                            .await?
-                        {
-                            self.maintenances += 1;
-                            self.revision = current;
-                            return Ok(Some(delta));
-                        }
-                        // Not maintainable for this query/rule shape:
-                        // fall through to a full recompute.
-                    }
-                    // A rule-range change can install or change a rule,
-                    // which can affect any row: recompute.
-                    Touched::Rules => {}
+                    // Not maintainable for this query/rule shape:
+                    // fall through to a full recompute.
                 }
+                // A rule-range change can install or change a rule,
+                // which can affect any row: recompute.
+                Touched::Rules => {}
             }
-
-            let demand = Demand::new();
-            let results = self.evaluate(env, &demand, &self.query).await?;
-            self.recomputes += 1;
-
-            let delta = Delta {
-                asserted: results
-                    .iter()
-                    .filter(|row| !self.results.contains(row))
-                    .cloned()
-                    .collect(),
-                retracted: self
-                    .results
-                    .iter()
-                    .filter(|row| !results.contains(row))
-                    .cloned()
-                    .collect(),
-            };
-
-            self.results = results;
-            self.demand = demand;
-            self.revision = current;
-            self.initialized = true;
-            Ok(Some(delta))
         }
+
+        let demand = Demand::new();
+        let results = self.evaluate(env, &demand, &self.query).await?;
+        self.recomputes += 1;
+
+        let delta = Delta {
+            asserted: results
+                .iter()
+                .filter(|row| !self.results.contains(row))
+                .cloned()
+                .collect(),
+            retracted: self
+                .results
+                .iter()
+                .filter(|row| !results.contains(row))
+                .cloned()
+                .collect(),
+        };
+
+        self.results = results;
+        self.demand = demand;
+        self.revision = current;
+        self.initialized = true;
+        Ok(Some(delta))
     }
 
     /// Classify what the changes between the pinned root and
@@ -461,11 +474,11 @@ where
     /// and are skipped.
     ///
     /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
-    fn touched<'a, Env>(
+    async fn touched<'a, Env>(
         &'a self,
         env: &'a Env,
         current: &'a Option<Revision>,
-    ) -> impl Future<Output = Result<Touched, EvaluationError>> + 'a
+    ) -> Result<Touched, EvaluationError>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -475,82 +488,78 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
-            let pinned = tree_hash(&self.revision);
-            let target = tree_hash(current);
-            if pinned == target {
-                return Ok(Touched::Nothing);
-            }
-            let scope = self.demand.ranges();
-            if scope.is_empty() {
-                return Ok(Touched::Nothing);
-            }
+        let pinned = tree_hash(&self.revision);
+        let target = tree_hash(current);
+        if pinned == target {
+            return Ok(Touched::Nothing);
+        }
+        let scope = self.demand.ranges();
+        if scope.is_empty() {
+            return Ok(Touched::Nothing);
+        }
 
-            let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
-            let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
-            let previous =
-                Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
-            let next =
-                Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
+        let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
+        let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
+        let previous =
+            Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
+        let next = Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
 
-            let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
-            let mut changes = Box::pin(changes);
-            let mut subjects = BTreeSet::new();
-            let mut asserted = Vec::new();
-            let mut retracted = Vec::new();
-            // A fact change surfaces once per index order; dedup on the
-            // datum triple, per direction.
-            let mut seen = BTreeSet::new();
-            while let Some(change) = changes
-                .try_next()
-                .await
-                .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-            {
-                let entry = match &change {
-                    Change::Add(entry) => entry,
-                    Change::Remove(entry) => entry,
-                };
-                if self.demand.covers_rules(&entry.key) {
-                    return Ok(Touched::Rules);
+        let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
+        let mut changes = Box::pin(changes);
+        let mut subjects = BTreeSet::new();
+        let mut asserted = Vec::new();
+        let mut retracted = Vec::new();
+        // A fact change surfaces once per index order; dedup on the
+        // datum triple, per direction.
+        let mut seen = BTreeSet::new();
+        while let Some(change) = changes
+            .try_next()
+            .await
+            .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
+        {
+            let entry = match &change {
+                Change::Add(entry) => entry,
+                Change::Remove(entry) => entry,
+            };
+            if self.demand.covers_rules(&entry.key) {
+                return Ok(Touched::Rules);
+            }
+            // An entry arriving with a datum became readable; an
+            // entry leaving with a datum stopped being readable.
+            // Tombstone-valued entries carry no datum: their effect
+            // (if any) surfaces as the paired datum-bearing change
+            // at the same key.
+            let arriving = matches!(&change, Change::Add(_));
+            if let State::Added(datum) = &entry.value {
+                if !seen.insert((
+                    arriving,
+                    datum.entity.clone(),
+                    datum.attribute.clone(),
+                    datum.value.clone(),
+                )) {
+                    continue;
                 }
-                // An entry arriving with a datum became readable; an
-                // entry leaving with a datum stopped being readable.
-                // Tombstone-valued entries carry no datum: their effect
-                // (if any) surfaces as the paired datum-bearing change
-                // at the same key.
-                let arriving = matches!(&change, Change::Add(_));
-                if let State::Added(datum) = &entry.value {
-                    if !seen.insert((
-                        arriving,
-                        datum.entity.clone(),
-                        datum.attribute.clone(),
-                        datum.value.clone(),
-                    )) {
-                        continue;
-                    }
-                    let fact = Artifact::try_from(datum.clone()).map_err(|error| {
-                        EvaluationError::Store(format!("changed datum: {error:?}"))
-                    })?;
-                    subjects.insert(fact.of.clone());
-                    if arriving {
-                        asserted.push(fact);
-                    } else {
-                        retracted.push(fact);
-                    }
+                let fact = Artifact::try_from(datum.clone())
+                    .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
+                subjects.insert(fact.of.clone());
+                if arriving {
+                    asserted.push(fact);
+                } else {
+                    retracted.push(fact);
                 }
             }
+        }
 
-            if subjects.is_empty() {
-                Ok(Touched::Nothing)
-            } else {
-                let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
-                Ok(Touched::Facts {
-                    subjects,
-                    facts,
-                    asserted,
-                    retracted,
-                })
-            }
+        if subjects.is_empty() {
+            Ok(Touched::Nothing)
+        } else {
+            let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
+            Ok(Touched::Facts {
+                subjects,
+                facts,
+                asserted,
+                retracted,
+            })
         }
     }
 
@@ -574,7 +583,7 @@ where
         facts: &'a [Artifact],
         asserted: &'a [Artifact],
         retracted: &'a [Artifact],
-    ) -> impl Future<Output = Result<Option<Delta<Q::Conclusion>>, EvaluationError>> + 'a
+    ) -> EvaluationFuture<'a, Option<Delta<Q::Conclusion>>>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -585,7 +594,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
+        Box::pin(async move {
             // For a concept query the affected heads are discovered
             // against the resolved rule set: entity-local rules
             // contribute the changed subjects, non-local rules (concept
@@ -606,8 +615,13 @@ where
                 let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
                 let overlay = layer.overlay(&operator);
                 let tombstones = tombstones_from(&overlay);
-                let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                    .with_demand(self.demand.clone());
+                // Typed with the *named* env lifetime (owned branch
+                // clone, no generator-local borrows) so the poll
+                // future stays Send-general on native — see the note
+                // on `QueryEnv::branches`.
+                let query_env: QueryEnv<'a, Env> =
+                    QueryEnv::new(vec![self.branch.clone()], overlay, tombstones, env)
+                        .with_demand(self.demand.clone());
                 let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
                 if rules.recursion().is_some() {
                     // Fixpoint continuation: deletions retract via DRed,
@@ -681,22 +695,19 @@ where
                 asserted,
                 retracted,
             }))
-        }
+        })
     }
 
     /// Evaluate the query against the branch, recording every
     /// demanded range into `demand`. Mirrors the ordinary
     /// `branch.select(query).perform(env)` path with a
     /// demand-recording environment.
-    // `impl Future + 'a` (not `async fn`) so the env lifetime is
-    // named, keeping the enclosing `poll` future Send-general on
-    // native — see the note on `poll`.
     fn evaluate<'a, Env>(
         &'a self,
         env: &'a Env,
         demand: &'a Demand,
         query: &'a Q,
-    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    ) -> EvaluationFuture<'a, Vec<Q::Conclusion>>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -707,7 +718,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
+        Box::pin(async move {
             let operator = Identify
                 .perform(env)
                 .await
@@ -715,8 +726,11 @@ where
             let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
-            let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                .with_demand(demand.clone());
+            // Named env lifetime: keeps the poll future Send-general
+            // on native — see the note on `QueryEnv::branches`.
+            let mut query_env: QueryEnv<'a, Env> =
+                QueryEnv::new(vec![self.branch.clone()], overlay, tombstones, env)
+                    .with_demand(demand.clone());
             // Recursive concept subscriptions retain their fixpoint
             // across polls: a recompute rebuilds into the retained
             // table so a later additions-only poll can extend it.
@@ -725,7 +739,7 @@ where
                     .with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
             }
             query.clone().perform(&query_env).try_vec().await
-        }
+        })
     }
 
     /// Evaluate the standing query with the retained fixpoint
@@ -737,7 +751,7 @@ where
         env: &'a Env,
         additions: Arc<Vec<Artifact>>,
         deletions: Arc<Vec<Artifact>>,
-    ) -> impl Future<Output = Result<Vec<Q::Conclusion>, EvaluationError>> + 'a
+    ) -> EvaluationFuture<'a, Vec<Q::Conclusion>>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -748,7 +762,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        async move {
+        Box::pin(async move {
             let concept = self
                 .query
                 .concept()
@@ -760,14 +774,17 @@ where
             let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
-            let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
-                .with_demand(self.demand.clone())
-                .with_fixpoint(
-                    concept.this(),
-                    Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
-                );
+            // Named env lifetime: keeps the poll future Send-general
+            // on native — see the note on `QueryEnv::branches`.
+            let query_env: QueryEnv<'a, Env> =
+                QueryEnv::new(vec![self.branch.clone()], overlay, tombstones, env)
+                    .with_demand(self.demand.clone())
+                    .with_fixpoint(
+                        concept.this(),
+                        Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
+                    );
             self.query.clone().perform(&query_env).try_vec().await
-        }
+        })
     }
 }
 
@@ -776,11 +793,75 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+    use crate::RemoteSite;
     use crate::helpers::{test_operator_with_profile, test_repo};
     use dialog_artifacts::{Entity, Value};
+    use dialog_capability::{Fork, Provider};
+    use dialog_common::{ConditionalSend, ConditionalSync};
+    use dialog_effects::archive::{Get, Put};
+    use dialog_effects::authority::Identify;
+    use dialog_effects::memory::Resolve;
     use dialog_query::attribute::The;
     use dialog_query::types::Any;
     use dialog_query::{AttributeQuery, Claim, Term, the};
+
+    /// Compile-time proof that the poll future is `Send` on native
+    /// (`ConditionalSend` = `Send` there, nothing on wasm): the
+    /// consumer drains subscription polls from axum handlers, whose
+    /// futures must be `Send`. Generic over the env so the guarantee
+    /// holds for any consumer's environment, not just the test
+    /// operator. Exercised by
+    /// [`it_keeps_the_poll_future_send_general`].
+    fn require_send_poll<Env>(subscription: &mut super::Subscription<AttributeQuery>, env: &Env)
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSend
+            + ConditionalSync
+            + 'static,
+    {
+        fn assert_send<T: ConditionalSend>(_: T) {}
+        assert_send(subscription.poll(env));
+    }
+
+    /// The poll future stays `Send`-general: the reactor's native
+    /// build drives polls from axum handlers, so a regression here
+    /// is a compile error in [`require_send_poll`], and the
+    /// subscription still evaluates normally afterwards.
+    #[dialog_common::test]
+    async fn it_keeps_the_poll_future_send_general() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        // Builds (and drops) a poll future through the Send-requiring
+        // bound; the compile is the assertion.
+        require_send_poll(&mut subscription, &operator);
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("first poll evaluates");
+        assert_eq!(names(&delta.asserted), vec![(alice, "Alice".to_string())]);
+        Ok(())
+    }
 
     /// A standing query over every `person/name` fact.
     fn names_query() -> AttributeQuery {

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -44,7 +44,7 @@ use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
 use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output as _};
-use dialog_search_tree::{Change, ContentAddressedStorage};
+use dialog_search_tree::ContentAddressedStorage;
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
 
@@ -87,6 +87,12 @@ impl Demand {
             .expect("demand lock")
             .iter()
             .any(|range| range.contains(key))
+    }
+
+    /// A snapshot of the recorded ranges: the scope a cover-gated
+    /// tree diff walks.
+    pub(crate) fn ranges(&self) -> Vec<RangeInclusive<KeyBytes>> {
+        self.ranges.lock().expect("demand lock").clone()
     }
 
     /// Number of distinct recorded ranges.
@@ -235,8 +241,17 @@ where
     }
 
     /// Whether any change between the pinned root and `current`
-    /// falls inside the demand cover. Streams the tree diff and
-    /// stops at the first hit.
+    /// falls inside the demand cover.
+    ///
+    /// The diff itself is *scoped to the cover*
+    /// ([`differentiate_within`]): subtrees whose key span misses
+    /// every demanded range are dropped from the comparison without
+    /// being loaded, so on a partial replica the poll never fetches
+    /// subtrees the subscription didn't demand — the walk is bounded
+    /// by the changes *within the cover*, not the full delta between
+    /// the roots. The first in-scope change decides.
+    ///
+    /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
     async fn intersects<Env>(
         &self,
         env: &Env,
@@ -256,6 +271,10 @@ where
         if pinned == target {
             return Ok(false);
         }
+        let scope = self.demand.ranges();
+        if scope.is_empty() {
+            return Ok(false);
+        }
 
         let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
         let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
@@ -263,22 +282,13 @@ where
             Index::from_hash_with_cache(NodeHash::from(pinned), self.branch.node_cache());
         let next = Index::from_hash_with_cache(NodeHash::from(target), self.branch.node_cache());
 
-        let changes = previous.differentiate(&next, &storage, &storage);
+        let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
-        while let Some(change) = changes
+        Ok(changes
             .try_next()
             .await
             .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-        {
-            let entry = match change {
-                Change::Add(entry) => entry,
-                Change::Remove(entry) => entry,
-            };
-            if self.demand.covers(&entry.key) {
-                return Ok(true);
-            }
-        }
-        Ok(false)
+            .is_some())
     }
 
     /// Evaluate the query against the branch, recording every

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -12,29 +12,56 @@
 //! - root changed but no diff entry falls inside the cover → the
 //!   result cannot have changed; the pin advances without
 //!   re-evaluating (this is the point: unrelated writes are free);
-//! - a diff entry falls inside the cover → re-evaluate, emit the
-//!   result [`Delta`], re-record the cover, advance the pin.
+//! - a diff entry falls inside a *fact* range → maintain
+//!   incrementally when the query supports it (see below), emit the
+//!   result [`Delta`], advance the pin;
+//! - a diff entry falls inside a *rule-discovery* range → the rule
+//!   set may have changed, which can affect any row: full
+//!   re-evaluation, cover re-recorded.
 //!
 //! The cover is the *demanded* range, not the touched data: a scan
 //! that came back empty still recorded its range, so absence reads
 //! (a fact that wasn't there yet, a rule that wasn't installed yet)
-//! are invalidated by later writes into the demanded range. Rule
-//! discovery reads (`db.rule/*` scans) record the same way, so
-//! committing a new rule for a subscribed concept re-triggers too.
+//! are invalidated by later writes into the demanded range.
+//!
+//! # Incremental maintenance (DRed / FBF)
+//!
+//! For fact changes, the delta is derived without re-evaluating the
+//! whole query: the changed datums name their subject entities, and
+//! for each touched entity the retained rows are over-deleted and
+//! re-derived by evaluating the query *restricted to that entity*
+//! ([`Application::restrict`]) — DRed's delete / re-derive / insert,
+//! with the goal-directed re-evaluation playing both the re-derive
+//! and insert steps. A row with surviving alternate derivations is
+//! simply re-derived, which handles the multi-derivation retraction
+//! case (FBF's concern) exactly, without counting.
+//!
+//! Per-entity re-derivation is sound only when a change to entity
+//! `E` can only affect rows whose subject is `E`. Attribute queries
+//! have this by construction; concept queries are gated on their
+//! resolved rule set — every rule entity-local
+//! ([`AnalyzedRule::is_entity_local`]) and non-recursive — and
+//! anything else falls back to a full recompute, which is always
+//! sound. [`recomputes`](Subscription::recomputes) and
+//! [`maintenances`](Subscription::maintenances) expose which path
+//! each poll took.
 //!
 //! Deliberately pull-driven: nothing here retains operator state or
 //! integrated inputs. Demand transformation over the existing
 //! top-down engine is the architecture; the diff is the signal, the
-//! cover is the gate, and re-evaluation is the (current) recompute
-//! step. Per-delta DRed/FBF maintenance and dynamically maintained
-//! demand (cones that grow with data) build on this same surface.
+//! cover is the gate, and per-entity re-derivation is the
+//! maintenance step. Dynamically maintained demand (cones that grow
+//! with data) builds on this same surface.
+//!
+//! [`AnalyzedRule::is_entity_local`]: dialog_query::rule::analyzer::AnalyzedRule::is_entity_local
 
+use std::collections::BTreeSet;
 use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{ArtifactSelector, KeyBytes};
+use dialog_artifacts::{ArtifactSelector, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -42,9 +69,11 @@ use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
 use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
+use dialog_query::Conclusion;
 use dialog_query::error::EvaluationError;
-use dialog_query::query::{Application, Output as _};
-use dialog_search_tree::ContentAddressedStorage;
+use dialog_query::query::{Application, Output as _, Restriction};
+use dialog_query::source::SelectRules;
+use dialog_search_tree::{Change, ContentAddressedStorage};
 use dialog_storage::Blake3Hash;
 use futures_util::TryStreamExt as _;
 
@@ -60,7 +89,20 @@ use crate::{
 /// while the evaluation streams.
 #[derive(Clone, Debug, Default)]
 pub struct Demand {
-    ranges: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
+    /// Ranges read by fact scans: the query's data demand.
+    facts: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
+    /// Ranges read by rule-discovery scans (`db.rule/*`). Kept
+    /// apart because a change here can install a rule, which can
+    /// affect any row — it invalidates the whole result, not one
+    /// entity's slice.
+    rules: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
+}
+
+fn record_range(ranges: &Mutex<Vec<RangeInclusive<KeyBytes>>>, range: RangeInclusive<KeyBytes>) {
+    let mut ranges = ranges.lock().expect("demand lock");
+    if !ranges.contains(&range) {
+        ranges.push(range);
+    }
 }
 
 impl Demand {
@@ -69,35 +111,51 @@ impl Demand {
         Self::default()
     }
 
-    /// Record a selector's demanded range. The range covers
+    /// Record a fact scan's demanded range. The range covers
     /// everything the selector's scan would touch — including where
     /// no entries exist, so misses are demanded too.
     pub(crate) fn record(&self, selector: &ArtifactSelector<Constrained>) {
-        let range = selector_range(selector);
-        let mut ranges = self.ranges.lock().expect("demand lock");
-        if !ranges.contains(&range) {
-            ranges.push(range);
-        }
+        record_range(&self.facts, selector_range(selector));
+    }
+
+    /// Record a rule-discovery scan's demanded range.
+    pub(crate) fn record_rules(&self, selector: &ArtifactSelector<Constrained>) {
+        record_range(&self.rules, selector_range(selector));
     }
 
     /// Whether the key falls inside any recorded range.
     pub fn covers(&self, key: &KeyBytes) -> bool {
-        self.ranges
+        self.covers_facts(key) || self.covers_rules(key)
+    }
+
+    fn covers_facts(&self, key: &KeyBytes) -> bool {
+        self.facts
             .lock()
             .expect("demand lock")
             .iter()
             .any(|range| range.contains(key))
     }
 
-    /// A snapshot of the recorded ranges: the scope a cover-gated
-    /// tree diff walks.
+    fn covers_rules(&self, key: &KeyBytes) -> bool {
+        self.rules
+            .lock()
+            .expect("demand lock")
+            .iter()
+            .any(|range| range.contains(key))
+    }
+
+    /// A snapshot of every recorded range (facts and rules): the
+    /// scope a cover-gated tree diff walks.
     pub(crate) fn ranges(&self) -> Vec<RangeInclusive<KeyBytes>> {
-        self.ranges.lock().expect("demand lock").clone()
+        let mut ranges = self.facts.lock().expect("demand lock").clone();
+        ranges.extend(self.rules.lock().expect("demand lock").iter().cloned());
+        ranges
     }
 
     /// Number of distinct recorded ranges.
     pub fn len(&self) -> usize {
-        self.ranges.lock().expect("demand lock").len()
+        self.facts.lock().expect("demand lock").len()
+            + self.rules.lock().expect("demand lock").len()
     }
 
     /// Whether nothing was demanded.
@@ -136,6 +194,10 @@ pub struct Subscription<Q: Application> {
     /// next delta.
     results: Vec<Q::Conclusion>,
     initialized: bool,
+    /// Full evaluations performed (first poll + fallbacks).
+    recomputes: usize,
+    /// Polls maintained incrementally (per-entity re-derivation).
+    maintenances: usize,
 }
 
 impl Branch {
@@ -150,8 +212,23 @@ impl Branch {
             demand: Demand::new(),
             results: Vec::new(),
             initialized: false,
+            recomputes: 0,
+            maintenances: 0,
         }
     }
+}
+
+/// What the in-cover changes between two roots touched.
+enum Touched {
+    /// Nothing inside the cover changed (or the changes cannot
+    /// alter any read: tombstones over never-asserted keys).
+    Nothing,
+    /// A rule-discovery range changed: the rule set may differ, so
+    /// any row may be affected.
+    Rules,
+    /// Only fact ranges changed; the set of subject entities whose
+    /// facts changed.
+    Facts(BTreeSet<Entity>),
 }
 
 /// The index root a revision pins, or the empty tree for an
@@ -166,7 +243,7 @@ fn tree_hash(revision: &Option<Revision>) -> Blake3Hash {
 impl<Q> Subscription<Q>
 where
     Q: Application + Clone,
-    Q::Conclusion: PartialEq + Clone,
+    Q::Conclusion: Conclusion + PartialEq + Clone,
 {
     /// The retained result of the last evaluation.
     pub fn results(&self) -> &[Q::Conclusion] {
@@ -176,6 +253,20 @@ where
     /// The demand cover recorded by the last evaluation.
     pub fn demand(&self) -> &Demand {
         &self.demand
+    }
+
+    /// Full evaluations performed so far (the first poll plus every
+    /// fallback from incremental maintenance).
+    pub fn recomputes(&self) -> usize {
+        self.recomputes
+    }
+
+    /// Polls that were maintained incrementally: the delta was
+    /// derived by re-evaluating only the touched entities (DRed's
+    /// delete/re-derive, goal-directed per subject) instead of the
+    /// whole query.
+    pub fn maintenances(&self) -> usize {
+        self.maintenances
     }
 
     /// Poll the subscription against the branch's current state.
@@ -210,14 +301,29 @@ where
             if current == self.revision {
                 return Ok(None);
             }
-            if !self.intersects(env, &current).await? {
-                self.revision = current;
-                return Ok(None);
+            match self.touched(env, &current).await? {
+                Touched::Nothing => {
+                    self.revision = current;
+                    return Ok(None);
+                }
+                Touched::Facts(entities) => {
+                    if let Some(delta) = self.maintain(env, &entities).await? {
+                        self.maintenances += 1;
+                        self.revision = current;
+                        return Ok(Some(delta));
+                    }
+                    // Not maintainable for this query/rule shape:
+                    // fall through to a full recompute.
+                }
+                // A rule-range change can install or change a rule,
+                // which can affect any row: recompute.
+                Touched::Rules => {}
             }
         }
 
         let demand = Demand::new();
-        let results = self.evaluate(env, &demand).await?;
+        let results = self.evaluate(env, &demand, &self.query).await?;
+        self.recomputes += 1;
 
         let delta = Delta {
             asserted: results
@@ -240,23 +346,30 @@ where
         Ok(Some(delta))
     }
 
-    /// Whether any change between the pinned root and `current`
-    /// falls inside the demand cover.
+    /// Classify what the changes between the pinned root and
+    /// `current` touched within the demand cover.
     ///
-    /// The diff itself is *scoped to the cover*
+    /// The diff is *scoped to the cover*
     /// ([`differentiate_within`]): subtrees whose key span misses
     /// every demanded range are dropped from the comparison without
     /// being loaded, so on a partial replica the poll never fetches
     /// subtrees the subscription didn't demand — the walk is bounded
     /// by the changes *within the cover*, not the full delta between
-    /// the roots. The first in-scope change decides.
+    /// the roots.
+    ///
+    /// A change inside a rule-discovery range short-circuits to
+    /// [`Touched::Rules`]. Fact changes collect the subject entities
+    /// of the changed datums; changes with no datum on either side
+    /// (a tombstone written where nothing was asserted, or a
+    /// tombstone entry disappearing) never alter what a scan reads
+    /// and are skipped.
     ///
     /// [`differentiate_within`]: dialog_search_tree::PersistentTree::differentiate_within
-    async fn intersects<Env>(
+    async fn touched<Env>(
         &self,
         env: &Env,
         current: &Option<Revision>,
-    ) -> Result<bool, EvaluationError>
+    ) -> Result<Touched, EvaluationError>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -269,11 +382,11 @@ where
         let pinned = tree_hash(&self.revision);
         let target = tree_hash(current);
         if pinned == target {
-            return Ok(false);
+            return Ok(Touched::Nothing);
         }
         let scope = self.demand.ranges();
         if scope.is_empty() {
-            return Ok(false);
+            return Ok(Touched::Nothing);
         }
 
         let store = NetworkedIndex::new(env, self.branch.subject().archive().index(), None);
@@ -284,11 +397,123 @@ where
 
         let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
-        Ok(changes
+        let mut entities = BTreeSet::new();
+        while let Some(change) = changes
             .try_next()
             .await
             .map_err(|error| EvaluationError::Store(format!("subscription diff: {error}")))?
-            .is_some())
+        {
+            let entry = match &change {
+                Change::Add(entry) => entry,
+                Change::Remove(entry) => entry,
+            };
+            if self.demand.covers_rules(&entry.key) {
+                return Ok(Touched::Rules);
+            }
+            if let State::Added(datum) = &entry.value {
+                let entity = datum.entity.parse().map_err(|error| {
+                    EvaluationError::Store(format!("changed datum entity: {error:?}"))
+                })?;
+                entities.insert(entity);
+            }
+        }
+
+        if entities.is_empty() {
+            Ok(Touched::Nothing)
+        } else {
+            Ok(Touched::Facts(entities))
+        }
+    }
+
+    /// Maintain the retained result incrementally: for each touched
+    /// entity, over-delete its retained rows and re-derive them with
+    /// the query restricted to that entity (DRed's delete /
+    /// re-derive / insert, with the goal-directed re-evaluation
+    /// playing both the re-derive and insert steps — a row with
+    /// surviving alternate derivations is simply re-derived, which
+    /// is what makes multi-derivation retractions exact without
+    /// counting).
+    ///
+    /// Returns `Ok(None)` when the query or its rule set cannot be
+    /// maintained per-entity — the query is not restrictable, a rule
+    /// reads other entities' facts (not entity-local), or the
+    /// concept is recursive — in which case the caller falls back to
+    /// a full recompute.
+    async fn maintain<Env>(
+        &mut self,
+        env: &Env,
+        entities: &BTreeSet<Entity>,
+    ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        // Soundness gate for concept queries: every rule must be
+        // entity-local (reads only `?this`'s facts) and
+        // non-recursive, otherwise a change to entity E can affect
+        // other entities' rows and per-entity re-derivation would
+        // miss them.
+        if let Some(concept) = self.query.concept() {
+            let operator = Identify
+                .perform(env)
+                .await
+                .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
+            let layer = QueryLayer::from(&self.branch);
+            let overlay = layer.overlay(&operator);
+            let tombstones = tombstones_from(&overlay);
+            let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
+                .with_demand(self.demand.clone());
+            let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
+            if rules.recursion().is_some() {
+                return Ok(None);
+            }
+            if !rules.rules().all(|rule| rule.analysis().is_entity_local()) {
+                return Ok(None);
+            }
+        }
+
+        let mut asserted = Vec::new();
+        let mut retracted = Vec::new();
+        for entity in entities {
+            let scoped = match self.query.restrict(entity) {
+                Restriction::Scoped(query) => query,
+                Restriction::Unaffected => continue,
+                Restriction::Unsupported => return Ok(None),
+            };
+            // Over-delete: every retained row for this entity...
+            let before: Vec<Q::Conclusion> = self
+                .results
+                .iter()
+                .filter(|row| row.this() == entity)
+                .cloned()
+                .collect();
+            // ...re-derive + insert: goal-directed re-evaluation,
+            // recording into the existing cover (the standing
+            // demand only ever grows between recomputes).
+            let after = self.evaluate(env, &self.demand.clone(), &scoped).await?;
+            for row in &after {
+                if !before.contains(row) {
+                    asserted.push(row.clone());
+                }
+            }
+            for row in &before {
+                if !after.contains(row) {
+                    retracted.push(row.clone());
+                }
+            }
+            self.results.retain(|row| row.this() != entity);
+            self.results.extend(after);
+        }
+        Ok(Some(Delta {
+            asserted,
+            retracted,
+        }))
     }
 
     /// Evaluate the query against the branch, recording every
@@ -299,6 +524,7 @@ where
         &self,
         env: &Env,
         demand: &Demand,
+        query: &Q,
     ) -> Result<Vec<Q::Conclusion>, EvaluationError>
     where
         Env: Provider<Get>
@@ -319,7 +545,7 @@ where
         let tombstones = tombstones_from(&overlay);
         let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
             .with_demand(demand.clone());
-        self.query.clone().perform(&query_env).try_vec().await
+        query.clone().perform(&query_env).try_vec().await
     }
 }
 
@@ -563,6 +789,187 @@ mod tests {
             names(&delta.asserted),
             vec![(alice.clone(), "Alice".to_string())]
         );
+        Ok(())
+    }
+
+    /// Covered writes are maintained incrementally: after the first
+    /// full evaluation, deltas come from per-entity re-derivation,
+    /// never a whole-query recompute.
+    #[dialog_common::test]
+    async fn it_maintains_covered_writes_without_recompute() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 0);
+
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("covered write");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(bob.clone(), "Bob".to_string())]
+        );
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the delta came from per-entity re-derivation, not a recompute"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+
+        branch
+            .transaction()
+            .retract(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(alice.clone(), "Alice".to_string())]
+        );
+        assert!(delta.asserted.is_empty());
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
+        assert_eq!(
+            names(subscription.results()),
+            vec![(bob, "Bob".to_string())],
+            "retained results track the maintained state"
+        );
+        Ok(())
+    }
+
+    /// The multi-derivation retraction case (what FBF solves without
+    /// counting): an entity carries two values for the same
+    /// attribute; retracting one must retract exactly that row and
+    /// keep the other, because the survivor re-derives during the
+    /// per-entity re-evaluation.
+    #[dialog_common::test]
+    async fn it_rederives_surviving_rows_on_partial_retraction() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        branch
+            .transaction()
+            .assert(the!("person/name").of(alice.clone()).is("Ali".to_string()))
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(initial.asserted.len(), 2, "both values surface");
+
+        branch
+            .transaction()
+            .retract(the!("person/name").of(alice.clone()).is("Ali".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(
+            names(&delta.retracted),
+            vec![(alice.clone(), "Ali".to_string())],
+            "only the retracted value goes"
+        );
+        assert!(delta.asserted.is_empty());
+        assert_eq!(
+            names(subscription.results()),
+            vec![(alice.clone(), "Alice".to_string())],
+            "the surviving value re-derived"
+        );
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 1);
+        Ok(())
+    }
+
+    /// A write touching only *other* entities' facts inside the
+    /// cover maintains just those entities: the untouched entity's
+    /// rows are never re-derived, and the delta is scoped to what
+    /// changed.
+    #[dialog_common::test]
+    async fn it_scopes_maintenance_to_touched_entities() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let alice = Entity::new()?;
+        let bob = Entity::new()?;
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(alice.clone())
+                    .is("Alice".to_string()),
+            )
+            .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(names_query());
+        subscription.poll(&operator).await?.expect("initial");
+
+        branch
+            .transaction()
+            .assert(the!("person/name").of(bob.clone()).is("Bobby".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("covered write");
+        assert_eq!(
+            names(&delta.asserted),
+            vec![(bob.clone(), "Bobby".to_string())]
+        );
+        assert!(
+            delta.retracted.is_empty(),
+            "cardinality-many: the prior value stays"
+        );
+        let mut retained = names(subscription.results());
+        retained.sort();
+        let mut expected = vec![
+            (alice.clone(), "Alice".to_string()),
+            (bob.clone(), "Bob".to_string()),
+            (bob.clone(), "Bobby".to_string()),
+        ];
+        expected.sort();
+        assert_eq!(retained, expected);
+        assert_eq!(subscription.maintenances(), 1);
         Ok(())
     }
 }

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -66,7 +66,7 @@ use std::sync::{Arc, Mutex};
 
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
-use dialog_artifacts::{Artifact, ArtifactSelector, Entity, KeyBytes, State};
+use dialog_artifacts::{Artifact, ArtifactSelector, Changes, Entity, KeyBytes, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::ConditionalSync;
@@ -207,6 +207,18 @@ impl<T> Delta<T> {
 pub struct Subscription<Q: Application> {
     branch: Branch,
     query: Q,
+    /// A caller-supplied transient overlay folded into every
+    /// evaluation alongside the branch facts — the same role
+    /// [`QueryLayer::with`] plays for a one-shot query. Ephemeral:
+    /// off-tree, never committed, so the tree-diff gate in
+    /// [`touched`](Subscription::touched) can't observe a change to
+    /// it. The owner must therefore call
+    /// [`set_overlay`](Subscription::set_overlay) and force a poll
+    /// when the overlay mutates; a poll then recomputes (the overlay
+    /// delta is not derivable from the tree). Empty by default
+    /// ([`subscribe`](Branch::subscribe)); populated via
+    /// [`subscribe_with`](Branch::subscribe_with).
+    overlay: Changes,
     /// The revision the retained results were evaluated at. `None`
     /// until the first poll.
     revision: Option<Revision>,
@@ -231,9 +243,21 @@ impl Branch {
     /// evaluates on its first [`poll`](Subscription::poll) and is
     /// incrementally gated afterwards.
     pub fn subscribe<Q: Application>(&self, query: Q) -> Subscription<Q> {
+        self.subscribe_with(query, Changes::new())
+    }
+
+    /// Register a standing query with a transient `overlay` folded
+    /// into every evaluation — ephemeral facts (an invite seed, a
+    /// UI status stamp) that participate in reads and in the demand
+    /// cover but are never committed. Because the overlay is
+    /// off-tree, a change to it is invisible to the poll's tree-diff
+    /// gate: after mutating it via [`Subscription::set_overlay`], the
+    /// owner must force a poll to pick the change up.
+    pub fn subscribe_with<Q: Application>(&self, query: Q, overlay: Changes) -> Subscription<Q> {
         Subscription {
             branch: self.clone(),
             query,
+            overlay,
             revision: None,
             demand: Demand::new(),
             results: Vec::new(),
@@ -290,6 +314,15 @@ where
     /// The demand cover recorded by the last evaluation.
     pub fn demand(&self) -> &Demand {
         &self.demand
+    }
+
+    /// Replace the transient overlay folded into evaluations. The
+    /// overlay is off-tree, so this alone changes nothing: the caller
+    /// must follow with a [`poll`](Subscription::poll), which then
+    /// recomputes (the overlay delta can't be derived from the tree
+    /// diff) and reports the result change as a delta.
+    pub fn set_overlay(&mut self, overlay: Changes) {
+        self.overlay = overlay;
     }
 
     /// Full evaluations performed so far (the first poll plus every
@@ -547,7 +580,7 @@ where
                 .perform(env)
                 .await
                 .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-            let layer = QueryLayer::from(&self.branch);
+            let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
             let overlay = layer.overlay(&operator);
             let tombstones = tombstones_from(&overlay);
             let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
@@ -651,7 +684,7 @@ where
             .perform(env)
             .await
             .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch);
+        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
         let overlay = layer.overlay(&operator);
         let tombstones = tombstones_from(&overlay);
         let mut query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)
@@ -694,7 +727,7 @@ where
             .perform(env)
             .await
             .map_err(|error| EvaluationError::Store(format!("identify: {error}")))?;
-        let layer = QueryLayer::from(&self.branch);
+        let layer = QueryLayer::from(&self.branch).with(self.overlay.clone());
         let overlay = layer.overlay(&operator);
         let tombstones = tombstones_from(&overlay);
         let query_env = QueryEnv::new(layer.branches().to_vec(), overlay, tombstones, env)

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -105,11 +105,26 @@ pub struct Demand {
     rules: Arc<Mutex<Vec<RangeInclusive<KeyBytes>>>>,
 }
 
+/// Insert a range into a cover, merging overlaps: the cover stays a
+/// sorted list of disjoint intervals, so it cannot grow beyond the
+/// number of genuinely distinct demanded regions no matter how many
+/// (nested, repeated) selectors record into it.
 fn record_range(ranges: &Mutex<Vec<RangeInclusive<KeyBytes>>>, range: RangeInclusive<KeyBytes>) {
     let mut ranges = ranges.lock().expect("demand lock");
-    if !ranges.contains(&range) {
-        ranges.push(range);
+    let (mut start, mut end) = range.into_inner();
+    // Absorb every existing interval the new one overlaps.
+    let mut merged = Vec::with_capacity(ranges.len() + 1);
+    for existing in ranges.drain(..) {
+        if *existing.start() > end || *existing.end() < start {
+            merged.push(existing);
+        } else {
+            start = start.min(*existing.start());
+            end = end.max(*existing.end());
+        }
     }
+    merged.push(start..=end);
+    merged.sort_by(|a, b| a.start().cmp(b.start()));
+    *ranges = merged;
 }
 
 impl Demand {
@@ -243,12 +258,13 @@ enum Touched {
     Facts {
         /// Subjects of the changed facts.
         subjects: BTreeSet<Entity>,
-        /// The changed facts themselves, for delta-join discovery.
+        /// Every changed fact (asserted and retracted alike), for
+        /// delta-join discovery.
         facts: Vec<Artifact>,
-        /// Whether every change was an addition (no fact left the
-        /// index and no tombstone was written): the precondition
-        /// for semi-naive fixpoint continuation.
-        additions_only: bool,
+        /// Facts that became readable.
+        asserted: Vec<Artifact>,
+        /// Facts that stopped being readable.
+        retracted: Vec<Artifact>,
     },
 }
 
@@ -330,10 +346,11 @@ where
                 Touched::Facts {
                     subjects,
                     facts,
-                    additions_only,
+                    asserted,
+                    retracted,
                 } => {
                     if let Some(delta) = self
-                        .maintain(env, &subjects, &facts, additions_only)
+                        .maintain(env, &subjects, &facts, &asserted, &retracted)
                         .await?
                     {
                         self.maintenances += 1;
@@ -426,10 +443,10 @@ where
         let changes = previous.differentiate_within(&next, &scope, &storage, &storage);
         let mut changes = Box::pin(changes);
         let mut subjects = BTreeSet::new();
-        let mut facts = Vec::new();
-        let mut additions_only = true;
+        let mut asserted = Vec::new();
+        let mut retracted = Vec::new();
         // A fact change surfaces once per index order; dedup on the
-        // datum triple.
+        // datum triple, per direction.
         let mut seen = BTreeSet::new();
         while let Some(change) = changes
             .try_next()
@@ -443,15 +460,15 @@ where
             if self.demand.covers_rules(&entry.key) {
                 return Ok(Touched::Rules);
             }
-            // An entry leaving the index, or a tombstone arriving,
-            // means a fact stopped being readable: not an addition.
-            match (&change, &entry.value) {
-                (Change::Remove(_), State::Added(_)) => additions_only = false,
-                (Change::Add(_), State::Removed) => additions_only = false,
-                _ => {}
-            }
+            // An entry arriving with a datum became readable; an
+            // entry leaving with a datum stopped being readable.
+            // Tombstone-valued entries carry no datum: their effect
+            // (if any) surfaces as the paired datum-bearing change
+            // at the same key.
+            let arriving = matches!(&change, Change::Add(_));
             if let State::Added(datum) = &entry.value {
                 if !seen.insert((
+                    arriving,
                     datum.entity.clone(),
                     datum.attribute.clone(),
                     datum.value.clone(),
@@ -461,17 +478,23 @@ where
                 let fact = Artifact::try_from(datum.clone())
                     .map_err(|error| EvaluationError::Store(format!("changed datum: {error:?}")))?;
                 subjects.insert(fact.of.clone());
-                facts.push(fact);
+                if arriving {
+                    asserted.push(fact);
+                } else {
+                    retracted.push(fact);
+                }
             }
         }
 
         if subjects.is_empty() {
             Ok(Touched::Nothing)
         } else {
+            let facts = asserted.iter().chain(retracted.iter()).cloned().collect();
             Ok(Touched::Facts {
                 subjects,
                 facts,
-                additions_only,
+                asserted,
+                retracted,
             })
         }
     }
@@ -494,7 +517,8 @@ where
         env: &Env,
         subjects: &BTreeSet<Entity>,
         facts: &[Artifact],
-        additions_only: bool,
+        asserted: &[Artifact],
+        retracted: &[Artifact],
     ) -> Result<Option<Delta<Q::Conclusion>>, EvaluationError>
     where
         Env: Provider<Get>
@@ -530,17 +554,16 @@ where
                 .with_demand(self.demand.clone());
             let rules = Provider::<SelectRules>::execute(&query_env, concept.clone()).await?;
             if rules.recursion().is_some() {
-                // Fixpoint continuation: additions extend the
-                // retained answer table semi-naively (rebuilding
-                // when the rule set is not additively extendable);
-                // deletions fall back to a recompute, which rebuilds
-                // the table.
-                if !additions_only {
-                    return Ok(None);
-                }
+                // Fixpoint continuation: deletions retract via DRed,
+                // additions extend semi-naively — rebuilding into
+                // the retained table when either phase declines.
                 drop(query_env);
                 let results = self
-                    .evaluate_with_continuation(env, Some(Arc::new(facts.to_vec())))
+                    .evaluate_with_continuation(
+                        env,
+                        Arc::new(asserted.to_vec()),
+                        Arc::new(retracted.to_vec()),
+                    )
                     .await?;
                 let delta = Delta {
                     asserted: results
@@ -637,10 +660,8 @@ where
         // across polls: a recompute rebuilds into the retained
         // table so a later additions-only poll can extend it.
         if let Some(concept) = query.concept() {
-            query_env = query_env.with_fixpoint(
-                concept.this(),
-                Continuation::new(self.fixpoint.clone(), None),
-            );
+            query_env =
+                query_env.with_fixpoint(concept.this(), Continuation::new(self.fixpoint.clone()));
         }
         query.clone().perform(&query_env).try_vec().await
     }
@@ -652,7 +673,8 @@ where
     async fn evaluate_with_continuation<Env>(
         &self,
         env: &Env,
-        additions: Option<Arc<Vec<Artifact>>>,
+        additions: Arc<Vec<Artifact>>,
+        deletions: Arc<Vec<Artifact>>,
     ) -> Result<Vec<Q::Conclusion>, EvaluationError>
     where
         Env: Provider<Get>
@@ -679,7 +701,7 @@ where
             .with_demand(self.demand.clone())
             .with_fixpoint(
                 concept.this(),
-                Continuation::new(self.fixpoint.clone(), additions),
+                Continuation::new(self.fixpoint.clone()).with_changes(additions, deletions),
             );
         self.query.clone().perform(&query_env).try_vec().await
     }
@@ -1151,6 +1173,29 @@ mod tests {
             /// Their manager, who must hold a badge.
             #[dialog(conforms = BadgeHolder)]
             pub manager: Manager,
+        }
+
+        /// The chief's deputy (`chief/deputy`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("chief")]
+        pub struct Deputy(pub Entity);
+
+        /// The chief's title (`chief/title`).
+        #[derive(Attribute, Clone, PartialEq)]
+        #[domain("chief")]
+        pub struct Title(pub String);
+
+        /// Someone whose deputy is a valid report — two conformance
+        /// layers deep (Chief -> Report -> BadgeHolder).
+        #[derive(Concept, Debug, Clone, PartialEq)]
+        pub struct Chief {
+            /// The chief entity.
+            pub this: Entity,
+            /// Their title.
+            pub title: Title,
+            /// Their deputy, who must be a valid report.
+            #[dialog(conforms = Report)]
+            pub deputy: Deputy,
         }
 
         /// An email handle (`comm/email`).
@@ -1628,10 +1673,10 @@ mod tests {
         assert_eq!(subscription.recomputes(), 1);
         assert_eq!(subscription.maintenances(), 2);
 
-        // A deletion shrinks the closure: not additively
-        // extendable, so the poll rebuilds the fixpoint (and the
-        // retained table), retracting everything derived through
-        // the removed edge.
+        // A deletion shrinks the closure: DRed over the retained
+        // table — over-delete forward from the removed edge,
+        // re-derive survivors — retracting exactly what was
+        // derivable through it, still without a recompute.
         branch
             .transaction()
             .retract(Parent::of(c.clone()).is(b.clone()))
@@ -1646,9 +1691,14 @@ mod tests {
             "everything derived through the removed edge goes: \
              (c,b), (c,a), (d,b), (d,a); (d,c) survives"
         );
-        assert_eq!(subscription.recomputes(), 2, "deletions rebuild");
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "the deletion was retracted via DRed, not a rebuild"
+        );
+        assert_eq!(subscription.maintenances(), 3);
 
-        // And the rebuilt table continues extending afterwards.
+        // And the retracted table continues extending afterwards.
         let e = Entity::new()?;
         branch
             .transaction()
@@ -1674,8 +1724,88 @@ mod tests {
             asserted, expected,
             "e's ancestors follow the surviving chain"
         );
-        assert_eq!(subscription.recomputes(), 2);
-        assert_eq!(subscription.maintenances(), 3);
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "never recomputed after the first poll"
+        );
+        assert_eq!(subscription.maintenances(), 4);
+        Ok(())
+    }
+
+    /// Deep nesting: a badge change three derivation layers away
+    /// (badge -> BadgeHolder -> Report -> Chief) propagates through
+    /// the bottom-up affected discovery and maintains without a
+    /// recompute.
+    #[dialog_common::test]
+    async fn it_maintains_deeply_nested_conformance() -> anyhow::Result<()> {
+        use concepts::{Badge, Chief, Deputy, Manager, Name, Title};
+        use dialog_query::Query;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let carol = Entity::new()?; // manager, unbadged (yet)
+        let mallory = Entity::new()?; // reports to carol
+        let frank = Entity::new()?; // chief whose deputy is mallory
+
+        branch
+            .transaction()
+            .assert(Name::of(mallory.clone()).is("Mallory"))
+            .assert(Manager::of(mallory.clone()).is(carol.clone()))
+            .assert(Title::of(frank.clone()).is("Frank"))
+            .assert(Deputy::of(frank.clone()).is(mallory.clone()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(Query::<Chief>::default());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert!(
+            initial.asserted.is_empty(),
+            "mallory is not a valid report while carol is unbadged"
+        );
+
+        // Badge carol: mallory becomes a Report, so frank becomes a
+        // Chief — two layers above the changed fact's subject.
+        branch
+            .transaction()
+            .assert(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("deeply nested effect");
+        assert_eq!(
+            delta.asserted,
+            vec![Chief {
+                this: frank.clone(),
+                title: Title("Frank".into()),
+                deputy: Deputy(mallory.clone()),
+            }]
+        );
+        assert_eq!(
+            subscription.recomputes(),
+            1,
+            "discovered through two conformance layers, not recomputed"
+        );
+        assert_eq!(subscription.maintenances(), 1);
+
+        // And back out again.
+        branch
+            .transaction()
+            .retract(Badge::of(carol.clone()).is("C-3"))
+            .commit()
+            .perform(&operator)
+            .await?;
+        let delta = subscription.poll(&operator).await?.expect("retraction");
+        assert_eq!(delta.retracted.len(), 1);
+        assert_eq!(subscription.recomputes(), 1);
+        assert_eq!(subscription.maintenances(), 2);
         Ok(())
     }
 }

--- a/rust/dialog-repository/src/repository/branch/transaction/query.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/query.rs
@@ -152,7 +152,7 @@ impl<'a, Q: Application> TransactionSelectQuery<'a, Q> {
             // uses is what guarantees identical behavior — fact reads,
             // tombstones, schema metadata, and deductive-rule
             // resolution all share one implementation.
-            let query_env = QueryEnv::new(vec![branch], overlay, tombstones, env);
+            let query_env = QueryEnv::new(vec![branch.clone()], overlay, tombstones, env);
             let results = Box::pin(query.perform(&query_env));
             for await result in results {
                 yield result?;

--- a/rust/dialog-repository/src/transaction_query.rs
+++ b/rust/dialog-repository/src/transaction_query.rs
@@ -165,7 +165,7 @@ where
         // retracts. Tombstones touch only the branch source; the
         // overlay's facts (below) pass through unfiltered so a
         // `retract(x).assert(x)` pattern surfaces `x` correctly.
-        let raw = select_from_branch(self.branch, self.env, input.clone()).await?;
+        let raw = select_from_branch(self.branch.clone(), self.env, input.clone());
         let filtered_branch = filter_tombstones(raw, self.tombstones.clone());
 
         // Pending changes overlay — Changes itself is a Provider<Select>.

--- a/rust/dialog-search-tree/src/differential.rs
+++ b/rust/dialog-search-tree/src/differential.rs
@@ -224,6 +224,43 @@ where
         }
     }
 
+    /// Removes nodes whose key span cannot intersect any range in
+    /// `scope`, so out-of-scope subtrees are never expanded (and, on
+    /// a partial replica, never fetched).
+    ///
+    /// Links carry only upper bounds, so a node's span is bounded
+    /// conservatively: within the frontier (sorted by upper bound,
+    /// where pruning only ever *removes* nodes), a node's true span
+    /// is contained in `(predecessor's upper bound, own upper bound]`.
+    /// A node is dropped only when that conservative span misses
+    /// every scope range, which can only over-retain, never
+    /// over-drop — in-scope changes are always preserved. Dropping is
+    /// per-side, so the entry walk may surface spurious out-of-scope
+    /// changes where only one side dropped a shared region;
+    /// [`TreeDifference::changes_within`] filters those.
+    fn retain_scope(&mut self, scope: &[core::ops::RangeInclusive<Key>]) {
+        let mut lower: Option<Key> = None;
+        let mut kept = Vec::with_capacity(self.nodes.len());
+        for node in self.nodes.drain(..) {
+            let upper = node.upper_bound().clone();
+            let intersects = scope.iter().any(|range| {
+                // (lower, upper] ∩ [start, end] is non-empty iff
+                // upper >= start and lower < end (with lower = -∞
+                // for the first node).
+                *range.start() <= upper
+                    && match &lower {
+                        Some(lower) => lower < range.end(),
+                        None => true,
+                    }
+            });
+            if intersects {
+                kept.push(node);
+            }
+            lower = Some(upper);
+        }
+        self.nodes = kept;
+    }
+
     /// Removes nodes that are shared between `self` and `other`, keeping
     /// only nodes that differ.
     ///
@@ -397,6 +434,77 @@ where
     where
         D: Distribution,
     {
+        let mut difference = Self::compute_scoped(
+            source_tree,
+            target_tree,
+            source_storage,
+            target_storage,
+            None,
+        )
+        .await?;
+
+        // Expand any remaining target index nodes so novel_nodes() can
+        // enumerate every novel node, not just unexpanded subtree roots.
+        // These reads are not wasted: every remaining target node is novel
+        // by construction and must be visited to be reported.
+        loop {
+            let mut expanded = false;
+            for index in 0..difference.target.nodes.len() {
+                let bound = difference.target.nodes[index].upper_bound().clone();
+                if difference.target.expand_at(&bound).await? {
+                    expanded = true;
+                    break;
+                }
+            }
+            if !expanded {
+                break;
+            }
+        }
+
+        Ok(difference)
+    }
+
+    /// Computes the difference between two trees *restricted to
+    /// `scope`*: subtrees whose key span cannot intersect any scope
+    /// range are dropped from the comparison without being loaded,
+    /// so reads are proportional to the differing regions *within
+    /// the scope* rather than to the full difference. On a partial
+    /// replica this is what keeps a subscription's diff from
+    /// fetching subtrees it never demanded.
+    ///
+    /// Consume via [`changes_within`](Self::changes_within) (which
+    /// filters boundary spillover); [`novel_nodes`](Self::novel_nodes)
+    /// is not meaningful on a scoped difference.
+    pub async fn compute_within<D>(
+        source_tree: &PersistentTree<Key, Value, D>,
+        target_tree: &PersistentTree<Key, Value, D>,
+        source_storage: &'a ContentAddressedStorage<Backend>,
+        target_storage: &'a ContentAddressedStorage<Backend>,
+        scope: &[core::ops::RangeInclusive<Key>],
+    ) -> Result<TreeDifference<'a, Key, Value, Backend>, DialogSearchTreeError>
+    where
+        D: Distribution,
+    {
+        Self::compute_scoped(
+            source_tree,
+            target_tree,
+            source_storage,
+            target_storage,
+            Some(scope),
+        )
+        .await
+    }
+
+    async fn compute_scoped<D>(
+        source_tree: &PersistentTree<Key, Value, D>,
+        target_tree: &PersistentTree<Key, Value, D>,
+        source_storage: &'a ContentAddressedStorage<Backend>,
+        target_storage: &'a ContentAddressedStorage<Backend>,
+        scope: Option<&[core::ops::RangeInclusive<Key>]>,
+    ) -> Result<TreeDifference<'a, Key, Value, Backend>, DialogSearchTreeError>
+    where
+        D: Distribution,
+    {
         // Identical trees (including two empty trees) share their root
         // hash; nothing needs to be read at all.
         if source_tree.root() == target_tree.root() {
@@ -423,6 +531,10 @@ where
         // fixed point: only differing leaf segments (and unique-range
         // subtrees) remain.
         loop {
+            if let Some(scope) = scope {
+                source.retain_scope(scope);
+                target.retain_scope(scope);
+            }
             source.prune(&mut target);
 
             let mut expanded = false;
@@ -473,25 +585,34 @@ where
             }
         }
 
-        // Expand any remaining target index nodes so novel_nodes() can
-        // enumerate every novel node, not just unexpanded subtree roots.
-        // These reads are not wasted: every remaining target node is novel
-        // by construction and must be visited to be reported.
-        loop {
-            let mut expanded = false;
-            for index in 0..target.nodes.len() {
-                let bound = target.nodes[index].upper_bound().clone();
-                if target.expand_at(&bound).await? {
-                    expanded = true;
-                    break;
+        Ok(TreeDifference { source, target })
+    }
+
+    /// Returns a stream of the changes within `scope` that transform
+    /// the source tree into the target tree. Use on a difference
+    /// built by [`compute_within`](Self::compute_within): scope
+    /// pruning is per-side, so a shared region dropped from only one
+    /// frontier surfaces as spurious out-of-scope changes in the raw
+    /// entry walk — this filter removes them, leaving exactly the
+    /// in-scope changes.
+    pub fn changes_within(
+        &'a self,
+        scope: &'a [core::ops::RangeInclusive<Key>],
+    ) -> impl Differential<Key, Value> + 'a {
+        let changes = self.changes();
+        try_stream! {
+            futures_util::pin_mut!(changes);
+            for await change in changes {
+                let change = change?;
+                let key = match &change {
+                    Change::Add(entry) => &entry.key,
+                    Change::Remove(entry) => &entry.key,
+                };
+                if scope.iter().any(|range| range.contains(key)) {
+                    yield change;
                 }
             }
-            if !expanded {
-                break;
-            }
         }
-
-        Ok(TreeDifference { source, target })
     }
 
     /// Returns a stream of entry-level changes that transform the source
@@ -680,6 +801,127 @@ mod tests {
             }
         }
         Ok(tree)
+    }
+
+    async fn collect_scoped_changes(
+        source: &TestTree,
+        target: &TestTree,
+        scope: &[core::ops::RangeInclusive<[u8; 4]>],
+        storage: &ContentAddressedStorage<CountingBackend>,
+    ) -> Result<Vec<Change<[u8; 4], Vec<u8>>>> {
+        let stream = source.differentiate_within(target, scope, storage, storage);
+        futures_util::pin_mut!(stream);
+        let mut changes = vec![];
+        while let Some(change) = stream.next().await {
+            changes.push(change?);
+        }
+        Ok(changes)
+    }
+
+    /// A scoped diff yields exactly the full diff filtered to the
+    /// scope: in-scope changes are never dropped, boundary spillover
+    /// from one-sided pruning is filtered out.
+    ///
+    /// Keys stay below 256 so little-endian key bytes order the same
+    /// as the numbers they encode.
+    #[dialog_common::test]
+    async fn it_scopes_changes_to_the_given_ranges() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(CountingBackend::new());
+        let base = build((0..250u32).map(|i| (i, vec![0])), &mut storage).await?;
+
+        // Two changed regions far apart in key space.
+        let mut target = base.clone();
+        let mut delta = Delta::zero();
+        for i in (10..20u32).chain(200..210u32) {
+            target = target
+                .edit()
+                .insert(i.to_le_bytes(), vec![1], &storage)
+                .await?
+                .persist(&mut delta)?;
+            for (_, buffer) in delta.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
+            }
+        }
+
+        let scope = vec![0u32.to_le_bytes()..=50u32.to_le_bytes()];
+
+        let full = collect_changes(&base, &target, &storage).await?;
+        let scoped = collect_scoped_changes(&base, &target, &scope, &storage).await?;
+
+        let key = |change: &Change<[u8; 4], Vec<u8>>| match change {
+            Change::Add(entry) => entry.key,
+            Change::Remove(entry) => entry.key,
+        };
+        let expected: Vec<[u8; 4]> = full
+            .iter()
+            .filter(|change| scope.iter().any(|range| range.contains(&key(change))))
+            .map(&key)
+            .collect();
+        let actual: Vec<[u8; 4]> = scoped.iter().map(&key).collect();
+
+        assert_eq!(
+            actual, expected,
+            "scoped diff must equal the full diff filtered to scope"
+        );
+        assert_eq!(
+            scoped.len(),
+            20,
+            "ten modified keys in scope, one Remove + one Add each"
+        );
+        assert!(
+            scoped.iter().all(|change| {
+                key(change) >= 10u32.to_le_bytes() && key(change) < 20u32.to_le_bytes()
+            }),
+            "only the in-scope region's keys appear"
+        );
+        Ok(())
+    }
+
+    /// The point of scoping on a partial replica: subtrees whose key
+    /// span misses the scope are never read, so a scoped diff reads
+    /// strictly fewer blocks than the full diff when the
+    /// out-of-scope region changed heavily.
+    #[dialog_common::test]
+    async fn it_avoids_reading_out_of_scope_subtrees() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(CountingBackend::new());
+        let base = build((0..250u32).map(|i| (i, vec![0])), &mut storage).await?;
+
+        // A small in-scope change and a heavy out-of-scope change.
+        let mut target = base.clone();
+        let mut delta = Delta::zero();
+        for i in (10..12u32).chain(100..250u32) {
+            target = target
+                .edit()
+                .insert(i.to_le_bytes(), vec![1], &storage)
+                .await?
+                .persist(&mut delta)?;
+            for (_, buffer) in delta.flush() {
+                storage
+                    .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                    .await?;
+            }
+        }
+
+        let scope = vec![0u32.to_le_bytes()..=20u32.to_le_bytes()];
+
+        let before_full = storage.backend().reads();
+        let full = collect_changes(&base, &target, &storage).await?;
+        let full_reads = storage.backend().reads() - before_full;
+
+        let before_scoped = storage.backend().reads();
+        let scoped = collect_scoped_changes(&base, &target, &scope, &storage).await?;
+        let scoped_reads = storage.backend().reads() - before_scoped;
+
+        assert_eq!(scoped.len(), 4, "two in-scope keys, Remove + Add each");
+        assert!(full.len() > scoped.len());
+        assert!(
+            scoped_reads < full_reads,
+            "scoped diff must skip out-of-scope subtrees: \
+             scoped {scoped_reads} reads vs full {full_reads} reads"
+        );
+        Ok(())
     }
 
     async fn collect_changes(

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -263,6 +263,37 @@ where
         }
     }
 
+    /// Streams the changes *within `scope`* that transform this tree into
+    /// `other`.
+    ///
+    /// Like [`differentiate`](Self::differentiate), but subtrees whose key
+    /// span cannot intersect any scope range are dropped from the
+    /// comparison without being loaded: reads are proportional to the
+    /// differing regions within the scope, not to the full difference. On
+    /// a partial replica this keeps the diff from fetching subtrees the
+    /// caller never demanded.
+    pub fn differentiate_within<'a, Backend>(
+        &'a self,
+        other: &'a Self,
+        scope: &'a [core::ops::RangeInclusive<Key>],
+        self_storage: &'a ContentAddressedStorage<Backend>,
+        other_storage: &'a ContentAddressedStorage<Backend>,
+    ) -> impl Differential<Key, Value> + 'a
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+        Value: PartialEq,
+    {
+        async_stream::try_stream! {
+            let difference =
+                TreeDifference::compute_within(self, other, self_storage, other_storage, scope)
+                    .await?;
+            for await change in difference.changes_within(scope) {
+                yield change?;
+            }
+        }
+    }
+
     /// Builds a persistent tree from a sealed root hash and a node cache. Used
     /// by [`TransientTree::persist`] to turn a finished edit batch back into a
     /// [`PersistentTree`] while carrying its cache forward. The batch's new nodes

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -278,11 +278,20 @@ where
         scope: &'a [core::ops::RangeInclusive<Key>],
         self_storage: &'a ContentAddressedStorage<Backend>,
         other_storage: &'a ContentAddressedStorage<Backend>,
-    ) -> impl Differential<Key, Value> + 'a
+    ) -> impl Differential<Key, Value> + ConditionalSend + 'a
     where
         Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
             + ConditionalSync,
-        Value: PartialEq,
+        // `Key`/`Value` bound `ConditionalSync` (not just the trait's
+        // `ConditionalSend`) so that `&PersistentTree` — which the
+        // returned `async_stream` captures — is `Send` on native.
+        // `PersistentTree` holds `PhantomData<Key>`/`PhantomData<Value>`,
+        // so its `Sync` (hence `&_: Send`) needs `Key: Sync`/`Value: Sync`.
+        // Subscriptions poll this diff inside an axum handler future that
+        // must be `Send`; without the bound the whole handler is `!Send`.
+        Key: ConditionalSync,
+        Value: PartialEq + ConditionalSync,
+        D: ConditionalSync,
     {
         async_stream::try_stream! {
             let difference =

--- a/rust/dialog-storage/Cargo.toml
+++ b/rust/dialog-storage/Cargo.toml
@@ -67,6 +67,7 @@ dirs = { workspace = true }
 js-sys = { workspace = true }
 rexie = { workspace = true }
 wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 web-time = { workspace = true }
 
 [dev-dependencies]

--- a/rust/dialog-storage/src/resource.rs
+++ b/rust/dialog-storage/src/resource.rs
@@ -7,6 +7,8 @@
 mod pool;
 pub use pool::*;
 
+use dialog_common::ConditionalSync;
+
 /// A resource that can be opened from an address.
 ///
 /// The address carries all information needed to construct the resource
@@ -17,6 +19,24 @@ pub trait Resource<Address>: Sized {
     /// Error that can occur when opening the resource.
     type Error;
 
-    /// Open a new resource from the given address.
+    /// Open a resource at the given address, creating its backing store
+    /// if absent. This is the open-or-create path.
     async fn open(address: &Address) -> Result<Self, Self::Error>;
+
+    /// Open an *existing* resource at the given address, failing if it
+    /// does not already exist. Unlike [`open`](Resource::open) this must
+    /// never bring the backing store into being.
+    ///
+    /// The default delegates to [`open`](Resource::open), which is correct
+    /// for backends whose `open` is lazy — it constructs a handle without
+    /// materializing anything (e.g. a filesystem path is created only on
+    /// first write). A backend whose `open` eagerly creates its store
+    /// (IndexedDB opens a database into existence) MUST override this to
+    /// probe for existence first and error when absent.
+    async fn load(address: &Address) -> Result<Self, Self::Error>
+    where
+        Address: ConditionalSync,
+    {
+        Self::open(address).await
+    }
 }

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -32,6 +32,78 @@ use url::Url;
 /// platform's data and temp directories.
 const STORAGE_NAMESPACE: &str = "dialog";
 
+/// Percent-encode characters illegal in a Windows path component.
+///
+/// DIDs (`did:key:z6Mk...`) are used directly as directory names by the
+/// certificate/credential layout. Windows forbids `< > : " \ | ? *` and
+/// control characters in filenames, so writing e.g. `certificate/{did}/...`
+/// fails with ERROR_INVALID_NAME (os error 123). `Url::to_file_path` does not
+/// escape these (it only percent-decodes and handles structural conversion),
+/// so the colon passes straight through into an invalid path.
+///
+/// We keep the URL/logical layer OS-agnostic and escape only when rendering to
+/// an OS path, like escaping at render time for HTML. The mapping is reversible
+/// (`:` -> `%3A`), so distinct names never collide and reads recover the
+/// original. `%` is encoded too so decoding is unambiguous. Applied per
+/// `Normal` path component, so the drive-letter colon (a `Prefix` component) is
+/// never touched. Windows-only; other targets keep their exact layout.
+#[cfg(windows)]
+fn encode_reserved(component: &str) -> String {
+    fn reserved(c: char) -> bool {
+        matches!(c, '<' | '>' | ':' | '"' | '\\' | '|' | '?' | '*' | '%') || (c as u32) < 0x20
+    }
+    let mut out = String::with_capacity(component.len());
+    for c in component.chars() {
+        if reserved(c) {
+            out.push_str(&format!("%{:02X}", c as u32));
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Inverse of [`encode_reserved`]. Only ASCII bytes are ever encoded, so a
+/// decoded `%XX` is always a valid single-byte char.
+#[cfg(windows)]
+fn decode_reserved(name: &str) -> String {
+    let bytes = name.as_bytes();
+    let mut out = String::with_capacity(name.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let Ok(byte) = u8::from_str_radix(&name[i + 1..i + 3], 16)
+        {
+            out.push(byte as char);
+            i += 3;
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Render an OS path, percent-encoding reserved characters in every `Normal`
+/// component. Rebuilding from `components()` also drops any trailing separator
+/// (which on Windows otherwise yields os error 267).
+#[cfg(windows)]
+fn encode_windows_path(path: PathBuf) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::Normal(os) => match os.to_str() {
+                Some(s) => out.push(encode_reserved(s)),
+                None => out.push(os),
+            },
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
 /// Filesystem-based storage provider.
 ///
 /// A transparent wrapper over a [`Location`] that manages storage directories
@@ -180,17 +252,28 @@ impl TryFrom<FileSystemHandle> for PathBuf {
             .to_file_path()
             .map_err(|_| FileSystemError::Io("Failed to convert URL to path".to_string()))?;
 
+        // On Windows, escape characters illegal in filenames (DIDs carry
+        // colons) per path component, and drop the trailing separator that
+        // `components()` rebuilding naturally removes. See `encode_windows_path`.
+        #[cfg(windows)]
+        {
+            Ok(encode_windows_path(path))
+        }
+
         // Strip trailing slash added by FileSystemHandle for URL semantics.
         // Filesystem operations (read, write, rename) need clean file paths.
         // Use `to_str` (not `to_string_lossy`) so non-UTF-8 paths don't
         // collide via lossy substitutions; require UTF-8 for the trim.
-        let s = path.to_str().ok_or_else(|| {
-            FileSystemError::Io("Path is not valid UTF-8 and cannot be normalized".to_string())
-        })?;
-        if s.ends_with('/') && s.len() > 1 {
-            Ok(PathBuf::from(s.trim_end_matches('/')))
-        } else {
-            Ok(path)
+        #[cfg(not(windows))]
+        {
+            let s = path.to_str().ok_or_else(|| {
+                FileSystemError::Io("Path is not valid UTF-8 and cannot be normalized".to_string())
+            })?;
+            if s.ends_with('/') && s.len() > 1 {
+                Ok(PathBuf::from(s.trim_end_matches('/')))
+            } else {
+                Ok(path)
+            }
         }
     }
 }
@@ -322,6 +405,12 @@ impl FileSystemHandle {
             .map_err(|e| FileSystemError::Io(e.to_string()))?
         {
             if let Some(name) = entry.file_name().to_str() {
+                // On-disk names are escaped (see `encode_windows_path`); decode
+                // so callers always see logical names and re-encode correctly on
+                // the next resolve.
+                #[cfg(windows)]
+                names.push(decode_reserved(name));
+                #[cfg(not(windows))]
                 names.push(name.to_string());
             }
         }
@@ -384,6 +473,53 @@ mod tests {
         let archive = space.archive().unwrap();
         let nested = archive.resolve("deep/nested/catalog").unwrap();
         assert!(nested.path().ends_with("/archive/deep/nested/catalog"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn it_encodes_and_decodes_reserved_chars_reversibly() {
+        let did = "did:key:z6MkExampleColonSegment";
+        let encoded = encode_reserved(did);
+        assert!(!encoded.contains(':'), "encoded name must not contain ':'");
+        assert_eq!(encoded, "did%3Akey%3Az6MkExampleColonSegment");
+        assert_eq!(decode_reserved(&encoded), did, "must round-trip");
+
+        // Distinct inputs that the lossy '_' mapping would have collided.
+        assert_ne!(encode_reserved("a:b"), encode_reserved("a|b"));
+        assert_eq!(decode_reserved(&encode_reserved("a:b")), "a:b");
+        // A literal '%' is preserved (encoded so decoding stays unambiguous).
+        assert_eq!(decode_reserved(&encode_reserved("a%3Ab")), "a%3Ab");
+    }
+
+    #[cfg(windows)]
+    #[dialog_common::test]
+    async fn it_round_trips_a_did_named_path_on_windows() {
+        let space = test_space("did-path-round-trip").await;
+        let did = "did:key:z6MkExampleColonSegment";
+
+        // Write under a DID-named directory (would fail with os error 123
+        // before the fix).
+        let handle = space.certificate().unwrap().resolve(did).unwrap();
+        handle.write(b"x").await.unwrap();
+
+        // On disk the colon is escaped, never present.
+        let names = space.certificate().unwrap().list().await.unwrap();
+        assert_eq!(names, vec![did.to_string()], "list recovers the logical name");
+
+        // The decoded name resolves back to the same bytes, no double-encoding.
+        let again = space.certificate().unwrap().resolve(&names[0]).unwrap();
+        assert_eq!(again.read().await.unwrap(), b"x");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn it_preserves_the_drive_letter_colon() {
+        let path = env::temp_dir().join("dialog-file-handle.tmp");
+        let handle = FileSystemHandle::try_from(path.clone()).unwrap();
+        let round_trip: PathBuf = handle.try_into().unwrap();
+        // Drive-letter colon (a Prefix component) is untouched; trailing
+        // separators are dropped.
+        assert_eq!(round_trip, path);
     }
 
     #[dialog_common::test]

--- a/rust/dialog-storage/src/storage/provider/fs.rs
+++ b/rust/dialog-storage/src/storage/provider/fs.rs
@@ -504,7 +504,11 @@ mod tests {
 
         // On disk the colon is escaped, never present.
         let names = space.certificate().unwrap().list().await.unwrap();
-        assert_eq!(names, vec![did.to_string()], "list recovers the logical name");
+        assert_eq!(
+            names,
+            vec![did.to_string()],
+            "list recovers the logical name"
+        );
 
         // The decoded name resolves back to the same bytes, no double-encoding.
         let again = space.certificate().unwrap().resolve(&names[0]).unwrap();

--- a/rust/dialog-storage/src/storage/provider/fs/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/certificate.rs
@@ -7,6 +7,7 @@ use dialog_capability::access::{
     AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
 };
 use dialog_capability::{Capability, Policy, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_varsig::Did;
 
 use super::{FileSystem, FileSystemError, FileSystemHandle};
@@ -20,10 +21,11 @@ impl FileSystem {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<P: Protocol> CertificateStore<P> for FileSystem
 where
-    P::Certificate: Send + Sync,
+    P::Certificate: ConditionalSend + ConditionalSync,
 {
     /// List certificates where `audience` is the recipient and `subject`
     /// is either the specific subject DID or, when `None`, a
@@ -95,13 +97,14 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<P> Provider<Prove<P>> for FileSystem
 where
     P: Protocol,
-    P::Access: Clone + Send + Sync,
-    P::Certificate: Clone + Send + Sync,
-    P::Proof: Send,
+    P::Access: Clone + ConditionalSend + ConditionalSync,
+    P::Certificate: Clone + ConditionalSend + ConditionalSync,
+    P::Proof: ConditionalSend,
 {
     async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
         let auth = Prove::<P>::of(&input);
@@ -111,11 +114,12 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<P> Provider<Retain<P>> for FileSystem
 where
     P: Protocol,
-    P::Delegation: Send + Sync,
+    P::Delegation: ConditionalSend + ConditionalSync,
 {
     async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
         let delegation = &Retain::<P>::of(&input).delegation;

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -55,11 +55,13 @@ mod certificate;
 mod credential;
 mod memory;
 
-use js_sys::Uint8Array;
+use js_sys::{Array, Function, Promise, Reflect, Uint8Array, global};
 use rexie::{ObjectStore, Rexie, RexieBuilder, TransactionMode};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 
 /// Convert bytes to a JS Uint8Array.
 fn to_uint8array(bytes: &[u8]) -> Uint8Array {
@@ -271,18 +273,69 @@ impl Drop for IndexedDb {
 use crate::resource::Resource;
 use dialog_effects::storage::{Directory, Location};
 
+/// Derive the IndexedDB database name for a [`Location`].
+fn database_name(location: &Location) -> String {
+    match &location.directory {
+        Directory::Profile => format!("{}.profile", location.name),
+        Directory::Current => location.name.clone(),
+        Directory::Temp => format!("temp.{}", location.name),
+        Directory::At(path) => format!("{}/{}", path, location.name),
+    }
+}
+
+/// Whether an IndexedDB database with this name currently exists.
+///
+/// Uses `indexedDB.databases()`, which enumerates existing databases
+/// *without opening* (so it never creates one). The factory is read off
+/// the global scope (`self`) rather than `window`, so it works in a
+/// worker where `window` is absent.
+async fn database_exists(name: &str) -> Result<bool, IndexedDbError> {
+    let err = |m: String| IndexedDbError::Database(m);
+
+    let scope = global();
+    let factory = Reflect::get(&scope, &JsValue::from_str("indexedDB"))
+        .map_err(|e| err(format!("reading global indexedDB: {e:?}")))?;
+    let databases: Function = Reflect::get(&factory, &JsValue::from_str("databases"))
+        .map_err(|e| err(format!("reading indexedDB.databases: {e:?}")))?
+        .dyn_into()
+        .map_err(|_| err("indexedDB.databases is not callable".into()))?;
+    let promise: Promise = databases
+        .call0(&factory)
+        .map_err(|e| err(format!("calling indexedDB.databases(): {e:?}")))?
+        .dyn_into()
+        .map_err(|_| err("indexedDB.databases() did not return a promise".into()))?;
+    let list = JsFuture::from(promise)
+        .await
+        .map_err(|e| err(format!("indexedDB.databases() rejected: {e:?}")))?;
+
+    Ok(Array::from(&list).iter().any(|info| {
+        Reflect::get(&info, &JsValue::from_str("name"))
+            .ok()
+            .and_then(|n| n.as_string())
+            .as_deref()
+            == Some(name)
+    }))
+}
+
 #[async_trait::async_trait(?Send)]
 impl Resource<Location> for IndexedDb {
     type Error = IndexedDbError;
 
     async fn open(location: &Location) -> Result<Self, Self::Error> {
-        let name = match &location.directory {
-            Directory::Profile => format!("{}.profile", location.name),
-            Directory::Current => location.name.clone(),
-            Directory::Temp => format!("temp.{}", location.name),
-            Directory::At(path) => format!("{}/{}", path, location.name),
-        };
+        Self::connect(database_name(location)).await
+    }
 
+    /// Open an existing database, failing if it was never created.
+    ///
+    /// IndexedDB's `open` brings a database into being, so the base
+    /// `Resource::load` (which delegates to `open`) would leak a fresh
+    /// empty database on every miss. Probe `indexedDB.databases()` first
+    /// and refuse when absent — creating nothing.
+    async fn load(location: &Location) -> Result<Self, Self::Error> {
+        let name = database_name(location);
+        if !database_exists(&name).await? {
+            return Err(IndexedDbError::NotFound(name));
+        }
         Self::connect(name).await
     }
 }
@@ -305,6 +358,11 @@ pub enum IndexedDbError {
     /// Value conversion failed.
     #[error("Value conversion error: {0}")]
     Conversion(String),
+
+    /// No database exists at the requested name (a `load` of something
+    /// that was never created).
+    #[error("IndexedDB database not found: {0}")]
+    NotFound(String),
 }
 
 use dialog_capability::access::AuthorizeError;

--- a/rust/dialog-storage/src/storage/provider/space.rs
+++ b/rust/dialog-storage/src/storage/provider/space.rs
@@ -183,4 +183,21 @@ where
                 .map_err(|e| StorageError::Storage(e.to_string()))?,
         })
     }
+
+    async fn load(location: &Location) -> Result<Self, StorageError> {
+        Ok(Space {
+            archive: A::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+            memory: M::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+            credential: C::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+            certificate: P::load(location)
+                .await
+                .map_err(|e| StorageError::Storage(e.to_string()))?,
+        })
+    }
 }

--- a/rust/dialog-storage/src/storage/provider/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/storage.rs
@@ -362,6 +362,35 @@ mod tests {
             assert_eq!(result.unwrap(), Some(content));
         }
 
+        // `load` is "open an existing space, fail if absent" — it must
+        // never bring a space into being. A `load` of a name that was
+        // never created has to error AND leave nothing behind on disk
+        // (the bug it guards: a missing-name `load` materializing an
+        // empty backing store, e.g. a stray IndexedDB database).
+        #[dialog_common::test]
+        async fn it_does_not_create_on_load_of_missing_space() {
+            use std::path::PathBuf;
+
+            let env = Storage::temp();
+            let name = unique_name("fs-load-missing");
+
+            // Where `TempFileSystem` roots a `Directory::Profile` space.
+            let root: PathBuf = std::env::temp_dir()
+                .join("dialog")
+                .join("profile")
+                .join(&name);
+            assert!(!root.exists(), "precondition: space must not exist yet");
+
+            let result = StorageFx::profile(&name).load().perform(&env).await;
+
+            assert!(result.is_err(), "load of a missing space must fail");
+            assert!(
+                !root.exists(),
+                "load must not create the space directory: {}",
+                root.display(),
+            );
+        }
+
         #[dialog_common::test]
         async fn it_rejects_duplicate_create_on_filesystem() {
             let env = Storage::temp();
@@ -380,6 +409,73 @@ mod tests {
                 .perform(&env)
                 .await;
             assert!(result.is_err(), "duplicate create should fail");
+        }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    mod web_tests {
+        use super::*;
+        use crate::helpers::unique_name;
+
+        // `load` is "open an existing space, fail if absent" — it must never
+        // bring a space into being. On IndexedDB a space is one database, so a
+        // `load` of a never-created profile has to error AND leave no database
+        // behind (the bug it guards: a missing-name load materializing a stray
+        // IndexedDB database, e.g. the literal `{subject}` DB an unbound
+        // template once produced).
+        #[dialog_common::test]
+        async fn it_does_not_create_on_load_of_missing_space() {
+            use crate::provider::storage::WebSpace;
+
+            let env: Storage<WebSpace> = Storage::default();
+            let name = unique_name("idb-load-missing");
+            // `Directory::Profile` names the database `"{name}.profile"`.
+            let db_name = format!("{name}.profile");
+
+            assert!(
+                !idb_database_exists(&db_name).await,
+                "precondition: database must not exist yet",
+            );
+
+            let result = StorageFx::profile(&name).load().perform(&env).await;
+
+            assert!(result.is_err(), "load of a missing space must fail");
+            assert!(
+                !idb_database_exists(&db_name).await,
+                "load must not create the IndexedDB database `{db_name}`",
+            );
+        }
+
+        /// True if an IndexedDB database with this name currently exists.
+        ///
+        /// Calls `indexedDB.databases()` (which lists without opening, so it
+        /// never creates one) off the worker/window global — the test runs in
+        /// a dedicated worker where `window` is absent, so the factory is read
+        /// from `self`, not `window`.
+        async fn idb_database_exists(name: &str) -> bool {
+            use js_sys::{Array, Function, Promise, Reflect};
+            use wasm_bindgen::{JsCast, JsValue};
+            use wasm_bindgen_futures::JsFuture;
+
+            let global = js_sys::global();
+            let factory =
+                Reflect::get(&global, &JsValue::from_str("indexedDB")).expect("global indexedDB");
+            let databases: Function = Reflect::get(&factory, &JsValue::from_str("databases"))
+                .expect("indexedDB.databases")
+                .unchecked_into();
+            let promise: Promise = databases
+                .call0(&factory)
+                .expect("databases() call")
+                .unchecked_into();
+            let list = JsFuture::from(promise).await.expect("databases() resolves");
+
+            Array::from(&list).iter().any(|info| {
+                Reflect::get(&info, &JsValue::from_str("name"))
+                    .ok()
+                    .and_then(|n| n.as_string())
+                    .as_deref()
+                    == Some(name)
+            })
         }
     }
 }

--- a/rust/dialog-storage/src/storage/provider/storage/loader.rs
+++ b/rust/dialog-storage/src/storage/provider/storage/loader.rs
@@ -74,9 +74,12 @@ where
                 .map_err(|e| StorageError::NotFound(e.to_string()));
         }
 
-        let store = S::open(location)
+        // `load`, not `open`: a `storage::Load` of a space that was never
+        // created must fail without materializing its backing store (an
+        // `open` here would, on IndexedDB, create the database into being).
+        let store = S::load(location)
             .await
-            .map_err(|e| StorageError::Storage(e.to_string()))?;
+            .map_err(|e| StorageError::NotFound(e.to_string()))?;
 
         let cred: Credential = did!("local:storage")
             .credential()

--- a/rust/dialog-ucan-core/src/delegation/store.rs
+++ b/rust/dialog-ucan-core/src/delegation/store.rs
@@ -139,6 +139,8 @@ impl<S: Signature, H: BuildHasher> DelegationStore<Local, S, Arc<Delegation<S>>>
     }
 }
 
+// bare-send-ok: the Sendable future-kind variant deliberately requires real
+// Send/Sync to produce BoxFuture; the Local variant above is its counterpart
 impl<S: Signature + Send + Sync, H: BuildHasher + Send>
     DelegationStore<Sendable, S, Arc<Delegation<S>>>
     for Arc<Mutex<HashMap<Cid, Arc<Delegation<S>>, H>>>


### PR DESCRIPTION
## Why

`Branch::push().perform()` re-published the revision pointer to the upstream on **every** call, even when the local head already equaled the recorded upstream sync point — i.e. when there was nothing new to push.

The tonk service worker drains sync every ~10s while a tab holds a live subscription, and each drain calls `push()`. With no no-op guard, an idle branch (no commits since the last push) still:

- re-fetched the upstream branch,
- computed the tree diff against the recorded base (empty novelty),
- **PUT `branch/<b>/revision` to the remote anyway** (`upstream.publish(revision)`),
- re-published the local upstream sync point.

The visible symptom is a stream of `.../branch/main/revision` PUTs to R2/S3 with no transactions behind them — ongoing pushes on a quiet, idle space.

## What

Short-circuit at the top of `perform`, after resolving the local `revision` and the recorded `base` (`upstream_state.tree()`):

```rust
if revision.tree == base {
    return Ok(Some(revision));
}
```

When the local head already equals the recorded sync point there is nothing to upload and nothing to re-point, so an idle branch now does zero push I/O. The first push after a commit is unaffected (`revision.tree != base`), and the non-fast-forward divergence check still runs for real pushes.

Covered by a new test (`it_is_a_noop_when_nothing_new_to_push`): a second push with no intervening commit returns the current revision without re-publishing. The existing 5 push tests still pass.

Stacked on `feat/inductive-self-negation`.
