### PR TITLE
fix(dialog-remote-ucan-s3): permit cache review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "serde_bytes",
  "serde_ipld_dagcbor",
  "serde_json",
+ "sieve-cache",
  "signature",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/dialog-network/src/lib.rs
+++ b/rust/dialog-network/src/lib.rs
@@ -33,7 +33,7 @@ use dialog_remote_ucan_s3::UcanSite;
 /// - `Site for Network`, `SiteAddress for NetworkAddress`,
 ///   `Authorize<Env> for NetworkFork<Fx>`, and
 ///   `Provider<ForkInvocation<Network, Fx>> for Network`.
-#[derive(Debug, Clone, Copy, Default, Site)]
+#[derive(Debug, Clone, Default, Site)]
 pub struct Network {
     s3: S3,
     ucan: UcanSite,

--- a/rust/dialog-remote-s3/src/error.rs
+++ b/rust/dialog-remote-s3/src/error.rs
@@ -1,6 +1,7 @@
 //! Error types for S3 operations.
 
 use dialog_effects::archive::ArchiveError;
+use dialog_effects::blob::BlobError;
 use dialog_effects::memory::MemoryError;
 use thiserror::Error;
 
@@ -46,9 +47,42 @@ impl From<S3Error> for MemoryError {
     }
 }
 
-impl From<S3Error> for dialog_effects::blob::BlobError {
+impl From<S3Error> for BlobError {
     fn from(error: S3Error) -> Self {
-        dialog_effects::blob::BlobError::Storage(error.to_string())
+        BlobError::Storage(error.to_string())
+    }
+}
+
+/// Whether an error means the presented permit itself was rejected.
+///
+/// The S3 providers map an HTTP 401/403 to their error type's
+/// authorization variant; everything else is either a semantic outcome
+/// (a missing object, a CAS conflict) or a transport failure that
+/// proves nothing about the permit. A permit cache uses this split to
+/// decide when a cached permit must be dropped and redeemed afresh:
+/// invalidating on any error would let a routine presence probe (a 404)
+/// evict a perfectly reusable permit.
+pub trait PermitRejection {
+    /// `true` when the service rejected the permit this operation
+    /// presented, so retrying with the same permit cannot succeed.
+    fn is_permit_rejection(&self) -> bool;
+}
+
+impl PermitRejection for ArchiveError {
+    fn is_permit_rejection(&self) -> bool {
+        matches!(self, ArchiveError::AuthorizationError(_))
+    }
+}
+
+impl PermitRejection for BlobError {
+    fn is_permit_rejection(&self) -> bool {
+        matches!(self, BlobError::AuthorizationError(_))
+    }
+}
+
+impl PermitRejection for MemoryError {
+    fn is_permit_rejection(&self) -> bool {
+        matches!(self, MemoryError::Authorization(_))
     }
 }
 

--- a/rust/dialog-remote-s3/src/lib.rs
+++ b/rust/dialog-remote-s3/src/lib.rs
@@ -49,7 +49,7 @@ pub mod s3;
 #[cfg(feature = "helpers")]
 pub mod helpers;
 
-pub use error::{AuthorizationFormatError, S3Error};
-pub use request::{IntoRequest, Precondition, S3Request};
+pub use error::{AuthorizationFormatError, PermitRejection, S3Error};
+pub use request::{IntoRequest, Precondition, RequestMethod, S3Request};
 pub use request::{archive, memory};
 pub use s3::*;

--- a/rust/dialog-remote-s3/src/request.rs
+++ b/rust/dialog-remote-s3/src/request.rs
@@ -120,7 +120,79 @@ where
     }
 }
 
+/// The HTTP method a value's [`S3Request`] translation will carry,
+/// available without materializing the request.
+///
+/// Building an [`S3Request`] can cost far more than reading its method:
+/// a `Put` translation checksums its entire payload. Callers that only
+/// need to know whether a request is a read, such as the permit cache
+/// deciding cacheability, consult this constant instead of building and
+/// discarding the request.
+///
+/// Every `From<&Capability<Fx>> for S3Request` impl has a matching
+/// `RequestMethod` impl beside it; the consistency tests in this module
+/// keep the two from drifting apart.
+pub trait RequestMethod {
+    /// The HTTP method [`IntoRequest::to_request`] would produce.
+    const METHOD: &'static str;
+}
+
 /// Get the current time as a UTC datetime.
 pub fn current_time() -> DateTime<Utc> {
     DateTime::<Utc>::from(dialog_common::time::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IntoRequest, RequestMethod};
+    use dialog_capability::{Subject, did};
+    use dialog_common::{Blake3Hash, Buffer};
+    use dialog_effects::archive::{Archive, Catalog, Get, Put};
+    use dialog_effects::blob::prelude::{ArchiveBlobExt, BlobExt};
+    use dialog_effects::memory::Version;
+    use dialog_effects::memory::prelude::{CellExt, MemoryExt, MemorySubjectExt, SpaceExt};
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    fn method_matches<T: IntoRequest + RequestMethod>(capability: &T) {
+        assert_eq!(
+            capability.to_request().method,
+            T::METHOD,
+            "RequestMethod::METHOD must match the materialized request"
+        );
+    }
+
+    fn subject() -> Subject {
+        Subject::from(did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"))
+    }
+
+    #[dialog_common::test]
+    fn it_reports_the_method_the_archive_translations_produce() {
+        let digest = Blake3Hash::hash(b"content");
+        let catalog = || {
+            subject()
+                .attenuate(Archive)
+                .attenuate(Catalog::new("index"))
+        };
+        method_matches(&catalog().invoke(Get::new(digest)));
+        method_matches(&catalog().invoke(Put::new(Buffer::from(vec![1, 2, 3]))));
+    }
+
+    #[dialog_common::test]
+    fn it_reports_the_method_the_blob_translations_produce() {
+        let digest = Blake3Hash::hash(b"content");
+        method_matches(&subject().attenuate(Archive).blob().read(digest.clone()));
+        method_matches(&subject().attenuate(Archive).blob().import(digest, 3));
+    }
+
+    #[dialog_common::test]
+    fn it_reports_the_method_the_memory_translations_produce() {
+        let cell = || subject().memory().space("space").cell("cell");
+        method_matches(&cell().resolve());
+        method_matches(&cell().publish(vec![1, 2, 3], None));
+        method_matches(&cell().retract(Version::from("v1".to_string())));
+    }
 }

--- a/rust/dialog-remote-s3/src/request/archive.rs
+++ b/rust/dialog-remote-s3/src/request/archive.rs
@@ -4,7 +4,7 @@
 //! archive (content-addressed) capabilities, enabling them to be
 //! translated into concrete S3 request descriptions.
 
-use super::S3Request;
+use super::{RequestMethod, S3Request};
 use base58::ToBase58;
 use dialog_capability::{Capability, Policy};
 use dialog_common::Hasher;
@@ -26,6 +26,10 @@ impl From<&Capability<Get>> for S3Request {
     }
 }
 
+impl RequestMethod for Capability<Get> {
+    const METHOD: &'static str = "GET";
+}
+
 impl From<&Capability<Put>> for S3Request {
     fn from(capability: &Capability<Put>) -> Self {
         S3Request {
@@ -40,6 +44,10 @@ impl From<&Capability<Put>> for S3Request {
             ..S3Request::default()
         }
     }
+}
+
+impl RequestMethod for Capability<Put> {
+    const METHOD: &'static str = "PUT";
 }
 
 impl From<&Capability<PutAttenuation>> for S3Request {
@@ -57,4 +65,8 @@ impl From<&Capability<PutAttenuation>> for S3Request {
             ..S3Request::default()
         }
     }
+}
+
+impl RequestMethod for Capability<PutAttenuation> {
+    const METHOD: &'static str = "PUT";
 }

--- a/rust/dialog-remote-s3/src/request/blob.rs
+++ b/rust/dialog-remote-s3/src/request/blob.rs
@@ -5,7 +5,7 @@
 //! provider adds a `Range` header from the effect's range); an `Import` is a
 //! PUT.
 
-use super::S3Request;
+use super::{RequestMethod, S3Request};
 use base58::ToBase58;
 use dialog_capability::Capability;
 use dialog_effects::blob::prelude::{BlobImportExt as _, BlobReadExt as _};
@@ -25,6 +25,10 @@ impl From<&Capability<Read>> for S3Request {
     }
 }
 
+impl RequestMethod for Capability<Read> {
+    const METHOD: &'static str = "GET";
+}
+
 impl From<&Capability<Import>> for S3Request {
     fn from(capability: &Capability<Import>) -> Self {
         S3Request {
@@ -37,4 +41,8 @@ impl From<&Capability<Import>> for S3Request {
             ..S3Request::default()
         }
     }
+}
+
+impl RequestMethod for Capability<Import> {
+    const METHOD: &'static str = "PUT";
 }

--- a/rust/dialog-remote-s3/src/request/memory.rs
+++ b/rust/dialog-remote-s3/src/request/memory.rs
@@ -4,7 +4,7 @@
 //! memory (CAS cell) capabilities, enabling them to be translated into
 //! concrete S3 request descriptions.
 
-use super::{Precondition, S3Request};
+use super::{Precondition, RequestMethod, S3Request};
 use dialog_capability::{Capability, Policy};
 use dialog_common::Hasher;
 use dialog_effects::memory::prelude::{PublishExt, ResolveExt, RetractExt};
@@ -40,6 +40,10 @@ impl From<&Capability<Resolve>> for S3Request {
     }
 }
 
+impl RequestMethod for Capability<Resolve> {
+    const METHOD: &'static str = "GET";
+}
+
 impl From<&Capability<Publish>> for S3Request {
     fn from(capability: &Capability<Publish>) -> Self {
         S3Request {
@@ -55,6 +59,10 @@ impl From<&Capability<Publish>> for S3Request {
             ..S3Request::default()
         }
     }
+}
+
+impl RequestMethod for Capability<Publish> {
+    const METHOD: &'static str = "PUT";
 }
 
 impl From<&Capability<PublishAttenuation>> for S3Request {
@@ -75,6 +83,10 @@ impl From<&Capability<PublishAttenuation>> for S3Request {
     }
 }
 
+impl RequestMethod for Capability<PublishAttenuation> {
+    const METHOD: &'static str = "PUT";
+}
+
 impl From<&Capability<Retract>> for S3Request {
     fn from(capability: &Capability<Retract>) -> Self {
         S3Request {
@@ -89,4 +101,8 @@ impl From<&Capability<Retract>> for S3Request {
             ..S3Request::default()
         }
     }
+}
+
+impl RequestMethod for Capability<Retract> {
+    const METHOD: &'static str = "DELETE";
 }

--- a/rust/dialog-remote-s3/src/s3/provider/archive.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/archive.rs
@@ -36,6 +36,14 @@ impl Provider<S3Invocation<Get>> for S3 {
             Ok(Some(bytes.to_vec()))
         } else if response.status() == StatusCode::NOT_FOUND {
             Ok(None)
+        } else if matches!(
+            response.status(),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ) {
+            Err(ArchiveError::AuthorizationError(format!(
+                "Failed to get value: {}",
+                response.status()
+            )))
         } else {
             Err(ArchiveError::Storage(format!(
                 "Failed to get value: {}",
@@ -68,6 +76,14 @@ impl Provider<S3Invocation<Put>> for S3 {
 
         if response.status().is_success() {
             Ok(())
+        } else if matches!(
+            response.status(),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ) {
+            Err(ArchiveError::AuthorizationError(format!(
+                "Failed to put value: {}",
+                response.status()
+            )))
         } else {
             Err(ArchiveError::Storage(format!(
                 "Failed to put value: {}",

--- a/rust/dialog-remote-s3/src/s3/provider/blob.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/blob.rs
@@ -88,6 +88,11 @@ impl Provider<S3Invocation<Read>> for S3 {
                 input.capability.digest().as_bytes().to_base58(),
             ));
         }
+        if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+            return Err(BlobError::AuthorizationError(format!(
+                "blob read failed: {status}"
+            )));
+        }
         if !status.is_success() {
             return Err(BlobError::Storage(format!("blob read failed: {status}")));
         }
@@ -184,6 +189,14 @@ impl BlobSink for S3BlobSink {
             .map_err(|e| BlobError::Storage(e.to_string()))?;
         if response.status().is_success() {
             Ok(hash)
+        } else if matches!(
+            response.status(),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ) {
+            Err(BlobError::AuthorizationError(format!(
+                "blob import failed: {}",
+                response.status()
+            )))
         } else {
             Err(BlobError::Storage(format!(
                 "blob import failed: {}",

--- a/rust/dialog-remote-s3/src/s3/provider/memory.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/memory.rs
@@ -49,6 +49,14 @@ impl Provider<S3Invocation<Resolve>> for S3 {
             }))
         } else if response.status() == StatusCode::NOT_FOUND {
             Ok(None)
+        } else if matches!(
+            response.status(),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ) {
+            Err(MemoryError::Authorization(format!(
+                "Failed to resolve value: {}",
+                response.status()
+            )))
         } else {
             Err(MemoryError::Storage(format!(
                 "Failed to resolve value: {}",
@@ -100,6 +108,9 @@ impl Provider<S3Invocation<Publish>> for S3 {
                 expected: when,
                 actual: None,
             }),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(MemoryError::Authorization(
+                format!("Failed to publish value: {}", response.status()),
+            )),
             status => Err(MemoryError::Storage(format!(
                 "Failed to publish value: {}",
                 status
@@ -137,6 +148,9 @@ impl Provider<S3Invocation<Retract>> for S3 {
                 expected: Some(when),
                 actual: None,
             }),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(MemoryError::Authorization(
+                format!("Failed to retract value: {}", response.status()),
+            )),
             status => Err(MemoryError::Storage(format!(
                 "Failed to retract value: {}",
                 status

--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -42,6 +42,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_ipld_dagcbor = { workspace = true }
 serde_json = { workspace = true }
+sieve-cache = { workspace = true }
 signature = { workspace = true }
 thiserror = { workspace = true }
 
@@ -69,6 +70,9 @@ dialog-storage = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 wasm-bindgen-test = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+dialog-remote-s3 = { workspace = true, features = ["helpers"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/rust/dialog-remote-ucan-s3/src/permit_cache.rs
+++ b/rust/dialog-remote-ucan-s3/src/permit_cache.rs
@@ -1,29 +1,36 @@
 //! Cache of redeemed access-service permits.
 //!
 //! Every remote effect used to POST its UCAN invocation to the access
-//! service and receive a fresh presigned URL, even though presigned URLs
-//! stay valid for an hour — on a periodically syncing replica the redeem
-//! round-trip doubled the cost of every idle poll.
+//! service and receive a fresh presigned URL on every request, even
+//! though presigned URLs stay valid for an hour. On a periodically
+//! syncing replica the redeem round-trip doubled the cost of every idle
+//! poll.
 //!
-//! A permit presigns one S3 object, so an entry is keyed by the
-//! access-service endpoint and the object path — not by the capability
-//! that produced it. That keeps the key payload-free (a `Put` capability
-//! carries the whole block) and lets requests that differ only in
-//! headers, such as ranged blob reads, share one permit.
+//! Each [`UcanSite`](crate::UcanSite) owns one cache, so cached permits
+//! are scoped to the operator whose network holds that site and are
+//! dropped with it. Nothing outside that operator's session can be
+//! served a permit its own authorization did not redeem.
 //!
-//! Only GET permits are reusable: a mutating presign can bind
-//! payload-specific signing material. [`PermitKey::cacheable`] is the
-//! sole constructor and returns `None` for anything else, so a mutating
-//! permit cannot be stored — there is no key to store it under.
+//! An entry is keyed by access-service endpoint, method, and object
+//! path. [`PermitKey::cacheable`] is the sole constructor and returns
+//! `None` for anything but a plain GET (no query parameters, no
+//! precondition), so a permit for any other request shape cannot be
+//! stored: there is no key to store it under. Requests that differ only
+//! in headers, such as ranged blob reads, share one permit.
+//!
+//! Retention is a [`SieveCache`] bounded at `MAX_ENTRIES`. At capacity
+//! an insert evicts one cold entry instead of flushing the map, so a
+//! bulk read sweep cannot wipe the hot entries an idle poll relies on.
+//! Entries also lapse [`PERMIT_TTL`] after being stored.
 
-use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::fmt;
 use std::time::{Duration, SystemTime};
 
 use dialog_capability::SiteId;
-use dialog_remote_s3::Permit;
 use dialog_remote_s3::request::S3Request;
+use dialog_remote_s3::{Permit, Precondition};
 use parking_lot::Mutex;
+use sieve_cache::SieveCache;
 
 use crate::site::UcanAddress;
 
@@ -36,21 +43,31 @@ pub const PERMIT_TTL: Duration = Duration::from_secs(300);
 /// sweep would otherwise retain a permit per block for the whole TTL.
 const MAX_ENTRIES: usize = 512;
 
-/// Cache key: access-service endpoint plus the S3 object path the permit
-/// presigns.
+/// Cache key: access-service endpoint plus the method and S3 object
+/// path the permit presigns.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PermitKey {
     site: SiteId,
+    method: String,
     path: String,
 }
 
 impl PermitKey {
-    /// The key `request` is cached under at `address`, or `None` when the
-    /// request is not cacheable. Only GET permits are reusable: a
-    /// mutating presign can bind payload-specific signing material.
+    /// The key `request` is cached under at `address`, or `None` when
+    /// the request is not cacheable.
+    ///
+    /// Only plain GET permits are reusable: a mutating presign can bind
+    /// payload-specific signing material, and the presigned signature
+    /// covers the query string, so a request carrying parameters or a
+    /// precondition fails closed here rather than sharing a permit that
+    /// was signed for a different request shape.
     pub fn cacheable(address: &UcanAddress, request: S3Request) -> Option<Self> {
-        (request.method == "GET").then(|| Self {
+        (request.method == "GET"
+            && request.params.is_none()
+            && matches!(request.precondition, Precondition::None))
+        .then(|| Self {
             site: SiteId::from(address.clone()),
+            method: request.method,
             path: request.path,
         })
     }
@@ -62,37 +79,44 @@ struct Entry {
 }
 
 /// TTL cache of redeemed permits, keyed by [`PermitKey`].
-#[derive(Default)]
 pub struct PermitCache {
-    entries: Mutex<HashMap<PermitKey, Entry>>,
+    entries: Mutex<SieveCache<PermitKey, Entry>>,
+}
+
+impl Default for PermitCache {
+    fn default() -> Self {
+        Self {
+            entries: Mutex::new(SieveCache::new(MAX_ENTRIES).expect("capacity is non-zero")),
+        }
+    }
+}
+
+impl fmt::Debug for PermitCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PermitCache")
+            .field("entries", &self.entries.lock().len())
+            .finish()
+    }
 }
 
 impl PermitCache {
-    /// The process-wide cache the providers share.
-    pub fn shared() -> &'static PermitCache {
-        static CACHE: OnceLock<PermitCache> = OnceLock::new();
-        CACHE.get_or_init(PermitCache::default)
-    }
-
-    /// The cached permit for `key`, unless it has passed its TTL.
+    /// The cached permit for `key`, unless it has passed its TTL. An
+    /// entry found past its TTL is removed on the way out.
     pub fn lookup(&self, key: &PermitKey, now: SystemTime) -> Option<Permit> {
-        let entries = self.entries.lock();
-        let entry = entries.get(key)?;
-        (now < entry.expires_at).then(|| entry.permit.clone())
+        let mut entries = self.entries.lock();
+        match entries.get(key) {
+            Some(entry) if now < entry.expires_at => return Some(entry.permit.clone()),
+            Some(_) => {}
+            None => return None,
+        }
+        entries.remove(key);
+        None
     }
 
-    /// Cache `permit` under `key`.
+    /// Cache `permit` under `key`. At capacity the sieve evicts one
+    /// cold entry to make room; hot entries survive.
     pub fn store(&self, key: PermitKey, permit: &Permit, now: SystemTime) {
-        let mut entries = self.entries.lock();
-        if entries.len() >= MAX_ENTRIES {
-            entries.retain(|_, entry| now < entry.expires_at);
-            if entries.len() >= MAX_ENTRIES {
-                // Still full of live entries. A miss costs one redeem, so
-                // a rare full flush beats growing without bound.
-                entries.clear();
-            }
-        }
-        entries.insert(
+        self.entries.lock().insert(
             key,
             Entry {
                 permit: permit.clone(),
@@ -101,23 +125,38 @@ impl PermitCache {
         );
     }
 
-    /// Drop the entry for `key`, so the next redeem goes to the service.
-    pub fn invalidate(&self, key: &PermitKey) {
-        self.entries.lock().remove(key);
+    /// Drop the entry for `key`, provided it still holds `permit`. A
+    /// concurrent task may have redeemed and stored a fresh permit
+    /// under the same key after this one was looked up; that fresh
+    /// entry is left alone.
+    pub fn invalidate(&self, key: &PermitKey, permit: &Permit) {
+        let mut entries = self.entries.lock();
+        if entries
+            .get(key)
+            .is_some_and(|entry| entry.permit.url == permit.url)
+        {
+            entries.remove(key);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use dialog_capability::{Subject, did};
-    use dialog_common::Buffer;
+    use std::time::Duration;
+
+    use super::{MAX_ENTRIES, PERMIT_TTL, PermitCache, PermitKey};
+    use dialog_capability::{Capability, Subject, did};
+    use dialog_common::{Buffer, time};
     use dialog_effects::archive::{Archive, Catalog, Get, Put};
-    use dialog_remote_s3::request::IntoRequest;
+    use dialog_remote_s3::request::{IntoRequest, S3Request};
+    use dialog_remote_s3::{Permit, Precondition};
+
+    use crate::site::UcanAddress;
+
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test_configure!(run_in_browser);
+    wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     fn permit() -> Permit {
         Permit {
@@ -133,7 +172,7 @@ mod tests {
         UcanAddress::new("https://access.example/ucan/")
     }
 
-    fn catalog() -> dialog_capability::Capability<Catalog> {
+    fn catalog() -> Capability<Catalog> {
         Subject::from(did!("key:zPermitCacheTest"))
             .attenuate(Archive)
             .attenuate(Catalog::new("blocks"))
@@ -150,7 +189,7 @@ mod tests {
     #[dialog_common::test]
     fn it_returns_a_cached_permit_before_expiry() {
         let cache = PermitCache::default();
-        let now = dialog_common::time::now();
+        let now = time::now();
         cache.store(key([0u8; 32]), &permit(), now);
         let hit = cache.lookup(&key([0u8; 32]), now + PERMIT_TTL - Duration::from_secs(1));
         assert_eq!(hit.map(|p| p.method), Some("GET".to_string()));
@@ -159,7 +198,7 @@ mod tests {
     #[dialog_common::test]
     fn it_expires_a_permit_after_its_ttl() {
         let cache = PermitCache::default();
-        let now = dialog_common::time::now();
+        let now = time::now();
         cache.store(key([0u8; 32]), &permit(), now);
         assert!(cache.lookup(&key([0u8; 32]), now + PERMIT_TTL).is_none());
     }
@@ -167,7 +206,7 @@ mod tests {
     #[dialog_common::test]
     fn it_keys_permits_by_endpoint_and_object_path() {
         let cache = PermitCache::default();
-        let now = dialog_common::time::now();
+        let now = time::now();
         cache.store(key([0u8; 32]), &permit(), now);
 
         assert!(
@@ -192,23 +231,87 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_invalidates_a_permit_on_demand() {
+    fn it_has_no_cache_key_for_a_parameterized_request() {
+        let with_params = S3Request {
+            params: Some(vec![("versionId".to_string(), "7".to_string())]),
+            ..get_request([0u8; 32])
+        };
+        assert!(
+            PermitKey::cacheable(&address(), with_params).is_none(),
+            "the presigned signature covers the query string, so a \
+             parameterized request must fail closed"
+        );
+
+        let with_precondition = S3Request {
+            precondition: Precondition::IfNoneMatch,
+            ..get_request([0u8; 32])
+        };
+        assert!(
+            PermitKey::cacheable(&address(), with_precondition).is_none(),
+            "a conditional request must fail closed"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_invalidates_the_entry_holding_the_failed_permit() {
         let cache = PermitCache::default();
-        let now = dialog_common::time::now();
+        let now = time::now();
         cache.store(key([0u8; 32]), &permit(), now);
-        cache.invalidate(&key([0u8; 32]));
+        cache.invalidate(&key([0u8; 32]), &permit());
         assert!(cache.lookup(&key([0u8; 32]), now).is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_retains_a_fresh_permit_when_invalidating_a_stale_one() {
+        let cache = PermitCache::default();
+        let now = time::now();
+        let stale = Permit {
+            url: "https://bucket.example/key?X-Amz-Signature=old"
+                .parse()
+                .unwrap(),
+            method: "GET".to_string(),
+            headers: vec![],
+        };
+        // A concurrent task redeemed a fresh permit after `stale` was
+        // looked up; the slow failure must not delete it.
+        cache.store(key([0u8; 32]), &permit(), now);
+        cache.invalidate(&key([0u8; 32]), &stale);
+        assert!(
+            cache.lookup(&key([0u8; 32]), now).is_some(),
+            "invalidation is scoped to the permit that actually failed"
+        );
     }
 
     #[dialog_common::test]
     fn it_bounds_the_number_of_retained_entries() {
         let cache = PermitCache::default();
-        let now = dialog_common::time::now();
+        let now = time::now();
         for i in 0..=MAX_ENTRIES {
             let mut digest = [0u8; 32];
             digest[..8].copy_from_slice(&(i as u64).to_le_bytes());
             cache.store(key(digest), &permit(), now);
         }
         assert!(cache.entries.lock().len() <= MAX_ENTRIES);
+    }
+
+    #[dialog_common::test]
+    fn it_evicts_cold_entries_instead_of_flushing_the_cache() {
+        let cache = PermitCache::default();
+        let now = time::now();
+        let hot = key([255u8; 32]);
+        cache.store(hot.clone(), &permit(), now);
+
+        // A bulk sweep past capacity while the hot entry keeps being
+        // read: the sieve evicts cold entries and the hot one survives,
+        // where a full flush would have dropped it at capacity.
+        for i in 0..MAX_ENTRIES {
+            let mut digest = [0u8; 32];
+            digest[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            cache.store(key(digest), &permit(), now);
+            assert!(
+                cache.lookup(&hot, now).is_some(),
+                "a hot entry must survive a sweep of cold inserts"
+            );
+        }
     }
 }

--- a/rust/dialog-remote-ucan-s3/src/provider.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider.rs
@@ -3,22 +3,28 @@
 //! Every remote effect follows the same two steps: redeem the UCAN
 //! authorization at the access service for a presigned permit, then hand
 //! the permit to [`S3`] for the actual HTTP request. The access service
-//! is responsible for presigning the right object — `{subject}/{catalog}/{digest}`
+//! is responsible for presigning the right object -- `{subject}/{catalog}/{digest}`
 //! for the block archive, `{subject}/blob/{digest}` for blobs,
-//! `{subject}/{space}/{cell}` for memory cells — and for choosing the
+//! `{subject}/{space}/{cell}` for memory cells -- and for choosing the
 //! method, so this side is uniform across effects and expressed as one
 //! blanket impl rather than one impl per effect.
 //!
 //! Redeeming is skipped when a fresh permit for the same object is
-//! already cached; see [`crate::permit_cache`].
+//! already cached on the site; see [`crate::permit_cache`]. When the
+//! service rejects a cached permit (it can lapse server-side under
+//! clock skew or configuration), the entry is invalidated and the
+//! authorization redeemed afresh for one retry. Semantic failures such
+//! as a missing object or a CAS conflict leave the permit cached: it is
+//! still good, and dropping it would restore the redeem round-trip this
+//! cache exists to remove.
 
 use async_trait::async_trait;
 use dialog_capability::{Capability, Constraint, Effect, ForkInvocation, Provider};
-use dialog_common::{ConditionalSend, ConditionalSync};
-use dialog_remote_s3::request::IntoRequest;
-use dialog_remote_s3::{S3, S3Error, S3Invocation};
+use dialog_common::{ConditionalSend, time};
+use dialog_remote_s3::request::{IntoRequest, RequestMethod};
+use dialog_remote_s3::{PermitRejection, S3, S3Error, S3Invocation};
 
-use crate::permit_cache::{PermitCache, PermitKey};
+use crate::permit_cache::PermitKey;
 use crate::site::UcanSite;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -27,19 +33,24 @@ impl<Fx, T, E> Provider<ForkInvocation<UcanSite, Fx>> for UcanSite
 where
     Fx: Effect<Output = Result<T, E>> + 'static,
     Fx::Of: Constraint,
-    Capability<Fx>: IntoRequest + ConditionalSend + ConditionalSync,
-    ForkInvocation<UcanSite, Fx>: ConditionalSend,
-    S3: Provider<S3Invocation<Fx>> + ConditionalSync,
+    Capability<Fx>: IntoRequest + RequestMethod + Clone + ConditionalSend,
+    S3: Provider<S3Invocation<Fx>>,
     T: ConditionalSend,
-    E: From<S3Error> + ConditionalSend,
+    E: From<S3Error> + PermitRejection + ConditionalSend,
 {
     async fn execute(&self, invocation: ForkInvocation<UcanSite, Fx>) -> Result<T, E> {
-        let cache = PermitCache::shared();
-        let now = dialog_common::time::now();
-        // `None` for a mutating effect, which must redeem every time.
-        let key = PermitKey::cacheable(&invocation.address, invocation.capability.to_request());
+        let cache = self.permits();
+        let now = time::now();
+        // Consult the method before building the request at all: a
+        // mutating effect never has a cache key, and its request
+        // translation checksums the entire payload.
+        let key = (Capability::<Fx>::METHOD == "GET")
+            .then(|| invocation.capability.to_request())
+            .and_then(|request| PermitKey::cacheable(&invocation.address, request));
 
-        let permit = match key.as_ref().and_then(|key| cache.lookup(key, now)) {
+        let cached = key.as_ref().and_then(|key| cache.lookup(key, now));
+        let from_cache = cached.is_some();
+        let permit = match cached {
             Some(permit) => permit,
             None => {
                 let permit = invocation.authorization.redeem(&invocation.address).await?;
@@ -50,23 +61,35 @@ where
             }
         };
 
-        let result = permit.invoke(invocation.capability).perform(&S3).await;
-        if let (Err(_), Some(key)) = (&result, &key) {
-            // Drop the permit on any downstream failure. It may genuinely
-            // be unusable while this process still thinks it has TTL left:
-            // the presign can lapse server-side under clock skew, and the
-            // delegation it was redeemed against carries its own expiry.
-            // For a merely transient error the cost of dropping it is one
-            // extra redeem, which beats retrying a dead permit until the
-            // TTL runs out.
-            cache.invalidate(key);
+        // A retry presents the capability a second time, so it is
+        // cloned only when a cached permit makes a retry possible.
+        let retry = from_cache.then(|| invocation.capability.clone());
+        let presented = key.map(|key| (key, permit.clone()));
+        let outcome = permit.invoke(invocation.capability).perform(&S3).await;
+
+        match (outcome, presented) {
+            (Err(error), Some((key, permit))) if error.is_permit_rejection() => {
+                cache.invalidate(&key, &permit);
+                match retry {
+                    Some(capability) => {
+                        let fresh = invocation.authorization.redeem(&invocation.address).await?;
+                        cache.store(key, &fresh, now);
+                        fresh.invoke(capability).perform(&S3).await
+                    }
+                    // The rejected permit was redeemed moments ago;
+                    // redeeming again would present the same material.
+                    None => Err(error),
+                }
+            }
+            (outcome, _) => outcome,
         }
-        result
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use dialog_capability::{Principal, Subject, did};
     use dialog_credentials::Ed25519Signer;
@@ -80,12 +103,12 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test_configure!(run_in_browser);
+    wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     /// A self-signed (issuer == subject, no delegation) UCAN
     /// authorization. Enough to satisfy `ForkInvocation`'s type, but
-    /// never actually redeemed below: the cache is pre-seeded so the
-    /// provider never reaches `authorization.redeem`.
+    /// never successfully redeemed below: tests either pre-seed the
+    /// cache or point the address at a dead endpoint.
     async fn self_authorization(signer: &Ed25519Signer) -> UcanAuthorization {
         let did = signer.did();
         let invocation = InvocationBuilder::new()
@@ -97,7 +120,7 @@ mod tests {
             .try_build()
             .await
             .expect("failed to build self-signed invocation");
-        let chain = InvocationChain::new(invocation, std::collections::HashMap::new());
+        let chain = InvocationChain::new(invocation, HashMap::new());
         UcanInvocation {
             chain: Box::new(chain),
             subject: did,
@@ -116,44 +139,171 @@ mod tests {
         }
     }
 
-    /// Invalidate-on-failure only fires by driving a real invocation
-    /// through the provider, which always runs against the real `S3` and
-    /// the process-wide `PermitCache::shared()` — neither is injectable.
-    /// So this primes the shared cache and forces the request to fail by
-    /// pointing the permit at a dead loopback port: deterministic and
-    /// network-free, without reaching for a mock HTTP layer.
+    /// A transport failure proves nothing about the permit: the entry
+    /// must survive so the next attempt skips the redeem round-trip.
+    /// (Only a rejection by the service, an HTTP 401/403, invalidates.)
     #[dialog_common::test]
-    async fn it_invalidates_the_cache_entry_after_a_failed_request() {
+    async fn it_retains_the_permit_after_a_transport_error() {
         let signer = Ed25519Signer::import(&[9u8; 32]).await.unwrap();
-        let capability = Subject::from(did!("key:zPermitCacheFailureTest"))
+        let capability = Subject::from(did!("key:zPermitCacheTransportTest"))
             .attenuate(Archive)
             .attenuate(Catalog::new("blobs"))
             .invoke(Get::new([0u8; 32]));
 
+        let site = UcanSite::default();
         let address = UcanAddress::new("http://127.0.0.1:1/redeem");
         let key = PermitKey::cacheable(&address, capability.to_request())
             .expect("a GET request is cacheable");
-        let now = dialog_common::time::now();
+        let now = time::now();
 
         // Prime the entry the provider will look up, so it reuses this
         // permit instead of redeeming.
-        PermitCache::shared().store(key.clone(), &unreachable_permit(), now);
-        assert!(
-            PermitCache::shared().lookup(&key, now).is_some(),
-            "precondition: cache should be primed before the call"
-        );
+        site.permits()
+            .store(key.clone(), &unreachable_permit(), now);
 
         let invocation =
             ForkInvocation::new(capability, address, self_authorization(&signer).await);
-        let result: Result<Option<Vec<u8>>, ArchiveError> = UcanSite.execute(invocation).await;
+        let result: Result<Option<Vec<u8>>, ArchiveError> = site.execute(invocation).await;
 
         assert!(
             result.is_err(),
             "a request against an unreachable permit should fail"
         );
         assert!(
-            PermitCache::shared().lookup(&key, now).is_none(),
-            "a failed request should invalidate its cache entry"
+            site.permits().lookup(&key, now).is_some(),
+            "a transport error must not invalidate the cached permit"
         );
+    }
+
+    /// Each site owns its cache: permits redeemed through one site are
+    /// invisible to another, so one operator can never ride a permit a
+    /// different operator's authorization redeemed.
+    #[dialog_common::test]
+    fn it_scopes_cached_permits_to_the_site() {
+        let capability = Subject::from(did!("key:zPermitCacheScopeTest"))
+            .attenuate(Archive)
+            .attenuate(Catalog::new("blobs"))
+            .invoke(Get::new([0u8; 32]));
+        let address = UcanAddress::new("http://127.0.0.1:1/redeem");
+        let key = PermitKey::cacheable(&address, capability.to_request())
+            .expect("a GET request is cacheable");
+        let now = time::now();
+
+        let site = UcanSite::default();
+        site.permits()
+            .store(key.clone(), &unreachable_permit(), now);
+
+        assert!(
+            site.clone().permits().lookup(&key, now).is_some(),
+            "clones of a site share its cache"
+        );
+        assert!(
+            UcanSite::default().permits().lookup(&key, now).is_none(),
+            "a separate site must not see another site's permits"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    mod native {
+        use super::*;
+        use dialog_common::Blake3Hash;
+        use dialog_effects::blob::BlobError;
+        use dialog_effects::blob::prelude::{ArchiveBlobExt, BlobExt};
+        use dialog_remote_s3::helpers::LocalS3;
+
+        /// The pin for the presence-probe finding: a GET that comes
+        /// back 404 is a semantic outcome, not a permit failure. The
+        /// cached permit must survive, otherwise every poll for a blob
+        /// a peer has not uploaded yet would pay the redeem round-trip
+        /// this cache exists to remove.
+        #[dialog_common::test]
+        async fn it_retains_the_permit_when_the_blob_is_absent() {
+            let server = LocalS3::start(&["probe-bucket"])
+                .await
+                .expect("local S3 starts");
+
+            let signer = Ed25519Signer::import(&[7u8; 32]).await.unwrap();
+            let digest = Blake3Hash::hash(b"not uploaded yet");
+            let capability = Subject::from(did!("key:zPermitCacheProbeTest"))
+                .attenuate(Archive)
+                .blob()
+                .read(digest);
+
+            let site = UcanSite::default();
+            let address = UcanAddress::new("http://127.0.0.1:1/redeem");
+            let key = PermitKey::cacheable(&address, capability.to_request())
+                .expect("a GET request is cacheable");
+            let now = time::now();
+
+            // A live permit for an object nobody has uploaded: the
+            // server genuinely answers 404.
+            let url = format!("{}/probe-bucket/{}", server.endpoint, "missing-object");
+            let permit = Permit {
+                url: url.parse().expect("valid url"),
+                method: "GET".to_string(),
+                headers: vec![],
+            };
+            site.permits().store(key.clone(), &permit, now);
+
+            let invocation =
+                ForkInvocation::new(capability, address, self_authorization(&signer).await);
+            let result: Result<dialog_effects::blob::BlobReader, BlobError> =
+                site.execute(invocation).await;
+
+            assert!(
+                matches!(result, Err(BlobError::NotFound(_))),
+                "an absent blob should surface as NotFound"
+            );
+            assert!(
+                site.permits().lookup(&key, now).is_some(),
+                "a presence probe must not invalidate the cached permit"
+            );
+        }
+
+        /// A 403 means the service rejected the permit itself: the
+        /// entry is invalidated and the provider redeems afresh for a
+        /// retry (here the redeem fails too, at the dead endpoint, so
+        /// the call errors; what matters is that the entry is gone).
+        #[dialog_common::test]
+        async fn it_invalidates_a_permit_the_service_rejects() {
+            // An auth-enabled server rejects unsigned requests, so a
+            // bare object URL yields a genuine 401/403.
+            let server = LocalS3::start_with_auth("access-key", "secret-key", &["auth-bucket"])
+                .await
+                .expect("local S3 starts");
+
+            let signer = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+            let capability = Subject::from(did!("key:zPermitCacheRejectTest"))
+                .attenuate(Archive)
+                .attenuate(Catalog::new("blocks"))
+                .invoke(Get::new([2u8; 32]));
+
+            let site = UcanSite::default();
+            let address = UcanAddress::new("http://127.0.0.1:1/redeem");
+            let key = PermitKey::cacheable(&address, capability.to_request())
+                .expect("a GET request is cacheable");
+            let now = time::now();
+
+            let url = format!("{}/auth-bucket/some-object", server.endpoint);
+            let permit = Permit {
+                url: url.parse().expect("valid url"),
+                method: "GET".to_string(),
+                headers: vec![],
+            };
+            site.permits().store(key.clone(), &permit, now);
+
+            let invocation =
+                ForkInvocation::new(capability, address, self_authorization(&signer).await);
+            let result: Result<Option<Vec<u8>>, ArchiveError> = site.execute(invocation).await;
+
+            assert!(
+                result.is_err(),
+                "a rejected permit whose re-redeem also fails should error"
+            );
+            assert!(
+                site.permits().lookup(&key, now).is_none(),
+                "a permit the service rejected must be invalidated"
+            );
+        }
     }
 }

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -1,4 +1,6 @@
-//! UCAN site configuration -- marker trait + address type.
+//! UCAN site configuration -- site type + address type.
+
+use std::sync::Arc;
 
 use dialog_capability::access::{
     Access, Authorization as _, Authorize as AuthorizeEffect, AuthorizeError, FromCapability,
@@ -11,6 +13,8 @@ use dialog_capability::{
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::authority::{self, OperatorExt};
 use dialog_remote_s3::{Permit, S3Error};
+
+use crate::permit_cache::PermitCache;
 
 // Re-export UCAN types for convenience.
 pub use dialog_ucan::{Ucan, UcanInvocation};
@@ -140,9 +144,22 @@ where
 
 /// UCAN site configuration for delegated authorization.
 ///
-/// A marker type -- no fields. Address info lives in `UcanAddress`.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct UcanSite;
+/// Address info lives in `UcanAddress`. The site owns the cache of
+/// redeemed GET permits, so cached permits are scoped to whoever holds
+/// this site (one `Network`, hence one `Operator`) and are dropped with
+/// it; another operator in the same process has its own site and can
+/// never be served a permit this one redeemed. Clones share the cache.
+#[derive(Debug, Clone, Default)]
+pub struct UcanSite {
+    permits: Arc<PermitCache>,
+}
+
+impl UcanSite {
+    /// The cache of redeemed GET permits shared by clones of this site.
+    pub(crate) fn permits(&self) -> &PermitCache {
+        &self.permits
+    }
+}
 
 impl Site for UcanSite {
     type Authorization = UcanAuthorization;


### PR DESCRIPTION
Stacked on #402, addressing the review findings on the permit cache.

**Cache scope.** The cache moves off the process-wide static onto `UcanSite`: permits are scoped to the operator whose `Network` owns the site and die with it, so one operator can never be served a permit another operator's authorization redeemed, and tests construct isolated caches instead of priming a global. `Network` loses `Copy` (it now holds an `Arc`), keeping `Clone` and `Default`.

**Invalidation policy.** Only a rejection of the permit itself invalidates. The S3 providers now map 401/403 to each error type's authorization variant, and a new `PermitRejection` trait lets the blanket impl ask the domain error whether the permit was rejected. A 404 presence probe or a transport error leaves the permit cached; previously every poll for a not-yet-uploaded blob dropped a live permit and restored the double round-trip the cache exists to remove (pinned by `it_retains_the_permit_when_the_blob_is_absent`, driven against the in-repo `LocalS3` returning a genuine 404). A rejected cached permit is invalidated and redeemed afresh for one retry instead of surfacing a spurious error. Invalidation is scoped to the permit that failed, so a slow failing request cannot delete the fresh permit a concurrent task stored under the same key.

**Eviction.** Retention is a `SieveCache` (the workspace's existing cache crate) instead of retain-then-clear: at capacity one cold entry is evicted, so a bulk read sweep past 512 objects no longer flushes the hot idle-poll permits (`it_evicts_cold_entries_instead_of_flushing_the_cache`).

**Key shape.** The key includes the method, and a GET carrying query params or a precondition fails closed (no key, always redeems), since the presigned signature covers the query string.

**Write-path cost.** A new `RequestMethod` trait exposes the method as a constant beside every `From<&Capability<Fx>>` impl, so cacheability is decided without building the request; `Put`/`Publish` no longer SHA-256 their entire payload just to learn they are not cacheable. Consistency tests keep the constant and the materialized request from drifting.

Also switches the new test modules to `run_in_dedicated_worker` per repo convention and trims three inert bounds from the blanket impl.