### PR TITLE
Reserve the rule namespace: db.rule/* -> dialog.rule/*, privileged write only

### DIFF
--- a/notes/layered-rule-resolution.md
+++ b/notes/layered-rule-resolution.md
@@ -10,7 +10,7 @@ the same way. This note records how that works and why.
 Each layer in the stack is a query source:
 
 - **Durable layer** — one per branch in scope. Facts come from the
-  branch's committed tree; rules come from `db.rule/*` facts on that
+  branch's committed tree; rules come from `dialog.rule/*` facts on that
   tree.
 - **Transient layer** — the per-query `Changes` overlay (`.with(...)`
   and a transaction's pending writes). Facts and rules both come from
@@ -22,13 +22,13 @@ the branches + overlay and implements `Provider<Select>` (facts) and
 single-branch `QueryEnv`, so committed and mid-transaction reads share
 one implementation and cannot diverge.
 
-## Rule storage (`db.rule/*`)
+## Rule storage (`dialog.rule/*`)
 
 A deductive rule is stored as two facts (see `rules.rs`):
 
-- `db.rule/conclusion` `of` rule-entity `is` concept-entity — the index;
-  "which rules conclude concept X".
-- `db.rule/source` `of` rule-entity `is` the rule body as canonical
+- `dialog.rule/conclusion` `of` rule-entity `is` concept-entity — the
+  index; "which rules conclude concept X".
+- `dialog.rule/source` `of` rule-entity `is` the rule body as canonical
   dag-cbor `DeductiveRuleDescriptor` (a `Value::Bytes`), hydrated with
   `DeductiveRule::decode`.
 
@@ -40,8 +40,14 @@ manual key sorting. (Stored as `Value::Bytes` rather than
 `Value::Record`: Record isn't yet supported end-to-end through the
 index; the bytes are opaque to the query layer either way.)
 
-These attribute names are a dialog-repository convention, like
-`dialog.session/*` and `dialog.meta/*`.
+These names live under the **reserved** `dialog.` namespace, the same
+prefix version-control lineage uses (`dialog.db/revision`). The write
+gate in `dialog_artifacts::tree::write_instructions` refuses any
+Assert/Replace/Retract whose attribute starts with `dialog.` on the
+public instruction path, so an app cannot forge a rule by hand-asserting
+`dialog.rule/*` — the way it could under the old, unreserved `db.rule/*`
+names. Rules therefore have a **privileged write path** (see *Writes*
+below), exactly like revision records.
 
 ## Resolution
 
@@ -51,7 +57,7 @@ These attribute names are a dialog-repository convention, like
    It reads the concept's attributes directly; it is not stored and has
    no content identity.
 2. For each branch, gather its **durable** rules: look up
-   `db.rule/conclusion = concept` against the tree, hydrate each body.
+   `dialog.rule/conclusion = concept` against the tree, hydrate each body.
 3. Gather **transient** rules from the overlay `Changes`.
 4. Install the durable + transient rules onto the implicit one and
    return the `ConceptRules`.
@@ -110,10 +116,31 @@ caller's names. Proven by `it_plans_independently_of_caller_variable_names`.
 
 ## Writes
 
-`tx.assert(rule)`, `tx.retract(rule)`, and `.with(rule)` all go through
-the existing `Statement` impl that writes/removes the `db.rule/*` facts.
-There is no separate rule-write path: the layer holding the facts
-(committed → durable, overlay → transient) surfaces them via resolution.
+Because `dialog.rule/*` is reserved, there are now two distinct write
+surfaces, split by whether the rule is *committed* or merely *overlaid*:
+
+- **Durable install (privileged).** `tx.install_rule(rule)` /
+  `tx.remove_rule(rule)` stage the rule on the transaction's rule rail,
+  separate from its `Changes`. At commit the facts enter the tree through
+  `BufferedBatch::install` / `uninstall` — the same privileged rail
+  revision records ride via `BufferedBatch::record` — so they bypass the
+  reserved-namespace gate that guards the public instruction stream. An
+  install writes all three (EAV/AEV/VAE) index orderings and marks the
+  batch changed (so a commit whose only writes are rule installs still
+  mints a revision); a remove erases those keys. Removal is an outright
+  key erase rather than a version-control retraction: rule entities are
+  content-addressed and reinstalled idempotently, so there is no
+  cross-replica merge contest to preserve a coverage record for.
+
+- **Transient overlay (unprivileged, never committed).** `.with(rule)`
+  and rule facts staged into a transaction's `Changes` surface as
+  transient-layer rules for that one query. They never reach the tree, so
+  the gate never applies; the overlay is a per-query read surface only.
+
+There is deliberately no public `assert(the!("dialog.rule/..."))` path: a
+committed rule can only come through the privileged install rail, which
+is what closes the spoofing gap the old unreserved `db.rule/*` names
+left open.
 
 ## Tests
 

--- a/rust/dialog-artifacts/src/buffered.rs
+++ b/rust/dialog-artifacts/src/buffered.rs
@@ -42,8 +42,10 @@ use futures_util::Stream;
 use std::ops::RangeInclusive;
 
 use crate::history::Version;
-use crate::tree::{ArtifactTree, TreeStorageBridge, write_instructions};
-use crate::{Datum, DialogArtifactsError, Instruction, Key, State};
+use crate::tree::{
+    ArtifactTree, TreeStorageBridge, privileged_entries, privileged_keys, write_instructions,
+};
+use crate::{Artifact, Datum, DialogArtifactsError, Instruction, Key, State};
 
 /// The buffered counterpart of [`ArtifactTree`].
 ///
@@ -340,6 +342,70 @@ impl BufferedBatch {
         let storage = ContentAddressedStorage::new(TreeStorageBridge(store.clone()));
         for (key, value) in entries {
             self.tree = self.tree.write(key, value, &storage).await?;
+        }
+        Ok(self)
+    }
+
+    /// Installs privileged facts (deductive rules — see
+    /// [`privileged_entries`](crate::tree::privileged_entries)) into the open
+    /// buffered tree, spilling any large value block into `store` first.
+    ///
+    /// This is the sanctioned rule-write rail. Rules live under the reserved
+    /// `dialog.rule/*` namespace, which the public instruction path refuses;
+    /// routing them through this surface — the same one revision records use —
+    /// is what lets an app install a rule without being able to forge one
+    /// through an ordinary `assert`. The facts get all three index orderings so
+    /// the `conclusion` (by value) and `source` (by entity) scans both find
+    /// them, and marks the batch changed so a commit whose only writes are rule
+    /// installs still mints a revision.
+    #[tracing::instrument(skip_all, name = "install_rules")]
+    pub async fn install<S>(
+        mut self,
+        store: &mut S,
+        rules: &[Artifact],
+    ) -> Result<Self, DialogArtifactsError>
+    where
+        S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync,
+    {
+        let storage = ContentAddressedStorage::new(TreeStorageBridge(store.clone()));
+        for artifact in rules {
+            let entries = privileged_entries(store, artifact, &self.manifest).await?;
+            for (key, value) in entries {
+                self.tree = self.tree.write(key, value, &storage).await?;
+                self.changed = true;
+            }
+        }
+        Ok(self)
+    }
+
+    /// Removes privileged facts installed by [`install`](Self::install),
+    /// erasing every index key of each fact from the open buffered tree.
+    ///
+    /// A removal that erased nothing (the rule was never installed) leaves the
+    /// tree untouched and does not mark the batch changed, so a commit whose
+    /// only instruction is such a removal stays a no-op — the same shape a
+    /// retract of an absent fact takes on the public path.
+    #[tracing::instrument(skip_all, name = "uninstall_rules")]
+    pub async fn uninstall<S>(
+        mut self,
+        store: &S,
+        rules: &[Artifact],
+    ) -> Result<Self, DialogArtifactsError>
+    where
+        S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync,
+    {
+        let storage = ContentAddressedStorage::new(TreeStorageBridge(store.clone()));
+        for artifact in rules {
+            for key in privileged_keys(artifact, &self.manifest) {
+                if self.tree.read(&key, &storage).await?.is_some() {
+                    self.tree = self.tree.erase(&key, &storage).await?;
+                    self.changed = true;
+                }
+            }
         }
         Ok(self)
     }

--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -153,6 +153,52 @@ where
     Ok(())
 }
 
+/// Builds the tree entries that assert `artifact` as a *privileged* fact,
+/// spilling a large value into `store` first.
+///
+/// This is the privileged counterpart of the assert branch in
+/// [`write_instructions`]: it produces the three (EAV / AEV / VAE) index keys
+/// for the fact so it is discoverable by every scan shape, and persists a
+/// spilling value's block just as the ordinary path does. What it does NOT do
+/// is ride the instruction stream, so the fact is exempt from the reserved
+/// `dialog.` namespace gate that guards user writes.
+///
+/// It exists so a caller holding privileged data (rules installed through a
+/// sanctioned API) can write facts under the reserved `dialog.rule/*`
+/// namespace, which the public write path refuses. Unlike a revision record,
+/// which only needs the EAV and AEV orderings, a rule is looked up by value
+/// (its `conclusion` index) as well, so all three orderings are written.
+pub async fn privileged_entries<S>(
+    store: &mut S,
+    artifact: &Artifact,
+    manifest: &Manifest,
+) -> Result<Vec<(Key, State<Datum>)>, DialogArtifactsError>
+where
+    S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>,
+{
+    store_spilled_value(store, artifact, manifest).await?;
+    let (eav, aev, vae) = artifact_index_keys(artifact, manifest);
+    let added = State::Added(Datum::for_artifact(artifact));
+    Ok(vec![
+        (eav, added.clone()),
+        (aev, added.clone()),
+        (vae, added),
+    ])
+}
+
+/// The three (EAV / AEV / VAE) index keys of `artifact`, to erase a
+/// privileged fact written by [`privileged_entries`].
+///
+/// Removal of a privileged fact is an outright erase of its keys rather than a
+/// version-control retraction: rule facts are content-addressed (the rule
+/// entity is the hash of its body) and reinstalled idempotently, so there is no
+/// cross-replica merge contest to preserve a coverage record for. The spilled
+/// value block, being content-addressed and shared, is left in place.
+pub fn privileged_keys(artifact: &Artifact, manifest: &Manifest) -> Vec<Key> {
+    let (eav, aev, vae) = artifact_index_keys(artifact, manifest);
+    vec![eav, aev, vae]
+}
+
 /// A byte-bounded cache of spilled value blocks, keyed by their 32-byte
 /// content reference.
 ///

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -124,7 +124,7 @@ impl DeductiveRule {
     /// directly from raw [`AttributeQuery`] premises encode to nothing,
     /// because `Proposition`'s formal-notation `Serialize` rejects
     /// attribute propositions. Only rules with concept/formula bodies
-    /// (what `rule!:` notation and stored `db.rule/*` rules produce)
+    /// (what `rule!:` notation and stored `dialog.rule/*` rules produce)
     /// have a canonical encoding.
     ///
     /// dag-cbor canonicalizes map keys per the spec, so the encoding is

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -111,7 +111,7 @@ pub struct Branch {
     spill_cache: SpillCache,
     /// Shared deductive-rule cache (discovery by head + hydrated bodies).
     /// Like `node_cache`, created once per opened branch and carried into
-    /// every query's durable rule resolution, so the `db.rule/*` scan is
+    /// every query's durable rule resolution, so the `dialog.rule/*` scan is
     /// paid once per (concept, head) rather than per query.
     rule_cache: SharedRuleCache,
     /// Transient session overlay: ephemeral facts folded into every

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -1,3 +1,4 @@
+use crate::rules::rule_facts;
 use crate::{
     Branch, CommitError, EMPTY_TREE_HASH, Index, NetworkedIndex, PublishError, RemoteSite,
     RepositoryArchiveExt as _, RepositoryMemoryExt, Revision, TreeReference,
@@ -11,8 +12,24 @@ use dialog_effects::archive::prelude::CatalogExt as _;
 use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify, OperatorExt};
 use dialog_effects::memory::{Publish, Resolve};
+use dialog_query::DeductiveRule;
 use dialog_search_tree::Delta;
 use futures_util::Stream;
+
+/// A privileged deductive-rule write staged on a [`Commit`].
+///
+/// Rules live under the reserved `dialog.rule/*` namespace, which the public
+/// instruction path refuses. A `RuleWrite` carries a rule to the commit's
+/// privileged rail — the same one revision records ride — so an app installs
+/// or removes a rule without being able to forge one through an ordinary
+/// assert.
+#[derive(Debug, Clone)]
+pub enum RuleWrite {
+    /// Install the rule: write its `dialog.rule/*` facts.
+    Install(DeductiveRule),
+    /// Remove the rule: erase its `dialog.rule/*` facts.
+    Remove(DeductiveRule),
+}
 
 /// Command that commits a stream of changes (assert/retract) to a branch.
 ///
@@ -22,6 +39,7 @@ pub struct Commit<'a, Changes> {
     changes: Changes,
     allow_empty: bool,
     canonicalize: bool,
+    rules: Vec<RuleWrite>,
 }
 
 impl<'a, Changes> Commit<'a, Changes> {
@@ -31,7 +49,21 @@ impl<'a, Changes> Commit<'a, Changes> {
             changes,
             allow_empty: false,
             canonicalize: false,
+            rules: Vec::new(),
         }
+    }
+
+    /// Stage privileged rule writes to travel with this commit.
+    ///
+    /// Called by [`Transaction::commit`](crate::Transaction::commit) to carry
+    /// rules staged via `install_rule` / `remove_rule` onto the commit's
+    /// privileged rail. They land in the tree through
+    /// [`BufferedBatch::install`](dialog_artifacts::BufferedBatch::install) /
+    /// [`uninstall`](dialog_artifacts::BufferedBatch::uninstall), never the
+    /// gated instruction stream.
+    pub fn with_rules(mut self, rules: Vec<RuleWrite>) -> Self {
+        self.rules = rules;
+        self
     }
 
     /// Flush the write buffers to the leaves before publishing, so the
@@ -120,6 +152,7 @@ where
     {
         let branch = self.branch;
         let changes = self.changes;
+        let rules = self.rules;
         // Checkpoint the head: capture the version we build this commit on top
         // of, so the publish below CAS's against it. A concurrent commit or
         // pull that advances the head while we apply changes then makes this
@@ -199,6 +232,27 @@ where
         let batch =
             dialog_artifacts::BufferedBatch::apply(&tree, &mut store, Some(version), changes)
                 .await?;
+
+        // Privileged rule writes ride the same buffered batch as the data, but
+        // enter through the install/uninstall rail rather than the instruction
+        // stream, so the reserved `dialog.` gate that refuses a hand-asserted
+        // `dialog.rule/*` fact never sees them. `install` spills a large rule
+        // body and writes all three index orderings; `uninstall` erases them.
+        // Both flip the batch's `changed` flag when they touch the tree, so a
+        // commit whose only writes are rule installs still mints a revision.
+        let mut batch = batch;
+        for rule in &rules {
+            batch = match rule {
+                RuleWrite::Install(rule) => {
+                    let facts = rule_facts(rule);
+                    batch.install(&mut store, &facts).await?
+                }
+                RuleWrite::Remove(rule) => {
+                    let facts = rule_facts(rule);
+                    batch.uninstall(&store, &facts).await?
+                }
+            };
+        }
         let changed = batch.changed();
 
         // A batch that left the indexes untouched (e.g. a transaction
@@ -722,6 +776,50 @@ mod history_tests {
                 ),
                 "writes to the reserved namespace must be refused: {result:?}"
             );
+        }
+
+        Ok(())
+    }
+
+    /// The rule namespace `dialog.rule/*` is reserved just like the rest of
+    /// `dialog.`: an app cannot forge a deductive rule by hand-asserting its
+    /// facts through the public write path. Only the privileged install rail
+    /// (`Transaction::install_rule`) may write them. This is the spoofing gap
+    /// the rename from the unreserved `db.rule/*` closed.
+    #[dialog_common::test]
+    async fn it_rejects_public_writes_to_the_reserved_rule_namespace() -> Result<()> {
+        use dialog_artifacts::DialogArtifactsError;
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        for attribute in ["dialog.rule/conclusion", "dialog.rule/source"] {
+            let forged = Artifact {
+                the: attribute.parse()?,
+                of: "forged:rule".parse()?,
+                is: Value::String("lies".to_string()),
+                cause: None,
+            };
+            for instruction in [
+                Instruction::Assert(forged.clone()),
+                Instruction::Replace(forged.clone()),
+                Instruction::Retract(forged.clone()),
+            ] {
+                let result = branch
+                    .commit(stream::iter(vec![instruction]))
+                    .perform(&operator)
+                    .await;
+                assert!(
+                    matches!(
+                        result,
+                        Err(crate::CommitError::Artifact(
+                            DialogArtifactsError::ReservedAttribute(_)
+                        ))
+                    ),
+                    "a public write to {attribute} must be refused: {result:?}"
+                );
+            }
         }
 
         Ok(())

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -437,7 +437,7 @@ where
         + ConditionalSync
         + 'static,
 {
-    /// Read a `db.rule/*` selector against a single branch's committed
+    /// Read a `dialog.rule/*` selector against a single branch's committed
     /// tree only (NOT the overlay) and collect the matching artifacts.
     /// The durable layer's reads must be tree-only so the head-keyed
     /// discovery cache stays correct — overlay rules are handled
@@ -461,7 +461,7 @@ where
     }
 
     /// The durable rules concluding `concept` on `branch`: the committed
-    /// `db.rule/*` rules, read from the tree and cached by branch head
+    /// `dialog.rule/*` rules, read from the tree and cached by branch head
     /// (re-scanned only when the head moves), with hydrated bodies
     /// cached by content-addressed rule entity.
     async fn durable_rules(
@@ -492,7 +492,7 @@ where
         };
 
         // Hydration: reuse cached bodies (content-addressed, never stale),
-        // fetch + compile the rest from each rule's `db.rule/source`.
+        // fetch + compile the rest from each rule's `dialog.rule/source`.
         let mut rules = Vec::with_capacity(rule_entities.len());
         for rule_entity in rule_entities {
             if let Some(body) = cache.body(&rule_entity) {
@@ -527,8 +527,8 @@ where
         + 'static,
 {
     /// Resolve a concept's deductive rules by unioning across layers:
-    /// each branch is a durable layer (committed `db.rule/*`, head-cached),
-    /// the overlay is a transient layer (uncommitted `db.rule/*`, fresh).
+    /// each branch is a durable layer (committed `dialog.rule/*`, head-cached),
+    /// the overlay is a transient layer (uncommitted `dialog.rule/*`, fresh).
     /// The implicit per-descriptor rule is assembled once on top.
     ///
     /// The resolved rule set is checked against the program analysis
@@ -720,19 +720,25 @@ mod rule_tests {
         d.compile().expect("rule compiles")
     }
 
-    /// The `db.rule/*` facts that store `rule`: a `conclusion` index
-    /// pointing at the concept it concludes, and the `source` body.
-    /// Asserting these makes the durable/transient layer resolve it.
+    /// The `dialog.rule/*` facts that store `rule`, as query-overlay
+    /// statements: a `conclusion` index pointing at the concept it concludes,
+    /// and the `source` body. Staging these with `.query().with(..)` makes the
+    /// transient layer resolve the rule for that one query.
+    ///
+    /// This is the OVERLAY path only. A durable install goes through
+    /// `Transaction::install_rule`, because `dialog.rule/*` is a reserved
+    /// namespace the public commit path refuses — these statements would be
+    /// rejected if committed rather than kept in the per-query overlay.
     fn rule_statements(
         rule: &DeductiveRule,
     ) -> (impl Statement + 'static, impl Statement + 'static) {
         let rule_entity = rule.this();
         let conclusion = rule.conclusion().this();
         (
-            the!("db.rule/conclusion")
+            the!("dialog.rule/conclusion")
                 .of(rule_entity.clone())
                 .is(conclusion),
-            the!("db.rule/source").of(rule_entity).is(rule.encode()),
+            the!("dialog.rule/source").of(rule_entity).is(rule.encode()),
         )
     }
 
@@ -773,7 +779,6 @@ mod rule_tests {
         let branch = repo.branch("main").open().perform(&operator).await?;
 
         let alice: Entity = "id:alice".parse()?;
-        let (conc, src) = rule_statements(&employee_from_person());
         branch
             .transaction()
             .assert(
@@ -781,8 +786,7 @@ mod rule_tests {
                     .of(alice.clone())
                     .is("Alice".to_string()),
             )
-            .assert(conc)
-            .assert(src)
+            .install_rule(&employee_from_person())
             .commit()
             .perform(&operator)
             .await?;
@@ -791,6 +795,64 @@ mod rule_tests {
 
         let employees = query_employees(&branch, &operator).await?;
         assert!(employees.contains(&alice), "committed rule must resolve");
+        Ok(())
+    }
+
+    // ----- round-trip: privileged install is discoverable + hydrates --
+    // A rule installed through the privileged rail lands in the tree as
+    // the same `dialog.rule/*` facts the discovery scan reads: the
+    // `conclusion` index finds the rule entity by concept, and its
+    // `source` body hydrates back into the compiled rule. This proves
+    // the privileged write produces exactly the shape the reader expects,
+    // not merely that a query happens to resolve.
+
+    #[dialog_common::test]
+    async fn it_round_trips_a_privileged_rule_install() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let rule = employee_from_person();
+        branch
+            .transaction()
+            .install_rule(&rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        // The `dialog.rule/conclusion` scan finds the rule entity by the
+        // concept it concludes.
+        let concept = rule.conclusion().this();
+        let conclusion_claims: Vec<Artifact> = branch
+            .claims()
+            .select(conclusion_selector(&concept))
+            .perform(&operator)
+            .await?
+            .try_collect()
+            .await?;
+        let entities = rule_entities(conclusion_claims);
+        assert_eq!(
+            entities,
+            vec![rule.this()],
+            "the conclusion index discovers the installed rule entity"
+        );
+
+        // Its `dialog.rule/source` body hydrates back into the rule.
+        let source_claims: Vec<Artifact> = branch
+            .claims()
+            .select(source_selector(&rule.this()))
+            .perform(&operator)
+            .await?
+            .try_collect()
+            .await?;
+        let bytes = source_bytes(source_claims).expect("the source body is present");
+        let hydrated = hydrate(&bytes).expect("the source body hydrates");
+        assert_eq!(
+            hydrated.this(),
+            rule.this(),
+            "the hydrated body is the installed rule"
+        );
         Ok(())
     }
 
@@ -982,11 +1044,9 @@ mod rule_tests {
         assert!(query_employees(&branch, &operator).await?.is_empty());
 
         // Commit the rule on the SAME handle → its head advances.
-        let (conc, src) = rule_statements(&employee_from_person());
         branch
             .transaction()
-            .assert(conc)
-            .assert(src)
+            .install_rule(&employee_from_person())
             .commit()
             .perform(&operator)
             .await?;
@@ -1020,8 +1080,6 @@ mod rule_tests {
             "distinct bodies ⇒ distinct identities"
         );
 
-        let (c1, s1) = rule_statements(&r1);
-        let (c2, s2) = rule_statements(&r2);
         branch
             .transaction()
             .assert(
@@ -1034,10 +1092,8 @@ mod rule_tests {
                     .of(bob.clone())
                     .is("Bob".to_string()),
             )
-            .assert(c1)
-            .assert(s1)
-            .assert(c2)
-            .assert(s2)
+            .install_rule(&r1)
+            .install_rule(&r2)
             .commit()
             .perform(&operator)
             .await?;
@@ -1068,7 +1124,6 @@ mod rule_tests {
         let bob: Entity = "id:bob".parse()?;
         // Commit rule #1 (person) + a person fact + a contractor fact.
         let r1 = rule_with_person_attr("org/person-name");
-        let (c1, s1) = rule_statements(&r1);
         branch
             .transaction()
             .assert(
@@ -1081,8 +1136,7 @@ mod rule_tests {
                     .of(bob.clone())
                     .is("Bob".to_string()),
             )
-            .assert(c1)
-            .assert(s1)
+            .install_rule(&r1)
             .commit()
             .perform(&operator)
             .await?;
@@ -1144,14 +1198,12 @@ mod rule_tests {
         assert!(query_employees(&handle_a, &operator).await?.is_empty());
 
         // Handle B (independent handle) commits the rule → branch head -> H1.
-        let (conc, src) = rule_statements(&employee_from_person());
         repo.branch("main")
             .open()
             .perform(&operator)
             .await?
             .transaction()
-            .assert(conc)
-            .assert(src)
+            .install_rule(&employee_from_person())
             .commit()
             .perform(&operator)
             .await?;
@@ -1184,7 +1236,6 @@ mod rule_tests {
         // `main` holds a person + the person rule.
         let alice: Entity = "id:alice".parse()?;
         let r_person = rule_with_person_attr("org/person-name");
-        let (cp, sp) = rule_statements(&r_person);
         repo.branch("main")
             .open()
             .perform(&operator)
@@ -1195,8 +1246,7 @@ mod rule_tests {
                     .of(alice.clone())
                     .is("Alice".to_string()),
             )
-            .assert(cp)
-            .assert(sp)
+            .install_rule(&r_person)
             .commit()
             .perform(&operator)
             .await?;
@@ -1204,7 +1254,6 @@ mod rule_tests {
         // A second branch holds a contractor + the contractor rule.
         let bob: Entity = "id:bob".parse()?;
         let r_contractor = rule_with_person_attr("org/contractor-name");
-        let (cc, sc) = rule_statements(&r_contractor);
         repo.branch("other")
             .open()
             .perform(&operator)
@@ -1215,8 +1264,7 @@ mod rule_tests {
                     .of(bob.clone())
                     .is("Bob".to_string()),
             )
-            .assert(cc)
-            .assert(sc)
+            .install_rule(&r_contractor)
             .commit()
             .perform(&operator)
             .await?;
@@ -1249,7 +1297,7 @@ mod rule_tests {
 
     // A committed rule that is later RETRACTED must stop resolving: the
     // retract moves the head, so the discovery cache re-scans and finds
-    // the rule's `db.rule/*` facts gone. The inverse of the
+    // the rule's `dialog.rule/*` facts gone. The inverse of the
     // head-move-adds case.
 
     #[dialog_common::test]
@@ -1260,7 +1308,6 @@ mod rule_tests {
 
         let alice: Entity = "id:alice".parse()?;
         let rule = employee_from_person();
-        let (conc, src) = rule_statements(&rule);
         branch
             .transaction()
             .assert(
@@ -1268,8 +1315,7 @@ mod rule_tests {
                     .of(alice.clone())
                     .is("Alice".to_string()),
             )
-            .assert(conc)
-            .assert(src)
+            .install_rule(&rule)
             .commit()
             .perform(&operator)
             .await?;
@@ -1277,12 +1323,10 @@ mod rule_tests {
         // Resolves while committed (also primes the cache at this head).
         assert!(query_employees(&branch, &operator).await?.contains(&alice));
 
-        // Retract the rule's facts on the same handle → head advances.
-        let (conc, src) = rule_statements(&rule);
+        // Remove the rule's facts on the same handle → head advances.
         branch
             .transaction()
-            .retract(conc)
-            .retract(src)
+            .remove_rule(&rule)
             .commit()
             .perform(&operator)
             .await?;
@@ -1310,7 +1354,6 @@ mod rule_tests {
         // v1 reads org/person-name; commit it + a matching person fact.
         let alice: Entity = "id:alice".parse()?;
         let v1 = rule_with_person_attr("org/person-name");
-        let (c1, s1) = rule_statements(&v1);
         branch
             .transaction()
             .assert(
@@ -1318,8 +1361,7 @@ mod rule_tests {
                     .of(alice.clone())
                     .is("Alice".to_string()),
             )
-            .assert(c1)
-            .assert(s1)
+            .install_rule(&v1)
             .commit()
             .perform(&operator)
             .await?;
@@ -1333,7 +1375,6 @@ mod rule_tests {
         let carol: Entity = "id:carol".parse()?;
         let v2 = rule_with_person_attr("org/agent-name");
         assert_ne!(v1.this(), v2.this());
-        let (c2, s2) = rule_statements(&v2);
         branch
             .transaction()
             .assert(
@@ -1341,8 +1382,7 @@ mod rule_tests {
                     .of(carol.clone())
                     .is("Carol".to_string()),
             )
-            .assert(c2)
-            .assert(s2)
+            .install_rule(&v2)
             .commit()
             .perform(&operator)
             .await?;

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -101,7 +101,7 @@ use crate::{
 pub struct Demand {
     /// Ranges read by fact scans: the query's data demand.
     facts: Arc<Mutex<Vec<RangeInclusive<Key>>>>,
-    /// Ranges read by rule-discovery scans (`db.rule/*`). Kept
+    /// Ranges read by rule-discovery scans (`dialog.rule/*`). Kept
     /// apart because a change here can install a rule, which can
     /// affect any row — it invalidates the whole result, not one
     /// entity's slice.
@@ -1705,20 +1705,14 @@ mod tests {
         }
     }
 
-    /// Stage the `db.rule/*` facts that persist a deductive rule
-    /// durably (the storage shape from `crate::rules`).
+    /// Install a deductive rule durably on `transaction` through the
+    /// privileged rail. Rules carry the reserved `dialog.rule/*` attributes,
+    /// so this uses `install_rule` rather than a public assert.
     fn with_rule<'t>(
         transaction: crate::Transaction<'t>,
         rule: &dialog_query::DeductiveRule,
     ) -> crate::Transaction<'t> {
-        let entity = rule.this();
-        transaction
-            .assert(
-                the!("db.rule/conclusion")
-                    .of(entity.clone())
-                    .is(rule.conclusion().this()),
-            )
-            .assert(the!("db.rule/source").of(entity).is(rule.encode()))
+        transaction.install_rule(rule)
     }
 
     /// A rule `conclusion :- Concept(target, terms)` built from

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -1,16 +1,25 @@
 mod query;
 pub use query::{TransactionQuery, TransactionSelectQuery};
 
-use crate::{Branch, Commit};
+use crate::{Branch, Commit, RuleWrite};
 use dialog_artifacts::{ChangeStream, Changes, Instruction, Statement, Update};
+use dialog_query::DeductiveRule;
 
 /// A transaction on a branch.
 ///
 /// Created by [`Branch::transaction`]. Accumulates changes via `.assert()`
 /// and `.retract()`, then commits atomically via `.commit().perform(&env)`.
+///
+/// Deductive rules are a distinct, privileged kind of write: they live under
+/// the reserved `dialog.rule/*` namespace, which the public assert path
+/// refuses, so they are staged separately via [`install_rule`](Self::install_rule)
+/// / [`remove_rule`](Self::remove_rule) and travel to the commit on their own
+/// rail — the same one revision records use — rather than through the gated
+/// instruction stream.
 pub struct Transaction<'a> {
     branch: &'a Branch,
     changes: Changes,
+    rules: Vec<RuleWrite>,
 }
 
 impl<'a> Transaction<'a> {
@@ -26,6 +35,30 @@ impl<'a> Transaction<'a> {
     /// Retract a claim from this transaction.
     pub fn retract<C: Statement>(mut self, claim: C) -> Self {
         claim.retract(&mut self.changes);
+        self
+    }
+
+    /// Install a deductive `rule` durably on the branch.
+    ///
+    /// This is the sanctioned way an app persists a rule: the rule's
+    /// `dialog.rule/*` facts are staged for the privileged write rail rather
+    /// than the public instruction stream, so the reserved-namespace gate that
+    /// refuses a hand-asserted `dialog.rule/*` fact does not reject a
+    /// legitimate install. When the transaction commits, the facts land in the
+    /// tree through [`BufferedBatch::install`](dialog_artifacts::BufferedBatch::install),
+    /// the same rail carrying revision records.
+    pub fn install_rule(mut self, rule: &DeductiveRule) -> Self {
+        self.rules.push(RuleWrite::Install(rule.clone()));
+        self
+    }
+
+    /// Remove a previously installed deductive `rule` from the branch.
+    ///
+    /// The inverse of [`install_rule`](Self::install_rule): the rule's
+    /// `dialog.rule/*` facts are erased through the privileged rail at commit
+    /// time. Removing a rule that was never installed is a no-op.
+    pub fn remove_rule(mut self, rule: &DeductiveRule) -> Self {
+        self.rules.push(RuleWrite::Remove(rule.clone()));
         self
     }
 
@@ -68,7 +101,9 @@ impl<'a> Transaction<'a> {
 
     /// Finalize the transaction into a commit command.
     pub fn commit(self) -> Commit<'a, ChangeStream> {
-        self.branch.commit(self.changes.into_stream())
+        self.branch
+            .commit(self.changes.into_stream())
+            .with_rules(self.rules)
     }
 }
 
@@ -81,6 +116,7 @@ impl Branch {
         Transaction {
             branch: self,
             changes: Changes::new(),
+            rules: Vec::new(),
         }
     }
 }

--- a/rust/dialog-repository/src/repository/branch/transaction/query.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/query.rs
@@ -584,10 +584,15 @@ mod tests {
         Ok(())
     }
 
-    /// A rule whose `db.rule/*` facts are pending in the transaction
-    /// resolves as a transient overlay rule: the uncommitted view
-    /// derives through it without the rule (or the data) ever being
+    /// A rule whose `dialog.rule/*` facts are pending in the transaction's
+    /// change overlay resolves as a transient overlay rule: the uncommitted
+    /// view derives through it without the rule (or the data) ever being
     /// committed.
+    ///
+    /// This stages the rule facts directly into the transaction's `Changes`
+    /// (the overlay the pending-view query reads), NOT through `install_rule`,
+    /// which is the durable/privileged rail. The two are distinct: the overlay
+    /// is a per-view read surface, never persisted or gated.
     #[dialog_common::test]
     async fn it_resolves_rules_pending_in_the_transaction() -> anyhow::Result<()> {
         use dialog_query::rule::DeductiveRuleDescriptor;
@@ -619,11 +624,11 @@ mod tests {
         let tx = branch
             .transaction()
             .assert(
-                the!("db.rule/conclusion")
+                the!("dialog.rule/conclusion")
                     .of(rule.this())
                     .is(employee.this()),
             )
-            .assert(the!("db.rule/source").of(rule.this()).is(rule.encode()))
+            .assert(the!("dialog.rule/source").of(rule.this()).is(rule.encode()))
             .assert(
                 the!("org/person-name")
                     .of(alice.clone())

--- a/rust/dialog-repository/src/rules.rs
+++ b/rust/dialog-repository/src/rules.rs
@@ -7,19 +7,27 @@
 //! and the union of those — plus the implicit per-descriptor rule built
 //! once — is what the query engine plans.
 //!
-//! # Storage shape (`db.rule/*`)
+//! # Storage shape (`dialog.rule/*`)
 //!
 //! A deductive rule is stored as facts:
-//! - `db.rule/conclusion` `of` rule-entity `is` the concept entity it
+//! - `dialog.rule/conclusion` `of` rule-entity `is` the concept entity it
 //!   concludes — the index a layer looks rules up by.
-//! - `db.rule/source` `of` rule-entity `is` the canonical dag-cbor
+//! - `dialog.rule/source` `of` rule-entity `is` the canonical dag-cbor
 //!   `DeductiveRuleDescriptor` (a `Value::Bytes`) — the body, hydrated
 //!   via `DeductiveRule::decode`. (Bytes, not Record: `Value::Record`
 //!   isn't yet supported end-to-end through the index; the bytes are
 //!   opaque to the query layer either way.)
 //!
-//! These names are a dialog-repository convention (like
-//! `dialog.session/*`).
+//! These names live under the reserved `dialog.` namespace, the same
+//! prefix version-control lineage uses (`dialog.db/revision`). That
+//! namespace is refused on the public write path (see the reservation
+//! gate in `dialog_artifacts::tree::write_instructions`), so a rule can
+//! only be *installed* through the sanctioned privileged rail
+//! (`Transaction::install_rule`, which writes through
+//! `BufferedBatch::install` exactly as revision records write through
+//! `BufferedBatch::record`). An app therefore cannot forge a rule by
+//! hand-asserting `dialog.rule/*` the way it once could under the
+//! unreserved `db.rule/*` names.
 //!
 //! # Two layers, two caches
 //!
@@ -53,17 +61,22 @@ use parking_lot::RwLock;
 
 use crate::{Revision, schema};
 
-/// The `db.rule/conclusion` index attribute, validated at compile time.
-fn conclusion_attr() -> Attribute {
-    the!("db.rule/conclusion").into()
+/// The `dialog.rule/conclusion` index attribute, validated at compile time.
+///
+/// This lives under the reserved `dialog.` namespace: it is writable only
+/// through the privileged install rail, never a public assert.
+pub(crate) fn conclusion_attr() -> Attribute {
+    the!("dialog.rule/conclusion").into()
 }
 
-/// The `db.rule/source` body attribute, validated at compile time.
-fn source_attr() -> Attribute {
-    the!("db.rule/source").into()
+/// The `dialog.rule/source` body attribute, validated at compile time.
+///
+/// Reserved like [`conclusion_attr`]; privileged-write only.
+pub(crate) fn source_attr() -> Attribute {
+    the!("dialog.rule/source").into()
 }
 
-/// Selector for `db.rule/conclusion is = <concept>` — finds the rule
+/// Selector for `dialog.rule/conclusion is = <concept>` — finds the rule
 /// entities concluding a concept.
 pub(crate) fn conclusion_selector(concept: &Entity) -> ArtifactSelector<Constrained> {
     ArtifactSelector::new()
@@ -71,25 +84,50 @@ pub(crate) fn conclusion_selector(concept: &Entity) -> ArtifactSelector<Constrai
         .is(Value::Entity(concept.clone()))
 }
 
-/// Selector for `db.rule/source of = <rule>` — fetches a rule's body.
+/// Selector for `dialog.rule/source of = <rule>` — fetches a rule's body.
 pub(crate) fn source_selector(rule: &Entity) -> ArtifactSelector<Constrained> {
     ArtifactSelector::new().the(source_attr()).of(rule.clone())
 }
 
-/// Hydrate a compiled [`DeductiveRule`] from a `db.rule/source` claim
+/// Hydrate a compiled [`DeductiveRule`] from a `dialog.rule/source` claim
 /// value (the canonical dag-cbor [`DeductiveRuleDescriptor`]).
 pub(crate) fn hydrate(source: &[u8]) -> Result<DeductiveRule, EvaluationError> {
     DeductiveRule::decode(source)
         .map_err(|reason| EvaluationError::Store(format!("rule hydrate: {reason}")))
 }
 
-/// Extract the rule entities from a batch of `db.rule/conclusion`
+/// Extract the rule entities from a batch of `dialog.rule/conclusion`
 /// artifacts — each artifact's `of` is a rule entity.
 pub(crate) fn rule_entities(conclusion_claims: Vec<Artifact>) -> Vec<Entity> {
     conclusion_claims.into_iter().map(|a| a.of).collect()
 }
 
-/// Extract the source bytes from a `db.rule/source` artifact batch.
+/// The two privileged facts that persist `rule`: the `conclusion` index
+/// (rule-entity `is` the concept it concludes) and the `source` body
+/// (rule-entity `is` the canonical dag-cbor bytes).
+///
+/// These carry the reserved `dialog.rule/*` attributes, so they are written
+/// through the privileged install rail (`Transaction::install_rule` →
+/// `BufferedBatch::install`), never the gated instruction path.
+pub(crate) fn rule_facts(rule: &DeductiveRule) -> [Artifact; 2] {
+    let entity = rule.this();
+    [
+        Artifact {
+            the: conclusion_attr(),
+            of: entity.clone(),
+            is: Value::Entity(rule.conclusion().this()),
+            cause: None,
+        },
+        Artifact {
+            the: source_attr(),
+            of: entity,
+            is: Value::from(rule.encode()),
+            cause: None,
+        },
+    ]
+}
+
+/// Extract the source bytes from a `dialog.rule/source` artifact batch.
 pub(crate) fn source_bytes(source_claims: Vec<Artifact>) -> Option<Vec<u8>> {
     source_claims.into_iter().find_map(|a| match a.is {
         Value::Bytes(bytes) => Some(bytes),
@@ -311,8 +349,8 @@ pub(crate) fn assemble(
 /// Read rules from an overlay [`Changes`] batch concluding `concept`.
 ///
 /// The overlay is in-memory, so this is cheap and done fresh every
-/// query (never cached). Walks the batch for `db.rule/conclusion`
-/// pointing at `concept`, then their `db.rule/source` bodies.
+/// query (never cached). Walks the batch for `dialog.rule/conclusion`
+/// pointing at `concept`, then their `dialog.rule/source` bodies.
 pub(crate) fn overlay_rules(changes: &Changes, concept: &Entity) -> Vec<DeductiveRule> {
     use dialog_artifacts::Change;
 


### PR DESCRIPTION
Renames the deductive-rule attributes from the unreserved `db.rule/*` to `dialog.rule/*`, moving them under the reserved `dialog.` prefix, and closes the spoofing gap that rename exposes.

## Why

`dialog.` is a reserved namespace: the write gate in `dialog-artifacts` refuses any public Assert/Replace/Retract whose attribute begins with `dialog.`, so an application cannot forge version-control lineage. Rules, however, lived under `db.rule/*` — outside the reserve — and were written as ordinary asserts, so **any app could forge a deductive rule** by hand-writing `db.rule/conclusion` / `db.rule/source` facts. This was the one system-owned namespace with the vaguer `db.` root and no protection.

Moving rules to `dialog.rule/*` makes the reservation gate cover them, and standardizes on a single reserved prefix (`dialog.`) with one taxonomy: `revision`, `branch`, `session`, `replica`, `rule`.

## What changed

Because `dialog.` is refused on the public write path, rule writes now travel the **privileged record rail** — the same surface revision records use — instead of ordinary asserts:

- **dialog-artifacts**: `BufferedArtifactTree::install` / `uninstall` write a rule's facts (all three EAV/AEV/VAE index orderings, spilling a large body to the block store) directly into the buffered tree, off the instruction stream, so the `starts_with("dialog.")` gate never sees them and a rule-only commit still mints a revision.
- **dialog-repository**: a `RuleWrite { Install, Remove }` side channel on the commit, and a sanctioned `Transaction::install_rule` / `remove_rule` API. Apps install rules through this; they can no longer forge one through `assert`. The gate itself is untouched (still a plain `starts_with` rejection, no allowlist).

The uncommitted overlay path (a transaction's pending rules) is unchanged — it stages into in-memory `Changes`, never hitting the tree write gate.

## Tests

- `it_rejects_public_writes_to_the_reserved_rule_namespace` — public Assert/Replace/Retract of both `dialog.rule/*` attributes are all refused with `ReservedAttribute` (proves the gap is closed).
- `it_round_trips_a_privileged_rule_install` — a rule installed via the sanctioned path is found by the `conclusion` discovery scan and its `source` body hydrates.
- Existing committed- and overlay-rule resolution tests adapted to the new install/remove API and passing.

Full native suite: 2062 passed, 0 failed.

## Migration

Attribute-name space, not on-disk format — no format version bump. Pre-existing `db.rule/*` data won't be discovered under the new names, but rules are re-installable, so regeneration is the migration.
