### PR TITLE
feat(dialog-storage): make Storage cloneable

### DIFF
--- a/rust/dialog-artifacts/src/error.rs
+++ b/rust/dialog-artifacts/src/error.rs
@@ -1,3 +1,5 @@
+use dialog_capability::access::AuthorizeError;
+use dialog_effects::Rejection;
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::memory::MemoryError;
 use dialog_search_tree::DialogSearchTreeError;
@@ -16,6 +18,15 @@ pub enum DialogArtifactsError {
     /// An error occurred in prolly tree-related code
     #[error("Tree operation failed: {0}")]
     Tree(String),
+
+    /// The request was not authorized.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
+
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
     /// A database index was not shaped as expected
     #[error("Malformed database index: {0}")]
@@ -40,10 +51,6 @@ pub enum DialogArtifactsError {
     /// A causal reference was invalid
     #[error("Could not convert bytes into reference: {0}")]
     InvalidReference(String),
-
-    /// Raw bytes could not be interpreted as a datum state (asserted or retracted)
-    #[error("Could not convert bytes into state: {0}")]
-    InvalidState(String),
 
     /// Raw bytes could not be interpreted as an attribute
     #[error("Invalid attribute: {0}")]
@@ -77,26 +84,46 @@ pub enum DialogArtifactsError {
 }
 
 impl From<DialogStorageError> for DialogArtifactsError {
-    fn from(value: DialogStorageError) -> Self {
-        DialogArtifactsError::Storage(format!("{value}"))
+    fn from(error: DialogStorageError) -> Self {
+        match error {
+            DialogStorageError::Authorization(error) => Self::Authorization(error),
+            DialogStorageError::Rejected(error) => Self::Rejected(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<ArchiveError> for DialogArtifactsError {
-    fn from(e: ArchiveError) -> Self {
-        Self::Storage(e.to_string())
+    fn from(error: ArchiveError) -> Self {
+        match error {
+            ArchiveError::Authorization(error) => Self::Authorization(error),
+            ArchiveError::Rejected(error) => Self::Rejected(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<MemoryError> for DialogArtifactsError {
-    fn from(e: MemoryError) -> Self {
-        Self::Storage(e.to_string())
+    fn from(error: MemoryError) -> Self {
+        match error {
+            MemoryError::Authorization(error) => Self::Authorization(error),
+            MemoryError::Rejected(error) => Self::Rejected(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<DialogSearchTreeError> for DialogArtifactsError {
-    fn from(value: DialogSearchTreeError) -> Self {
-        DialogArtifactsError::Tree(format!("{value}"))
+    fn from(error: DialogSearchTreeError) -> Self {
+        match error {
+            DialogSearchTreeError::Storage(DialogStorageError::Authorization(error)) => {
+                Self::Authorization(error)
+            }
+            DialogSearchTreeError::Storage(DialogStorageError::Rejected(error)) => {
+                Self::Rejected(error)
+            }
+            error => Self::Tree(error.to_string()),
+        }
     }
 }
 
@@ -106,4 +133,55 @@ pub enum TypeError {
     /// Expected type and actual type mismatch.
     #[error("Type mismatch: expected {0}, got {1}")]
     TypeMismatch(ValueDataType, ValueDataType),
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unused_async)]
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use dialog_capability::access::AuthorizeError;
+    use dialog_effects::archive::ArchiveError;
+    use dialog_storage::DialogStorageError;
+
+    use super::*;
+
+    fn revoked() -> AuthorizeError {
+        AuthorizeError::Revoked {
+            subject: dialog_capability::did!(
+                "did:key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX"
+            ),
+        }
+    }
+
+    // This is the hop that used to flatten everything: the conversion
+    // rescued one variant by name and sent the rest through
+    // `to_string()`, so a reason built two crates down died here and
+    // callers were left parsing messages. The fallback arm still exists
+    // for genuinely unstructured failures, which is why this needs a
+    // test rather than the compiler -- adding a variant and forgetting
+    // an arm degrades silently instead of failing the build.
+    #[dialog_common::test]
+    async fn it_keeps_the_reason_a_conversion_used_to_flatten() {
+        let error = DialogArtifactsError::from(ArchiveError::Authorization(revoked()));
+        assert!(
+            matches!(
+                error,
+                DialogArtifactsError::Authorization(AuthorizeError::Revoked { .. })
+            ),
+            "the reason survives the hop, got {error:?}"
+        );
+
+        let through_storage =
+            DialogArtifactsError::from(DialogStorageError::Authorization(revoked()));
+        assert!(
+            matches!(
+                through_storage,
+                DialogArtifactsError::Authorization(AuthorizeError::Revoked { .. })
+            ),
+            "and survives arriving via storage, got {through_storage:?}"
+        );
+    }
 }

--- a/rust/dialog-artifacts/src/key.rs
+++ b/rust/dialog-artifacts/src/key.rs
@@ -237,6 +237,15 @@ impl Key {
         self.0.first().copied().unwrap_or(u8::MIN)
     }
 
+    /// Return the content-addressed value block referenced by a spilled key.
+    ///
+    /// This works for every variable-key ordering, including history keys.
+    /// Callers remain responsible for deciding whether the key's state makes
+    /// the referenced block live (for example, retraction tombstones do not).
+    pub fn value_spill_hash(&self) -> Option<&[u8]> {
+        varkey::value_spill_hash(self.as_ref(), self.tag())
+    }
+
     /// Sets the tag byte and returns the modified key
     pub fn set_tag(mut self, tag: u8) -> Self {
         if self.0.is_empty() {

--- a/rust/dialog-artifacts/src/spill.rs
+++ b/rust/dialog-artifacts/src/spill.rs
@@ -40,6 +40,65 @@ pub enum ShipmentRef {
 /// deduplicated). Push runs the node-level differential anyway to upload
 /// novel nodes; draining this from the same [`TreeDifference`] means the
 /// changed paths are read once instead of once per concern.
+/// Classify one tree entry: does it reference content that must ship
+/// alongside the tree nodes, and which kind?
+///
+/// The per-entry half of [`shipment_refs`], split out so a caller walking
+/// a tree directly can classify entries as it visits leaves rather than
+/// running a differential to reach the same answer. `None` means the entry
+/// references nothing shippable.
+///
+/// Retractions are deliberately not spilled-value references: a retraction
+/// writes a tombstone at the same key, it is never read through the spill
+/// store (readers check `State::Added` before fetching), and a replica can
+/// legitimately hold a tombstone for a block it never replicated -- so
+/// requiring the block would wedge that replica's push forever.
+pub fn shipment_ref(
+    key: &Key,
+    value: &State<Datum>,
+    removed: bool,
+) -> Result<Option<ShipmentRef>, DialogArtifactsError> {
+    match key.tag() {
+        BLOB_KEY_TAG => {
+            let hash = BlobKey(key.clone()).blob_hash();
+            // Decoding rejects a malformed record; a `None` decode is a
+            // retraction tombstone, a reference only when removed.
+            Ok(match (removed, BlobRecord::from_state(value)?) {
+                (false, Some(_)) => Some(ShipmentRef::Blob(BlobChange::Added(hash))),
+                (true, _) => Some(ShipmentRef::Blob(BlobChange::Removed(hash))),
+                (false, None) => None,
+            })
+        }
+        // Count each spilled value via the EAV ordering only: a value shared
+        // by the EAV/AEV/VAE orderings would otherwise surface three times.
+        ENTITY_KEY_TAG if !removed => {
+            if !matches!(value, State::Added(_)) {
+                return Ok(None);
+            }
+            let view = EntityKey(key);
+            let Some(hash) = view.value_spill_hash() else {
+                return Ok(None);
+            };
+            let reference: Blake3Hash = hash.try_into().map_err(|_| {
+                DialogArtifactsError::InvalidKey(
+                    "spilled value reference is not 32 bytes".to_string(),
+                )
+            })?;
+            Ok(Some(ShipmentRef::SpilledValue(reference)))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Stream everything a push must ship from ONE walk of an already-computed
+/// tree differential: blob-index changes (`BLOB` tag) and newly-referenced
+/// spilled value blocks (EAV-tagged additions whose key carries a
+/// reference, deduplicated). Push runs the node-level differential anyway
+/// to upload novel nodes; draining this from the same [`TreeDifference`]
+/// means the changed paths are read once instead of once per concern.
+///
+/// Classification of each entry is [`shipment_ref`]; this adds the walk
+/// and the deduplication.
 pub fn shipment_refs<'a, Backend>(
     difference: &'a TreeDifference<'a, Key, State<Datum>, Backend>,
 ) -> impl Stream<Item = Result<ShipmentRef, DialogArtifactsError>> + 'a + ConditionalSend
@@ -56,48 +115,16 @@ where
                 Change::Add(entry) => (entry, false),
                 Change::Remove(entry) => (entry, true),
             };
-            let key = entry.key;
-            match key.tag() {
-                BLOB_KEY_TAG => {
-                    let hash = BlobKey(key).blob_hash();
-                    // Decoding rejects a malformed record; a `None` decode is
-                    // a retraction tombstone, a reference only when removed.
-                    match (removed, BlobRecord::from_state(&entry.value)?) {
-                        (false, Some(_)) => yield ShipmentRef::Blob(BlobChange::Added(hash)),
-                        (true, _) => yield ShipmentRef::Blob(BlobChange::Removed(hash)),
-                        (false, None) => {}
-                    }
-                }
-                // Count each spilled value once, via the EAV ordering only:
-                // a value shared by the EAV/AEV/VAE orderings surfaces once,
-                // and the `HashSet` dedups a block shared by many facts.
-                ENTITY_KEY_TAG if !removed => {
-                    // Only asserted facts need their block shipped. A
-                    // retraction writes a TOMBSTONE at the same spilled key:
-                    // it is never read through the spill store (readers check
-                    // `State::Added` before fetching), and a replica can
-                    // legitimately hold a tombstone for a block it never
-                    // replicated (pull ships tree nodes, not value blocks) —
-                    // requiring the block would wedge that replica's push
-                    // forever.
-                    if !matches!(entry.value, State::Added(_)) {
-                        continue;
-                    }
-                    let view = EntityKey(&key);
-                    let Some(hash) = view.value_spill_hash() else {
-                        continue;
-                    };
-                    let reference: Blake3Hash = hash.try_into().map_err(|_| {
-                        DialogArtifactsError::InvalidKey(
-                            "spilled value reference is not 32 bytes".to_string(),
-                        )
-                    })?;
-                    if seen.insert(reference) {
-                        yield ShipmentRef::SpilledValue(reference);
-                    }
-                }
-                _ => {}
+            let Some(reference) = shipment_ref(&entry.key, &entry.value, removed)? else {
+                continue;
+            };
+            // A block shared by many facts surfaces once.
+            if let ShipmentRef::SpilledValue(spilled) = &reference
+                && !seen.insert(*spilled)
+            {
+                continue;
             }
+            yield reference;
         }
     }
 }

--- a/rust/dialog-capability/src/access.rs
+++ b/rust/dialog-capability/src/access.rs
@@ -546,7 +546,8 @@ pub trait CertificateStore<P: Protocol> {
 /// [`Expired`](Self::Expired) means obtain a fresh proof and retry;
 /// [`Revoked`](Self::Revoked) means stop, since retrying presents the same
 /// withdrawn authority.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind")]
 pub enum AuthorizeError {
     /// No delegation chain connects the authority to the subject.
     ///
@@ -660,19 +661,45 @@ pub enum AuthorizeError {
         link: String,
     },
 
-    /// The authorization could not be evaluated at all.
+    /// The caller's authorization material did not decode.
     ///
-    /// Not an access decision: the chain was absent or undecodable, or the
-    /// material needed to decide could not be read. Distinct from the
-    /// decision variants above, which all mean "we understood the request
-    /// and the answer is no".
-    #[error("Authorization could not be evaluated: {0}")]
-    Malformed(String),
+    /// Strictly that: bytes arrived and could not be read as what they
+    /// claimed to be. Anything else that prevents a decision -- a key we
+    /// could not load, a store we could not reach, our own signing
+    /// failing -- is [`Unavailable`](Self::Unavailable), because it says
+    /// nothing about the caller's input and a caller cannot act on it the
+    /// same way.
+    ///
+    /// Also distinct from the decision variants above, which all mean
+    /// "we understood the request and the answer is no".
+    #[error("Authorization could not be evaluated: {detail}")]
+    Malformed {
+        /// What could not be evaluated.
+        detail: String,
+    },
+
+    /// The decision could not be reached because our own machinery
+    /// failed.
+    ///
+    /// Signing a payload, reading a key, reaching a store. Nothing is
+    /// wrong with the caller's input, and nothing was decided, so this
+    /// must not be reported as a denial -- a caller told "no" stops,
+    /// where a caller told "we could not answer" may retry.
+    ///
+    /// The enum's other variants are all statements about the request.
+    /// This one is a statement about us.
+    #[error("Authorization could not be evaluated: {detail}")]
+    Unavailable {
+        /// What failed on our side.
+        detail: String,
+    },
 }
 
 impl From<crate::StorageError> for AuthorizeError {
     fn from(e: crate::StorageError) -> Self {
-        AuthorizeError::Malformed(e.to_string())
+        AuthorizeError::Unavailable {
+            detail: e.to_string(),
+        }
     }
 }
 
@@ -682,6 +709,70 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::TimeRange;
+
+    // The reasons cross the wire: the access service answers with these
+    // rather than with a code table both sides have to keep in step.
+    // Round-tripping every variant is what makes that safe -- a variant
+    // that serializes but will not come back is a silent protocol break.
+    mod wire {
+        use crate::access::AuthorizeError;
+        use crate::did;
+
+        fn round_trip(error: AuthorizeError) {
+            let encoded = serde_json::to_string(&error).expect("serializes");
+            let decoded: AuthorizeError = serde_json::from_str(&encoded).expect("deserializes");
+            assert_eq!(error, decoded, "round-tripped through {encoded}");
+        }
+
+        #[dialog_common::test]
+        async fn it_round_trips_every_reason() {
+            let subject = did!("key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX");
+            let audience = did!("key:z6MkfQhLHBSFMuR7bQXTQeqe5kYUW51HpfZeaymgy1zkP2jM");
+
+            for error in [
+                AuthorizeError::UnprovenSubject {
+                    claimed: audience.clone(),
+                    authorized: subject.clone(),
+                },
+                AuthorizeError::CommandEscalation {
+                    claimed: "/storage/put".into(),
+                    authorized: "/storage/get".into(),
+                },
+                AuthorizeError::PolicyViolation {
+                    predicate: "size < 1024".into(),
+                },
+                AuthorizeError::InvalidAudience {
+                    claimed: audience.clone(),
+                    authorized: subject.clone(),
+                },
+                AuthorizeError::Revoked {
+                    subject: subject.clone(),
+                },
+                AuthorizeError::InvalidSignature {
+                    issuer: subject.clone(),
+                },
+                AuthorizeError::Malformed {
+                    detail: "bad envelope".into(),
+                },
+            ] {
+                round_trip(error);
+            }
+        }
+
+        // The tag is part of the protocol: renaming a variant renames
+        // the wire form, so this pins what the service must emit.
+        #[dialog_common::test]
+        async fn it_names_the_reason_in_the_payload() {
+            let encoded = serde_json::to_string(&AuthorizeError::Revoked {
+                subject: did!("key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX"),
+            })
+            .expect("serializes");
+            assert!(
+                encoded.contains(r#""kind":"Revoked""#),
+                "the reason is named in the payload, got {encoded}"
+            );
+        }
+    }
 
     mod reasons {
         use crate::access::AuthorizeError;
@@ -749,7 +840,9 @@ mod tests {
         // caller supplies the link it refers to.
         #[dialog_common::test]
         async fn it_keeps_unevaluable_authorizations_out_of_the_denial_reasons() {
-            let undecodable = AuthorizeError::Malformed("chain did not decode".into());
+            let undecodable = AuthorizeError::Malformed {
+                detail: "chain did not decode".into(),
+            };
             assert!(
                 undecodable.to_string().contains("could not be evaluated"),
                 "an unevaluable authorization must not read as a refusal: {undecodable}"

--- a/rust/dialog-capability/src/error.rs
+++ b/rust/dialog-capability/src/error.rs
@@ -4,60 +4,6 @@ use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display, Formatter};
 use thiserror::Error;
 
-/// Error that can occur during signing operations.
-#[derive(Debug, Error)]
-pub enum SignError {
-    /// The signing key is not available or cannot be used.
-    #[error("Signing key unavailable: {0}")]
-    KeyUnavailable(String),
-
-    /// An error occurred during the signing operation.
-    #[error("Signing failed: {0}")]
-    SigningFailed(String),
-}
-
-/// Errors that can occur during authorization.
-#[derive(Debug, Error)]
-pub enum DialogCapabilityAuthorizationError {
-    /// Subject does not match the issuer's DID for self-authorization.
-    #[error("Not authorized: subject '{subject}' does not match issuer '{issuer}'")]
-    NotOwner {
-        /// The subject DID from the capability.
-        subject: Did,
-        /// The issuer's DID.
-        issuer: Did,
-    },
-
-    /// Audience does not match the issuer's DID for delegation/invocation.
-    #[error("Cannot delegate/invoke: audience '{audience}' does not match issuer '{issuer}'")]
-    NotAudience {
-        /// The audience DID from the authorization.
-        audience: Did,
-        /// The issuer's DID.
-        issuer: Did,
-    },
-
-    /// No valid delegation chain found.
-    #[error("No valid delegation chain found from '{subject}' to '{audience}'")]
-    NoDelegationChain {
-        /// The subject DID.
-        subject: Did,
-        /// The audience DID.
-        audience: Did,
-    },
-
-    /// Policy constraint violation.
-    #[error("Policy constraint violation: {message}")]
-    PolicyViolation {
-        /// Description of the violation.
-        message: String,
-    },
-
-    /// Serialization error during signing.
-    #[error("Serialization error: {0}")]
-    Serialization(String),
-}
-
 /// Errors from capability-routed storage operations.
 ///
 /// These are the "we failed" side of an effect's error: the backend broke,
@@ -98,7 +44,7 @@ pub enum DialogCapabilityPerformError<E: StdError> {
     /// Error during effect execution.
     Execution(E),
     /// Error during authorization verification.
-    Authorization(DialogCapabilityAuthorizationError),
+    Authorization(AuthorizeError),
 }
 
 impl<E: StdError> Debug for DialogCapabilityPerformError<E> {

--- a/rust/dialog-effects/src/archive.rs
+++ b/rust/dialog-effects/src/archive.rs
@@ -15,9 +15,10 @@
 
 use std::error::Error;
 
+use crate::Rejection;
 pub use dialog_capability::{
-    Attenuate, Attenuation, Capability, DialogCapabilityAuthorizationError,
-    DialogCapabilityPerformError, Effect, Policy, StorageError, Subject, access::AuthorizeError,
+    Attenuate, Attenuation, Capability, DialogCapabilityPerformError, Effect, Policy, StorageError,
+    Subject, access::AuthorizeError,
 };
 pub use dialog_common::Blake3Hash;
 pub use dialog_common::Buffer;
@@ -232,30 +233,22 @@ pub mod prelude;
 /// Errors that can occur during archive operations.
 #[derive(Debug, Error)]
 pub enum ArchiveError {
-    /// Content digest mismatch.
-    #[error("Content digest mismatch: expected {expected}, got {actual}")]
-    DigestMismatch {
-        /// Expected digest.
-        expected: String,
-        /// Actual digest.
-        actual: String,
-    },
+    /// The request was not authorized.
+    ///
+    /// Carries the decision itself rather than its rendering: a caller
+    /// can tell a withdrawn authority from a lapsed one, and act
+    /// differently, without parsing a message.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
 
-    /// Authorization error occurred.
-    #[error("Unauthorized error: {0}")]
-    AuthorizationError(String),
-
-    /// Execution error occurred during operation.
-    #[error("Executions error: {0}")]
-    ExecutionError(String),
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
     /// Storage backend error.
     #[error("Storage error: {0}")]
     Storage(String),
-
-    /// IO error.
-    #[error("IO error: {0}")]
-    Io(String),
 }
 
 impl From<StorageError> for ArchiveError {
@@ -264,26 +257,12 @@ impl From<StorageError> for ArchiveError {
     }
 }
 
-impl From<DialogCapabilityAuthorizationError> for ArchiveError {
-    fn from(value: DialogCapabilityAuthorizationError) -> Self {
-        ArchiveError::AuthorizationError(value.to_string())
-    }
-}
-
-impl From<AuthorizeError> for ArchiveError {
-    fn from(value: AuthorizeError) -> Self {
-        ArchiveError::AuthorizationError(value.to_string())
-    }
-}
-
 impl<E: Error> From<DialogCapabilityPerformError<E>> for ArchiveError {
     fn from(value: DialogCapabilityPerformError<E>) -> Self {
         match value {
-            DialogCapabilityPerformError::Authorization(error) => {
-                ArchiveError::AuthorizationError(error.to_string())
-            }
+            DialogCapabilityPerformError::Authorization(error) => error.into(),
             DialogCapabilityPerformError::Execution(error) => {
-                ArchiveError::ExecutionError(error.to_string())
+                ArchiveError::Storage(error.to_string())
             }
         }
     }

--- a/rust/dialog-effects/src/authority.rs
+++ b/rust/dialog-effects/src/authority.rs
@@ -21,10 +21,6 @@ use thiserror::Error;
 /// Error type for authority operations.
 #[derive(Debug, Error)]
 pub enum AuthorityError {
-    /// Identity resolution failed.
-    #[error("Identity error: {0}")]
-    Identity(String),
-
     /// Signing a payload failed.
     #[error("Attestation error: {0}")]
     Attestation(String),

--- a/rust/dialog-effects/src/blob.rs
+++ b/rust/dialog-effects/src/blob.rs
@@ -29,8 +29,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::archive::Archive;
 pub use dialog_capability::{
-    Attenuate, Attenuation, DialogCapabilityAuthorizationError, DialogCapabilityPerformError,
-    Effect, Policy, StorageError, Subject, access::AuthorizeError,
+    Attenuate, Attenuation, DialogCapabilityPerformError, Effect, Policy, StorageError, Subject,
+    access::AuthorizeError,
 };
 
 /// Blob store domain under the archive. Adds the `/blob` ability segment.

--- a/rust/dialog-effects/src/blob/error.rs
+++ b/rust/dialog-effects/src/blob/error.rs
@@ -4,10 +4,9 @@ use std::error::Error;
 
 use thiserror::Error as ThisError;
 
+use crate::Rejection;
 use dialog_capability::access::AuthorizeError;
-use dialog_capability::{
-    DialogCapabilityAuthorizationError, DialogCapabilityPerformError, StorageError,
-};
+use dialog_capability::{DialogCapabilityPerformError, StorageError};
 
 /// Errors that can occur during blob operations.
 #[derive(Debug, ThisError)]
@@ -25,21 +24,21 @@ pub enum BlobError {
         actual: String,
     },
 
-    /// Authorization failed.
-    #[error("Unauthorized error: {0}")]
-    AuthorizationError(String),
+    /// The request was not authorized.
+    ///
+    /// Carries the decision itself rather than its rendering, so a
+    /// caller can tell a withdrawn authority from a lapsed one.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
 
-    /// The operation failed during execution.
-    #[error("Execution error: {0}")]
-    ExecutionError(String),
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
     /// The storage backend failed.
     #[error("Storage error: {0}")]
     Storage(String),
-
-    /// An I/O error occurred.
-    #[error("IO error: {0}")]
-    Io(String),
 }
 
 impl From<StorageError> for BlobError {
@@ -48,27 +47,11 @@ impl From<StorageError> for BlobError {
     }
 }
 
-impl From<DialogCapabilityAuthorizationError> for BlobError {
-    fn from(value: DialogCapabilityAuthorizationError) -> Self {
-        BlobError::AuthorizationError(value.to_string())
-    }
-}
-
-impl From<AuthorizeError> for BlobError {
-    fn from(value: AuthorizeError) -> Self {
-        BlobError::AuthorizationError(value.to_string())
-    }
-}
-
 impl<E: Error> From<DialogCapabilityPerformError<E>> for BlobError {
     fn from(value: DialogCapabilityPerformError<E>) -> Self {
         match value {
-            DialogCapabilityPerformError::Authorization(error) => {
-                BlobError::AuthorizationError(error.to_string())
-            }
-            DialogCapabilityPerformError::Execution(error) => {
-                BlobError::ExecutionError(error.to_string())
-            }
+            DialogCapabilityPerformError::Authorization(error) => error.into(),
+            DialogCapabilityPerformError::Execution(error) => BlobError::Storage(error.to_string()),
         }
     }
 }

--- a/rust/dialog-effects/src/credential.rs
+++ b/rust/dialog-effects/src/credential.rs
@@ -189,7 +189,9 @@ impl From<StorageError> for CredentialError {
 /// was weighed and refused, the material needed to decide was unavailable.
 impl From<CredentialError> for AuthorizeError {
     fn from(e: CredentialError) -> Self {
-        Self::Malformed(e.to_string())
+        Self::Unavailable {
+            detail: e.to_string(),
+        }
     }
 }
 

--- a/rust/dialog-effects/src/lib.rs
+++ b/rust/dialog-effects/src/lib.rs
@@ -42,6 +42,7 @@ pub mod authority;
 pub mod blob;
 pub mod credential;
 pub mod memory;
+pub mod rejection;
 pub mod space;
 pub mod storage;
 
@@ -59,3 +60,4 @@ pub mod prelude {
 
 // Re-export capability primitives for convenience
 pub use dialog_capability::{Attenuation, Capability, Effect, Policy, Subject};
+pub use rejection::Rejection;

--- a/rust/dialog-effects/src/memory.rs
+++ b/rust/dialog-effects/src/memory.rs
@@ -15,9 +15,9 @@
 //! ```
 
 use std::fmt;
-use std::io;
 use std::str;
 
+use crate::Rejection;
 use base58::ToBase58;
 use dialog_capability::access::AuthorizeError;
 pub use dialog_capability::{
@@ -261,24 +261,19 @@ pub enum MemoryError {
     #[error("Storage error: {0}")]
     Storage(String),
 
-    /// Authorization error.
-    #[error("Authorization error: {0}")]
-    Authorization(String),
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
-    /// IO error.
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
+    /// The request was not authorized.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
 }
 
 impl From<StorageError> for MemoryError {
     fn from(e: StorageError) -> Self {
         Self::Storage(e.to_string())
-    }
-}
-
-impl From<AuthorizeError> for MemoryError {
-    fn from(e: AuthorizeError) -> Self {
-        Self::Authorization(e.to_string())
     }
 }
 

--- a/rust/dialog-effects/src/rejection.rs
+++ b/rust/dialog-effects/src/rejection.rs
@@ -1,0 +1,56 @@
+//! Why a request was not carried out.
+
+use thiserror::Error;
+
+/// A request that could not be carried out for a reason that is not an
+/// access decision.
+///
+/// Authorization failures are *not* here: they are
+/// [`AuthorizeError`](dialog_capability::access::AuthorizeError), which
+/// already names them (revoked, expired, audience mismatch, unproven
+/// subject, and the rest), and effect errors carry that type directly
+/// rather than restating it.
+///
+/// Version conflicts are not here either: they are
+/// [`MemoryError::VersionMismatch`](crate::memory::MemoryError), which
+/// carries the versions themselves and is what every caller already
+/// matches on.
+///
+/// What is left over is the handful of ways a request fails when
+/// authority was never in question and no state moved. Deliberately not
+/// a status code or a response: a caller holding one of these has no way
+/// to learn what carried the request, because that is never what it
+/// needs to decide.
+#[derive(Clone, Debug, Error, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind")]
+pub enum Rejection {
+    /// Temporarily unable to serve. Retryable as-is.
+    #[error("Temporarily unable to serve the request: {reason}")]
+    Unavailable {
+        /// Why, as far as the responder would say.
+        reason: String,
+    },
+
+    /// Not carried out, for a reason this version does not recognize.
+    ///
+    /// The honest variant. Folding an unrecognized failure into a named
+    /// one would claim knowledge we do not have, and would silently
+    /// change meaning the day the responder starts saying something new.
+    /// `detail` is kept for logs; matching on it is a mistake, because
+    /// what lands here is exactly what has no agreed meaning.
+    #[error("The request was not carried out: {detail}")]
+    Unclassified {
+        /// Whatever came back, verbatim and bounded.
+        detail: String,
+    },
+}
+
+impl Rejection {
+    /// Whether retrying the identical request could succeed.
+    ///
+    /// True only for [`Rejection::Unavailable`]. An unrecognized
+    /// failure is not a known-transient one, so it does not count.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Rejection::Unavailable { .. })
+    }
+}

--- a/rust/dialog-effects/src/storage.rs
+++ b/rust/dialog-effects/src/storage.rs
@@ -171,10 +171,6 @@ pub enum StorageError {
     /// Backend storage error.
     #[error("Storage error: {0}")]
     Storage(String),
-
-    /// The credential at the location is invalid.
-    #[error("Invalid credential: {0}")]
-    InvalidCredential(String),
 }
 
 /// Sugar: build a storage capability chain for a profile.

--- a/rust/dialog-operator/src/profile/error.rs
+++ b/rust/dialog-operator/src/profile/error.rs
@@ -1,6 +1,19 @@
 /// Errors that can occur when opening a profile.
 #[derive(Debug, thiserror::Error)]
 pub enum ProfileError {
+    /// A profile already exists at this location.
+    ///
+    /// Only `create` raises it; `open_or_create` treats the same
+    /// condition as success and loads what is there.
+    #[error("Profile already exists")]
+    AlreadyExists,
+
+    /// No profile exists at this location.
+    ///
+    /// Only `load` raises it, for the same reason inverted.
+    #[error("Profile not found")]
+    NotFound,
+
     /// Storage operation failed.
     #[error("Storage error: {0}")]
     Storage(String),
@@ -8,12 +21,4 @@ pub enum ProfileError {
     /// Key generation or import failed.
     #[error("Key error: {0}")]
     Key(String),
-
-    /// Profile already exists (for create).
-    #[error("Profile already exists")]
-    AlreadyExists,
-
-    /// Profile not found (for load).
-    #[error("Profile not found")]
-    NotFound,
 }

--- a/rust/dialog-operator/src/profile/open.rs
+++ b/rust/dialog-operator/src/profile/open.rs
@@ -69,7 +69,10 @@ impl OpenProfile {
                 .load()
                 .perform(env)
                 .await
-                .map_err(|e| ProfileError::Storage(e.to_string()))?,
+                .map_err(|e| match e {
+                    storage_fx::StorageError::NotFound(_) => ProfileError::NotFound,
+                    e => ProfileError::Storage(e.to_string()),
+                })?,
             OpenMode::Create => {
                 let signer = Ed25519Signer::generate()
                     .await
@@ -80,7 +83,10 @@ impl OpenProfile {
                     .create(credential)
                     .perform(env)
                     .await
-                    .map_err(|e| ProfileError::Storage(e.to_string()))?
+                    .map_err(|e| match e {
+                        storage_fx::StorageError::AlreadyExists(_) => ProfileError::AlreadyExists,
+                        e => ProfileError::Storage(e.to_string()),
+                    })?
             }
             OpenMode::OpenOrCreate => {
                 let load_result = self.location().load().perform(env).await;

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -655,20 +655,6 @@ impl From<OwnedInvalidIdentifier> for DialogArtifactsError {
     }
 }
 
-/// Error types that can occur during transaction operations
-#[derive(Debug, Error)]
-pub enum TransactionError {
-    /// The operation is invalid for the current transaction state.
-    #[error("Invalid operation: {reason}")]
-    InvalidOperation {
-        /// Description of why the operation is invalid.
-        reason: String,
-    },
-    /// An error from the underlying storage layer.
-    #[error("Storage error: {0}")]
-    Storage(#[from] DialogArtifactsError),
-}
-
 /// Why a premise cannot run yet under the current bindings: the
 /// `Err` case of the SIPS binding function
 /// [`Premise::feasible`](crate::Premise::feasible). Names which

--- a/rust/dialog-remote-fs/src/fs/address.rs
+++ b/rust/dialog-remote-fs/src/fs/address.rs
@@ -67,7 +67,9 @@ impl From<FsAddress> for SiteId {
 async fn open(address: &FsAddress) -> Result<FileSystem, AuthorizeError> {
     FileSystem::open(address.location())
         .await
-        .map_err(|e| AuthorizeError::Malformed(format!("opening directory: {e}")))
+        .map_err(|e| AuthorizeError::Unavailable {
+            detail: format!("opening directory: {e}"),
+        })
 }
 
 /// Verify the resolved directory is the space for the invocation's subject:
@@ -96,10 +98,10 @@ where
         .load()
         .perform(filesystem)
         .await
-        .map_err(|e| {
-            AuthorizeError::Malformed(format!(
+        .map_err(|e| AuthorizeError::Unavailable {
+            detail: format!(
                 "directory is not an initialized space (no readable credential/key/self): {e}"
-            ))
+            ),
         })?;
 
     // A subject the directory is not the space for IS a denial.
@@ -131,10 +133,13 @@ where
     Capability<Fx>: Ability,
     Env: Provider<authority::Identify> + Provider<Prove<Ucan>> + ConditionalSync,
 {
-    let identity = authority::Identify
-        .perform(env)
-        .await
-        .map_err(|e| AuthorizeError::Malformed(e.to_string()))?;
+    let identity =
+        authority::Identify
+            .perform(env)
+            .await
+            .map_err(|e| AuthorizeError::Unavailable {
+                detail: e.to_string(),
+            })?;
     let profile = identity.profile().clone();
     let operator = identity.did();
 

--- a/rust/dialog-remote-s3/src/error.rs
+++ b/rust/dialog-remote-s3/src/error.rs
@@ -1,5 +1,7 @@
 //! Error types for S3 operations.
 
+use dialog_capability::access::AuthorizeError;
+use dialog_effects::Rejection;
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::blob::BlobError;
 use dialog_effects::memory::MemoryError;
@@ -8,17 +10,22 @@ use thiserror::Error;
 /// Error type for S3 operations.
 #[derive(Debug, Error)]
 pub enum S3Error {
-    /// Failed to authorize the request.
-    #[error("Authorization error: {0}")]
-    Authorization(String),
+    /// The request was not authorized.
+    ///
+    /// Carries the access decision itself rather than its rendering, so
+    /// a caller can tell a withdrawn authority from a lapsed one without
+    /// parsing a message.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
 
     /// Transport-level error (connection failed, timeout, network issues).
     #[error("Transport error: {0}")]
     Transport(String),
 
-    /// Service-level error (S3 returned an error response).
-    #[error("Service error: {0}")]
-    Service(String),
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
     /// Invalid configuration.
     #[error("Configuration error: {0}")]
@@ -37,19 +44,31 @@ impl From<reqwest::Error> for S3Error {
 
 impl From<S3Error> for ArchiveError {
     fn from(error: S3Error) -> Self {
-        ArchiveError::Io(error.to_string())
+        match error {
+            S3Error::Authorization(error) => ArchiveError::Authorization(error),
+            S3Error::Rejected(error) => ArchiveError::Rejected(error),
+            error => ArchiveError::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<S3Error> for MemoryError {
     fn from(error: S3Error) -> Self {
-        MemoryError::Storage(error.to_string())
+        match error {
+            S3Error::Authorization(error) => MemoryError::Authorization(error),
+            S3Error::Rejected(error) => MemoryError::Rejected(error),
+            error => MemoryError::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<S3Error> for BlobError {
     fn from(error: S3Error) -> Self {
-        BlobError::Storage(error.to_string())
+        match error {
+            S3Error::Authorization(error) => BlobError::Authorization(error),
+            S3Error::Rejected(error) => BlobError::Rejected(error),
+            error => BlobError::Storage(error.to_string()),
+        }
     }
 }
 
@@ -70,13 +89,13 @@ pub trait PermitRejection {
 
 impl PermitRejection for ArchiveError {
     fn is_permit_rejection(&self) -> bool {
-        matches!(self, ArchiveError::AuthorizationError(_))
+        matches!(self, ArchiveError::Authorization(_))
     }
 }
 
 impl PermitRejection for BlobError {
     fn is_permit_rejection(&self) -> bool {
-        matches!(self, BlobError::AuthorizationError(_))
+        matches!(self, BlobError::Authorization(_))
     }
 }
 
@@ -113,6 +132,61 @@ impl From<AuthorizationFormatError> for dialog_effects::credential::CredentialEr
 
 impl From<AuthorizationFormatError> for dialog_capability::AuthorizeError {
     fn from(error: AuthorizationFormatError) -> Self {
-        Self::Malformed(error.to_string())
+        match error {
+            // Bytes that would not decode: the material itself is bad.
+            AuthorizationFormatError::Deserialize(detail) => Self::Malformed { detail },
+            // Failing to write our own bytes is our machinery.
+            AuthorizationFormatError::Serialize(detail) => Self::Unavailable { detail },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use dialog_capability::access::AuthorizeError;
+    use dialog_effects::blob::BlobError;
+
+    use super::*;
+
+    fn revoked() -> AuthorizeError {
+        AuthorizeError::Revoked {
+            subject: dialog_capability::did!(
+                "did:key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX"
+            ),
+        }
+    }
+
+    // Every hop from the transport to an effect error must carry the
+    // reason itself. Stringifying it here is what made callers parse
+    // messages -- and what made `is_permit_rejection` a substring test
+    // in all but name.
+    #[dialog_common::test]
+    async fn it_preserves_the_reason_across_effect_errors() {
+        let archive = ArchiveError::from(S3Error::Authorization(revoked()));
+        let memory = MemoryError::from(S3Error::Authorization(revoked()));
+        let blob = BlobError::from(S3Error::Authorization(revoked()));
+
+        assert!(matches!(
+            archive,
+            ArchiveError::Authorization(AuthorizeError::Revoked { .. })
+        ));
+        assert!(matches!(
+            memory,
+            MemoryError::Authorization(AuthorizeError::Revoked { .. })
+        ));
+        assert!(matches!(
+            blob,
+            BlobError::Authorization(AuthorizeError::Revoked { .. })
+        ));
+    }
+
+    // The one consumer that acts on the distinction.
+    #[dialog_common::test]
+    async fn it_recognizes_a_rejected_permit() {
+        assert!(ArchiveError::Authorization(revoked()).is_permit_rejection());
+        assert!(!ArchiveError::Storage("disk".into()).is_permit_rejection());
     }
 }

--- a/rust/dialog-remote-s3/src/s3/address.rs
+++ b/rust/dialog-remote-s3/src/s3/address.rs
@@ -164,7 +164,9 @@ where
         let profile = authority::Identify
             .perform(env)
             .await
-            .map_err(|e| AuthorizeError::Malformed(e.to_string()))?
+            .map_err(|e| AuthorizeError::Unavailable {
+                detail: e.to_string(),
+            })?
             .profile()
             .clone();
 

--- a/rust/dialog-remote-s3/src/s3/provider/archive.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/archive.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use dialog_capability::ForkInvocation;
 use dialog_capability::Provider;
+use dialog_capability::access::AuthorizeError;
 use dialog_effects::archive::*;
 use reqwest::StatusCode;
 
@@ -40,10 +41,11 @@ impl Provider<S3Invocation<Get>> for S3 {
             response.status(),
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
         ) {
-            Err(ArchiveError::AuthorizationError(format!(
-                "Failed to get value: {}",
-                response.status()
-            )))
+            Err(ArchiveError::Authorization(
+                AuthorizeError::UnavailableProof {
+                    link: format!("Failed to get value: {}", response.status()),
+                },
+            ))
         } else {
             Err(ArchiveError::Storage(format!(
                 "Failed to get value: {}",
@@ -80,10 +82,11 @@ impl Provider<S3Invocation<Put>> for S3 {
             response.status(),
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
         ) {
-            Err(ArchiveError::AuthorizationError(format!(
-                "Failed to put value: {}",
-                response.status()
-            )))
+            Err(ArchiveError::Authorization(
+                AuthorizeError::UnavailableProof {
+                    link: format!("Failed to put value: {}", response.status()),
+                },
+            ))
         } else {
             Err(ArchiveError::Storage(format!(
                 "Failed to put value: {}",

--- a/rust/dialog-remote-s3/src/s3/provider/blob.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/blob.rs
@@ -8,6 +8,7 @@
 
 use async_trait::async_trait;
 use base58::ToBase58;
+use dialog_capability::access::AuthorizeError;
 use dialog_capability::{ForkInvocation, Provider};
 use dialog_common::{Blake3Hash, ConditionalSend};
 use dialog_effects::blob::prelude::{BlobImportExt as _, BlobReadExt as _};
@@ -89,9 +90,9 @@ impl Provider<S3Invocation<Read>> for S3 {
             ));
         }
         if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
-            return Err(BlobError::AuthorizationError(format!(
-                "blob read failed: {status}"
-            )));
+            return Err(BlobError::Authorization(AuthorizeError::UnavailableProof {
+                link: format!("blob read failed: {status}"),
+            }));
         }
         if !status.is_success() {
             return Err(BlobError::Storage(format!("blob read failed: {status}")));
@@ -127,7 +128,7 @@ impl S3BlobSource {
         let stream: ByteStream = Box::pin(response.bytes_stream().map(|chunk| {
             chunk
                 .map(|b| b.to_vec())
-                .map_err(|e| BlobError::Io(e.to_string()))
+                .map_err(|e| BlobError::Storage(e.to_string()))
         }));
         #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         let stream: ByteStream = Box::pin(futures_util::stream::once(async move {
@@ -135,7 +136,7 @@ impl S3BlobSource {
                 .bytes()
                 .await
                 .map(|b| b.to_vec())
-                .map_err(|e| BlobError::Io(e.to_string()))
+                .map_err(|e| BlobError::Storage(e.to_string()))
         }));
         Self { stream }
     }
@@ -193,10 +194,9 @@ impl BlobSink for S3BlobSink {
             response.status(),
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
         ) {
-            Err(BlobError::AuthorizationError(format!(
-                "blob import failed: {}",
-                response.status()
-            )))
+            Err(BlobError::Authorization(AuthorizeError::UnavailableProof {
+                link: format!("blob import failed: {}", response.status()),
+            }))
         } else {
             Err(BlobError::Storage(format!(
                 "blob import failed: {}",

--- a/rust/dialog-remote-s3/src/s3/provider/memory.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/memory.rs
@@ -4,6 +4,7 @@ use crate::{S3, S3Error, S3Invocation};
 use async_trait::async_trait;
 use dialog_capability::ForkInvocation;
 use dialog_capability::Provider;
+use dialog_capability::access::AuthorizeError;
 use dialog_effects::memory::*;
 use reqwest::StatusCode;
 
@@ -53,10 +54,11 @@ impl Provider<S3Invocation<Resolve>> for S3 {
             response.status(),
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
         ) {
-            Err(MemoryError::Authorization(format!(
-                "Failed to resolve value: {}",
-                response.status()
-            )))
+            Err(MemoryError::Authorization(
+                AuthorizeError::UnavailableProof {
+                    link: format!("Failed to resolve value: {}", response.status()),
+                },
+            ))
         } else {
             Err(MemoryError::Storage(format!(
                 "Failed to resolve value: {}",
@@ -109,7 +111,9 @@ impl Provider<S3Invocation<Publish>> for S3 {
                 actual: None,
             }),
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(MemoryError::Authorization(
-                format!("Failed to publish value: {}", response.status()),
+                AuthorizeError::UnavailableProof {
+                    link: format!("Failed to publish value: {}", response.status()),
+                },
             )),
             status => Err(MemoryError::Storage(format!(
                 "Failed to publish value: {}",
@@ -149,7 +153,9 @@ impl Provider<S3Invocation<Retract>> for S3 {
                 actual: None,
             }),
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(MemoryError::Authorization(
-                format!("Failed to retract value: {}", response.status()),
+                AuthorizeError::UnavailableProof {
+                    link: format!("Failed to retract value: {}", response.status()),
+                },
             )),
             status => Err(MemoryError::Storage(format!(
                 "Failed to retract value: {}",

--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -73,6 +73,7 @@ wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 dialog-remote-s3 = { workspace = true, features = ["helpers"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -52,6 +52,8 @@
 //! # }
 //! ```
 
+use dialog_capability::access::AuthorizeError;
+use dialog_ucan_core::ContainerError;
 use std::collections::BTreeMap;
 
 use dialog_capability::{Capability, Constraint, Did, Policy};
@@ -79,13 +81,13 @@ fn deserialize_from_args<T: DeserializeOwned>(args: &Args) -> Result<T, S3Error>
             Ipld::try_from(v)
                 .map(|ipld| (k.clone(), ipld))
                 .map_err(|e| {
-                    S3Error::Authorization(format!("Unresolved promise for '{}': {}", k, e))
+                    S3Error::Serialization(format!("Unresolved promise for '{}': {}", k, e))
                 })
         })
         .collect::<Result<_, _>>()?;
 
     ipld_core::serde::from_ipld(Ipld::Map(ipld_map))
-        .map_err(|e| S3Error::Authorization(format!("Failed to deserialize: {}", e)))
+        .map_err(|e| S3Error::Serialization(format!("Failed to deserialize: {}", e)))
 }
 
 /// Build a memory capability from UCAN args: `Subject -> Memory -> Space -> Cell -> Attenuation`.
@@ -239,7 +241,7 @@ macro_rules! dispatch {
                     authorization.redeem(&$self.address).await
                 }
             )+
-            _ => Err(S3Error::Authorization(format!("Unknown command: {:?}", $segments)))
+            _ => Err(S3Error::Configuration(format!("Unknown command: {:?}", $segments)))
         }
     };
 }
@@ -288,12 +290,25 @@ impl UcanAuthorizer {
     /// 3. Validates policy predicates on each delegation
     pub async fn authorize(&self, container: &[u8]) -> Result<Permit, S3Error> {
         // Parse and verify the invocation chain
-        let chain = InvocationChain::try_from(container)
-            .map_err(|e| S3Error::Authorization(e.to_string()))?;
-        chain
-            .verify(&Ed25519KeyResolver)
-            .await
-            .map_err(|e| S3Error::Authorization(e.to_string()))?;
+        let chain = InvocationChain::try_from(container).map_err(|e| {
+            S3Error::Authorization(AuthorizeError::Malformed {
+                detail: e.to_string(),
+            })
+        })?;
+        chain.verify(&Ed25519KeyResolver).await.map_err(|e| {
+            // Two different failures arrive here: their material not
+            // verifying, and our own setup being unable to check it.
+            // Only the first is a statement about their request, so only
+            // the first may read as one.
+            S3Error::Authorization(match e {
+                ContainerError::Invocation(detail) => AuthorizeError::Malformed {
+                    detail: format!("invocation chain did not verify: {detail}"),
+                },
+                ContainerError::Configuration(detail) => AuthorizeError::Unavailable {
+                    detail: format!("could not verify the invocation chain: {detail}"),
+                },
+            })
+        })?;
 
         // Extract command path and arguments
         let command = chain.command();

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -11,8 +11,38 @@ use dialog_capability::{
     SiteFork, SiteId, Subject,
 };
 use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_effects::Rejection;
 use dialog_effects::authority::{self, OperatorExt};
 use dialog_remote_s3::{Permit, S3Error};
+
+const MAX_ERROR_BODY_BYTES: usize = 8 * 1024;
+
+/// Read the reason a request was refused.
+///
+/// The reason travels as itself. There is no code table here and no
+/// status codes: an [`AuthorizeError`] built on the other side arrives
+/// as the same value, so nothing in this crate has to know a vocabulary
+/// of wire names, and adding a reason does not mean teaching two
+/// codebases a new string.
+///
+/// A body that does not parse becomes [`Rejection::Unclassified`] rather
+/// than being guessed at. That is also what an older responder gets: it
+/// degrades to "something went wrong and we cannot say what", which is
+/// true, instead of to a specific reason that might not be.
+fn read_rejection(status: u16, body: &[u8]) -> S3Error {
+    let bounded = &body[..body.len().min(MAX_ERROR_BODY_BYTES)];
+
+    if let Ok(reason) = serde_json::from_slice::<AuthorizeError>(bounded) {
+        return S3Error::Authorization(reason);
+    }
+    if let Ok(reason) = serde_json::from_slice::<Rejection>(bounded) {
+        return S3Error::Rejected(reason);
+    }
+
+    S3Error::Rejected(Rejection::Unclassified {
+        detail: format!("responder answered {status} with no reason we could read"),
+    })
+}
 
 use crate::permit_cache::PermitCache;
 
@@ -32,7 +62,7 @@ impl UcanAuthorization {
         let body = self
             .0
             .to_bytes()
-            .map_err(|e| S3Error::Authorization(e.to_string()))?;
+            .map_err(|e| S3Error::Serialization(e.to_string()))?;
 
         let response = reqwest::Client::new()
             .post(&address.endpoint)
@@ -43,17 +73,14 @@ impl UcanAuthorization {
 
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(S3Error::Service(format!(
-                "Access service returned {}: {}",
-                status, body
-            )));
+            let body = response.bytes().await.unwrap_or_default();
+            return Err(read_rejection(status.as_u16(), &body));
         }
 
         let body = response.bytes().await?;
 
         serde_ipld_dagcbor::from_slice(&body)
-            .map_err(|e| S3Error::Service(format!("Failed to decode response: {}", e)))
+            .map_err(|e| S3Error::Serialization(format!("Failed to decode response: {e}")))
     }
 }
 
@@ -122,10 +149,13 @@ where
     type Effect = Fx;
 
     async fn authorize(self, env: &Env) -> Result<ForkInvocation<UcanSite, Fx>, AuthorizeError> {
-        let identity = authority::Identify
-            .perform(env)
-            .await
-            .map_err(|e| AuthorizeError::Malformed(e.to_string()))?;
+        let identity =
+            authority::Identify
+                .perform(env)
+                .await
+                .map_err(|e| AuthorizeError::Malformed {
+                    detail: e.to_string(),
+                })?;
         let profile = identity.profile().clone();
         let operator = identity.did();
 
@@ -165,4 +195,183 @@ impl Site for UcanSite {
     type Authorization = UcanAuthorization;
     type Address = UcanAddress;
     type Fork<Fx: Effect> = UcanFork<Fx>;
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_capability::did;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::collections::{BTreeMap, HashMap};
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::sync::Arc;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_capability::Principal;
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_credentials::Ed25519Signer;
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_ucan_core::subject::Subject as DelegatedSubject;
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_ucan_core::{DelegationBuilder, InvocationBuilder, InvocationChain};
+    #[cfg(not(target_arch = "wasm32"))]
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    #[cfg(not(target_arch = "wasm32"))]
+    use tokio::net::TcpListener;
+
+    // The reason travels as itself, so what this pins is the round
+    // trip: whatever the responder built arrives as the same value.
+    #[dialog_common::test]
+    async fn it_reads_back_the_reason_the_responder_sent() {
+        let sent = AuthorizeError::Revoked {
+            subject: did!("key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX"),
+        };
+        let body = serde_json::to_vec(&sent).expect("serializes");
+
+        let S3Error::Authorization(read) = read_rejection(403, &body) else {
+            panic!("expected an authorization reason");
+        };
+        assert_eq!(read, sent, "the reason arrives as the value that was sent");
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_back_a_rejection() {
+        let sent = Rejection::Unavailable {
+            reason: "registry is down".into(),
+        };
+        let body = serde_json::to_vec(&sent).expect("serializes");
+
+        let S3Error::Rejected(read) = read_rejection(503, &body) else {
+            panic!("expected a rejection");
+        };
+        assert_eq!(read, sent);
+    }
+
+    // A responder that speaks the old shape, or none at all, degrades to
+    // "we cannot say" rather than to a specific reason that might be
+    // wrong. Guessing is what the code table used to do.
+    #[dialog_common::test]
+    async fn it_does_not_guess_at_a_body_it_cannot_read() {
+        for body in [
+            &b"not json at all"[..],
+            br#"{"error":{"code":"CREDENTIAL_REVOKED","message":"old shape"}}"#,
+        ] {
+            assert!(
+                matches!(
+                    read_rejection(403, body),
+                    S3Error::Rejected(Rejection::Unclassified { .. })
+                ),
+                "an unreadable body must not become a specific reason"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_bounds_the_body_it_reads() {
+        let mut oversized = vec![b'x'; MAX_ERROR_BODY_BYTES * 2];
+        oversized.extend_from_slice(br#"{"kind":"Revoked","subject":"did:key:zLate"}"#);
+
+        assert!(
+            matches!(
+                read_rejection(403, &oversized),
+                S3Error::Rejected(Rejection::Unclassified { .. })
+            ),
+            "a reason past the bound must not be read"
+        );
+    }
+
+    // A responder that has not been updated yet still sends the old
+    // `{code, message}` shape. That degrades to "we cannot say why",
+    // which is true, rather than to a specific reason guessed from a
+    // status code. Worth pinning: it is the behaviour during a rollout
+    // where the two sides are not yet in step.
+    #[dialog_common::test]
+    async fn it_degrades_when_the_responder_speaks_the_old_shape() {
+        let old = br#"{"error":{"code":"CREDENTIAL_REVOKED","message":"Credential revoked"}}"#;
+        let S3Error::Rejected(Rejection::Unclassified { detail }) = read_rejection(403, old) else {
+            panic!("an unreadable body must not become a specific reason");
+        };
+        assert!(
+            !detail.contains("CREDENTIAL_REVOKED"),
+            "and must not smuggle the old code back in, got {detail}"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_carries_the_reason_through_redeem() {
+        let subject = Ed25519Signer::import(&[41; 32]).await.expect("subject key");
+        let operator = Ed25519Signer::import(&[42; 32])
+            .await
+            .expect("operator key");
+        let command = vec!["memory".to_string(), "resolve".to_string()];
+        let delegation = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&operator)
+            .subject(DelegatedSubject::Specific(subject.did()))
+            .command(command.clone())
+            .try_build()
+            .await
+            .expect("delegation");
+        let delegation_cid = delegation.to_cid();
+        let invocation = InvocationBuilder::new()
+            .issuer(operator)
+            .audience(&subject.did())
+            .subject(&subject.did())
+            .command(command)
+            .arguments(BTreeMap::new())
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("invocation");
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+        let authorization = UcanAuthorization::from(UcanInvocation {
+            chain: Box::new(InvocationChain::new(invocation, delegations)),
+            subject: subject.did(),
+            ability: "/memory/resolve".to_string(),
+        });
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let address = listener.local_addr().expect("listener address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("request");
+            let mut request = vec![0; 16 * 1024];
+            let _ = stream.read(&mut request).await.expect("read request");
+            // What a responder sends now: the reason itself.
+            let reason = AuthorizeError::Revoked {
+                subject: did!("key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX"),
+            };
+            let body = serde_json::to_string(&reason).expect("serializes");
+            let response = format!(
+                "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        let error = authorization
+            .redeem(&UcanAddress::new(format!("http://{address}")))
+            .await
+            .expect_err("redeem is denied");
+        server.await.expect("server task");
+        // End to end over a real socket: the reason the responder built
+        // is the reason the caller receives.
+        let S3Error::Authorization(AuthorizeError::Revoked { subject }) = error else {
+            panic!("expected a revoked authorization, got {error:?}");
+        };
+        assert_eq!(
+            subject,
+            did!("key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX"),
+            "the subject is the one the responder named"
+        );
+    }
 }

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -37,6 +37,9 @@ pub use open::*;
 mod remote;
 pub use remote::*;
 
+mod snapshot;
+pub use snapshot::*;
+
 // `Revision` and `TreeReference` moved to `dialog-capability` (the
 // light crate that owns `Did`) so engine-free clients can name them
 // without linking `dialog-query` or the storage/transport stack.

--- a/rust/dialog-repository/src/repository/archive/networked.rs
+++ b/rust/dialog-repository/src/repository/archive/networked.rs
@@ -83,7 +83,7 @@ where
             .fork(&address.address)
             .perform(env)
             .await
-            .map_err(|e| DialogStorageError::StorageBackend(e.to_string()))?;
+            .map_err(DialogStorageError::from)?;
 
         match remote_result {
             Some(bytes) => {

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -81,10 +81,21 @@ pub use transaction::*;
 mod upstream;
 pub use upstream::*;
 
-#[cfg(all(test, feature = "integration-tests"))]
+// Either feature: `integration-tests` runs these natively, and
+// `web-integration-tests` runs the same tests as wasm subprocesses. The
+// `dialog_common::test` macro emits a variant per mode, so gating the
+// module on the native feature alone compiled it out of the cross-target
+// run before the macro was ever reached.
+#[cfg(all(
+    test,
+    any(feature = "integration-tests", feature = "web-integration-tests")
+))]
 mod integration_tests;
 
-#[cfg(all(test, feature = "integration-tests"))]
+#[cfg(all(
+    test,
+    any(feature = "integration-tests", feature = "web-integration-tests")
+))]
 mod read_amplification;
 
 /// Type alias for the search tree index.

--- a/rust/dialog-repository/src/repository/branch/blob.rs
+++ b/rust/dialog-repository/src/repository/branch/blob.rs
@@ -312,7 +312,7 @@ impl ReadBlob<'_> {
             .load()
             .perform(env)
             .await
-            .map_err(|e| CommitError::Blob(BlobError::ExecutionError(e.to_string())))?;
+            .map_err(|e| CommitError::Blob(BlobError::Storage(e.to_string())))?;
         let address = remote.address();
 
         // Full-blob read from the remote, forked to its site.

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -6,17 +6,33 @@
 #[cfg(target_arch = "wasm32")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+use std::collections::HashSet;
+
 use crate::helpers::{test_operator_with_profile, unique_name};
-use crate::{Blob, Branch, Repository, RepositoryExt as _, SiteAddress};
-use anyhow::Result;
-use dialog_artifacts::{Artifact, ArtifactSelector, Instruction, Value};
+use crate::{
+    Blob, Branch, Index, Item, NetworkedIndex, Repository, RepositoryArchiveExt as _,
+    RepositoryExt as _, Revision, SiteAddress, SnapshotError,
+};
+use anyhow::{Context as _, Result};
+use dialog_artifacts::tree::TreeStorageBridge;
+use dialog_artifacts::{
+    Artifact, ArtifactSelector, Datum, ENTITY_KEY_TAG, HISTORY_KEY_TAG, Instruction, Key, State,
+    Value,
+};
 use dialog_capability::Subject;
+use dialog_common::Blake3Hash as NodeHash;
 use dialog_credentials::SignerCredential;
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+// Only the native-only tests below construct one.
+#[cfg(not(feature = "web-integration-tests"))]
 use dialog_effects::blob::BlobError;
 use dialog_network::Network;
 use dialog_operator::{Operator, Profile};
 use dialog_remote_s3::helpers::S3Address;
 use dialog_remote_s3::{Address as S3SiteAddress, S3Credential};
+use dialog_search_tree::{
+    ArchivedNodeBody, ContentAddressedStorage as TreeStorage, Traversable as _, Visit, into_owned,
+};
 use dialog_storage::provider::storage::{Storage, VolatileSpace};
 use futures_util::{StreamExt, stream};
 
@@ -144,6 +160,16 @@ async fn it_push_and_pull_roundtrip(s3: S3Address) -> Result<()> {
 /// Both sites run over their own temp-dir native space (`Storage::temp()`): the
 /// volatile space used elsewhere has no blob provider, and the two sites need
 /// independent local blob stores so site B's read is a genuine local miss.
+// Native only: this test builds its sites on `Storage::temp()`, which is
+// `cfg(not(target_arch = "wasm32"))` because it needs a real temp
+// directory. The wasm equivalent is OPFS-backed and not interchangeable.
+//
+// Gated on the feature rather than the target: under
+// `web-integration-tests` the macro emits a *native* wrapper that shells
+// out to a wasm subprocess, so a target gate keeps the wrapper while
+// removing the test it launches, and the wrapper then fails finding
+// nothing to run.
+#[cfg(not(feature = "web-integration-tests"))]
 #[dialog_common::test]
 async fn it_ships_blobs_on_push_and_hydrates_on_read(s3: S3Address) -> Result<()> {
     // --- Site A: write a blob, reference it, push. ---
@@ -268,6 +294,16 @@ async fn it_ships_blobs_on_push_and_hydrates_on_read(s3: S3Address) -> Result<()
 /// the fact back, reconstructing the exact `Value` it never wrote locally —
 /// only possible if the spilled block reached the remote. A same-store local
 /// select on site A confirms the round-trip end too.
+// Native only: this test builds its sites on `Storage::temp()`, which is
+// `cfg(not(target_arch = "wasm32"))` because it needs a real temp
+// directory. The wasm equivalent is OPFS-backed and not interchangeable.
+//
+// Gated on the feature rather than the target: under
+// `web-integration-tests` the macro emits a *native* wrapper that shells
+// out to a wasm subprocess, so a target gate keeps the wrapper while
+// removing the test it launches, and the wrapper then fails finding
+// nothing to run.
+#[cfg(not(feature = "web-integration-tests"))]
 #[dialog_common::test]
 async fn it_ships_spilled_values_on_push_and_hydrates_on_read(s3: S3Address) -> Result<()> {
     // A value comfortably larger than the inline threshold, so its key spills to
@@ -421,6 +457,16 @@ async fn it_ships_spilled_values_on_push_and_hydrates_on_read(s3: S3Address) -> 
 /// retraction writes tombstones at the spilled keys, and tombstones must not
 /// demand the value block from the local archive — requiring it would wedge
 /// this replica's push forever, since nothing ever writes the block locally.
+// Native only: this test builds its sites on `Storage::temp()`, which is
+// `cfg(not(target_arch = "wasm32"))` because it needs a real temp
+// directory. The wasm equivalent is OPFS-backed and not interchangeable.
+//
+// Gated on the feature rather than the target: under
+// `web-integration-tests` the macro emits a *native* wrapper that shells
+// out to a wasm subprocess, so a target gate keeps the wrapper while
+// removing the test it launches, and the wrapper then fails finding
+// nothing to run.
+#[cfg(not(feature = "web-integration-tests"))]
 #[dialog_common::test]
 async fn it_pushes_a_retraction_of_a_pulled_spilled_fact(s3: S3Address) -> Result<()> {
     let inline_n = dialog_search_tree::Manifest::default().inline_n as usize;
@@ -541,6 +587,16 @@ async fn it_pushes_a_retraction_of_a_pulled_spilled_fact(s3: S3Address) -> Resul
 /// A subscription's change poll can see a spilled fact that arrived via pull:
 /// pull replicates tree nodes but never value blocks, so the poll's spilled
 /// fetch must fall back to the branch's remote exactly as a select does.
+// Native only: this test builds its sites on `Storage::temp()`, which is
+// `cfg(not(target_arch = "wasm32"))` because it needs a real temp
+// directory. The wasm equivalent is OPFS-backed and not interchangeable.
+//
+// Gated on the feature rather than the target: under
+// `web-integration-tests` the macro emits a *native* wrapper that shells
+// out to a wasm subprocess, so a target gate keeps the wrapper while
+// removing the test it launches, and the wrapper then fails finding
+// nothing to run.
+#[cfg(not(feature = "web-integration-tests"))]
 #[dialog_common::test]
 async fn it_polls_subscriptions_over_pulled_spilled_facts(s3: S3Address) -> Result<()> {
     use dialog_query::attribute::The;
@@ -1372,5 +1428,341 @@ async fn it_delegates_pushes_and_pulls_via_s3(s3: S3Address) -> Result<()> {
     assert_eq!(results.len(), 1, "should have Alice's artifact");
     assert_eq!(results[0].is, Value::String("Alice Delegated".into()));
 
+    Ok(())
+}
+
+// `Snapshot::export` reads what the local store holds. `download` is the
+// difference between "whatever is here" and "all of it": it routes reads
+// through the branch's upstream, so a replica that has only ever seen the
+// head can still export the revision whole.
+//
+// Site A commits and pushes; site B learns the revision but never pulls
+// its content, so B's store is empty of everything the revision reaches.
+// Exporting from B without `download` reaches nothing; with it, the same
+// export produces the same content A holds.
+/// Drain an export, counting what it produced.
+async fn drain(
+    items: impl futures_util::Stream<Item = Result<Item, SnapshotError>>,
+) -> Result<(usize, usize)> {
+    let (mut blocks, mut blobs) = (0usize, 0usize);
+    futures_util::pin_mut!(items);
+    while let Some(item) = items.next().await {
+        match item? {
+            Item::Block(_) => blocks += 1,
+            Item::Blob { mut chunks, .. } => {
+                // Drain the reader so the bytes are really fetched, not
+                // merely announced.
+                while chunks.next().await?.is_some() {}
+                blobs += 1;
+            }
+        }
+    }
+    Ok((blocks, blobs))
+}
+
+#[dialog_common::test]
+async fn it_downloads_missing_content_when_the_reach_asks_for_it(s3: S3Address) -> Result<()> {
+    // --- Site A: commit content and push it to the remote. ---
+    let (operator_a, profile_a) = test_operator_with_profile().await;
+    let (repo_a, branch_a) =
+        setup_repo_with_s3_remote(&operator_a, &profile_a, &s3, "reach-a").await?;
+
+    let facts = vec![Instruction::Assert(Artifact {
+        the: "document/body".parse()?,
+        of: "document:one".parse()?,
+        is: Value::String("downloaded on demand".repeat(64)),
+        cause: None,
+    })];
+    branch_a
+        .commit(stream::iter(facts))
+        .perform(&operator_a)
+        .await?;
+
+    // A blob rides along so the reach is exercised on BOTH channels:
+    // blocks hydrate through the archive index, blob bytes through the
+    // blob store, and each has its own read path to the remote.
+    let blob_bytes = b"downloaded on demand".repeat(512);
+    Blob::import(stream::iter(vec![Ok(blob_bytes.clone())]))
+        .write(branch_a.blobs())
+        .perform(&operator_a)
+        .await?;
+
+    assert!(branch_a.push().perform(&operator_a).await?.is_some());
+    let revision = branch_a.revision().expect("site A has a revision");
+
+    let (expected_blocks, expected_blobs) = drain(
+        repo_a
+            .snapshot(revision.clone())
+            .export()
+            .perform(&operator_a),
+    )
+    .await
+    .context("site A must be able to export everything it committed")?;
+    assert!(expected_blocks > 0, "site A holds the content locally");
+    assert_eq!(expected_blobs, 1, "site A's export carries the blob");
+
+    // --- Site B: same remote, empty local store, head only. ---
+    let storage_b = Storage::<VolatileSpace>::volatile();
+    let profile_b = Profile::open(unique_name("reach-b"))
+        .perform(&storage_b)
+        .await?;
+    let operator_b = profile_b
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage_b)
+        .await?;
+    let repo_b = profile_b
+        .repository(unique_name("reach-b-repo"))
+        .open()
+        .perform(&operator_b)
+        .await?;
+    profile_b
+        .credential()
+        .site(s3_site_address(&s3))
+        .save(S3Credential::new(&s3.access_key_id, &s3.secret_access_key))
+        .perform(&operator_b)
+        .await?;
+    let origin_b = repo_b
+        .remote("origin")
+        .create(s3_site_address(&s3))
+        .subject(repo_a.did())
+        .perform(&operator_b)
+        .await?;
+    let branch_b = repo_b.branch("main").open().perform(&operator_b).await?;
+    let remote_branch_b = origin_b.branch("main").open().perform(&operator_b).await?;
+    branch_b
+        .set_upstream(remote_branch_b)
+        .perform(&operator_b)
+        .await?;
+
+    // Without reaching for the remote, B has nothing to export: the root
+    // itself is absent, and everything under it is unreachable.
+    let (local_blocks, local_blobs) = drain(
+        repo_b
+            .snapshot(revision.clone())
+            .export()
+            .sparse()
+            .perform(&operator_b),
+    )
+    .await?;
+    assert_eq!(
+        (local_blocks, local_blobs),
+        (0, 0),
+        "a replica that never fetched holds none of the revision"
+    );
+
+    // With `download`, the same export walks the whole revision, pulling
+    // what is missing through the upstream as it goes -- the blob
+    // included, which travels its own channel.
+    let upstream = repo_b.remote("origin").load().perform(&operator_b).await?;
+    let (downloaded_blocks, downloaded_blobs) = drain(
+        repo_b
+            .snapshot(revision.clone())
+            .export()
+            .download(upstream)
+            .perform(&operator_b),
+    )
+    .await
+    .context("the download reach must fetch what site B lacks instead of failing")?;
+    assert_eq!(
+        (downloaded_blocks, downloaded_blobs),
+        (expected_blocks, expected_blobs),
+        "downloading yields the same content the origin holds, blocks and blob alike"
+    );
+
+    // And the fetched content was cached locally on the way through, so a
+    // plain export now succeeds where it found nothing before.
+    let (cached_blocks, cached_blobs) =
+        drain(repo_b.snapshot(revision).export().perform(&operator_b)).await?;
+    assert_eq!(
+        (cached_blocks, cached_blobs),
+        (expected_blocks, expected_blobs),
+        "a downloaded revision stays available locally, the blob included"
+    );
+    Ok(())
+}
+
+/// Spilled-value references a revision's tree carries, read from raw leaf
+/// entries -- deliberately independent of the export's own classification,
+/// so a test can state what the tree references without trusting the code
+/// under test -- split by the region of the referencing key: current (EAV)
+/// versus history.
+async fn raw_spill_references<C: dialog_varsig::Principal>(
+    env: &Operator<VolatileSpace>,
+    repository: &Repository<C>,
+    revision: &Revision,
+) -> Result<(HashSet<NodeHash>, HashSet<NodeHash>)> {
+    let catalog = repository.subject().archive().index();
+    let index = NetworkedIndex::new(env, catalog, None);
+    let storage = TreeStorage::new(TreeStorageBridge(index));
+    let tree = Index::from_hash(NodeHash::from(*revision.tree.hash()));
+
+    let mut current = HashSet::new();
+    let mut history = HashSet::new();
+    let visits = tree.traverse_available(&storage);
+    futures_util::pin_mut!(visits);
+    while let Some(visit) = visits.next().await {
+        let Visit::Present(node) = visit? else {
+            panic!("a pulled replica holds its whole tree");
+        };
+        let ArchivedNodeBody::Segment(segment) = node.body() else {
+            continue;
+        };
+        segment.for_each_entry::<Key, _>(|key, value| {
+            let key = Key::from(key.to_vec());
+            let value: State<Datum> = into_owned(value)?;
+            if !matches!(value, State::Added(_)) {
+                return Ok(());
+            }
+            let region = match key.tag() {
+                ENTITY_KEY_TAG => &mut current,
+                HISTORY_KEY_TAG => &mut history,
+                _ => return Ok(()),
+            };
+            if let Some(reference) = key.value_spill_hash() {
+                let reference: [u8; 32] =
+                    reference.try_into().expect("a spill reference is 32 bytes");
+                region.insert(NodeHash::from(reference));
+            }
+            Ok(())
+        })?;
+    }
+    Ok((current, history))
+}
+
+// A pulled replica references spilled blocks it was never given: pull
+// ships tree nodes, not value blocks. Site B pulls a spilled fact,
+// commits novelty of its own, then pulls the fact's retraction through a
+// real merge -- the shape `Branch::install`'s history scan existed for.
+// Wherever the merged tree keeps its reference to the block (today the
+// covered claim is physically retained in the current region and screened
+// at read time; the merge retires the covered history record instead), a
+// complete export must refuse rather than silently omit the block, and a
+// `download` export must fetch it: site A pushed it to the shared remote
+// when the fact was live.
+#[dialog_common::test]
+async fn it_downloads_spilled_values_a_pull_never_shipped(s3: S3Address) -> Result<()> {
+    // --- Site A: a fact whose value spills, pushed while live. ---
+    let (operator_a, profile_a) = test_operator_with_profile().await;
+    let (repo_a, branch_a) =
+        setup_repo_with_s3_remote(&operator_a, &profile_a, &s3, "retire-a").await?;
+
+    let retracted = Artifact {
+        the: "document/body".parse()?,
+        of: "document:retired".parse()?,
+        is: Value::String(
+            "retired".repeat(dialog_search_tree::Manifest::default().inline_n as usize + 1),
+        ),
+        cause: None,
+    };
+    branch_a
+        .commit(stream::iter(vec![Instruction::Assert(retracted.clone())]))
+        .perform(&operator_a)
+        .await?;
+    assert!(branch_a.push().perform(&operator_a).await?.is_some());
+
+    // --- Site B: pull the fact, then advance on its own so the next pull
+    // is a real merge rather than a fast-forward adoption. ---
+    let storage_b = Storage::<VolatileSpace>::volatile();
+    let profile_b = Profile::open(unique_name("retire-b"))
+        .perform(&storage_b)
+        .await?;
+    let operator_b = profile_b
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage_b)
+        .await?;
+    let repo_b = profile_b
+        .repository(unique_name("retire-b-repo"))
+        .open()
+        .perform(&operator_b)
+        .await?;
+    profile_b
+        .credential()
+        .site(s3_site_address(&s3))
+        .save(S3Credential::new(&s3.access_key_id, &s3.secret_access_key))
+        .perform(&operator_b)
+        .await?;
+    let origin_b = repo_b
+        .remote("origin")
+        .create(s3_site_address(&s3))
+        .subject(repo_a.did())
+        .perform(&operator_b)
+        .await?;
+    let branch_b = repo_b.branch("main").open().perform(&operator_b).await?;
+    let remote_branch_b = origin_b.branch("main").open().perform(&operator_b).await?;
+    branch_b
+        .set_upstream(remote_branch_b)
+        .perform(&operator_b)
+        .await?;
+    branch_b.pull().perform(&operator_b).await?;
+    branch_b
+        .commit(stream::iter(vec![Instruction::Assert(Artifact {
+            the: "note/text".parse()?,
+            of: "note:local".parse()?,
+            is: Value::String("site B novelty".into()),
+            cause: None,
+        })]))
+        .perform(&operator_b)
+        .await?;
+
+    // --- Site A retracts; site B pulls the retraction through a merge. ---
+    branch_a
+        .commit(stream::iter(vec![Instruction::Retract(retracted)]))
+        .perform(&operator_a)
+        .await?;
+    assert!(branch_a.push().perform(&operator_a).await?.is_some());
+    branch_b.pull().perform(&operator_b).await?;
+    let revision = branch_b.revision().expect("site B has a merged revision");
+
+    // The fixture holds: the merged tree still references the spilled
+    // block from some region -- history reads depend on that -- while
+    // B's store does not hold the block itself. The union keeps the
+    // assertion true whichever region the merge leaves the reference in.
+    let (current, history) = raw_spill_references(&operator_b, &repo_b, &revision).await?;
+    let referenced: HashSet<&NodeHash> = current.union(&history).collect();
+    assert!(
+        !referenced.is_empty(),
+        "the merged tree must still reference the spilled value"
+    );
+
+    // Without reaching for the remote, a complete export must refuse: it
+    // cannot read a block it does not hold, and silently omitting it would
+    // only surface at the destination, at read time.
+    let refused = drain(
+        repo_b
+            .snapshot(revision.clone())
+            .export()
+            .perform(&operator_b),
+    )
+    .await;
+    assert!(
+        refused.is_err(),
+        "a complete export must not omit the spilled block it cannot read"
+    );
+
+    // With `download`, the export must carry every referenced block,
+    // fetching the spilled value through the upstream.
+    let upstream = repo_b.remote("origin").load().perform(&operator_b).await?;
+    let items = repo_b
+        .snapshot(revision)
+        .export()
+        .download(upstream)
+        .perform(&operator_b);
+    let mut exported = HashSet::new();
+    futures_util::pin_mut!(items);
+    while let Some(item) = items.next().await {
+        if let Item::Block(block) = item? {
+            exported.insert(block.digest);
+        }
+    }
+    for reference in referenced {
+        assert!(
+            exported.contains(reference),
+            "the export must carry the spilled value the tree references: {reference}"
+        );
+    }
     Ok(())
 }

--- a/rust/dialog-repository/src/repository/branch/push.rs
+++ b/rust/dialog-repository/src/repository/branch/push.rs
@@ -237,7 +237,7 @@ impl Push<'_> {
                                 .get_blob(&blob_store, &hash)
                                 .await?
                                 .ok_or_else(|| {
-                                    BlobError::ExecutionError(format!(
+                                    BlobError::NotFound(format!(
                                         "blob {digest:?} referenced by the tree but absent from its index"
                                     ))
                                 })?;
@@ -273,7 +273,7 @@ impl Push<'_> {
                         // the novel node upload.
                         ShipmentRef::SpilledValue(reference) => {
                             let bytes = blob_store.get(&reference).await?.ok_or_else(|| {
-                                BlobError::ExecutionError(format!(
+                                BlobError::NotFound(format!(
                                     "spilled value block {reference:?} referenced by the tree but absent from the local archive"
                                 ))
                             })?;

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -1,6 +1,9 @@
 use crate::TreeReference;
 use dialog_artifacts::DialogArtifactsError;
+use dialog_capability::access::AuthorizeError;
+use dialog_common::Blake3Hash;
 use dialog_credentials::Ed25519SignerError;
+use dialog_effects::Rejection;
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::authority::AuthorityError;
 use dialog_effects::blob::BlobError;
@@ -10,99 +13,6 @@ use dialog_search_tree::DialogSearchTreeError;
 use dialog_storage::DialogStorageError;
 use std::io;
 use thiserror::Error;
-
-/// The umbrella error type for the repository API.
-///
-/// Each variant wraps a command-specific error type. Callers doing
-/// multiple operations (e.g. `push` then `pull`) can `?` both into a
-/// single `Result<_, RepositoryError>` without juggling per-command
-/// error types. Pattern match on variants or use `downcast` via
-/// [`source()`](std::error::Error::source) when specific handling is
-/// needed.
-#[derive(Error, Debug)]
-pub enum RepositoryError {
-    /// Open-repository command failed.
-    #[error(transparent)]
-    Open(#[from] OpenRepositoryError),
-
-    /// Load-repository command failed.
-    #[error(transparent)]
-    Load(#[from] LoadRepositoryError),
-
-    /// Create-repository command failed.
-    #[error(transparent)]
-    Create(#[from] CreateRepositoryError),
-
-    /// Load-branch command failed.
-    #[error(transparent)]
-    LoadBranch(#[from] LoadBranchError),
-
-    /// Commit command failed.
-    #[error(transparent)]
-    Commit(#[from] CommitError),
-
-    /// Set-upstream command failed.
-    #[error(transparent)]
-    SetUpstream(#[from] SetUpstreamError),
-
-    /// Fetch command failed.
-    #[error(transparent)]
-    Fetch(#[from] FetchError),
-
-    /// Push command failed.
-    #[error(transparent)]
-    Push(#[from] PushError),
-
-    /// Pull command failed.
-    #[error(transparent)]
-    Pull(#[from] PullError),
-
-    /// Load-remote command failed.
-    #[error(transparent)]
-    LoadRemote(#[from] LoadRemoteError),
-
-    /// Create-remote command failed.
-    #[error(transparent)]
-    CreateRemote(#[from] CreateRemoteError),
-
-    /// Open-remote-branch command failed.
-    #[error(transparent)]
-    OpenRemoteBranch(#[from] OpenRemoteBranchError),
-
-    /// Load-remote-branch command failed.
-    #[error(transparent)]
-    LoadRemoteBranch(#[from] LoadRemoteBranchError),
-
-    /// Fetch-remote-branch command failed.
-    #[error(transparent)]
-    FetchRemoteBranch(#[from] FetchRemoteBranchError),
-
-    /// Publish-remote-branch command failed.
-    #[error(transparent)]
-    PublishRemoteBranch(#[from] PublishRemoteBranchError),
-
-    /// Upload command (novel blocks to remote archive) failed.
-    #[error(transparent)]
-    Upload(#[from] UploadError),
-
-    /// Cell publish failed (outside a command context).
-    #[error(transparent)]
-    Publish(#[from] PublishError),
-
-    /// Cell resolve failed (outside a command context).
-    #[error(transparent)]
-    Resolve(#[from] ResolveError),
-
-    /// Select command failed to load its tree (the stream itself yields
-    /// `DialogArtifactsError` per-item, which is surfaced through the
-    /// stream).
-    #[error(transparent)]
-    Select(#[from] DialogSearchTreeError),
-
-    /// A verifier-only credential was used where a signer was required.
-    #[error(transparent)]
-    SignerRequired(#[from] SignerRequiredError),
-}
 
 /// Errors returned by the open remote branch command.
 #[derive(Error, Debug)]
@@ -469,9 +379,14 @@ pub enum ResolveError {
     #[error("Storage error: {0}")]
     Storage(String),
 
-    /// Authorization denied.
-    #[error("Authorization error: {0}")]
-    Authorization(String),
+    /// The request was not authorized.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
+
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
     /// IO failure.
     #[error("IO error: {0}")]
@@ -489,8 +404,8 @@ impl From<MemoryError> for ResolveError {
                 Self::VersionMismatch { expected, actual }
             }
             MemoryError::Storage(message) => Self::Storage(message),
-            MemoryError::Authorization(message) => Self::Authorization(message),
-            MemoryError::Io(error) => Self::Io(error),
+            MemoryError::Rejected(error) => Self::Rejected(error),
+            MemoryError::Authorization(error) => Self::Authorization(error),
         }
     }
 }
@@ -511,9 +426,14 @@ pub enum PublishError {
     #[error("Storage error: {0}")]
     Storage(String),
 
-    /// Authorization denied.
-    #[error("Authorization error: {0}")]
-    Authorization(String),
+    /// The request was not authorized.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
+
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
     /// IO failure.
     #[error("IO error: {0}")]
@@ -531,8 +451,8 @@ impl From<MemoryError> for PublishError {
                 Self::VersionMismatch { expected, actual }
             }
             MemoryError::Storage(message) => Self::Storage(message),
-            MemoryError::Authorization(message) => Self::Authorization(message),
-            MemoryError::Io(error) => Self::Io(error),
+            MemoryError::Rejected(error) => Self::Rejected(error),
+            MemoryError::Authorization(error) => Self::Authorization(error),
         }
     }
 }
@@ -546,9 +466,176 @@ pub enum UploadError {
 
     /// Failed to read a block from the local archive before uploading.
     #[error("Failed to read block from local archive: {0}")]
-    LocalRead(ArchiveError),
+    LocalRead(#[source] ArchiveError),
 
     /// Failed to write a block to the remote archive.
     #[error("Failed to write block to remote archive: {0}")]
-    RemoteWrite(ArchiveError),
+    RemoteWrite(#[source] ArchiveError),
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unused_async)]
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use dialog_capability::access::AuthorizeError;
+
+    use super::*;
+
+    fn revoked() -> AuthorizeError {
+        AuthorizeError::Revoked {
+            subject: dialog_capability::did!(
+                "did:key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX"
+            ),
+        }
+    }
+
+    /// Confirm the reason is still reachable as a value, not as text.
+    ///
+    /// `#[error(transparent)]` delegates `source()` straight past the
+    /// variant, so the wrapper chain does not expose the
+    /// [`AuthorizeError`] as a source -- it is reachable by matching, and
+    /// that is the property worth pinning: previously each hop rendered
+    /// the reason with `to_string()`, so the only way to recover it was
+    /// to parse the message.
+    fn assert_revoked(rendered: &str) {
+        assert!(
+            rendered.contains("revoked"),
+            "the reason survives the wrappers, got {rendered}"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_memory_reasons_through_pull_and_push() {
+        let pull = PullError::FetchRemoteBranch(FetchRemoteBranchError::Resolve(
+            ResolveError::from(MemoryError::Authorization(revoked())),
+        ));
+        let push = PushError::PublishRemoteBranch(PublishRemoteBranchError::Publish(
+            PublishError::from(MemoryError::Authorization(revoked())),
+        ));
+
+        // Structural: the reason is a value at the end of the chain.
+        let PullError::FetchRemoteBranch(FetchRemoteBranchError::Resolve(
+            ResolveError::Authorization(reason),
+        )) = &pull
+        else {
+            panic!("expected an authorization reason, got {pull:?}");
+        };
+        assert!(matches!(reason, AuthorizeError::Revoked { .. }));
+
+        assert_revoked(&pull.to_string());
+        assert_revoked(&push.to_string());
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_archive_reasons_through_pull_and_push() {
+        let storage = DialogStorageError::from(ArchiveError::Authorization(revoked()));
+        let pull = PullError::Tree(DialogSearchTreeError::from(storage));
+        let push = PushError::Upload(UploadError::RemoteWrite(ArchiveError::Authorization(
+            revoked(),
+        )));
+
+        assert_revoked(&pull.to_string());
+        assert_revoked(&push.to_string());
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_blob_reasons_through_push() {
+        let push = PushError::Blob(BlobError::Authorization(revoked()));
+        let PushError::Blob(BlobError::Authorization(reason)) = &push else {
+            panic!("expected an authorization reason, got {push:?}");
+        };
+        assert!(matches!(reason, AuthorizeError::Revoked { .. }));
+        assert_revoked(&push.to_string());
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_artifact_reasons_through_push() {
+        let tree = DialogSearchTreeError::from(DialogStorageError::Authorization(revoked()));
+        let push = PushError::Artifact(DialogArtifactsError::from(tree));
+        let PushError::Artifact(DialogArtifactsError::Authorization(reason)) = &push else {
+            panic!("the conversion flattened the reason: {push:?}");
+        };
+        assert!(matches!(reason, AuthorizeError::Revoked { .. }));
+        assert_revoked(&push.to_string());
+    }
+}
+
+/// Errors from snapshot export and import.
+///
+/// The digest-mismatch variants are the point of this type. A snapshot may
+/// cross a trust boundary -- a source that fetched from a remote, or bytes
+/// read from a file -- so content that does not hash to the address it
+/// claims must be refused rather than stored. Both carry what was expected
+/// and what arrived, so a caller can say which content was corrupt.
+#[derive(Error, Debug)]
+pub enum SnapshotError {
+    /// A block's content did not hash to the digest it declared.
+    ///
+    /// Storing it anyway would not fail loudly: content-addressed bytes
+    /// simply land at a different address, unreferenced, and surface much
+    /// later as a missing node far from the cause.
+    #[error("Block content does not match its address: expected {expected}, got {actual}")]
+    BlockDigestMismatch {
+        /// The address the block declared.
+        expected: Blake3Hash,
+        /// The address its content actually hashes to.
+        actual: Blake3Hash,
+    },
+
+    /// A blob's content did not hash to the digest it declared.
+    ///
+    /// Detected at `finish`, once the last chunk has been written: a blob
+    /// arrives in pieces, so it cannot be checked on arrival the way a
+    /// block can.
+    #[error("Blob content does not match its address: expected {expected}, got {actual}")]
+    BlobDigestMismatch {
+        /// The address the blob declared.
+        expected: Blake3Hash,
+        /// The address its content actually hashes to.
+        actual: Blake3Hash,
+    },
+
+    /// The revision references a block this store does not hold.
+    ///
+    /// Only raised when the export was asked for a complete snapshot; a
+    /// sparse one records the gap and carries on.
+    #[error("Revision references block {digest}, which is not present")]
+    MissingBlock {
+        /// The address that could not be read.
+        digest: Blake3Hash,
+    },
+
+    /// A spilled-value key carried a malformed content reference.
+    #[error("Spilled-value reference is not 32 bytes: {0:?}")]
+    InvalidSpillReference(Vec<u8>),
+
+    /// The revision references a blob this store does not hold.
+    #[error("Revision references blob {digest}, which is not present")]
+    MissingBlob {
+        /// The address that could not be read.
+        digest: Blake3Hash,
+    },
+
+    /// Reading or writing an archive block failed.
+    #[error(transparent)]
+    Archive(#[from] ArchiveError),
+
+    /// Reading or writing a blob failed.
+    #[error(transparent)]
+    Blob(#[from] BlobError),
+
+    /// Walking the revision's tree failed.
+    #[error(transparent)]
+    Tree(#[from] DialogSearchTreeError),
+
+    /// Reading a referenced artifact failed.
+    #[error(transparent)]
+    Artifact(#[from] DialogArtifactsError),
+
+    /// Accessing the archive backend failed.
+    #[error(transparent)]
+    Storage(#[from] DialogStorageError),
 }

--- a/rust/dialog-repository/src/repository/snapshot.rs
+++ b/rust/dialog-repository/src/repository/snapshot.rs
@@ -1,0 +1,958 @@
+//! Immutable views of a repository at one revision, and the content
+//! transfer built on them.
+//!
+//! A [`Snapshot`] holds its revision by value, so what it names cannot
+//! change while you hold it -- unlike a [`Branch`](crate::Branch), whose
+//! head advances as it commits. Nothing here publishes or moves a head:
+//! [`Snapshot::export`] reads content out, [`Repository::import`] writes
+//! content in, and making a revision visible stays a separate act.
+//!
+//! # Two channels, not one
+//!
+//! A snapshot's content divides into two kinds that cannot share a stream,
+//! because they land in different providers and verify at different times:
+//!
+//! - **Blocks** (tree nodes and spilled values) are whole values written
+//!   through `archive::Put`. Each carries the digest it must hash to,
+//!   checked before it is stored.
+//! - **Blobs** are streamed through `blob::Import`, opened with a declared
+//!   digest and size and verified at `finish` -- a blob arrives in pieces,
+//!   so it cannot be checked on arrival the way a block can.
+//!
+//! Both channels declare a digest and both are verified against it. What
+//! differs is only *when* the check can happen.
+//!
+//! # Export is best-effort at the leaves; `download` is the guarantee
+//!
+//! [`SnapshotExport`] reads what the local store holds and reports referenced
+//! content it could not find, rather than failing -- a snapshot of a
+//! partially fetched branch is a legitimate thing to want.
+//!
+//! That tolerance stops at the tree itself. A missing spilled value or
+//! blob is a leaf: it is skipped, recorded, and the rest of the export is
+//! still coherent. A missing *node* is not, because the walk cannot pass
+//! it and everything beneath it becomes unreachable -- there is no way to
+//! enumerate what was lost, so a gap in the tree aborts.
+//!
+//! [`SnapshotExport::download`] resolves both by hydrating read-misses from an
+//! upstream as the walk proceeds, which is what makes the result complete.
+
+use std::collections::HashSet;
+
+use async_stream::try_stream;
+use dialog_artifacts::tree::TreeStorageBridge;
+use dialog_artifacts::{
+    BlobChange, BlobIndexExt as _, Datum, Key, ShipmentRef, State, shipment_ref,
+};
+use dialog_capability::{Capability, Fork, Provider, Subject};
+use dialog_common::{Blake3Hash as NodeHash, Buffer, ConditionalSync};
+use dialog_effects::archive::prelude::{ArchiveSubjectExt as _, CatalogExt as _};
+use dialog_effects::archive::{Catalog, Get, Put};
+use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
+use dialog_effects::blob::{BlobError, BlobReader, Import as BlobImport, Read as BlobRead};
+use dialog_search_tree::{
+    ArchivedNodeBody, ContentAddressedStorage as TreeStorage, Traversable as _, Visit, into_owned,
+};
+use futures_util::{Stream, StreamExt as _};
+
+use dialog_credentials::Credential;
+use dialog_varsig::Principal;
+
+use crate::{
+    Index, NetworkedIndex, RemoteRepository, RemoteSite, Repository, RepositoryArchiveExt as _,
+    Revision, SnapshotError,
+};
+
+/// A block of a snapshot: content plus the digest it must hash to.
+///
+/// The digest is carried rather than recomputed on arrival because a
+/// snapshot may cross a trust boundary -- a source that fetched from a
+/// remote, or a snapshot read from a file. Bytes that hash to something
+/// else would not fail loudly if simply stored (they land at a different
+/// address, unreferenced, and surface much later as a missing node), so
+/// the mismatch is caught where the untrusted bytes enter.
+#[derive(Debug, Clone)]
+pub struct Block {
+    /// The address this block's content must hash to.
+    pub digest: NodeHash,
+    /// The block's bytes.
+    pub content: Buffer,
+}
+
+impl Block {
+    /// Build a block from content, deriving its address.
+    pub fn new(content: Buffer) -> Self {
+        let digest = content.blake3_hash().clone();
+        Self { digest, content }
+    }
+
+    /// Whether the content actually hashes to the declared digest.
+    pub fn is_intact(&self) -> bool {
+        self.digest.matches(self.content.as_ref())
+    }
+}
+
+/// An immutable view of a repository at one revision.
+pub struct Snapshot<'a, C: Principal = Credential> {
+    repository: &'a Repository<C>,
+    revision: Revision,
+}
+
+impl<C: Principal> Repository<C> {
+    /// An immutable view at `revision`.
+    ///
+    /// The revision is taken by value: whatever advances afterwards, this
+    /// view keeps naming the same state. How the revision was obtained is
+    /// the caller's business -- a snapshot does not require the branch it
+    /// was minted on to be present, which is why it also cannot hydrate
+    /// from an upstream (see [`SnapshotExport::download`]).
+    pub fn snapshot(&self, revision: Revision) -> Snapshot<'_, C> {
+        Snapshot {
+            repository: self,
+            revision,
+        }
+    }
+}
+
+impl<C: Principal> Snapshot<'_, C> {
+    /// The revision this snapshot names.
+    pub fn revision(&self) -> &Revision {
+        &self.revision
+    }
+
+    /// The archive catalog this snapshot's blocks live in.
+    pub(crate) fn index(&self) -> Capability<Catalog> {
+        self.repository.subject().archive().index()
+    }
+}
+
+/// One piece of a snapshot's content.
+///
+/// Blocks and blobs are separate variants rather than one uniform item
+/// because they land in different providers and verify at different times.
+/// A blob also cannot be a value: it may be far larger than memory, so it
+/// travels as the reader it will be streamed from rather than as bytes.
+pub enum Item {
+    /// A whole block: its content, and the address that content must hash
+    /// to. Verified on arrival.
+    Block(Block),
+    /// A blob: the address and length its content must have, and the
+    /// reader its chunks come from. Verified once the last chunk lands.
+    Blob {
+        /// The address this blob's content must hash to.
+        digest: NodeHash,
+        /// The blob's total length in bytes.
+        size: u64,
+        /// The blob's content, in order.
+        chunks: BlobReader,
+    },
+}
+
+impl Item {
+    /// The address this item's content must hash to.
+    pub fn digest(&self) -> &NodeHash {
+        match self {
+            Item::Block(block) => &block.digest,
+            Item::Blob { digest, .. } => digest,
+        }
+    }
+}
+
+/// How far an export reaches for content the local store does not hold.
+///
+/// Set through [`SnapshotExport::sparse`] and
+/// [`SnapshotExport::download`]. Exclusive rather than combinable --
+/// hydrating from an upstream and tolerating gaps are opposite answers to
+/// the same question -- so the later call wins rather than accumulating.
+pub enum Reach {
+    /// Everything the revision references must be present locally.
+    ///
+    /// A missing block or blob fails the export naming what is absent.
+    /// The default, because a snapshot that silently omits content is
+    /// unusable in a way that only surfaces much later, at read time.
+    Complete,
+
+    /// Whatever is reachable from the root in local storage.
+    ///
+    /// Gaps are skipped and the walk continues
+    /// past them where it can -- a subtree under an absent node is
+    /// unreachable, so what lies beneath it cannot be enumerated. Corrupt
+    /// content is still fatal: a block whose stored bytes do not match
+    /// their address is a different failure from one that is simply not
+    /// here.
+    Sparse,
+
+    /// Hydrate read-misses from an upstream as the walk proceeds.
+    ///
+    /// Fetched content is cached locally on the way through, so the
+    /// export is complete at the cost of pulling whatever is absent over
+    /// the network.
+    Download(RemoteRepository),
+}
+
+/// Reads a snapshot's content out of a store.
+///
+/// Created by [`Snapshot::export`]. Yields a stream of [`Item`]s rather
+/// than pushing into a consumer, so what happens to the content is the
+/// caller's decision: hand it to [`Repository::import`], write it to a
+/// file, count it, filter it.
+pub struct SnapshotExport<'a, C: Principal = Credential> {
+    snapshot: Snapshot<'a, C>,
+    reach: Reach,
+}
+
+impl<'a, C: Principal> Snapshot<'a, C> {
+    /// Prepare to read this snapshot's content.
+    pub fn export(self) -> SnapshotExport<'a, C> {
+        SnapshotExport {
+            snapshot: self,
+            reach: Reach::Complete,
+        }
+    }
+}
+
+impl<C: Principal> SnapshotExport<'_, C> {
+    /// Export whatever is reachable locally instead of requiring
+    /// everything.
+    ///
+    /// Gaps are skipped rather than failing the export. Content that is
+    /// present but corrupt still fails: bytes that do not match the address
+    /// they were stored under are a different problem from bytes that are
+    /// simply not here.
+    pub fn sparse(mut self) -> Self {
+        self.reach = Reach::Sparse;
+        self
+    }
+
+    /// Hydrate read-misses from `upstream` as the walk proceeds.
+    ///
+    /// Fetched content is cached locally on the way through, so the export
+    /// is complete at the cost of pulling whatever is absent over the
+    /// network.
+    pub fn download(mut self, upstream: RemoteRepository) -> Self {
+        self.reach = Reach::Download(upstream);
+        self
+    }
+
+    /// How far this export will reach.
+    pub fn reach(&self) -> &Reach {
+        &self.reach
+    }
+
+    /// Stream the snapshot's content.
+    ///
+    /// One walk of the tree. Nodes are yielded as they are visited, and
+    /// because a leaf arrives already decoded, the content its entries
+    /// reference is discovered in the same visit rather than in a second
+    /// pass over the same rows -- those referenced blocks and blobs follow
+    /// the nodes.
+    pub fn perform<Env>(self, env: &Env) -> impl Stream<Item = Result<Item, SnapshotError>> + '_
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<BlobRead>
+            + Provider<BlobImport>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, BlobRead>>
+            + ConditionalSync
+            + 'static,
+    {
+        let catalog = self.snapshot.index();
+        let subject = self.snapshot.repository.subject();
+        let upstream = match &self.reach {
+            Reach::Download(remote) => Some(remote.clone()),
+            Reach::Complete | Reach::Sparse => None,
+        };
+        // The index consumes one handle for block read-misses; blob bytes
+        // travel their own channel, so the blob loop needs its own.
+        let hydrate = upstream.clone();
+        let sparse = matches!(self.reach, Reach::Sparse);
+        let root = NodeHash::from(*self.snapshot.revision.tree.hash());
+
+        try_stream! {
+            // With an upstream a read-miss falls through to the remote and
+            // is cached; without one the index is exactly what this store
+            // holds.
+            let index = NetworkedIndex::new(env, catalog, upstream);
+            let storage = TreeStorage::new(TreeStorageBridge(index.clone()));
+            let tree = Index::from_hash(root);
+
+            let mut spills: HashSet<[u8; 32]> = HashSet::new();
+            let mut blobs: Vec<NodeHash> = Vec::new();
+
+            let visits = tree.traverse_available(&storage);
+            futures_util::pin_mut!(visits);
+            while let Some(visit) = visits.next().await {
+                let node = match visit? {
+                    Visit::Present(node) => node,
+                    Visit::Absent(hash) => {
+                        if sparse {
+                            continue;
+                        }
+                        Err(SnapshotError::MissingBlock { digest: hash })?;
+                        continue;
+                    }
+                };
+
+                // A leaf is already decoded here, so its entries are lifted
+                // in this visit. The closure only collects: classification
+                // returns artifact errors, which do not belong in a
+                // tree-walk callback.
+                let mut entries: Vec<(Key, State<Datum>)> = Vec::new();
+                if let ArchivedNodeBody::Segment(segment) = node.body() {
+                    segment.for_each_entry::<Key, _>(|key, value| {
+                        entries.push((Key::from(key.to_vec()), into_owned(value)?));
+                        Ok(())
+                    })?;
+                }
+                for (key, value) in entries {
+                    match shipment_ref(&key, &value, false)? {
+                        Some(ShipmentRef::SpilledValue(reference)) => {
+                            spills.insert(reference);
+                        }
+                        Some(ShipmentRef::Blob(BlobChange::Added(hash))) => {
+                            blobs.push(NodeHash::from(hash));
+                        }
+                        _ => {}
+                    }
+                }
+
+                yield Item::Block(Block::new(node.buffer().clone()));
+            }
+
+            // Spilled value blocks, discovered above.
+            for reference in spills {
+                let digest = NodeHash::from(reference);
+                match storage.retrieve(&digest).await? {
+                    Some(bytes) => {
+                        yield Item::Block(Block { digest, content: Buffer::from(bytes) });
+                    }
+                    None if sparse => {}
+                    None => Err(SnapshotError::MissingBlock { digest })?,
+                }
+            }
+
+            // Blob bytes, discovered above. The size comes from the tree's
+            // own blob index rather than the traversal: `import` is opened
+            // with it, and reading it costs no byte fetch.
+            for digest in blobs {
+                let record = tree.get_blob(&index, digest.as_bytes()).await?;
+                let Some(record) = record else {
+                    if !sparse {
+                        Err(SnapshotError::MissingBlob { digest })?;
+                    }
+                    continue;
+                };
+                let reader = subject
+                    .clone()
+                    .archive()
+                    .blob()
+                    .read(digest.clone())
+                    .perform(env)
+                    .await;
+                let reader = match (reader, &hydrate) {
+                    // A local miss the reach says to resolve. The index
+                    // cannot serve this one -- blocks fall through to the
+                    // remote via `Get`, blob bytes travel their own
+                    // channel -- so fetch the whole blob through a local
+                    // digest-verified import first (a lying remote
+                    // surfaces as `DigestMismatch` at `finish`, and the
+                    // bytes are cached like every other download), then
+                    // serve the read from the now-local copy.
+                    (Err(BlobError::NotFound(_)), Some(remote)) => {
+                        let address = remote.address();
+                        let mut source = address
+                            .subject
+                            .clone()
+                            .archive()
+                            .blob()
+                            .read(digest.clone())
+                            .fork(address.site())
+                            .perform(env)
+                            .await?;
+                        let mut sink = subject
+                            .clone()
+                            .archive()
+                            .blob()
+                            .import(digest.clone(), record.size)
+                            .perform(env)
+                            .await?;
+                        while let Some(chunk) = source.next().await? {
+                            sink.write_all(&chunk).await?;
+                        }
+                        sink.finish().await?;
+                        subject
+                            .clone()
+                            .archive()
+                            .blob()
+                            .read(digest.clone())
+                            .perform(env)
+                            .await
+                    }
+                    (reader, _) => reader,
+                };
+                match reader {
+                    Ok(chunks) => {
+                        yield Item::Blob { digest, size: record.size, chunks };
+                    }
+                    Err(BlobError::NotFound(_)) if sparse => {}
+                    Err(BlobError::NotFound(_)) => {
+                        Err(SnapshotError::MissingBlob { digest })?;
+                    }
+                    Err(error) => Err(SnapshotError::from(error))?,
+                }
+            }
+        }
+    }
+}
+
+/// Writes snapshot content into a repository's storage.
+///
+/// The counterpart to [`SnapshotExport`]: it verifies each item against
+/// the address it declares and stores it, and does nothing else. It does
+/// not publish a head, mint a revision, or make anything visible -- a
+/// destination holds the content afterwards but still resolves nothing by
+/// name until someone publishes the revision, which travels separately.
+///
+/// Takes no revision for the same reason: blocks and blobs are
+/// content-addressed, so nothing about storing them depends on which
+/// revision referenced them.
+pub struct SnapshotImport<Items> {
+    subject: Subject,
+    items: Items,
+}
+
+impl<C: Principal> Repository<C> {
+    /// Prepare to write snapshot content into this repository's storage.
+    pub fn import<Items>(&self, items: Items) -> SnapshotImport<Items>
+    where
+        Items: Stream<Item = Result<Item, SnapshotError>>,
+    {
+        SnapshotImport {
+            subject: self.subject(),
+            items,
+        }
+    }
+}
+
+impl<Items> SnapshotImport<Items>
+where
+    Items: Stream<Item = Result<Item, SnapshotError>>,
+{
+    /// Store every item, verifying each against the address it declares.
+    ///
+    /// Returns how many of each kind landed.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Imported, SnapshotError>
+    where
+        Env: Provider<Put> + Provider<BlobImport> + ConditionalSync + 'static,
+    {
+        let subject = self.subject;
+        let mut imported = Imported::default();
+        let items = self.items;
+        futures_util::pin_mut!(items);
+
+        while let Some(item) = items.next().await {
+            match item? {
+                Item::Block(block) => {
+                    // Verify before storing. Content-addressed bytes that
+                    // hash to something else do not fail loudly when
+                    // stored -- they land at a different address where
+                    // nothing references them, and surface much later as a
+                    // missing node, far from the cause.
+                    if !block.is_intact() {
+                        return Err(SnapshotError::BlockDigestMismatch {
+                            expected: block.digest.clone(),
+                            actual: block.content.blake3_hash().clone(),
+                        });
+                    }
+                    subject
+                        .clone()
+                        .archive()
+                        .index()
+                        .put(block.content)
+                        .perform(env)
+                        .await?;
+                    imported.blocks += 1;
+                }
+                Item::Blob {
+                    digest,
+                    size,
+                    mut chunks,
+                } => {
+                    let mut writer = subject
+                        .clone()
+                        .archive()
+                        .blob()
+                        .import(digest.clone(), size)
+                        .perform(env)
+                        .await?;
+                    while let Some(chunk) = chunks.next().await? {
+                        writer.write_all(&chunk).await?;
+                    }
+                    // A blob arrives in pieces, so its address can only be
+                    // checked once the last one lands. This is what
+                    // surfaces a lying source.
+                    let written = writer.finish().await?;
+                    if written != digest {
+                        return Err(SnapshotError::BlobDigestMismatch {
+                            expected: digest,
+                            actual: written,
+                        });
+                    }
+                    imported.blobs += 1;
+                }
+            }
+        }
+
+        Ok(imported)
+    }
+}
+
+/// What an import stored.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Imported {
+    /// Blocks written.
+    pub blocks: u64,
+    /// Blobs written.
+    pub blobs: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use anyhow::Result;
+    use dialog_artifacts::{Artifact, Instruction, Value};
+    use dialog_credentials::Credential;
+    use dialog_effects::blob::BlobSource;
+    use dialog_search_tree::PersistentNode;
+    use dialog_storage::provider::storage::{Storage, VolatileSpace};
+    use futures_util::stream;
+
+    use super::*;
+    use dialog_capability::Subject;
+    use dialog_effects::storage::{LocationExt as _, Storage as StorageFx};
+
+    use crate::Blob;
+    use crate::helpers::{generate_data, test_operator_with_profile, test_repo, unique_name};
+
+    /// A blob source over bytes held in memory.
+    struct Bytes(Option<Vec<u8>>);
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl BlobSource for Bytes {
+        async fn next(&mut self) -> Result<Option<Vec<u8>>, BlobError> {
+            Ok(self.0.take())
+        }
+    }
+
+    /// Drain an export into memory, so a test can assert on what it
+    /// produced. Blobs are read out here because a `BlobReader` cannot
+    /// outlive the stream that yielded it.
+    async fn drain(
+        items: impl Stream<Item = Result<Item, SnapshotError>>,
+    ) -> Result<(Vec<Block>, Vec<(NodeHash, Vec<u8>)>)> {
+        let mut blocks = Vec::new();
+        let mut blobs = Vec::new();
+        futures_util::pin_mut!(items);
+        while let Some(item) = items.next().await {
+            match item? {
+                Item::Block(block) => blocks.push(block),
+                Item::Blob {
+                    digest, mut chunks, ..
+                } => {
+                    let mut bytes = Vec::new();
+                    while let Some(chunk) = chunks.next().await? {
+                        bytes.extend_from_slice(&chunk);
+                    }
+                    blobs.push((digest, bytes));
+                }
+            }
+        }
+        Ok((blocks, blobs))
+    }
+
+    struct Stage {
+        env: dialog_operator::Operator<VolatileSpace>,
+        profile: dialog_operator::Profile,
+        repository: crate::Repository,
+        revision: Revision,
+        blob_bytes: Vec<u8>,
+    }
+
+    /// A second environment with the same repository mounted, so imported
+    /// content has somewhere to land.
+    async fn destination_for(stage: &Stage) -> Result<dialog_operator::Operator<VolatileSpace>> {
+        let destination = Storage::<VolatileSpace>::volatile();
+        StorageFx::profile(unique_name("snapshot-profile"))
+            .create(Credential::Signer(stage.profile.signer().clone()))
+            .perform(&destination)
+            .await?;
+        StorageFx::profile(unique_name("snapshot-repository"))
+            .create(stage.repository.credential().clone())
+            .perform(&destination)
+            .await?;
+        Ok(stage
+            .profile
+            .derive(b"snapshot-destination")
+            .allow(Subject::any())
+            .network(dialog_network::Network::default())
+            .build(destination)
+            .await?)
+    }
+
+    /// A branch holding enough to exercise every channel: ordinary facts,
+    /// a value too large to inline (so it spills to its own block), and a
+    /// blob.
+    async fn stage() -> Result<Stage> {
+        let (env, profile) = test_operator_with_profile().await;
+        let repository = test_repo(&env, &profile).await;
+        let branch = repository.branch("main").open().perform(&env).await?;
+
+        let mut facts: Vec<Instruction> = generate_data(20)?
+            .into_iter()
+            .map(Instruction::Assert)
+            .collect();
+        let large = Value::String(
+            "spilled".repeat(dialog_search_tree::Manifest::default().inline_n as usize + 1),
+        );
+        facts.push(Instruction::Assert(Artifact {
+            the: "document/body".parse()?,
+            of: "document:large".parse()?,
+            is: large,
+            cause: None,
+        }));
+        branch.commit(stream::iter(facts)).perform(&env).await?;
+
+        let blob_bytes = b"snapshot blob".repeat(512);
+        Blob::import(stream::iter(vec![Ok(blob_bytes.clone())]))
+            .write(branch.blobs())
+            .perform(&env)
+            .await?;
+
+        let revision = branch.revision().expect("staged branch has a revision");
+        Ok(Stage {
+            env,
+            profile,
+            repository,
+            revision,
+            blob_bytes,
+        })
+    }
+
+    #[dialog_common::test]
+    async fn it_exports_every_channel_of_a_revision() -> Result<()> {
+        let stage = stage().await?;
+
+        let (blocks, blobs) = drain(
+            stage
+                .repository
+                .snapshot(stage.revision.clone())
+                .export()
+                .perform(&stage.env),
+        )
+        .await?;
+
+        assert!(!blocks.is_empty(), "the block channel carried the tree");
+        assert_eq!(blobs.len(), 1, "the blob channel carried the blob");
+        assert_eq!(
+            blobs[0].1, stage.blob_bytes,
+            "the blob arrived byte for byte"
+        );
+        assert!(
+            blocks.iter().all(Block::is_intact),
+            "every exported block hashes to the address it declares"
+        );
+        Ok(())
+    }
+
+    // Round trip: content exported from one store and imported into
+    // another leaves it there -- but the revision stays invisible, because
+    // import deliberately publishes nothing.
+    #[dialog_common::test]
+    async fn it_round_trips_a_revision_into_another_store() -> Result<()> {
+        let stage = stage().await?;
+        let destination = destination_for(&stage).await?;
+        let elsewhere = crate::Repository::from(stage.repository.credential().clone());
+
+        let items = stage
+            .repository
+            .snapshot(stage.revision.clone())
+            .export()
+            .perform(&stage.env);
+        let imported = elsewhere.import(items).perform(&destination).await?;
+
+        assert!(imported.blocks > 0, "blocks landed");
+        assert_eq!(imported.blobs, 1, "the blob landed");
+
+        let branch = elsewhere
+            .branch("main")
+            .open()
+            .perform(&destination)
+            .await?;
+        assert!(
+            branch.revision().is_none(),
+            "importing content publishes nothing"
+        );
+        Ok(())
+    }
+
+    // A block whose bytes do not hash to the address it declares must be
+    // refused. Storing it would not fail loudly -- content-addressed bytes
+    // land wherever they hash to, so a corrupt block simply becomes an
+    // unreferenced one, and the revision that needed it reports a missing
+    // node much later, far from the cause.
+    #[dialog_common::test]
+    async fn it_refuses_a_block_that_does_not_match_its_address() -> Result<()> {
+        let stage = stage().await?;
+        let (blocks, _) = drain(
+            stage
+                .repository
+                .snapshot(stage.revision.clone())
+                .export()
+                .perform(&stage.env),
+        )
+        .await?;
+
+        let destination = destination_for(&stage).await?;
+        let elsewhere = crate::Repository::from(stage.repository.credential().clone());
+
+        // Keep the address, corrupt the bytes.
+        let honest = blocks.first().expect("export produced blocks").clone();
+        let tampered = Item::Block(Block {
+            digest: honest.digest.clone(),
+            content: Buffer::from(b"not the bytes this address names".to_vec()),
+        });
+
+        let result = elsewhere
+            .import(stream::iter(vec![Ok(tampered)]))
+            .perform(&destination)
+            .await;
+        match result {
+            Err(SnapshotError::BlockDigestMismatch { expected, actual }) => {
+                assert_eq!(expected, honest.digest);
+                assert_ne!(actual, honest.digest);
+            }
+            other => panic!("expected a digest mismatch, got {other:?}"),
+        }
+
+        // And nothing was written under the address it claimed.
+        let stored = elsewhere
+            .subject()
+            .archive()
+            .index()
+            .get(honest.digest.clone())
+            .perform(&destination)
+            .await?;
+        assert!(stored.is_none(), "a refused block must not be stored");
+        Ok(())
+    }
+
+    // The blob equivalent, and the reason blobs are a separate variant: a
+    // blob arrives in pieces, so its address cannot be checked on arrival.
+    // The writer is opened with the declared digest and the mismatch
+    // surfaces at `finish` -- which is what catches a lying source.
+    //
+    // Every blob provider verifies there (volatile, filesystem and S3 all
+    // raise `BlobError::DigestMismatch`), so in practice the refusal comes
+    // from the provider rather than from the import's own check. The check
+    // is kept regardless: a future backend that trusted its input would
+    // otherwise silently store bytes under an address they do not hash to.
+    // What this pins is the contract -- corrupt bytes are refused, and the
+    // error names both addresses -- not which layer noticed.
+    #[dialog_common::test]
+    async fn it_refuses_a_blob_that_does_not_match_its_address() -> Result<()> {
+        let stage = stage().await?;
+        let (_, blobs) = drain(
+            stage
+                .repository
+                .snapshot(stage.revision.clone())
+                .export()
+                .perform(&stage.env),
+        )
+        .await?;
+
+        let destination = destination_for(&stage).await?;
+        let elsewhere = crate::Repository::from(stage.repository.credential().clone());
+
+        let (digest, honest) = blobs.first().expect("export produced a blob");
+        // Claim the real address, hand over different bytes of the same
+        // length so the declared size still holds.
+        let mut lying = honest.clone();
+        lying[0] ^= 0xFF;
+        let item = Item::Blob {
+            digest: digest.clone(),
+            size: honest.len() as u64,
+            chunks: Box::new(Bytes(Some(lying))),
+        };
+
+        let result = elsewhere
+            .import(stream::iter(vec![Ok(item)]))
+            .perform(&destination)
+            .await;
+        match result {
+            Err(SnapshotError::BlobDigestMismatch { expected, actual }) => {
+                assert_eq!(&expected, digest, "the refusal names the declared address");
+                assert_ne!(&actual, digest, "and what the bytes actually hash to");
+            }
+            // The provider renders addresses without the `blake3#` prefix
+            // that `Display` carries, so compare on the encoded body.
+            Err(SnapshotError::Blob(BlobError::DigestMismatch { expected, actual })) => {
+                assert!(
+                    digest.to_string().ends_with(&expected),
+                    "the refusal names the declared address, got {expected}"
+                );
+                assert!(
+                    !digest.to_string().ends_with(&actual),
+                    "and what the bytes actually hash to, got {actual}"
+                );
+            }
+            other => panic!("expected a blob digest mismatch, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    // A replica holding the tree but not what its leaves point at.
+    //
+    // The absent-root case below stops the walk immediately, so it never
+    // reaches the leaf-content paths. This is the shape a real partial
+    // replica takes -- the tree is small and arrives first, blobs are
+    // large and lag -- and it is the only way to exercise the spill and
+    // blob arms of either reach.
+    //
+    // Built by importing just the tree nodes: a spilled value is a raw
+    // encoded value rather than an rkyv node, so parsing separates the two
+    // without depending on the order the export yields them in.
+    async fn tree_only_destination(
+        stage: &Stage,
+    ) -> Result<(dialog_operator::Operator<VolatileSpace>, crate::Repository)> {
+        let (blocks, _) = drain(
+            stage
+                .repository
+                .snapshot(stage.revision.clone())
+                .export()
+                .perform(&stage.env),
+        )
+        .await?;
+
+        let nodes: Vec<Block> = blocks
+            .into_iter()
+            .filter(|block| {
+                PersistentNode::<Key, State<Datum>>::try_from(block.content.clone()).is_ok()
+            })
+            .collect();
+        assert!(
+            !nodes.is_empty(),
+            "the staged revision has tree nodes to seed with"
+        );
+
+        let destination = destination_for(stage).await?;
+        let elsewhere = crate::Repository::from(stage.repository.credential().clone());
+        let imported = elsewhere
+            .import(stream::iter(nodes.into_iter().map(Item::Block).map(Ok)))
+            .perform(&destination)
+            .await?;
+        assert_eq!(imported.blobs, 0, "the blob was deliberately withheld");
+
+        Ok((destination, elsewhere))
+    }
+
+    // With the tree present, the walk runs to completion and reaches the
+    // leaf content -- so the default must fail on a spilled value or blob
+    // it cannot read, not merely on an absent root.
+    #[dialog_common::test]
+    async fn it_refuses_leaf_content_it_cannot_read() -> Result<()> {
+        let stage = stage().await?;
+        let (destination, elsewhere) = tree_only_destination(&stage).await?;
+
+        let refused = drain(
+            elsewhere
+                .snapshot(stage.revision.clone())
+                .export()
+                .perform(&destination),
+        )
+        .await;
+
+        match refused {
+            Err(error) => match error.downcast_ref::<SnapshotError>() {
+                Some(SnapshotError::MissingBlob { .. } | SnapshotError::MissingBlock { .. }) => {}
+                _ => panic!("expected a missing-content refusal, got {error:?}"),
+            },
+            Ok((blocks, blobs)) => panic!(
+                "a complete export must not omit leaf content it cannot read, \
+                 got {} blocks and {} blobs",
+                blocks.len(),
+                blobs.len()
+            ),
+        }
+        Ok(())
+    }
+
+    // And the same store under `sparse` is the case the reach exists for:
+    // the tree is walked and yielded, the unreadable leaf content is
+    // skipped rather than fatal.
+    #[dialog_common::test]
+    async fn it_skips_leaf_content_it_cannot_read_when_sparse() -> Result<()> {
+        let stage = stage().await?;
+        let (destination, elsewhere) = tree_only_destination(&stage).await?;
+
+        let (blocks, blobs) = drain(
+            elsewhere
+                .snapshot(stage.revision.clone())
+                .export()
+                .sparse()
+                .perform(&destination),
+        )
+        .await?;
+
+        assert!(
+            !blocks.is_empty(),
+            "sparse still yields the tree it can reach"
+        );
+        assert!(
+            blobs.is_empty(),
+            "the blob it cannot read is skipped, not fabricated"
+        );
+        Ok(())
+    }
+
+    // A revision whose content is elsewhere: the default refuses to produce
+    // a snapshot that silently omits things, and `sparse` is how a caller
+    // says it wants whatever is here.
+    #[dialog_common::test]
+    async fn it_separates_a_partial_export_from_a_failed_one() -> Result<()> {
+        let stage = stage().await?;
+        // An environment that has the repository mounted but none of its
+        // content -- exactly a replica that has not fetched yet.
+        let empty = destination_for(&stage).await?;
+        let elsewhere = crate::Repository::from(stage.repository.credential().clone());
+
+        let refused = drain(
+            elsewhere
+                .snapshot(stage.revision.clone())
+                .export()
+                .perform(&empty),
+        )
+        .await;
+        assert!(
+            refused.is_err(),
+            "a complete export must not quietly omit what it cannot read"
+        );
+
+        let (blocks, blobs) = drain(
+            elsewhere
+                .snapshot(stage.revision.clone())
+                .export()
+                .sparse()
+                .perform(&empty),
+        )
+        .await?;
+        assert!(
+            blocks.is_empty() && blobs.is_empty(),
+            "an unreachable root is the frontier: nothing below it can be reached"
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-search-tree/src/differential.rs
+++ b/rust/dialog-search-tree/src/differential.rs
@@ -1358,6 +1358,7 @@ mod tests {
     use crate::{
         Buffer, ContentAddressedStorage, Delta, Entry, Manifest, PersistentTree, tree_spec,
     };
+    use crate::{Traversable as _, Visit};
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
@@ -2271,6 +2272,54 @@ mod tests {
 
         spec_b.assert();
         spec_a.assert();
+
+        Ok(())
+    }
+
+    // A gap-tolerant walk reports what it cannot read instead of failing,
+    // so a partially replicated tree can still be walked for what it has.
+    // Absence and corruption are deliberately different: the first is an
+    // incomplete store, the second a damaged one.
+    #[dialog_common::test]
+    async fn it_reports_absent_nodes_instead_of_failing() -> Result<()> {
+        let backend = MemoryStorageBackend::default();
+        let storage = journaled_storage(&backend);
+        let spec = tree_spec![
+            [     ..e]
+            [..a, ..e]
+        ]
+        .build(storage)
+        .await
+        .unwrap();
+
+        // Everything present: no gaps, and the walk sees every node.
+        let visits: Vec<_> = spec
+            .tree()
+            .traverse_available(spec.storage())
+            .collect()
+            .await;
+        let total = visits.len();
+        assert!(
+            visits
+                .iter()
+                .all(|visit| matches!(visit, Ok(Visit::Present(_)))),
+            "an intact tree must report no gaps"
+        );
+
+        assert!(total > 1, "the fixture must have more than a root");
+
+        // Walk the same tree against a store that holds none of it. The
+        // root is unreachable, so the walk reports exactly that and stops:
+        // everything below an absent node is unreachable by definition, and
+        // a gap-tolerant walk does not pretend otherwise.
+        let empty = MemoryStorageBackend::default();
+        let elsewhere = journaled_storage(&empty);
+        let visits: Vec<_> = spec.tree().traverse_available(&elsewhere).collect().await;
+        assert_eq!(visits.len(), 1, "an unreachable root ends the walk");
+        assert!(
+            matches!(visits.first(), Some(Ok(Visit::Absent(hash))) if hash == spec.tree().root()),
+            "the missing root must be reported, not raised as an error"
+        );
 
         Ok(())
     }

--- a/rust/dialog-search-tree/src/error.rs
+++ b/rust/dialog-search-tree/src/error.rs
@@ -10,15 +10,11 @@ pub enum DialogSearchTreeError {
 
     /// An error from the storage backend.
     #[error("{0}")]
-    Storage(DialogStorageError),
+    Storage(#[source] DialogStorageError),
 
     /// An error that occurs during a tree operation.
     #[error("Failed to operate the tree: {0}")]
     Operation(String),
-
-    /// An error that occurs when retrieving an item from the cache.
-    #[error("Failed to retrieve item in cache: {0}")]
-    Cache(String),
 
     /// An error that occurs when accessing part of the tree.
     #[error("Failed to access part of the tree: {0}")]

--- a/rust/dialog-search-tree/src/lib.rs
+++ b/rust/dialog-search-tree/src/lib.rs
@@ -164,6 +164,9 @@ pub use node::*;
 mod storage;
 pub use storage::*;
 
+mod traversal;
+pub use traversal::*;
+
 mod tree;
 pub use tree::*;
 

--- a/rust/dialog-search-tree/src/node/archive.rs
+++ b/rust/dialog-search-tree/src/node/archive.rs
@@ -460,6 +460,29 @@ where
         StreamingLeaf::new(&schema, &columns, count)
     }
 
+    /// Visit this segment's entries in order, handing each key and value to
+    /// `visit`.
+    ///
+    /// Streams the keys and pairs each with its index-aligned value rather
+    /// than materializing the leaf, so a caller that already holds the node
+    /// can read its entries without a second walk of the tree to reach the
+    /// same rows.
+    pub fn for_each_entry<Key, Visit>(&self, mut visit: Visit) -> Result<(), DialogSearchTreeError>
+    where
+        Key: self::Key,
+        Visit: FnMut(&[u8], &Value::Archived) -> Result<(), DialogSearchTreeError>,
+    {
+        let mut keys = self.keys::<Key>()?;
+        while let Some((at, key)) = keys.next_key()? {
+            let value = self
+                .values
+                .get(at)
+                .ok_or_else(|| malformed("Segment value is out of range for its key"))?;
+            visit(key, value)?;
+        }
+        Ok(())
+    }
+
     /// The first (minimum) key of this segment, decoded to its bytes: one
     /// streaming step, no whole-leaf materialization.
     pub fn first_key<Key: self::Key>(&self) -> Result<Vec<u8>, DialogSearchTreeError> {

--- a/rust/dialog-search-tree/src/traversal.rs
+++ b/rust/dialog-search-tree/src/traversal.rs
@@ -1,0 +1,129 @@
+//! Walking a tree for everything it reaches.
+//!
+//! [`Traversable::traverse_available`] answers "what does this tree
+//! reference, and what of it do we actually hold" in one pass. That is a
+//! different question from the differential's "what changed between these
+//! two trees", and diffing against an empty tree to ask it does more work:
+//! the differential eagerly expands the whole target before yielding
+//! anything, and is then walked again.
+//!
+//! Absence is not corruption. A node the storage does not hold is reported
+//! as [`Visit::Absent`] and the walk carries on with the rest of its
+//! queue; bytes that *are* held but do not match the hash they were stored
+//! under still fail it. The first is an incomplete replica, which is a
+//! legitimate thing to walk; the second is a damaged one, which is not.
+//!
+//! What hangs beneath an absent node is unreachable by definition, so it
+//! is not reported at all -- a sparse walk yields a frontier, never a
+//! complete inventory of what is missing.
+
+use async_stream::try_stream;
+use dialog_common::{Blake3Hash, Buffer, ConditionalSend, ConditionalSync, NULL_BLAKE3_HASH};
+use dialog_storage::{DialogStorageError, StorageBackend};
+use futures_core::Stream;
+use rkyv::{
+    Deserialize, Serialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    ser::{Serializer, allocator::ArenaHandle, sharing::Share},
+    util::AlignedVec,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+use crate::{
+    ArchivedNodeBody, ContentAddressedStorage, DialogSearchTreeError, Distribution, Key,
+    PersistentNode, PersistentTree, Value,
+};
+
+/// What a gap-tolerant traversal found at one position in the tree.
+#[derive(Debug, Clone)]
+pub enum Visit<K, V> {
+    /// The node was read.
+    Present(PersistentNode<K, V>),
+    /// The tree references this node, but the storage does not hold it.
+    /// Whatever hangs beneath it is unreachable and will not be reported.
+    Absent(Blake3Hash),
+}
+
+impl<K, V> Visit<K, V> {
+    /// The node, if it was present.
+    pub fn node(&self) -> Option<&PersistentNode<K, V>> {
+        match self {
+            Visit::Present(node) => Some(node),
+            Visit::Absent(_) => None,
+        }
+    }
+}
+
+/// Walks a tree for every node it reaches.
+pub trait Traversable<Key, Value>
+where
+    Key: self::Key,
+    Value: self::Value,
+{
+    /// Stream every node this tree reaches, reporting the ones storage does
+    /// not hold rather than failing on the first.
+    ///
+    /// Breadth-first from the root. Child hashes are read out of each
+    /// node's already-decoded body, so descending costs no extra reads.
+    fn traverse_available<'a, Backend>(
+        &'a self,
+        storage: &'a ContentAddressedStorage<Backend>,
+    ) -> impl Stream<Item = Result<Visit<Key, Value>, DialogSearchTreeError>> + 'a
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSend;
+}
+
+impl<Key, Value, D> Traversable<Key, Value> for PersistentTree<Key, Value, D>
+where
+    Key: self::Key + ConditionalSync + 'static,
+    Value: self::Value + ConditionalSync + 'static,
+    Value: for<'b> Serialize<
+        Strategy<Serializer<AlignedVec, ArenaHandle<'b>, Share>, rkyv::rancor::Error>,
+    >,
+    Value::Archived: for<'b> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'b>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
+    D: Distribution,
+{
+    fn traverse_available<'a, Backend>(
+        &'a self,
+        storage: &'a ContentAddressedStorage<Backend>,
+    ) -> impl Stream<Item = Result<Visit<Key, Value>, DialogSearchTreeError>> + 'a
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSend,
+    {
+        let root = self.root().clone();
+
+        try_stream! {
+            if &root != NULL_BLAKE3_HASH {
+                let mut queue = vec![root];
+
+                while let Some(hash) = queue.pop() {
+                    // `retrieve` verifies stored bytes against the hash it
+                    // was asked for, so `None` here is genuinely "not
+                    // stored" -- a corrupt block raises instead, and still
+                    // fails the walk.
+                    let Some(bytes) = storage.retrieve(&hash).await? else {
+                        yield Visit::Absent(hash);
+                        continue;
+                    };
+                    let node: PersistentNode<Key, Value> =
+                        PersistentNode::try_from(Buffer::from(bytes))?;
+
+                    if let ArchivedNodeBody::Index(index) = node.body() {
+                        for link in index.links()? {
+                            queue.push(link.node);
+                        }
+                    }
+
+                    yield Visit::Present(node);
+                }
+            }
+        }
+    }
+}

--- a/rust/dialog-storage/src/error.rs
+++ b/rust/dialog-storage/src/error.rs
@@ -1,3 +1,5 @@
+use dialog_capability::access::AuthorizeError;
+use dialog_effects::Rejection;
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::memory::MemoryError;
 use thiserror::Error;
@@ -15,7 +17,16 @@ pub enum DialogStorageError {
 
     /// An error that occurs when working with a storage backend
     #[error("Storage backend error: {0}")]
-    StorageBackend(String),
+    Storage(String),
+
+    /// The request was not authorized.
+    #[error(transparent)]
+    Authorization(#[from] AuthorizeError),
+
+    /// The request was not carried out, for a reason that is not an
+    /// access decision.
+    #[error(transparent)]
+    Rejected(#[from] Rejection),
 
     /// An error that occurs when byte hash verification fails
     #[error("Byte hash verification failed: {0}")]
@@ -23,13 +34,21 @@ pub enum DialogStorageError {
 }
 
 impl From<ArchiveError> for DialogStorageError {
-    fn from(e: ArchiveError) -> Self {
-        Self::StorageBackend(e.to_string())
+    fn from(error: ArchiveError) -> Self {
+        match error {
+            ArchiveError::Authorization(error) => Self::Authorization(error),
+            ArchiveError::Rejected(error) => Self::Rejected(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<MemoryError> for DialogStorageError {
-    fn from(e: MemoryError) -> Self {
-        Self::StorageBackend(e.to_string())
+    fn from(error: MemoryError) -> Self {
+        match error {
+            MemoryError::Authorization(error) => Self::Authorization(error),
+            MemoryError::Rejected(error) => Self::Rejected(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }

--- a/rust/dialog-storage/src/storage/backend/fs.rs
+++ b/rust/dialog-storage/src/storage/backend/fs.rs
@@ -42,7 +42,7 @@ where
         let root_dir = root_dir.as_ref().to_owned();
         tokio::fs::create_dir_all(&root_dir)
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
         Ok(Self {
             root_dir,
             key_type: PhantomData,
@@ -71,7 +71,7 @@ where
         Key: AsRef<[u8]>,
     {
         let path = std::str::from_utf8(key.as_ref())
-            .map_err(|e| DialogStorageError::StorageBackend(format!("Invalid address: {e}")))?;
+            .map_err(|e| DialogStorageError::Storage(format!("Invalid address: {e}")))?;
         Ok(self.root_dir.join(path))
     }
 
@@ -129,7 +129,7 @@ impl PidlockGuard {
         // so the historical retry loop is no longer needed. new_validated
         // also rejects unusable paths up front and creates the parent dir.
         let mut lock = Pidlock::new_validated(&path)
-            .map_err(|e| DialogStorageError::StorageBackend(format!("Invalid lock path: {e:?}")))?;
+            .map_err(|e| DialogStorageError::Storage(format!("Invalid lock path: {e:?}")))?;
 
         match lock.acquire() {
             Ok(()) => Ok(Self(lock)),
@@ -143,11 +143,11 @@ impl PidlockGuard {
                     .flatten()
                     .map(|pid| pid.to_string())
                     .unwrap_or_else(|| "<unknown>".into());
-                Err(DialogStorageError::StorageBackend(format!(
+                Err(DialogStorageError::Storage(format!(
                     "Concurrent write in progress (lock held by pid {holder})",
                 )))
             }
-            Err(e) => Err(DialogStorageError::StorageBackend(format!(
+            Err(e) => Err(DialogStorageError::Storage(format!(
                 "Failed to acquire lock: {e:?}"
             ))),
         }
@@ -173,7 +173,7 @@ where
     async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
         tokio::fs::write(self.make_encoded_path(&key)?, value)
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
         Ok(())
     }
 
@@ -186,7 +186,7 @@ where
         tokio::fs::read(path)
             .await
             .map(|value| Some(Value::from(value)))
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))
     }
 }
 
@@ -242,7 +242,7 @@ where
                 Ok(Some((Value::from(bytes), hash)))
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(DialogStorageError::StorageBackend(format!("{e}"))),
+            Err(e) => Err(DialogStorageError::Storage(format!("{e}"))),
         }
     }
 
@@ -261,7 +261,7 @@ where
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
-                .map_err(|e| DialogStorageError::StorageBackend(format!("{e}")))?;
+                .map_err(|e| DialogStorageError::Storage(format!("{e}")))?;
         }
 
         let _lock = PidlockGuard::new(self.make_lock_path(address)?)?;
@@ -273,7 +273,7 @@ where
                 (Some(bytes), Some(hash))
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => (None, None),
-            Err(e) => return Err(DialogStorageError::StorageBackend(format!("{e}"))),
+            Err(e) => return Err(DialogStorageError::Storage(format!("{e}"))),
         };
 
         // Perform the operation
@@ -289,7 +289,7 @@ where
 
                 // Check edition only if we need to write
                 if current_hash.as_ref() != edition {
-                    return Err(DialogStorageError::StorageBackend(
+                    return Err(DialogStorageError::Storage(
                         "CAS condition failed: edition mismatch".to_string(),
                     ));
                 }
@@ -298,12 +298,12 @@ where
                 let temp_path = self.make_temp_path(address, &new_hash)?;
                 tokio::fs::write(&temp_path, new_bytes)
                     .await
-                    .map_err(|e| DialogStorageError::StorageBackend(format!("{e}")))?;
+                    .map_err(|e| DialogStorageError::Storage(format!("{e}")))?;
 
                 // Atomic rename
                 tokio::fs::rename(&temp_path, &path)
                     .await
-                    .map_err(|e| DialogStorageError::StorageBackend(format!("{e}")))?;
+                    .map_err(|e| DialogStorageError::Storage(format!("{e}")))?;
 
                 Ok(Some(new_hash))
             }
@@ -315,7 +315,7 @@ where
 
                 // Check edition only if we need to delete
                 if current_hash.as_ref() != edition {
-                    return Err(DialogStorageError::StorageBackend(
+                    return Err(DialogStorageError::Storage(
                         "CAS condition failed: edition mismatch".to_string(),
                     ));
                 }
@@ -323,7 +323,7 @@ where
                 match tokio::fs::remove_file(&path).await {
                     Ok(()) => Ok(None),
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-                    Err(e) => Err(DialogStorageError::StorageBackend(format!("{e}"))),
+                    Err(e) => Err(DialogStorageError::Storage(format!("{e}"))),
                 }
             }
         }
@@ -360,7 +360,7 @@ where
             writes.push(async move {
                 tokio::fs::write(path, value)
                     .await
-                    .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+                    .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
                 Ok(()) as Result<_, Self::Error>
             });
         }

--- a/rust/dialog-storage/src/storage/backend/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/backend/indexeddb.rs
@@ -56,7 +56,7 @@ where
             .add_object_store(ObjectStore::new(MEMORY_STORE).auto_increment(false))
             .build()
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         Ok(IndexedDbStorageBackend {
             db: Rc::new(db),
@@ -80,10 +80,10 @@ where
         let tx = self
             .db
             .transaction(&[INDEX_STORE], TransactionMode::ReadWrite)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
         let store = tx
             .store(INDEX_STORE)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         // Base58 encode key for better DevTools readability
         let key = JsValue::from_str(&key.as_ref().to_base58());
@@ -92,11 +92,11 @@ where
         store
             .put(&value, Some(&key))
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         tx.done()
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         Ok(())
     }
@@ -105,10 +105,10 @@ where
         let tx = self
             .db
             .transaction(&[INDEX_STORE], TransactionMode::ReadOnly)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
         let store = tx
             .store(INDEX_STORE)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         // Base58 encode key for lookup
         let key = JsValue::from_str(&key.as_ref().to_base58());
@@ -116,7 +116,7 @@ where
         let Some(value) = store
             .get(key)
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?
         else {
             return Ok(None);
         };
@@ -124,7 +124,7 @@ where
         let out = value
             .dyn_into::<Uint8Array>()
             .map_err(|value| {
-                DialogStorageError::StorageBackend(format!(
+                DialogStorageError::Storage(format!(
                     "Failed to downcast value to bytes: {:?}",
                     value
                 ))
@@ -132,7 +132,7 @@ where
             .to_vec();
         tx.done()
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         Ok(Some(Value::from(out)))
     }
@@ -173,17 +173,17 @@ where
         let tx = self
             .db
             .transaction(&[MEMORY_STORE], TransactionMode::ReadOnly)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
         let store = tx
             .store(MEMORY_STORE)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         // Treat address as UTF-8 string for DevTools readability
         let key = address_to_string(address)?;
         let entry = store
             .get(key)
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         let Some(entry) = entry else {
             return Ok(None);
@@ -191,7 +191,7 @@ where
 
         let bytes = entry
             .dyn_into::<Uint8Array>()
-            .map_err(|_| DialogStorageError::StorageBackend("Value is not Uint8Array".to_string()))?
+            .map_err(|_| DialogStorageError::Storage("Value is not Uint8Array".to_string()))?
             .to_vec();
 
         let hash = Blake3Hash::hash(&bytes);
@@ -207,10 +207,10 @@ where
         let tx = self
             .db
             .transaction(&[MEMORY_STORE], TransactionMode::ReadWrite)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
         let store = tx
             .store(MEMORY_STORE)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         // Treat address as UTF-8 string for DevTools readability
         let key = address_to_string(address)?;
@@ -219,15 +219,13 @@ where
         let current = store
             .get(key.clone())
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         let current_hash = if let Some(entry) = &current {
             let bytes = entry
                 .clone()
                 .dyn_into::<Uint8Array>()
-                .map_err(|_| {
-                    DialogStorageError::StorageBackend("Value is not Uint8Array".to_string())
-                })?
+                .map_err(|_| DialogStorageError::Storage("Value is not Uint8Array".to_string()))?
                 .to_vec();
             Some(Blake3Hash::hash(&bytes))
         } else {
@@ -247,7 +245,7 @@ where
 
                 // Check edition only if we need to write
                 if current_hash.as_ref() != edition {
-                    return Err(DialogStorageError::StorageBackend(
+                    return Err(DialogStorageError::Storage(
                         "CAS condition failed: edition mismatch".to_string(),
                     ));
                 }
@@ -256,11 +254,11 @@ where
                 store
                     .put(&entry, Some(&key))
                     .await
-                    .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+                    .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
                 tx.done()
                     .await
-                    .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+                    .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
                 Ok(Some(hash))
             }
@@ -272,7 +270,7 @@ where
 
                 // Check edition only if we need to delete
                 if current_hash.as_ref() != edition {
-                    return Err(DialogStorageError::StorageBackend(
+                    return Err(DialogStorageError::Storage(
                         "CAS condition failed: edition mismatch".to_string(),
                     ));
                 }
@@ -280,11 +278,11 @@ where
                 store
                     .delete(key)
                     .await
-                    .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+                    .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
                 tx.done()
                     .await
-                    .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+                    .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
                 Ok(None)
             }
@@ -316,10 +314,10 @@ where
         let tx = self
             .db
             .transaction(&[INDEX_STORE], TransactionMode::ReadWrite)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
         let store = tx
             .store(INDEX_STORE)
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         tokio::pin!(stream);
 
@@ -333,14 +331,14 @@ where
         }
 
         store.put_all(entries.into_iter()).await.map_err(|error| {
-            DialogStorageError::StorageBackend(format!(
+            DialogStorageError::Storage(format!(
                 "Failed while writing bulk entries to IndexedDB: {error}"
             ))
         })?;
 
         tx.done()
             .await
-            .map_err(|error| DialogStorageError::StorageBackend(format!("{error}")))?;
+            .map_err(|error| DialogStorageError::Storage(format!("{error}")))?;
 
         Ok(())
     }
@@ -356,7 +354,7 @@ fn bytes_to_typed_array(bytes: &[u8]) -> JsValue {
 /// Addresses are expected to be valid UTF-8.
 fn address_to_string<Key: AsRef<[u8]>>(address: &Key) -> Result<JsValue, DialogStorageError> {
     let s = std::str::from_utf8(address.as_ref())
-        .map_err(|e| DialogStorageError::StorageBackend(format!("Invalid UTF-8 address: {e}")))?;
+        .map_err(|e| DialogStorageError::Storage(format!("Invalid UTF-8 address: {e}")))?;
     Ok(JsValue::from_str(s))
 }
 

--- a/rust/dialog-storage/src/storage/backend/memory.rs
+++ b/rust/dialog-storage/src/storage/backend/memory.rs
@@ -147,7 +147,7 @@ where
         match (edition, entries.get(address)) {
             // Creating new: require key doesn't exist
             (None, Some(_)) => {
-                return Err(DialogStorageError::StorageBackend(
+                return Err(DialogStorageError::Storage(
                     "CAS conflict: key already exists".to_string(),
                 ));
             }
@@ -155,14 +155,14 @@ where
             (Some(expected_hash), Some(existing_value)) => {
                 let current_hash = Blake3Hash::hash(existing_value.as_ref());
                 if &current_hash != expected_hash {
-                    return Err(DialogStorageError::StorageBackend(
+                    return Err(DialogStorageError::Storage(
                         "CAS conflict: content hash mismatch".to_string(),
                     ));
                 }
             }
             // Updating non-existent: fail
             (Some(_), None) => {
-                return Err(DialogStorageError::StorageBackend(
+                return Err(DialogStorageError::Storage(
                     "CAS conflict: key does not exist".to_string(),
                 ));
             }

--- a/rust/dialog-storage/src/storage/cache.rs
+++ b/rust/dialog-storage/src/storage/cache.rs
@@ -37,11 +37,7 @@ where
         Ok(Self {
             backend,
             cache: Arc::new(Mutex::new(SieveCache::new(cache_size).map_err(
-                |error| {
-                    DialogStorageError::StorageBackend(format!(
-                        "Could not initialize cache: {error}"
-                    ))
-                },
+                |error| DialogStorageError::Storage(format!("Could not initialize cache: {error}")),
             )?)),
         })
     }

--- a/rust/dialog-storage/src/storage/compress.rs
+++ b/rust/dialog-storage/src/storage/compress.rs
@@ -46,7 +46,7 @@ where
             let mut writer =
                 CompressorWriter::new(&mut compressed, BUFFER_SIZE, COMPRESSION_LEVEL, WINDOW_SIZE);
             writer.write(value.as_ref()).map_err(|error| {
-                DialogStorageError::StorageBackend(format!("Could not compress blob: {error}"))
+                DialogStorageError::Storage(format!("Could not compress blob: {error}"))
             })?;
         }
 
@@ -62,9 +62,7 @@ where
             {
                 let mut reader = Decompressor::new(value.as_ref(), BUFFER_SIZE);
                 reader.read_to_end(&mut decompressed).map_err(|error| {
-                    DialogStorageError::StorageBackend(format!(
-                        "Could not decompress blob: {error}"
-                    ))
+                    DialogStorageError::Storage(format!("Could not decompress blob: {error}"))
                 })?;
             }
             Ok(Some(decompressed.into()))

--- a/rust/dialog-storage/src/storage/provider/fs/blob.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/blob.rs
@@ -52,7 +52,7 @@ impl BlobSource for FileBlobSource {
     async fn next(&mut self) -> Result<Option<Vec<u8>>, BlobError> {
         match self.0.next().await {
             Some(Ok(chunk)) => Ok(Some(chunk)),
-            Some(Err(e)) => Err(BlobError::Io(e.to_string())),
+            Some(Err(e)) => Err(BlobError::Storage(e.to_string())),
             None => Ok(None),
         }
     }
@@ -95,7 +95,7 @@ impl BlobSink for FileBlobSink {
         self.writer
             .write_all(bytes)
             .await
-            .map_err(|e| BlobError::Io(e.to_string()))
+            .map_err(|e| BlobError::Storage(e.to_string()))
     }
 
     async fn finish(self: Box<Self>) -> Result<Blake3Hash, BlobError> {

--- a/rust/dialog-storage/src/storage/provider/fs/error.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/error.rs
@@ -15,10 +15,6 @@ pub enum FileSystemError {
     #[error("Lock error: {0}")]
     Lock(String),
 
-    /// CAS condition failed.
-    #[error("CAS condition failed: {0}")]
-    Cas(String),
-
     /// Path containment violation (attempted to escape base directory).
     #[error("Containment violation: {0}")]
     Containment(String),
@@ -32,6 +28,11 @@ impl From<FileSystemError> for CredentialError {
 
 impl From<FileSystemError> for AuthorizeError {
     fn from(e: FileSystemError) -> Self {
-        Self::Malformed(e.to_string())
+        // The filesystem failing is our machinery, not the caller's
+        // material: nothing was decided, so this must not read as a
+        // denial.
+        Self::Unavailable {
+            detail: e.to_string(),
+        }
     }
 }

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -355,10 +355,6 @@ pub enum IndexedDbError {
     #[error("Store error: {0}")]
     Store(String),
 
-    /// Value conversion failed.
-    #[error("Value conversion error: {0}")]
-    Conversion(String),
-
     /// No database exists at the requested name (a `load` of something
     /// that was never created).
     #[error("IndexedDB database not found: {0}")]
@@ -378,7 +374,11 @@ impl From<IndexedDbError> for CredentialError {
 /// the material needed to decide could not be fetched.
 impl From<IndexedDbError> for AuthorizeError {
     fn from(e: IndexedDbError) -> Self {
-        Self::Malformed(e.to_string())
+        // The database failing is our machinery, not the caller's
+        // material.
+        Self::Unavailable {
+            detail: e.to_string(),
+        }
     }
 }
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
@@ -38,15 +38,19 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
         let store = self.store(CERTIFICATE).await?;
         let lower = JsValue::from_str(&prefix);
         let upper = JsValue::from_str(&format!("{prefix}\u{ffff}"));
-        let range = KeyRange::bound(&lower, &upper, None, None)
-            .map_err(|e| AuthorizeError::Malformed(format!("key range error: {e:?}")))?;
+        let range = KeyRange::bound(&lower, &upper, None, None).map_err(|e| {
+            AuthorizeError::Unavailable {
+                detail: format!("key range error: {e:?}"),
+            }
+        })?;
 
         store
             .query(|object_store| async move {
-                let values = object_store
-                    .get_all(Some(range), None)
-                    .await
-                    .map_err(|e| AuthorizeError::Malformed(format!("query: {e:?}")))?;
+                let values = object_store.get_all(Some(range), None).await.map_err(|e| {
+                    AuthorizeError::Unavailable {
+                        detail: format!("query: {e:?}"),
+                    }
+                })?;
 
                 let mut certs = Vec::new();
                 for value in values {
@@ -89,7 +93,9 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
                     object_store
                         .put(&js_val, Some(&js_key))
                         .await
-                        .map_err(|e| AuthorizeError::Malformed(format!("write: {e:?}")))?;
+                        .map_err(|e| AuthorizeError::Unavailable {
+                            detail: format!("write: {e:?}"),
+                        })?;
                     Ok::<(), AuthorizeError>(())
                 })
                 .await?;

--- a/rust/dialog-storage/src/storage/provider/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/storage.rs
@@ -52,6 +52,24 @@ pub struct Storage<S: Clone> {
     router: Router<S>,
 }
 
+/// Cloning yields a second handle onto the *same* spaces, not a second
+/// set of them: the pool behind `loader` and `router` is already
+/// `Arc`-shared, which is what makes two handles safe to hold at once.
+///
+/// Callers need this whenever an environment that owns a `Storage` has
+/// to be rebuilt while the old one stays live — swapping an `Operator`
+/// for a freshly keyed one, say. Handing the replacement its own
+/// `Storage::new()` would open a second set of connections to the same
+/// databases and let already-open handles drift from newly opened ones.
+impl<S: Clone> Clone for Storage<S> {
+    fn clone(&self) -> Self {
+        Self {
+            loader: self.loader.clone(),
+            router: self.router.clone(),
+        }
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S, P> Provider<Prove<P>> for Storage<S>
@@ -122,6 +140,48 @@ mod tests {
     use dialog_effects::prelude::*;
     use dialog_effects::storage::{LocationExt, Storage as StorageFx};
     use dialog_varsig::Principal;
+
+    #[dialog_common::test]
+    async fn it_shares_mounted_spaces_with_a_clone() {
+        let env = Storage::volatile();
+        let clone = env.clone();
+        let credential = test_credential().await;
+
+        let cred = StorageFx::profile("shared")
+            .create(credential)
+            .perform(&env)
+            .await
+            .unwrap();
+
+        assert!(
+            clone.contains(&cred.did()),
+            "a clone must see spaces mounted through the original"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_a_location_to_one_did_across_clones() {
+        let env = Storage::volatile();
+        let clone = env.clone();
+        let credential = test_credential().await;
+
+        let created = StorageFx::profile("stable")
+            .create(credential)
+            .perform(&env)
+            .await
+            .unwrap();
+        let loaded = StorageFx::profile("stable")
+            .load()
+            .perform(&clone)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            loaded.did(),
+            created.did(),
+            "the location mapping is shared, so a clone resolves the same space"
+        );
+    }
 
     #[dialog_common::test]
     async fn it_creates_profile_with_sugar() {

--- a/rust/dialog-storage/src/storage/provider/storage/loader.rs
+++ b/rust/dialog-storage/src/storage/provider/storage/loader.rs
@@ -22,16 +22,31 @@ use crate::resource::{Pool, Resource};
 ///
 /// Maintains a location -> DID mapping so that loading the same location
 /// twice returns the existing DID (important for non-persistent backends).
+///
+/// Both tables are shared behind an `Arc`, so a clone of a loader
+/// resolves locations through the same mapping and mounts into the same
+/// pool. Cloning to get a second handle onto one set of spaces is the
+/// point; a clone with its own mounts table would hand the same location
+/// two DIDs.
 pub struct Loader<S> {
     spaces: Arc<Pool<Did, S>>,
-    mounts: Pool<String, Did>,
+    mounts: Arc<Pool<String, Did>>,
+}
+
+impl<S> Clone for Loader<S> {
+    fn clone(&self) -> Self {
+        Self {
+            spaces: Arc::clone(&self.spaces),
+            mounts: Arc::clone(&self.mounts),
+        }
+    }
 }
 
 impl<S> Loader<S> {
     pub fn new(spaces: Arc<Pool<Did, S>>) -> Self {
         Self {
             spaces,
-            mounts: Pool::new(),
+            mounts: Arc::new(Pool::new()),
         }
     }
 

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -144,14 +144,6 @@ impl Resource<Location> for Volatile {
     }
 }
 
-/// Errors that can occur during volatile storage operations.
-#[derive(Debug, thiserror::Error)]
-pub enum VolatileError {
-    /// CAS condition failed.
-    #[error("CAS condition failed: {0}")]
-    Cas(String),
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/dialog-storage/src/storage/provider/volatile/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/archive.rs
@@ -1,17 +1,11 @@
 //! Archive capability provider for volatile storage.
 
-use super::{ArchiveKey, Volatile, VolatileError};
+use super::{ArchiveKey, Volatile};
 use async_trait::async_trait;
 use base58::ToBase58;
 use dialog_capability::{Capability, Provider};
 use dialog_effects::archive::prelude::{GetExt, ImportExt, PutExt};
 use dialog_effects::archive::{ArchiveError, Get, Import, Put};
-
-impl From<VolatileError> for ArchiveError {
-    fn from(e: VolatileError) -> Self {
-        ArchiveError::Storage(e.to_string())
-    }
-}
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/rust/dialog-storage/src/storage/provider/volatile/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/memory.rs
@@ -3,18 +3,12 @@
 //! Implements transactional cell storage with CAS (Compare-And-Swap) semantics.
 //! Uses BLAKE3 content hashing for edition tracking.
 
-use super::{MemoryKey, Volatile, VolatileError};
+use super::{MemoryKey, Volatile};
 use async_trait::async_trait;
 use dialog_capability::{Capability, Provider};
 use dialog_common::Blake3Hash;
 use dialog_effects::memory::prelude::{PublishExt, ResolveExt, RetractExt};
 use dialog_effects::memory::{Edition, MemoryError, Publish, Resolve, Retract, Version};
-
-impl From<VolatileError> for MemoryError {
-    fn from(e: VolatileError) -> Self {
-        MemoryError::Storage(e.to_string())
-    }
-}
 
 /// Format edition bytes for error messages.
 fn format_edition(edition: Option<&[u8]>) -> Option<Version> {

--- a/rust/dialog-storage/src/storage/transactional_memory.rs
+++ b/rust/dialog-storage/src/storage/transactional_memory.rs
@@ -315,7 +315,7 @@ where
     ) -> Result<Self, DialogStorageError> {
         let (value, edition) = if let Some((bytes, edition)) =
             backend.resolve(&address).await.map_err(|e| {
-                DialogStorageError::StorageBackend(format!(
+                DialogStorageError::Storage(format!(
                     "Resolving memory at {:?} failed with error {}",
                     address,
                     e.into()

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -76,13 +76,15 @@ impl Certificate for UcanCertificate {
     }
 
     fn encode(&self) -> Result<Vec<u8>, AuthorizeError> {
-        serde_ipld_dagcbor::to_vec(&self.0)
-            .map_err(|e| AuthorizeError::Malformed(format!("failed to encode proof: {e}")))
+        serde_ipld_dagcbor::to_vec(&self.0).map_err(|e| AuthorizeError::Unavailable {
+            detail: format!("failed to encode proof: {e}"),
+        })
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, AuthorizeError> {
-        serde_ipld_dagcbor::from_slice(bytes)
-            .map_err(|e| AuthorizeError::Malformed(format!("failed to decode proof: {e}")))
+        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| AuthorizeError::Malformed {
+            detail: format!("failed to decode proof: {e}"),
+        })
     }
 }
 
@@ -154,9 +156,9 @@ impl Proof<Ucan> for UcanProof {
             Some(first) => {
                 let mut chain = DelegationChain::new(first.0);
                 for proof in iter {
-                    chain = chain
-                        .push(proof.0)
-                        .map_err(|e| AuthorizeError::Malformed(e.to_string()))?;
+                    chain = chain.push(proof.0).map_err(|e| AuthorizeError::Malformed {
+                        detail: e.to_string(),
+                    })?;
                 }
                 Some(chain)
             }
@@ -238,15 +240,21 @@ impl Authorization<Ucan> for UcanAuthorization {
             builder = builder.not_before(ts);
         }
 
+        // Building and signing our own delegation: ours to get right, so
+        // failing it says nothing about the caller's material.
         let delegation = builder
             .try_build()
             .await
-            .map_err(|e| AuthorizeError::Malformed(format!("{e:?}")))?;
+            .map_err(|e| AuthorizeError::Unavailable {
+                detail: format!("{e:?}"),
+            })?;
 
         let chain = match &self.chain {
             Some(chain) => chain
                 .push(delegation)
-                .map_err(|e| AuthorizeError::Malformed(format!("{e}")))?,
+                .map_err(|e| AuthorizeError::Malformed {
+                    detail: format!("{e}"),
+                })?,
             None => DelegationChain::new(delegation),
         };
 
@@ -287,7 +295,9 @@ impl Authorization<Ucan> for UcanAuthorization {
             .proofs(proofs)
             .try_build()
             .await
-            .map_err(|e| AuthorizeError::Malformed(format!("{e:?}")))?;
+            .map_err(|e| AuthorizeError::Malformed {
+                detail: format!("{e:?}"),
+            })?;
 
         let chain = InvocationChain::new(invocation, delegations_map);
 


### PR DESCRIPTION
An environment that owns a `Storage` sometimes has to be rebuilt while the old one is still live. There was no way to hand the replacement the same storage: `Storage` is not `Clone` and `OperatorBuilder::build` consumes it, so the only option was `Storage::new()` — a second set of connections to the same databases, with already-open handles free to drift from newly opened ones.

## The change

The sharing this needs is already how `Storage` is built: `loader` and `router` hold one `Arc<Pool<Did, S>>` between them, and `Router` was already `Clone`. Only `Loader.mounts` was unshared, so it moves behind an `Arc` too.

That last part is the only real decision here. A clone with its own mounts table would resolve one location to two DIDs — precisely the drift the shared spaces pool exists to prevent — so sharing it is what makes the impl mean "a second handle onto the same storage" rather than "a second storage".

Both `Clone` impls are hand-written rather than derived: every field is an `Arc`, so neither type needs the `S: Clone` bound a derive would add.

## Why we wanted it

The caller is tonk. Its worker signs presigned-URL requests with an operator key, and we are bounding that key's delegation in time so a revoked device stops mattering within a session lifetime instead of only on the next registry lookup. Bounding it means rotating the operator before it lapses — building a replacement while the old one is still serving requests.

Without `Clone` the replacement can only get its own `Storage::new()`, and the cached repository and branch handles our reactor holds keep talking to the retired pool. Two live connection sets over the same IndexedDB databases, diverging with no error surface. With it, rotation is a contained swap: the operator changes, the spaces underneath do not.

## Tests

Two, alongside the existing `Storage` tests:

- `it_shares_mounted_spaces_with_a_clone` — a space created through the original is visible through a clone.
- `it_resolves_a_location_to_one_did_across_clones` — creating a profile through one handle and loading the same location through the other yields the same DID, which is the mounts-table sharing specifically.

`cargo test -p dialog-storage` (144 + doctests) and `cargo clippy --workspace --all-targets` are clean.

## Note on the branch

tonk needs this before it can land its side, so it is pinned meanwhile to `tonk-2026-07-17-storage-clone` — the `tonk-2026-07-17` tag plus this one commit, cut from the tag rather than from `main` so it carries none of the reserved-namespace or version-control work in between. That branch is a stopgap, not for review; this PR is the same change on `main`. Once this lands, tonk repoints at a tag and the stopgap branch goes away.