### PR TITLE
perf(ci): run wasm tests through a pooled browser

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,9 @@
 [target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'
+# wbg-pool is a drop-in wasm-bindgen-test-runner replacement that keeps one
+# headless Chrome alive and gives each test a fresh origin, so nextest's
+# process-per-test model pays browser startup once instead of per test. It is
+# provided on PATH by the nix dev shell (see rust/wbg-pool).
+runner = 'wbg-pool'
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"', '--cfg', 'web_sys_unstable_apis']
 
 [target.aarch64-apple-darwin]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,14 +97,10 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       # TMPDIR must live on the large /nix volume, not the root
       # filesystem. nothing-but-nix leaves the root filesystem only
-      # root-safe-haven (16GB) of free space, and the web test suites
-      # leak a headless Chrome profile (scoped_dir*, ~10MB+ each) into
-      # TMPDIR for every one of the ~1600 per-test browser launches:
-      # wasm-bindgen-test-runner SIGKILLs chromedriver without ending
-      # the WebDriver session, so chromedriver never removes the
-      # profile. With TMPDIR on the root filesystem the leak exhausts
-      # it after ~1400 tests and the run dies with ENOSPC or SIGKILLed
-      # renderers; the /nix volume has ~90GB of headroom.
+      # root-safe-haven (16GB) of free space, and the wasm build and
+      # test artifacts (test binaries, the shared wasm cache, browser
+      # profiles) can outgrow that; the /nix volume has ~90GB of
+      # headroom.
       - name: 'Run test configuration'
         run: |
           sudo mkdir -p /nix/tmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base-x"
@@ -599,6 +657,15 @@ checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
  "spin 0.10.0",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1690,6 +1757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1783,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1865,6 +1948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2014,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -1931,6 +2026,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2073,7 +2170,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -2211,6 +2308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "idb"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2365,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2399,6 +2507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2476,6 +2590,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -2520,6 +2640,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2932,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.96"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3072,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3299,7 +3429,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -3388,6 +3518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,6 +3570,7 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3522,7 +3659,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.11.0-rc.5",
  "sha2 0.11.0-rc.5",
  "smallvec",
  "std-next",
@@ -3670,6 +3807,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +3827,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3774,6 +3933,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simdutf8"
@@ -3893,9 +4058,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4098,6 +4263,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4149,6 +4315,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,6 +4352,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4212,6 +4391,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4283,6 +4463,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1 0.10.7",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4342,6 +4539,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4359,6 +4574,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4420,6 +4641,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "walrus"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bfa49767bb3a9e1afb02aa95bbcbde8d82f2db4ca377afae94d688f14f62378"
+dependencies = [
+ "anyhow",
+ "gimli",
+ "id-arena",
+ "leb128",
+ "log",
+ "rayon",
+ "walrus-macro",
+ "wasm-encoder",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9b0525d7ea6e5f906aca581a172e5c91b4c595290dfa8ad4a2bc9ffef33b44"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,6 +4704,24 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-cli-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c3e3bac5bcdc2a15ba22862e2cb7c0d1beddf9d46dd320bec1f6ae82f2da53"
+dependencies = [
+ "anyhow",
+ "base64",
+ "leb128",
+ "log",
+ "rustc-demangle",
+ "serde",
+ "serde_json",
+ "walrus",
+ "wasm-bindgen-shared",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -4538,6 +4806,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,6 +4842,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.229.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3b1f053f5d41aa55640a1fa9b6d1b8a9e4418d118ce308d20e24ff3575a8c"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wbg-pool"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "futures-util",
+ "libc",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "ureq",
+ "wasm-bindgen-cli-support",
+ "wasmparser 0.229.0",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4581,6 +4903,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "rust/dialog-operator",
     "rust/dialog-repository",
     "rust/dialog-varsig",
+    "rust/wbg-pool",
 ]
 resolver = "2"
 
@@ -55,6 +56,7 @@ async-signature = "0.5"
 async-stream = "0.3"
 async-trait = "0.1"
 auto_enums = { version = "0.8", features = ["futures03"] }
+axum = "0.8"
 base58 = "0.2"
 base64 = "0.22"
 blake3 = "1"
@@ -86,6 +88,7 @@ itertools = "0.14"
 js-sys = "0.3"
 k256 = "0.13"
 leb128 = "0.2"
+libc = "0.2"
 leptos = "0.8"
 leptos_meta = "0.8"
 leptos_router = "0.8"
@@ -150,6 +153,7 @@ tokio = "1"
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tokio-util = { version = "0.7", features = ["io"] }
+tokio-tungstenite = "0.26"
 tower = "0.5"
 tower-http = "0.6"
 tracing = "0.1"
@@ -162,10 +166,15 @@ ucan = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "main", pack
 varsig = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "main", package = "varsig" }
 ulid = "1"
 url = { version = "2", features = ["serde"] }
+ureq = { version = "2", features = ["json"] }
 percent-encoding = "2"
 wasm-bindgen = "=0.2.126"
+# wasm-bindgen-cli-support must track wasm-bindgen exactly, like
+# wasm-bindgen-test-runner does; bump both pins in lockstep.
+wasm-bindgen-cli-support = "=0.2.126"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen-test = "0.3"
+wasmparser = "0.229"
 wasm-streams = "0.6"
 web-sys = "0.3"
 web-time = "1"

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
           cargoChecks
           rustToolchain
           wasm-bindgen-cli
+          wbg-pool
           ;
 
         developmentBuildInputs =
@@ -98,6 +99,9 @@
               rustToolchain
               chrome
               chromedriver
+              # The wasm32 target runner (see .cargo/config.toml); nextest
+              # invokes it once per test against a single shared browser.
+              wbg-pool
             ]
           );
 
@@ -109,6 +113,11 @@
             "CHROME_PATH" = "${chromePath}";
             "CHROME" = "${chromePath}";
             "CHROMEDRIVER" = "${chromedriver}/bin/chromedriver";
+
+            # The Chrome sandbox cannot initialize under the CI runner, so
+            # wbg-pool's headless Chrome exits before opening a tab. Test code
+            # is trusted, so disable the sandbox for the pooled browser.
+            "WBG_POOL_NO_SANDBOX" = "1";
           }
           // lib.optionalAttrs stdenv.isDarwin {
             "WASM_BINDGEN_TEST_WEBDRIVER_JSON" = webdriverConfig;
@@ -268,7 +277,7 @@
 
           "test:web:release" = menuTestCommand {
             description = "Unit and integration tests (wasm32-unknown-unknown, release)";
-            package = "tests-web-debug";
+            package = "tests-web-release";
           };
 
           "test:cross:integration" = menuTestCommand {
@@ -325,7 +334,7 @@
           };
 
           tests-web-release = buildTestArchive {
-            name = "web-debug";
+            name = "web-release";
             target = "wasm32-unknown-unknown";
             args = "--release";
           };

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -113,10 +113,14 @@ let
     CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
   };
 
+  # wbg-pool is a native host binary (the wasm test runner); its dependency
+  # tree (mio, tokio net/process/signal, ...) does not build for wasm32, so
+  # keep it out of the wasm dependency build.
   wasmArtifacts = craneLib.buildDepsOnly (
     wasmAttributes
     // {
       pname = "dialog-db-workspace-wasm-deps";
+      cargoExtraArgs = "--workspace --exclude wbg-pool";
     }
   );
 
@@ -131,6 +135,16 @@ let
       }
       // attributes
     );
+
+  # The wasm test runner. A native workspace binary that nextest invokes once
+  # per test via the wasm32 target runner; it keeps one headless Chrome alive
+  # and hands each test a fresh origin. Built from the workspace source so it
+  # tracks the same wasm-bindgen pin as the crates under test.
+  wbg-pool = buildCrate {
+    pname = "wbg-pool";
+    cargoExtraArgs = "--locked -p wbg-pool";
+    doCheck = false;
+  };
 
   buildWasmCrate =
     attributes:
@@ -172,9 +186,15 @@ let
       target ? null,
     }:
     let
-      targetAttributes = if target == "wasm32-unknown-unknown" then wasmAttributes else commonAttributes;
+      isWasm = target == "wasm32-unknown-unknown";
 
-      targetArtifacts = if target == "wasm32-unknown-unknown" then wasmArtifacts else nativeArtifacts;
+      targetAttributes = if isWasm then wasmAttributes else commonAttributes;
+
+      targetArtifacts = if isWasm then wasmArtifacts else nativeArtifacts;
+
+      # wbg-pool is a native host binary and does not build for wasm32, so keep
+      # it out of the wasm test archive.
+      excludeArgs = if isWasm then "--workspace --exclude wbg-pool" else "";
     in
     craneLib.mkCargoDerivation (
       targetAttributes
@@ -184,6 +204,7 @@ let
 
         buildPhaseCargoCommand = ''
           cargo nextest archive \
+            ${excludeArgs} \
             ${args} \
             --archive-file ./tests-${name}.tar.zst
         '';
@@ -234,5 +255,6 @@ in
     rustToolchain
     cargoChecks
     wasm-bindgen-cli
+    wbg-pool
     ;
 }

--- a/rust/wbg-pool/.gitignore
+++ b/rust/wbg-pool/.gitignore
@@ -1,0 +1,2 @@
+/target
+fixtures/*/target

--- a/rust/wbg-pool/Cargo.toml
+++ b/rust/wbg-pool/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "wbg-pool"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Pooled-browser test runner for wasm-bindgen: one shared headless Chrome, a unique origin per test, nextest-compatible"
+repository = "https://github.com/dialog-db/dialog-db"
+keywords = ["wasm", "wasm-bindgen", "testing", "nextest", "headless"]
+categories = ["development-tools::testing", "wasm"]
+
+# The isolation fixture is a standalone wasm project used to exercise the runner
+# by hand; it declares its own workspace and is not built as part of dialog-db.
+exclude = ["fixtures"]
+
+# wasm-bindgen-cli-support must match the wasm-bindgen version used by the crates
+# under test, exactly like wasm-bindgen-test-runner does. The pin lives in the
+# workspace manifest and is bumped in lockstep with wasm-bindgen.
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+futures-util = { workspace = true }
+libc = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "net",
+  "process",
+  "io-util",
+  "time",
+  "sync",
+  "signal",
+  "fs",
+] }
+tokio-tungstenite = { workspace = true }
+ureq = { workspace = true }
+wasm-bindgen-cli-support = { workspace = true }
+wasmparser = { workspace = true }

--- a/rust/wbg-pool/LICENSE-APACHE
+++ b/rust/wbg-pool/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rust/wbg-pool/LICENSE-MIT
+++ b/rust/wbg-pool/LICENSE-MIT
@@ -1,0 +1,26 @@
+Copyright (c) 2026 the wbg-pool contributors
+Portions adapted from wasm-bindgen, Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rust/wbg-pool/README.md
+++ b/rust/wbg-pool/README.md
@@ -1,0 +1,151 @@
+# wbg-pool
+
+A pooled-browser test runner for [`wasm-bindgen-test`], drop-in compatible
+with `wasm-bindgen-test-runner` and designed for [`cargo nextest`]'s
+process-per-test execution model.
+
+`wasm-bindgen-test-runner` starts a fresh chromedriver + headless Chrome and
+re-runs `wasm-bindgen` codegen on **every invocation** — roughly six seconds
+of startup before a single test executes. That is fine when one invocation
+runs a whole test binary, but nextest invokes the runner **once per test**,
+so a 1,400-test suite pays that startup tax 1,400 times (we watched a CI
+suite spend 84 minutes running tests whose actual bodies finish in seconds).
+
+`wbg-pool` keeps one headless Chrome alive in a background daemon and turns
+each runner invocation into a **fresh tab on a fresh origin**:
+
+- **Fast**: tab creation instead of browser boot, codegen cached per
+  binary, and one shared compiled-wasm cache across all test origins
+  (assets are served from a single fixed origin with cache partitioning
+  disabled, plus lazy wasm compilation). Warm per-test overhead is ~0.15s
+  even for a 200MB debug binary. A 76-test suite that took 214s under the
+  stock runner + nextest takes ~12s; a 1,717-test workspace whose CI test
+  phase took 84 minutes finishes in ~10 (4 cores, debug builds), at which
+  point actual test bodies dominate the wall clock.
+- **Isolated**: every test runs on its own `t-<n>.localhost` origin, with
+  pristine IndexedDB, OPFS, localStorage, caches and service worker
+  registrations. This is *stronger* isolation than sharing a page (what
+  `cargo test` does for a whole binary) and equivalent in practice to the
+  stock runner's fresh-profile-per-run for storage-touching tests.
+- **nextest-native**: because per-test processes are cheap again, you keep
+  nextest's parallel scheduling, retries, per-test timings and partitioning.
+  Concurrent invocations are served as concurrent tabs.
+
+## Usage
+
+Install the binary, then point your wasm target runner at it:
+
+```toml
+# .cargo/config.toml
+[target.wasm32-unknown-unknown]
+runner = 'wbg-pool'
+```
+
+That's it. `cargo test --target wasm32-unknown-unknown` and
+`cargo nextest run --target wasm32-unknown-unknown` now run through the
+pool. The first invocation spawns the daemon (and its browser) on demand;
+the daemon exits on its own after five idle minutes. No workflow changes
+are required for `cargo nextest --archive-file` setups either — extract and
+run as usual with the runner configured.
+
+Supported test configurations:
+
+| `wasm_bindgen_test_configure!` | handling |
+| --- | --- |
+| `run_in_browser` | page main thread |
+| `run_in_dedicated_worker` / `run_in_worker` | module worker |
+| `run_in_shared_worker` | shared worker |
+| `run_in_service_worker` | service worker (concurrent suites work — each run's origin gets its own registration) |
+| node / emscripten modes | delegated to `wasm-bindgen-test-runner` |
+
+Benchmarks (`--bench`) and coverage dumps are not supported yet; benches
+should keep using the stock runner (the shim refuses rather than
+misbehaving).
+
+## How it works
+
+```
+cargo nextest ──spawns──▶ wbg-pool (shim, one per test)
+                             │  POST /api/run {binary, filter, --exact, ...}
+                             ▼
+                      wbg-pool daemon ──── owns one headless Chrome (CDP)
+                       │        │
+                       │        └─ tab @ http://t-42.localhost:PORT/r/42/
+                       │             └─ loads harness page → runs the test
+                       │                  └─ POSTs libtest output back
+                       └─ wasm-bindgen codegen, once per binary, cached
+```
+
+- The shim mirrors the stock runner's CLI. `--list` is answered locally by
+  parsing the wasm exports (`__wbgt_*`), no browser involved.
+- The daemon runs `wasm-bindgen` over a test binary the first time it is
+  seen (exactly the `Bindgen` configuration the stock runner uses) and
+  serves the output under a stable asset path.
+- Each run gets a unique loopback origin — Chrome resolves any
+  `*.localhost` subdomain to 127.0.0.1, and such origins are secure
+  contexts, so OPFS, service workers and friends all work.
+- Generated assets are served from one fixed origin
+  (`assets.localhost`, fingerprinted immutable paths, CORS +
+  `Cross-Origin-Resource-Policy` for COEP pages), and the browser is
+  launched with HTTP-cache/code-cache partitioning disabled and
+  `--wasm-lazy-compilation`, so all test origins share one fetch and one
+  compilation of each test module instead of recompiling per test.
+- The page (or worker harness) reports the libtest-formatted result back
+  over `fetch`; the shim prints it and exits with the appropriate status,
+  byte-compatible with the stock runner's output on both success and
+  failure. On timeout the daemon scrapes whatever output the wedged page
+  accumulated via CDP before closing the tab.
+
+## Configuration
+
+Everything is optional:
+
+| Environment variable | Meaning |
+| --- | --- |
+| `CHROME` / `WBG_POOL_BROWSER` | Browser binary (default: first of chromium / chromium-browser / google-chrome / … on PATH) |
+| `WBG_POOL_BROWSER_ARGS` | Extra whitespace-separated browser flags |
+| `WBG_POOL_NO_SANDBOX` | Add `--no-sandbox` (added automatically when running as root) |
+| `WBG_POOL_DIR` | Daemon rendezvous dir (default `$XDG_RUNTIME_DIR/wbg-pool` or `$TMPDIR/wbg-pool-<uid>`) |
+| `WBG_POOL_URL` | Use an already-running daemon at this URL, skip discovery/spawn |
+| `WBG_POOL_FALLBACK_RUNNER` | Path to `wasm-bindgen-test-runner` for delegated modes (default: from PATH) |
+| `WASM_BINDGEN_TEST_TIMEOUT` | Per-invocation timeout in seconds (default 20, same as stock) |
+| `WASM_BINDGEN_NO_DEBUG`, `WASM_BINDGEN_SPLIT_LINKED_MODULES`, `WASM_BINDGEN_KEEP_LLD_EXPORTS`, `WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION` | Honored with stock-runner semantics |
+
+Daemon management is automatic, but explicit control exists:
+
+```console
+$ wbg-pool daemon --idle-timeout 600   # run in the foreground
+$ wbg-pool daemon --stop               # stop a running daemon
+```
+
+## Version coupling
+
+Like `wasm-bindgen-test-runner` itself, the daemon's codegen must match the
+`wasm-bindgen` version of the crates under test. This build pins
+`wasm-bindgen-cli-support 0.2.126` (compatible with `wasm-bindgen-test
+0.3.76`). Use a wbg-pool build whose pin matches your `Cargo.lock`.
+
+## Known limitations
+
+- `--bench` and coverage collection are not implemented.
+- The nested-worker `console.*` forwarding shim that the stock runner
+  injects into user-spawned workers is not replicated; harness-captured
+  per-test output (including panics) is unaffected.
+- One daemon serves one `wasm-bindgen` version (see above).
+- Unix only for now (the daemon/shim rendezvous uses Unix process
+  primitives).
+
+## Attribution
+
+The in-page harness templates (`index.html`, the run/worker driver scripts)
+are adapted from the ones `wasm-bindgen-test-runner` generates, from the
+[wasm-bindgen] project (MIT OR Apache-2.0).
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
+[MIT license](LICENSE-MIT) at your option.
+
+[`wasm-bindgen-test`]: https://docs.rs/wasm-bindgen-test
+[`cargo nextest`]: https://nexte.st
+[wasm-bindgen]: https://github.com/wasm-bindgen/wasm-bindgen

--- a/rust/wbg-pool/fixtures/isolation-fixture/Cargo.toml
+++ b/rust/wbg-pool/fixtures/isolation-fixture/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "isolation-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "=0.2.126"
+js-sys = "0.3"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "=0.3.76"
+web-sys = { version = "0.3", features = ["Window", "Storage", "console"] }
+
+[workspace]

--- a/rust/wbg-pool/fixtures/isolation-fixture/src/lib.rs
+++ b/rust/wbg-pool/fixtures/isolation-fixture/src/lib.rs
@@ -1,0 +1,61 @@
+//! Fixture tests for wbg-pool. The two storage tests write the same
+//! localStorage key and assert it was absent beforehand: they can only both
+//! pass when each test runs on its own fresh origin, which is exactly the
+//! isolation wbg-pool provides. Under a shared origin (for example a whole
+//! binary executed in one page) the second test fails.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn storage() -> web_sys::Storage {
+    web_sys::window()
+        .expect("no window")
+        .local_storage()
+        .expect("localStorage errored")
+        .expect("no localStorage")
+}
+
+const KEY: &str = "wbg-pool-isolation-canary";
+
+#[wasm_bindgen_test]
+fn storage_isolation_first() {
+    let storage = storage();
+    assert!(
+        storage.get_item(KEY).unwrap().is_none(),
+        "state leaked in from another test: this test did not get a fresh origin"
+    );
+    storage.set_item(KEY, "first").unwrap();
+}
+
+#[wasm_bindgen_test]
+fn storage_isolation_second() {
+    let storage = storage();
+    assert!(
+        storage.get_item(KEY).unwrap().is_none(),
+        "state leaked in from another test: this test did not get a fresh origin"
+    );
+    storage.set_item(KEY, "second").unwrap();
+}
+
+#[wasm_bindgen_test]
+async fn async_tests_work() {
+    let value = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(&wasm_bindgen::JsValue::from(42)))
+        .await
+        .unwrap();
+    assert_eq!(value.as_f64(), Some(42.0));
+}
+
+#[wasm_bindgen_test]
+fn console_output_is_captured() {
+    web_sys::console::log_1(&"console output from a passing test".into());
+}
+
+#[wasm_bindgen_test]
+#[ignore]
+fn deliberately_fails() {
+    web_sys::console::log_1(&"console context before the failure".into());
+    panic!("this test exists to exercise the failure path");
+}

--- a/rust/wbg-pool/fixtures/isolation-fixture/tests/worker.rs
+++ b/rust/wbg-pool/fixtures/isolation-fixture/tests/worker.rs
@@ -1,0 +1,25 @@
+//! Exercises the dedicated-worker harness path (the page spawns a module
+//! worker, tests run inside it, output is relayed back to the page).
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+#[wasm_bindgen_test]
+fn runs_inside_a_worker() {
+    let global = js_sys::global();
+    assert!(
+        js_sys::Reflect::has(&global, &"WorkerGlobalScope".into()).unwrap_or(false),
+        "expected to be running inside a worker"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn async_worker_tests_work() {
+    let value = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(&wasm_bindgen::JsValue::from(7)))
+        .await
+        .unwrap();
+    assert_eq!(value.as_f64(), Some(7.0));
+}

--- a/rust/wbg-pool/src/cli.rs
+++ b/rust/wbg-pool/src/cli.rs
@@ -1,0 +1,64 @@
+//! Command line interface mirroring `wasm-bindgen-test-runner` so that
+//! `wbg-pool` can be used as a drop-in `target.wasm32-unknown-unknown.runner`.
+//! The flag set (and its filtering semantics in [`crate::suite`]) must stay
+//! byte-compatible with what libtest-style harnesses such as `cargo test`
+//! and `cargo nextest` pass to target runners.
+
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug, Clone)]
+#[command(name = "wbg-pool", version, about, long_about = None)]
+pub struct RunnerCli {
+    #[arg(
+        index = 1,
+        help = "The wasm test binary to run. `cargo test` passes this argument for you."
+    )]
+    pub file: PathBuf,
+    #[arg(long, help = "Run benchmarks")]
+    pub bench: bool,
+    #[arg(long, conflicts_with = "ignored", help = "Run ignored tests")]
+    pub include_ignored: bool,
+    #[arg(long, conflicts_with = "include_ignored", help = "Run ignored tests")]
+    pub ignored: bool,
+    #[arg(long, help = "Exactly match filters rather than by substring")]
+    pub exact: bool,
+    #[arg(
+        long,
+        value_name = "FILTER",
+        help = "Skip tests whose names contain FILTER (this flag can be used multiple times)"
+    )]
+    pub skip: Vec<String>,
+    #[arg(long, help = "List all tests and benchmarks")]
+    pub list: bool,
+    #[arg(
+        long,
+        help = "don't capture `console.*()` of each task, allow printing directly"
+    )]
+    pub nocapture: bool,
+    #[arg(
+        long,
+        value_name = "terse",
+        help = "Configure formatting of output (accepted for libtest compatibility)"
+    )]
+    pub format: Option<String>,
+    #[arg(
+        index = 2,
+        value_name = "FILTER",
+        help = "The FILTER string is tested against the name of all tests, and only those tests \
+                whose names contain the filter are run."
+    )]
+    pub filter: Option<String>,
+}
+
+impl RunnerCli {
+    pub fn filter_args(&self) -> crate::suite::FilterArgs {
+        crate::suite::FilterArgs {
+            filter: self.filter.clone(),
+            exact: self.exact,
+            skip: self.skip.clone(),
+            ignored: self.ignored,
+            include_ignored: self.include_ignored,
+        }
+    }
+}

--- a/rust/wbg-pool/src/daemon.rs
+++ b/rust/wbg-pool/src/daemon.rs
@@ -1,0 +1,221 @@
+//! The shared-browser daemon. It owns one headless Chrome instance and an
+//! HTTP server; every `/api/run` request becomes a fresh tab on a fresh
+//! `t-<id>.localhost` origin, which gives each test pristine origin-scoped
+//! storage without paying a browser launch.
+
+mod browser;
+mod codegen;
+mod harness;
+mod server;
+
+use crate::protocol::DaemonState;
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Codegen results keyed by (canonical path, fingerprint); the OnceCell
+/// coalesces concurrent requests for the same binary into one codegen run.
+pub type BinaryCache = tokio::sync::Mutex<
+    HashMap<(PathBuf, String), Arc<tokio::sync::OnceCell<Arc<codegen::Binary>>>>,
+>;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "wbg-pool daemon",
+    version,
+    about = "Shared-browser daemon for wbg-pool"
+)]
+struct DaemonCli {
+    /// Directory for the daemon state file (daemon.json) and log.
+    #[arg(long)]
+    state_dir: Option<PathBuf>,
+    /// Exit after this many seconds without any test activity.
+    #[arg(long, default_value = "300")]
+    idle_timeout: u64,
+    /// Stop a running daemon instead of starting one.
+    #[arg(long)]
+    stop: bool,
+}
+
+pub fn main(args: Vec<OsString>) -> Result<()> {
+    let cli = DaemonCli::parse_from(args);
+    let state_dir = cli.state_dir.clone().unwrap_or_else(default_state_dir);
+
+    if cli.stop {
+        return stop(&state_dir);
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(run(state_dir, cli.idle_timeout))
+}
+
+/// Where shims and the daemon rendezvous. Overridable with WBG_POOL_DIR.
+pub fn default_state_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("WBG_POOL_DIR") {
+        return PathBuf::from(dir);
+    }
+    if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
+        return PathBuf::from(dir).join("wbg-pool");
+    }
+    let uid = unsafe { libc::geteuid() };
+    std::env::temp_dir().join(format!("wbg-pool-{uid}"))
+}
+
+fn stop(state_dir: &Path) -> Result<()> {
+    let state_path = state_dir.join("daemon.json");
+    let raw = match std::fs::read_to_string(&state_path) {
+        Ok(raw) => raw,
+        Err(_) => {
+            println!("no running daemon found at {}", state_path.display());
+            return Ok(());
+        }
+    };
+    let state: DaemonState = serde_json::from_str(&raw)?;
+    match ureq::post(&format!("{}/api/shutdown", state.url))
+        .timeout(Duration::from_secs(5))
+        .call()
+    {
+        Ok(_) => println!("stopped daemon at {}", state.url),
+        Err(error) => println!(
+            "daemon at {} did not respond ({error}); removing state file",
+            state.url
+        ),
+    }
+    let _ = std::fs::remove_file(&state_path);
+    Ok(())
+}
+
+pub struct Daemon {
+    pub port: u16,
+    pub state_dir: PathBuf,
+    pub work_dir: PathBuf,
+    pub browser: browser::BrowserPool,
+    pub binaries: BinaryCache,
+    pub runs: Mutex<HashMap<u64, server::RunSlot>>,
+    pub run_counter: AtomicU64,
+    pub active: AtomicUsize,
+    pub last_activity: Mutex<Instant>,
+}
+
+impl Daemon {
+    pub fn touch(&self) {
+        *self.last_activity.lock().unwrap() = Instant::now();
+    }
+}
+
+async fn run(state_dir: PathBuf, idle_timeout: u64) -> Result<()> {
+    std::fs::create_dir_all(&state_dir)
+        .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
+
+    sweep_stale_work_dirs(&state_dir);
+    let work_dir = state_dir.join(format!("work-{}", std::process::id()));
+    std::fs::create_dir_all(&work_dir)?;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    let daemon = std::sync::Arc::new(Daemon {
+        port,
+        state_dir: state_dir.clone(),
+        work_dir: work_dir.clone(),
+        browser: browser::BrowserPool::new(work_dir.join("browser-profile")),
+        binaries: tokio::sync::Mutex::new(HashMap::new()),
+        runs: Mutex::new(HashMap::new()),
+        run_counter: AtomicU64::new(1),
+        active: AtomicUsize::new(0),
+        last_activity: Mutex::new(Instant::now()),
+    });
+
+    write_state_file(&state_dir, port)?;
+    println!("wbg-pool daemon listening on http://127.0.0.1:{port}");
+
+    let app = server::router(daemon.clone());
+
+    let idle_daemon = daemon.clone();
+    tokio::spawn(async move {
+        let idle = Duration::from_secs(idle_timeout);
+        loop {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            let active = idle_daemon.active.load(Ordering::SeqCst);
+            let last = *idle_daemon.last_activity.lock().unwrap();
+            if active == 0 && last.elapsed() > idle {
+                println!("idle for {idle_timeout}s, shutting down");
+                shutdown(&idle_daemon).await;
+            }
+        }
+    });
+
+    let signal_daemon = daemon.clone();
+    tokio::spawn(async move {
+        let mut term = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+        shutdown(&signal_daemon).await;
+    });
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+pub async fn shutdown(daemon: &Daemon) -> ! {
+    daemon.browser.kill().await;
+    remove_state_file_if_ours(&daemon.state_dir);
+    let _ = std::fs::remove_dir_all(&daemon.work_dir);
+    std::process::exit(0)
+}
+
+/// Removes work directories left behind by daemons that exited uncleanly
+/// (their pid no longer exists).
+fn sweep_stale_work_dirs(state_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(state_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name
+            .to_str()
+            .and_then(|name| name.strip_prefix("work-"))
+            .and_then(|pid| pid.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid != std::process::id() && !std::path::Path::new(&format!("/proc/{pid}")).exists() {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+fn write_state_file(state_dir: &Path, port: u16) -> Result<()> {
+    let state = DaemonState {
+        url: format!("http://127.0.0.1:{port}"),
+        pid: std::process::id(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let path = state_dir.join("daemon.json");
+    let tmp = state_dir.join(format!("daemon.json.{}", std::process::id()));
+    std::fs::write(&tmp, serde_json::to_vec_pretty(&state)?)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn remove_state_file_if_ours(state_dir: &Path) {
+    let path = state_dir.join("daemon.json");
+    let ours = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<DaemonState>(&raw).ok())
+        .map(|state| state.pid == std::process::id())
+        .unwrap_or(false);
+    if ours {
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/rust/wbg-pool/src/daemon/browser.rs
+++ b/rust/wbg-pool/src/daemon/browser.rs
@@ -1,0 +1,365 @@
+//! Headless Chrome ownership and a minimal Chrome DevTools Protocol client.
+//! Only three CDP operations are needed: create a tab, close a tab, and (on
+//! timeout) scrape the harness output out of a wedged page.
+
+use anyhow::{anyhow, bail, Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::AsyncBufReadExt;
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+pub struct BrowserPool {
+    profile_dir: PathBuf,
+    inner: Mutex<Option<Browser>>,
+}
+
+impl BrowserPool {
+    pub fn new(profile_dir: PathBuf) -> Self {
+        BrowserPool {
+            profile_dir,
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Opens a tab at `url`, relaunching the browser once if the previous
+    /// instance died.
+    pub async fn create_tab(&self, url: &str) -> Result<String> {
+        let mut inner = self.inner.lock().await;
+        for attempt in 0..2 {
+            if inner.is_none() {
+                *inner = Some(Browser::launch(&self.profile_dir).await?);
+            }
+            let browser = inner.as_ref().unwrap();
+            match browser
+                .cdp
+                .call("Target.createTarget", json!({ "url": url }), None)
+                .await
+            {
+                Ok(result) => {
+                    let target_id = result
+                        .get("targetId")
+                        .and_then(Value::as_str)
+                        .context("Target.createTarget returned no targetId")?;
+                    return Ok(target_id.to_string());
+                }
+                Err(error) if attempt == 0 && !browser.cdp.is_alive() => {
+                    let _ = error;
+                    if let Some(mut browser) = inner.take() {
+                        browser.kill().await;
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        bail!("failed to create a browser tab after relaunching the browser")
+    }
+
+    pub async fn close_tab(&self, target_id: &str) {
+        let inner = self.inner.lock().await;
+        if let Some(browser) = inner.as_ref() {
+            let _ = browser
+                .cdp
+                .call("Target.closeTarget", json!({ "targetId": target_id }), None)
+                .await;
+        }
+    }
+
+    /// Reads `#output` / `#console_output` from a page that never reported,
+    /// so a timed-out test still surfaces whatever the harness printed.
+    pub async fn scrape_output(&self, target_id: &str) -> Result<(String, String)> {
+        let inner = self.inner.lock().await;
+        let browser = inner.as_ref().context("browser is not running")?;
+        let session = browser
+            .cdp
+            .call(
+                "Target.attachToTarget",
+                json!({ "targetId": target_id, "flatten": true }),
+                None,
+            )
+            .await?;
+        let session_id = session
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .context("Target.attachToTarget returned no sessionId")?
+            .to_string();
+
+        let expression = "JSON.stringify({\
+             output: (document.getElementById('output') || {}).textContent || '',\
+             console_output: (document.getElementById('console_output') || {}).textContent || ''\
+         })";
+        let evaluated = browser
+            .cdp
+            .call(
+                "Runtime.evaluate",
+                json!({ "expression": expression, "returnByValue": true }),
+                Some(&session_id),
+            )
+            .await?;
+        let raw = evaluated
+            .pointer("/result/value")
+            .and_then(Value::as_str)
+            .context("Runtime.evaluate returned no value")?;
+        let parsed: Value = serde_json::from_str(raw)?;
+        let output = parsed
+            .get("output")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let console_output = parsed
+            .get("console_output")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        Ok((output, console_output))
+    }
+
+    pub async fn kill(&self) {
+        let mut inner = self.inner.lock().await;
+        if let Some(mut browser) = inner.take() {
+            browser.kill().await;
+        }
+    }
+}
+
+struct Browser {
+    child: tokio::process::Child,
+    cdp: CdpClient,
+}
+
+impl Browser {
+    async fn launch(profile_dir: &PathBuf) -> Result<Browser> {
+        let binary = find_browser()?;
+        std::fs::create_dir_all(profile_dir)?;
+
+        let mut command = tokio::process::Command::new(&binary);
+        command
+            .arg("--headless")
+            .arg("--remote-debugging-port=0")
+            .arg(format!("--user-data-dir={}", profile_dir.display()))
+            .arg("--no-first-run")
+            .arg("--no-default-browser-check")
+            .arg("--disable-background-networking")
+            .arg("--disable-gpu")
+            .arg("--disable-dev-shm-usage")
+            // Every run lives on its own origin, which would normally give
+            // each test its own partition of the HTTP cache and compiled-code
+            // cache and force the wasm module to be refetched and recompiled
+            // per test. Assets are served from one fixed origin
+            // (assets.localhost), and these flags let all test origins share
+            // its cache entries. Site-isolation origin locks also key the
+            // compiled-code cache, hence the last flag; test code is trusted,
+            // so relaxing cross-tab process isolation is an acceptable trade.
+            .arg("--disable-features=SplitCacheByNetworkIsolationKey,SplitCodeCacheByNetworkIsolationKey,SplitHttpCacheByNetworkIsolationKey")
+            .arg("--disable-site-isolation-trials")
+            // Only compile the wasm functions a test actually calls; a
+            // single test typically touches a small fraction of a large
+            // debug-build module.
+            .arg("--js-flags=--wasm-lazy-compilation");
+
+        let is_root = unsafe { libc::geteuid() } == 0;
+        if is_root || std::env::var_os("WBG_POOL_NO_SANDBOX").is_some() {
+            command.arg("--no-sandbox");
+        }
+        if let Ok(extra) = std::env::var("WBG_POOL_BROWSER_ARGS") {
+            for arg in extra.split_whitespace() {
+                command.arg(arg);
+            }
+        }
+        command.arg("about:blank");
+
+        command
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = command
+            .spawn()
+            .with_context(|| format!("failed to launch browser {}", binary.display()))?;
+
+        let stderr = child.stderr.take().context("browser stderr not piped")?;
+        let mut lines = tokio::io::BufReader::new(stderr).lines();
+        // Keep the browser's own diagnostics so a failed launch reports why
+        // Chrome exited (a missing library, a sandbox it could not enter, ...)
+        // instead of just "exited before printing its DevTools address".
+        let mut log = String::new();
+        let ws_url = tokio::time::timeout(Duration::from_secs(30), async {
+            while let Some(line) = lines.next_line().await? {
+                if let Some(index) = line.find("DevTools listening on ") {
+                    return Ok::<_, anyhow::Error>(
+                        line[index + "DevTools listening on ".len()..]
+                            .trim()
+                            .to_string(),
+                    );
+                }
+                log.push_str(&line);
+                log.push('\n');
+            }
+            let detail = log.trim_end();
+            if detail.is_empty() {
+                bail!("browser exited before printing its DevTools address")
+            }
+            bail!("browser exited before printing its DevTools address:\n{detail}")
+        })
+        .await
+        .context("timed out waiting for the browser DevTools address")??;
+
+        // Keep draining stderr so the browser never blocks on a full pipe.
+        tokio::spawn(async move { while lines.next_line().await.ok().flatten().is_some() {} });
+
+        let cdp = CdpClient::connect(&ws_url).await?;
+        Ok(Browser { child, cdp })
+    }
+
+    async fn kill(&mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
+fn find_browser() -> Result<PathBuf> {
+    for var in ["WBG_POOL_BROWSER", "CHROME"] {
+        if let Ok(path) = std::env::var(var) {
+            if !path.is_empty() {
+                return Ok(PathBuf::from(path));
+            }
+        }
+    }
+    let candidates = [
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+        "chrome",
+        "headless_shell",
+    ];
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
+    for dir in std::env::split_paths(&path_var) {
+        for candidate in candidates {
+            let full = dir.join(candidate);
+            if full.is_file() {
+                return Ok(full);
+            }
+        }
+    }
+    bail!(
+        "no Chrome/Chromium binary found; set WBG_POOL_BROWSER or CHROME, \
+         or put chromium/google-chrome on PATH"
+    )
+}
+
+#[derive(Clone)]
+struct CdpClient {
+    tx: mpsc::Sender<CdpCall>,
+    alive: Arc<AtomicBool>,
+    next_id: Arc<AtomicU64>,
+}
+
+struct CdpCall {
+    id: u64,
+    method: String,
+    params: Value,
+    session_id: Option<String>,
+    reply: oneshot::Sender<Result<Value>>,
+}
+
+impl CdpClient {
+    async fn connect(ws_url: &str) -> Result<CdpClient> {
+        let (stream, _) = tokio_tungstenite::connect_async(ws_url)
+            .await
+            .with_context(|| format!("failed to connect to DevTools at {ws_url}"))?;
+        let (mut sink, mut source) = stream.split();
+
+        let (tx, mut rx) = mpsc::channel::<CdpCall>(64);
+        let alive = Arc::new(AtomicBool::new(true));
+
+        let task_alive = alive.clone();
+        tokio::spawn(async move {
+            let mut pending: HashMap<u64, oneshot::Sender<Result<Value>>> = HashMap::new();
+            loop {
+                tokio::select! {
+                    call = rx.recv() => {
+                        let Some(call) = call else { break };
+                        if !task_alive.load(Ordering::SeqCst) {
+                            let _ = call.reply.send(Err(anyhow!("browser connection lost")));
+                            continue;
+                        }
+                        let mut message = json!({
+                            "id": call.id,
+                            "method": call.method,
+                            "params": call.params,
+                        });
+                        if let Some(session_id) = &call.session_id {
+                            message["sessionId"] = json!(session_id);
+                        }
+                        match sink.send(tokio_tungstenite::tungstenite::Message::text(message.to_string())).await {
+                            Ok(()) => { pending.insert(call.id, call.reply); }
+                            Err(error) => {
+                                task_alive.store(false, Ordering::SeqCst);
+                                let _ = call.reply.send(Err(anyhow!("browser connection lost: {error}")));
+                            }
+                        }
+                    }
+                    incoming = source.next() => {
+                        let text = match incoming {
+                            Some(Ok(message)) => match message.into_text() {
+                                Ok(text) => text,
+                                Err(_) => continue,
+                            },
+                            _ => {
+                                task_alive.store(false, Ordering::SeqCst);
+                                for (_, reply) in pending.drain() {
+                                    let _ = reply.send(Err(anyhow!("browser connection lost")));
+                                }
+                                continue;
+                            }
+                        };
+                        let Ok(value) = serde_json::from_str::<Value>(text.as_str()) else { continue };
+                        let Some(id) = value.get("id").and_then(Value::as_u64) else { continue };
+                        if let Some(reply) = pending.remove(&id) {
+                            let result = if let Some(error) = value.get("error") {
+                                Err(anyhow!("CDP error: {error}"))
+                            } else {
+                                Ok(value.get("result").cloned().unwrap_or(Value::Null))
+                            };
+                            let _ = reply.send(result);
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(CdpClient {
+            tx,
+            alive,
+            next_id: Arc::new(AtomicU64::new(1)),
+        })
+    }
+
+    fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+
+    async fn call(&self, method: &str, params: Value, session_id: Option<&str>) -> Result<Value> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let call = CdpCall {
+            id: self.next_id.fetch_add(1, Ordering::SeqCst),
+            method: method.to_string(),
+            params,
+            session_id: session_id.map(str::to_string),
+            reply: reply_tx,
+        };
+        self.tx
+            .send(call)
+            .await
+            .map_err(|_| anyhow!("browser connection lost"))?;
+        tokio::time::timeout(Duration::from_secs(30), reply_rx)
+            .await
+            .context("timed out waiting for the browser to answer a CDP call")?
+            .map_err(|_| anyhow!("browser connection lost"))?
+    }
+}

--- a/rust/wbg-pool/src/daemon/codegen.rs
+++ b/rust/wbg-pool/src/daemon/codegen.rs
@@ -1,0 +1,70 @@
+//! Per-binary `wasm-bindgen` code generation, done once per test binary and
+//! cached for the daemon's lifetime. This is the work `wasm-bindgen-test-runner`
+//! repeats on every invocation.
+
+use crate::suite::{self, Suite};
+use anyhow::{Context, Result};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+/// Stable module name for generated assets, so every binary serves
+/// `wbg-test.js` + `wbg-test_bg.wasm` under its own `/a/<id>/` prefix.
+pub const MODULE_NAME: &str = "wbg-test";
+
+pub struct Binary {
+    /// Cache key derived from path + mtime + size; also the asset URL prefix
+    /// under which this binary's generated files are served.
+    pub id: String,
+    pub suite: Suite,
+}
+
+/// Fingerprints a binary so a recompiled test binary at the same path gets
+/// fresh codegen.
+pub fn fingerprint(path: &Path) -> Result<String> {
+    let metadata =
+        std::fs::metadata(path).with_context(|| format!("failed to stat {}", path.display()))?;
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    metadata.len().hash(&mut hasher);
+    if let Ok(modified) = metadata.modified() {
+        modified.hash(&mut hasher);
+    }
+    Ok(format!("{:016x}", hasher.finish()))
+}
+
+/// Runs wasm-bindgen over the test binary, mirroring the Bindgen
+/// configuration of `wasm-bindgen-test-runner` 0.2.126 (browser mode).
+pub fn generate(wasm_path: &Path, out_dir: &Path) -> Result<Binary> {
+    let bytes = std::fs::read(wasm_path)
+        .with_context(|| format!("failed to read wasm file {}", wasm_path.display()))?;
+    let suite = suite::inspect(&bytes)?;
+
+    let id = fingerprint(wasm_path)?;
+    let dir = out_dir.join(&id);
+    std::fs::create_dir_all(&dir)?;
+
+    // The debug flag adds assertions and error messages to the generated JS
+    // glue; it has nothing to do with the Rust profile.
+    let debug = std::env::var("WASM_BINDGEN_NO_DEBUG").is_err();
+
+    let mut bindgen = wasm_bindgen_cli_support::Bindgen::new();
+    bindgen
+        .web(true)
+        .map_err(|error| anyhow::anyhow!(error))?
+        .debug(debug)
+        .input_path(wasm_path)
+        .out_name(MODULE_NAME)
+        .emit_start(false);
+    if std::env::var("WASM_BINDGEN_SPLIT_LINKED_MODULES").is_ok() {
+        bindgen.split_linked_modules(true);
+    }
+    if std::env::var("WASM_BINDGEN_KEEP_LLD_EXPORTS").is_ok() {
+        bindgen.keep_lld_exports(true);
+    }
+    bindgen
+        .generate(&dir)
+        .with_context(|| format!("wasm-bindgen failed over {}", wasm_path.display()))?;
+
+    Ok(Binary { id, suite })
+}

--- a/rust/wbg-pool/src/daemon/harness.rs
+++ b/rust/wbg-pool/src/daemon/harness.rs
@@ -1,0 +1,127 @@
+//! Per-run generation of the JS that drives a test suite inside the shared
+//! browser. Browser-mode suites run on the page's main thread; worker-mode
+//! suites get a page-side relay plus a worker-side harness script.
+
+use crate::suite::TestMode;
+use anyhow::Result;
+
+const RUN_BROWSER: &str = include_str!("js/run-browser.js");
+const RUN_WORKER_PAGE: &str = include_str!("js/run-worker-page.js");
+const WORKER_BODY: &str = include_str!("js/worker-body.js");
+
+const SPAWN_DEDICATED: &str = r#"
+    const worker = new Worker('worker.js', { type: 'module' });
+    worker.onerror = event => report(false, event.message || 'worker error');
+    port = worker;
+"#;
+
+const SPAWN_SHARED: &str = r#"
+    const worker = new SharedWorker('worker.js?random=' + crypto.randomUUID(), { type: 'module' });
+    worker.onerror = event => report(false, event.message || 'shared worker error');
+    port = worker.port;
+"#;
+
+// Each run lives on its own origin, so concurrent service worker suites
+// cannot collide on a registration the way they do under the stock runner.
+const SPAWN_SERVICE: &str = r#"
+    const url = 'service.js?random=' + crypto.randomUUID();
+    const registration = await navigator.serviceWorker.register(url, { type: 'module' });
+    if (registration.installing) {
+        registration.installing.addEventListener('statechange', function () {
+            if (this.state === 'redundant') {
+                report(false, 'service worker installation failed');
+            }
+        });
+    }
+    await new Promise(resolve => {
+        navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
+    });
+    const channel = new MessageChannel();
+    navigator.serviceWorker.controller.postMessage(undefined, [channel.port2]);
+    port = channel.port1;
+"#;
+
+const PROLOGUE_DEDICATED: &str = "setup(self);\n";
+
+const PROLOGUE_SHARED: &str = r#"
+addEventListener('connect', event => {
+    setup(event.ports[0]);
+});
+"#;
+
+const PROLOGUE_SERVICE: &str = r#"
+addEventListener('install', () => skipWaiting());
+addEventListener('activate', event => event.waitUntil(clients.claim()));
+addEventListener('message', event => {
+    setup(event.ports[0]);
+});
+"#;
+
+pub struct RunScripts {
+    /// Served as `/r/<id>/run.js`, loaded by the page.
+    pub run_js: String,
+    /// Served as `/r/<id>/worker.js` and `/r/<id>/service.js` for
+    /// worker-mode suites.
+    pub worker_js: Option<String>,
+}
+
+pub struct RunConfig<'a> {
+    pub mode: TestMode,
+    pub module_js: &'a str,
+    pub module_wasm: &'a str,
+    pub exports: &'a [&'a str],
+    pub include_ignored: bool,
+    pub filtered_count: usize,
+    pub nocapture: bool,
+}
+
+pub fn generate(config: &RunConfig<'_>) -> Result<RunScripts> {
+    let tests_json = serde_json::to_string(config.exports)?;
+    let include_ignored = if config.include_ignored {
+        "true"
+    } else {
+        "false"
+    };
+    let nocapture = if config.nocapture { "true" } else { "false" };
+    let filtered = config.filtered_count.to_string();
+
+    let scripts = match config.mode {
+        TestMode::Browser => RunScripts {
+            run_js: RUN_BROWSER
+                .replace("{MODULE_JS}", config.module_js)
+                .replace("{MODULE_WASM}", config.module_wasm)
+                .replace("{INCLUDE_IGNORED}", include_ignored)
+                .replace("{FILTERED_COUNT}", &filtered)
+                .replace("{TESTS}", &tests_json),
+            worker_js: None,
+        },
+        TestMode::DedicatedWorker | TestMode::SharedWorker | TestMode::ServiceWorker => {
+            let (spawn, prologue) = match config.mode {
+                TestMode::DedicatedWorker => (SPAWN_DEDICATED, PROLOGUE_DEDICATED),
+                TestMode::SharedWorker => (SPAWN_SHARED, PROLOGUE_SHARED),
+                _ => (SPAWN_SERVICE, PROLOGUE_SERVICE),
+            };
+            RunScripts {
+                run_js: RUN_WORKER_PAGE
+                    .replace("{SPAWN}", spawn)
+                    .replace("{TESTS}", &tests_json),
+                worker_js: Some(
+                    WORKER_BODY
+                        .replace("{MODULE_JS}", config.module_js)
+                        .replace("{MODULE_WASM}", config.module_wasm)
+                        .replace("{INCLUDE_IGNORED}", include_ignored)
+                        .replace("{FILTERED_COUNT}", &filtered)
+                        .replace("{NOCAPTURE}", nocapture)
+                        .replace("{PORT_PROLOGUE}", prologue),
+                ),
+            }
+        }
+        TestMode::Node | TestMode::Emscripten => {
+            anyhow::bail!(
+                "wbg-pool cannot run {} tests in a browser",
+                config.mode.describe()
+            )
+        }
+    };
+    Ok(scripts)
+}

--- a/rust/wbg-pool/src/daemon/index.html
+++ b/rust/wbg-pool/src/daemon/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<!-- Adapted from wasm-bindgen-test-runner's index-headless.html
+     (wasm-bindgen project, MIT/Apache-2.0). The console wrapping and the
+     #output / #console_output elements are the contract the in-wasm
+     wasm-bindgen-test harness expects to find on the page. -->
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+  </head>
+  <body>
+    <pre id="output" style="display:none">Loading scripts...</pre>
+    <pre id="console_output" style="display:none"></pre>
+    <script>
+     const nocapture = /* {NOCAPTURE} */ false;
+
+     const orig = id => (...args) => {
+         const logs = document.getElementById(id);
+         for (const msg of args) {
+             logs.appendChild(document.createTextNode(String(msg) + "\n"));
+         }
+     };
+
+     const wrap = method => {
+         const on_method = `on_console_${method}`;
+         console[method] = function (...args) {
+             if (nocapture) {
+                 orig("output").apply(this, args);
+             } else {
+                 orig("console_output").apply(this, args);
+             }
+             if (window[on_method]) {
+                 window[on_method](args);
+             }
+         };
+     };
+
+     wrap("debug");
+     wrap("log");
+     wrap("info");
+     wrap("warn");
+     wrap("error");
+
+     window.__wbg_test_invoke = f => f();
+    </script>
+    <script src="run.js" type="module"></script>
+  </body>
+</html>

--- a/rust/wbg-pool/src/daemon/js/run-browser.js
+++ b/rust/wbg-pool/src/daemon/js/run-browser.js
@@ -1,0 +1,82 @@
+// Test driver template, adapted from the run.js that
+// wasm-bindgen-test-runner generates (wasm-bindgen project,
+// MIT/Apache-2.0). The daemon substitutes the {UPPERCASE} placeholders per
+// run. Unlike the original, this page reports its result back to the daemon
+// over fetch instead of being scraped over WebDriver.
+
+import {
+    WasmBindgenTestContext as Context,
+    __wbgtest_console_debug,
+    __wbgtest_console_log,
+    __wbgtest_console_info,
+    __wbgtest_console_warn,
+    __wbgtest_console_error,
+    __wbgtest_cov_dump,
+    __wbgtest_module_signature,
+    default as init,
+} from '{MODULE_JS}';
+
+function grab(id) {
+    const element = document.getElementById(id);
+    return element ? element.textContent : '';
+}
+
+let reported = false;
+async function report(ok, error) {
+    if (reported) {
+        return;
+    }
+    reported = true;
+    let output = grab('output');
+    if (error !== undefined) {
+        const detail = error && error.stack ? error.stack : String(error);
+        output += '\nharness error: ' + detail + '\n';
+    }
+    await fetch('report', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            ok: !!ok,
+            output,
+            console_output: grab('console_output'),
+        }),
+    });
+}
+
+async function dumpCoverage() {
+    try {
+        const coverage = __wbgtest_cov_dump();
+        if (coverage !== undefined) {
+            await fetch('/__wasm_bindgen/coverage', {
+                method: 'POST',
+                headers: { 'Module-Signature': String(__wbgtest_module_signature()) },
+                body: coverage,
+            });
+        }
+    } catch (error) {
+        console.warn('coverage dump failed: ' + error);
+    }
+}
+
+async function main() {
+    document.getElementById('output').textContent = 'Loading Wasm module...\n';
+
+    const wasm = await init({ module_or_path: '{MODULE_WASM}' });
+
+    const cx = new Context(false);
+    window.on_console_debug = __wbgtest_console_debug;
+    window.on_console_log = __wbgtest_console_log;
+    window.on_console_info = __wbgtest_console_info;
+    window.on_console_warn = __wbgtest_console_warn;
+    window.on_console_error = __wbgtest_console_error;
+
+    cx.include_ignored({INCLUDE_IGNORED});
+    cx.filtered_count({FILTERED_COUNT});
+
+    const tests = {TESTS};
+    const ok = await cx.run(tests.map(name => wasm[name]));
+    await dumpCoverage();
+    return ok;
+}
+
+main().then(ok => report(ok)).catch(error => report(false, error));

--- a/rust/wbg-pool/src/daemon/js/run-worker-page.js
+++ b/rust/wbg-pool/src/daemon/js/run-worker-page.js
@@ -1,0 +1,62 @@
+// Page-side driver for worker-mode test suites (dedicated worker, shared
+// worker, service worker). The page spawns the worker, sends it the test
+// list, relays harness output into #output, and reports the final verdict
+// back to the daemon. Adapted from the run.js that
+// wasm-bindgen-test-runner generates (wasm-bindgen project, MIT/Apache-2.0).
+
+function grab(id) {
+    const element = document.getElementById(id);
+    return element ? element.textContent : '';
+}
+
+let reported = false;
+async function report(ok, error) {
+    if (reported) {
+        return;
+    }
+    reported = true;
+    let output = grab('output');
+    if (error !== undefined) {
+        const detail = error && error.stack ? error.stack : String(error);
+        output += '\nharness error: ' + detail + '\n';
+    }
+    await fetch('report', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            ok: !!ok,
+            output,
+            console_output: grab('console_output'),
+        }),
+    });
+}
+
+function handleHarnessMessage(event) {
+    const data = event.data;
+    if (!data || !Array.isArray(data) || typeof data[0] !== 'string'
+        || !data[0].startsWith('__wbgtest_')) {
+        return;
+    }
+    const method = data[0].slice(10);
+    const args = data.slice(1);
+    if (method === 'output_append') {
+        document.getElementById('output').textContent += args[0];
+    } else if (method === 'done') {
+        report(args[0]);
+    }
+}
+
+async function main() {
+    document.getElementById('output').textContent = 'Loading Wasm module...\n';
+
+    let port;
+    {SPAWN}
+
+    port.addEventListener('message', handleHarnessMessage);
+    if (port.start) {
+        port.start();
+    }
+    port.postMessage({TESTS});
+}
+
+main().catch(error => report(false, error));

--- a/rust/wbg-pool/src/daemon/js/worker-body.js
+++ b/rust/wbg-pool/src/daemon/js/worker-body.js
@@ -1,0 +1,90 @@
+// Worker-side harness for worker-mode test suites, executed as a module
+// inside a dedicated worker, shared worker, or service worker. Adapted from
+// the worker.js that wasm-bindgen-test-runner generates (wasm-bindgen
+// project, MIT/Apache-2.0), with one addition: an explicit
+// `__wbgtest_done` message once the harness finishes, so the page does not
+// need to scrape output to detect completion.
+
+import {
+    WasmBindgenTestContext as Context,
+    __wbgtest_console_debug,
+    __wbgtest_console_log,
+    __wbgtest_console_info,
+    __wbgtest_console_warn,
+    __wbgtest_console_error,
+    __wbgtest_cov_dump,
+    __wbgtest_module_signature,
+    default as init,
+} from '{MODULE_JS}';
+
+const nocapture = {NOCAPTURE};
+
+function setup(port) {
+    self.__wbg_test_invoke = f => f();
+    self.__wbg_test_output_writeln = function (...args) {
+        port.postMessage(['__wbgtest_output_append', args.map(String).join(' ') + '\n']);
+    };
+
+    const wrap = method => {
+        const on_method = `on_console_${method}`;
+        self.console[method] = function (...args) {
+            if (nocapture) {
+                self.__wbg_test_output_writeln(...args);
+            }
+            if (self[on_method]) {
+                self[on_method](args);
+            }
+        };
+    };
+    wrap('debug');
+    wrap('log');
+    wrap('info');
+    wrap('warn');
+    wrap('error');
+
+    port.onmessage = event => {
+        runTests(port, event.data);
+    };
+    if (port.start) {
+        port.start();
+    }
+}
+
+async function runTests(port, tests) {
+    try {
+        const wasm = await init({ module_or_path: '{MODULE_WASM}' });
+
+        const cx = new Context(false);
+        self.on_console_debug = __wbgtest_console_debug;
+        self.on_console_log = __wbgtest_console_log;
+        self.on_console_info = __wbgtest_console_info;
+        self.on_console_warn = __wbgtest_console_warn;
+        self.on_console_error = __wbgtest_console_error;
+
+        cx.include_ignored({INCLUDE_IGNORED});
+        cx.filtered_count({FILTERED_COUNT});
+
+        const ok = await cx.run(tests.map(name => wasm[name]));
+
+        try {
+            const coverage = __wbgtest_cov_dump();
+            if (coverage !== undefined) {
+                await fetch('/__wasm_bindgen/coverage', {
+                    method: 'POST',
+                    headers: { 'Module-Signature': String(__wbgtest_module_signature()) },
+                    body: coverage,
+                });
+            }
+        } catch (error) {
+            console.warn('coverage dump failed: ' + error);
+        }
+
+        port.postMessage(['__wbgtest_done', !!ok]);
+    } catch (error) {
+        const detail = error && error.stack ? error.stack : String(error);
+        port.postMessage(['__wbgtest_output_append', '\nharness error: ' + detail + '\n']);
+        port.postMessage(['__wbgtest_done', false]);
+    }
+}
+
+{PORT_PROLOGUE}

--- a/rust/wbg-pool/src/daemon/server.rs
+++ b/rust/wbg-pool/src/daemon/server.rs
@@ -1,0 +1,347 @@
+//! HTTP surface of the daemon: the control API used by runner shims, plus
+//! the per-run pages and per-binary assets served to the browser.
+
+use super::{codegen, harness, Daemon};
+use crate::protocol::{RunReport, RunRequest};
+use crate::suite::{self, TestMode};
+use anyhow::{Context, Result};
+use axum::extract::{DefaultBodyLimit, Path, State};
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::oneshot;
+
+const INDEX_TEMPLATE: &str = include_str!("index.html");
+
+pub struct RunSlot {
+    pub index_html: String,
+    pub run_js: String,
+    pub worker_js: Option<String>,
+    pub report_tx: Option<oneshot::Sender<PageReport>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PageReport {
+    pub ok: bool,
+    #[serde(default)]
+    pub output: String,
+    #[serde(default)]
+    pub console_output: String,
+}
+
+pub fn router(daemon: Arc<Daemon>) -> Router {
+    Router::new()
+        .route("/api/health", get(health))
+        .route("/api/run", post(run))
+        .route("/api/shutdown", post(shutdown))
+        .route("/r/{run_id}/", get(run_index))
+        .route("/r/{run_id}/run.js", get(run_js))
+        .route("/r/{run_id}/worker.js", get(run_worker_js))
+        .route("/r/{run_id}/service.js", get(run_worker_js))
+        .route("/r/{run_id}/report", post(run_report))
+        .route("/__wasm_bindgen/coverage", post(coverage))
+        .route("/a/{binary_id}/{*path}", get(asset))
+        .layer(DefaultBodyLimit::max(256 * 1024 * 1024))
+        .layer(axum::middleware::map_response(isolate_origin_headers))
+        .with_state(daemon)
+}
+
+/// COOP/COEP headers matching wasm-bindgen-test-runner's defaults, required
+/// for tests that use SharedArrayBuffer and friends. Opt out with
+/// WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION, same as the stock runner.
+async fn isolate_origin_headers(mut response: Response) -> Response {
+    if std::env::var_os("WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION").is_none() {
+        response.headers_mut().insert(
+            "Cross-Origin-Opener-Policy",
+            HeaderValue::from_static("same-origin"),
+        );
+        response.headers_mut().insert(
+            "Cross-Origin-Embedder-Policy",
+            HeaderValue::from_static("require-corp"),
+        );
+    }
+    response
+}
+
+async fn health() -> String {
+    format!("wbg-pool {}", env!("CARGO_PKG_VERSION"))
+}
+
+async fn shutdown(State(daemon): State<Arc<Daemon>>) -> &'static str {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        super::shutdown(&daemon).await;
+    });
+    "shutting down"
+}
+
+async fn coverage() -> StatusCode {
+    // Coverage collection is not supported yet; acknowledge the dump so the
+    // page does not error, and rely on the harness output for results.
+    StatusCode::NO_CONTENT
+}
+
+struct ActiveGuard(Arc<Daemon>);
+
+impl ActiveGuard {
+    fn new(daemon: &Arc<Daemon>) -> ActiveGuard {
+        daemon.touch();
+        daemon.active.fetch_add(1, Ordering::SeqCst);
+        ActiveGuard(daemon.clone())
+    }
+}
+
+impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+        self.0.active.fetch_sub(1, Ordering::SeqCst);
+        self.0.touch();
+    }
+}
+
+async fn run(State(daemon): State<Arc<Daemon>>, Json(request): Json<RunRequest>) -> Response {
+    let _guard = ActiveGuard::new(&daemon);
+    match execute_run(&daemon, request).await {
+        Ok(report) => Json(report).into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}")).into_response(),
+    }
+}
+
+async fn execute_run(daemon: &Arc<Daemon>, request: RunRequest) -> Result<RunReport> {
+    let binary = ensure_binary(daemon, &request).await?;
+
+    let mode = binary.suite.effective_mode();
+    if matches!(mode, TestMode::Node | TestMode::Emscripten) {
+        anyhow::bail!(
+            "wbg-pool only runs browser-family tests, but {} is configured for {} \
+             (the wbg-pool shim delegates such binaries to wasm-bindgen-test-runner)",
+            request.binary.display(),
+            mode.describe()
+        );
+    }
+
+    if binary.suite.tests.is_empty() {
+        return Ok(RunReport {
+            ok: true,
+            output: "no tests to run!\n".to_string(),
+            console_output: String::new(),
+            timed_out: false,
+        });
+    }
+
+    let filtered = suite::filter(&binary.suite.tests, &request.args);
+    let exports: Vec<&str> = filtered
+        .to_run
+        .iter()
+        .map(|test| test.export.as_str())
+        .collect();
+
+    // Assets live on one fixed origin regardless of the per-run page origin.
+    // Together with disabled cache partitioning in the browser (see
+    // browser.rs) this lets every tab share one HTTP-cache and compiled-code
+    // cache entry for the (large) wasm module instead of recompiling it per
+    // origin. The asset path embeds the binary fingerprint, so entries are
+    // immutable and cacheable forever.
+    let assets = format!("http://assets.localhost:{}", daemon.port);
+    let run_id = daemon.run_counter.fetch_add(1, Ordering::SeqCst);
+    let scripts = harness::generate(&harness::RunConfig {
+        mode,
+        module_js: &format!("{assets}/a/{}/{}.js", binary.id, codegen::MODULE_NAME),
+        module_wasm: &format!("{assets}/a/{}/{}_bg.wasm", binary.id, codegen::MODULE_NAME),
+        exports: &exports,
+        include_ignored: request.args.include_ignored,
+        filtered_count: filtered.filtered,
+        nocapture: request.nocapture,
+    })?;
+    let index_html = INDEX_TEMPLATE.replace(
+        "/* {NOCAPTURE} */ false",
+        if request.nocapture { "true" } else { "false" },
+    );
+
+    let (report_tx, report_rx) = oneshot::channel();
+    daemon.runs.lock().unwrap().insert(
+        run_id,
+        RunSlot {
+            index_html,
+            run_js: scripts.run_js,
+            worker_js: scripts.worker_js,
+            report_tx: Some(report_tx),
+        },
+    );
+
+    // A unique loopback host per run: every test gets its own web origin,
+    // and with it fresh IndexedDB, OPFS, localStorage, caches and cookies.
+    let url = format!("http://t-{run_id}.localhost:{}/r/{run_id}/", daemon.port);
+
+    let target = match daemon.browser.create_tab(&url).await {
+        Ok(target) => target,
+        Err(error) => {
+            daemon.runs.lock().unwrap().remove(&run_id);
+            return Err(error).context("failed to open a browser tab");
+        }
+    };
+
+    let timeout = Duration::from_secs(request.timeout_secs.max(1));
+    let report = match tokio::time::timeout(timeout, report_rx).await {
+        Ok(Ok(page)) => RunReport {
+            ok: page.ok,
+            output: page.output,
+            console_output: page.console_output,
+            timed_out: false,
+        },
+        Ok(Err(_)) => RunReport {
+            ok: false,
+            output: "wbg-pool daemon dropped the test run unexpectedly\n".to_string(),
+            console_output: String::new(),
+            timed_out: false,
+        },
+        Err(_) => {
+            let (mut output, console_output) = daemon
+                .browser
+                .scrape_output(&target)
+                .await
+                .unwrap_or_default();
+            output.push_str(&format!(
+                "\ntest run timed out after {}s (set WASM_BINDGEN_TEST_TIMEOUT to change)\n",
+                request.timeout_secs
+            ));
+            RunReport {
+                ok: false,
+                output,
+                console_output,
+                timed_out: true,
+            }
+        }
+    };
+
+    daemon.browser.close_tab(&target).await;
+    daemon.runs.lock().unwrap().remove(&run_id);
+    daemon.touch();
+
+    Ok(report)
+}
+
+async fn ensure_binary(daemon: &Arc<Daemon>, request: &RunRequest) -> Result<Arc<codegen::Binary>> {
+    let canonical = std::fs::canonicalize(&request.binary)
+        .with_context(|| format!("failed to resolve {}", request.binary.display()))?;
+    let fingerprint = codegen::fingerprint(&canonical)?;
+
+    let cell = {
+        let mut binaries = daemon.binaries.lock().await;
+        binaries
+            .entry((canonical.clone(), fingerprint))
+            .or_insert_with(|| Arc::new(tokio::sync::OnceCell::new()))
+            .clone()
+    };
+
+    let out_dir = daemon.work_dir.join("bins");
+    let binary = cell
+        .get_or_try_init(|| async {
+            let path = canonical.clone();
+            let out_dir = out_dir.clone();
+            let generated = tokio::task::spawn_blocking(move || codegen::generate(&path, &out_dir))
+                .await
+                .context("codegen task panicked")??;
+            Ok::<_, anyhow::Error>(Arc::new(generated))
+        })
+        .await?
+        .clone();
+    Ok(binary)
+}
+
+async fn run_index(State(daemon): State<Arc<Daemon>>, Path(run_id): Path<u64>) -> Response {
+    let html = daemon
+        .runs
+        .lock()
+        .unwrap()
+        .get(&run_id)
+        .map(|slot| slot.index_html.clone());
+    match html {
+        Some(html) => ([(header::CONTENT_TYPE, "text/html")], html).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+async fn run_js(State(daemon): State<Arc<Daemon>>, Path(run_id): Path<u64>) -> Response {
+    let js = daemon
+        .runs
+        .lock()
+        .unwrap()
+        .get(&run_id)
+        .map(|slot| slot.run_js.clone());
+    match js {
+        Some(js) => ([(header::CONTENT_TYPE, "text/javascript")], js).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+async fn run_worker_js(State(daemon): State<Arc<Daemon>>, Path(run_id): Path<u64>) -> Response {
+    let js = daemon
+        .runs
+        .lock()
+        .unwrap()
+        .get(&run_id)
+        .and_then(|slot| slot.worker_js.clone());
+    match js {
+        Some(js) => ([(header::CONTENT_TYPE, "text/javascript")], js).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+async fn run_report(
+    State(daemon): State<Arc<Daemon>>,
+    Path(run_id): Path<u64>,
+    Json(report): Json<PageReport>,
+) -> StatusCode {
+    let sender = daemon
+        .runs
+        .lock()
+        .unwrap()
+        .get_mut(&run_id)
+        .and_then(|slot| slot.report_tx.take());
+    match sender {
+        Some(sender) => {
+            let _ = sender.send(report);
+            StatusCode::NO_CONTENT
+        }
+        None => StatusCode::NOT_FOUND,
+    }
+}
+
+async fn asset(
+    State(daemon): State<Arc<Daemon>>,
+    Path((binary_id, path)): Path<(String, String)>,
+) -> Response {
+    if binary_id.contains(['/', '\\', '.']) || path.split('/').any(|part| part == "..") {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let full = daemon.work_dir.join("bins").join(&binary_id).join(&path);
+    let bytes = match tokio::fs::read(&full).await {
+        Ok(bytes) => bytes,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let content_type = match full.extension().and_then(|ext| ext.to_str()) {
+        Some("js") | Some("mjs") => "text/javascript",
+        Some("wasm") => "application/wasm",
+        Some("html") => "text/html",
+        Some("json") | Some("map") => "application/json",
+        _ => "application/octet-stream",
+    };
+    // Pages load these cross-origin (from their per-run origin) while under
+    // COEP: require-corp, which needs CORS plus an explicit CORP grant. The
+    // fingerprinted path makes aggressive caching safe.
+    (
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+        ],
+        [("Cross-Origin-Resource-Policy", "cross-origin")],
+        bytes,
+    )
+        .into_response()
+}

--- a/rust/wbg-pool/src/main.rs
+++ b/rust/wbg-pool/src/main.rs
@@ -1,0 +1,31 @@
+//! `wbg-pool` is a drop-in replacement for `wasm-bindgen-test-runner` that
+//! amortizes browser startup across an entire test session. A background
+//! daemon owns one headless Chrome; every runner invocation becomes a fresh
+//! tab on a fresh `*.localhost` origin inside that browser, so per-test
+//! process spawns (the model `cargo nextest` uses) cost tab-creation instead
+//! of browser-boot, while each test still gets pristine origin-scoped
+//! storage (IndexedDB, OPFS, localStorage, caches).
+
+mod cli;
+mod daemon;
+mod protocol;
+mod shim;
+mod suite;
+
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+
+    // `wbg-pool daemon ...` runs the shared-browser daemon. Any other
+    // invocation is a libtest-style runner call from a test harness
+    // (cargo test / cargo nextest), where the first argument is the path
+    // to a compiled wasm test binary.
+    if args.get(1).map(|arg| arg == "daemon").unwrap_or(false) {
+        let mut daemon_args = vec![args[0].clone()];
+        daemon_args.extend_from_slice(&args[2..]);
+        daemon::main(daemon_args)
+    } else {
+        shim::main(args)
+    }
+}

--- a/rust/wbg-pool/src/protocol.rs
+++ b/rust/wbg-pool/src/protocol.rs
@@ -1,0 +1,34 @@
+//! Types shared between the runner shim (client) and the daemon (server).
+
+use crate::suite::FilterArgs;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// State file the daemon writes so shims can find it, stored as
+/// `daemon.json` inside the state directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonState {
+    pub url: String,
+    pub pid: u32,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunRequest {
+    /// Absolute path to the wasm test binary.
+    pub binary: PathBuf,
+    pub args: FilterArgs,
+    pub nocapture: bool,
+    /// Wall-clock budget for this invocation, in seconds.
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunReport {
+    pub ok: bool,
+    /// The libtest-style output the harness wrote to `#output`.
+    pub output: String,
+    /// Captured `console.*` output (`#console_output`), printed on failure.
+    pub console_output: String,
+    pub timed_out: bool,
+}

--- a/rust/wbg-pool/src/shim.rs
+++ b/rust/wbg-pool/src/shim.rs
@@ -1,0 +1,238 @@
+//! The runner shim: the process `cargo test` / `cargo nextest` invokes as
+//! the wasm target runner. It answers `--list` locally, delegates
+//! non-browser binaries to the stock `wasm-bindgen-test-runner`, and sends
+//! browser runs to the shared daemon (spawning it on first use).
+
+use crate::cli::RunnerCli;
+use crate::daemon::default_state_dir;
+use crate::protocol::{DaemonState, RunReport, RunRequest};
+use crate::suite::{self, TestMode};
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+pub fn main(args: Vec<OsString>) -> Result<()> {
+    let cli = match RunnerCli::try_parse_from(&args) {
+        Ok(cli) => cli,
+        Err(error) => match error.kind() {
+            clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
+                print!("{error}");
+                return Ok(());
+            }
+            _ => bail!(error),
+        },
+    };
+
+    // Emscripten test binaries are passed as a `.js` file; wbg-pool does not
+    // support them, so hand the invocation to the stock runner untouched.
+    if cli.file.extension().unwrap_or_default() == "js" {
+        return delegate(&args);
+    }
+
+    let wasm = std::fs::read(&cli.file)
+        .with_context(|| format!("failed to read wasm file {}", cli.file.display()))?;
+    let suite = suite::inspect(&wasm)?;
+
+    // Browser, dedicated worker, shared worker and service worker suites all
+    // run inside the pooled browser; only Node and Emscripten suites are
+    // handed to the stock runner.
+    if matches!(
+        suite.effective_mode(),
+        TestMode::Node | TestMode::Emscripten
+    ) {
+        return delegate(&args);
+    }
+
+    if cli.bench {
+        bail!(
+            "wbg-pool does not support --bench; run benchmarks with \
+             wasm-bindgen-test-runner directly"
+        );
+    }
+
+    if cli.list {
+        let filtered = suite::filter(&suite.tests, &cli.filter_args());
+        let mut stdout = std::io::stdout().lock();
+        for test in filtered.to_run {
+            // A closed stdout (e.g. `wbg-pool foo.wasm --list | head`) is
+            // not an error worth reporting.
+            if let Err(error) = writeln!(stdout, "{}: test", test.name) {
+                if error.kind() == std::io::ErrorKind::BrokenPipe {
+                    return Ok(());
+                }
+                return Err(error.into());
+            }
+        }
+        return Ok(());
+    }
+
+    if suite.tests.is_empty() {
+        println!("no tests to run!");
+        return Ok(());
+    }
+
+    let timeout_secs = std::env::var("WASM_BINDGEN_TEST_TIMEOUT")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(20);
+
+    let daemon_url = ensure_daemon()?;
+    let request = RunRequest {
+        binary: std::fs::canonicalize(&cli.file)?,
+        args: cli.filter_args(),
+        nocapture: cli.nocapture,
+        timeout_secs,
+    };
+
+    let response = ureq::post(&format!("{daemon_url}/api/run"))
+        .timeout(Duration::from_secs(timeout_secs + 120))
+        .send_json(&request);
+
+    let report: RunReport = match response {
+        Ok(response) => response.into_json()?,
+        Err(ureq::Error::Status(code, response)) => {
+            let body = response.into_string().unwrap_or_default();
+            bail!("wbg-pool daemon returned {code}: {body}");
+        }
+        Err(error) => bail!("failed to reach wbg-pool daemon: {error}"),
+    };
+
+    print!("{}", report.output);
+
+    if !report.ok {
+        if !report.console_output.is_empty() {
+            println!("console output:");
+            for line in report.console_output.lines() {
+                println!("    {line}");
+            }
+        }
+        eprintln!("Error: some tests failed");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Hands the invocation to the stock `wasm-bindgen-test-runner`, preserving
+/// arguments and exit status, for test modes wbg-pool does not handle.
+fn delegate(args: &[OsString]) -> Result<()> {
+    let runner = std::env::var_os("WBG_POOL_FALLBACK_RUNNER")
+        .unwrap_or_else(|| OsString::from("wasm-bindgen-test-runner"));
+    use std::os::unix::process::CommandExt;
+    let error = std::process::Command::new(&runner).args(&args[1..]).exec();
+    bail!(
+        "this binary is not a browser-mode test suite, and delegating to {} failed: {error}",
+        Path::new(&runner).display()
+    )
+}
+
+/// Finds a healthy daemon or spawns one, coordinating concurrent shims
+/// (nextest starts many at once) through a spawn lock file.
+fn ensure_daemon() -> Result<String> {
+    if let Ok(url) = std::env::var("WBG_POOL_URL") {
+        return Ok(url);
+    }
+
+    let dir = default_state_dir();
+    std::fs::create_dir_all(&dir)?;
+    let state_path = dir.join("daemon.json");
+    let lock_path = dir.join("spawn.lock");
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while Instant::now() < deadline {
+        if let Some(url) = healthy_daemon(&state_path) {
+            return Ok(url);
+        }
+
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock_path)
+        {
+            Ok(mut lock) => {
+                let _ = write!(lock, "{}", std::process::id());
+                let result = spawn_daemon(&dir)
+                    .and_then(|_| wait_for_daemon(&state_path, Duration::from_secs(30)));
+                let _ = std::fs::remove_file(&lock_path);
+                return result;
+            }
+            Err(_) => {
+                // Another shim is spawning the daemon; wait for it, but
+                // clear the lock if its owner appears to have died.
+                if let Ok(url) = wait_for_daemon(&state_path, Duration::from_secs(10)) {
+                    return Ok(url);
+                }
+                let stale = std::fs::metadata(&lock_path)
+                    .and_then(|meta| meta.modified())
+                    .map(|modified| {
+                        modified.elapsed().unwrap_or_default() > Duration::from_secs(30)
+                    })
+                    .unwrap_or(false);
+                if stale {
+                    let _ = std::fs::remove_file(&lock_path);
+                }
+            }
+        }
+    }
+    bail!("timed out waiting for the wbg-pool daemon to start")
+}
+
+fn healthy_daemon(state_path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(state_path).ok()?;
+    let state: DaemonState = serde_json::from_str(&raw).ok()?;
+    let response = ureq::get(&format!("{}/api/health", state.url))
+        .timeout(Duration::from_millis(500))
+        .call()
+        .ok()?;
+    if response.status() == 200 {
+        Some(state.url)
+    } else {
+        None
+    }
+}
+
+fn wait_for_daemon(state_path: &Path, timeout: Duration) -> Result<String> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(url) = healthy_daemon(state_path) {
+            return Ok(url);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    bail!("daemon did not become healthy within {timeout:?}")
+}
+
+fn spawn_daemon(state_dir: &PathBuf) -> Result<()> {
+    let exe = std::env::current_exe().context("failed to locate the wbg-pool binary")?;
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(state_dir.join("daemon.log"))?;
+
+    let mut command = std::process::Command::new(exe);
+    command
+        .arg("daemon")
+        .arg("--state-dir")
+        .arg(state_dir)
+        .stdin(std::process::Stdio::null())
+        .stdout(log.try_clone()?)
+        .stderr(log);
+
+    // Detach into its own session so the daemon outlives this shim and is
+    // not killed alongside it by the test harness.
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        command.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+
+    command
+        .spawn()
+        .context("failed to spawn the wbg-pool daemon")?;
+    Ok(())
+}

--- a/rust/wbg-pool/src/suite.rs
+++ b/rust/wbg-pool/src/suite.rs
@@ -1,0 +1,246 @@
+//! Inspection of compiled wasm test binaries: which tests they export, and
+//! which environment they are configured to run in.
+//!
+//! The `#[wasm_bindgen_test]` macro exports each test as a wasm export named
+//! `__wbgt_<modifiers>_<crate>::<module path>::<test name>`, where the
+//! modifiers segment contains `$` for `#[ignore]`d tests. The
+//! `wasm_bindgen_test_configure!` macro records the requested environment in
+//! a `__wasm_bindgen_test_unstable` custom section. Both conventions are
+//! defined by `wasm-bindgen-test` and read here the same way
+//! `wasm-bindgen-test-runner` reads them.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+pub const TEST_EXPORT_PREFIX: &str = "__wbgt_";
+pub const CONFIGURE_SECTION: &str = "__wasm_bindgen_test_unstable";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestMode {
+    Browser,
+    DedicatedWorker,
+    SharedWorker,
+    ServiceWorker,
+    Node,
+    Emscripten,
+}
+
+impl TestMode {
+    pub fn describe(&self) -> &'static str {
+        match self {
+            TestMode::Browser => "browser",
+            TestMode::DedicatedWorker => "dedicated worker",
+            TestMode::SharedWorker => "shared worker",
+            TestMode::ServiceWorker => "service worker",
+            TestMode::Node => "node",
+            TestMode::Emscripten => "emscripten",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestCase {
+    /// Human-facing test name (the part after the crate name).
+    pub name: String,
+    /// The wasm export implementing the test.
+    pub export: String,
+    /// Whether the test carries `#[ignore]`.
+    pub ignored: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct Suite {
+    /// The configured test environment; `None` when the binary carries no
+    /// `wasm_bindgen_test_configure!` section, which defaults to Node.
+    pub mode: Option<TestMode>,
+    pub tests: Vec<TestCase>,
+}
+
+impl Suite {
+    pub fn effective_mode(&self) -> TestMode {
+        self.mode.unwrap_or(TestMode::Node)
+    }
+}
+
+pub fn inspect(wasm: &[u8]) -> Result<Suite> {
+    use wasmparser::{Parser, Payload};
+
+    let mut tests = Vec::new();
+    let mut mode = None;
+
+    for payload in Parser::new(0).parse_all(wasm) {
+        match payload.context("failed to parse wasm module")? {
+            Payload::ExportSection(exports) => {
+                for export in exports {
+                    let export = export?;
+                    let Some(rest) = export.name.strip_prefix(TEST_EXPORT_PREFIX) else {
+                        continue;
+                    };
+                    let Some((modifiers, _)) = rest.split_once('_') else {
+                        continue;
+                    };
+                    let Some((_, name)) = export.name.split_once("::") else {
+                        continue;
+                    };
+                    tests.push(TestCase {
+                        name: name.to_string(),
+                        export: export.name.to_string(),
+                        ignored: modifiers.contains('$'),
+                    });
+                }
+            }
+            Payload::CustomSection(section) if section.name() == CONFIGURE_SECTION => {
+                let data = section.data();
+                mode = Some(if data.contains(&0x01) {
+                    TestMode::Browser
+                } else if data.contains(&0x02) {
+                    TestMode::DedicatedWorker
+                } else if data.contains(&0x03) {
+                    TestMode::SharedWorker
+                } else if data.contains(&0x04) {
+                    TestMode::ServiceWorker
+                } else if data.contains(&0x05) {
+                    TestMode::Node
+                } else if data.contains(&0x06) {
+                    TestMode::Emscripten
+                } else {
+                    bail!("invalid {CONFIGURE_SECTION} value")
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(Suite { mode, tests })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilterArgs {
+    pub filter: Option<String>,
+    pub exact: bool,
+    pub skip: Vec<String>,
+    pub ignored: bool,
+    pub include_ignored: bool,
+}
+
+pub struct Filtered {
+    pub to_run: Vec<TestCase>,
+    pub filtered: usize,
+}
+
+/// Applies libtest-style filtering with semantics identical to
+/// `wasm-bindgen-test-runner` 0.2.126: positional filter first, then
+/// `--skip`, then `--ignored` selection; every excluded test increments the
+/// `filtered` count that the in-browser harness reports back.
+pub fn filter(tests: &[TestCase], args: &FilterArgs) -> Filtered {
+    let mut to_run = Vec::new();
+    let mut filtered = 0;
+
+    'outer: for test in tests {
+        if let Some(filter) = &args.filter {
+            let matches = if args.exact {
+                test.name == *filter
+            } else {
+                test.name.contains(filter)
+            };
+            if !matches {
+                filtered += 1;
+                continue;
+            }
+        }
+
+        for skip in &args.skip {
+            let matches = if args.exact {
+                test.name == *skip
+            } else {
+                test.name.contains(skip)
+            };
+            if matches {
+                filtered += 1;
+                continue 'outer;
+            }
+        }
+
+        if !test.ignored && args.ignored {
+            filtered += 1;
+        } else {
+            to_run.push(test.clone());
+        }
+    }
+
+    Filtered { to_run, filtered }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn case(name: &str, ignored: bool) -> TestCase {
+        TestCase {
+            name: name.to_string(),
+            export: format!("__wbgt_{}_1_crate::{name}", if ignored { "$" } else { "" }),
+            ignored,
+        }
+    }
+
+    fn args() -> FilterArgs {
+        FilterArgs {
+            filter: None,
+            exact: false,
+            skip: Vec::new(),
+            ignored: false,
+            include_ignored: false,
+        }
+    }
+
+    #[test]
+    fn it_runs_everything_without_filters() {
+        let tests = [case("a::one", false), case("a::two", false)];
+        let result = filter(&tests, &args());
+        assert_eq!(result.to_run.len(), 2);
+        assert_eq!(result.filtered, 0);
+    }
+
+    #[test]
+    fn it_filters_by_substring_and_counts() {
+        let tests = [case("a::one", false), case("a::two", false)];
+        let mut a = args();
+        a.filter = Some("one".to_string());
+        let result = filter(&tests, &a);
+        assert_eq!(result.to_run.len(), 1);
+        assert_eq!(result.to_run[0].name, "a::one");
+        assert_eq!(result.filtered, 1);
+    }
+
+    #[test]
+    fn it_matches_exactly_when_requested() {
+        let tests = [case("a::one", false), case("a::one_more", false)];
+        let mut a = args();
+        a.filter = Some("a::one".to_string());
+        a.exact = true;
+        let result = filter(&tests, &a);
+        assert_eq!(result.to_run.len(), 1);
+        assert_eq!(result.filtered, 1);
+    }
+
+    #[test]
+    fn it_skips_and_counts() {
+        let tests = [case("a::one", false), case("a::two", false)];
+        let mut a = args();
+        a.skip = vec!["two".to_string()];
+        let result = filter(&tests, &a);
+        assert_eq!(result.to_run.len(), 1);
+        assert_eq!(result.filtered, 1);
+    }
+
+    #[test]
+    fn it_selects_only_ignored_with_the_ignored_flag() {
+        let tests = [case("a::one", false), case("a::two", true)];
+        let mut a = args();
+        a.ignored = true;
+        let result = filter(&tests, &a);
+        assert_eq!(result.to_run.len(), 1);
+        assert_eq!(result.to_run[0].name, "a::two");
+        assert_eq!(result.filtered, 1);
+    }
+}


### PR DESCRIPTION
The web CI jobs run the wasm suite through cargo-nextest, which spawns one process per test. With the wasm32 target runner that means a fresh chromedriver + headless Chrome launch and a full wasm compile for every one of the ~1400 tests, roughly six seconds of startup before any test body runs. The last run on `main` spent 84 minutes in the test phase; the actual test execution is a small fraction of that.

`wbg-pool` is a drop-in `wasm-bindgen-test-runner` replacement built for nextest's process-per-test model. A daemon keeps one headless Chrome alive and turns each runner invocation into a fresh tab on a fresh origin, so browser startup is paid once per run instead of once per test while every test is origin-seperated. It lands as a workspace member under `rust/wbg-pool` sharing the workspace's wasm-bindgen pin, is wired in as the wasm32 runner via `.cargo/config.toml`, and is provided on PATH by the nix dev shell. The web test menu commands stay on plain `cargo nextest run`.

This also fixes `test:web:release`, which pointed at the `tests-web-debug` package and named its archive `web-debug`: release-mode wasm tests were never actually exercised in CI, and both web jobs would have collided on the same archive filename.

The nix packaging (`rust/wbg-pool` as a crane crate, threaded into the dev shell) hasn't been built here, so the CI run is the first end-to-end validation of the flake changes.