### PR TITLE
feat(dialog-query): range predicates over all comparable types with scan push-down

### DIFF
--- a/notes/notation.md
+++ b/notes/notation.md
@@ -654,6 +654,83 @@ An equality constraint asserts that two terms must hold equal values. It can fil
 </pre>
 </details>
 
+##### Range
+
+Range constraints — `<`, `<=`, `>`, `>=` — assert that the `of` term stands in the relation to the `with` term. They order values of the comparable types: numbers, text, symbols, entities, and bytes. Both sides must hold values (the planner orders the constraint after the premises binding them); a row whose sides cannot be ordered — a non-comparable value, a differently-typed pair, a NaN — is a non-match, never an error.
+
+Within numbers, a *constant* side is a polymorphic literal that adapts losslessly to the data's type per row: `1` compares against float data as `1.0`, while `1.5` against integer data matches nothing (no integer is `1.5`). Data is never adapted, and non-numeric literals never adapt — a text bound orders only against text values.
+
+Like Datomic's range predicates, these take direct advantage of the value index: when a variable's type narrows to a single comparable type, the bound becomes an index range and the scan never reads values outside it.
+
+```json
+{
+  "when": [
+    {
+      "assert": {
+        "with": {
+          "name": { "the": "org.employee/name", "as": "Text" }
+        }
+      },
+      "where": {
+        "this": { "?": { "name": "person" } },
+        "name": { "?": { "name": "name" } }
+      }
+    },
+    {
+      "assert": ">=",
+      "where": {
+        "of": { "?": { "name": "name" } },
+        "with": "Q"
+      }
+    }
+  ]
+}
+```
+
+<details>
+<summary>RangeConstraint</summary>
+<pre>
+{
+  "<": {
+    "type": "object",
+    "description": "Asserts `of` is strictly less than `with`, over the comparable types.",
+    "properties": {
+      "of":   { "$ref": "#/$defs/Term", "description": "Left-hand term." },
+      "with": { "$ref": "#/$defs/Term", "description": "Right-hand term." }
+    },
+    "required": ["of", "with"]
+  },
+  "<=": {
+    "type": "object",
+    "description": "Asserts `of` is less than or equal to `with`, over the comparable types.",
+    "properties": {
+      "of":   { "$ref": "#/$defs/Term", "description": "Left-hand term." },
+      "with": { "$ref": "#/$defs/Term", "description": "Right-hand term." }
+    },
+    "required": ["of", "with"]
+  },
+  ">": {
+    "type": "object",
+    "description": "Asserts `of` is strictly greater than `with`, over the comparable types.",
+    "properties": {
+      "of":   { "$ref": "#/$defs/Term", "description": "Left-hand term." },
+      "with": { "$ref": "#/$defs/Term", "description": "Right-hand term." }
+    },
+    "required": ["of", "with"]
+  },
+  ">=": {
+    "type": "object",
+    "description": "Asserts `of` is greater than or equal to `with`, over the comparable types.",
+    "properties": {
+      "of":   { "$ref": "#/$defs/Term", "description": "Left-hand term." },
+      "with": { "$ref": "#/$defs/Term", "description": "Right-hand term." }
+    },
+    "required": ["of", "with"]
+  }
+}
+</pre>
+</details>
+
 #### Formulas
 
 A pure computation, similar to formulas in a spreadsheet. Given bound input fields, a formula derives output fields. Formulas can be used within rules and queries to compute values, filter matches, or transform data without leaving the query engine.
@@ -1584,6 +1661,58 @@ Expands to:
       "where": {
         "this": { "?": { "name": "name" } },
         "is": "Alice"
+      }
+    }
+  ]
+}
+```
+
+The range constraints `<`, `<=`, `>`, `>=` order the `of` term against the `with` term, over the comparable types (numbers, text, symbols, entities, bytes):
+
+```yaml
+org.example:
+  senior:
+    deduce:
+      Senior:
+        name: ?name
+        age: ?age
+    when:
+      - org.example/Person:
+          name: ?name
+          age: ?age
+      - '>=':
+          of: ?age
+          with: 65
+```
+
+Expands to:
+
+```json
+{
+  "deduce": {
+    "with": {
+      "name": { "the": "org.example.senior/name" },
+      "age": { "the": "org.example.senior/age" }
+    }
+  },
+  "when": [
+    {
+      "assert": {
+        "with": {
+          "name": { "the": "org.example.person/name" },
+          "age": { "the": "org.example.person/age" }
+        }
+      },
+      "where": {
+        "name": { "?": { "name": "name" } },
+        "age": { "?": { "name": "age" } }
+      }
+    },
+    {
+      "assert": ">=",
+      "where": {
+        "of": { "?": { "name": "age" } },
+        "with": 65
       }
     }
   ]

--- a/rust/dialog-query/src/artifact.rs
+++ b/rust/dialog-query/src/artifact.rs
@@ -2,7 +2,7 @@ pub use dialog_artifacts::selector::Constrained;
 pub use dialog_artifacts::{
     Artifact, ArtifactSelector, ArtifactStore, ArtifactStoreMut, ArtifactStoreMutExt, Artifacts,
     Attribute as ArtifactsAttribute, Cause, DialogArtifactsError, Entity, Instruction, Select,
-    TypeError as ArtifactTypeError, Value, ValueDataType as Type,
+    TypeError as ArtifactTypeError, Value, ValueDataType as Type, decode_value, encode_value_owned,
 };
 pub use futures_util::stream::Stream;
 

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -443,18 +443,22 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
                 }
                 // An interval refinement (from a comparison predicate on the
                 // value variable) becomes VAE range bounds. Pushed ONLY when
-                // the kind admits exactly one numeric type: a comparison
-                // adapts its literal to each ROW's type, so a NUMERIC-wide
-                // kind admits rows of other numeric types that a single-band
-                // range would silently drop. The bound literal adapts to the
-                // scanned type exactly as the row filter would; a literal
-                // that cannot adapt losslessly pushes nothing (the residual
-                // comparison filters every row of that type anyway).
+                // the kind admits exactly one comparable type: a numeric
+                // comparison adapts its literal to each ROW's type, so a
+                // NUMERIC-wide kind admits rows of other numeric types that a
+                // single-band range would silently drop (and a STRING_LIKE-
+                // wide kind admits symbol rows a String band would drop). The
+                // bound literal adapts to the scanned type exactly as the row
+                // filter would — numeric literals losslessly, non-numeric
+                // literals only to their own type; a bound that cannot adapt
+                // pushes nothing (the residual comparison filters every row
+                // of that type anyway).
                 if let Some(kind) = from.is.kind().as_ref()
                     && let Some(interval) = kind
                         .refinement()
                         .and_then(|refinement| refinement.interval.as_ref())
-                    && let Some(data_type) = single_numeric_type(kind.primitive_part().required())
+                    && let Some(data_type) =
+                        single_comparable_type(kind.primitive_part().required())
                 {
                     if let Some(bound) = &interval.lower
                         && let Some(value) =
@@ -478,20 +482,31 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
     }
 }
 
-/// The single numeric type a primitive set admits, or `None` when it admits
-/// none, several, or any non-numeric member — the gate for pushing an
-/// interval bound into a scan range (see the pushdown comment above).
-fn single_numeric_type(primitive: Primitive) -> Option<Type> {
-    [Type::UnsignedInt, Type::SignedInt, Type::Float]
-        .into_iter()
-        .find(|numeric| primitive == Primitive::from(*numeric))
+/// The single comparable type a primitive set admits, or `None` when it
+/// admits none, several, or any non-comparable member — the gate for
+/// pushing an interval bound into a scan range (see the pushdown comment
+/// above).
+fn single_comparable_type(primitive: Primitive) -> Option<Type> {
+    [
+        Type::UnsignedInt,
+        Type::SignedInt,
+        Type::Float,
+        Type::String,
+        Type::Symbol,
+        Type::Entity,
+        Type::Bytes,
+    ]
+    .into_iter()
+    .find(|comparable| primitive == Primitive::from(*comparable))
 }
 
-/// Decodes an interval bound's literal and adapts it LOSSLESSLY to the
-/// scanned column's type, exactly as the comparison predicate adapts its
-/// literal per row. `None` means no push: an unadaptable literal (`1.5`
-/// against integer data) admits no row of that type, and the residual
-/// comparison already filters them all.
+/// Decodes an interval bound's literal and adapts it to the scanned
+/// column's type, exactly as the comparison predicate adapts its literal
+/// per row: a same-type bound passes through, a numeric literal adapts
+/// LOSSLESSLY across the numeric types, and nothing else adapts. `None`
+/// means no push: an unadaptable literal (`1.5` against integer data, a
+/// string against a symbol column) admits no row of that type, and the
+/// residual comparison already filters them all.
 fn adapt_bound(literal_type: Type, encoded: &[u8], data_type: Type) -> Option<Value> {
     let (value, rest) = decode_value(literal_type, encoded)?;
     if !rest.is_empty() {
@@ -547,11 +562,14 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
+    use crate::artifact::encode_value_owned;
     use crate::query::Output;
     use crate::session::RuleRegistry;
     use crate::source::test::TestEnv;
     use crate::the;
+    use crate::type_system::{Interval, IntervalBound, Refinement};
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+    use std::collections::BTreeSet;
 
     /// A prefix refinement stamped onto a variable term becomes a
     /// range bound on the selector — the end of the
@@ -672,13 +690,34 @@ mod tests {
         Ok(())
     }
 
-    /// The single-numeric-type gate: a NUMERIC-wide kind pushes no
-    /// bound (rows of the other numeric types would be silently
-    /// dropped from the scan), and an unadaptable literal pushes no
-    /// bound (no row of the scanned type satisfies it; the residual
-    /// comparison filters every one).
+    /// A string (or other non-numeric comparable) bound pushes when
+    /// the kind admits exactly that one type, Datomic's
+    /// `[(<= "Q" ?name)]` shape.
     #[dialog_common::test]
-    fn it_gates_interval_pushdown_to_single_numeric_kinds() -> anyhow::Result<()> {
+    fn it_pushes_string_interval_refinements_into_the_selector() -> anyhow::Result<()> {
+        let kind = Kind::from(Type::String)
+            .with_interval(&Value::String("Q".into()), true, true)
+            .expect("string is comparable");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(kind),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        let lower = selector.value_lower().expect("the bound is pushed");
+        assert_eq!(lower.value, Value::String("Q".into()));
+        assert!(lower.inclusive);
+        Ok(())
+    }
+
+    /// The single-comparable-type gate: a kind admitting several
+    /// types pushes no bound (rows of the other types would be
+    /// silently dropped from the scan), and an unadaptable literal
+    /// pushes no bound (no row of the scanned type satisfies it; the
+    /// residual comparison filters every one).
+    #[dialog_common::test]
+    fn it_gates_interval_pushdown_to_single_comparable_kinds() -> anyhow::Result<()> {
         let wide = Kind::from(Primitive::NUMERIC)
             .with_interval(&Value::UnsignedInt(30), true, true)
             .expect("numeric admits an interval");
@@ -694,6 +733,54 @@ mod tests {
             "a kind admitting several numeric types pushes nothing"
         );
 
+        // A String bound on a STRING_LIKE kind narrows the membership
+        // to String (a non-numeric literal never adapts, so symbol
+        // rows could never match), which makes it pushable.
+        let narrowed = Kind::from(Primitive::STRING_LIKE)
+            .with_interval(&Value::String("Q".into()), true, true)
+            .expect("strings are comparable");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(narrowed),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert!(
+            selector.value_lower().is_some(),
+            "the narrowed membership admits only String, so the bound pushes"
+        );
+
+        // A hand-built (e.g. deserialized) kind that stayed wide must
+        // still gate: a String band would drop the symbol rows it
+        // admits.
+        let string_like = Kind::Refined(
+            Primitive::STRING_LIKE,
+            Refinement {
+                prefix: None,
+                conforms: BTreeSet::default(),
+                interval: Some(Box::new(Interval {
+                    value_type: Type::String,
+                    lower: Some(IntervalBound {
+                        encoded: encode_value_owned(&Value::String("Q".into())),
+                        inclusive: true,
+                    }),
+                    upper: None,
+                })),
+            },
+        );
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(string_like),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert!(
+            selector.value_lower().is_none() && selector.value_upper().is_none(),
+            "a kind still admitting Symbol pushes no String bound"
+        );
+
         let unadaptable = Kind::from(Type::UnsignedInt)
             .with_interval(&Value::Float(1.5), true, true)
             .expect("numeric admits an interval");
@@ -707,6 +794,37 @@ mod tests {
         assert!(
             selector.value_lower().is_none() && selector.value_upper().is_none(),
             "a literal that cannot adapt losslessly pushes nothing"
+        );
+
+        // Defense in depth: `with_interval` can no longer construct a
+        // kind whose interval type disagrees with its membership (the
+        // meet is empty), but a hand-built or deserialized kind still
+        // can — the adaptation gate must hold on its own.
+        let cross_type = Kind::Refined(
+            Primitive::from(Type::Symbol),
+            Refinement {
+                prefix: None,
+                conforms: BTreeSet::default(),
+                interval: Some(Box::new(Interval {
+                    value_type: Type::String,
+                    lower: Some(IntervalBound {
+                        encoded: encode_value_owned(&Value::String("Q".into())),
+                        inclusive: true,
+                    }),
+                    upper: None,
+                })),
+            },
+        );
+        let query = AttributeQueryAll::new(
+            Term::from(the!("tag/kind")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(cross_type),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert!(
+            selector.value_lower().is_none() && selector.value_upper().is_none(),
+            "a string literal never adapts to a symbol column"
         );
         Ok(())
     }
@@ -747,6 +865,50 @@ mod tests {
             "the range starts at the inclusive bound"
         );
         assert!(values.contains(&&Value::UnsignedInt(50)));
+        Ok(())
+    }
+
+    /// A pushed string bound scans the right rows from a real tree —
+    /// the Datomic `[(<= "Q" ?name)]` example, index-accelerated.
+    #[dialog_common::test]
+    async fn it_scans_with_pushed_string_bounds() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        branch
+            .transaction()
+            .assert(
+                the!("person/name")
+                    .of(Entity::new()?)
+                    .is("Alice".to_string()),
+            )
+            .assert(
+                the!("person/name")
+                    .of(Entity::new()?)
+                    .is("Quinn".to_string()),
+            )
+            .assert(the!("person/name").of(Entity::new()?).is("Zed".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let kind = Kind::from(Type::String)
+            .with_interval(&Value::String("Q".into()), true, true)
+            .expect("string is comparable");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/name")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(kind),
+            Term::var("cause"),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results = query.perform(&source).try_vec().await?;
+        let values: Vec<&Value> = results.iter().map(|artifact| artifact.is()).collect();
+        assert_eq!(values.len(), 2, "Alice sorts below the bound");
+        assert!(values.contains(&&Value::String("Quinn".into())));
+        assert!(values.contains(&&Value::String("Zed".into())));
         Ok(())
     }
 

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -1,8 +1,9 @@
 use crate::Cardinality;
 use crate::Claim;
-use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
+use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained, decode_value};
 use crate::attribute::The;
 use crate::environment::Environment;
+use crate::formula::number::Numeric;
 use crate::query::Application;
 use crate::query::Output;
 use crate::selection::{Match, Selection};
@@ -440,12 +441,92 @@ impl TryFrom<&AttributeQueryAll> for ArtifactSelector<Constrained> {
                         Some(s) => s.is_starting_with(prefix),
                     });
                 }
+                // An interval refinement (from a comparison predicate on the
+                // value variable) becomes VAE range bounds. Pushed ONLY when
+                // the kind admits exactly one numeric type: a comparison
+                // adapts its literal to each ROW's type, so a NUMERIC-wide
+                // kind admits rows of other numeric types that a single-band
+                // range would silently drop. The bound literal adapts to the
+                // scanned type exactly as the row filter would; a literal
+                // that cannot adapt losslessly pushes nothing (the residual
+                // comparison filters every row of that type anyway).
+                if let Some(kind) = from.is.kind().as_ref()
+                    && let Some(interval) = kind
+                        .refinement()
+                        .and_then(|refinement| refinement.interval.as_ref())
+                    && let Some(data_type) = single_numeric_type(kind.primitive_part().required())
+                {
+                    if let Some(bound) = &interval.lower
+                        && let Some(value) =
+                            adapt_bound(interval.value_type, &bound.encoded, data_type)
+                    {
+                        selector = Some(push_bound(selector.take(), value, bound.inclusive, true));
+                    }
+                    if let Some(bound) = &interval.upper
+                        && let Some(value) =
+                            adapt_bound(interval.value_type, &bound.encoded, data_type)
+                    {
+                        selector = Some(push_bound(selector.take(), value, bound.inclusive, false));
+                    }
+                }
             }
         }
 
         selector.ok_or_else(|| EvaluationError::EmptySelector {
             message: "At least one field must be constrained".to_string(),
         })
+    }
+}
+
+/// The single numeric type a primitive set admits, or `None` when it admits
+/// none, several, or any non-numeric member — the gate for pushing an
+/// interval bound into a scan range (see the pushdown comment above).
+fn single_numeric_type(primitive: Primitive) -> Option<Type> {
+    [Type::UnsignedInt, Type::SignedInt, Type::Float]
+        .into_iter()
+        .find(|numeric| primitive == Primitive::from(*numeric))
+}
+
+/// Decodes an interval bound's literal and adapts it LOSSLESSLY to the
+/// scanned column's type, exactly as the comparison predicate adapts its
+/// literal per row. `None` means no push: an unadaptable literal (`1.5`
+/// against integer data) admits no row of that type, and the residual
+/// comparison already filters them all.
+fn adapt_bound(literal_type: Type, encoded: &[u8], data_type: Type) -> Option<Value> {
+    let (value, rest) = decode_value(literal_type, encoded)?;
+    if !rest.is_empty() {
+        return None;
+    }
+    if literal_type == data_type {
+        return Some(value);
+    }
+    Numeric::try_from(value)
+        .ok()?
+        .instantiate(data_type)
+        .map(Value::from)
+}
+
+/// Extends `selector` with one interval bound, choosing the matching
+/// range constructor.
+fn push_bound(
+    selector: Option<ArtifactSelector<Constrained>>,
+    value: Value,
+    inclusive: bool,
+    lower: bool,
+) -> ArtifactSelector<Constrained> {
+    match selector {
+        Some(constrained) => match (lower, inclusive) {
+            (true, true) => constrained.is_at_least(value),
+            (true, false) => constrained.is_greater_than(value),
+            (false, true) => constrained.is_at_most(value),
+            (false, false) => constrained.is_less_than(value),
+        },
+        None => match (lower, inclusive) {
+            (true, true) => ArtifactSelector::new().is_at_least(value),
+            (true, false) => ArtifactSelector::new().is_greater_than(value),
+            (false, true) => ArtifactSelector::new().is_at_most(value),
+            (false, false) => ArtifactSelector::new().is_less_than(value),
+        },
     }
 }
 
@@ -526,6 +607,184 @@ mod tests {
         assert_eq!(selector.entity_prefix(), None);
         assert_eq!(selector.attribute_prefix(), None);
         assert_eq!(selector.value_prefix(), None);
+        Ok(())
+    }
+
+    /// An interval refinement stamped onto a single-numeric-typed value
+    /// variable becomes VAE range bounds on the selector; the bound
+    /// literal adapts to the scanned type exactly as the residual
+    /// comparison adapts per row.
+    #[dialog_common::test]
+    fn it_pushes_interval_refinements_into_the_selector() -> anyhow::Result<()> {
+        // A same-type bound is pushed verbatim.
+        let kind = Kind::from(Type::UnsignedInt)
+            .with_interval(&Value::UnsignedInt(30), true, true)
+            .expect("numeric admits an interval");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(kind),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        let lower = selector.value_lower().expect("the bound is pushed");
+        assert_eq!(lower.value, Value::UnsignedInt(30));
+        assert!(lower.inclusive);
+        assert!(selector.value_upper().is_none());
+
+        // An integer literal bounding float data adapts to `30.0`.
+        let kind = Kind::from(Type::Float)
+            .with_interval(&Value::UnsignedInt(30), false, false)
+            .expect("numeric admits an interval");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(kind),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        let upper = selector.value_upper().expect("the bound is pushed");
+        assert_eq!(upper.value, Value::Float(30.0));
+        assert!(!upper.inclusive);
+        assert!(selector.value_lower().is_none());
+
+        // Both sides of a two-sided interval push together.
+        let kind = Kind::from(Type::UnsignedInt)
+            .with_interval(&Value::UnsignedInt(10), true, true)
+            .expect("numeric admits an interval")
+            .with_interval(&Value::UnsignedInt(20), false, false)
+            .expect("the meet keeps both bounds");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(kind),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert_eq!(
+            selector.value_lower().expect("lower pushed").value,
+            Value::UnsignedInt(10)
+        );
+        assert_eq!(
+            selector.value_upper().expect("upper pushed").value,
+            Value::UnsignedInt(20)
+        );
+        Ok(())
+    }
+
+    /// The single-numeric-type gate: a NUMERIC-wide kind pushes no
+    /// bound (rows of the other numeric types would be silently
+    /// dropped from the scan), and an unadaptable literal pushes no
+    /// bound (no row of the scanned type satisfies it; the residual
+    /// comparison filters every one).
+    #[dialog_common::test]
+    fn it_gates_interval_pushdown_to_single_numeric_kinds() -> anyhow::Result<()> {
+        let wide = Kind::from(Primitive::NUMERIC)
+            .with_interval(&Value::UnsignedInt(30), true, true)
+            .expect("numeric admits an interval");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(wide),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert!(
+            selector.value_lower().is_none() && selector.value_upper().is_none(),
+            "a kind admitting several numeric types pushes nothing"
+        );
+
+        let unadaptable = Kind::from(Type::UnsignedInt)
+            .with_interval(&Value::Float(1.5), true, true)
+            .expect("numeric admits an interval");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(unadaptable),
+            Term::var("cause"),
+        );
+        let selector = ArtifactSelector::<Constrained>::try_from(&query)?;
+        assert!(
+            selector.value_lower().is_none() && selector.value_upper().is_none(),
+            "a literal that cannot adapt losslessly pushes nothing"
+        );
+        Ok(())
+    }
+
+    /// A pushed interval bound scans the right rows from a real tree,
+    /// bound-equal rows included.
+    #[dialog_common::test]
+    async fn it_scans_with_pushed_interval_bounds() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        branch
+            .transaction()
+            .assert(the!("person/age").of(Entity::new()?).is(10u64))
+            .assert(the!("person/age").of(Entity::new()?).is(30u64))
+            .assert(the!("person/age").of(Entity::new()?).is(50u64))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let kind = Kind::from(Type::UnsignedInt)
+            .with_interval(&Value::UnsignedInt(30), true, true)
+            .expect("numeric admits an interval");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(kind),
+            Term::var("cause"),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results = query.perform(&source).try_vec().await?;
+        let values: Vec<&Value> = results.iter().map(|artifact| artifact.is()).collect();
+        assert_eq!(values.len(), 2, "10 is below the bound");
+        assert!(
+            values.contains(&&Value::UnsignedInt(30)),
+            "the range starts at the inclusive bound"
+        );
+        assert!(values.contains(&&Value::UnsignedInt(50)));
+        Ok(())
+    }
+
+    /// Mixed numeric rows under a NUMERIC-wide kind: nothing is
+    /// pushed, so every numeric row reaches the residual comparison —
+    /// the scan produces no false negatives.
+    #[dialog_common::test]
+    async fn it_keeps_mixed_numeric_rows_without_single_type_kind() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        branch
+            .transaction()
+            .assert(the!("score/value").of(Entity::new()?).is(5u64))
+            .assert(the!("score/value").of(Entity::new()?).is(2.5f64))
+            .assert(the!("score/value").of(Entity::new()?).is(-3i64))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let wide = Kind::from(Primitive::NUMERIC)
+            .with_interval(&Value::UnsignedInt(1), true, true)
+            .expect("numeric admits an interval");
+        let query = AttributeQueryAll::new(
+            Term::from(the!("score/value")),
+            Term::<Entity>::var("e"),
+            Term::var("v").with_kind(wide),
+            Term::var("cause"),
+        );
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+        let results = query.perform(&source).try_vec().await?;
+        assert_eq!(
+            results.len(),
+            3,
+            "the un-narrowed scan yields every numeric row"
+        );
         Ok(())
     }
 

--- a/rust/dialog-query/src/constraint.rs
+++ b/rust/dialog-query/src/constraint.rs
@@ -46,17 +46,19 @@ pub enum Constraint {
     /// string prefix, over the TEXTUAL kinds.
     #[serde(rename = "starts-with")]
     StartsWith(StartsWith),
-    /// Range predicate — strictly less than, over the NUMERIC kinds.
+    /// Range predicate — strictly less than, over the COMPARABLE
+    /// kinds.
     #[serde(rename = "<")]
     LessThan(LessThan),
-    /// Range predicate — less than or equal, over the NUMERIC kinds.
+    /// Range predicate — less than or equal, over the COMPARABLE
+    /// kinds.
     #[serde(rename = "<=")]
     AtMost(AtMost),
-    /// Range predicate — strictly greater than, over the NUMERIC
+    /// Range predicate — strictly greater than, over the COMPARABLE
     /// kinds.
     #[serde(rename = ">")]
     GreaterThan(GreaterThan),
-    /// Range predicate — greater than or equal, over the NUMERIC
+    /// Range predicate — greater than or equal, over the COMPARABLE
     /// kinds.
     #[serde(rename = ">=")]
     AtLeast(AtLeast),

--- a/rust/dialog-query/src/constraint/compare.rs
+++ b/rust/dialog-query/src/constraint/compare.rs
@@ -1,28 +1,35 @@
-//! Numeric range predicates: `<`, `<=`, `>`, `>=` as premises.
+//! Range predicates: `<`, `<=`, `>`, `>=` as premises.
 //!
-//! Four constraints over the NUMERIC kinds, sharing one comparison
-//! core. Like every scalar premise they *filter*: a row whose sides
-//! cannot be ordered — a non-numeric value, a mixed-type pair, a
-//! NaN — is a non-match, never an error and never a coercion. The
-//! same strict no-promotion semantics as formula arithmetic
-//! (`notes/formula-schemes.md`), with the same release valve: a
-//! *constant* side is a polymorphic literal that adapts losslessly
-//! to the data's type per row (`1` compares against floats as
-//! `1.0`; `1.5` against integer data is a non-match because no
-//! integer is `1.5`). Data is never adapted.
+//! Four constraints over the COMPARABLE kinds (numbers, strings,
+//! symbols, entities, bytes), sharing one comparison core. Like
+//! every scalar premise they *filter*: a row whose sides cannot be
+//! ordered — a non-comparable value, a mixed-type pair, a NaN — is
+//! a non-match, never an error and never a coercion. The same
+//! strict no-promotion semantics as formula arithmetic
+//! (`notes/formula-schemes.md`), with one release valve: a
+//! *constant* NUMERIC side is a polymorphic literal that adapts
+//! losslessly to the data's type per row (`1` compares against
+//! floats as `1.0`; `1.5` against integer data is a non-match
+//! because no integer is `1.5`). Data is never adapted, and
+//! non-numeric literals never adapt (a string literal orders only
+//! against string rows).
 //!
-//! Inference: both slots carry the NUMERIC bound, narrowing the
-//! variables on use. The slots are not yet *linked* (a comparison
-//! does not force its sides to one instantiation the way a formula
-//! scheme does); the planned per-atom interval refinements will
-//! ride these same predicates into scan-range pushdown.
+//! Non-numeric comparables order within one type by their
+//! ORDER-PRESERVING encoding — the same order the value index sorts
+//! by, so a pushed scan range and this residual filter can never
+//! disagree about a row.
+//!
+//! Inference: both slots carry the COMPARABLE bound, narrowing the
+//! variables on use. A constant side additionally proves an
+//! interval refinement on the other side, which rides inference
+//! into the scan-range pushdown.
 
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::Display;
 use std::ops::Not;
 
-use crate::artifact::Value;
+use crate::artifact::{Value, encode_value_owned};
 use crate::error::EvaluationError;
 use crate::formula::number::Numeric;
 use crate::selection::Selection;
@@ -35,27 +42,39 @@ use crate::{Constraint, Negation, Premise, Proposition, try_stream};
 /// Cost for evaluating a comparison (single row lookup + ordering).
 const COMPARE_COST: usize = 1;
 
-/// Order two values for comparison, adapting literal sides.
+/// Order two values for comparison, adapting numeric literal sides.
 ///
-/// `None` is a non-match: a non-numeric value, a NaN, or a
-/// mixed-type pair neither side of which is a literal that adapts
-/// losslessly to the other's type.
+/// `None` is a non-match: a non-comparable value, a NaN, or a
+/// mixed-type pair neither side of which is a numeric literal that
+/// adapts losslessly to the other's type.
 fn ordering(
     of: &Value,
     of_is_literal: bool,
     with: &Value,
     with_is_literal: bool,
 ) -> Option<Ordering> {
-    let of = Numeric::try_from(of.clone()).ok()?;
-    let with = Numeric::try_from(with.clone()).ok()?;
-    if of.value_type() == with.value_type() {
-        return of.compare(with);
+    let of_type = of.data_type();
+    let with_type = with.data_type();
+    if Primitive::NUMERIC.contains(of_type) && Primitive::NUMERIC.contains(with_type) {
+        let of = Numeric::try_from(of.clone()).ok()?;
+        let with = Numeric::try_from(with.clone()).ok()?;
+        if of.value_type() == with.value_type() {
+            return of.compare(with);
+        }
+        if with_is_literal && let Some(adapted) = with.instantiate(of.value_type()) {
+            return of.compare(adapted);
+        }
+        if of_is_literal && let Some(adapted) = of.instantiate(with.value_type()) {
+            return adapted.compare(with);
+        }
+        return None;
     }
-    if with_is_literal && let Some(adapted) = with.instantiate(of.value_type()) {
-        return of.compare(adapted);
-    }
-    if of_is_literal && let Some(adapted) = of.instantiate(with.value_type()) {
-        return adapted.compare(with);
+    // Non-numeric comparables order within one type by their
+    // order-preserving encoding: exactly the byte order the value
+    // index sorts by, so a pushed range and this filter agree on
+    // every row by construction.
+    if of_type == with_type && Primitive::COMPARABLE.contains(of_type) {
+        return Some(encode_value_owned(of).cmp(&encode_value_owned(with)));
     }
     None
 }
@@ -85,38 +104,39 @@ macro_rules! define_comparison {
 
             /// Schema: both sides are *hard* requirements (the
             /// predicate consumes bound values; the planner orders
-            /// it after the premises binding them), bounded NUMERIC.
+            /// it after the premises binding them), bounded
+            /// COMPARABLE.
             ///
             /// A constant side additionally proves an interval bound
             /// on the OTHER side, carried as a
             /// [`Refinement`](crate::type_system::Refinement) — how
             /// the bound travels through inference to the scan-range
             /// pushdown. The interval records the literal's own type;
-            /// consumers must honor the per-row literal adaptation
-            /// (see the pushdown's single-numeric-type gate).
+            /// consumers must honor the per-row numeric literal
+            /// adaptation (see the pushdown's single-type gate).
             pub fn schema(&self) -> Schema {
-                let numeric = Kind::from(Primitive::NUMERIC);
+                let comparable = Kind::from(Primitive::COMPARABLE);
                 let (of_content, with_content) =
                     match (self.of.as_constant(), self.with.as_constant()) {
                         // `of REL bound`: the bound constrains `of` on
                         // this relation's own side.
                         (None, Some(bound)) => (
-                            numeric
+                            comparable
                                 .clone()
                                 .with_interval(bound, $inclusive, $lower)
-                                .unwrap_or_else(|| numeric.clone()),
-                            numeric.clone(),
+                                .unwrap_or_else(|| comparable.clone()),
+                            comparable.clone(),
                         ),
                         // `bound REL with`: mirrored — the bound sits on
                         // the opposite side of `with`.
                         (Some(bound), None) => (
-                            numeric.clone(),
-                            numeric
+                            comparable.clone(),
+                            comparable
                                 .clone()
                                 .with_interval(bound, $inclusive, !$lower)
-                                .unwrap_or_else(|| numeric.clone()),
+                                .unwrap_or_else(|| comparable.clone()),
                         ),
-                        _ => (numeric.clone(), numeric.clone()),
+                        _ => (comparable.clone(), comparable.clone()),
                     };
                 let mut schema = Schema::new();
                 schema.insert(
@@ -255,7 +275,7 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
-    use crate::artifact::{Type as ValueType, decode_value};
+    use crate::artifact::{ArtifactsAttribute, Type as ValueType, decode_value};
     use crate::rule::TypeEnv;
     use crate::selection::Match;
     use crate::types::Scalar;
@@ -336,6 +356,71 @@ mod tests {
         Ok(())
     }
 
+    /// Non-numeric comparables order within one type, Datomic-style:
+    /// strings, symbols, and bytes compare against same-typed
+    /// literals; a mixed pair is a non-match (no adaptation exists
+    /// between non-numeric types).
+    #[dialog_common::test]
+    async fn it_orders_non_numeric_comparables() -> Result<(), EvaluationError> {
+        assert_eq!(
+            count(below("m".to_string()), Value::String("alice".into())).await?,
+            1,
+            "strings order lexicographically"
+        );
+        assert_eq!(
+            count(below("m".to_string()), Value::String("zed".into())).await?,
+            0
+        );
+        assert_eq!(
+            count(below("m".to_string()), Value::String("m".into())).await?,
+            0,
+            "< is strict"
+        );
+
+        let at_least = AtLeast::new(Term::var("x"), Term::constant(vec![0x10u8]));
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::Bytes(vec![0x20]))?;
+        let results: Vec<Match> = at_least.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 1, "bytes order bytewise");
+
+        // A string literal orders against no symbol row and vice
+        // versa: mixed non-numeric pairs never adapt.
+        let symbol = Value::Symbol("user/name".to_string().try_into().expect("valid"));
+        assert_eq!(count(below("zzz".to_string()), symbol.clone()).await?, 0);
+        let below_symbol = LessThan::new(
+            Term::var("x"),
+            Term::constant(ArtifactsAttribute::try_from("user/name".to_string()).expect("valid")),
+        );
+        let mut row = Match::new();
+        row.bind(&Term::var("x"), Value::String("aaa".into()))?;
+        let results: Vec<Match> = below_symbol.evaluate(row.seed()).try_collect().await?;
+        assert_eq!(results.len(), 0);
+        Ok(())
+    }
+
+    /// A string constant proves an interval, same as a numeric one.
+    #[dialog_common::test]
+    fn it_stamps_string_interval_refinements() -> anyhow::Result<()> {
+        let premises = vec![Term::<Any>::var("x").at_least(Term::constant("Q".to_string()))];
+        let env = TypeEnv::infer(&premises)?;
+        let interval = env
+            .get("x")
+            .expect("inferred")
+            .refinement()
+            .expect("refined")
+            .interval
+            .clone()
+            .expect("interval recorded");
+        assert_eq!(interval.value_type, ValueType::String);
+        let lower = interval.lower.expect("lower bound");
+        assert!(lower.inclusive);
+        assert_eq!(
+            decode_value(ValueType::String, &lower.encoded).map(|(value, _)| value),
+            Some(Value::String("Q".into())),
+        );
+        Ok(())
+    }
+
     /// Values outside NUMERIC, NaN, and Absent are non-matches.
     #[dialog_common::test]
     async fn it_filters_unorderable_rows() -> Result<(), EvaluationError> {
@@ -365,15 +450,15 @@ mod tests {
         assert!(results.is_err(), "unbound left side must error");
     }
 
-    /// Comparisons narrow both sides to NUMERIC rule-wide.
+    /// Comparisons narrow both sides to COMPARABLE rule-wide.
     #[dialog_common::test]
-    fn it_bounds_both_sides_numeric() -> anyhow::Result<()> {
+    fn it_bounds_both_sides_comparable() -> anyhow::Result<()> {
         let premises = vec![Term::<Any>::var("x").less_than(Term::<Any>::var("y"))];
         let env = TypeEnv::infer(&premises)?;
         for var in ["x", "y"] {
             assert_eq!(
                 env.get(var).expect("inferred").primitive_part(),
-                Primitive::NUMERIC,
+                Primitive::COMPARABLE,
                 "{var} is bounded by the comparison"
             );
         }
@@ -457,16 +542,29 @@ mod tests {
         Ok(())
     }
 
-    /// A side already known non-numeric is a compile-time conflict.
+    /// A side already known non-comparable is a compile-time
+    /// conflict; a textual side is comparable and narrows cleanly.
     #[dialog_common::test]
-    fn it_rejects_known_non_numeric_sides() {
+    fn it_rejects_known_non_comparable_sides() -> anyhow::Result<()> {
         let premises = vec![
-            Term::<Any>::var("x").text(),
+            Term::<Any>::var("x").boolean(),
             Term::<Any>::var("x").less_than(Term::constant(5u64)),
         ];
         assert!(
             TypeEnv::infer(&premises).is_err(),
-            "String and NUMERIC have an empty meet"
+            "Boolean and COMPARABLE have an empty meet"
         );
+
+        let premises = vec![
+            Term::<Any>::var("x").text(),
+            Term::<Any>::var("x").less_than(Term::constant("Q".to_string())),
+        ];
+        let env = TypeEnv::infer(&premises)?;
+        assert_eq!(
+            env.get("x").expect("inferred").primitive_part(),
+            Primitive::from(ValueType::String),
+            "a string side is comparable, Datomic-style"
+        );
+        Ok(())
     }
 }

--- a/rust/dialog-query/src/constraint/compare.rs
+++ b/rust/dialog-query/src/constraint/compare.rs
@@ -63,7 +63,8 @@ fn ordering(
 macro_rules! define_comparison {
     (
         $(#[$doc:meta])*
-        $name:ident, $symbol:literal, [$($accepts:pat),+], $sugar:ident
+        $name:ident, $symbol:literal, [$($accepts:pat),+], $sugar:ident,
+        lower: $lower:literal, inclusive: $inclusive:literal
     ) => {
         $(#[$doc])*
         ///
@@ -85,13 +86,44 @@ macro_rules! define_comparison {
             /// Schema: both sides are *hard* requirements (the
             /// predicate consumes bound values; the planner orders
             /// it after the premises binding them), bounded NUMERIC.
+            ///
+            /// A constant side additionally proves an interval bound
+            /// on the OTHER side, carried as a
+            /// [`Refinement`](crate::type_system::Refinement) — how
+            /// the bound travels through inference to the scan-range
+            /// pushdown. The interval records the literal's own type;
+            /// consumers must honor the per-row literal adaptation
+            /// (see the pushdown's single-numeric-type gate).
             pub fn schema(&self) -> Schema {
+                let numeric = Kind::from(Primitive::NUMERIC);
+                let (of_content, with_content) =
+                    match (self.of.as_constant(), self.with.as_constant()) {
+                        // `of REL bound`: the bound constrains `of` on
+                        // this relation's own side.
+                        (None, Some(bound)) => (
+                            numeric
+                                .clone()
+                                .with_interval(bound, $inclusive, $lower)
+                                .unwrap_or_else(|| numeric.clone()),
+                            numeric.clone(),
+                        ),
+                        // `bound REL with`: mirrored — the bound sits on
+                        // the opposite side of `with`.
+                        (Some(bound), None) => (
+                            numeric.clone(),
+                            numeric
+                                .clone()
+                                .with_interval(bound, $inclusive, !$lower)
+                                .unwrap_or_else(|| numeric.clone()),
+                        ),
+                        _ => (numeric.clone(), numeric.clone()),
+                    };
                 let mut schema = Schema::new();
                 schema.insert(
                     "of".to_string(),
                     Field {
                         description: "Left side of the comparison".to_string(),
-                        content_type: Some(Kind::from(Primitive::NUMERIC)),
+                        content_type: Some(of_content),
                         requirement: Requirement::required(),
                         cardinality: Cardinality::One,
                     },
@@ -100,7 +132,7 @@ macro_rules! define_comparison {
                     "with".to_string(),
                     Field {
                         description: "Right side of the comparison".to_string(),
-                        content_type: Some(Kind::from(Primitive::NUMERIC)),
+                        content_type: Some(with_content),
                         requirement: Requirement::required(),
                         cardinality: Cardinality::One,
                     },
@@ -195,22 +227,26 @@ macro_rules! define_comparison {
 
 define_comparison!(
     /// Range predicate: `of` is strictly less than `with`.
-    LessThan, "<", [Ordering::Less], less_than
+    LessThan, "<", [Ordering::Less], less_than,
+    lower: false, inclusive: false
 );
 
 define_comparison!(
     /// Range predicate: `of` is less than or equal to `with`.
-    AtMost, "<=", [Ordering::Less, Ordering::Equal], at_most
+    AtMost, "<=", [Ordering::Less, Ordering::Equal], at_most,
+    lower: false, inclusive: true
 );
 
 define_comparison!(
     /// Range predicate: `of` is strictly greater than `with`.
-    GreaterThan, ">", [Ordering::Greater], greater_than
+    GreaterThan, ">", [Ordering::Greater], greater_than,
+    lower: true, inclusive: false
 );
 
 define_comparison!(
     /// Range predicate: `of` is greater than or equal to `with`.
-    AtLeast, ">=", [Ordering::Greater, Ordering::Equal], at_least
+    AtLeast, ">=", [Ordering::Greater, Ordering::Equal], at_least,
+    lower: true, inclusive: true
 );
 
 #[cfg(test)]
@@ -219,6 +255,7 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
+    use crate::artifact::{Type as ValueType, decode_value};
     use crate::rule::TypeEnv;
     use crate::selection::Match;
     use crate::types::Scalar;
@@ -338,6 +375,83 @@ mod tests {
                 env.get(var).expect("inferred").primitive_part(),
                 Primitive::NUMERIC,
                 "{var} is bounded by the comparison"
+            );
+        }
+        Ok(())
+    }
+
+    /// A constant side proves an interval on the variable side,
+    /// carried through inference as a refinement — the vehicle for
+    /// scan-range pushdown. The mirrored operand order flips the
+    /// bound onto the opposite side of the relation.
+    #[dialog_common::test]
+    fn it_stamps_interval_refinements_via_inference() -> anyhow::Result<()> {
+        // `x >= 5`: an inclusive lower bound on `x`.
+        let premises = vec![Term::<Any>::var("x").at_least(Term::constant(5u64))];
+        let env = TypeEnv::infer(&premises)?;
+        let interval = env
+            .get("x")
+            .expect("inferred")
+            .refinement()
+            .expect("refined")
+            .interval
+            .clone()
+            .expect("interval recorded");
+        assert_eq!(interval.value_type, ValueType::UnsignedInt);
+        let lower = interval.lower.expect("lower bound");
+        assert!(lower.inclusive, ">= is inclusive");
+        assert!(interval.upper.is_none());
+        assert_eq!(
+            decode_value(ValueType::UnsignedInt, &lower.encoded).map(|(value, _)| value),
+            Some(Value::UnsignedInt(5)),
+            "the bound round-trips through the order-preserving encoding"
+        );
+
+        // `5 < x` mirrors to an exclusive lower bound on `x`.
+        let premises = vec![Term::<Any>::constant(5u64).less_than(Term::<Any>::var("x"))];
+        let env = TypeEnv::infer(&premises)?;
+        let interval = env
+            .get("x")
+            .expect("inferred")
+            .refinement()
+            .expect("refined")
+            .interval
+            .clone()
+            .expect("interval recorded");
+        let lower = interval
+            .lower
+            .expect("the mirrored bound lands on the lower side");
+        assert!(!lower.inclusive, "a strict relation stays strict");
+        assert!(interval.upper.is_none());
+
+        // `x <= 9.5`: an inclusive upper bound recording the
+        // literal's own type.
+        let premises = vec![Term::<Any>::var("x").at_most(Term::constant(9.5f64))];
+        let env = TypeEnv::infer(&premises)?;
+        let interval = env
+            .get("x")
+            .expect("inferred")
+            .refinement()
+            .expect("refined")
+            .interval
+            .clone()
+            .expect("interval recorded");
+        assert_eq!(interval.value_type, ValueType::Float);
+        assert!(interval.lower.is_none());
+        assert!(interval.upper.expect("upper bound").inclusive);
+        Ok(())
+    }
+
+    /// Two variable sides prove no interval: the bound must be a
+    /// constant the schema can encode.
+    #[dialog_common::test]
+    fn it_stamps_no_interval_without_a_constant_side() -> anyhow::Result<()> {
+        let premises = vec![Term::<Any>::var("x").less_than(Term::<Any>::var("y"))];
+        let env = TypeEnv::infer(&premises)?;
+        for var in ["x", "y"] {
+            assert!(
+                env.get(var).expect("inferred").refinement().is_none(),
+                "{var} carries no interval from a variable-variable comparison"
             );
         }
         Ok(())

--- a/rust/dialog-query/src/planner/plan.rs
+++ b/rust/dialog-query/src/planner/plan.rs
@@ -439,6 +439,48 @@ mod tests {
         );
     }
 
+    /// The same pipeline pushes a comparison's interval down to the
+    /// scan's value term: the typed variable narrows the NUMERIC bound
+    /// to one type and the constant side's interval rides along, so
+    /// the VAE range bound (`ArtifactSelector::is_at_least`) is driven
+    /// by the predicate.
+    #[dialog_common::test]
+    fn it_stamps_interval_refinements_onto_scan_values() {
+        let scan: Premise = AttributeQuery::new(
+            Term::from(the!("person/age")),
+            Term::<Entity>::var("e"),
+            Term::<u64>::var("age").into(),
+            Term::blank(),
+            Some(Cardinality::One),
+        )
+        .into();
+        let predicate = Term::<Any>::var("age").at_least(Term::constant(30u64));
+
+        let plan = Planner::from(vec![scan, predicate])
+            .plan(&crate::Environment::new())
+            .unwrap();
+
+        let stamped = plan.steps.iter().find_map(|step| match step.as_premise() {
+            Premise::Assert(Proposition::Attribute(boxed)) => boxed.is().kind(),
+            _ => None,
+        });
+        let kind = stamped.expect("the scan's value term carries a kind");
+        assert_eq!(
+            kind.primitive_part().required().as_singleton(),
+            Some(ValueType::UnsignedInt),
+            "the typed variable narrows the comparison's NUMERIC bound"
+        );
+        let interval = kind
+            .refinement()
+            .expect("refined")
+            .interval
+            .clone()
+            .expect("the proved interval reaches the scan boundary");
+        let lower = interval.lower.expect("lower bound");
+        assert!(lower.inclusive, ">= stays inclusive at the boundary");
+        assert!(interval.upper.is_none());
+    }
+
     /// A standalone `Maybe` premise cannot be planned at empty
     /// scope: set-widening needs a known entity ("absent for
     /// whom?"), so its schema hard-requires `?this` and the planner

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -24,7 +24,9 @@ pub mod unifier;
 
 use crate::artifact::Type as ValueType;
 use crate::artifact::Value;
+use crate::artifact::{decode_value, encode_value_owned};
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
@@ -325,13 +327,13 @@ impl Display for ConceptRef {
 /// constraints), the join their weakest common implication — see
 /// [`Refinement::meet`] and [`Refinement::join`].
 ///
-/// Two constraints exist: a lexical prefix over the TEXTUAL kinds,
-/// and a conformance set over Entity — the value must satisfy a
-/// concept-typed field's target concepts. Numeric intervals extend
-/// this struct the same way rather than adding lattice variants.
+/// Three constraints exist: a lexical prefix over the TEXTUAL kinds,
+/// a conformance set over Entity, and a numeric interval proved by
+/// the comparison predicates.
 ///
-/// Invariant: never empty (no prefix and no conformance is no
-/// refinement; the constructors collapse it to an unrefined type).
+/// Invariant: never empty (no prefix, no conformance, and no
+/// interval is no refinement; the constructors collapse it to an
+/// unrefined type).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Refinement {
     /// Lexical prefix every admitted value must begin with.
@@ -346,6 +348,164 @@ pub struct Refinement {
     /// diagnostics.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub conforms: BTreeSet<ConceptRef>,
+    /// A numeric interval a comparison predicate proved about the
+    /// value. Carried as *information*, like `conforms`: enforcement
+    /// stays with the comparison premise itself (whose literal-
+    /// adaptation semantics [`Refinement::admits`] deliberately does
+    /// not reproduce), while this feeds the scan-range pushdown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval: Option<Box<Interval>>,
+}
+
+/// A numeric interval over a single value type, proved by comparison
+/// predicates on a variable: at most one lower and one upper bound.
+///
+/// Bounds are stored in the value's ORDER-PRESERVING encoding (see
+/// `dialog_artifacts::encode_value_owned`), so within one
+/// `value_type` the lattice operations are plain byte comparisons and
+/// the struct stays `Eq`/`Ord`/`Hash` for the type lattice (a raw
+/// `Value` would not, floats being only partially ordered).
+///
+/// The interval records the LITERAL's own type. A comparison adapts
+/// its literal to each row's type, so an interval typed `UnsignedInt`
+/// still admits floats; consumers that cannot honor that (the scan
+/// pushdown) must gate on the variable's kind being exactly one
+/// numeric type and adapt the bound, as the comparison would.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Interval {
+    /// The numeric type the bound literals were written in.
+    pub value_type: ValueType,
+    /// The lower bound, if one was proved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lower: Option<IntervalBound>,
+    /// The upper bound, if one was proved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upper: Option<IntervalBound>,
+}
+
+/// One side of an [`Interval`]: the bound value's order-preserving
+/// encoding and whether the bound itself is admitted.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct IntervalBound {
+    /// The bound value's order-preserving encoding.
+    pub encoded: Vec<u8>,
+    /// Whether the bound is inclusive (`>=`/`<=`) rather than strict.
+    pub inclusive: bool,
+}
+
+impl Interval {
+    /// The interval a single comparison proves: one bound of one side.
+    fn bound(value_type: ValueType, encoded: Vec<u8>, inclusive: bool, lower: bool) -> Interval {
+        let bound = Some(IntervalBound { encoded, inclusive });
+        Interval {
+            value_type,
+            lower: if lower { bound.clone() } else { None },
+            upper: if lower { None } else { bound },
+        }
+    }
+
+    /// Meet: the conjunction. Same-typed intervals intersect
+    /// (byte order equals numeric order within one type: the higher
+    /// lower bound and the lower upper bound win; equal encodings
+    /// keep the STRICTER inclusivity). Differently-typed intervals
+    /// cannot be compared without per-row adaptation, so the meet
+    /// conservatively keeps neither — a weaker refinement is always
+    /// sound, because enforcement lives with the comparison premises
+    /// themselves.
+    fn meet(&self, other: &Interval) -> Option<Interval> {
+        if self.value_type != other.value_type {
+            return None;
+        }
+        let lower = match (&self.lower, &other.lower) {
+            (Some(a), Some(b)) => Some(pick(a, b, Ordering::Greater, true)),
+            (Some(bound), None) | (None, Some(bound)) => Some(bound.clone()),
+            (None, None) => None,
+        };
+        let upper = match (&self.upper, &other.upper) {
+            (Some(a), Some(b)) => Some(pick(a, b, Ordering::Less, true)),
+            (Some(bound), None) | (None, Some(bound)) => Some(bound.clone()),
+            (None, None) => None,
+        };
+        Some(Interval {
+            value_type: self.value_type,
+            lower,
+            upper,
+        })
+    }
+
+    /// Join: the weakest interval both sides imply — same-typed
+    /// intervals take the convex hull; differently-typed intervals
+    /// share no interval.
+    fn join(&self, other: &Interval) -> Option<Interval> {
+        if self.value_type != other.value_type {
+            return None;
+        }
+        let lower = match (&self.lower, &other.lower) {
+            (Some(a), Some(b)) => Some(pick(a, b, Ordering::Less, false)),
+            _ => None,
+        };
+        let upper = match (&self.upper, &other.upper) {
+            (Some(a), Some(b)) => Some(pick(a, b, Ordering::Greater, false)),
+            _ => None,
+        };
+        if lower.is_none() && upper.is_none() {
+            return None;
+        }
+        Some(Interval {
+            value_type: self.value_type,
+            lower,
+            upper,
+        })
+    }
+
+    /// True when `other` implies `self`: same type, and `other`'s
+    /// bounds sit within `self`'s. Conservative (differently-typed
+    /// intervals are treated as unrelated), which only weakens
+    /// subsumption, never soundness.
+    fn implied_by(&self, other: &Interval) -> bool {
+        if self.value_type != other.value_type {
+            return false;
+        }
+        let lower_implied = match (&self.lower, &other.lower) {
+            (Some(a), Some(b)) => match a.encoded.cmp(&b.encoded) {
+                Ordering::Less => true,
+                Ordering::Equal => a.inclusive || !b.inclusive,
+                Ordering::Greater => false,
+            },
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        let upper_implied = match (&self.upper, &other.upper) {
+            (Some(a), Some(b)) => match a.encoded.cmp(&b.encoded) {
+                Ordering::Greater => true,
+                Ordering::Equal => a.inclusive || !b.inclusive,
+                Ordering::Less => false,
+            },
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        lower_implied && upper_implied
+    }
+}
+
+/// Of two same-side bounds, the one whose encoding wins `prefer` (for
+/// a meet: the greater lower bound / the lesser upper bound; reversed
+/// for a join). Equal encodings resolve by inclusivity: a meet
+/// (`strict`) admits the bound only if BOTH sides do; a join admits
+/// it if EITHER does.
+fn pick(a: &IntervalBound, b: &IntervalBound, prefer: Ordering, strict: bool) -> IntervalBound {
+    match a.encoded.cmp(&b.encoded) {
+        Ordering::Equal => IntervalBound {
+            encoded: a.encoded.clone(),
+            inclusive: if strict {
+                a.inclusive && b.inclusive
+            } else {
+                a.inclusive || b.inclusive
+            },
+        },
+        ordering if ordering == prefer => a.clone(),
+        _ => b.clone(),
+    }
 }
 
 impl Refinement {
@@ -354,19 +514,34 @@ impl Refinement {
         Refinement {
             prefix: Some(prefix),
             conforms: BTreeSet::new(),
+            interval: None,
+        }
+    }
+
+    /// An interval-only refinement.
+    fn interval(interval: Interval) -> Refinement {
+        Refinement {
+            prefix: None,
+            conforms: BTreeSet::new(),
+            // Boxed: the interval's bounds would otherwise dominate the
+            // size of every `Type` (and every error carrying one).
+            interval: Some(Box::new(interval)),
         }
     }
 
     /// True when the refinement constrains nothing — the shape the
     /// constructors collapse to an unrefined type.
     fn is_empty(&self) -> bool {
-        self.prefix.is_none() && self.conforms.is_empty()
+        self.prefix.is_none() && self.conforms.is_empty() && self.interval.is_none()
     }
 
     /// Meet: the conjunction of both constraints. Two prefixes are
     /// jointly satisfiable iff one extends the other (the meet is
     /// the longer; disjoint prefixes admit nothing); conformance
-    /// sets union — the value must satisfy both sides' concepts.
+    /// sets union — the value must satisfy both sides' concepts;
+    /// same-typed intervals intersect, and differently-typed ones
+    /// conservatively drop (the interval is advisory — see the field
+    /// doc — so a weaker meet is sound).
     fn meet(&self, other: &Refinement) -> Option<Refinement> {
         let prefix = match (&self.prefix, &other.prefix) {
             (Some(a), Some(b)) => {
@@ -382,7 +557,16 @@ impl Refinement {
             (None, None) => None,
         };
         let conforms = self.conforms.union(&other.conforms).cloned().collect();
-        Some(Refinement { prefix, conforms })
+        let interval = match (&self.interval, &other.interval) {
+            (Some(a), Some(b)) => a.meet(b).map(Box::new),
+            (Some(interval), None) | (None, Some(interval)) => Some(interval.clone()),
+            (None, None) => None,
+        };
+        Some(Refinement {
+            prefix,
+            conforms,
+            interval,
+        })
     }
 
     /// Join: the weakest constraint both sides imply — the longest
@@ -411,7 +595,15 @@ impl Refinement {
             .intersection(&other.conforms)
             .cloned()
             .collect();
-        let joined = Refinement { prefix, conforms };
+        let interval = match (&self.interval, &other.interval) {
+            (Some(a), Some(b)) => a.join(b).map(Box::new),
+            _ => None,
+        };
+        let joined = Refinement {
+            prefix,
+            conforms,
+            interval,
+        };
         if joined.is_empty() {
             None
         } else {
@@ -428,7 +620,12 @@ impl Refinement {
             (Some(_), None) => false,
             (None, _) => true,
         };
-        prefix_implied && self.conforms.is_subset(&other.conforms)
+        let interval_implied = match (&self.interval, &other.interval) {
+            (Some(a), Some(b)) => a.implied_by(b),
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        prefix_implied && interval_implied && self.conforms.is_subset(&other.conforms)
     }
 
     /// True when the value satisfies the row-locally checkable half
@@ -459,6 +656,28 @@ impl Display for Refinement {
             }
             write!(f, "conforms-to {concept}")?;
             separate = true;
+        }
+        if let Some(interval) = &self.interval {
+            let mut side = |bound: &Option<IntervalBound>,
+                            strict: &str,
+                            inclusive: &str,
+                            separate: &mut bool|
+             -> FmtResult {
+                if let Some(bound) = bound {
+                    if *separate {
+                        write!(f, " & ")?;
+                    }
+                    let relation = if bound.inclusive { inclusive } else { strict };
+                    match decode_value(interval.value_type, &bound.encoded) {
+                        Some((value, [])) => write!(f, "{relation} {value:?}")?,
+                        _ => write!(f, "{relation} <{} bytes>", bound.encoded.len())?,
+                    }
+                    *separate = true;
+                }
+                Ok(())
+            };
+            side(&interval.lower, ">", ">=", &mut separate)?;
+            side(&interval.upper, "<", "<=", &mut separate)?;
         }
         Ok(())
     }
@@ -543,6 +762,39 @@ impl Type {
         Some(Type::Refined(membership, refinement))
     }
 
+    /// Refine this type with one side of a numeric interval, as a
+    /// comparison predicate proves it: `lower` selects which side,
+    /// `inclusive` whether the bound itself is admitted.
+    ///
+    /// The membership narrows to the NUMERIC kinds (plus a riding
+    /// `Nothing` bit); the interval records the LITERAL's own type,
+    /// because a comparison adapts its literal to each row's type —
+    /// an interval typed `UnsignedInt` still admits floats. Returns
+    /// `None` when no member could be numeric — an empty meet. A
+    /// non-numeric bound value is no constraint and returns the type
+    /// unchanged (the comparison itself will filter every row).
+    pub fn with_interval(self, bound: &Value, inclusive: bool, lower: bool) -> Option<Type> {
+        let value_type = bound.data_type();
+        if !matches!(
+            value_type,
+            ValueType::UnsignedInt | ValueType::SignedInt | ValueType::Float
+        ) {
+            return Some(self);
+        }
+        let membership = self
+            .primitive_part()
+            .intersect(Primitive::NUMERIC.union(Primitive::NOTHING))?;
+        if membership.required().is_empty() {
+            return None;
+        }
+        let interval = Interval::bound(value_type, encode_value_owned(bound), inclusive, lower);
+        let refinement = match &self {
+            Type::Refined(_, existing) => existing.meet(&Refinement::interval(interval))?,
+            _ => Refinement::interval(interval),
+        };
+        Some(Type::Refined(membership, refinement))
+    }
+
     /// Constrain this type's values to entities conforming to the
     /// given concept — the lattice form of a concept-typed field.
     ///
@@ -601,8 +853,10 @@ impl Type {
             (None, None) => None,
         };
         Some(match refinement {
-            Some(refinement) => Type::Refined(p, refinement),
-            None => Type::Primitive(p),
+            // A meet can leave nothing behind (mixed-type intervals drop
+            // conservatively); uphold the never-empty refinement invariant.
+            Some(refinement) if !refinement.is_empty() => Type::Refined(p, refinement),
+            _ => Type::Primitive(p),
         })
     }
 
@@ -676,6 +930,86 @@ mod tests {
     }
     fn o(vt: ValueType) -> Type {
         Type::from(vt).optional()
+    }
+
+    /// Interval refinements meet by intersection and join by convex hull
+    /// within one literal type; the membership narrows to NUMERIC and a
+    /// non-numeric member set is an empty meet.
+    #[dialog_common::test]
+    fn it_meets_and_joins_intervals() {
+        let base = Type::from(Primitive::NUMERIC);
+        let ge2 = base
+            .clone()
+            .with_interval(&Value::UnsignedInt(2), true, true)
+            .expect("numeric admits an interval");
+        let ge5 = base
+            .clone()
+            .with_interval(&Value::UnsignedInt(5), true, true)
+            .unwrap();
+        let le9 = base
+            .clone()
+            .with_interval(&Value::UnsignedInt(9), true, false)
+            .unwrap();
+
+        // meet(x >= 2, x >= 5) keeps the tighter lower bound.
+        let met = ge2.clone().intersect(&ge5).expect("compatible");
+        assert_eq!(
+            met.refinement().unwrap().interval,
+            ge5.refinement().unwrap().interval,
+        );
+
+        // meet of a lower with an upper carries both sides.
+        let both = ge5.clone().intersect(&le9).expect("compatible");
+        let interval = both.refinement().unwrap().interval.clone().unwrap();
+        assert!(interval.lower.is_some() && interval.upper.is_some());
+
+        // join(x >= 2, x >= 5) keeps the weaker bound.
+        let joined = ge2.clone().union(&ge5);
+        assert_eq!(
+            joined.refinement().unwrap().interval,
+            ge2.refinement().unwrap().interval,
+        );
+
+        // Inclusion: `x >= 5` implies `x >= 2`, not vice versa.
+        assert!(ge2.includes(&ge5));
+        assert!(!ge5.includes(&ge2));
+
+        // A known non-numeric membership is an empty meet.
+        assert!(
+            Type::from(ValueType::String)
+                .with_interval(&Value::UnsignedInt(1), true, true)
+                .is_none()
+        );
+        // A non-numeric bound refines nothing.
+        let unchanged = base
+            .clone()
+            .with_interval(&Value::String("x".into()), true, true)
+            .unwrap();
+        assert!(unchanged.refinement().is_none());
+    }
+
+    /// Differently-typed intervals cannot be compared without per-row
+    /// literal adaptation, so the lattice treats them conservatively:
+    /// the meet keeps neither (weaker is sound — enforcement lives with
+    /// the comparison premises) and inclusion says "unrelated".
+    #[dialog_common::test]
+    fn it_drops_mixed_type_intervals_conservatively() {
+        let base = Type::from(Primitive::NUMERIC);
+        let ge_int = base
+            .clone()
+            .with_interval(&Value::UnsignedInt(1), true, true)
+            .unwrap();
+        let le_float = base
+            .clone()
+            .with_interval(&Value::Float(10.5), true, false)
+            .unwrap();
+
+        let met = ge_int.clone().intersect(&le_float).expect("compatible");
+        assert!(
+            met.refinement().is_none(),
+            "mixed-type intervals drop rather than conflict: {met}"
+        );
+        assert!(!ge_int.includes(&le_float));
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -328,8 +328,8 @@ impl Display for ConceptRef {
 /// [`Refinement::meet`] and [`Refinement::join`].
 ///
 /// Three constraints exist: a lexical prefix over the TEXTUAL kinds,
-/// a conformance set over Entity, and a numeric interval proved by
-/// the comparison predicates.
+/// a conformance set over Entity, and an interval over the
+/// COMPARABLE kinds proved by the comparison predicates.
 ///
 /// Invariant: never empty (no prefix, no conformance, and no
 /// interval is no refinement; the constructors collapse it to an
@@ -348,7 +348,7 @@ pub struct Refinement {
     /// diagnostics.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub conforms: BTreeSet<ConceptRef>,
-    /// A numeric interval a comparison predicate proved about the
+    /// An interval a comparison predicate proved about the
     /// value. Carried as *information*, like `conforms`: enforcement
     /// stays with the comparison premise itself (whose literal-
     /// adaptation semantics [`Refinement::admits`] deliberately does
@@ -357,8 +357,9 @@ pub struct Refinement {
     pub interval: Option<Box<Interval>>,
 }
 
-/// A numeric interval over a single value type, proved by comparison
-/// predicates on a variable: at most one lower and one upper bound.
+/// An interval over a single COMPARABLE value type, proved by
+/// comparison predicates on a variable: at most one lower and one
+/// upper bound.
 ///
 /// Bounds are stored in the value's ORDER-PRESERVING encoding (see
 /// `dialog_artifacts::encode_value_owned`), so within one
@@ -366,11 +367,12 @@ pub struct Refinement {
 /// the struct stays `Eq`/`Ord`/`Hash` for the type lattice (a raw
 /// `Value` would not, floats being only partially ordered).
 ///
-/// The interval records the LITERAL's own type. A comparison adapts
-/// its literal to each row's type, so an interval typed `UnsignedInt`
-/// still admits floats; consumers that cannot honor that (the scan
-/// pushdown) must gate on the variable's kind being exactly one
-/// numeric type and adapt the bound, as the comparison would.
+/// The interval records the LITERAL's own type. A NUMERIC comparison
+/// adapts its literal to each row's type, so an interval typed
+/// `UnsignedInt` still admits floats; consumers that cannot honor
+/// that (the scan pushdown) must gate on the variable's kind being
+/// exactly one comparable type and adapt the bound, as the comparison
+/// would.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Interval {
     /// The numeric type the bound literals were written in.
@@ -762,28 +764,36 @@ impl Type {
         Some(Type::Refined(membership, refinement))
     }
 
-    /// Refine this type with one side of a numeric interval, as a
+    /// Refine this type with one side of an interval, as a
     /// comparison predicate proves it: `lower` selects which side,
     /// `inclusive` whether the bound itself is admitted.
     ///
-    /// The membership narrows to the NUMERIC kinds (plus a riding
+    /// The membership narrows to the COMPARABLE kinds (plus a riding
     /// `Nothing` bit); the interval records the LITERAL's own type,
-    /// because a comparison adapts its literal to each row's type —
-    /// an interval typed `UnsignedInt` still admits floats. Returns
-    /// `None` when no member could be numeric — an empty meet. A
-    /// non-numeric bound value is no constraint and returns the type
-    /// unchanged (the comparison itself will filter every row).
+    /// because a NUMERIC comparison adapts its literal to each row's
+    /// type — an interval typed `UnsignedInt` still admits floats.
+    /// (Non-numeric literals never adapt, but the interval stays
+    /// advisory either way — see the field doc.) Returns `None` when
+    /// no member could be comparable — an empty meet. A
+    /// non-comparable bound value is no constraint and returns the
+    /// type unchanged (the comparison itself will filter every row).
     pub fn with_interval(self, bound: &Value, inclusive: bool, lower: bool) -> Option<Type> {
         let value_type = bound.data_type();
-        if !matches!(
-            value_type,
-            ValueType::UnsignedInt | ValueType::SignedInt | ValueType::Float
-        ) {
+        if !Primitive::COMPARABLE.contains(value_type) {
             return Some(self);
         }
+        // A numeric literal adapts to each row's numeric type, so any
+        // numeric member may still match; a non-numeric literal never
+        // adapts, so only rows of the literal's own type can order
+        // against it and the membership narrows to exactly that type.
+        let admissible = if Primitive::NUMERIC.contains(value_type) {
+            Primitive::NUMERIC
+        } else {
+            Primitive::singleton(value_type)
+        };
         let membership = self
             .primitive_part()
-            .intersect(Primitive::NUMERIC.union(Primitive::NOTHING))?;
+            .intersect(admissible.union(Primitive::NOTHING))?;
         if membership.required().is_empty() {
             return None;
         }
@@ -974,16 +984,32 @@ mod tests {
         assert!(ge2.includes(&ge5));
         assert!(!ge5.includes(&ge2));
 
-        // A known non-numeric membership is an empty meet.
+        // A numeric bound on a known non-numeric membership is an
+        // empty meet.
         assert!(
             Type::from(ValueType::String)
                 .with_interval(&Value::UnsignedInt(1), true, true)
                 .is_none()
         );
-        // A non-numeric bound refines nothing.
-        let unchanged = base
-            .clone()
+        // A non-numeric bound never adapts, so it narrows membership
+        // to the literal's own type...
+        let narrowed = Type::from(Primitive::ALL)
             .with_interval(&Value::String("x".into()), true, true)
+            .expect("string rows remain");
+        assert_eq!(
+            narrowed.primitive_part(),
+            Primitive::from(ValueType::String)
+        );
+        assert!(narrowed.refinement().expect("refined").interval.is_some());
+        // ...and meets empty against a membership that excludes it.
+        assert!(
+            base.clone()
+                .with_interval(&Value::String("x".into()), true, true)
+                .is_none()
+        );
+        // A non-comparable bound value is no constraint at all.
+        let unchanged = base
+            .with_interval(&Value::Boolean(true), true, true)
             .unwrap();
         assert!(unchanged.refinement().is_none());
     }

--- a/rust/dialog-query/tests/formal_notation.rs
+++ b/rust/dialog-query/tests/formal_notation.rs
@@ -269,6 +269,58 @@ fn it_parses_equality_constraint_with_two_variables() {
     ));
 }
 
+// Range Constraints
+
+#[dialog_common::test]
+fn it_parses_range_constraints() {
+    for symbol in ["<", "<=", ">", ">="] {
+        let json = json!({
+            "assert": symbol,
+            "where": {
+                "of": { "?": { "name": "age" } },
+                "with": 21
+            }
+        });
+
+        let prop: Proposition = serde_json::from_value(json.clone()).unwrap();
+        let of = match (&prop, symbol) {
+            (Proposition::Constraint(Constraint::LessThan(c)), "<") => &c.of,
+            (Proposition::Constraint(Constraint::AtMost(c)), "<=") => &c.of,
+            (Proposition::Constraint(Constraint::GreaterThan(c)), ">") => &c.of,
+            (Proposition::Constraint(Constraint::AtLeast(c)), ">=") => &c.of,
+            (other, _) => panic!("Expected range constraint for {symbol}, got {other:?}"),
+        };
+        assert_eq!(of, &Term::<Any>::var("age"));
+
+        let reserialized = serde_json::to_value(&prop).unwrap();
+        assert_eq!(reserialized["assert"], symbol);
+        assert!(reserialized["where"]["of"].is_object());
+        assert_eq!(reserialized["where"]["with"], 21);
+    }
+}
+
+#[dialog_common::test]
+fn it_parses_string_range_constraint() {
+    // Datomic's `[(<= "Q" ?name)]` shape: a string bound on the
+    // constant side.
+    let json = json!({
+        "assert": "<=",
+        "where": {
+            "of": "Q",
+            "with": { "?": { "name": "name" } }
+        }
+    });
+
+    let prop: Proposition = serde_json::from_value(json).unwrap();
+    match &prop {
+        Proposition::Constraint(Constraint::AtMost(c)) => {
+            assert!(c.of.is_constant());
+            assert_eq!(c.with, Term::<Any>::var("name"));
+        }
+        other => panic!("Expected AtMost, got {:?}", other),
+    }
+}
+
 // Math Formulas
 
 #[dialog_common::test]


### PR DESCRIPTION
## What

Makes the range predicates (`<`, `<=`, `>`, `>=`) first-class, Datomic-style: they order **all comparable types** — numbers, strings, symbols, entities, bytes — and push down into value scans as index range bounds, completing the pipeline #393 opened for `text/starts-with`: predicate → inference → planner → `ArtifactSelector` range → VAE scan. Matches Datomic's range-predicate set (`=` is a constant `is` term / `Equality`; `!=` is a negated equality, which no index accelerates there either).

The four predicates were already in the wire format (`"assert": "<"` … with `of`/`with` operands); they are now documented in the formal notation spec (`notes/notation.md`) next to `==` — a Range subsection in both the JSON-schema and YAML-sugar sections — and covered by formal-notation round-trip tests, including the `[(<= "Q" ?name)]` string-bound shape.

## How

A comparison with a constant side proves an **interval refinement** on its variable side, declared in the predicate's schema and carried by the existing `Refinement` machinery:

- `Interval` / `IntervalBound` live on `Refinement` (boxed, so `Type` stays small). Bounds are stored in the order-preserving value encoding, so the lattice operations (meet = intersection, join = convex hull, inclusion) are plain byte comparisons and `Type` stays `Eq`/`Ord`/`Hash`.
- Both operand orders stamp correctly: `x >= 5` and `5 < x` each put a lower bound on `x`, preserving strictness/inclusivity. A variable-variable comparison proves nothing.
- The planner stamps the inferred kind onto the scan's value term exactly as it does for prefixes; the selector conversion turns the interval into `is_at_least` / `is_greater_than` / `is_at_most` / `is_less_than` bounds.

**Filter order = index order, by construction.** Non-numeric comparables order within one type by their order-preserving encoding — the same byte order the value index sorts by — so a pushed range and the residual filter can never disagree about a row. Mixed-type pairs stay non-matches (strict no-promotion, as in formula arithmetic), and only *numeric* literals adapt to the row's type (`1` compares against floats as `1.0`; `1.5` against integer data matches nothing).

The interval is **advisory**: enforcement stays with the comparison premise, which filters per row. The pushdown only narrows what the scan reads, gated so it can never drop a row the residual filter would keep:

1. **Single-type gate.** Bounds push only when the variable's kind admits exactly one comparable type. A numeric literal admits rows of every numeric type (adaptation), so a NUMERIC-wide kind pushes nothing until the variable is typed. A *non-numeric* literal never adapts, so it narrows the membership to the literal's own type by itself — a bare `name >= "Q"` is single-typed and index-accelerated with no annotation.
2. **Adaptation.** The bound literal adapts to the scanned type exactly as the row filter would: same-type passes through, numeric literals adapt losslessly (`30` bounding a Float column pushes `30.0`), nothing else adapts. An unadaptable bound pushes nothing — the residual comparison filters every row of that type anyway.

Differently-typed intervals meet conservatively (keep neither), and `Type::intersect` collapses an empty met refinement to the unrefined type, upholding the documented never-empty `Refinement` invariant.

## Tests

Each seam of the pipeline is pinned:

- Interval lattice: meet keeps the tighter bound, join the weaker, two-sided meets carry both sides, mixed-type intervals drop, inclusion is conservative; non-numeric bounds narrow membership to the literal's type and meet empty against disjoint memberships (`type_system.rs`).
- Schema → inference: intervals stamped through `TypeEnv::infer` in both operand orders with correct strictness, for numeric and string bounds; no interval without a constant side; a boolean side is a compile-time conflict while a text side narrows cleanly (`compare.rs`).
- Filter semantics: strings/bytes order within one type, symbols never order against string literals, mixed numerics adapt only via literals (`compare.rs`).
- Inference → plan: a typed scan variable narrows the comparison's bound to one type and the interval reaches the scan's value term (`planner/plan.rs`).
- Kind → selector: bounds push verbatim for same-type literals, adapt across numeric types, compose two-sided; the single-type and adaptation gates hold, including against hand-built wide/cross-typed kinds `with_interval` can no longer construct (`attribute/query/all.rs`).
- Selector → store: pushed inclusive bounds return exactly the right rows from a real tree for both numeric and string ranges, and a NUMERIC-wide kind over mixed `u64`/`i64`/`f64` rows returns all of them — no false negatives (`attribute/query/all.rs`).
- Wire format: round-trips for all four `assert` names and the string-bound operand order (`tests/formal_notation.rs`).

Full native suite 1846/1846 via nix, clippy `-D warnings` clean, wasm32 compiles.

## Follow-ups

- Datomic also orders booleans (and instants); our `COMPARABLE` deliberately excludes Boolean and Record, and timestamps stored as integers compare fine. Widen only if a real need appears.
- `is_between` sugar (two-sided interval in one premise) falls out of the existing meet if ever wanted.
