### PR TITLE
fix(dialog-repository): serve the eager root probe from the node cache

### DIFF
--- a/rust/dialog-repository/src/repository/branch/select.rs
+++ b/rust/dialog-repository/src/repository/branch/select.rs
@@ -8,7 +8,7 @@ use dialog_common::ConditionalSync;
 use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
 use dialog_effects::archive::{Catalog, Get, Put};
 use dialog_effects::memory::Resolve;
-use dialog_search_tree::DialogSearchTreeError;
+use dialog_search_tree::{Buffer, DialogSearchTreeError};
 use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
 use futures_util::Stream;
 
@@ -106,17 +106,35 @@ impl Select<'_> {
         // through the stream, so probe the root block eagerly. Through a
         // `NetworkedIndex` this also replicates and caches the root
         // locally, so the scan's own root read stays local.
+        //
+        // Route the probe through the shared node cache, not a raw
+        // `store.get`: the root is the single most-reused block, and a
+        // multi-premise query re-selects the same branch once per outer
+        // binding. A raw probe would re-fetch the root from the backend on
+        // every one of those selects (defeating the cache); `get_or_fetch`
+        // makes the first select warm the cache and the rest hit it, while
+        // still fetching (and, through `NetworkedIndex`, replicating) on a
+        // genuine miss and failing fast when the root is truly absent.
         let tree_hash = self.tree_hash();
+        let node_cache = self.branch.node_cache();
         if tree_hash != EMPTY_TREE_HASH {
-            store.get(&tree_hash).await?.ok_or_else(|| {
-                DialogSearchTreeError::Node(format!(
-                    "Blob not found in storage: {}",
-                    tree_hash.to_base58(),
-                ))
-            })?;
+            node_cache
+                .get_or_fetch(&NodeHash::from(tree_hash), async |hash| {
+                    store
+                        .get(hash.as_bytes())
+                        .await
+                        .map(|maybe| maybe.map(Buffer::from))
+                })
+                .await?
+                .ok_or_else(|| {
+                    DialogSearchTreeError::Node(format!(
+                        "Blob not found in storage: {}",
+                        tree_hash.to_base58(),
+                    ))
+                })?;
         }
 
-        let tree = Index::from_hash_with_cache(NodeHash::from(tree_hash), self.branch.node_cache());
+        let tree = Index::from_hash_with_cache(NodeHash::from(tree_hash), node_cache);
 
         // EAV/AEV/VAE dispatch + per-entry filtering lives in the shared
         // `ArtifactTreeExt::scan` so branch scans and Changes-overlay


### PR DESCRIPTION
`Select` probes the tree root eagerly (to fail fast on an unreachable root, and through a `NetworkedIndex` to warm local replication) before starting the lazy scan. That probe was a raw `store.get`, bypassing the shared node cache. A multi-premise query re-selects the same branch once per outer binding, so it re-fetched the root — the single most-reused block — from the backend on every one of those selects.

Route the probe through the branch's node cache via `get_or_fetch`: the first select warms it, the rest hit it. A genuine miss still fetches (and, through `NetworkedIndex`, replicates) and still fails fast when the root is truly absent, so both purposes of the eager probe are preserved.

Effect on block reads (the planner's deterministic objective), a realistic bug-tracker concept join over 300 bugs on an on-disk backend:

| all-bugs join | reads | wall-clock |
|---|---|---|
| before (cache-bypass) | 1 209 | 41.6 ms |
| after | 6 | 16.6 ms |

`reads` now equals the unique block count — the ~N redundant root re-reads a join issued are gone. In-memory wall-clock moves little (those reads were cheap RAM hits), but on disk or over a network each eliminated read is a real round-trip, so this is a large win there.

Backported from the M3 branch (`feat/truncated-separators`) so it can land on `main` independently of the value-in-key format change.