### PR TITLE
fix(dialog-artifacts): don't tombstone a retract with no committed prior

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -454,7 +454,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, str::FromStr, sync::Arc};
+    use std::{collections::BTreeSet, iter::once, str::FromStr, sync::Arc};
     use tokio::io::{BufReader, BufWriter};
 
     use anyhow::Result;
@@ -546,6 +546,139 @@ mod tests {
 
         assert_eq!(data, facts);
 
+        Ok(())
+    }
+
+    /// Retracting a fact that was never asserted is a no-op: no tombstone is
+    /// written, so the tree root (and therefore the branch revision) is
+    /// unchanged. Otherwise an idle synced branch would push a revision whose
+    /// only content is a tombstone for a fact that never existed.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_treats_retracting_a_missing_fact_as_a_noop() -> Result<()> {
+        let (storage_backend, _temp) = make_target_storage().await?;
+        let mut facts = Artifacts::anonymous(storage_backend).await?;
+
+        // Seed an unrelated fact so the tree is non-empty.
+        let base_root = facts
+            .commit(once(Instruction::Assert(Artifact {
+                the: Attribute::from_str("user/name")?,
+                of: Entity::new()?,
+                is: Value::String("Alice".into()),
+                cause: None,
+            })))
+            .await?;
+
+        // Retract a fact that was never asserted.
+        let after_root = facts
+            .commit(once(Instruction::Retract(Artifact {
+                the: Attribute::from_str("user/session")?,
+                of: Entity::new()?,
+                is: Value::String("ephemeral".into()),
+                cause: None,
+            })))
+            .await?;
+
+        assert_eq!(
+            base_root, after_root,
+            "retracting a fact that was never present must not change the tree"
+        );
+        Ok(())
+    }
+
+    /// Assert + retract of a fact in the same batch, when that fact had **no
+    /// prior committed value**, leaves nothing behind: the assert and retract
+    /// cancel at the tree, no tombstone is written, and the root is unchanged.
+    /// This is the transient-command shape (a concept asserted then retracted
+    /// in one commit) that used to churn the branch head on every occurrence.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_leaves_no_key_when_assert_and_retract_a_novel_fact_in_one_batch() -> Result<()> {
+        let (storage_backend, _temp) = make_target_storage().await?;
+        let mut facts = Artifacts::anonymous(storage_backend).await?;
+
+        let base_root = facts
+            .commit(once(Instruction::Assert(Artifact {
+                the: Attribute::from_str("user/name")?,
+                of: Entity::new()?,
+                is: Value::String("Alice".into()),
+                cause: None,
+            })))
+            .await?;
+
+        let session = Attribute::from_str("user/session")?;
+        let transient = Artifact {
+            the: session.clone(),
+            of: Entity::new()?,
+            is: Value::String("ephemeral".into()),
+            cause: None,
+        };
+        let after_root = facts
+            .commit(
+                vec![
+                    Instruction::Assert(transient.clone()),
+                    Instruction::Retract(transient.clone()),
+                ]
+                .into_iter(),
+            )
+            .await?;
+
+        // No tree churn: the novel fact left no key at all.
+        assert_eq!(
+            base_root, after_root,
+            "assert+retract of a novel fact must leave the tree unchanged"
+        );
+        // And the fact is not queryable.
+        let hits: Vec<Artifact> = facts
+            .select(ArtifactSelector::new().the(session))
+            .try_collect()
+            .await?;
+        assert!(hits.is_empty(), "the transient fact must not be queryable");
+        Ok(())
+    }
+
+    /// Assert + retract of a fact whose value was **already committed** ends in
+    /// a retraction: a `Removed` tombstone replaces the live value, so the tree
+    /// changes (the removal must propagate on merge and beat a stale remote
+    /// assert) and the fact is no longer queryable.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_tombstones_when_retracting_a_fact_that_had_a_committed_value() -> Result<()> {
+        let (storage_backend, _temp) = make_target_storage().await?;
+        let mut facts = Artifacts::anonymous(storage_backend).await?;
+
+        let name = Attribute::from_str("user/name")?;
+        let alice = Artifact {
+            the: name.clone(),
+            of: Entity::new()?,
+            is: Value::String("Alice".into()),
+            cause: None,
+        };
+
+        // Commit the fact so it has a durable prior.
+        let committed_root = facts
+            .commit(once(Instruction::Assert(alice.clone())))
+            .await?;
+
+        // Retract it in a later commit.
+        let after_root = facts
+            .commit(once(Instruction::Retract(alice.clone())))
+            .await?;
+
+        // The retraction changed the tree (a tombstone replaced the value).
+        assert_ne!(
+            committed_root, after_root,
+            "retracting a committed fact must write a tombstone (tree changes)"
+        );
+        // The fact is gone from queries.
+        let hits: Vec<Artifact> = facts
+            .select(ArtifactSelector::new().the(name))
+            .try_collect()
+            .await?;
+        assert!(
+            hits.is_empty(),
+            "the retracted fact must not be queryable after the tombstone"
+        );
         Ok(())
     }
 

--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -199,6 +199,14 @@ impl ArtifactTreeExt for ArtifactTree {
     {
         let storage = ContentAddressedStorage::new(TreeStorageBridge(store.clone()));
 
+        // Snapshot the committed tree before editing. A retract consults it to
+        // tell a fact that existed *before this batch* (tombstone it, so the
+        // removal propagates on merge) from one that only appears within the
+        // batch or not at all (drop it, leaving no tombstone). `edit()` borrows
+        // `self`, so this cheap Arc-backed clone stays readable alongside the
+        // in-flight `transient`.
+        let base = self.clone();
+
         // Open one transient edit batch over this tree's spine and apply every
         // instruction's writes to it in flight, so the whole instruction stream
         // costs a single persist instead of one full tree rebuild per key.
@@ -303,16 +311,46 @@ impl ArtifactTreeExt for ArtifactTree {
                     let value_key = ValueKey::from_key(&entity_key);
                     let attribute_key = AttributeKey::from_key(&entity_key);
 
-                    let removed: State<Datum> = State::Removed;
-                    transient = transient
-                        .insert(entity_key.into_key().into(), removed.clone(), &storage)
-                        .await?;
-                    transient = transient
-                        .insert(attribute_key.into_key().into(), removed.clone(), &storage)
-                        .await?;
-                    transient = transient
-                        .insert(value_key.into_key().into(), removed, &storage)
-                        .await?;
+                    // Was this exact fact committed *before* this batch? Read the
+                    // value key (the fact identity) from the base snapshot, not
+                    // the transient tree — so an assert earlier in this same
+                    // batch doesn't count as a prior.
+                    let committed = matches!(
+                        base.get(&value_key.clone().into_key().into(), &storage)
+                            .await?,
+                        Some(State::Added(_))
+                    );
+
+                    if committed {
+                        // Retracting a durable fact: replace it with a `Removed`
+                        // tombstone across all three orderings so the removal
+                        // survives a merge and beats a stale remote assert.
+                        let removed: State<Datum> = State::Removed;
+                        transient = transient
+                            .insert(entity_key.into_key().into(), removed.clone(), &storage)
+                            .await?;
+                        transient = transient
+                            .insert(attribute_key.into_key().into(), removed.clone(), &storage)
+                            .await?;
+                        transient = transient
+                            .insert(value_key.into_key().into(), removed, &storage)
+                            .await?;
+                    } else {
+                        // No committed prior: the fact only exists (if at all) as
+                        // an assert earlier in this batch. Delete the keys so the
+                        // assert and retract cancel to nothing — no tombstone,
+                        // no tree churn. Deleting an absent key is a no-op, so a
+                        // retract of a fact that never existed changes nothing.
+                        transient = transient
+                            .delete(&entity_key.into_key().into(), &storage)
+                            .await?;
+                        transient = transient
+                            .delete(&attribute_key.into_key().into(), &storage)
+                            .await?;
+                        transient = transient
+                            .delete(&value_key.into_key().into(), &storage)
+                            .await?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Motivation

Retracting a fact wrote a `State::Removed` tombstone into all three index orderings unconditionally — even when that fact had never been committed. A concept asserted and retracted in the same batch (the transient-command shape: fire an effect, leave no durable trace) therefore left tombstones the base tree never had, which moves the tree root.

On a synced branch that is expensive: the churned root mints a fresh revision whose only content is a tombstone for a fact that never existed, so an otherwise-idle replica pushes a no-op revision to the remote **on every occurrence** (e.g. once per page load, where a `<tonk-site>` fires a transient `Load` command).

## Approach

The `apply` loop now snapshots the committed tree before it starts editing. A retract decides against that snapshot:

- **committed prior exists** → write the `Removed` tombstone as before, so the removal still propagates on merge and beats a stale remote assert;
- **no committed prior** → `delete` the keys instead. This cancels an in-batch assert to nothing (no tombstone, no churn) and is a plain no-op when the key never existed.

The snapshot is what lets a retract tell "asserted earlier *in this batch*" from "committed *before* this batch" — reading the in-flight transient tree alone can't distinguish them.

## Tests

- retracting a fact that was never asserted is a no-op (tree unchanged);
- assert + retract of a novel fact in one batch leaves no key and doesn't move the root, and the fact isn't queryable;
- assert + retract of a fact with a committed value tombstones it (tree changes) and it's no longer queryable.

Full `dialog-artifacts`, `dialog-repository`, `dialog-search-tree`, and `dialog-query` suites pass.