### PR TITLE
fix(dialog-artifacts): don't parse whitespace-bearing strings as URIs

### DIFF
--- a/rust/dialog-artifacts/src/artifacts/value.rs
+++ b/rust/dialog-artifacts/src/artifacts/value.rs
@@ -946,3 +946,57 @@ impl From<ValueDataType> for PhantomData<ValueDataType> {
         PhantomData
     }
 }
+
+#[cfg(test)]
+mod deserialize_tests {
+    use super::*;
+
+    /// A multi-line text value must deserialize as `Value::String`, byte
+    /// for byte — NOT be captured by the untagged enum's `Entity` variant
+    /// and mangled through `url::Url` (which strips newlines and
+    /// lowercases the leading token). Regression for a corruption where a
+    /// text value beginning with a `scheme:`-shaped token (e.g. the
+    /// `Tonk-Prose-Version: 1\r\n…` envelope) round-tripped as a broken
+    /// entity.
+    #[test]
+    fn it_deserializes_a_multiline_text_value_as_string() {
+        let text = "Tonk-Prose-Version: 1\r\nETag: \"999\"\r\n\r\n# Hello\n\nbody";
+        let json = serde_json::to_string(text).expect("serialize");
+        let value: Value = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            value,
+            Value::String(text.to_string()),
+            "a multi-line text value must decode as a byte-exact String, not a mangled Entity",
+        );
+    }
+
+    /// A plain text value with a colon and a space is text, not an entity.
+    #[test]
+    fn it_deserializes_colon_text_as_string() {
+        for text in ["note: buy milk", "value: with colon", "http status: 200"] {
+            let json = serde_json::to_string(text).expect("serialize");
+            let value: Value = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(value, Value::String(text.to_string()), "{text:?}");
+        }
+    }
+
+    /// Real entity URIs still deserialize as `Value::Entity` — the fix
+    /// only excludes whitespace-bearing strings, which no canonical URI
+    /// contains.
+    #[test]
+    fn it_still_deserializes_entity_uris_as_entity() {
+        for uri in [
+            "did:key:z6MkhcqMSivySW3g74SchZQBgEUHHR3EQ1uUp4exY9cev6Ug",
+            "did:web:cdata.earth",
+            "id:prose/doc",
+            "db:transient",
+        ] {
+            let json = serde_json::to_string(uri).expect("serialize");
+            let value: Value = serde_json::from_str(&json).expect("deserialize");
+            assert!(
+                matches!(value, Value::Entity(_)),
+                "{uri:?} should decode as an Entity, got {value:?}",
+            );
+        }
+    }
+}

--- a/rust/dialog-artifacts/src/artifacts/value.rs
+++ b/rust/dialog-artifacts/src/artifacts/value.rs
@@ -949,6 +949,9 @@ impl From<ValueDataType> for PhantomData<ValueDataType> {
 
 #[cfg(test)]
 mod deserialize_tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
     use super::*;
 
     /// A multi-line text value must deserialize as `Value::String`, byte
@@ -958,7 +961,7 @@ mod deserialize_tests {
     /// text value beginning with a `scheme:`-shaped token (e.g. the
     /// `Tonk-Prose-Version: 1\r\n…` envelope) round-tripped as a broken
     /// entity.
-    #[test]
+    #[dialog_common::test]
     fn it_deserializes_a_multiline_text_value_as_string() {
         let text = "Tonk-Prose-Version: 1\r\nETag: \"999\"\r\n\r\n# Hello\n\nbody";
         let json = serde_json::to_string(text).expect("serialize");
@@ -971,7 +974,7 @@ mod deserialize_tests {
     }
 
     /// A plain text value with a colon and a space is text, not an entity.
-    #[test]
+    #[dialog_common::test]
     fn it_deserializes_colon_text_as_string() {
         for text in ["note: buy milk", "value: with colon", "http status: 200"] {
             let json = serde_json::to_string(text).expect("serialize");
@@ -983,7 +986,7 @@ mod deserialize_tests {
     /// Real entity URIs still deserialize as `Value::Entity` — the fix
     /// only excludes whitespace-bearing strings, which no canonical URI
     /// contains.
-    #[test]
+    #[dialog_common::test]
     fn it_still_deserializes_entity_uris_as_entity() {
         for uri in [
             "did:key:z6MkhcqMSivySW3g74SchZQBgEUHHR3EQ1uUp4exY9cev6Ug",

--- a/rust/dialog-artifacts/src/uri.rs
+++ b/rust/dialog-artifacts/src/uri.rs
@@ -104,6 +104,25 @@ impl FromStr for Uri {
     type Err = DialogArtifactsError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Reject strings that only *look* URI-ish because they carry
+        // whitespace. `url::Url::parse` is lenient: it silently strips
+        // ASCII whitespace — spaces, tabs, and crucially `\r`/`\n` — and
+        // lowercases the scheme, so an arbitrary text value like
+        // `"Tonk-Prose-Version: 1\r\n…"` parses "successfully" into a
+        // mangled URL (newlines gone, first token lowercased). Because
+        // `Value` deserializes untagged and tries `Entity` before
+        // `String`, that mangled parse would win and a plain multi-line
+        // text value stored in an entity-less field would be corrupted.
+        // A canonical URI never contains raw whitespace or control
+        // characters, so their presence marks the value as text, not a
+        // URI. (We deliberately don't require full round-trip stability:
+        // `url` legitimately normalizes some real URLs, e.g. adding a
+        // trailing slash to `https://host`, and those are valid entities.)
+        if s.chars().any(|c| c.is_ascii_whitespace() || c.is_control()) {
+            return Err(DialogArtifactsError::InvalidUri(format!(
+                "URI must not contain whitespace or control characters: {s:?}"
+            )));
+        }
         Ok(Self(s.parse().map_err(|error| {
             DialogArtifactsError::InvalidUri(format!("{error}"))
         })?))


### PR DESCRIPTION
`Value` deserializes untagged and tries the `Entity` variant before `String`. `Entity` accepts any string `url::Url::parse` accepts, and that parser is lenient: it silently strips ASCII whitespace (including `\r` and `\n`) and lowercases the scheme. So a plain multi-line text value beginning with a `scheme:`-shaped token (for example a `Tonk-Prose-Version: 1\r\n…` envelope) parsed "successfully" into a mangled URL and was captured as a corrupted `Value::Entity` instead of the intended `Value::String`: newlines gone, first token lowercased, the rest percent-encoded. Any text field whose value happened to look URI-ish was silently corrupted on the JSON wire path.

Reject strings containing whitespace or control characters in `Uri::from_str` (a canonical URI contains none) so such values fall through to `Value::String` and survive byte for byte. Real entity URIs (`did:`, `id:`, `db:`, `https:`, …) carry no whitespace and are unaffected; round-trip stability is deliberately not required, since `url` legitimately normalizes some valid URLs (e.g. a trailing slash).

This is the last change needed for `main` to reach content equivalence with the `tonk-2026-07-17` tag.