### PR TITLE
Add dialog-baseline: SQLite reference benchmarks with real-data replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +958,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-baseline"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base58",
+ "criterion",
+ "dialog-artifacts",
+ "dialog-storage",
+ "futures-util",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rusqlite",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "dialog-capability"
 version = "0.1.0"
 dependencies = [
@@ -1690,6 +1719,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +1951,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1931,6 +1975,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2420,6 +2473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +2922,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -3385,6 +3455,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4097,7 +4181,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4387,6 +4473,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 rexie = "0.6"
 rkyv = "0.8"
 rsa = "0.9"
+rusqlite = { version = "0.32", features = ["bundled"] }
 s3s = "0.13"
 serde = "1"
 serde-value = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ strip = "debuginfo"
 [workspace]
 members = [
     "rust/dialog-artifacts",
+    "rust/dialog-baseline",
     "rust/dialog-capability",
     "rust/dialog-credentials",
     "rust/dialog-common",

--- a/notes/sqlite-baseline-results.md
+++ b/notes/sqlite-baseline-results.md
@@ -1,0 +1,75 @@
+# SQLite baseline: first captured numbers
+
+Produced by `rust/dialog-baseline` (see its crate docs for methodology):
+
+```sh
+cargo bench -p dialog-baseline --bench sqlite_vs_dialog -- --warm-up-time 1 --measurement-time 3
+DIALOG_SE_CSV=<retro-facts.csv> cargo bench -p dialog-baseline --bench se_replay -- --warm-up-time 1 --measurement-time 3
+```
+
+Environment for the numbers below: 4-core x86_64 Linux container,
+2026-07-28, criterion medians, branch `claude/perf-1-sqlite-baseline`
+(commit before any optimization work). Absolute numbers are
+machine-specific; the *ratios* are the signal, and the same commands
+re-run on any machine reproduce them.
+
+SQLite is configured as a faithful model of the dialog information model:
+one `facts` table with the EAV ordering as `PRIMARY KEY (of, the, val)
+WITHOUT ROWID`, plus `(the, of, val)` (AEV) and `(val, the, of)` (VAE)
+secondary indexes — the same three orderings `dialog-artifacts` maintains.
+`sqlite_disk` is WAL + `synchronous=NORMAL` (the production bar);
+`sqlite_disk_nosync` is `synchronous=OFF`, which matches the durability
+dialog's fsync-free filesystem backend actually provides today.
+
+## Synthetic `stuff` workload (mirrors dialog-query's `seed_stuff`)
+
+| workload | sqlite_mem | sqlite_disk | sqlite_disk_nosync | dialog_mem | dialog_disk |
+|---|---|---|---|---|---|
+| write_small_txns (100 entities, 1 txn each) | 0.719 ms | 2.80 ms | 2.58 ms | 13.7 ms | 96.1 ms |
+| write_batch (1000 entities, 1 txn) | 4.66 ms | 6.27 ms | 5.07 ms | 1.833 s | 1.867 s |
+| point_get (of 1000 entities) | 0.82 µs | 2.26 µs | 2.16 µs | 23.6 µs | 23.2 µs |
+| attr_scan (1000 rows) | 163 µs | 168 µs | 171 µs | 1.118 ms | 1.162 ms |
+| join (1000 rows, storage-layer hash join) | 542 µs | 577 µs | 562 µs | 2.673 ms | 2.580 ms |
+
+### What the gaps say
+
+- **Small commits: 19× (memory) / 34× (disk, with *weaker* durability than
+  SQLite's NORMAL).** ~137 µs per 2-fact commit in memory is commit-path
+  CPU (audit findings: per-instruction value encodes, canonical rebuild
+  path instead of the buffered one); the additional ~10× on disk
+  (~960 µs/commit) is the file-per-block backend (multiple files + syscalls
+  per commit, no batching).
+- **Batch writes: ~390×, and superlinear.** 1000 entities in one commit
+  cost 1.83 ms *per entity* in memory — 13× worse per entity than the
+  small-commit path at 100 entities. A single big commit degrades as the
+  transient tree grows (per-instruction descents ping-ponging across the
+  EAV/AEV/VAE regions, linear `child_for` routing). This is the
+  bulk-import finding made measurable.
+- **Point get: 10–29×, all CPU.** dialog_mem and dialog_disk are
+  identical (23 µs) — the OS cache hides the disk, so the whole gap is
+  per-read validation + linear leaf decode (rkyv bytecheck on every
+  `body()`, front-coded linear `find`, `Entity`/URL reconstruction per
+  row).
+- **Scan and join: 5–7×.** The smallest gaps — the streaming scan path is
+  the best-optimized part of the read side — but per-row `Entity::parse` +
+  blake3 and per-row allocations still cost ~1 µs/row where SQLite pays
+  ~0.16 µs/row.
+
+## Stack Exchange replay (real data: retrocomputing.stackexchange.com)
+
+Transformed with `scripts/se-transform.py` (117,236 facts / 50,553
+transactions; see `notes/benchmark-dataset.md`). The replay commits one
+transaction per commit — real commit boundaries, real supersession
+(cardinality-one writes are `Instruction::Replace` in dialog, delete+insert
+in SQLite), real long-tailed value sizes crossing the 4096-byte spill
+boundary.
+
+<!-- SE_RESULTS -->
+
+## Reading the numbers
+
+The write-side gaps are the priority: they are 1-2 orders of magnitude and
+they are the local-first interactive case (many small commits). The
+audit's phase-1/phase-2 items target exactly these constants; each
+improvement group PR should re-run both benches above and quote the deltas
+against this file, then update it.

--- a/notes/sqlite-baseline-results.md
+++ b/notes/sqlite-baseline-results.md
@@ -64,7 +64,28 @@ transaction per commit — real commit boundaries, real supersession
 in SQLite), real long-tailed value sizes crossing the 4096-byte spill
 boundary.
 
-<!-- SE_RESULTS -->
+Replay of the first 500 real transactions (1,289 facts), fresh store per
+iteration; reads against a store seeded with the first 2,000 transactions:
+
+| workload | sqlite_mem | sqlite_disk | sqlite_disk_nosync | dialog_mem | dialog_disk |
+|---|---|---|---|---|---|
+| replay 500 txns | 10.2 ms | 93.6 ms | 23.4 ms | 444 ms | 1.61 s |
+| per commit | 20 µs | 187 µs | 47 µs | 888 µs | 3.2 ms |
+| kind lookup (value-indexed, ~700 rows) | 34.9 µs | 40.5 µs | 35.5 µs | 261 µs | 244 µs |
+| title point get (superseded pair) | 0.97 µs | 6.07 µs | 2.68 µs | 9.34 µs | 9.41 µs |
+
+### What the real workload adds
+
+- **Small real commits: 43× (memory), 17× against SQLite's *durable*
+  NORMAL config, 69× against the durability-equivalent nosync config.**
+  Real commits average 2.6 facts and include `Replace` supersession
+  (prior scan + retract + assert), which costs more than the synthetic
+  pure-assert path — the realistic per-commit price is ~0.9 ms CPU plus
+  ~2.3 ms of file-per-block I/O.
+- **Value-indexed lookups: 7×** — consistent with the synthetic scan gap;
+  per-row reconstruction costs dominate.
+- **Point gets: ~1.5× vs cold-ish sqlite_disk, ~10× vs sqlite_mem.** The
+  dialog store again shows memory ≡ disk (9.4 µs both): pure CPU.
 
 ## Reading the numbers
 

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -1142,13 +1142,10 @@ mod tests {
             cause: None,
         };
         let after_root = facts
-            .commit(
-                vec![
-                    Instruction::Assert(transient.clone()),
-                    Instruction::Retract(transient.clone()),
-                ]
-                .into_iter(),
-            )
+            .commit(vec![
+                Instruction::Assert(transient.clone()),
+                Instruction::Retract(transient.clone()),
+            ])
             .await?;
 
         // No tree churn: the novel fact left no key at all.

--- a/rust/dialog-artifacts/src/artifacts/artifact.rs
+++ b/rust/dialog-artifacts/src/artifacts/artifact.rs
@@ -59,7 +59,7 @@ impl Debug for Artifact {
 impl Display for Artifact {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let attribute = self.the.to_string();
-        let entity = format!("{}", &self.of);
+        let entity = self.of.to_string();
         let value = self.is.to_utf8();
 
         write!(f, "Artifact: the '{attribute}' of '{entity}' is '{value}'")

--- a/rust/dialog-baseline/Cargo.toml
+++ b/rust/dialog-baseline/Cargo.toml
@@ -14,11 +14,11 @@ dialog-storage = { workspace = true }
 futures-util = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
 
 [[bench]]

--- a/rust/dialog-baseline/Cargo.toml
+++ b/rust/dialog-baseline/Cargo.toml
@@ -6,6 +6,11 @@ edition = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 
+# This crate is native-only (bundled SQLite, filesystem-backed stores,
+# multi-threaded tokio); the library compiles to nothing on wasm32 (see the
+# crate-level cfg in src/lib.rs), and every native-only dependency is
+# target-gated so the workspace's wasm dependency set is unaffected.
+
 [dependencies]
 anyhow = { workspace = true }
 base58 = { workspace = true }
@@ -14,6 +19,8 @@ dialog-storage = { workspace = true }
 futures-util = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rusqlite = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/rust/dialog-baseline/Cargo.toml
+++ b/rust/dialog-baseline/Cargo.toml
@@ -24,3 +24,7 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 [[bench]]
 name = "sqlite_vs_dialog"
 harness = false
+
+[[bench]]
+name = "se_replay"
+harness = false

--- a/rust/dialog-baseline/Cargo.toml
+++ b/rust/dialog-baseline/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "dialog-baseline"
+description = "Reference benchmarks comparing dialog-db against SQLite on identical workloads"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+base58 = { workspace = true }
+dialog-artifacts = { workspace = true }
+dialog-storage = { workspace = true }
+futures-util = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+rusqlite = { version = "0.32", features = ["bundled"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
+
+[[bench]]
+name = "sqlite_vs_dialog"
+harness = false

--- a/rust/dialog-baseline/benches/se_replay.rs
+++ b/rust/dialog-baseline/benches/se_replay.rs
@@ -1,0 +1,156 @@
+//! Realistic-workload benchmark: replay of the Stack Exchange fact log.
+//!
+//! Replays a transaction-ordered fact log (real commit boundaries, real
+//! supersession churn — see `notes/benchmark-dataset.md`) into both stores,
+//! one commit per transaction, then measures reads against the replayed
+//! store: a value-indexed lookup (`se.post/kind = "question"`, the VAE
+//! shape) and a point read of a heavily-superseded pair (`se.post/title`).
+//!
+//! Data source: the deterministic synthetic approximation by default;
+//! point `DIALOG_SE_CSV` at a transformed dump (produced by
+//! `scripts/se-transform.py`) to run against real data. `DIALOG_SE_TXNS`
+//! overrides the replayed transaction count (default 500 for writes,
+//! 2000 for the read-side seed).
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo bench -p dialog-baseline --bench se_replay
+//! DIALOG_SE_CSV=path/to/retro-facts.csv cargo bench -p dialog-baseline --bench se_replay
+//! ```
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_baseline::se::SeLog;
+use dialog_baseline::{DialogFacts, DialogMode, SqliteFacts, SqliteMode};
+
+const SQLITE_MODES: &[(&str, SqliteMode)] = &[
+    ("sqlite_mem", SqliteMode::Memory),
+    ("sqlite_disk", SqliteMode::Disk),
+    ("sqlite_disk_nosync", SqliteMode::DiskNoSync),
+];
+
+const DIALOG_MODES: &[(&str, DialogMode)] = &[
+    ("dialog_mem", DialogMode::Memory),
+    ("dialog_disk", DialogMode::Disk),
+];
+
+/// A fresh multi-threaded tokio runtime for driving the async dialog side.
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().expect("tokio runtime")
+}
+
+/// Transaction count from `DIALOG_SE_TXNS`, or the given default.
+fn txn_count(default: usize) -> usize {
+    std::env::var("DIALOG_SE_TXNS")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(default)
+}
+
+fn bench_replay_write(c: &mut Criterion) {
+    let rt = runtime();
+    let size = txn_count(500);
+    let log = SeLog::load(size).expect("load SE log");
+    println!(
+        "se_replay_write txns={} facts={}",
+        log.transactions.len(),
+        log.fact_count()
+    );
+
+    let mut group = c.benchmark_group("se_replay_write");
+    group.throughput(criterion::Throughput::Elements(
+        log.transactions.len() as u64
+    ));
+    group.sample_size(10);
+
+    for (label, mode) in SQLITE_MODES {
+        group.bench_with_input(BenchmarkId::new(*label, size), &log, |b, log| {
+            b.iter_batched(
+                || SqliteFacts::open(*mode).expect("open sqlite"),
+                |mut store| {
+                    store.replay_se(log).expect("replay");
+                    store
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+
+    for (label, mode) in DIALOG_MODES {
+        group.bench_with_input(BenchmarkId::new(*label, size), &log, |b, log| {
+            b.iter_batched(
+                || rt.block_on(async { DialogFacts::open(*mode).await.expect("open dialog") }),
+                |mut store| {
+                    rt.block_on(async { store.replay_se(log).await.expect("replay") });
+                    store
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_replay_reads(c: &mut Criterion) {
+    let rt = runtime();
+    let size = txn_count(2000);
+    let log = SeLog::load(size).expect("load SE log");
+    // A post that carries a title (titles are edited, so this pair is
+    // superseded in the log with high likelihood).
+    let titled_post = log
+        .transactions
+        .iter()
+        .flatten()
+        .find(|fact| fact.the == "se.post/title")
+        .map(|fact| fact.of.clone())
+        .expect("log contains a titled post");
+
+    let sqlite: Vec<(&str, SqliteFacts)> = SQLITE_MODES
+        .iter()
+        .map(|(label, mode)| {
+            let mut store = SqliteFacts::open(*mode).expect("open sqlite");
+            store.replay_se(&log).expect("seed sqlite");
+            (*label, store)
+        })
+        .collect();
+    let dialog: Vec<(&str, DialogFacts)> = DIALOG_MODES
+        .iter()
+        .map(|(label, mode)| {
+            let store = rt.block_on(async {
+                let mut store = DialogFacts::open(*mode).await.expect("open dialog");
+                store.replay_se(&log).await.expect("seed dialog");
+                store
+            });
+            (*label, store)
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("se_kind_lookup");
+    for (label, store) in &sqlite {
+        group.bench_with_input(BenchmarkId::new(*label, size), store, |b, store| {
+            b.iter(|| store.se_by_kind("question").expect("kind lookup"));
+        });
+    }
+    for (label, store) in &dialog {
+        group.bench_with_input(BenchmarkId::new(*label, size), store, |b, store| {
+            b.iter(|| rt.block_on(async { store.se_by_kind("question").await.expect("kind") }));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("se_title_get");
+    for (label, store) in &sqlite {
+        group.bench_with_input(BenchmarkId::new(*label, size), store, |b, store| {
+            b.iter(|| store.se_title(&titled_post).expect("title"));
+        });
+    }
+    for (label, store) in &dialog {
+        group.bench_with_input(BenchmarkId::new(*label, size), store, |b, store| {
+            b.iter(|| rt.block_on(async { store.se_title(&titled_post).await.expect("title") }));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_replay_write, bench_replay_reads);
+criterion_main!(benches);

--- a/rust/dialog-baseline/benches/sqlite_vs_dialog.rs
+++ b/rust/dialog-baseline/benches/sqlite_vs_dialog.rs
@@ -1,0 +1,201 @@
+//! Side-by-side criterion benchmarks: dialog-db vs SQLite on identical
+//! fact workloads.
+//!
+//! Five operations × five store configurations, all in shared criterion
+//! groups so each report page shows the stores next to each other:
+//!
+//! - `write_small_txns`: N entities committed one transaction each (the
+//!   interactive-edit shape; the Stack Exchange dataset's p50 is 1 fact
+//!   per transaction).
+//! - `write_batch`: N entities in one transaction (bulk load).
+//! - `point_get`: value of `(entity, stuff/name)` for a rotating entity.
+//! - `attr_scan`: all `stuff/name` facts.
+//! - `join`: `(entity, name, role)` two-attribute join.
+//!
+//! Store configurations: `sqlite_mem`, `sqlite_disk` (WAL +
+//! `synchronous=NORMAL`), `sqlite_disk_nosync` (`synchronous=OFF` — the
+//! durability semantics dialog's fs backend has today), `dialog_mem`,
+//! `dialog_disk`.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo bench -p dialog-baseline
+//! ```
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_baseline::{DialogFacts, DialogMode, FactRow, SqliteFacts, SqliteMode, generate_rows};
+
+const WRITE_SMALL_SIZE: usize = 100;
+const WRITE_BATCH_SIZE: usize = 1_000;
+const READ_SIZE: usize = 1_000;
+
+/// A fresh multi-threaded tokio runtime for driving the async dialog side.
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().expect("tokio runtime")
+}
+
+const SQLITE_MODES: &[(&str, SqliteMode)] = &[
+    ("sqlite_mem", SqliteMode::Memory),
+    ("sqlite_disk", SqliteMode::Disk),
+    ("sqlite_disk_nosync", SqliteMode::DiskNoSync),
+];
+
+const DIALOG_MODES: &[(&str, DialogMode)] = &[
+    ("dialog_mem", DialogMode::Memory),
+    ("dialog_disk", DialogMode::Disk),
+];
+
+/// A seeded pair of read-side stores, built once per configuration with
+/// the same rows so read benches compare identical content.
+struct Seeded {
+    rows: Vec<FactRow>,
+    sqlite: Vec<(&'static str, SqliteFacts)>,
+    dialog: Vec<(&'static str, DialogFacts)>,
+}
+
+fn seed(size: usize) -> Seeded {
+    let rows = generate_rows(size);
+    let sqlite = SQLITE_MODES
+        .iter()
+        .map(|(label, mode)| {
+            let mut store = SqliteFacts::open(*mode).expect("open sqlite");
+            store.insert_one_transaction(&rows).expect("seed sqlite");
+            (*label, store)
+        })
+        .collect();
+    let rt = runtime();
+    let dialog = DIALOG_MODES
+        .iter()
+        .map(|(label, mode)| {
+            let store = rt.block_on(async {
+                let mut store = DialogFacts::open(*mode).await.expect("open dialog");
+                store
+                    .insert_one_transaction(&rows)
+                    .await
+                    .expect("seed dialog");
+                store
+            });
+            (*label, store)
+        })
+        .collect();
+    Seeded {
+        rows,
+        sqlite,
+        dialog,
+    }
+}
+
+fn bench_writes(c: &mut Criterion) {
+    let rt = runtime();
+    for (group_name, size, per_row) in [
+        ("write_small_txns", WRITE_SMALL_SIZE, true),
+        ("write_batch", WRITE_BATCH_SIZE, false),
+    ] {
+        let mut group = c.benchmark_group(group_name);
+        // Each sample writes `size` entities (2 facts each); report
+        // throughput in entities so configurations are comparable.
+        group.throughput(criterion::Throughput::Elements(size as u64));
+        group.sample_size(10);
+        let rows = generate_rows(size);
+
+        for (label, mode) in SQLITE_MODES {
+            group.bench_with_input(BenchmarkId::new(*label, size), &rows, |b, rows| {
+                b.iter_batched(
+                    || SqliteFacts::open(*mode).expect("open sqlite"),
+                    |mut store| {
+                        if per_row {
+                            store.insert_per_row_transactions(rows).expect("insert");
+                        } else {
+                            store.insert_one_transaction(rows).expect("insert");
+                        }
+                        store
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+
+        for (label, mode) in DIALOG_MODES {
+            group.bench_with_input(BenchmarkId::new(*label, size), &rows, |b, rows| {
+                b.iter_batched(
+                    || rt.block_on(async { DialogFacts::open(*mode).await.expect("open dialog") }),
+                    |mut store| {
+                        rt.block_on(async {
+                            if per_row {
+                                store
+                                    .insert_per_row_transactions(rows)
+                                    .await
+                                    .expect("insert");
+                            } else {
+                                store.insert_one_transaction(rows).await.expect("insert");
+                            }
+                        });
+                        store
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_reads(c: &mut Criterion) {
+    let rt = runtime();
+    let seeded = seed(READ_SIZE);
+
+    let mut group = c.benchmark_group("point_get");
+    let cursor = AtomicUsize::new(0);
+    for (label, store) in &seeded.sqlite {
+        group.bench_with_input(BenchmarkId::new(*label, READ_SIZE), store, |b, store| {
+            b.iter(|| {
+                let row = &seeded.rows[cursor.fetch_add(1, Ordering::Relaxed) % seeded.rows.len()];
+                store.point_get(&row.entity).expect("point get")
+            });
+        });
+    }
+    for (label, store) in &seeded.dialog {
+        group.bench_with_input(BenchmarkId::new(*label, READ_SIZE), store, |b, store| {
+            b.iter(|| {
+                let row = &seeded.rows[cursor.fetch_add(1, Ordering::Relaxed) % seeded.rows.len()];
+                rt.block_on(async { store.point_get(&row.entity).await.expect("point get") })
+            });
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("attr_scan");
+    group.throughput(criterion::Throughput::Elements(READ_SIZE as u64));
+    for (label, store) in &seeded.sqlite {
+        group.bench_with_input(BenchmarkId::new(*label, READ_SIZE), store, |b, store| {
+            b.iter(|| store.attribute_scan().expect("scan"));
+        });
+    }
+    for (label, store) in &seeded.dialog {
+        group.bench_with_input(BenchmarkId::new(*label, READ_SIZE), store, |b, store| {
+            b.iter(|| rt.block_on(async { store.attribute_scan().await.expect("scan") }));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("join");
+    group.throughput(criterion::Throughput::Elements(READ_SIZE as u64));
+    group.sample_size(20);
+    for (label, store) in &seeded.sqlite {
+        group.bench_with_input(BenchmarkId::new(*label, READ_SIZE), store, |b, store| {
+            b.iter(|| store.join().expect("join"));
+        });
+    }
+    for (label, store) in &seeded.dialog {
+        group.bench_with_input(BenchmarkId::new(*label, READ_SIZE), store, |b, store| {
+            b.iter(|| rt.block_on(async { store.join().await.expect("join") }));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_writes, bench_reads);
+criterion_main!(benches);

--- a/rust/dialog-baseline/src/lib.rs
+++ b/rust/dialog-baseline/src/lib.rs
@@ -26,6 +26,8 @@
 //! production SQLite deployment would actually run, and is the number to
 //! beat once dialog has an explicit durability story.
 
+pub mod se;
+
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -101,6 +103,16 @@ pub struct SqliteFacts {
 }
 
 impl SqliteFacts {
+    /// The underlying connection, for sibling workload modules.
+    pub(crate) fn connection(&self) -> &Connection {
+        &self.connection
+    }
+
+    /// The underlying connection, mutably, for sibling workload modules.
+    pub(crate) fn connection_mut(&mut self) -> &mut Connection {
+        &mut self.connection
+    }
+
     /// Open a fresh store in the given mode with the schema applied.
     pub fn open(mode: SqliteMode) -> Result<Self> {
         let (connection, dir) = match mode {
@@ -293,7 +305,7 @@ impl DialogFacts {
         Ok(())
     }
 
-    async fn collect(
+    pub(crate) async fn collect(
         &self,
         selector: ArtifactSelector<dialog_artifacts::selector::Constrained>,
     ) -> Result<Vec<Artifact>> {

--- a/rust/dialog-baseline/src/lib.rs
+++ b/rust/dialog-baseline/src/lib.rs
@@ -1,4 +1,9 @@
 #![warn(missing_docs)]
+// Native-only: SQLite links a bundled C library and the harness drives
+// filesystem stores and a multi-threaded runtime, none of which exist on
+// wasm32. The crate compiles to nothing there so the workspace's wasm
+// builds are unaffected.
+#![cfg(not(target_arch = "wasm32"))]
 
 //! Reference benchmarks: dialog-db vs SQLite on identical workloads.
 //!

--- a/rust/dialog-baseline/src/lib.rs
+++ b/rust/dialog-baseline/src/lib.rs
@@ -1,0 +1,388 @@
+#![warn(missing_docs)]
+
+//! Reference benchmarks: dialog-db vs SQLite on identical workloads.
+//!
+//! SQLite is the bar dialog-db aims to clear for local performance while
+//! keeping content-addressed storage for partial on-demand replication.
+//! This crate pins that bar down with numbers instead of assumptions: the
+//! same fact-shaped workload is run against
+//!
+//! - **SQLite** modeling the dialog information model faithfully: one
+//!   `facts` table whose primary key is the EAV ordering, plus secondary
+//!   AEV and VAE indexes — the exact three orderings `dialog-artifacts`
+//!   maintains in its prolly tree.
+//! - **dialog-db** through the public [`Artifacts`] fact-store API
+//!   (`commit` / `select`), over both the in-memory and the native
+//!   filesystem storage backends.
+//!
+//! The workload shape mirrors the existing `dialog-query` benches
+//! (`seed_stuff`: each entity carries a `stuff/name` and a `stuff/role`)
+//! so numbers line up across crates.
+//!
+//! Durability caveat, so comparisons stay honest: dialog's filesystem
+//! backend does not fsync block writes today, so the closest SQLite
+//! configuration is `synchronous=OFF` (the `sqlite_disk_nosync` variant).
+//! The `sqlite_disk` variant uses WAL + `synchronous=NORMAL`, i.e. what a
+//! production SQLite deployment would actually run, and is the number to
+//! beat once dialog has an explicit durability story.
+
+use std::str::FromStr;
+
+use anyhow::Result;
+use base58::ToBase58;
+use dialog_artifacts::{
+    Artifact, ArtifactSelector, ArtifactStoreMut, Artifacts, Attribute, Entity, Instruction, Value,
+};
+use dialog_storage::{Blake3Hash, FileSystemStorageBackend, MemoryStorageBackend};
+use futures_util::{TryStreamExt, stream};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+/// The attribute carrying an entity's name, mirroring
+/// `dialog-query`'s `stuff/name`.
+pub const NAME_ATTRIBUTE: &str = "stuff/name";
+
+/// The attribute carrying an entity's role, mirroring
+/// `dialog-query`'s `stuff/role`.
+pub const ROLE_ATTRIBUTE: &str = "stuff/role";
+
+/// Number of distinct role values; keeps the role attribute low-cardinality
+/// the way real enum-ish attributes are.
+pub const ROLE_COUNT: usize = 8;
+
+/// One entity's worth of seeded facts, in both representations.
+#[derive(Clone, Debug)]
+pub struct FactRow {
+    /// The entity identifier (`entity:<base58>`), identical across both
+    /// stores.
+    pub entity: String,
+    /// The `stuff/name` value for this entity.
+    pub name: String,
+    /// The `stuff/role` value for this entity.
+    pub role: String,
+}
+
+/// Deterministically generate `count` entities with a name and a role each,
+/// seeded the same way `dialog-operator`'s `generate_data` seeds its
+/// entities so runs are reproducible.
+pub fn generate_rows(count: usize) -> Vec<FactRow> {
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
+    (0..count)
+        .map(|i| FactRow {
+            entity: format!("entity:{}", rng.r#gen::<[u8; 32]>().to_base58()),
+            name: format!("name{i}"),
+            role: format!("role{}", i % ROLE_COUNT),
+        })
+        .collect()
+}
+
+/// How the SQLite connection is persisted and synced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SqliteMode {
+    /// `:memory:` database — CPU-isolation signal.
+    Memory,
+    /// On-disk database, `journal_mode=WAL`, `synchronous=NORMAL`: the
+    /// production-realistic configuration.
+    Disk,
+    /// On-disk database, `journal_mode=WAL`, `synchronous=OFF`: durability
+    /// semantics equivalent to dialog's current fsync-free filesystem
+    /// backend.
+    DiskNoSync,
+}
+
+/// A SQLite fact store modeling dialog's information model: one row per
+/// fact, EAV primary key, AEV + VAE secondary indexes.
+pub struct SqliteFacts {
+    connection: Connection,
+    // Held so the on-disk database lives as long as the store.
+    _dir: Option<TempDir>,
+}
+
+impl SqliteFacts {
+    /// Open a fresh store in the given mode with the schema applied.
+    pub fn open(mode: SqliteMode) -> Result<Self> {
+        let (connection, dir) = match mode {
+            SqliteMode::Memory => (Connection::open_in_memory()?, None),
+            SqliteMode::Disk | SqliteMode::DiskNoSync => {
+                let dir = TempDir::new()?;
+                let connection = Connection::open(dir.path().join("facts.sqlite"))?;
+                connection.pragma_update(None, "journal_mode", "WAL")?;
+                let synchronous = if mode == SqliteMode::DiskNoSync {
+                    "OFF"
+                } else {
+                    "NORMAL"
+                };
+                connection.pragma_update(None, "synchronous", synchronous)?;
+                (connection, Some(dir))
+            }
+        };
+        connection.execute_batch(
+            "CREATE TABLE facts (
+                 the TEXT NOT NULL,
+                 of  TEXT NOT NULL,
+                 val TEXT NOT NULL,
+                 PRIMARY KEY (of, the, val)
+             ) WITHOUT ROWID;
+             CREATE INDEX facts_aev ON facts (the, of, val);
+             CREATE INDEX facts_vae ON facts (val, the, of);",
+        )?;
+        Ok(Self {
+            connection,
+            _dir: dir,
+        })
+    }
+
+    /// Insert each row in its own transaction (the small-commit shape:
+    /// real edits are 1-5 facts per transaction).
+    pub fn insert_per_row_transactions(&mut self, rows: &[FactRow]) -> Result<()> {
+        for row in rows {
+            let tx = self.connection.transaction()?;
+            {
+                let mut statement =
+                    tx.prepare_cached("INSERT INTO facts (the, of, val) VALUES (?1, ?2, ?3)")?;
+                statement.execute((NAME_ATTRIBUTE, &row.entity, &row.name))?;
+                statement.execute((ROLE_ATTRIBUTE, &row.entity, &row.role))?;
+            }
+            tx.commit()?;
+        }
+        Ok(())
+    }
+
+    /// Insert every row in one transaction (the bulk-load shape).
+    pub fn insert_one_transaction(&mut self, rows: &[FactRow]) -> Result<()> {
+        let tx = self.connection.transaction()?;
+        {
+            let mut statement =
+                tx.prepare_cached("INSERT INTO facts (the, of, val) VALUES (?1, ?2, ?3)")?;
+            for row in rows {
+                statement.execute((NAME_ATTRIBUTE, &row.entity, &row.name))?;
+                statement.execute((ROLE_ATTRIBUTE, &row.entity, &row.role))?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Point lookup: the value of `(entity, stuff/name)`.
+    pub fn point_get(&self, entity: &str) -> Result<Option<String>> {
+        let mut statement = self
+            .connection
+            .prepare_cached("SELECT val FROM facts WHERE of = ?1 AND the = ?2")?;
+        let mut result = statement.query((entity, NAME_ATTRIBUTE))?;
+        Ok(match result.next()? {
+            Some(found) => Some(found.get(0)?),
+            None => None,
+        })
+    }
+
+    /// Attribute scan: every `(entity, value)` pair of `stuff/name`.
+    pub fn attribute_scan(&self) -> Result<usize> {
+        let mut statement = self
+            .connection
+            .prepare_cached("SELECT of, val FROM facts WHERE the = ?1")?;
+        let mut count = 0;
+        let mut result = statement.query((NAME_ATTRIBUTE,))?;
+        while let Some(found) = result.next()? {
+            let _entity: String = found.get(0)?;
+            let _value: String = found.get(1)?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Two-attribute join on the shared entity: `(entity, name, role)`
+    /// tuples — the SQL statement of the `query_join` concept query.
+    pub fn join(&self) -> Result<usize> {
+        let mut statement = self.connection.prepare_cached(
+            "SELECT n.of, n.val, r.val
+             FROM facts n JOIN facts r ON n.of = r.of
+             WHERE n.the = ?1 AND r.the = ?2",
+        )?;
+        let mut count = 0;
+        let mut result = statement.query((NAME_ATTRIBUTE, ROLE_ATTRIBUTE))?;
+        while let Some(found) = result.next()? {
+            let _entity: String = found.get(0)?;
+            let _name: String = found.get(1)?;
+            let _role: String = found.get(2)?;
+            count += 1;
+        }
+        Ok(count)
+    }
+}
+
+/// Where a dialog [`Artifacts`] store keeps its blocks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DialogMode {
+    /// In-memory storage backend — CPU-isolation signal.
+    Memory,
+    /// Native filesystem backend in a fresh temp directory.
+    Disk,
+}
+
+/// A dialog fact store over either storage backend, exposed through one
+/// enum so benches treat both uniformly.
+pub enum DialogFacts {
+    /// Backed by [`MemoryStorageBackend`].
+    Memory(Artifacts<MemoryStorageBackend<Blake3Hash, Vec<u8>>>),
+    /// Backed by [`FileSystemStorageBackend`]; the temp dir lives as long
+    /// as the store.
+    Disk(
+        Artifacts<FileSystemStorageBackend<Blake3Hash, Vec<u8>>>,
+        TempDir,
+    ),
+}
+
+impl DialogFacts {
+    /// Open a fresh store in the given mode.
+    pub async fn open(mode: DialogMode) -> Result<Self> {
+        match mode {
+            DialogMode::Memory => {
+                let backend = MemoryStorageBackend::default();
+                Ok(Self::Memory(Artifacts::anonymous(backend).await?))
+            }
+            DialogMode::Disk => {
+                let dir = TempDir::new()?;
+                let backend = FileSystemStorageBackend::new(dir.path()).await?;
+                Ok(Self::Disk(Artifacts::anonymous(backend).await?, dir))
+            }
+        }
+    }
+
+    fn artifacts_for(row: &FactRow) -> Result<[Artifact; 2]> {
+        let entity = Entity::from_str(&row.entity)?;
+        Ok([
+            Artifact {
+                the: Attribute::from_str(NAME_ATTRIBUTE)?,
+                of: entity.clone(),
+                is: Value::String(row.name.clone()),
+                cause: None,
+            },
+            Artifact {
+                the: Attribute::from_str(ROLE_ATTRIBUTE)?,
+                of: entity,
+                is: Value::String(row.role.clone()),
+                cause: None,
+            },
+        ])
+    }
+
+    /// Commit each row as its own transaction (the small-commit shape).
+    pub async fn insert_per_row_transactions(&mut self, rows: &[FactRow]) -> Result<()> {
+        for row in rows {
+            let instructions = stream::iter(Self::artifacts_for(row)?.map(Instruction::Assert));
+            match self {
+                Self::Memory(artifacts) => artifacts.commit(instructions).await?,
+                Self::Disk(artifacts, _) => artifacts.commit(instructions).await?,
+            };
+        }
+        Ok(())
+    }
+
+    /// Commit every row in one transaction (the bulk-load shape).
+    pub async fn insert_one_transaction(&mut self, rows: &[FactRow]) -> Result<()> {
+        let mut instructions = Vec::with_capacity(rows.len() * 2);
+        for row in rows {
+            instructions.extend(Self::artifacts_for(row)?.map(Instruction::Assert));
+        }
+        match self {
+            Self::Memory(artifacts) => artifacts.commit(stream::iter(instructions)).await?,
+            Self::Disk(artifacts, _) => artifacts.commit(stream::iter(instructions)).await?,
+        };
+        Ok(())
+    }
+
+    async fn collect(
+        &self,
+        selector: ArtifactSelector<dialog_artifacts::selector::Constrained>,
+    ) -> Result<Vec<Artifact>> {
+        Ok(match self {
+            Self::Memory(artifacts) => artifacts.select(selector).try_collect().await?,
+            Self::Disk(artifacts, _) => artifacts.select(selector).try_collect().await?,
+        })
+    }
+
+    /// Point lookup: the value of `(entity, stuff/name)`.
+    pub async fn point_get(&self, entity: &str) -> Result<Option<Value>> {
+        let selector = ArtifactSelector::new()
+            .the(Attribute::from_str(NAME_ATTRIBUTE)?)
+            .of(Entity::from_str(entity)?);
+        Ok(self.collect(selector).await?.pop().map(|found| found.is))
+    }
+
+    /// Attribute scan: every `stuff/name` fact.
+    pub async fn attribute_scan(&self) -> Result<usize> {
+        let selector = ArtifactSelector::new().the(Attribute::from_str(NAME_ATTRIBUTE)?);
+        Ok(self.collect(selector).await?.len())
+    }
+
+    /// Two-attribute hash join on the shared entity, at the fact-store
+    /// layer: one AEV scan per attribute, joined in memory. This is the
+    /// storage-layer ceiling for the `query_join` engine benchmark — the
+    /// gap between this number and `query_join` is engine overhead.
+    pub async fn join(&self) -> Result<usize> {
+        let names = self
+            .collect(ArtifactSelector::new().the(Attribute::from_str(NAME_ATTRIBUTE)?))
+            .await?;
+        let roles = self
+            .collect(ArtifactSelector::new().the(Attribute::from_str(ROLE_ATTRIBUTE)?))
+            .await?;
+        let names_by_entity: std::collections::HashMap<String, Value> = names
+            .into_iter()
+            .map(|artifact| (artifact.of.to_string(), artifact.is))
+            .collect();
+        let mut count = 0;
+        for role in roles {
+            if names_by_entity.contains_key(&role.of.to_string()) {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_roundtrip() -> Result<()> {
+        let rows = generate_rows(10);
+        let mut store = SqliteFacts::open(SqliteMode::Memory)?;
+        store.insert_one_transaction(&rows)?;
+        assert_eq!(
+            store.point_get(&rows[3].entity)?,
+            Some(rows[3].name.clone())
+        );
+        assert_eq!(store.attribute_scan()?, 10);
+        assert_eq!(store.join()?, 10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dialog_roundtrip() -> Result<()> {
+        let rows = generate_rows(10);
+        let mut store = DialogFacts::open(DialogMode::Memory).await?;
+        store.insert_one_transaction(&rows).await?;
+        assert_eq!(
+            store.point_get(&rows[3].entity).await?,
+            Some(Value::String(rows[3].name.clone()))
+        );
+        assert_eq!(store.attribute_scan().await?, 10);
+        assert_eq!(store.join().await?, 10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stores_agree() -> Result<()> {
+        let rows = generate_rows(25);
+        let mut sqlite = SqliteFacts::open(SqliteMode::Memory)?;
+        sqlite.insert_per_row_transactions(&rows)?;
+        let mut dialog = DialogFacts::open(DialogMode::Memory).await?;
+        dialog.insert_per_row_transactions(&rows).await?;
+        assert_eq!(sqlite.attribute_scan()?, dialog.attribute_scan().await?);
+        assert_eq!(sqlite.join()?, dialog.join().await?);
+        Ok(())
+    }
+}

--- a/rust/dialog-baseline/src/se.rs
+++ b/rust/dialog-baseline/src/se.rs
@@ -1,0 +1,453 @@
+//! Stack Exchange fact-log replay: the realistic workload.
+//!
+//! `scripts/se-transform.py` turns a Stack Exchange site dump into a flat,
+//! transaction-ordered fact log (`txn,at,the,of,as,is` — see
+//! `notes/benchmark-dataset.md`). Rows sharing a `txn` are one commit, and
+//! commit boundaries are the site's real ones. This module replays that log
+//! against both stores, one commit per transaction, which exercises exactly
+//! the shape the synthetic `stuff` workload cannot: small skewed commits
+//! (p50 of 1 fact), genuine cardinality-one supersession (44% of pairs are
+//! written more than once), and a long-tailed value-size distribution that
+//! crosses the spill boundary.
+//!
+//! Two data sources:
+//!
+//! - **Real data** when `DIALOG_SE_CSV` points at a transformed dump. This
+//!   is the reporting configuration.
+//! - **A deterministic synthetic approximation** otherwise, so the bench
+//!   runs out of the box. The generator reproduces the *measured* statistics
+//!   of the retrocomputing dump documented in `notes/benchmark-dataset.md`
+//!   (revision skew p50 3 / p90 7 / p99 12 / max 122; body sizes with ~9%
+//!   past the 4096-byte inline threshold; ~36% questions carrying titles and
+//!   ~2.5 tags each). It approximates — the real log is the reference.
+//!
+//! Supersession mapping, kept honest on both sides: a repeated write to a
+//! cardinality-one `(entity, attribute)` is [`Instruction::Replace`] in
+//! dialog (remove all priors from the three indexes, insert the new value)
+//! and `DELETE (of, the)` + `INSERT` inside the same SQLite transaction.
+//! Multi-valued attributes (`se.post/tag`) are plain asserts / inserts.
+
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+use dialog_artifacts::{
+    Artifact, ArtifactSelector, ArtifactStoreMut, Attribute, Entity, Instruction, Value,
+};
+use futures_util::stream;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use crate::{DialogFacts, SqliteFacts};
+
+/// A single fact in a Stack Exchange transaction.
+#[derive(Clone, Debug)]
+pub struct SeFact {
+    /// The attribute, e.g. `se.post/body`.
+    pub the: String,
+    /// The entity, e.g. `post:1`.
+    pub of: String,
+    /// The value, already reduced to its textual form plus a type tag.
+    pub value: SeValue,
+}
+
+/// The value types the transformed dump contains (text / entity / boolean).
+#[derive(Clone, Debug)]
+pub enum SeValue {
+    /// A `text` value.
+    Text(String),
+    /// An `entity` reference value.
+    Entity(String),
+    /// A `boolean` value.
+    Boolean(bool),
+}
+
+impl SeValue {
+    /// The value rendered as SQLite TEXT.
+    pub fn as_sql_text(&self) -> &str {
+        match self {
+            SeValue::Text(text) => text,
+            SeValue::Entity(entity) => entity,
+            SeValue::Boolean(true) => "true",
+            SeValue::Boolean(false) => "false",
+        }
+    }
+
+    /// The value as a dialog [`Value`].
+    pub fn to_dialog(&self) -> Result<Value> {
+        Ok(match self {
+            SeValue::Text(text) => Value::String(text.clone()),
+            SeValue::Entity(entity) => Value::Entity(Entity::from_str(entity)?),
+            SeValue::Boolean(flag) => Value::Boolean(*flag),
+        })
+    }
+}
+
+/// Whether an attribute is multi-valued (asserted, never superseded).
+/// In the SE schema only `se.post/tag` accumulates values.
+pub fn is_multi_valued(attribute: &str) -> bool {
+    attribute == "se.post/tag"
+}
+
+/// A transaction-ordered fact log ready to replay.
+#[derive(Clone, Debug, Default)]
+pub struct SeLog {
+    /// Commits in order; each inner vector is one transaction.
+    pub transactions: Vec<Vec<SeFact>>,
+}
+
+impl SeLog {
+    /// Total fact count across all transactions.
+    pub fn fact_count(&self) -> usize {
+        self.transactions.iter().map(Vec::len).sum()
+    }
+
+    /// Load the log used by the benchmarks: the real transformed dump when
+    /// `DIALOG_SE_CSV` is set (truncated to `limit` transactions), the
+    /// synthetic approximation otherwise.
+    pub fn load(limit: usize) -> Result<Self> {
+        match std::env::var("DIALOG_SE_CSV") {
+            Ok(path) => Self::from_csv_path(&path, limit)
+                .with_context(|| format!("loading DIALOG_SE_CSV={path}")),
+            Err(_) => Ok(Self::synthetic(limit)),
+        }
+    }
+
+    /// Parse a transformed dump (`txn,at,the,of,as,is`), keeping the first
+    /// `limit` transactions (`usize::MAX` for all).
+    pub fn from_csv_path(path: &str, limit: usize) -> Result<Self> {
+        let text = std::fs::read_to_string(path)?;
+        let mut transactions: Vec<Vec<SeFact>> = Vec::new();
+        let mut current_txn: Option<String> = None;
+        for record in parse_csv(&text).into_iter().skip(1) {
+            if record.len() < 6 {
+                continue;
+            }
+            let [txn, _at, the, of, value_type, is] = &record[..6] else {
+                continue;
+            };
+            if current_txn.as_deref() != Some(txn.as_str()) {
+                if transactions.len() == limit {
+                    break;
+                }
+                current_txn = Some(txn.clone());
+                transactions.push(Vec::new());
+            }
+            let value = match value_type.as_str() {
+                "text" => SeValue::Text(is.clone()),
+                "entity" => SeValue::Entity(is.clone()),
+                "boolean" => match bool::from_str(is) {
+                    Ok(flag) => SeValue::Boolean(flag),
+                    Err(_) => continue,
+                },
+                _ => continue,
+            };
+            transactions
+                .last_mut()
+                .expect("transaction pushed above")
+                .push(SeFact {
+                    the: the.clone(),
+                    of: of.clone(),
+                    value,
+                });
+        }
+        Ok(Self { transactions })
+    }
+
+    /// Deterministic synthetic approximation of the retrocomputing dump's
+    /// measured statistics (see the module docs). Produces exactly
+    /// `transaction_count` commits, seeded, so every run replays the same
+    /// log.
+    pub fn synthetic(transaction_count: usize) -> Self {
+        let mut rng = ChaCha8Rng::from_seed([11u8; 32]);
+        let mut transactions = Vec::with_capacity(transaction_count);
+        let user_pool = (transaction_count / 8).max(4);
+
+        // Interleave post creations with edit revisions of already-created
+        // posts, matching the scattered-writes property (commits land across
+        // the keyspace, not in one region).
+        let mut posts: Vec<(usize, bool)> = Vec::new(); // (post id, is question)
+        let mut next_post = 0usize;
+
+        while transactions.len() < transaction_count {
+            // Roughly 40% of commits create a post (21,771 entities across
+            // 50,553 commits); the rest edit an existing one.
+            let create = posts.is_empty() || rng.gen_bool(0.4);
+            let mut txn = Vec::new();
+            if create {
+                next_post += 1;
+                let is_question = rng.gen_bool(0.36);
+                posts.push((next_post, is_question));
+                let post = format!("post:{next_post}");
+                txn.push(SeFact {
+                    the: "se.post/kind".into(),
+                    of: post.clone(),
+                    value: SeValue::Text(if is_question { "question" } else { "answer" }.into()),
+                });
+                txn.push(SeFact {
+                    the: "se.post/author".into(),
+                    of: post.clone(),
+                    value: SeValue::Entity(format!("user:{}", rng.gen_range(1..=user_pool))),
+                });
+                txn.push(SeFact {
+                    the: "se.post/body".into(),
+                    of: post.clone(),
+                    value: SeValue::Text(body_text(&mut rng)),
+                });
+                if is_question {
+                    txn.push(SeFact {
+                        the: "se.post/title".into(),
+                        of: post.clone(),
+                        value: SeValue::Text(format!("Question number {next_post}?")),
+                    });
+                    for _ in 0..rng.gen_range(1..=4) {
+                        txn.push(SeFact {
+                            the: "se.post/tag".into(),
+                            of: post.clone(),
+                            value: SeValue::Text(format!("tag{}", rng.gen_range(0..64))),
+                        });
+                    }
+                }
+            } else {
+                // Edit-frequency skew: bias picks toward recent posts a bit,
+                // but let any post be edited (the long tail comes from
+                // repeatedly re-picking the same busy posts by chance).
+                let (post_id, is_question) = posts[rng.gen_range(0..posts.len())];
+                let post = format!("post:{post_id}");
+                let roll: f64 = rng.r#gen();
+                if roll < 0.85 {
+                    txn.push(SeFact {
+                        the: "se.post/body".into(),
+                        of: post,
+                        value: SeValue::Text(body_text(&mut rng)),
+                    });
+                } else if roll < 0.90 && is_question {
+                    txn.push(SeFact {
+                        the: "se.post/title".into(),
+                        of: post,
+                        value: SeValue::Text(format!("Question number {post_id} (edited)?")),
+                    });
+                } else {
+                    txn.push(SeFact {
+                        the: "se.post/tag".into(),
+                        of: post,
+                        value: SeValue::Text(format!("tag{}", rng.gen_range(0..64))),
+                    });
+                }
+            }
+            transactions.push(txn);
+        }
+        Self { transactions }
+    }
+}
+
+/// A body value with the measured long-tailed size distribution: log-normal
+/// around a ~700-byte median with roughly 9% of bodies past the 4096-byte
+/// inline threshold, clamped at the observed 29,597-byte maximum.
+fn body_text(rng: &mut ChaCha8Rng) -> String {
+    let normal: f64 = {
+        // Box-Muller from two uniforms; avoids a distribution dependency.
+        let u1: f64 = rng.gen_range(f64::EPSILON..1.0);
+        let u2: f64 = rng.r#gen();
+        (-2.0 * u1.ln()).sqrt() * (std::f64::consts::TAU * u2).cos()
+    };
+    let length = (700.0 * (1.32 * normal).exp()).clamp(8.0, 29_597.0) as usize;
+    // Compressible, position-dependent filler; content does not matter, size
+    // does.
+    let mut body = String::with_capacity(length);
+    while body.len() < length {
+        body.push_str("lorem ipsum dolor sit amet ");
+    }
+    body.truncate(length);
+    body
+}
+
+/// Minimal RFC-4180 parser (quoted fields, doubled quotes, embedded commas
+/// and newlines) — post bodies contain both, so naive splitting silently
+/// corrupts the log.
+fn parse_csv(text: &str) -> Vec<Vec<String>> {
+    let mut records = Vec::new();
+    let mut record = Vec::new();
+    let mut field = String::new();
+    let mut in_quotes = false;
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' if in_quotes && chars.peek() == Some(&'"') => {
+                field.push('"');
+                chars.next();
+            }
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => record.push(std::mem::take(&mut field)),
+            '\n' if !in_quotes => {
+                record.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut record));
+            }
+            '\r' if !in_quotes => {}
+            _ => field.push(ch),
+        }
+    }
+    if !field.is_empty() || !record.is_empty() {
+        record.push(field);
+        records.push(record);
+    }
+    records
+}
+
+impl SqliteFacts {
+    /// Replay the log, one SQLite transaction per commit. Cardinality-one
+    /// writes delete the prior `(of, the)` rows before inserting; tag writes
+    /// insert alongside.
+    pub fn replay_se(&mut self, log: &SeLog) -> Result<()> {
+        let connection = self.connection_mut();
+        for commit in &log.transactions {
+            let tx = connection.transaction()?;
+            {
+                let mut delete =
+                    tx.prepare_cached("DELETE FROM facts WHERE of = ?1 AND the = ?2")?;
+                let mut insert = tx.prepare_cached(
+                    "INSERT OR REPLACE INTO facts (the, of, val) VALUES (?1, ?2, ?3)",
+                )?;
+                for fact in commit {
+                    if !is_multi_valued(&fact.the) {
+                        delete.execute((&fact.of, &fact.the))?;
+                    }
+                    insert.execute((&fact.the, &fact.of, fact.value.as_sql_text()))?;
+                }
+            }
+            tx.commit()?;
+        }
+        Ok(())
+    }
+
+    /// The current title of a post (point read of a superseded pair).
+    pub fn se_title(&self, post: &str) -> Result<Option<String>> {
+        let mut statement = self
+            .connection()
+            .prepare_cached("SELECT val FROM facts WHERE of = ?1 AND the = 'se.post/title'")?;
+        let mut result = statement.query((post,))?;
+        Ok(match result.next()? {
+            Some(found) => Some(found.get(0)?),
+            None => None,
+        })
+    }
+
+    /// All entities whose `se.post/kind` is `kind` (a value-indexed lookup).
+    pub fn se_by_kind(&self, kind: &str) -> Result<usize> {
+        let mut statement = self
+            .connection()
+            .prepare_cached("SELECT of FROM facts WHERE the = 'se.post/kind' AND val = ?1")?;
+        let mut count = 0;
+        let mut result = statement.query((kind,))?;
+        while let Some(found) = result.next()? {
+            let _entity: String = found.get(0)?;
+            count += 1;
+        }
+        Ok(count)
+    }
+}
+
+impl DialogFacts {
+    /// Replay the log, one dialog commit per transaction. Cardinality-one
+    /// writes are [`Instruction::Replace`]; tag writes are asserts.
+    pub async fn replay_se(&mut self, log: &SeLog) -> Result<()> {
+        for commit in &log.transactions {
+            let mut instructions = Vec::with_capacity(commit.len());
+            for fact in commit {
+                let artifact = Artifact {
+                    the: Attribute::from_str(&fact.the)?,
+                    of: Entity::from_str(&fact.of)?,
+                    is: fact.value.to_dialog()?,
+                    cause: None,
+                };
+                instructions.push(if is_multi_valued(&fact.the) {
+                    Instruction::Assert(artifact)
+                } else {
+                    Instruction::Replace(artifact)
+                });
+            }
+            match self {
+                Self::Memory(artifacts) => {
+                    artifacts.commit(stream::iter(instructions)).await?;
+                }
+                Self::Disk(artifacts, _) => {
+                    artifacts.commit(stream::iter(instructions)).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The current title of a post (point read of a superseded pair).
+    pub async fn se_title(&self, post: &str) -> Result<Option<Value>> {
+        let selector = ArtifactSelector::new()
+            .the(Attribute::from_str("se.post/title")?)
+            .of(Entity::from_str(post)?);
+        Ok(self.collect(selector).await?.pop().map(|found| found.is))
+    }
+
+    /// All entities whose `se.post/kind` is `kind` (a VAE-indexed lookup).
+    pub async fn se_by_kind(&self, kind: &str) -> Result<usize> {
+        let selector = ArtifactSelector::new()
+            .the(Attribute::from_str("se.post/kind")?)
+            .is(Value::String(kind.to_owned()));
+        Ok(self.collect(selector).await?.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DialogMode, SqliteMode};
+
+    #[test]
+    fn synthetic_log_shape() {
+        let log = SeLog::synthetic(200);
+        assert_eq!(log.transactions.len(), 200);
+        // Some commits are single-fact edits, some are multi-fact creations.
+        let sizes: Vec<usize> = log.transactions.iter().map(Vec::len).collect();
+        assert!(sizes.contains(&1));
+        assert!(sizes.iter().any(|&len| len >= 3));
+        // Supersession exists: at least one (of, the) pair written twice.
+        let mut seen = std::collections::HashSet::new();
+        let mut superseded = false;
+        for fact in log.transactions.iter().flatten() {
+            if !is_multi_valued(&fact.the) && !seen.insert((fact.of.clone(), fact.the.clone())) {
+                superseded = true;
+            }
+        }
+        assert!(superseded);
+    }
+
+    #[tokio::test]
+    async fn stores_agree_after_replay() -> Result<()> {
+        let log = SeLog::synthetic(120);
+        let mut sqlite = SqliteFacts::open(SqliteMode::Memory)?;
+        sqlite.replay_se(&log)?;
+        let mut dialog = DialogFacts::open(DialogMode::Memory).await?;
+        dialog.replay_se(&log).await?;
+
+        assert_eq!(
+            sqlite.se_by_kind("question")?,
+            dialog.se_by_kind("question").await?
+        );
+        assert_eq!(
+            sqlite.se_by_kind("answer")?,
+            dialog.se_by_kind("answer").await?
+        );
+        // A superseded title reads back the same current value.
+        let post = log
+            .transactions
+            .iter()
+            .flatten()
+            .find(|fact| fact.the == "se.post/title")
+            .map(|fact| fact.of.clone())
+            .expect("synthetic log contains titles");
+        let sqlite_title = sqlite.se_title(&post)?;
+        let dialog_title = dialog.se_title(&post).await?;
+        match (sqlite_title, dialog_title) {
+            (Some(expected), Some(Value::String(actual))) => assert_eq!(expected, actual),
+            (expected, actual) => panic!("title mismatch: {expected:?} vs {actual:?}"),
+        }
+        Ok(())
+    }
+}

--- a/rust/dialog-common/src/helpers.rs
+++ b/rust/dialog-common/src/helpers.rs
@@ -393,6 +393,7 @@ mod tests {
     /// Settings for the server
     #[cfg(not(target_arch = "wasm32"))]
     #[derive(Debug, Clone, Default)]
+    #[allow(unused)]
     pub struct ServerSettings {
         pub port: u16,
     }

--- a/rust/dialog-remote-s3/src/request/memory.rs
+++ b/rust/dialog-remote-s3/src/request/memory.rs
@@ -65,8 +65,8 @@ impl From<&Capability<PublishAttenuation>> for S3Request {
             path: format!(
                 "{}/{}/{}",
                 capability.subject(),
-                &Space::of(capability).space,
-                &Cell::of(capability).cell
+                Space::of(capability).space,
+                Cell::of(capability).cell
             ),
             checksum: Some(publish.checksum.clone()),
             precondition: publish.when.as_ref().into(),

--- a/rust/dialog-search-tree/src/tree/transient.rs
+++ b/rust/dialog-search-tree/src/tree/transient.rs
@@ -2665,10 +2665,7 @@ where
     // Strip a non-canonical chain of single-child index nodes over indices. A
     // persistent single child is lifted first: its kind (index or segment)
     // decides whether the wrapper above it is canonical.
-    loop {
-        let TransientNode::Index(index) = &mut root else {
-            break;
-        };
+    while let TransientNode::Index(index) = &mut root {
         if index.children.len() != 1 {
             break;
         }
@@ -6127,7 +6124,7 @@ mod tests {
     /// of 15 near-duplicate keys sharing a 24-byte cluster prefix.
     fn semantic_cluster() -> Vec<VarKey> {
         let mut keys = Vec::new();
-        for sub in [b'A', b'B', b'C'] {
+        for sub in *b"ABC" {
             for n in 0..15u32 {
                 let mut bytes = vec![b'W'];
                 bytes.extend(vec![b'q'; 23]);

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -754,7 +754,7 @@ mod walker_novelty_tests {
             expected.push((key, value));
 
             // Every write so far must be readable, by scan and by point read.
-            expected.sort_by(|(a, _), (b, _)| a.cmp(b));
+            expected.sort_by_key(|(a, _)| *a);
             let mut seen = Vec::new();
             {
                 let stream = tree.stream_range(.., &storage);

--- a/rust/dialog-ucan-core/src/delegation/store.rs
+++ b/rust/dialog-ucan-core/src/delegation/store.rs
@@ -130,7 +130,7 @@ impl<S: Signature, H: BuildHasher> DelegationStore<Local, S, Arc<Delegation<S>>>
                 if let Some(dlg) = locked.get(c) {
                     dlgs.push(dlg.clone());
                 } else {
-                    return Err(Missing(*c))?;
+                    Err(Missing(*c))?;
                 }
             }
             Ok(dlgs)
@@ -174,7 +174,7 @@ where
                 if let Some(dlg) = locked.get(c) {
                     dlgs.push(dlg.clone());
                 } else {
-                    return Err(Missing(*c))?;
+                    Err(Missing(*c))?;
                 }
             }
             Ok(dlgs)


### PR DESCRIPTION
## Summary

Stacks on #408. Adds `rust/dialog-baseline`: reference benchmarks that pin the "competitive with SQLite" goal to numbers instead of assumptions, so every optimization PR in the stack can quote measured deltas.

**SQLite models the dialog information model faithfully**: one `facts` table with the EAV ordering as `PRIMARY KEY (of, the, val) WITHOUT ROWID` plus AEV and VAE secondary indexes — the same three orderings `dialog-artifacts` maintains in its prolly tree. Three configurations: `:memory:`, WAL + `synchronous=NORMAL` (production bar), and WAL + `synchronous=OFF` (the durability equivalent of dialog's current fsync-free fs backend). The dialog side drives the public `Artifacts` API (`commit`/`select`) over the memory and filesystem backends.

Two benches:

- **`sqlite_vs_dialog`** — synthetic `stuff` workload mirroring `dialog-query`'s `seed_stuff`: small-transaction writes, batch writes, point get, attribute scan, two-attribute join.
- **`se_replay`** — the realistic workload: replays the Stack Exchange transaction-ordered fact log (`notes/benchmark-dataset.md`), one commit per transaction, with cardinality-one supersession mapped honestly on both sides (`Instruction::Replace` vs delete+insert in the same SQLite transaction). Runs against a deterministic synthetic approximation of the documented dataset statistics by default; `DIALOG_SE_CSV=<retro-facts.csv>` switches to real data.

Tests cross-check that both stores return identical results, including after supersession-heavy replay.

**First captured numbers** are in `notes/sqlite-baseline-results.md`. Headlines (criterion medians, 4-core container):

- Small commits: dialog is **19×** slower than SQLite in memory, **34×** on disk (with weaker durability than SQLite NORMAL)
- 1000-entity batch commit: **~390×**, and superlinear in batch size
- Point get: **10–29×**, identical on memory vs disk — pure CPU (per-read validation/decode)
- Attribute scan / join: **5–7×**, the smallest gaps

These match the audit's findings: the commit path and per-read validation constants are the dominant gaps, and the file-per-block backend adds ~10× on small disk commits.

Also includes a small commit fixing pre-existing workspace clippy warnings so `cargo clippy --all --all-targets --all-features -- -D warnings` passes cleanly.

## Test plan

- `cargo test -p dialog-baseline` (5 tests, including store-agreement cross-checks)
- `cargo bench -p dialog-baseline --bench sqlite_vs_dialog -- --warm-up-time 1 --measurement-time 3`
- `cargo bench -p dialog-baseline --bench se_replay -- --warm-up-time 1 --measurement-time 3` (optionally with `DIALOG_SE_CSV` pointing at a transformed dump)
- `cargo clippy --all --all-targets --all-features -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As9XD9t4tzozu6Skhincve

---
_Generated by [Claude Code](https://claude.ai/code/session_01As9XD9t4tzozu6Skhincve)_