### PR TITLE
refactor(dialog-capability): name unmounted subjects, drop dead IO variant

### DIFF
--- a/rust/dialog-capability/src/error.rs
+++ b/rust/dialog-capability/src/error.rs
@@ -2,7 +2,6 @@ use crate::access::AuthorizeError;
 use crate::subject::Did;
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display, Formatter};
-use std::io;
 use thiserror::Error;
 
 /// Error that can occur during signing operations.
@@ -60,15 +59,30 @@ pub enum DialogCapabilityAuthorizationError {
 }
 
 /// Errors from capability-routed storage operations.
+///
+/// These are the "we failed" side of an effect's error: the backend broke,
+/// or the request named a subject this environment cannot serve. A caller
+/// supplying bad input is reported by the effect's own error type, not here.
 #[derive(Debug, Error)]
 pub enum StorageError {
     /// Storage backend error.
     #[error("Storage error: {0}")]
     Storage(String),
 
-    /// IO error.
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
+    /// This environment has no provider for the requested subject.
+    ///
+    /// Distinct from a backend failure: nothing is broken. Not-found is
+    /// relative to this environment rather than absolute -- the subject may
+    /// exist elsewhere, and loading the space it belongs to makes the same
+    /// request succeed -- so callers may retry after mounting rather than
+    /// treat it as terminal.
+    #[error(
+        "No provider found for subject {subject}; it must be mounted before it can be accessed"
+    )]
+    SubjectNotFound {
+        /// The subject this environment cannot serve.
+        subject: Did,
+    },
 }
 
 /// Error during fork execution.

--- a/rust/dialog-storage/src/storage/provider/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/storage.rs
@@ -211,17 +211,39 @@ mod tests {
         assert_eq!(resolved.unwrap().content, content);
     }
 
+    // A subject this environment cannot serve is its own condition, not a
+    // backend failure: the store is not broken, the subject was simply never
+    // loaded here. Callers need to tell "load it and retry" apart from "the
+    // backend is down".
+    //
+    // Asserted on the message rather than the variant because
+    // `From<StorageError> for ArchiveError` is `Self::Storage(e.to_string())`
+    // -- the typed variant is flattened to prose one layer up, so it cannot
+    // be matched from here. Fixing that is the effect-error rework; until
+    // then this pins the routing behaviour and the subject it names.
     #[dialog_common::test]
     async fn it_errors_for_unmounted_did() {
         let env = Storage::volatile();
+        let subject = did!("key:zUnknown");
 
-        let result = did!("key:zUnknown")
+        let result = subject
+            .clone()
             .archive()
             .catalog("index")
             .get([0u8; 32])
             .perform(&env)
             .await;
-        assert!(result.is_err());
+
+        let error = result.expect_err("an unserviceable subject must not resolve");
+        let message = error.to_string();
+        assert!(
+            message.contains(&subject.to_string()),
+            "the error must name the subject it cannot serve, got: {message}"
+        );
+        assert!(
+            message.contains("mounted"),
+            "the error must say what to do about it, not just that it failed: {message}"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/dialog-storage/src/storage/provider/storage/router.rs
+++ b/rust/dialog-storage/src/storage/provider/storage/router.rs
@@ -23,13 +23,16 @@ impl<S> Router<S> {
     }
 }
 
-trait FromUnmounted {
-    fn unmounted(did: &Did) -> Self;
+trait FromSubjectNotFound {
+    fn subject_not_found(did: &Did) -> Self;
 }
 
-impl<T, E: From<StorageError>> FromUnmounted for Result<T, E> {
-    fn unmounted(did: &Did) -> Self {
-        Err(StorageError::Storage(format!("no mount for {did}")).into())
+impl<T, E: From<StorageError>> FromSubjectNotFound for Result<T, E> {
+    fn subject_not_found(did: &Did) -> Self {
+        Err(StorageError::SubjectNotFound {
+            subject: did.clone(),
+        }
+        .into())
     }
 }
 
@@ -39,7 +42,7 @@ impl<S, Fx> Provider<Fx> for Router<S>
 where
     S: Provider<Fx> + ConditionalSync + Clone,
     Fx: Effect + ConditionalSend + 'static,
-    Fx::Output: FromUnmounted,
+    Fx::Output: FromSubjectNotFound,
     Capability<Fx>: ConditionalSend,
     Self: ConditionalSend + ConditionalSync,
 {
@@ -48,7 +51,33 @@ where
         let store = self.spaces.get(&did);
         match store {
             Some(store) => input.perform(&store).await,
-            None => Fx::Output::unmounted(&did),
+            None => Fx::Output::subject_not_found(&did),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use dialog_capability::did;
+
+    // A subject this environment cannot serve is not a backend failure --
+    // nothing is broken, and loading the space it belongs to makes the same
+    // request succeed. It reports as its own condition, naming the subject,
+    // so callers can tell that apart from "the store is down".
+    #[dialog_common::test]
+    async fn it_reports_a_subject_it_cannot_serve_as_its_own_condition() {
+        let subject = did!("key:zUnknown");
+        let result: Result<(), StorageError> = Result::subject_not_found(&subject);
+
+        match result {
+            Err(StorageError::SubjectNotFound { subject: reported }) => {
+                assert_eq!(reported, subject)
+            }
+            other => panic!("expected SubjectNotFound naming the subject, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
Two small corrections to `StorageError`, both groundwork for naming what actually failed instead of stringifying it.

## `Io` was dead

`StorageError::Io(#[from] io::Error)` has **zero construction sites** in the workspace, and no `?` conversion path feeds it either — the only `From<io::Error>` in the tree is on `DialogEncodingError`, unrelated. Nothing could ever observe it.

It also sat awkwardly beside its sibling. `Storage(String)` names an *outcome* (the backend failed); `Io` names a *mechanism* (this came from the OS). A caller asking "what do I do about this?" gets no answer from `Io`, because a disk-full and a transient EINTR are both `io::Error`. Mixing an origin variant with an outcome variant leaves neither axis complete. And the pair disagreed on shape: one carried a typed error, the other prose.

## `Storage` was doing double duty

The router reported an unroutable subject as:

```rust
StorageError::Storage(format!("no mount for {did}"))
```

That is not a backend failure. Nothing is broken — the subject was simply never loaded into this environment, and mounting it (or loading the space it belongs to) makes the same request succeed. Callers may retry; for a genuine backend failure they may not.

`Unmounted { subject: Did }` names that condition and carries the subject typed rather than interpolated, so a caller reads it back instead of parsing a message.

## Known limitation

The new variant is **not yet observable above `dialog-storage`**. `From<StorageError> for ArchiveError` is:

```rust
fn from(e: StorageError) -> Self {
    Self::Storage(e.to_string())   // <- typed variant flattened back to prose
}
```

So an effect-level caller still sees a string. Reaching it requires the effect-error rework, which is separate work. This PR is the layer beneath that.

Because of the flattening, the end-to-end test asserts on the message naming the subject, and a second test at the router pins the variant where the type survives. Both carry comments explaining why, so the split isn't mistaken for an oversight.

## Verification

`nix develop --command test:native:debug` green, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, and all libs compile for `wasm32-unknown-unknown`.
