### PR TITLE
fix(dialog-repository): skip push when nothing new to push

### DIFF
--- a/rust/dialog-repository/src/repository/branch/push.rs
+++ b/rust/dialog-repository/src/repository/branch/push.rs
@@ -80,6 +80,16 @@ impl Push<'_> {
         };
         let base = upstream_state.tree().clone();
 
+        // Nothing new to push: the local head already equals the recorded
+        // upstream sync point. Without this guard every sync tick re-publishes
+        // the revision pointer to the remote (an ongoing `branch/*/revision`
+        // PUT) and re-fetches + diffs the upstream for an empty novelty set,
+        // even when no commit has landed since the last push. Short-circuit so
+        // an idle branch does no push I/O.
+        if revision.tree == base {
+            return Ok(Some(revision));
+        }
+
         match &upstream_state {
             Upstream::Local {
                 branch: upstream_name,
@@ -266,6 +276,51 @@ mod tests {
             .revision()
             .expect("main should have a revision after push");
         assert_eq!(main_rev.tree, feature_revision.tree);
+
+        Ok(())
+    }
+
+    /// A second push with no intervening commit is a no-op: the local head
+    /// already equals the recorded upstream sync point, so it returns the
+    /// current revision without re-publishing. Guards the ongoing-`revision`-PUT
+    /// regression where an idle sync tick re-pushed on every drain.
+    #[dialog_common::test]
+    async fn it_is_a_noop_when_nothing_new_to_push() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+
+        let main = repo.branch("main").open().perform(&operator).await?;
+        let feature = repo.branch("feature").open().perform(&operator).await?;
+        feature.set_upstream(&main).perform(&operator).await?;
+
+        feature
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:123".parse()?,
+                is: Value::String("Alice".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+
+        let revision = feature.revision().expect("feature should have a revision");
+
+        // First push lands the commit.
+        let first = feature.push().perform(&operator).await?;
+        assert_eq!(
+            first.map(|r| r.tree),
+            Some(revision.tree.clone()),
+            "first push lands the local head"
+        );
+
+        // Second push, with no new commit, is a no-op that still reports the
+        // current revision.
+        let second = feature.push().perform(&operator).await?;
+        assert_eq!(
+            second.map(|r| r.tree),
+            Some(revision.tree),
+            "second push with nothing new returns the current revision as a no-op"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Why

`Branch::push().perform()` re-published the revision pointer to the upstream on **every** call, even when the local head already equaled the recorded upstream sync point — i.e. when there was nothing new to push.

The tonk service worker drains sync every ~10s while a tab holds a live subscription, and each drain calls `push()`. With no no-op guard, an idle branch (no commits since the last push) still:

- re-fetched the upstream branch,
- computed the tree diff against the recorded base (empty novelty),
- **PUT `branch/<b>/revision` to the remote anyway** (`upstream.publish(revision)`),
- re-published the local upstream sync point.

The visible symptom is a stream of `.../branch/main/revision` PUTs to R2/S3 with no transactions behind them — ongoing pushes on a quiet, idle space.

## What

Short-circuit at the top of `perform`, after resolving the local `revision` and the recorded `base` (`upstream_state.tree()`):

```rust
if revision.tree == base {
    return Ok(Some(revision));
}
```

When the local head already equals the recorded sync point there is nothing to upload and nothing to re-point, so an idle branch now does zero push I/O. The first push after a commit is unaffected (`revision.tree != base`), and the non-fast-forward divergence check still runs for real pushes.

Covered by a new test (`it_is_a_noop_when_nothing_new_to_push`): a second push with no intervening commit returns the current revision without re-publishing. The existing 5 push tests still pass.

Stacked on `feat/inductive-self-negation`.
