### PR TITLE
Add retain_entities to Changes and Overlay

### DIFF
--- a/rust/dialog-artifacts/src/artifacts/update.rs
+++ b/rust/dialog-artifacts/src/artifacts/update.rs
@@ -87,6 +87,19 @@ impl Changes {
         ChangeStream::from(self)
     }
 
+    /// Drop every change recorded for entities that fail `keep`,
+    /// asserts and retracts alike. Returns `true` when anything was
+    /// removed. Unlike [`retract`](Self::retract), which records a
+    /// tombstone alongside the prior changes, this removes the
+    /// entity's entries from the batch outright — the primitive a
+    /// session overlay needs to garbage-collect per-client facts
+    /// without growing.
+    pub fn retain_entities<F: FnMut(&Entity) -> bool>(&mut self, mut keep: F) -> bool {
+        let before = self.0.len();
+        self.0.retain(|entity, _| keep(entity));
+        self.0.len() != before
+    }
+
     /// Borrowing iterator over every recorded `(entity, attribute,
     /// change)` triple. Use this when you need to inspect the batch
     /// without consuming it — e.g. to extract tombstones from

--- a/rust/dialog-repository/src/repository/branch/overlay.rs
+++ b/rust/dialog-repository/src/repository/branch/overlay.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use dialog_artifacts::{Changes, Statement};
+use dialog_artifacts::{Changes, Entity, Statement};
 
 use crate::Branch;
 
@@ -48,6 +48,27 @@ impl Overlay {
         statement.retract(&mut state.changes);
         state.epoch += 1;
         self
+    }
+
+    /// Drop every session fact recorded for entities that fail
+    /// `keep` — asserts and retracts alike, removed outright rather
+    /// than tombstoned. Bumps the epoch only when something was
+    /// removed, so subscriptions re-evaluate exactly when the
+    /// overlay's readable contents changed. Returns whether anything
+    /// was removed.
+    ///
+    /// This is the garbage-collection primitive for per-session
+    /// facts keyed by short-lived entities (e.g. a service worker's
+    /// per-client `site:` stamps): retracting them would grow the
+    /// overlay with tombstones, clearing would drop unrelated
+    /// sessions' facts.
+    pub fn retain_entities<F: FnMut(&Entity) -> bool>(&self, keep: F) -> bool {
+        let mut state = self.state.lock().expect("overlay lock");
+        let changed = state.changes.retain_entities(keep);
+        if changed {
+            state.epoch += 1;
+        }
+        changed
     }
 
     /// Drop every session fact.


### PR DESCRIPTION
Tonk's service worker stamps per-client session facts (`site:<client-id>`) into branch overlays. When a page reloads, the browser assigns a new client id, so the old client's facts must be garbage-collected — but the overlay offered no primitive for it: `retract` appends tombstones (the overlay grows on every sweep) and `clear` drops unrelated sessions' facts along with the dead ones. In practice this made every reload permanently enlarge the overlay every read folds, degrading load times until the worker restarted.

`retain_entities` removes an entity's recorded changes outright, asserts and retracts alike. The `Overlay` wrapper bumps its epoch only when something was actually removed, so subscriptions re-evaluate exactly when the readable contents changed.

Based on `feat/inductive-self-negation` (the rev tonk pins) so the consumer can bump its pin directly on merge.