### PR TITLE
perf(search-tree): single-flight node fetches and read ahead on range scans

### DIFF
--- a/rust/dialog-repository/src/repository/branch/select.rs
+++ b/rust/dialog-repository/src/repository/branch/select.rs
@@ -4,7 +4,7 @@ use dialog_artifacts::tree::ArtifactTreeExt as _;
 use dialog_artifacts::{Artifact, ArtifactSelector, DialogArtifactsError};
 use dialog_capability::{Capability, Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
-use dialog_common::ConditionalSync;
+use dialog_common::{Buffer, ConditionalSync};
 use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
 use dialog_effects::archive::{Catalog, Get, Put};
 use dialog_effects::memory::Resolve;
@@ -106,17 +106,33 @@ impl Select<'_> {
         // through the stream, so probe the root block eagerly. Through a
         // `NetworkedIndex` this also replicates and caches the root
         // locally, so the scan's own root read stays local.
+        //
+        // The probe goes through the branch's node cache rather than
+        // straight to the store: queries that start together on a cold
+        // branch all probe the same root, and the cache is where they meet
+        // to replicate it once between them instead of once each.
         let tree_hash = self.tree_hash();
+        let root = NodeHash::from(tree_hash);
+        let node_cache = self.branch.node_cache();
+
         if tree_hash != EMPTY_TREE_HASH {
-            store.get(&tree_hash).await?.ok_or_else(|| {
-                DialogSearchTreeError::Node(format!(
-                    "Blob not found in storage: {}",
-                    tree_hash.to_base58(),
-                ))
-            })?;
+            node_cache
+                .get_or_fetch(&root, async |hash| {
+                    store
+                        .get(hash.as_bytes())
+                        .await
+                        .map(|bytes| bytes.map(Buffer::from))
+                })
+                .await?
+                .ok_or_else(|| {
+                    DialogSearchTreeError::Node(format!(
+                        "Blob not found in storage: {}",
+                        tree_hash.to_base58(),
+                    ))
+                })?;
         }
 
-        let tree = Index::from_hash_with_cache(NodeHash::from(tree_hash), self.branch.node_cache());
+        let tree = Index::from_hash_with_cache(root, node_cache);
 
         // EAV/AEV/VAE dispatch + per-entry filtering lives in the shared
         // `ArtifactTreeExt::scan` so branch scans and Changes-overlay

--- a/rust/dialog-search-tree/src/accessor.rs
+++ b/rust/dialog-search-tree/src/accessor.rs
@@ -47,6 +47,26 @@ where
         Self { cache, storage }
     }
 
+    /// Loads the node at `hash` into the cache, without decoding it or
+    /// reporting what happened.
+    ///
+    /// This is a read nobody is waiting on: it makes the node local so that a
+    /// later [`get_node`](Self::get_node) is served from the cache, and it is
+    /// deduplicated against any read of the same node already in flight.
+    /// Nothing observes its outcome, so a node that is missing or fails to
+    /// load is left to the read that actually needs it.
+    pub(crate) async fn warm(&self, hash: Blake3Hash) {
+        let _ = self
+            .cache
+            .get_or_fetch(&hash, async |key| {
+                self.storage
+                    .retrieve(key)
+                    .await
+                    .map(|maybe_bytes| maybe_bytes.map(Buffer::from))
+            })
+            .await;
+    }
+
     /// Retrieves a node by its content hash.
     ///
     /// Checks the cache first, then the storage backend. Returns an error if the

--- a/rust/dialog-search-tree/src/accessor.rs
+++ b/rust/dialog-search-tree/src/accessor.rs
@@ -83,3 +83,41 @@ where
             .map(|buffer| PersistentNode::new(buffer))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use anyhow::Result;
+    use dialog_common::Blake3Hash;
+    use futures_util::future::join_all;
+
+    use crate::{
+        Accessor, Cache, ContentAddressedStorage, PersistentNode, helpers::ObservingBackend,
+    };
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[dialog_common::test]
+    async fn it_deduplicates_concurrent_fetches_of_one_node() -> Result<()> {
+        let backend = ObservingBackend::new();
+        let mut storage = ContentAddressedStorage::new(backend.clone());
+
+        let bytes = b"the bytes of one node".to_vec();
+        let hash = Blake3Hash::hash(&bytes);
+        storage.store(bytes, &hash).await?;
+
+        let accessor = Accessor::new(Cache::new(), storage);
+        backend.reset();
+
+        let reads = join_all((0..8).map(|_| accessor.get_node(&hash))).await;
+
+        for read in reads {
+            let _: PersistentNode<[u8; 4], Vec<u8>> = read?;
+        }
+        assert_eq!(backend.read_log(), vec![hash]);
+
+        Ok(())
+    }
+}

--- a/rust/dialog-search-tree/src/cache.rs
+++ b/rust/dialog-search-tree/src/cache.rs
@@ -1,3 +1,6 @@
+mod fetches;
+use fetches::{Claim, Fetches};
+
 use dialog_common::{ConditionalSend, ConditionalSync};
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -12,6 +15,11 @@ use std::{cell::RefCell, rc::Rc};
 const CACHE_CAPACITY: usize = 2048;
 
 /// A thread-safe cache for storing frequently accessed values.
+///
+/// Misses are single-flighted: concurrent misses for one key perform a single
+/// fetch and share its outcome. Everything holding a clone of the same cache
+/// shares that arbitration, so readers that arrive at the same cold value from
+/// different queries pay for it once between them.
 #[derive(Clone)]
 pub struct Cache<K, V>
 where
@@ -26,6 +34,8 @@ where
     // `Clone` but would deep-clone the cache without the wrapping `Rc`.
     #[cfg(target_arch = "wasm32")]
     cache: Rc<RefCell<SieveCache<K, V>>>,
+
+    fetches: Fetches<K, V>,
 }
 
 impl<K, V> std::fmt::Debug for Cache<K, V>
@@ -70,36 +80,49 @@ where
             cache,
             #[cfg(target_arch = "wasm32")]
             cache: Rc::new(RefCell::new(cache)),
+
+            fetches: Fetches::new(),
         }
     }
 
     /// Retrieves a value from the cache, or fetches it using the provided
     /// function.
+    ///
+    /// Only one fetch per key is ever in flight through a given cache: a
+    /// caller that misses while another caller is already fetching the same
+    /// key waits for that fetch instead of issuing its own. A fetch that fails
+    /// or is dropped before it publishes leaves nothing behind, so the callers
+    /// waiting on it start over and fetch for themselves.
     pub async fn get_or_fetch<F, E>(&self, key: &K, fetcher: F) -> Result<Option<V>, E>
     where
         F: AsyncFnOnce(&K) -> Result<Option<V>, E>,
     {
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Some(value) = self.cache.get(key) {
-            return Ok(Some(value));
+        let fetch = loop {
+            if let Some(value) = self.get(key) {
+                return Ok(Some(value));
+            }
+
+            match self.fetches.claim(key) {
+                Claim::Ours(fetch) => break fetch,
+                Claim::InFlight(mut outcome) => match outcome.recv().await {
+                    Ok(value) => return Ok(value),
+                    // The fetch we were waiting on failed or was dropped. Its
+                    // claim is already withdrawn, so start over: either the
+                    // value landed in the cache anyway, or we fetch it.
+                    Err(_) => continue,
+                },
+            }
+        };
+
+        // A failure returns here, dropping the claim and releasing the key.
+        let value = fetcher(key).await?;
+
+        if let Some(value) = &value {
+            self.insert(key.clone(), value.clone());
         }
+        fetch.publish(&value);
 
-        #[cfg(target_arch = "wasm32")]
-        if let Some(value) = self.cache.borrow_mut().get(key) {
-            let value = value.clone();
-            return Ok(Some(value));
-        }
-
-        Ok(if let Some(value) = fetcher(key).await? {
-            #[cfg(not(target_arch = "wasm32"))]
-            self.cache.insert(key.clone(), value.clone());
-            #[cfg(target_arch = "wasm32")]
-            self.cache.borrow_mut().insert(key.clone(), value.clone());
-
-            Some(value)
-        } else {
-            None
-        })
+        Ok(value)
     }
 
     /// Inserts a key-value pair into the cache.
@@ -110,5 +133,130 @@ where
         let mut cache = self.cache.borrow_mut();
 
         cache.insert(key, value)
+    }
+
+    /// Retrieves a value from the cache, if it is cached.
+    fn get(&self, key: &K) -> Option<V> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let value = self.cache.get(key);
+        #[cfg(target_arch = "wasm32")]
+        let value = self.cache.borrow_mut().get(key).cloned();
+
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use anyhow::Result;
+
+    use super::Cache;
+    use crate::helpers::yield_once;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[dialog_common::test]
+    async fn it_clears_the_inflight_entry_when_a_fetch_fails() -> Result<()> {
+        let cache = Cache::<u8, u8>::new();
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let failed = cache
+            .get_or_fetch(&1, async |_| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                yield_once().await;
+                Err::<Option<u8>, &str>("no")
+            })
+            .await;
+
+        assert!(failed.is_err());
+        assert_eq!(cache.fetches.len(), 0);
+
+        let retried = cache
+            .get_or_fetch(&1, async |_| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                yield_once().await;
+                Ok::<Option<u8>, &str>(Some(7))
+            })
+            .await;
+
+        assert_eq!(retried, Ok(Some(7)));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(cache.fetches.len(), 0);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_lets_waiters_retry_a_failed_fetch() -> Result<()> {
+        let cache = Cache::<u8, u8>::new();
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let fetch = async |_: &u8| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            yield_once().await;
+            if attempt == 0 { Err("no") } else { Ok(Some(7)) }
+        };
+
+        let (first, second) = futures_util::future::join(
+            cache.get_or_fetch(&1, fetch),
+            cache.get_or_fetch(&1, fetch),
+        )
+        .await;
+
+        // Whichever of the two claimed the fetch failed; the other found the
+        // claim withdrawn and fetched successfully for itself.
+        assert!(first.is_err() || second.is_err());
+        assert_eq!(first.or(second), Ok(Some(7)));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(cache.fetches.len(), 0);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_opens_an_outcome_channel_only_when_a_waiter_arrives() -> Result<()> {
+        let cache = Cache::<u8, u8>::new();
+
+        let lone = cache.get_or_fetch(&1, async |_| {
+            assert!(
+                !cache.fetches.awaited(&1),
+                "a fetch nobody waits on should hold a bare claim"
+            );
+            yield_once().await;
+            Ok::<Option<u8>, &str>(Some(7))
+        });
+
+        assert_eq!(lone.await, Ok(Some(7)));
+
+        let contended = cache.get_or_fetch(&2, async |_| {
+            yield_once().await;
+            assert!(
+                cache.fetches.awaited(&2),
+                "a waiter's arrival should open the outcome channel"
+            );
+            Ok::<Option<u8>, &str>(Some(9))
+        });
+
+        let (first, second) = futures_util::future::join(
+            contended,
+            cache.get_or_fetch(&2, async |_| -> Result<Option<u8>, &str> {
+                unreachable!("the waiter must share the claimed fetch, not issue its own")
+            }),
+        )
+        .await;
+
+        assert_eq!(first, Ok(Some(9)));
+        assert_eq!(second, Ok(Some(9)));
+        assert_eq!(cache.fetches.len(), 0);
+
+        Ok(())
     }
 }

--- a/rust/dialog-search-tree/src/cache/fetches.rs
+++ b/rust/dialog-search-tree/src/cache/fetches.rs
@@ -1,0 +1,168 @@
+use std::{collections::HashMap, hash::Hash, sync::Arc};
+
+use parking_lot::Mutex;
+use tokio::sync::broadcast;
+
+/// A claim's presence in the registry. A fetch starts [`Entry::Claimed`] —
+/// a bare marker, nothing allocated — and is upgraded to [`Entry::Awaited`]
+/// the moment a second caller arrives and needs a channel to wait on. A
+/// fetch nobody waits on never pays for one.
+enum Entry<V> {
+    /// A fetch is in flight; nobody is waiting on it yet.
+    Claimed,
+    /// A fetch is in flight and callers are subscribed to its outcome.
+    Awaited(broadcast::Sender<Option<V>>),
+}
+
+type Claims<K, V> = HashMap<K, Entry<V>>;
+
+/// The fetches that are currently in flight for a [`Cache`](super::Cache),
+/// keyed exactly like the cache they front.
+///
+/// A miss that finds no claim for its key takes one out and performs the
+/// fetch. A concurrent miss for the same key finds that claim and waits on its
+/// outcome instead of issuing a second fetch of its own. This matters most
+/// where a miss is expensive and shared: a cold tree read walks the same upper
+/// nodes for every query descending it at that moment.
+///
+/// The registry only ever holds claims that are still in flight. Publishing an
+/// outcome, failing, and dropping a claim all withdraw it, so a key is never
+/// left pointing at a fetch that no longer exists.
+pub(super) struct Fetches<K, V>
+where
+    K: Eq + Hash,
+{
+    claims: Arc<Mutex<Claims<K, V>>>,
+}
+
+impl<K, V> Clone for Fetches<K, V>
+where
+    K: Eq + Hash,
+{
+    fn clone(&self) -> Self {
+        Self {
+            claims: self.claims.clone(),
+        }
+    }
+}
+
+impl<K, V> Fetches<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self {
+            claims: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Take out the claim on `key`, or subscribe to the claim already in
+    /// flight for it.
+    pub fn claim(&self, key: &K) -> Claim<K, V> {
+        let mut claims = self.claims.lock();
+
+        match claims.get_mut(key) {
+            None => {
+                claims.insert(key.clone(), Entry::Claimed);
+                Claim::Ours(Fetch {
+                    key: key.clone(),
+                    claims: self.claims.clone(),
+                    withdrawn: false,
+                })
+            }
+            Some(entry) => match entry {
+                // First waiter: give the claim its outcome channel.
+                Entry::Claimed => {
+                    let (outcome, receiver) = broadcast::channel(1);
+                    *entry = Entry::Awaited(outcome);
+                    Claim::InFlight(receiver)
+                }
+                Entry::Awaited(outcome) => Claim::InFlight(outcome.subscribe()),
+            },
+        }
+    }
+
+    /// The number of fetches currently in flight.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.claims.lock().len()
+    }
+
+    /// Whether the in-flight fetch for `key` has waiters (and hence an
+    /// allocated outcome channel).
+    #[cfg(test)]
+    pub fn awaited(&self, key: &K) -> bool {
+        matches!(self.claims.lock().get(key), Some(Entry::Awaited(_)))
+    }
+}
+
+/// The outcome of claiming a key in a [`Fetches`] registry.
+pub(super) enum Claim<K, V>
+where
+    K: Eq + Hash,
+{
+    /// No fetch was in flight for the key, so this caller performs it.
+    Ours(Fetch<K, V>),
+    /// A fetch was already in flight; this receiver carries its outcome.
+    InFlight(broadcast::Receiver<Option<V>>),
+}
+
+/// A claim on the fetch for one key, held for as long as that fetch is in
+/// flight.
+///
+/// Dropping the claim without [`publish`](Self::publish)ing withdraws it and
+/// closes the outcome channel (if any waiter opened one), which is how a
+/// failed or abandoned fetch tells its waiters to start over instead of
+/// leaving them attached to a fetch that will never complete.
+pub(super) struct Fetch<K, V>
+where
+    K: Eq + Hash,
+{
+    key: K,
+    claims: Arc<Mutex<Claims<K, V>>>,
+    withdrawn: bool,
+}
+
+impl<K, V> Fetch<K, V>
+where
+    K: Eq + Hash,
+{
+    fn withdraw(&mut self) -> Option<Entry<V>> {
+        if self.withdrawn {
+            return None;
+        }
+        self.withdrawn = true;
+        self.claims.lock().remove(&self.key)
+    }
+}
+
+impl<K, V> Fetch<K, V>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    /// Hand the fetched value to everyone waiting on this claim.
+    ///
+    /// The value is only cloned if someone is actually waiting; the common
+    /// uncontended fetch publishes to nobody and pays nothing.
+    pub fn publish(mut self, value: &Option<V>) {
+        // Withdraw first so a caller arriving after the send takes out a fresh
+        // claim rather than subscribing to a channel that has already spoken.
+        if let Some(Entry::Awaited(outcome)) = self.withdraw() {
+            let _ = outcome.send(value.clone());
+        }
+    }
+}
+
+impl<K, V> Drop for Fetch<K, V>
+where
+    K: Eq + Hash,
+{
+    fn drop(&mut self) {
+        // Removing an `Awaited` entry drops its sender, which closes the
+        // channel and sends every waiter back to the start.
+        drop(self.withdraw());
+    }
+}

--- a/rust/dialog-search-tree/src/helpers.rs
+++ b/rust/dialog-search-tree/src/helpers.rs
@@ -33,6 +33,7 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fmt::Debug,
+    sync::Arc,
 };
 
 use async_stream::try_stream;
@@ -40,6 +41,7 @@ use dialog_common::{Blake3Hash, ConditionalSend, ConditionalSync, NULL_BLAKE3_HA
 use dialog_storage::{DialogStorageError, JournaledStorage, MemoryStorageBackend, StorageBackend};
 use futures_core::Stream;
 use futures_util::StreamExt;
+use parking_lot::Mutex;
 use rkyv::{
     Deserialize, Serialize,
     bytecheck::CheckBytes,
@@ -303,6 +305,96 @@ pub type TestTree = PersistentTree<SpecKey, Vec<u8>, DistributionSimulator>;
 /// Creates an empty journaled [`TestStorage`].
 pub fn test_storage() -> TestStorage {
     ContentAddressedStorage::new(JournaledStorage::new(MemoryStorageBackend::default()))
+}
+
+/// Yields to the executor exactly once, giving work polled alongside the
+/// caller a chance to run before the caller resumes.
+pub async fn yield_once() {
+    let mut yielded = false;
+
+    std::future::poll_fn(move |context| {
+        if yielded {
+            std::task::Poll::Ready(())
+        } else {
+            yielded = true;
+            context.waker().wake_by_ref();
+            std::task::Poll::Pending
+        }
+    })
+    .await
+}
+
+/// A storage backend that records the reads that reach it, in order, and how
+/// many of them were in flight at once.
+///
+/// Every read yields once before it is answered, so reads issued by work that
+/// is polled concurrently are genuinely in flight together and their overlap
+/// shows up in [`peak_reads_in_flight`](Self::peak_reads_in_flight). The
+/// ordered log in [`read_log`](Self::read_log) says which nodes a read path
+/// touched, in the order it touched them, and how often.
+#[derive(Clone, Default)]
+pub struct ObservingBackend {
+    backend: MemoryStorageBackend<Blake3Hash, Vec<u8>>,
+    reads: Arc<Mutex<Reads>>,
+}
+
+#[derive(Default)]
+struct Reads {
+    log: Vec<Blake3Hash>,
+    in_flight: usize,
+    peak_in_flight: usize,
+}
+
+impl ObservingBackend {
+    /// An empty backend, observing from the first read.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Forgets everything observed so far, keeping the stored values.
+    pub fn reset(&self) {
+        *self.reads.lock() = Reads::default();
+    }
+
+    /// The keys read since the last [`reset`](Self::reset), in the order the
+    /// reads were issued. A key read twice appears twice.
+    pub fn read_log(&self) -> Vec<Blake3Hash> {
+        self.reads.lock().log.clone()
+    }
+
+    /// The greatest number of reads that were ever in flight at once since
+    /// the last [`reset`](Self::reset).
+    pub fn peak_reads_in_flight(&self) -> usize {
+        self.reads.lock().peak_in_flight
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl StorageBackend for ObservingBackend {
+    type Key = Blake3Hash;
+    type Value = Vec<u8>;
+    type Error = DialogStorageError;
+
+    async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
+        self.backend.set(key, value).await
+    }
+
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
+        {
+            let mut reads = self.reads.lock();
+            reads.log.push(key.clone());
+            reads.in_flight += 1;
+            reads.peak_in_flight = reads.peak_in_flight.max(reads.in_flight);
+        }
+
+        yield_once().await;
+        let value = self.backend.get(key).await;
+
+        self.reads.lock().in_flight -= 1;
+
+        value
+    }
 }
 
 /// A distribution that reads ranks directly from keys.

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -1,12 +1,15 @@
 use std::{
+    future::Future,
     marker::PhantomData,
     ops::{Bound, RangeBounds},
+    task::Poll,
 };
 
 use async_stream::try_stream;
 use dialog_common::{Blake3Hash, ConditionalSend, ConditionalSync, NULL_BLAKE3_HASH};
 use dialog_storage::{DialogStorageError, StorageBackend};
 use futures_core::Stream;
+use futures_util::{StreamExt as _, stream::FuturesUnordered};
 use nonempty::NonEmpty;
 use rkyv::{
     Deserialize,
@@ -20,6 +23,14 @@ use crate::{
     Accessor, ArchivedNodeBody, DialogSearchTreeError, Entry, Key, Link, PersistentNode,
     SymmetryWith, Value, into_owned,
 };
+
+/// How many sibling reads a range scan keeps in flight while it walks.
+///
+/// A scan reads a whole run of siblings, one after another, and each read that
+/// misses locally can cost a round trip. Reading ahead of the walk turns a run
+/// of round trips into an overlapping few, and bounding it keeps a scan that
+/// stops early from having fetched much it never looked at.
+const PREFETCH_CONCURRENCY: usize = 16;
 
 /// A traversal mechanism for walking through a tree structure.
 pub struct TreeWalker<Key, Value>
@@ -100,6 +111,7 @@ where
             };
             let mut search_path = search_result.into_indexed();
             let mut entered_range = false;
+            let mut warming = FuturesUnordered::new();
 
             while let Some((node, maybe_index)) = search_path.pop() {
                 match node.body()? {
@@ -112,7 +124,21 @@ where
 
                         match index.links.get(child_index) {
                             Some(link) => {
-                                let next_node = accessor.get_node(<&Blake3Hash>::from(&link.node)).await?;
+                                // The scan will walk this node's remaining
+                                // children in turn, so start reading them now
+                                // and let them land in the cache while the
+                                // walk descends into the first of them.
+                                for sibling in index.links.iter().skip(child_index + 1) {
+                                    if warming.len() >= PREFETCH_CONCURRENCY {
+                                        break;
+                                    }
+                                    warming.push(accessor.warm(<&Blake3Hash>::from(&sibling.node).clone()));
+                                }
+
+                                let next_node = while_warming(
+                                    accessor.get_node(<&Blake3Hash>::from(&link.node)),
+                                    &mut warming,
+                                ).await?;
                                 search_path.push((node, Some(child_index)));
                                 search_path.push((next_node, None));
                             }
@@ -204,6 +230,32 @@ where
             }
         }
     }
+}
+
+/// Polls `read` to completion, making progress on queued cache-warming reads
+/// whenever it is not ready.
+///
+/// The queued reads only populate the cache; nothing waits on them and their
+/// outcomes are discarded, so this changes neither what `read` resolves to nor
+/// when its caller observes it. Reads still queued when the caller is dropped
+/// are dropped with it.
+async fn while_warming<Read, Warm>(read: Read, warming: &mut FuturesUnordered<Warm>) -> Read::Output
+where
+    Read: Future,
+    Warm: Future<Output = ()>,
+{
+    let mut read = std::pin::pin!(read);
+
+    std::future::poll_fn(move |context| {
+        if let Poll::Ready(output) = read.as_mut().poll(context) {
+            return Poll::Ready(output);
+        }
+
+        while let Poll::Ready(Some(())) = warming.poll_next_unpin(context) {}
+
+        Poll::Pending
+    })
+    .await
 }
 
 /// Walks the narrow "overflow" path for [`RightNeighbor`] prefetching.
@@ -491,5 +543,134 @@ where
 
         path.reverse();
         path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use std::collections::HashSet;
+
+    use anyhow::Result;
+    use dialog_common::Blake3Hash;
+    use futures_util::TryStreamExt as _;
+
+    use crate::{
+        ArchivedNodeBody, Buffer, ContentAddressedStorage, Delta, PersistentNode, PersistentTree,
+        helpers::ObservingBackend,
+    };
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    type Tree = PersistentTree<[u8; 4], Vec<u8>>;
+    type Storage = ContentAddressedStorage<ObservingBackend>;
+
+    const ENTRIES: u32 = 512;
+
+    /// Builds a tree of [`ENTRIES`] entries and hands back a handle to it whose
+    /// node cache is cold, so that reads reach the backend.
+    async fn built_tree(storage: &mut Storage) -> Result<Tree> {
+        let mut delta = Delta::zero();
+        let mut edit = Tree::empty().edit();
+
+        for entry in 0..ENTRIES {
+            edit = edit
+                .insert(entry.to_be_bytes(), entry.to_be_bytes().to_vec(), storage)
+                .await?;
+        }
+
+        let tree = edit.persist(&mut delta)?;
+        for (_, buffer) in delta.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
+        }
+
+        Ok(Tree::from_hash(tree.root().clone()))
+    }
+
+    async fn load(
+        storage: &Storage,
+        hash: &Blake3Hash,
+    ) -> Result<PersistentNode<[u8; 4], Vec<u8>>> {
+        let bytes = storage
+            .retrieve(hash)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Node not stored"))?;
+
+        Ok(PersistentNode::new(Buffer::from(bytes)))
+    }
+
+    #[dialog_common::test]
+    async fn it_warms_sibling_nodes_during_a_range_scan() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(ObservingBackend::new());
+        let tree = built_tree(&mut storage).await?;
+        let backend = storage.backend().clone();
+        backend.reset();
+
+        let entries: Vec<_> = tree.stream(&storage).try_collect().await?;
+
+        assert_eq!(entries.len() as u32, ENTRIES);
+        assert!(
+            entries.windows(2).all(|pair| pair[0].key < pair[1].key),
+            "the scan yields entries in key order"
+        );
+
+        let reads = backend.read_log();
+        let distinct = reads.iter().collect::<HashSet<_>>();
+
+        assert!(reads.len() > 1, "the scan reads more than the root");
+        assert_eq!(
+            reads.len(),
+            distinct.len(),
+            "no node was read from the backend twice"
+        );
+        assert!(
+            backend.peak_reads_in_flight() > 1,
+            "sibling reads overlap the read the scan is waiting on"
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_prefetch_on_point_lookups() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(ObservingBackend::new());
+        let tree = built_tree(&mut storage).await?;
+        let backend = storage.backend().clone();
+        backend.reset();
+
+        let found = tree.get(&257u32.to_be_bytes(), &storage).await?;
+
+        assert_eq!(found, Some(257u32.to_be_bytes().to_vec()));
+
+        let path = backend.read_log();
+        assert!(path.len() > 1, "the tree has at least one index level");
+        assert_eq!(path.first(), Some(tree.root()));
+        assert_eq!(backend.peak_reads_in_flight(), 1);
+
+        // Every read but the last is an index node holding the read that
+        // follows it: the lookup descended a single root-to-leaf path and
+        // read nothing beside it.
+        for step in path.windows(2) {
+            let node = load(&storage, &step[0]).await?;
+            match node.body()? {
+                ArchivedNodeBody::Index(index) => assert!(
+                    index
+                        .links
+                        .iter()
+                        .any(|link| <&Blake3Hash>::from(&link.node) == &step[1]),
+                    "a read that is not a child of the read before it"
+                ),
+                ArchivedNodeBody::Segment(_) => panic!("a segment cannot hold a further read"),
+            }
+        }
+
+        let leaf = load(&storage, path.last().expect("a read")).await?;
+        assert!(matches!(leaf.body()?, ArchivedNodeBody::Segment(_)));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
A branch synced to a remote reads locally-missing tree nodes through
`NetworkedIndex`: one authorized round trip per node (~350ms cold on a wasm
deployment). Two compounding problems:

1. **No single-flight.** Concurrent misses for the same key each fetch. The
   storage cache layer explicitly tolerates this — harmless for local reads,
   expensive for authorized remote fetches. During a cold load, many
   concurrent queries descend the same cold tree and re-fetch the same upper
   nodes.
2. **A strictly serial walk.** The walker awaits one node per iteration;
   there is no concurrency anywhere on the read path, while the write path
   already uploads with `buffer_unordered(UPLOAD_CONCURRENCY = 16)`.

## Changes

**`perf(search-tree): single-flight the node cache's misses`** — the
arbitration lives in `dialog_search_tree::Cache` (the per-branch node
cache), because it is the one layer every read passes through — the walker's
own gets and the prefetch below included. `Fetches` is a registry of
in-flight claims; the claimant runs the caller's fetcher, concurrent misses
await a receiver. The uncontended path is deliberately free of allocation: a
claim starts as a bare map entry, and the `broadcast` outcome channel is
only materialized the moment a second caller actually arrives — so the
common miss with no waiter pays a map insert/remove and nothing else, and
`publish` clones the value only when someone is listening. (An earlier
eager-channel draft cost a measured 6-12% across the native search-tree
benches; the lazy variant benches at parity with the pre-change baseline.)
A claim withdraws itself on `Drop` — so a failed fetch or a cancelled reader
clears the key — and waiters that see a closed channel loop back, re-check
the cache, and fetch themselves if the leader failed. A stored `Shared`
future does not work here: the fetch future borrows the accessor and is not
`'static`. No new dependencies; the mutex guard is never held across an
await, and the `?Send` cfg split is untouched.

**`perf(search-tree): read a range scan's siblings ahead of the walk`** —
when the range stream descends into child N of an index node, it queues
cache-warming reads for children N+1.. up to 16 in flight, drained only
while the walk's own read is pending (`while_warming` poll adapter). The
walk awaits exactly the nodes it awaited before, in the same order — all 126
pre-existing ordering tests pass unmodified. Point lookups do not prefetch:
descent is serial by nature and fan-out would fetch nodes the lookup skips.
Warming goes through the cache, hence through single-flight, so a prefetched
sibling and the walk's own read of it are one backend fetch. Dropping the
stream stops issuing prefetches.

**`perf(repository): probe a branch's root through its node cache`** — the
eager root probe was the one read per query that bypassed the node cache,
so concurrent cold queries duplicated it; 24 lines to route it through.

## Tests

New, all `#[dialog_common::test]`, all native-runnable:

- `it_deduplicates_concurrent_fetches_of_one_node`
- `it_clears_the_inflight_entry_when_a_fetch_fails`
- `it_lets_waiters_retry_a_failed_fetch`
- `it_opens_an_outcome_channel_only_when_a_waiter_arrives`
- `it_warms_sibling_nodes_during_a_range_scan`
- `it_does_not_prefetch_on_point_lookups`

Each was verified to bite: `PREFETCH_CONCURRENCY = 0` fails the overlap
assertion; bypassing single-flight fails the dedupe test (8 backend reads)
and makes prefetch duplicate work; a no-op `Drop` fails the registry-clear
test. `cargo test` green on dialog-search-tree / dialog-storage /
dialog-repository plus dialog-artifacts and dialog-query as read-path
consumers; the search-tree suite ran three times with identical results.
Clippy `--all-targets --all-features` clean on touched crates; fmt clean.

## Review notes

- Prefetch can over-fetch on narrow scans: a scan that stops after two
  siblings may have warmed up to 14 nodes it never reads. If narrow selects
  dominate real workloads, a ramp (1, 2, 4, ...) would cut the waste —
  worth measuring before tuning.
- No timeout on a claim: a leaked, never-polled stream holding a claim makes
  waiters wait with it. Dropping the stream withdraws the claim immediately;
  there is no cross-target timer in the async helpers to do better without a
  new dependency.
- `NetworkedIndex`'s non-tree reads (blob, commit/pull paths) are not
  deduplicated here; out of scope.
- The latency win is not measured on wasm here; the native tests pin the
  mechanics (one fetch per key, overlapping sibling reads, unchanged yield
  order).

