### PR TITLE
feat(dialog): backport staged install and typed service errors

### DIFF
--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -43,30 +43,40 @@ let
     buildWasmBindgenCli rec {
       src = fetchCrate {
         pname = "wasm-bindgen-cli";
-        version = "0.2.108";
-        hash = "sha256-UsuxILm1G6PkmVw0I/JF12CRltAfCJQFOaT4hFwvR8E=";
+        version = "0.2.126";
+        hash = "sha256-H6Is3fiZVxZCfOMWK5dWMSrtn50VGv0sfdnsT+cTtyk=";
       };
 
       cargoDeps = rustPlatform.fetchCargoVendor {
         inherit src;
         inherit (src) pname version;
-        hash = "sha256-iqQiWbsKlLBiJFeqIYiXo3cqxGLSjNM8SOWXGM9u43E=";
+        hash = "sha256-VucqkXbCi4qtQzY/HrXiDnbSURsagPsdNVMn1Tw3UiY=";
       };
     };
 
+  # Built with crane (rather than rustPlatform.buildRustPackage) so its
+  # vendored dependencies are cached in the shared binary cache alongside the
+  # rest of the workspace. buildRustPackage's cargoHash drives a vendor-staging
+  # fixed-output derivation that fetches crates live from crates.io on every
+  # cache miss, which fails intermittently when crates.io rate-limits CI
+  # runners (HTTP 403). Crane vendors from the crate's bundled Cargo.lock and
+  # the resulting artifacts substitute from cachix like everything else.
   enforce-workspace-deps =
-    with pkgs;
-    rustPlatform.buildRustPackage rec {
-      pname = "cargo-enforce-shared-workspace-deps";
-      version = "0.1.0";
-      buildInputs = [ rustToolchain ];
-
-      src = fetchCrate {
-        inherit pname version;
+    let
+      src = pkgs.fetchCrate {
+        pname = "cargo-enforce-shared-workspace-deps";
+        version = "0.1.0";
         sha256 = "sha256-XOdKeg9tNt/HT+WO9QKtdX3fUMUssVTlXRV0LOIMMzc=";
       };
-
-      cargoHash = "sha256-O6DQXK8/VVwTLuFlSyh8jtBJyAFMfAUNXnTeMWrXTCM=";
+    in
+    craneLib.buildPackage {
+      inherit src;
+      pname = "cargo-enforce-shared-workspace-deps";
+      version = "0.1.0";
+      strictDeps = true;
+      cargoVendorDir = craneLib.vendorCargoDeps { inherit src; };
+      nativeBuildInputs = [ rustToolchain ];
+      doCheck = false;
     };
 
   nativeBuildInputs = buildInputs ++ [

--- a/rust/dialog-artifacts/src/error.rs
+++ b/rust/dialog-artifacts/src/error.rs
@@ -1,5 +1,6 @@
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::memory::MemoryError;
+use dialog_effects::service::ServiceResponseError;
 use dialog_search_tree::DialogSearchTreeError;
 use dialog_storage::DialogStorageError;
 use thiserror::Error;
@@ -16,6 +17,10 @@ pub enum DialogArtifactsError {
     /// An error occurred in prolly tree-related code
     #[error("Tree operation failed: {0}")]
     Tree(String),
+
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
 
     /// A database index was not shaped as expected
     #[error("Malformed database index: {0}")]
@@ -62,27 +67,47 @@ pub enum DialogArtifactsError {
     EmptySelector,
 }
 
+impl From<ServiceResponseError> for DialogArtifactsError {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
+}
+
 impl From<DialogStorageError> for DialogArtifactsError {
-    fn from(value: DialogStorageError) -> Self {
-        DialogArtifactsError::Storage(format!("{value}"))
+    fn from(error: DialogStorageError) -> Self {
+        match error {
+            DialogStorageError::ServiceResponse(error) => Self::ServiceResponse(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<ArchiveError> for DialogArtifactsError {
-    fn from(e: ArchiveError) -> Self {
-        Self::Storage(e.to_string())
+    fn from(error: ArchiveError) -> Self {
+        match error {
+            ArchiveError::ServiceResponse(error) => Self::ServiceResponse(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<MemoryError> for DialogArtifactsError {
-    fn from(e: MemoryError) -> Self {
-        Self::Storage(e.to_string())
+    fn from(error: MemoryError) -> Self {
+        match error {
+            MemoryError::ServiceResponse(error) => Self::ServiceResponse(error),
+            error => Self::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<DialogSearchTreeError> for DialogArtifactsError {
-    fn from(value: DialogSearchTreeError) -> Self {
-        DialogArtifactsError::Tree(format!("{value}"))
+    fn from(error: DialogSearchTreeError) -> Self {
+        match error {
+            DialogSearchTreeError::Storage(DialogStorageError::ServiceResponse(error)) => {
+                Self::ServiceResponse(error)
+            }
+            error => Self::Tree(error.to_string()),
+        }
     }
 }
 

--- a/rust/dialog-effects/src/archive.rs
+++ b/rust/dialog-effects/src/archive.rs
@@ -15,6 +15,7 @@
 
 use std::error::Error;
 
+use crate::service::ServiceResponseError;
 pub use dialog_capability::{
     Attenuate, Attenuation, Capability, DialogCapabilityAuthorizationError,
     DialogCapabilityPerformError, Effect, Policy, StorageError, Subject, access::AuthorizeError,
@@ -253,9 +254,19 @@ pub enum ArchiveError {
     #[error("Storage error: {0}")]
     Storage(String),
 
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
+
     /// IO error.
     #[error("IO error: {0}")]
     Io(String),
+}
+
+impl From<ServiceResponseError> for ArchiveError {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
 }
 
 impl From<StorageError> for ArchiveError {

--- a/rust/dialog-effects/src/blob/error.rs
+++ b/rust/dialog-effects/src/blob/error.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 
 use thiserror::Error as ThisError;
 
+use crate::service::ServiceResponseError;
 use dialog_capability::access::AuthorizeError;
 use dialog_capability::{
     DialogCapabilityAuthorizationError, DialogCapabilityPerformError, StorageError,
@@ -37,9 +38,19 @@ pub enum BlobError {
     #[error("Storage error: {0}")]
     Storage(String),
 
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
+
     /// An I/O error occurred.
     #[error("IO error: {0}")]
     Io(String),
+}
+
+impl From<ServiceResponseError> for BlobError {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
 }
 
 impl From<StorageError> for BlobError {

--- a/rust/dialog-effects/src/lib.rs
+++ b/rust/dialog-effects/src/lib.rs
@@ -42,6 +42,7 @@ pub mod authority;
 pub mod blob;
 pub mod credential;
 pub mod memory;
+pub mod service;
 pub mod space;
 pub mod storage;
 

--- a/rust/dialog-effects/src/memory.rs
+++ b/rust/dialog-effects/src/memory.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use std::io;
 use std::str;
 
+use crate::service::ServiceResponseError;
 use base58::ToBase58;
 use dialog_capability::access::AuthorizeError;
 pub use dialog_capability::{
@@ -261,6 +262,10 @@ pub enum MemoryError {
     #[error("Storage error: {0}")]
     Storage(String),
 
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
+
     /// Authorization error.
     #[error("Authorization error: {0}")]
     Authorization(String),
@@ -268,6 +273,12 @@ pub enum MemoryError {
     /// IO error.
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
+}
+
+impl From<ServiceResponseError> for MemoryError {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
 }
 
 impl From<StorageError> for MemoryError {

--- a/rust/dialog-effects/src/service.rs
+++ b/rust/dialog-effects/src/service.rs
@@ -1,0 +1,50 @@
+//! Structured errors returned by remote HTTP services.
+
+use std::error::Error as StdError;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A non-success response returned by a remote HTTP service.
+///
+/// Transport implementations should bound response bodies before constructing
+/// this value. `code` is the service's stable machine-readable classification
+/// when its error envelope supplied one; `message` is safe, bounded detail for
+/// the immediate caller.
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
+#[error("Service returned HTTP {status}: {message}")]
+pub struct ServiceResponseError {
+    /// HTTP response status.
+    pub status: u16,
+    /// Stable service error code, when supplied.
+    pub code: Option<String>,
+    /// Bounded service error detail.
+    pub message: String,
+}
+
+impl ServiceResponseError {
+    /// Construct a structured service response error.
+    pub fn new(status: u16, code: Option<String>, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// Find a structured service response in an error's source chain.
+///
+/// Higher-level operations such as repository pull and push wrap several
+/// command-specific errors. This helper lets callers classify the original
+/// HTTP response without matching every intermediate wrapper.
+pub fn find_service_response<'a>(
+    mut error: &'a (dyn StdError + 'static),
+) -> Option<&'a ServiceResponseError> {
+    loop {
+        if let Some(service) = error.downcast_ref::<ServiceResponseError>() {
+            return Some(service);
+        }
+        error = error.source()?;
+    }
+}

--- a/rust/dialog-remote-s3/src/error.rs
+++ b/rust/dialog-remote-s3/src/error.rs
@@ -2,6 +2,7 @@
 
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::memory::MemoryError;
+use dialog_effects::service::ServiceResponseError;
 use thiserror::Error;
 
 /// Error type for S3 operations.
@@ -15,9 +16,9 @@ pub enum S3Error {
     #[error("Transport error: {0}")]
     Transport(String),
 
-    /// Service-level error (S3 returned an error response).
-    #[error("Service error: {0}")]
-    Service(String),
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
 
     /// Invalid configuration.
     #[error("Configuration error: {0}")]
@@ -28,6 +29,12 @@ pub enum S3Error {
     Serialization(String),
 }
 
+impl From<ServiceResponseError> for S3Error {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
+}
+
 impl From<reqwest::Error> for S3Error {
     fn from(error: reqwest::Error) -> Self {
         S3Error::Transport(error.to_string())
@@ -36,19 +43,30 @@ impl From<reqwest::Error> for S3Error {
 
 impl From<S3Error> for ArchiveError {
     fn from(error: S3Error) -> Self {
-        ArchiveError::Io(error.to_string())
+        match error {
+            S3Error::ServiceResponse(error) => ArchiveError::ServiceResponse(error),
+            error => ArchiveError::Io(error.to_string()),
+        }
     }
 }
 
 impl From<S3Error> for MemoryError {
     fn from(error: S3Error) -> Self {
-        MemoryError::Storage(error.to_string())
+        match error {
+            S3Error::ServiceResponse(error) => MemoryError::ServiceResponse(error),
+            error => MemoryError::Storage(error.to_string()),
+        }
     }
 }
 
 impl From<S3Error> for dialog_effects::blob::BlobError {
     fn from(error: S3Error) -> Self {
-        dialog_effects::blob::BlobError::Storage(error.to_string())
+        match error {
+            S3Error::ServiceResponse(error) => {
+                dialog_effects::blob::BlobError::ServiceResponse(error)
+            }
+            error => dialog_effects::blob::BlobError::Storage(error.to_string()),
+        }
     }
 }
 
@@ -80,5 +98,43 @@ impl From<AuthorizationFormatError> for dialog_effects::credential::CredentialEr
 impl From<AuthorizationFormatError> for dialog_capability::AuthorizeError {
     fn from(error: AuthorizationFormatError) -> Self {
         Self::Configuration(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use dialog_effects::blob::BlobError;
+
+    use super::*;
+
+    fn service_error() -> ServiceResponseError {
+        ServiceResponseError::new(
+            403,
+            Some("CREDENTIAL_REVOKED".to_string()),
+            "Credential revoked",
+        )
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_service_responses_across_effect_errors() {
+        let archive = ArchiveError::from(S3Error::ServiceResponse(service_error()));
+        let memory = MemoryError::from(S3Error::ServiceResponse(service_error()));
+        let blob = BlobError::from(S3Error::ServiceResponse(service_error()));
+
+        assert!(matches!(
+            archive,
+            ArchiveError::ServiceResponse(ServiceResponseError { status: 403, .. })
+        ));
+        assert!(matches!(
+            memory,
+            MemoryError::ServiceResponse(ServiceResponseError { status: 403, .. })
+        ));
+        assert!(matches!(
+            blob,
+            BlobError::ServiceResponse(ServiceResponseError { status: 403, .. })
+        ));
     }
 }

--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -60,6 +60,9 @@ tower-http = { workspace = true, features = ["cors"], optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt"] }
+
 [dev-dependencies]
 anyhow = { workspace = true }
 async-signature = { workspace = true }

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -10,7 +10,39 @@ use dialog_capability::{
 };
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::authority::{self, OperatorExt};
+use dialog_effects::service::ServiceResponseError;
 use dialog_remote_s3::{Permit, S3Error};
+use serde::Deserialize;
+
+const MAX_SERVICE_ERROR_BODY_BYTES: usize = 8 * 1024;
+const MALFORMED_SERVICE_ERROR_MESSAGE: &str = "Service returned a malformed error response";
+
+#[derive(Deserialize)]
+struct ServiceErrorEnvelope {
+    error: ServiceErrorBody,
+}
+
+#[derive(Deserialize)]
+struct ServiceErrorBody {
+    code: Option<String>,
+    message: Option<String>,
+}
+
+fn service_response_error(status: u16, body: &[u8]) -> ServiceResponseError {
+    let bounded = &body[..body.len().min(MAX_SERVICE_ERROR_BODY_BYTES)];
+    match serde_json::from_slice::<ServiceErrorEnvelope>(bounded) {
+        Ok(envelope) => ServiceResponseError::new(
+            status,
+            envelope.error.code,
+            envelope
+                .error
+                .message
+                .filter(|message| !message.is_empty())
+                .unwrap_or_else(|| MALFORMED_SERVICE_ERROR_MESSAGE.to_string()),
+        ),
+        Err(_) => ServiceResponseError::new(status, None, MALFORMED_SERVICE_ERROR_MESSAGE),
+    }
+}
 
 // Re-export UCAN types for convenience.
 pub use dialog_ucan::{Ucan, UcanInvocation};
@@ -39,17 +71,14 @@ impl UcanAuthorization {
 
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(S3Error::Service(format!(
-                "Access service returned {}: {}",
-                status, body
-            )));
+            let body = response.bytes().await.unwrap_or_default();
+            return Err(service_response_error(status.as_u16(), &body).into());
         }
 
         let body = response.bytes().await?;
 
         serde_ipld_dagcbor::from_slice(&body)
-            .map_err(|e| S3Error::Service(format!("Failed to decode response: {}", e)))
+            .map_err(|e| S3Error::Serialization(format!("Failed to decode response: {e}")))
     }
 }
 
@@ -148,4 +177,131 @@ impl Site for UcanSite {
     type Authorization = UcanAuthorization;
     type Address = UcanAddress;
     type Fork<Fx: Effect> = UcanFork<Fx>;
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::collections::{BTreeMap, HashMap};
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::sync::Arc;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_capability::Principal;
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_credentials::Ed25519Signer;
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_ucan_core::subject::Subject as DelegatedSubject;
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_ucan_core::{DelegationBuilder, InvocationBuilder, InvocationChain};
+    #[cfg(not(target_arch = "wasm32"))]
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    #[cfg(not(target_arch = "wasm32"))]
+    use tokio::net::TcpListener;
+
+    #[dialog_common::test]
+    async fn it_preserves_structured_service_responses() {
+        for (status, code) in [
+            (403, "CREDENTIAL_REVOKED"),
+            (403, "DEVICE_REVOKED"),
+            (409, "SYNC_CONFLICT"),
+            (503, "REVOCATION_UNAVAILABLE"),
+            (500, "INTERNAL_ERROR"),
+        ] {
+            let body = serde_json::json!({
+                "error": {
+                    "code": code,
+                    "message": "bounded detail"
+                }
+            });
+            let error = service_response_error(status, body.to_string().as_bytes());
+            assert_eq!(error.status, status);
+            assert_eq!(error.code.as_deref(), Some(code));
+            assert_eq!(error.message, "bounded detail");
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_bounds_and_rejects_malformed_service_responses() {
+        let mut malformed = vec![b'x'; MAX_SERVICE_ERROR_BODY_BYTES * 2];
+        malformed
+            .extend_from_slice(br#"{"error":{"code":"LATE_CODE","message":"must not parse"}}"#);
+
+        let error = service_response_error(502, &malformed);
+        assert_eq!(error.status, 502);
+        assert_eq!(error.code, None);
+        assert_eq!(error.message, MALFORMED_SERVICE_ERROR_MESSAGE);
+        assert!(!error.message.contains("LATE_CODE"));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_preserves_a_service_response_through_redeem() {
+        let subject = Ed25519Signer::import(&[41; 32]).await.expect("subject key");
+        let operator = Ed25519Signer::import(&[42; 32])
+            .await
+            .expect("operator key");
+        let command = vec!["memory".to_string(), "resolve".to_string()];
+        let delegation = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&operator)
+            .subject(DelegatedSubject::Specific(subject.did()))
+            .command(command.clone())
+            .try_build()
+            .await
+            .expect("delegation");
+        let delegation_cid = delegation.to_cid();
+        let invocation = InvocationBuilder::new()
+            .issuer(operator)
+            .audience(&subject.did())
+            .subject(&subject.did())
+            .command(command)
+            .arguments(BTreeMap::new())
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("invocation");
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+        let authorization = UcanAuthorization::from(UcanInvocation {
+            chain: Box::new(InvocationChain::new(invocation, delegations)),
+            subject: subject.did(),
+            ability: "/memory/resolve".to_string(),
+        });
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let address = listener.local_addr().expect("listener address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("request");
+            let mut request = vec![0; 16 * 1024];
+            let _ = stream.read(&mut request).await.expect("read request");
+            let body = r#"{"error":{"code":"CREDENTIAL_REVOKED","message":"Credential revoked"}}"#;
+            let response = format!(
+                "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        let error = authorization
+            .redeem(&UcanAddress::new(format!("http://{address}")))
+            .await
+            .expect_err("redeem is denied");
+        server.await.expect("server task");
+        let S3Error::ServiceResponse(error) = error else {
+            panic!("expected structured service response");
+        };
+        assert_eq!(error.status, 403);
+        assert_eq!(error.code.as_deref(), Some("CREDENTIAL_REVOKED"));
+        assert_eq!(error.message, "Credential revoked");
+    }
 }

--- a/rust/dialog-repository/src/repository/archive/networked.rs
+++ b/rust/dialog-repository/src/repository/archive/networked.rs
@@ -83,7 +83,7 @@ where
             .fork(&address.address)
             .perform(env)
             .await
-            .map_err(|e| DialogStorageError::StorageBackend(e.to_string()))?;
+            .map_err(DialogStorageError::from)?;
 
         match remote_result {
             Some(bytes) => {

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -32,6 +32,9 @@ pub use fetch::*;
 mod import;
 pub use import::*;
 
+mod install;
+pub use install::*;
+
 mod load;
 pub use load::*;
 

--- a/rust/dialog-repository/src/repository/branch/install.rs
+++ b/rust/dialog-repository/src/repository/branch/install.rs
@@ -1,0 +1,366 @@
+//! Lossless installation of an exact branch revision into another storage environment.
+
+use dialog_artifacts::BlobIndexExt as _;
+use dialog_artifacts::tree::TreeStorageBridge;
+use dialog_capability::{Fork, Provider};
+use dialog_common::{Blake3Hash as NodeHash, ConditionalSync};
+use dialog_effects::archive::prelude::{ArchiveSubjectExt as _, CatalogExt as _};
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
+use dialog_effects::blob::{BlobError, Import as BlobImport, Read as BlobRead};
+use dialog_effects::memory::Resolve;
+use dialog_search_tree::{ContentAddressedStorage as TreeStorage, TreeDifference};
+use futures_util::StreamExt as _;
+
+use crate::{
+    Branch, Index, InstallRevisionError, NetworkedIndex, RemoteRepository, RemoteSite,
+    RepositoryArchiveExt as _, RepositoryMemoryExt as _, Revision, Upstream,
+};
+
+/// Install an exact branch revision into another storage environment.
+///
+/// Created by [`Branch::install`]. The command copies the revision's complete
+/// reachable tree and referenced blobs. It does not publish a branch head,
+/// create a commit, or otherwise make the destination branch visible.
+pub struct InstallRevision<'a> {
+    branch: &'a Branch,
+    revision: Revision,
+}
+
+impl Branch {
+    /// Prepare to install `revision` from this branch's storage into another
+    /// storage environment.
+    ///
+    /// The destination must already have the same repository DID mounted. The
+    /// caller may publish the returned revision only after this operation
+    /// succeeds; installation itself deliberately leaves branch memory cells
+    /// untouched.
+    pub fn install(&self, revision: Revision) -> InstallRevision<'_> {
+        InstallRevision {
+            branch: self,
+            revision,
+        }
+    }
+}
+
+impl InstallRevision<'_> {
+    /// Copy the exact revision and all content it references from `source` to
+    /// `destination` without minting a new revision.
+    pub async fn perform<Source, Destination>(
+        self,
+        source: &Source,
+        destination: &Destination,
+    ) -> Result<Revision, InstallRevisionError>
+    where
+        Source: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<BlobRead>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, BlobRead>>
+            + ConditionalSync
+            + 'static,
+        Destination: Provider<Put> + Provider<BlobImport> + ConditionalSync + 'static,
+    {
+        let branch = self.branch;
+        let remote = match branch.upstream() {
+            Some(Upstream::Remote { remote, .. }) => Some(
+                branch
+                    .subject()
+                    .remote(remote)
+                    .load()
+                    .perform(source)
+                    .await?,
+            ),
+            _ => None,
+        };
+
+        let catalog = branch.archive().index();
+        let source_index = NetworkedIndex::new(source, catalog.clone(), remote.clone());
+        let destination_index = catalog.clone();
+        let current = Index::from_hash(NodeHash::from(*self.revision.tree.hash()));
+        let empty = Index::empty();
+        let tree_storage = TreeStorage::new(TreeStorageBridge(source_index.clone()));
+        let difference =
+            TreeDifference::compute(&empty, &current, &tree_storage, &tree_storage).await?;
+
+        let nodes = difference.novel_nodes();
+        futures_util::pin_mut!(nodes);
+        while let Some(node) = nodes.next().await {
+            destination_index
+                .clone()
+                .put(node?.buffer().clone())
+                .perform(destination)
+                .await?;
+        }
+
+        let blobs = current.list_blobs(source_index);
+        futures_util::pin_mut!(blobs);
+        while let Some(blob) = blobs.next().await {
+            let (hash, record) = blob?;
+            install_blob(
+                branch,
+                remote.as_ref(),
+                hash,
+                record.size,
+                source,
+                destination,
+            )
+            .await?;
+        }
+
+        Ok(self.revision)
+    }
+}
+
+async fn install_blob<Source, Destination>(
+    branch: &Branch,
+    remote: Option<&RemoteRepository>,
+    hash: [u8; 32],
+    size: u64,
+    source: &Source,
+    destination: &Destination,
+) -> Result<(), InstallRevisionError>
+where
+    Source: Provider<BlobRead> + Provider<Fork<RemoteSite, BlobRead>> + ConditionalSync,
+    Destination: Provider<BlobImport> + ConditionalSync,
+{
+    let digest = NodeHash::from(hash);
+    let local = branch
+        .archive()
+        .blob()
+        .read(digest.clone())
+        .perform(source)
+        .await;
+    let mut reader = match (local, remote) {
+        (Ok(reader), _) => reader,
+        (Err(BlobError::NotFound(_)), Some(remote)) => {
+            let address = remote.address();
+            address
+                .subject
+                .clone()
+                .archive()
+                .blob()
+                .read(digest.clone())
+                .fork(address.site())
+                .perform(source)
+                .await?
+        }
+        (Err(error), _) => return Err(error.into()),
+    };
+
+    let mut writer = branch
+        .archive()
+        .blob()
+        .import(digest.clone(), size)
+        .perform(destination)
+        .await?;
+    while let Some(chunk) = reader.next().await? {
+        writer.write_all(&chunk).await?;
+    }
+    let installed = writer.finish().await?;
+    if installed != digest {
+        return Err(InstallRevisionError::BlobDigestMismatch {
+            expected: digest,
+            actual: installed,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use anyhow::Result;
+    use dialog_artifacts::{Artifact, ArtifactSelector, Entity, Instruction, Value};
+    use dialog_capability::{Fork, Provider, Subject};
+    use dialog_common::ConditionalSync;
+    use dialog_credentials::Credential;
+    use dialog_effects::archive::{Get, Put};
+    use dialog_effects::blob::{Import as BlobImport, Read as BlobRead};
+    use dialog_effects::memory::{Publish, Resolve};
+    use dialog_effects::storage::{LocationExt as _, Storage as StorageFx};
+    use dialog_network::Network;
+    use dialog_operator::{Operator, Profile};
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_storage::NativeTempSpace;
+    use dialog_storage::provider::storage::{Storage, VolatileSpace};
+    use futures_util::{StreamExt as _, stream};
+
+    use crate::helpers::{generate_data, test_operator_with_profile, test_repo, unique_name};
+    use crate::{Blob, Branch, RemoteSite, Repository, Revision};
+
+    struct Stage {
+        source: Operator<VolatileSpace>,
+        profile: Profile,
+        repository: Repository,
+        branch: Branch,
+        revision: Revision,
+        blob: Entity,
+        blob_bytes: Vec<u8>,
+        large: Value,
+    }
+
+    async fn prepare_stage() -> Result<Stage> {
+        let (source, profile) = test_operator_with_profile().await;
+        let repository = test_repo(&source, &profile).await;
+        let branch = repository.branch("main").open().perform(&source).await?;
+
+        let mut facts: Vec<Instruction> = generate_data(80)?
+            .into_iter()
+            .map(Instruction::Assert)
+            .collect();
+        let large = Value::String("staged".repeat(1024));
+        facts.push(Instruction::Assert(Artifact {
+            the: "document/body".parse()?,
+            of: "document:large".parse()?,
+            is: large.clone(),
+            cause: None,
+        }));
+        branch.commit(stream::iter(facts)).perform(&source).await?;
+
+        let blob_bytes = b"lossless staged blob".repeat(1024);
+        let blob = Blob::import(stream::iter(vec![Ok(blob_bytes.clone())]))
+            .write(branch.blobs())
+            .perform(&source)
+            .await?;
+        let revision = branch.revision().expect("staged branch has a revision");
+
+        Ok(Stage {
+            source,
+            profile,
+            repository,
+            branch,
+            revision,
+            blob,
+            blob_bytes,
+            large,
+        })
+    }
+
+    async fn verify_install<Destination>(stage: Stage, destination: &Destination) -> Result<()>
+    where
+        Destination: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<BlobRead>
+            + Provider<BlobImport>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + Provider<Fork<RemoteSite, BlobRead>>
+            + ConditionalSync
+            + 'static,
+    {
+        let destination_repository: Repository = stage.repository.credential().clone().into();
+        let destination_branch = destination_repository
+            .branch("main")
+            .open()
+            .perform(destination)
+            .await?;
+        assert!(
+            destination_branch.revision().is_none(),
+            "the destination starts unindexed"
+        );
+
+        let installed = stage
+            .branch
+            .install(stage.revision.clone())
+            .perform(&stage.source, destination)
+            .await?;
+        assert_eq!(
+            installed, stage.revision,
+            "installation preserves the exact head"
+        );
+
+        let still_hidden = destination_repository
+            .branch("main")
+            .load()
+            .perform(destination)
+            .await;
+        assert!(
+            still_hidden.is_err(),
+            "installing blocks does not publish the branch head"
+        );
+
+        destination_branch
+            .reset(installed.clone())
+            .perform(destination)
+            .await?;
+        let destination_branch = destination_repository
+            .branch("main")
+            .load()
+            .perform(destination)
+            .await?;
+        assert_eq!(destination_branch.revision(), Some(installed));
+
+        let large_facts: Vec<_> = destination_branch
+            .claims()
+            .select(ArtifactSelector::new().the("document/body".parse()?))
+            .perform(destination)
+            .await?
+            .collect()
+            .await;
+        assert_eq!(large_facts.len(), 1);
+        assert_eq!(large_facts[0].as_ref().expect("valid fact").is, stage.large);
+
+        let mut reader = Blob::from(stage.blob)
+            .read(destination_branch.blobs())
+            .perform(destination)
+            .await?;
+        let mut copied_blob = Vec::new();
+        while let Some(chunk) = reader.next().await? {
+            copied_blob.extend_from_slice(&chunk);
+        }
+        assert_eq!(copied_blob, stage.blob_bytes);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_installs_an_exact_revision_between_volatile_spaces() -> Result<()> {
+        let stage = prepare_stage().await?;
+        let destination = Storage::<VolatileSpace>::volatile();
+        StorageFx::profile(unique_name("install-profile"))
+            .create(Credential::Signer(stage.profile.signer().clone()))
+            .perform(&destination)
+            .await?;
+        StorageFx::profile(unique_name("install-repository"))
+            .create(stage.repository.credential().clone())
+            .perform(&destination)
+            .await?;
+        let operator = stage
+            .profile
+            .derive(b"install-volatile")
+            .allow(Subject::any())
+            .network(Network::default())
+            .build(destination)
+            .await?;
+        verify_install(stage, &operator).await
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_installs_an_exact_revision_into_durable_storage() -> Result<()> {
+        let stage = prepare_stage().await?;
+        let destination = Storage::<NativeTempSpace>::temp();
+        StorageFx::profile(unique_name("install-profile"))
+            .create(Credential::Signer(stage.profile.signer().clone()))
+            .perform(&destination)
+            .await?;
+        StorageFx::profile(unique_name("install-repository"))
+            .create(stage.repository.credential().clone())
+            .perform(&destination)
+            .await?;
+        let operator = stage
+            .profile
+            .derive(b"install-durable")
+            .allow(Subject::any())
+            .network(Network::default())
+            .build(destination)
+            .await?;
+        verify_install(stage, &operator).await
+    }
+}

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -1,10 +1,12 @@
 use crate::TreeReference;
 use dialog_artifacts::DialogArtifactsError;
+use dialog_common::Blake3Hash;
 use dialog_credentials::Ed25519SignerError;
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::authority::AuthorityError;
 use dialog_effects::blob::BlobError;
 use dialog_effects::memory::{MemoryError, Version};
+use dialog_effects::service::ServiceResponseError;
 use dialog_effects::storage::StorageError;
 use dialog_search_tree::DialogSearchTreeError;
 use dialog_storage::DialogStorageError;
@@ -135,6 +137,43 @@ pub enum PublishRemoteBranchError {
     /// not happen in normal operation.
     #[error("Upstream cell missing edition after publish")]
     MissingEdition,
+}
+
+/// Errors returned while installing an exact revision into another storage.
+#[derive(Error, Debug)]
+pub enum InstallRevisionError {
+    /// A referenced artifact failed validation.
+    #[error(transparent)]
+    Artifact(#[from] DialogArtifactsError),
+
+    /// Walking the revision's tree failed.
+    #[error(transparent)]
+    Tree(#[from] DialogSearchTreeError),
+
+    /// Reading or writing an archive block failed.
+    #[error(transparent)]
+    Archive(#[from] ArchiveError),
+
+    /// Reading or writing a blob failed.
+    #[error(transparent)]
+    Blob(#[from] BlobError),
+
+    /// Loading the staged branch's remote failed.
+    #[error(transparent)]
+    LoadRemote(#[from] LoadRemoteError),
+
+    /// A destination blob import returned a digest other than its declared address.
+    #[error("Installed blob digest mismatch: expected {expected}, got {actual}")]
+    BlobDigestMismatch {
+        /// Digest declared by the staged revision.
+        expected: Blake3Hash,
+        /// Digest returned by the destination import.
+        actual: Blake3Hash,
+    },
+
+    /// Accessing the staged archive backend failed.
+    #[error(transparent)]
+    Storage(#[from] DialogStorageError),
 }
 
 /// Errors returned by the load remote branch command.
@@ -442,6 +481,10 @@ pub enum ResolveError {
     #[error("Authorization error: {0}")]
     Authorization(String),
 
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
+
     /// IO failure.
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
@@ -451,6 +494,12 @@ pub enum ResolveError {
     Decode(String),
 }
 
+impl From<ServiceResponseError> for ResolveError {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
+}
+
 impl From<MemoryError> for ResolveError {
     fn from(error: MemoryError) -> Self {
         match error {
@@ -458,6 +507,7 @@ impl From<MemoryError> for ResolveError {
                 Self::VersionMismatch { expected, actual }
             }
             MemoryError::Storage(message) => Self::Storage(message),
+            MemoryError::ServiceResponse(error) => Self::ServiceResponse(error),
             MemoryError::Authorization(message) => Self::Authorization(message),
             MemoryError::Io(error) => Self::Io(error),
         }
@@ -484,6 +534,10 @@ pub enum PublishError {
     #[error("Authorization error: {0}")]
     Authorization(String),
 
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
+
     /// IO failure.
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
@@ -493,6 +547,12 @@ pub enum PublishError {
     Encode(String),
 }
 
+impl From<ServiceResponseError> for PublishError {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
+}
+
 impl From<MemoryError> for PublishError {
     fn from(error: MemoryError) -> Self {
         match error {
@@ -500,6 +560,7 @@ impl From<MemoryError> for PublishError {
                 Self::VersionMismatch { expected, actual }
             }
             MemoryError::Storage(message) => Self::Storage(message),
+            MemoryError::ServiceResponse(error) => Self::ServiceResponse(error),
             MemoryError::Authorization(message) => Self::Authorization(message),
             MemoryError::Io(error) => Self::Io(error),
         }
@@ -515,9 +576,75 @@ pub enum UploadError {
 
     /// Failed to read a block from the local archive before uploading.
     #[error("Failed to read block from local archive: {0}")]
-    LocalRead(ArchiveError),
+    LocalRead(#[source] ArchiveError),
 
     /// Failed to write a block to the remote archive.
     #[error("Failed to write block to remote archive: {0}")]
-    RemoteWrite(ArchiveError),
+    RemoteWrite(#[source] ArchiveError),
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unused_async)]
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use std::error::Error as StdError;
+
+    use dialog_effects::service::find_service_response;
+
+    use super::*;
+
+    fn response() -> ServiceResponseError {
+        ServiceResponseError::new(
+            403,
+            Some("CREDENTIAL_REVOKED".to_string()),
+            "Credential revoked",
+        )
+    }
+
+    fn assert_response(error: &(dyn StdError + 'static)) {
+        let response = find_service_response(error).expect("structured response survives");
+        assert_eq!(response.status, 403);
+        assert_eq!(response.code.as_deref(), Some("CREDENTIAL_REVOKED"));
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_memory_service_responses_through_pull_and_push() {
+        let pull = PullError::FetchRemoteBranch(FetchRemoteBranchError::Resolve(
+            ResolveError::from(MemoryError::ServiceResponse(response())),
+        ));
+        let push = PushError::PublishRemoteBranch(PublishRemoteBranchError::Publish(
+            PublishError::from(MemoryError::ServiceResponse(response())),
+        ));
+
+        assert_response(&pull);
+        assert_response(&push);
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_archive_service_responses_through_pull_and_push() {
+        let storage = DialogStorageError::from(ArchiveError::ServiceResponse(response()));
+        let pull = PullError::Tree(DialogSearchTreeError::from(storage));
+        let push = PushError::Upload(UploadError::RemoteWrite(ArchiveError::ServiceResponse(
+            response(),
+        )));
+
+        assert_response(&pull);
+        assert_response(&push);
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_blob_service_responses_through_push() {
+        let push = PushError::Blob(BlobError::ServiceResponse(response()));
+        assert_response(&push);
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_artifact_service_responses_through_push() {
+        let tree = DialogSearchTreeError::from(DialogStorageError::ServiceResponse(response()));
+        let push = PushError::Artifact(DialogArtifactsError::from(tree));
+        assert_response(&push);
+    }
 }

--- a/rust/dialog-search-tree/src/error.rs
+++ b/rust/dialog-search-tree/src/error.rs
@@ -10,7 +10,7 @@ pub enum DialogSearchTreeError {
 
     /// An error from the storage backend.
     #[error("{0}")]
-    Storage(DialogStorageError),
+    Storage(#[source] DialogStorageError),
 
     /// An error that occurs during a tree operation.
     #[error("Failed to operate the tree: {0}")]

--- a/rust/dialog-storage/src/error.rs
+++ b/rust/dialog-storage/src/error.rs
@@ -1,5 +1,6 @@
 use dialog_effects::archive::ArchiveError;
 use dialog_effects::memory::MemoryError;
+use dialog_effects::service::ServiceResponseError;
 use thiserror::Error;
 
 /// The common error type used by this crate
@@ -17,19 +18,35 @@ pub enum DialogStorageError {
     #[error("Storage backend error: {0}")]
     StorageBackend(String),
 
+    /// A remote service returned a non-success HTTP response.
+    #[error("{0}")]
+    ServiceResponse(#[source] ServiceResponseError),
+
     /// An error that occurs when byte hash verification fails
     #[error("Byte hash verification failed: {0}")]
     Verification(String),
 }
 
+impl From<ServiceResponseError> for DialogStorageError {
+    fn from(error: ServiceResponseError) -> Self {
+        Self::ServiceResponse(error)
+    }
+}
+
 impl From<ArchiveError> for DialogStorageError {
-    fn from(e: ArchiveError) -> Self {
-        Self::StorageBackend(e.to_string())
+    fn from(error: ArchiveError) -> Self {
+        match error {
+            ArchiveError::ServiceResponse(error) => Self::ServiceResponse(error),
+            error => Self::StorageBackend(error.to_string()),
+        }
     }
 }
 
 impl From<MemoryError> for DialogStorageError {
-    fn from(e: MemoryError) -> Self {
-        Self::StorageBackend(e.to_string())
+    fn from(error: MemoryError) -> Self {
+        match error {
+            MemoryError::ServiceResponse(error) => Self::ServiceResponse(error),
+            error => Self::StorageBackend(error.to_string()),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- backport PR #410's structured service-response errors onto `2395873d`
- backport `Branch::install` for exact, non-publishing tree/blob installation
- exclude the unrelated newer-main version-control and search-tree format migrations

The implementation commit is based directly on `2395873d9a0e764ca32853545d35159988b86e77`; the branch head is `25fac91eaa4d23fc220721df19f9e2593be618d7`.

## Compatibility adaptations

The pinned line has unsigned `dialog_capability::Revision` values and stores artifact values directly inside fixed-format tree nodes. It therefore has no `Revision::verify`, history index, variable keys, or spilled-value blocks to port. This backport copies every reachable tree node plus every blob referenced by the pinned line's blob index, returns the input revision unchanged, and leaves destination branch memory cells untouched.

## CI compatibility support

- align the Nix-provided `wasm-bindgen-cli` with the workspace's existing `wasm-bindgen 0.2.126` pin
- build `cargo-enforce-shared-workspace-deps` with Crane so lint CI uses cached vendored dependencies instead of crates.io live fetches
- verified `Lint Rust`, `r2 (wasm)`, `s3 (wasm)`, and both native S3/R2 jobs pass on the branch head

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p dialog-repository`
- `cargo test -p dialog-repository install::tests --lib` (2 passed)
- `cargo test -p dialog-repository repository::error::tests --lib` (4 passed)
- `cargo test -p dialog-remote-s3 error::tests --lib` (1 passed)
- `cargo test -p dialog-remote-ucan-s3 site::tests --lib` (3 passed)
- `cargo test -p dialog-effects --lib` (15 passed)
- `cargo test -p dialog-storage --lib` (144 passed)
- `cargo test -p dialog-artifacts --lib` (44 passed)
- `cargo test -p dialog-search-tree --lib` (126 passed)
- disposable Tonk revocation-tree check with all 16 `dialog-*` dependencies pointed at this checkout: `cargo check -p dialog-reactor -p tonk-access-service -p tonk-worker -p tonk-ui -p tonk-fab`
