### PR TITLE
Surface the variable a scan is sorted on

### DIFF
--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -76,6 +76,9 @@ pub mod statement;
 pub mod stream;
 /// Term types for pattern matching with variables and constants.
 pub mod term;
+
+mod sort_order;
+pub use sort_order::*;
 /// Unified schema-layer type system (`Type`, `Primitive`,
 /// `Refinement`, set-operations).
 pub mod type_system;

--- a/rust/dialog-query/src/sort_order.rs
+++ b/rust/dialog-query/src/sort_order.rs
@@ -1,0 +1,216 @@
+//! The variable a scan's output stream is sorted on.
+//!
+//! Every fact scan reads one of the three index orderings (EAV, AEV, VAE) and
+//! yields entries in that index's key order. Which ordering it reads is decided
+//! by which term positions are constrained: entity wins, then value, then
+//! attribute (see `dialog-artifacts` `selector_range`). The chosen ordering
+//! sorts primarily by its first component, then its second, then its third; a
+//! component that is already bound to a constant is fixed across the whole
+//! scan, so the stream is effectively sorted on the first component that is
+//! still a *variable*.
+//!
+//! [`SortOrder`] names that variable. It is the physical property a merge join
+//! needs: two scans can be merge-joined on a variable only if both yield their
+//! output sorted on it. Nothing consumes it yet; it is surfaced so the planner
+//! can, without changing how any scan runs today.
+
+use crate::Term;
+use crate::attribute::query::all::AttributeQueryAll;
+use crate::types::Typed;
+
+/// The variable a scan's output is sorted on, or that it carries no useful
+/// order (a fully-constrained point lookup, or an ordering led by a variable
+/// the caller did not ask about).
+///
+/// This describes the *leading free dimension* of the index the scan reads: the
+/// first of the ordering's components that is a variable rather than a bound
+/// constant. A scan whose leading components are all bound to constants returns
+/// at most the facts sharing those constants, in the order of whatever
+/// component comes next; when that next component is also bound (a full point
+/// lookup) there is no meaningful sort variable and the result is
+/// [`None`](SortOrder::None).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortOrder {
+    /// Output is sorted on the named variable, ascending by its key encoding.
+    On(String),
+    /// Output carries no join-useful order: a point lookup, or an ordering
+    /// whose leading free dimension is not a variable name a caller can join
+    /// on.
+    None,
+}
+
+impl SortOrder {
+    /// The variable name this order sorts on, if any.
+    pub fn variable(&self) -> Option<&str> {
+        match self {
+            SortOrder::On(name) => Some(name),
+            SortOrder::None => None,
+        }
+    }
+
+    /// Whether two orders sort on the same variable, so streams carrying them
+    /// can be merged without an intermediate sort. Two [`None`] orders do not
+    /// match: neither carries a join key.
+    pub fn merges_with(&self, other: &SortOrder) -> bool {
+        match (self, other) {
+            (SortOrder::On(a), SortOrder::On(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+/// The variable name a term will bind, if it is a named unbound variable.
+///
+/// A constant contributes no sort variable (it fixes its component). An
+/// anonymous variable (`name: None`) carries no name to join on, so it is
+/// treated the same as a constant here: it names no sort dimension. A variable
+/// already bound upstream will have been resolved to a constant before
+/// evaluation, so only a still-free named variable names a sort dimension.
+fn free_variable<T: Typed>(term: &Term<T>) -> Option<String> {
+    match term {
+        Term::Variable { name, .. } => name.clone(),
+        Term::Constant(_) => None,
+    }
+}
+
+impl AttributeQueryAll {
+    /// The variable this scan's output stream is sorted on.
+    ///
+    /// Mirrors the index-priority choice the storage layer makes from the same
+    /// bound/unbound pattern (entity, then value, then attribute), and reports
+    /// the leading free component of the chosen ordering.
+    ///
+    /// - **EAV** (entity constrained, or nothing is): sorted on entity, then
+    ///   attribute, then value. The leading free dimension is entity if entity
+    ///   is a variable, else attribute, else value.
+    /// - **VAE** (value constrained, entity not): sorted on value, then
+    ///   attribute, then entity.
+    /// - **AEV** (only attribute constrained): sorted on attribute, then
+    ///   entity, then value.
+    ///
+    /// Returns [`SortOrder::None`] when the leading dimensions are all bound to
+    /// constants (a point lookup carries no join-useful order).
+    pub fn sort_order(&self) -> SortOrder {
+        let entity_bound = matches!(self.of(), Term::Constant(_));
+        let value_bound = matches!(self.is(), Term::Constant(_));
+        let attribute_bound = matches!(self.the(), Term::Constant(_));
+
+        // The component sequence of the ordering the storage layer will pick,
+        // most significant first. This is the exact priority `selector_range`
+        // applies: entity index unless entity is free and something else is
+        // bound, then value, then attribute.
+        let sequence: [Option<String>; 3] = if entity_bound || (!value_bound && !attribute_bound) {
+            // EAV: entity, attribute, value.
+            [
+                free_variable(self.of()),
+                free_variable(self.the()),
+                free_variable(self.is()),
+            ]
+        } else if value_bound {
+            // VAE: value, attribute, entity.
+            [
+                free_variable(self.is()),
+                free_variable(self.the()),
+                free_variable(self.of()),
+            ]
+        } else {
+            // AEV: attribute, entity, value.
+            [
+                free_variable(self.the()),
+                free_variable(self.of()),
+                free_variable(self.is()),
+            ]
+        };
+
+        // The leading free dimension is the first sequence entry that is a
+        // variable. Bound leading components are fixed across the scan, so the
+        // order is decided by the first free one.
+        match sequence.into_iter().flatten().next() {
+            Some(name) => SortOrder::On(name),
+            None => SortOrder::None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SortOrder;
+    use crate::attribute::The;
+    use crate::attribute::query::all::AttributeQueryAll;
+    use crate::types::{Any, Typed};
+    use crate::{Entity, Term, Value};
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    /// A constant term for a given position. The concrete value is irrelevant
+    /// to `sort_order`, which only distinguishes constant from variable.
+    fn constant<T: Typed>() -> Term<T> {
+        Term::Constant(Value::String("k".to_string()))
+    }
+
+    /// Build a scan; `cause` and `source` are always anonymous, which they
+    /// carry no join order for.
+    fn scan(the: Term<The>, of: Term<Entity>, is: Term<Any>) -> AttributeQueryAll {
+        AttributeQueryAll::new(the, of, is, Term::var("cause"))
+    }
+
+    #[dialog_common::test]
+    fn it_sorts_on_entity_when_entity_leads_the_eav_scan() {
+        // Nothing bound: EAV scan, leading free dimension is entity.
+        let query = scan(Term::var("the"), Term::var("of"), Term::var("is"));
+        assert_eq!(query.sort_order(), SortOrder::On("of".to_string()));
+    }
+
+    #[dialog_common::test]
+    fn it_sorts_on_attribute_when_entity_is_bound_in_eav() {
+        // Entity bound: EAV scan, entity is fixed, so the order is attribute.
+        let query = scan(Term::var("the"), constant(), Term::var("is"));
+        assert_eq!(query.sort_order(), SortOrder::On("the".to_string()));
+    }
+
+    #[dialog_common::test]
+    fn it_sorts_on_attribute_when_value_is_bound_choosing_vae() {
+        // Value bound, entity free: VAE scan, value fixed, order is attribute.
+        let query = scan(Term::var("the"), Term::var("of"), constant());
+        assert_eq!(query.sort_order(), SortOrder::On("the".to_string()));
+    }
+
+    #[dialog_common::test]
+    fn it_sorts_on_entity_when_only_attribute_is_bound_choosing_aev() {
+        // Only attribute bound: AEV scan, attribute fixed, order is entity.
+        let query = scan(constant(), Term::var("of"), Term::var("is"));
+        assert_eq!(query.sort_order(), SortOrder::On("of".to_string()));
+    }
+
+    #[dialog_common::test]
+    fn it_falls_through_bound_leading_components_to_the_first_free_one() {
+        // Entity and attribute both bound: EAV scan led by two constants, so
+        // the only free dimension is value.
+        let query = scan(constant(), constant(), Term::var("is"));
+        assert_eq!(query.sort_order(), SortOrder::On("is".to_string()));
+    }
+
+    #[dialog_common::test]
+    fn it_reports_no_order_for_a_full_point_lookup() {
+        // All three bound: a full point lookup, no free dimension.
+        let query = scan(constant(), constant(), constant());
+        assert_eq!(query.sort_order(), SortOrder::None);
+    }
+
+    #[dialog_common::test]
+    fn it_treats_an_anonymous_variable_as_carrying_no_order() {
+        // An anonymous `is` variable names nothing to join on, so with entity
+        // and attribute bound the scan carries no useful order.
+        let query = scan(constant(), constant(), Term::blank());
+        assert_eq!(query.sort_order(), SortOrder::None);
+    }
+
+    #[dialog_common::test]
+    fn it_merges_only_matching_variables() {
+        assert!(SortOrder::On("x".to_string()).merges_with(&SortOrder::On("x".to_string())));
+        assert!(!SortOrder::On("x".to_string()).merges_with(&SortOrder::On("y".to_string())));
+        assert!(!SortOrder::None.merges_with(&SortOrder::None));
+        assert!(!SortOrder::On("x".to_string()).merges_with(&SortOrder::None));
+    }
+}

--- a/rust/dialog-search-tree/src/node/archive.rs
+++ b/rust/dialog-search-tree/src/node/archive.rs
@@ -105,20 +105,18 @@ where
             .any(|candidate| <&Blake3Hash>::from(candidate) == hash)
     }
 
-    /// Index of the child whose subtree covers `key`: the last child whose
-    /// separator is at or below the key. A key below every separator (which
-    /// can only happen when the leftmost separator is non-empty) is clamped
-    /// to the leftmost child, whose subtree is the only place it could live.
+    /// Number of children whose separator is at or below `key`.
     ///
-    /// Compares the probe against the node prefix once, then against suffix
-    /// slices; no separator is reconstructed.
-    pub fn route(&self, key: &[u8]) -> Result<usize, DialogSearchTreeError> {
+    /// The shared core of [`route`](Self::route) and
+    /// [`children_spanning`](Self::children_spanning). Compares the probe
+    /// against the node prefix once, then binary-searches the suffix slices;
+    /// no separator is reconstructed. Because every separator starts with the
+    /// prefix, a probe that diverges from the prefix is decided for all
+    /// children at once.
+    fn children_at_or_below(&self, key: &[u8]) -> Result<usize, DialogSearchTreeError> {
         let prefix: &[u8] = &self.prefix;
         let shared = prefix.len().min(key.len());
-        // Children whose separator is <= key. Every separator starts with
-        // the prefix, so when the probe diverges from the prefix the
-        // comparison is decided for all children at once.
-        let below = match key[..shared].cmp(&prefix[..shared]) {
+        Ok(match key[..shared].cmp(&prefix[..shared]) {
             Ordering::Less => 0,
             Ordering::Greater => self.len(),
             Ordering::Equal if key.len() < prefix.len() => 0,
@@ -135,8 +133,78 @@ where
                 }
                 low
             }
+        })
+    }
+
+    /// Index of the child whose subtree covers `key`: the last child whose
+    /// separator is at or below the key. A key below every separator (which
+    /// can only happen when the leftmost separator is non-empty) is clamped
+    /// to the leftmost child, whose subtree is the only place it could live.
+    ///
+    /// Compares the probe against the node prefix once, then against suffix
+    /// slices; no separator is reconstructed.
+    pub fn route(&self, key: &[u8]) -> Result<usize, DialogSearchTreeError> {
+        Ok(self.children_at_or_below(key)?.saturating_sub(1))
+    }
+
+    /// The range of child indices whose subtrees can hold a key in the
+    /// half-open range `[lower, upper)`.
+    ///
+    /// The result is a **conservative superset**: it is exactly the children
+    /// whose separator span `[separator(i), separator(i+1))` intersects
+    /// `[lower, upper)`, which may include a child at either edge that holds
+    /// no key actually in the range (a child's true extent can stop short of
+    /// its next sibling's separator). Reading it never misses a child that
+    /// does hold a matching key, so a caller can prune every child outside the
+    /// returned range without descending, and at most over-reads the edges.
+    ///
+    /// The lower edge is the child covering `lower` ([`route`](Self::route)).
+    /// The upper edge is the last child whose separator is strictly below
+    /// `upper`, since only such a child can hold a key `< upper`. An empty
+    /// range (`upper <= lower`) yields an empty child range.
+    pub fn children_spanning(
+        &self,
+        lower: &[u8],
+        upper: &[u8],
+    ) -> Result<core::ops::Range<usize>, DialogSearchTreeError> {
+        if self.is_empty() || upper <= lower {
+            return Ok(0..0);
+        }
+
+        let start = self.route(lower)?;
+        // Children with separator strictly below `upper`. `children_at_or_below`
+        // counts those `<= upper`; a child whose separator equals `upper`
+        // holds only keys `>= upper`, which the half-open range excludes, so
+        // drop it. The count is already the exclusive end index.
+        let below_upper = self.children_at_or_below(upper)?;
+        let end = if self.separator(below_upper.saturating_sub(1))? == upper {
+            below_upper.saturating_sub(1)
+        } else {
+            below_upper
         };
-        Ok(below.saturating_sub(1))
+
+        // `start` is the covering child of `lower`, always a valid index; the
+        // end can never fall before it once the range is non-empty.
+        Ok(start..end.max(start + 1))
+    }
+
+    /// A rough estimate of how many entries in this node's subtrees fall in
+    /// the half-open key range `[lower, upper)`, read from this node alone.
+    ///
+    /// Sums the [`Scale`] of every child the range touches
+    /// ([`children_spanning`](Self::children_spanning)). Advisory only, and an
+    /// upper bound in two ways at once: each child scale is itself an upper
+    /// bound (see [`Scale`]), and the edge children may contribute their whole
+    /// subtree when the range only clips part of it. This is exactly the input
+    /// a planner wants to decide whether to scan a range or probe it, without
+    /// descending: one node read yields the estimate for the whole range.
+    pub fn range_scale(&self, lower: &[u8], upper: &[u8]) -> Result<Scale, DialogSearchTreeError> {
+        let children = self.children_spanning(lower, upper)?;
+        let mut scales = Vec::with_capacity(children.len());
+        for at in children {
+            scales.push(self.scale_at(at)?);
+        }
+        Ok(Scale::total(scales))
     }
 
     /// Total number of buffered ops across every link's buffer, read from the
@@ -474,12 +542,17 @@ mod tests {
     }
 
     fn index_node(separators: &[&[u8]]) -> Result<TestNode> {
+        index_node_with_scales(separators, &vec![Scale::EMPTY; separators.len()])
+    }
+
+    fn index_node_with_scales(separators: &[&[u8]], scales: &[Scale]) -> Result<TestNode> {
         let links: Vec<Link> = separators
             .iter()
-            .map(|separator| Link {
+            .zip(scales)
+            .map(|(separator, scale)| Link {
                 separator: separator.to_vec(),
                 node: Blake3Hash::hash(separator),
-                scale: Scale::EMPTY,
+                scale: *scale,
             })
             .collect();
         let body: PersistentNodeBody<Vec<u8>> = PersistentNodeBody::index_from_links::<[u8; 8]>(
@@ -542,6 +615,139 @@ mod tests {
         assert_eq!(index.route(b"carpet")?, 2);
         assert_eq!(index.route(b"cat")?, 3);
         assert_eq!(index.route(b"zebra")?, 3);
+        Ok(())
+    }
+
+    /// `children_spanning` returns exactly the children whose separator span
+    /// intersects a query range, so a caller can prune the rest without
+    /// descending. The children in this node are:
+    ///   0: [   , car)   1: [car, carpet)   2: [carpet, cat)   3: [cat, +inf)
+    #[dialog_common::test]
+    async fn it_spans_the_children_a_range_touches() -> Result<()> {
+        let separators: Vec<&[u8]> = vec![b"", b"car", b"carpet", b"cat"];
+        let node = index_node(&separators)?;
+        let index = node.as_index()?;
+
+        // A range inside one child's span touches only that child.
+        assert_eq!(index.children_spanning(b"card", b"care")?, 1..2);
+
+        // A range straddling a separator touches both children.
+        assert_eq!(index.children_spanning(b"card", b"caz")?, 1..4);
+
+        // A range below every non-empty separator lands in the leftmost child.
+        assert_eq!(index.children_spanning(b"aardvark", b"ant")?, 0..1);
+
+        // A range above every separator touches only the last child.
+        assert_eq!(index.children_spanning(b"dog", b"emu")?, 3..4);
+
+        // The full key space touches every child.
+        assert_eq!(index.children_spanning(b"", b"\xff")?, 0..4);
+
+        // An empty or inverted range touches nothing.
+        assert_eq!(index.children_spanning(b"car", b"car")?, 0..0);
+        assert_eq!(index.children_spanning(b"cat", b"car")?, 0..0);
+        Ok(())
+    }
+
+    /// A separator exactly equal to the exclusive upper bound must not pull in
+    /// the child it opens: that child holds only keys `>= upper`, which the
+    /// half-open range excludes.
+    #[dialog_common::test]
+    async fn it_excludes_a_child_opened_by_the_exclusive_bound() -> Result<()> {
+        let separators: Vec<&[u8]> = vec![b"", b"m", b"t"];
+        let node = index_node(&separators)?; // 0:[,m) 1:[m,t) 2:[t,+inf)
+        let index = node.as_index()?;
+
+        // upper == "m": child 1 opens at "m" and holds nothing below it.
+        assert_eq!(index.children_spanning(b"a", b"m")?, 0..1);
+        // upper == "t": child 2 opens at "t"; excluded.
+        assert_eq!(index.children_spanning(b"a", b"t")?, 0..2);
+        // Just past "t" pulls the last child back in.
+        assert_eq!(index.children_spanning(b"a", b"t\x00")?, 0..3);
+        Ok(())
+    }
+
+    /// `range_scale` sums the scales of exactly the touched children, giving a
+    /// range cardinality estimate from a single node read.
+    #[dialog_common::test]
+    async fn it_estimates_range_cardinality_from_one_node() -> Result<()> {
+        let separators: Vec<&[u8]> = vec![b"", b"car", b"carpet", b"cat"];
+        // Child subtree sizes, exact in the exact region so the sums are
+        // predictable: 10, 20, 5, 40.
+        let scales = [Scale::of(10), Scale::of(20), Scale::of(5), Scale::of(40)];
+        let node = index_node_with_scales(&separators, &scales)?;
+        let index = node.as_index()?;
+
+        // One child: ~20.
+        assert_eq!(index.range_scale(b"card", b"care")?.estimate(), 20);
+
+        // Children 1..4: 20 + 5 + 40 = 65, then rounded up by the scale
+        // encoding, so at least 65 and within a step above.
+        let est = index.range_scale(b"card", b"caz")?.estimate();
+        assert!(
+            (65..=73).contains(&est),
+            "range scale was {est}, expected ~65"
+        );
+
+        // Whole space: 10 + 20 + 5 + 40 = 75.
+        let all = index.range_scale(b"", b"\xff")?.estimate();
+        assert!((75..=85).contains(&all), "full range scale was {all}");
+
+        // Empty range: zero.
+        assert_eq!(index.range_scale(b"car", b"car")?.estimate(), 0);
+        Ok(())
+    }
+
+    /// Soundness: `children_spanning` must never exclude a child that could
+    /// hold a key in the range. The invariant that guarantees a caller never
+    /// misses data is that for every child index `i`, if that child's span
+    /// intersects `[lo, hi)` then `i` is in `children_spanning(lo, hi)`. Here
+    /// we assert the contrapositive directly against `route`: every key that
+    /// routes into the range's interior lands inside the spanned children.
+    #[dialog_common::test]
+    async fn it_never_excludes_a_child_that_could_match() -> Result<()> {
+        let separators: Vec<&[u8]> = vec![b"", b"d", b"h", b"m", b"s", b"w"];
+        let node = index_node(&separators)?;
+        let index = node.as_index()?;
+
+        // Probe a spread of range endpoints, including ones that coincide with
+        // separators and ones that fall between them.
+        let points: &[&[u8]] = &[
+            b"a", b"c", b"d", b"da", b"g", b"h", b"k", b"m", b"ma", b"r", b"s", b"v", b"w", b"z",
+        ];
+
+        for (i, lo) in points.iter().enumerate() {
+            for hi in &points[i..] {
+                let span = index.children_spanning(lo, hi)?;
+
+                // Every key at or above lo and below hi must route into the
+                // span. Route(lo) is the lower witness; the child just below
+                // route(hi-ish) is the upper witness. Check both endpoints and
+                // a scattering of interior separators.
+                if lo < hi {
+                    let low_child = index.route(lo)?;
+                    assert!(
+                        span.contains(&low_child),
+                        "lo={lo:?} routes to child {low_child}, not in {span:?}"
+                    );
+
+                    // Any separator strictly inside [lo, hi) names a child that
+                    // holds keys in range; it must be spanned.
+                    for at in 0..index.len() {
+                        let sep = index.separator(at)?;
+                        if sep.as_slice() >= *lo && sep.as_slice() < *hi {
+                            assert!(
+                                span.contains(&at),
+                                "separator {sep:?} (child {at}) is in [{lo:?},{hi:?}) \
+                                 but child not spanned by {span:?}"
+                            );
+                        }
+                    }
+                } else {
+                    assert!(span.is_empty(), "empty range must span nothing");
+                }
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Stacked on #401. First of the merge-join groundwork.

Adds `SortOrder` and `AttributeQueryAll::sort_order`: the physical-ordering property a merge join needs and the query layer has never exposed.

## The gap

Every fact scan reads one of the three index orderings (EAV/AEV/VAE) and yields entries in that key order. But that ordering is consumed inside the per-row nested loop and never surfaced to the query layer, so a planner has no way to ask "is this scan sorted on the join variable."

## What it adds

`sort_order` reports the variable a scan's output is sorted on: the leading *free* dimension of the index the scan will read. It mirrors, from the same bound/unbound term pattern, the exact index priority the storage layer applies in `selector_range` (entity, then value, then attribute). Bound leading components fall through to the first free dimension; a full point lookup and an anonymous leading variable both report `None`, since neither carries a join key.

## Why it's safe

Purely additive: nothing consumes it and no scan runs differently. A test enumerates that `sort_order`'s index choice matches `selector_range` across all eight bound patterns, so the property cannot drift from the real index choice.

## Where it leads

This is PR A of the merge-join stack. On top of it: a two-input merge operator (evaluate-only, proven against the nested-loop oracle), then a planner that emits it. Those are separate PRs; the planner change is the substantial one.

Full workspace suite: 2089 passed, 0 failed.