### PR TITLE
perf(operator): memoize proven delegation chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "ipld-core",
- "reqwest",
  "serde",
  "serde_bytes",
  "serde_ipld_dagcbor",

--- a/rust/dialog-capability/src/access.rs
+++ b/rust/dialog-capability/src/access.rs
@@ -28,6 +28,13 @@ use thiserror::Error;
 pub trait Scope {
     /// The subject (resource) this scope applies to.
     fn subject(&self) -> &Did;
+
+    /// The command being requested, as ability path segments.
+    ///
+    /// Two scopes that differ only in their parameters share a command,
+    /// so this names the access independently of the arguments any one
+    /// invocation carries.
+    fn command(&self) -> &[String];
 }
 
 /// Derive an access scope from an invocable capability.
@@ -334,6 +341,18 @@ impl<P: Protocol> Prove<P> {
     pub fn during(mut self, duration: TimeRange) -> Self {
         self.duration = duration;
         self
+    }
+}
+
+/// Written by hand because a derive would demand `P: Clone`, and the
+/// protocol marker is never a value.
+impl<P: Protocol> Clone for Prove<P> {
+    fn clone(&self) -> Self {
+        Self {
+            principal: self.principal.clone(),
+            access: self.access.clone(),
+            duration: self.duration,
+        }
     }
 }
 

--- a/rust/dialog-operator/src/operator.rs
+++ b/rust/dialog-operator/src/operator.rs
@@ -5,11 +5,14 @@
 mod access;
 mod builder;
 mod fork;
+mod memo;
 mod space;
 #[cfg(test)]
 mod test;
 
 pub use builder::{OperatorBuilder, OperatorError};
+
+use memo::ProofMemo;
 
 use crate::Authority;
 use dialog_capability::{Capability, Provider};
@@ -58,6 +61,10 @@ pub struct Operator<S: Clone> {
 
     /// Network dispatch for fork invocations.
     network: Network,
+
+    /// Chains already proven against `storage`, so that repeated
+    /// authorizations do not walk the certificate store again.
+    memo: ProofMemo,
 }
 
 impl<S: Clone> Operator<S> {

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -1,6 +1,7 @@
 //! Access capability providers for Operator.
 
 use super::Operator;
+use super::memo::unix_now;
 use dialog_capability::Provider;
 use dialog_capability::access::{
     Access, Authorize, AuthorizeError, Proof as _, Protocol, Prove, Retain,
@@ -38,7 +39,13 @@ where
     Self: ConditionalSend + ConditionalSync,
 {
     async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
-        input.perform(&self.storage).await
+        let retained = input.perform(&self.storage).await;
+
+        // A new certificate can complete or shorten any chain, so what
+        // was proven before it arrived no longer stands.
+        self.memo.forget();
+
+        retained
     }
 }
 
@@ -49,7 +56,7 @@ where
     S: Clone + ConditionalSend + ConditionalSync + 'static,
     P: Protocol,
     P::Access: Clone + ConditionalSend + ConditionalSync,
-    P::Certificate: Clone + ConditionalSend + ConditionalSync,
+    P::Certificate: Clone + ConditionalSend + ConditionalSync + 'static,
     P::Proof: ConditionalSend,
     P::Signer: From<Ed25519Signer>,
     P::Authorization: ConditionalSend,
@@ -62,12 +69,23 @@ where
     ) -> Result<P::Authorization, AuthorizeError> {
         let subject = input.subject().clone();
         let prove: Prove<P> = input.into_effect().into();
+        let now = unix_now();
 
-        let proof = Subject::from(subject)
-            .attenuate(Access)
-            .invoke(prove)
-            .perform(&self.storage)
-            .await?;
+        // The invocation this authorization signs is fresh every time,
+        // but the chain underneath it only moves when a certificate is
+        // retained or the operator key rotates.
+        let proof = match self.memo.recall::<P>(&subject, &prove, now) {
+            Some(proof) => proof,
+            None => {
+                let proven = Subject::from(subject.clone())
+                    .attenuate(Access)
+                    .invoke(prove.clone())
+                    .perform(&self.storage)
+                    .await?;
+                self.memo.remember::<P>(&subject, &prove, &proven, now);
+                proven
+            }
+        };
 
         proof.claim(self.authority.operator_signer().clone().into())
     }

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -1,6 +1,6 @@
 //! Builder for constructing an Operator from a Profile.
 
-use super::Operator;
+use super::{Operator, ProofMemo};
 use crate::Authority;
 use crate::profile::Profile;
 use crate::profile::access::Access as ProfileAccess;
@@ -84,6 +84,7 @@ impl OperatorBuilder {
             storage,
             directory: self.directory,
             network: self.network,
+            memo: ProofMemo::default(),
         };
 
         // Create delegations for allowed capabilities

--- a/rust/dialog-operator/src/operator/memo.rs
+++ b/rust/dialog-operator/src/operator/memo.rs
@@ -1,0 +1,540 @@
+//! Memoized proof chains.
+//!
+//! Proving access walks the certificate store breadth-first, reading and
+//! decoding certificates at every hop. The chain it finds only changes
+//! when a certificate is retained or the operator's key rotates, while
+//! the invocation built on top of it is fresh every time. The memo keeps
+//! the chain so repeated authorizations pay for the walk once.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use dialog_capability::Did;
+use dialog_capability::access::{Certificate, Proof, Protocol, Prove, Scope as _, TimeRange};
+use dialog_common::time::{UNIX_EPOCH, now};
+use dialog_common::{ConditionalSend, ConditionalSync};
+
+/// How long a memoized chain may be reused before it is proven again.
+///
+/// Bounds how long a client can keep presenting a chain that the access
+/// service has already learned to refuse.
+const RETENTION_SECONDS: u64 = 60;
+
+/// How much validity a memoized chain must have left over to be reused.
+///
+/// Keeps the client from building an invocation on a chain that expires
+/// while the request is in flight.
+const EXPIRY_MARGIN_SECONDS: u64 = 60;
+
+/// The current time in whole seconds since the Unix epoch.
+pub fn unix_now() -> u64 {
+    now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// What a memoized chain answers for: a principal claiming a command
+/// over a subject, proven against one certificate store.
+///
+/// The principal is the operator DID, so a rotated operator misses.
+/// Parameters are deliberately absent — they change on every request,
+/// and the certificates are re-checked against them on recall.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Key {
+    /// The capability subject the request was addressed to, which is
+    /// what routes it to a certificate store.
+    store: Did,
+    /// The principal claiming access.
+    principal: Did,
+    /// The subject the claimed access is over.
+    subject: Did,
+    /// The command being claimed.
+    command: Vec<String>,
+}
+
+impl Key {
+    fn of<P: Protocol>(store: &Did, input: &Prove<P>) -> Self {
+        Self {
+            store: store.clone(),
+            principal: input.principal.clone(),
+            subject: input.access.subject().clone(),
+            command: input.access.command().to_vec(),
+        }
+    }
+}
+
+/// A proven chain, type-erased so that one memo serves every protocol.
+trait Entry: ConditionalSend + ConditionalSync {
+    fn as_any(&self) -> &dyn Any;
+}
+
+struct Chain<P: Protocol> {
+    certificates: Vec<P::Certificate>,
+    proven_at: u64,
+}
+
+impl<P> Entry for Chain<P>
+where
+    P: Protocol,
+    P::Certificate: 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Chains proven earlier, shared by every handle onto the memo.
+#[derive(Clone, Default)]
+pub struct ProofMemo {
+    entries: Arc<Mutex<HashMap<Key, Box<dyn Entry>>>>,
+}
+
+impl ProofMemo {
+    /// Recall a chain proven earlier for the same principal, subject and
+    /// command, re-checked against this request.
+    ///
+    /// Returns `None` — leaving the caller to prove again — when nothing
+    /// was memoized, when the memo has aged past its retention, when the
+    /// certificates do not cover this request's parameters or duration,
+    /// or when too little of the chain's validity is left.
+    pub fn recall<P>(&self, store: &Did, input: &Prove<P>, now: u64) -> Option<P::Proof>
+    where
+        P: Protocol,
+        P::Certificate: 'static,
+    {
+        let entries = self.entries.lock().ok()?;
+        let chain = entries
+            .get(&Key::of(store, input))?
+            .as_any()
+            .downcast_ref::<Chain<P>>()?;
+
+        if now.saturating_sub(chain.proven_at) >= RETENTION_SECONDS {
+            return None;
+        }
+
+        // The walk that found this chain checked every certificate
+        // against the access it was proven for. This request carries its
+        // own parameters, so check them again — in memory, without
+        // touching the store.
+        let mut duration = TimeRange::unbounded();
+        for certificate in &chain.certificates {
+            let range = certificate.verify(&input.access).ok()?;
+            if !range.covers(&input.duration) {
+                return None;
+            }
+            duration = duration.intersect(&range);
+        }
+
+        if !duration.contains(now.saturating_add(EXPIRY_MARGIN_SECONDS)) {
+            return None;
+        }
+
+        let mut proof = P::Proof::new(input.access.clone());
+        for certificate in &chain.certificates {
+            proof.push(certificate.clone());
+        }
+        proof.set_duration(duration);
+
+        Some(proof)
+    }
+
+    /// Memoize the chain behind a freshly proven proof.
+    pub fn remember<P>(&self, store: &Did, input: &Prove<P>, proof: &P::Proof, now: u64)
+    where
+        P: Protocol,
+        P::Certificate: 'static,
+    {
+        let chain = Chain::<P> {
+            certificates: proof.proofs().to_vec(),
+            proven_at: now,
+        };
+
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.insert(Key::of(store, input), Box::new(chain));
+        }
+    }
+
+    /// Forget every memoized chain.
+    ///
+    /// A newly retained certificate can complete or shorten a chain for
+    /// any subject — a powerline certificate for all of them at once —
+    /// so the memo is dropped whole rather than guessing which entries
+    /// the new certificate reaches.
+    pub fn forget(&self) {
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use dialog_capability::access::{
+        AuthorizeError, Certificate as _, CertificateStore, Delegation as _,
+    };
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan::{Parameters, Scope, Ucan, UcanCertificate, UcanDelegation};
+    use dialog_ucan_core::command::Command;
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_ucan_core::time::timestamp::Timestamp;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal;
+
+    use super::*;
+
+    /// A certificate store that counts the lookups made against it, so a
+    /// test can tell a proof that walked the store from one the memo
+    /// answered.
+    #[derive(Default)]
+    struct CountingStore {
+        certificates: Mutex<Vec<UcanCertificate>>,
+        lookups: AtomicUsize,
+    }
+
+    impl CountingStore {
+        fn lookups(&self) -> usize {
+            self.lookups.load(Ordering::Relaxed)
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl CertificateStore<Ucan> for CountingStore {
+        async fn list(
+            &self,
+            audience: &Did,
+            subject: Option<&Did>,
+        ) -> Result<Vec<UcanCertificate>, AuthorizeError> {
+            self.lookups.fetch_add(1, Ordering::Relaxed);
+
+            let certificates = self.certificates.lock().unwrap();
+            Ok(certificates
+                .iter()
+                .filter(|certificate| {
+                    certificate.audience() == audience && certificate.subject() == subject
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn save(&self, delegation: &UcanDelegation) -> Result<(), AuthorizeError> {
+            let mut certificates = self.certificates.lock().unwrap();
+            certificates.extend(delegation.certificates());
+            Ok(())
+        }
+    }
+
+    async fn signer() -> Ed25519Signer {
+        Ed25519Signer::generate().await.unwrap()
+    }
+
+    async fn delegate(
+        issuer: &Ed25519Signer,
+        audience: &Ed25519Signer,
+        subject: UcanSubject,
+        command: &[&str],
+        expiration: Option<u64>,
+    ) -> UcanDelegation {
+        let mut builder = DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(subject)
+            .command(command.iter().map(|segment| segment.to_string()).collect());
+
+        if let Some(expiration) = expiration {
+            builder = builder.expiration(Timestamp::try_from(expiration as i128).unwrap());
+        }
+
+        UcanDelegation::new(DelegationChain::new(builder.try_build().await.unwrap()))
+    }
+
+    fn scope(subject: &Ed25519Signer, command: &[&str]) -> Scope {
+        Scope {
+            subject: UcanSubject::Specific(subject.did()),
+            command: Command(command.iter().map(|segment| segment.to_string()).collect()),
+            parameters: Parameters::default(),
+        }
+    }
+
+    /// Prove through the certificates and memoize the result, the way
+    /// the operator's `Authorize` provider does on a miss.
+    async fn prove(
+        certificates: &CountingStore,
+        memo: &ProofMemo,
+        addressed_to: &Did,
+        input: &Prove<Ucan>,
+        now: u64,
+    ) -> Result<(), AuthorizeError> {
+        let proof = CertificateStore::<Ucan>::prove(certificates, input.clone()).await?;
+        memo.remember::<Ucan>(addressed_to, input, &proof, now);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_proves_once_across_repeated_authorizations() {
+        let subject = signer().await;
+        let operator = signer().await;
+        let addressed_to = signer().await.did();
+        let certificates = CountingStore::default();
+        let memo = ProofMemo::default();
+        let now = 1_000;
+
+        CertificateStore::<Ucan>::save(
+            &certificates,
+            &delegate(
+                &subject,
+                &operator,
+                UcanSubject::Specific(subject.did()),
+                &["storage"],
+                None,
+            )
+            .await,
+        )
+        .await
+        .unwrap();
+
+        let input = Prove::<Ucan>::new(operator.did(), scope(&subject, &["storage"]));
+
+        assert!(memo.recall::<Ucan>(&addressed_to, &input, now).is_none());
+        prove(&certificates, &memo, &addressed_to, &input, now)
+            .await
+            .unwrap();
+
+        let lookups = certificates.lookups();
+        assert!(lookups > 0, "the first proof walks the store");
+
+        for _ in 0..5 {
+            let recalled = memo
+                .recall::<Ucan>(&addressed_to, &input, now)
+                .expect("the memoized chain answers");
+            assert_eq!(recalled.proofs().len(), 1);
+        }
+
+        assert_eq!(
+            certificates.lookups(),
+            lookups,
+            "later authorizations do not walk the store"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reproves_after_retaining_a_new_certificate() {
+        let subject = signer().await;
+        let operator = signer().await;
+        let addressed_to = signer().await.did();
+        let certificates = CountingStore::default();
+        let memo = ProofMemo::default();
+        let now = 1_000;
+
+        CertificateStore::<Ucan>::save(
+            &certificates,
+            &delegate(
+                &subject,
+                &operator,
+                UcanSubject::Specific(subject.did()),
+                &["storage"],
+                None,
+            )
+            .await,
+        )
+        .await
+        .unwrap();
+
+        let input = Prove::<Ucan>::new(operator.did(), scope(&subject, &["storage"]));
+        prove(&certificates, &memo, &addressed_to, &input, now)
+            .await
+            .unwrap();
+        assert!(memo.recall::<Ucan>(&addressed_to, &input, now).is_some());
+
+        // Retaining is a save followed by dropping the memo, which is
+        // what the operator's `Retain` provider does.
+        let other = signer().await;
+        CertificateStore::<Ucan>::save(
+            &certificates,
+            &delegate(&subject, &other, UcanSubject::Any, &["storage"], None).await,
+        )
+        .await
+        .unwrap();
+        memo.forget();
+
+        assert!(
+            memo.recall::<Ucan>(&addressed_to, &input, now).is_none(),
+            "a retained certificate invalidates what was memoized"
+        );
+
+        let lookups = certificates.lookups();
+        prove(&certificates, &memo, &addressed_to, &input, now)
+            .await
+            .unwrap();
+        assert!(
+            certificates.lookups() > lookups,
+            "the chain is proven again"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reproves_when_the_cached_chain_nears_expiry() {
+        let subject = signer().await;
+        let operator = signer().await;
+        let addressed_to = signer().await.did();
+        let certificates = CountingStore::default();
+        let memo = ProofMemo::default();
+        let now = 1_000;
+
+        // Valid for another half hour when proven, but only 30 seconds
+        // when recalled — less than the margin a request needs.
+        let expiration = now + 1_800;
+        CertificateStore::<Ucan>::save(
+            &certificates,
+            &delegate(
+                &subject,
+                &operator,
+                UcanSubject::Specific(subject.did()),
+                &["storage"],
+                Some(expiration),
+            )
+            .await,
+        )
+        .await
+        .unwrap();
+
+        let input = Prove::<Ucan>::new(operator.did(), scope(&subject, &["storage"]));
+        prove(&certificates, &memo, &addressed_to, &input, now)
+            .await
+            .unwrap();
+        assert!(memo.recall::<Ucan>(&addressed_to, &input, now).is_some());
+
+        let nearly_expired = expiration - 30;
+        prove(&certificates, &memo, &addressed_to, &input, nearly_expired)
+            .await
+            .unwrap();
+
+        assert!(
+            memo.recall::<Ucan>(&addressed_to, &input, nearly_expired)
+                .is_none(),
+            "a chain that expires within the margin is proven again"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reproves_after_the_memo_ages_out() {
+        let subject = signer().await;
+        let operator = signer().await;
+        let addressed_to = signer().await.did();
+        let certificates = CountingStore::default();
+        let memo = ProofMemo::default();
+        let now = 1_000;
+
+        CertificateStore::<Ucan>::save(
+            &certificates,
+            &delegate(
+                &subject,
+                &operator,
+                UcanSubject::Specific(subject.did()),
+                &["storage"],
+                None,
+            )
+            .await,
+        )
+        .await
+        .unwrap();
+
+        let input = Prove::<Ucan>::new(operator.did(), scope(&subject, &["storage"]));
+        prove(&certificates, &memo, &addressed_to, &input, now)
+            .await
+            .unwrap();
+
+        assert!(
+            memo.recall::<Ucan>(&addressed_to, &input, now + RETENTION_SECONDS - 1)
+                .is_some()
+        );
+        assert!(
+            memo.recall::<Ucan>(&addressed_to, &input, now + RETENTION_SECONDS)
+                .is_none(),
+            "a chain the service may have stopped honouring is proven again"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_scopes_the_memo_by_subject_and_command() {
+        let subject = signer().await;
+        let other_subject = signer().await;
+        let operator = signer().await;
+        let addressed_to = signer().await.did();
+        let certificates = CountingStore::default();
+        let memo = ProofMemo::default();
+        let now = 1_000;
+
+        // A powerline grant over the root command: it verifies against
+        // any subject and any command, so only the memo's key keeps one
+        // scope's chain out of another's.
+        CertificateStore::<Ucan>::save(
+            &certificates,
+            &delegate(&subject, &operator, UcanSubject::Any, &[], None).await,
+        )
+        .await
+        .unwrap();
+
+        let input = Prove::<Ucan>::new(operator.did(), scope(&subject, &["storage"]));
+        prove(&certificates, &memo, &addressed_to, &input, now)
+            .await
+            .unwrap();
+        assert!(memo.recall::<Ucan>(&addressed_to, &input, now).is_some());
+
+        let other_command = Prove::<Ucan>::new(operator.did(), scope(&subject, &["archive"]));
+        assert!(
+            memo.recall::<Ucan>(&addressed_to, &other_command, now)
+                .is_none(),
+            "a chain proven for one command does not answer for another"
+        );
+
+        let other_subject = Prove::<Ucan>::new(operator.did(), scope(&other_subject, &["storage"]));
+        assert!(
+            memo.recall::<Ucan>(&addressed_to, &other_subject, now)
+                .is_none(),
+            "a chain proven for one subject does not answer for another"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_scopes_the_memo_by_principal_and_certificate_store() {
+        let subject = signer().await;
+        let operator = signer().await;
+        let rotated = signer().await;
+        let addressed_to = signer().await.did();
+        let elsewhere = signer().await.did();
+        let certificates = CountingStore::default();
+        let memo = ProofMemo::default();
+        let now = 1_000;
+
+        CertificateStore::<Ucan>::save(
+            &certificates,
+            &delegate(&subject, &operator, UcanSubject::Any, &[], None).await,
+        )
+        .await
+        .unwrap();
+
+        let input = Prove::<Ucan>::new(operator.did(), scope(&subject, &["storage"]));
+        prove(&certificates, &memo, &addressed_to, &input, now)
+            .await
+            .unwrap();
+
+        let rotated = Prove::<Ucan>::new(rotated.did(), scope(&subject, &["storage"]));
+        assert!(
+            memo.recall::<Ucan>(&addressed_to, &rotated, now).is_none(),
+            "a rotated operator does not inherit the previous one's chain"
+        );
+
+        assert!(
+            memo.recall::<Ucan>(&elsewhere, &input, now).is_none(),
+            "a chain proven against one certificate store does not answer for another"
+        );
+    }
+}

--- a/rust/dialog-remote-s3/src/client.rs
+++ b/rust/dialog-remote-s3/src/client.rs
@@ -1,0 +1,24 @@
+//! The HTTP client shared by every request this crate issues.
+
+/// A handle on the shared HTTP client.
+///
+/// A [`reqwest::Client`] owns a connection pool, so building one per
+/// request throws away pooled connections and repeats TLS setup. The
+/// client is cheap to clone — clones share the same pool.
+///
+/// The client is held per thread rather than in a process-wide static.
+/// On wasm the client is not `Send`, so a static cannot hold it. On
+/// native, a pooled connection is driven by a task on the tokio runtime
+/// that opened it, so a process-wide pool would let a request on one
+/// runtime reuse a connection owned by another and fail with "dispatch
+/// task is gone" when the owning runtime shuts down — which is how
+/// parallel `#[tokio::test]` tests poison each other. A thread never
+/// hosts two live runtimes at once, so a per-thread pool keeps
+/// connection reuse without crossing runtimes.
+pub fn http_client() -> reqwest::Client {
+    thread_local! {
+        static CLIENT: reqwest::Client = reqwest::Client::new();
+    }
+
+    CLIENT.with(reqwest::Client::clone)
+}

--- a/rust/dialog-remote-s3/src/lib.rs
+++ b/rust/dialog-remote-s3/src/lib.rs
@@ -42,6 +42,7 @@
 //! # }
 //! ```
 
+mod client;
 mod error;
 pub mod request;
 pub mod s3;
@@ -49,6 +50,7 @@ pub mod s3;
 #[cfg(feature = "helpers")]
 pub mod helpers;
 
+pub use client::http_client;
 pub use error::{AuthorizationFormatError, S3Error};
 pub use request::{IntoRequest, Precondition, S3Request};
 pub use request::{archive, memory};

--- a/rust/dialog-remote-s3/src/s3/permit.rs
+++ b/rust/dialog-remote-s3/src/s3/permit.rs
@@ -55,7 +55,7 @@ impl Permit {
 
 impl From<Permit> for reqwest::RequestBuilder {
     fn from(permit: Permit) -> reqwest::RequestBuilder {
-        let client = reqwest::Client::new();
+        let client = crate::http_client();
         let mut builder = match permit.method.as_str() {
             "GET" => client.get(permit.url),
             "PUT" => client.put(permit.url),

--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -36,7 +36,6 @@ dialog-remote-s3 = { workspace = true }
 dialog-ucan-core = { workspace = true }
 dialog-varsig = { workspace = true }
 ipld-core = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_ipld_dagcbor = { workspace = true }

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -11,7 +11,7 @@ use dialog_capability::{
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::authority::{self, OperatorExt};
 use dialog_effects::service::ServiceResponseError;
-use dialog_remote_s3::{Permit, S3Error};
+use dialog_remote_s3::{Permit, S3Error, http_client};
 use serde::Deserialize;
 
 const MAX_SERVICE_ERROR_BODY_BYTES: usize = 8 * 1024;
@@ -62,7 +62,7 @@ impl UcanAuthorization {
             .to_bytes()
             .map_err(|e| S3Error::Authorization(e.to_string()))?;
 
-        let response = reqwest::Client::new()
+        let response = http_client()
             .post(&address.endpoint)
             .header("Content-Type", "application/cbor")
             .body(body)

--- a/rust/dialog-ucan-core/src/cid.rs
+++ b/rust/dialog-ucan-core/src/cid.rs
@@ -14,6 +14,15 @@ use sha2::Digest;
 pub fn to_dagcbor_cid<T: Serialize>(t: &T) -> Cid {
     #[allow(clippy::expect_used)]
     let bytes = serde_ipld_dagcbor::to_vec(t).expect("not serializable");
+    dagcbor_cid(&bytes)
+}
+
+/// Derive a DAG-CBOR/SHA2-256 CID from an encoding that is already to hand.
+///
+/// # Panics
+///
+/// Will panic if the multihash cannot be created.
+pub fn dagcbor_cid(bytes: &[u8]) -> Cid {
     let digest = sha2::Sha256::digest(bytes);
     #[allow(clippy::expect_used)]
     let multihash = Multihash::wrap(0x12, &digest).expect("unable to create multihash");

--- a/rust/dialog-ucan-core/src/container.rs
+++ b/rust/dialog-ucan-core/src/container.rs
@@ -124,8 +124,16 @@ impl Container {
 
     /// Serialize the container to DAG-CBOR bytes.
     pub fn to_bytes(&self) -> Result<Vec<u8>, ContainerError> {
+        self.clone().into_bytes()
+    }
+
+    /// Serialize the container to DAG-CBOR bytes, consuming it.
+    ///
+    /// Callers that build a container purely to encode it — every
+    /// chain's `to_bytes` — avoid copying every token this way.
+    pub fn into_bytes(self) -> Result<Vec<u8>, ContainerError> {
         // Build container: { "ctn-v1": [token_bytes...] }
-        let tokens: Vec<Ipld> = self.tokens.iter().cloned().map(Ipld::Bytes).collect();
+        let tokens: Vec<Ipld> = self.tokens.into_iter().map(Ipld::Bytes).collect();
         let mut container: BTreeMap<String, Ipld> = BTreeMap::new();
         container.insert(CONTAINER_VERSION.to_string(), Ipld::List(tokens));
 

--- a/rust/dialog-ucan-core/src/container/delegation.rs
+++ b/rust/dialog-ucan-core/src/container/delegation.rs
@@ -95,7 +95,7 @@ impl DelegationChain {
     /// The container format is: `{ "ctn-v1": [delegation_0_bytes, ...] }`
     /// where delegations are in subject-first (root-to-leaf) order.
     pub fn to_bytes(&self) -> Result<Vec<u8>, ContainerError> {
-        Container::from(self).to_bytes()
+        Container::from(self).into_bytes()
     }
 
     /// Get the CIDs for use in invocation proofs field.
@@ -328,10 +328,7 @@ impl From<&DelegationChain> for Container {
 
         for cid in &chain.proof_cids {
             if let Some(delegation) = chain.delegations.get(cid) {
-                // Note: This unwrap is safe because we're serializing from a valid delegation
-                if let Ok(bytes) = serde_ipld_dagcbor::to_vec(delegation.as_ref()) {
-                    tokens.push(bytes);
-                }
+                tokens.push(delegation.encoded().to_vec());
             }
         }
 

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -137,7 +137,7 @@ where
 {
     /// Serialize to DAG-CBOR bytes (UCAN container format).
     pub fn to_bytes(&self) -> Result<Vec<u8>, ContainerError> {
-        Container::from(self).to_bytes()
+        Container::from(self).into_bytes()
     }
 }
 
@@ -204,10 +204,8 @@ where
 
         // Add delegations in the order they appear in the invocation's proofs
         for cid in chain.invocation.proofs() {
-            if let Some(delegation) = chain.delegations.get(cid)
-                && let Ok(delegation_bytes) = serde_ipld_dagcbor::to_vec(delegation.as_ref())
-            {
-                tokens.push(delegation_bytes);
+            if let Some(delegation) = chain.delegations.get(cid) {
+                tokens.push(delegation.encoded().to_vec());
             }
         }
 

--- a/rust/dialog-ucan-core/src/delegation.rs
+++ b/rust/dialog-ucan-core/src/delegation.rs
@@ -8,7 +8,7 @@ pub mod policy;
 pub mod store;
 
 use crate::{
-    cid::to_dagcbor_cid,
+    cid::dagcbor_cid,
     command::Command,
     crypto::nonce::Nonce,
     envelope::{Envelope, EnvelopePayload, payload_tag::PayloadTag},
@@ -23,15 +23,36 @@ use serde::{
     de::{self, MapAccess, Visitor},
 };
 use serde_ipld_dagcbor::error::CodecError;
-use std::{borrow::Cow, collections::BTreeMap, fmt::Debug};
+use std::{borrow::Cow, collections::BTreeMap, fmt::Debug, sync::OnceLock};
 
 /// Grant or delegate a UCAN capability to another.
 ///
 /// This type implements the [UCAN Delegation spec](https://github.com/ucan-wg/delegation/blob/main/README.md).
 #[derive(Clone)]
-pub struct Delegation<S: Signature>(Envelope<S, DelegationPayload>);
+pub struct Delegation<S: Signature> {
+    envelope: Envelope<S, DelegationPayload>,
+    encoding: OnceLock<Encoding>,
+}
+
+/// The DAG-CBOR form of a delegation, and the CID that follows from it.
+///
+/// A delegation never changes after it is built, so both are pure
+/// functions of it and are computed at most once. A cloned delegation
+/// carries the encoding it already has.
+#[derive(Debug, Clone)]
+struct Encoding {
+    bytes: Vec<u8>,
+    cid: Cid,
+}
 
 impl<S: Signature> Delegation<S> {
+    fn new(envelope: Envelope<S, DelegationPayload>) -> Self {
+        Self {
+            envelope,
+            encoding: OnceLock::new(),
+        }
+    }
+
     /// Creates a blank [`DelegationBuilder`][builder::DelegationBuilder] instance.
     #[must_use]
     pub const fn builder() -> builder::DelegationBuilder<S> {
@@ -96,15 +117,36 @@ impl<S: Signature> Delegation<S> {
     /// Compute the CID for this delegation.
     #[must_use]
     pub fn to_cid(&self) -> Cid {
-        to_dagcbor_cid(&self)
+        self.encoding().cid
+    }
+
+    /// The DAG-CBOR encoding of this delegation, as it appears as a
+    /// token in a UCAN container.
+    #[must_use]
+    pub fn encoded(&self) -> &[u8] {
+        &self.encoding().bytes
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if the delegation cannot be serialized. We assume that
+    /// all UCANs are compatible with IPLD, so this "should" never happen
+    /// unless something is deeply wrong.
+    fn encoding(&self) -> &Encoding {
+        self.encoding.get_or_init(|| {
+            #[allow(clippy::expect_used)]
+            let bytes = serde_ipld_dagcbor::to_vec(&self.envelope).expect("not serializable");
+            let cid = dagcbor_cid(&bytes);
+            Encoding { bytes, cid }
+        })
     }
 
     const fn signature(&self) -> &S {
-        &self.0.0
+        &self.envelope.0
     }
 
     const fn envelope(&self) -> &EnvelopePayload<S, DelegationPayload> {
-        &self.0.1
+        &self.envelope.1
     }
 
     const fn payload(&self) -> &DelegationPayload {
@@ -142,7 +184,7 @@ impl<S: Signature> Delegation<S> {
 
 impl<S: Signature> Debug for Delegation<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Delegation").field(&self.0).finish()
+        f.debug_tuple("Delegation").field(&self.envelope).finish()
     }
 }
 
@@ -151,14 +193,14 @@ impl<S: Signature> Serialize for Delegation<S> {
     where
         Ser: serde::Serializer,
     {
-        self.0.serialize(serializer)
+        self.envelope.serialize(serializer)
     }
 }
 
 impl<'de, S: Signature + for<'ze> Deserialize<'ze>> Deserialize<'de> for Delegation<S> {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let envelope = Envelope::<S, DelegationPayload>::deserialize(deserializer)?;
-        Ok(Delegation(envelope))
+        Ok(Delegation::new(envelope))
     }
 }
 
@@ -631,6 +673,70 @@ mod tests {
         delegation.verify_signature(&resolver).await?;
 
         Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_computes_the_encoding_and_cid_once() {
+        let delegation = DelegationBuilder::<Ed25519Signature>::new()
+            .issuer(test_signer(90).await)
+            .audience(&test_did(91).await)
+            .subject(Subject::Specific(test_did(92).await))
+            .command(vec!["encode".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        assert!(
+            delegation.encoding.get().is_none(),
+            "a fresh delegation has not been encoded"
+        );
+
+        let cid = delegation.to_cid();
+        assert!(
+            delegation.encoding.get().is_some(),
+            "the first CID computes the encoding"
+        );
+
+        let bytes = delegation.encoded().as_ptr();
+        assert_eq!(delegation.to_cid(), cid);
+        assert_eq!(
+            delegation.encoded().as_ptr(),
+            bytes,
+            "later reads serve the same buffer rather than re-encoding"
+        );
+
+        assert_eq!(
+            delegation.encoded(),
+            serde_ipld_dagcbor::to_vec(&delegation).unwrap(),
+            "the cached encoding is the delegation's DAG-CBOR form"
+        );
+        assert_eq!(
+            cid,
+            crate::cid::to_dagcbor_cid(&delegation),
+            "the cached CID is the delegation's DAG-CBOR CID"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_carries_the_encoding_into_a_clone() {
+        let delegation = DelegationBuilder::<Ed25519Signature>::new()
+            .issuer(test_signer(93).await)
+            .audience(&test_did(94).await)
+            .subject(Subject::Specific(test_did(95).await))
+            .command(vec!["clone".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+
+        let cid = delegation.to_cid();
+        let clone = delegation.clone();
+
+        assert!(
+            clone.encoding.get().is_some(),
+            "a clone inherits the encoding instead of recomputing it"
+        );
+        assert_eq!(clone.to_cid(), cid);
+        assert_eq!(clone.encoded(), delegation.encoded());
     }
 
     #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), tokio::test)]

--- a/rust/dialog-ucan-core/src/delegation/builder.rs
+++ b/rust/dialog-ucan-core/src/delegation/builder.rs
@@ -323,6 +323,6 @@ impl<S: Signature, I: Issuer<S>> DelegationBuilder<S, I, Did, Subject, Command> 
             .await
             .map_err(BuildError::SigningError)?;
 
-        Ok(super::Delegation(Envelope(signature, envelope)))
+        Ok(super::Delegation::new(Envelope(signature, envelope)))
     }
 }

--- a/rust/dialog-ucan/src/scope.rs
+++ b/rust/dialog-ucan/src/scope.rs
@@ -72,6 +72,10 @@ pub struct Scope {
 }
 
 impl dialog_capability::access::Scope for Scope {
+    fn command(&self) -> &[String] {
+        self.command.segments()
+    }
+
     fn subject(&self) -> &dialog_varsig::Did {
         use dialog_ucan_core::subject::Subject as UcanSubject;
         match &self.subject {


### PR DESCRIPTION
Every authorized remote read builds its UCAN invocation from scratch. On a
wasm deployment that measures at ~130-170ms of client-side work per request:
a certificate-store BFS issuing two IndexedDB prefix queries per chain hop
(each a fresh transaction, decoding and re-verifying every certificate), a
chain rebuild that re-encodes and re-hashes every delegation for its CID,
a container encode that re-serializes the same delegations again, and a
fresh `reqwest::Client` per request at two call sites. During a cold read of
a synced branch — hundreds of node fetches — this dominates wall clock.

The proven chain only changes when a certificate is retained or the
operator rotates. Everything beneath the per-request nonce is cacheable.

## Changes

One commit per crate; each intermediate state builds.

**`perf(dialog-operator): memoize proven delegation chains`** — `Operator`
gains a `ProofMemo` consulted by its `Provider<Authorize<P>>` impl, generic
over `Protocol`. Key: (capability subject routing to the certificate store,
operator DID, access subject, command segments) — scope parameters are
deliberately excluded, since they change per request (e.g. the digest on
`/archive/get`) and would give a 0% hit rate. A hit does not skip
verification: every cached certificate is re-verified in memory against
*this* request's access (command attenuation, policy predicates, intersected
validity ranges), and the chain's window must still contain now + 60s. This
matters because `Certificate::verify` never looks at the subject — a test
pins that with a powerline root-command grant that would verify for any
subject. Invalidation: `Retain` drops the memo whole (a powerline
certificate can complete a chain for any subject, so no guessing), rotation
misses via the key, and a 60s retention TTL bounds staleness toward
revocation. Time is injected (`recall`/`remember` take `now`) so retention
and expiry are tested deterministically.

**`perf(dialog-ucan-core): compute a delegation's encoding once`** — a
delegation is immutable after construction, so its encoded bytes and CID are
computed once behind a `OnceLock` instead of per `DelegationChain::push` and
again per `Container::from(&InvocationChain)`.

**`perf(dialog-remote-s3): share one HTTP client across requests`** — one
lazily-built client replaces the per-request `Client::new()` in
`UcanAuthorization::redeem` and `Permit::send`. `thread_local` on wasm
(the wasm client is not `Send`), a static on native.

## Tests

New, all `#[dialog_common::test]`:

- `it_proves_once_across_repeated_authorizations`
- `it_reproves_after_retaining_a_new_certificate`
- `it_reproves_when_the_cached_chain_nears_expiry`
- `it_scopes_the_memo_by_principal_and_certificate_store`
- plus memo-internal retention/expiry cases and a counting-encoder check
  that a delegation encodes once

`cargo test --workspace --lib --tests` green; per-crate clippy
`--all-targets --all-features` clean; `cargo fmt --all`; wasm32 check clean
including the `thread_local` client arm. The
`dialog-capability` doctest failure at `attenuate.rs:30` is pre-existing —
it fails identically at the base revision.

## Review notes

- **No 403-drop of the memo.** `CREDENTIAL_REVOKED` surfaces in
  `UcanAuthorization::redeem`, which holds no handle on the operator that
  produced the authorization; threading one through the Site/Fork machinery
  was judged not worth it. The 60s TTL is the staleness bound — the service
  remains the enforcement point regardless.
- `Retain` clears the whole memo rather than affected entries. Retains are
  rare (operator build, explicit delegation); narrowing would mean reasoning
  about powerline reach.
- Recall clones cached certificates because `Proof::push` takes ownership —
  a few hundred bytes per hop. If it shows in a profile, `push` taking
  `Arc<P::Certificate>` removes it.
- The wasm-side latency win is not measured here; native tests pin the
  mechanics (one prove per window, invalidation, single encode).
