### PR TITLE
refactor(dialog-capability): name why an authorization was denied

### DIFF
--- a/rust/dialog-capability/src/access.rs
+++ b/rust/dialog-capability/src/access.rs
@@ -519,28 +519,160 @@ pub trait CertificateStore<P: Protocol> {
             }
         }
 
-        Err(AuthorizeError::Denied(format!(
-            "no delegation chain found for '{}' to access '{}'",
-            authority, subject
-        )))
+        Err(AuthorizeError::UnprovenSubject {
+            claimed: authority.clone(),
+            authorized: subject.clone(),
+        })
     }
 }
 
 /// Error during the authorize step.
+///
+/// Most variants here are the caller's input failing to authorize what it
+/// asked for -- the request is answerable, and the answer is no. The
+/// exceptions are [`UnavailableProof`](Self::UnavailableProof) and
+/// [`Malformed`](Self::Malformed), which mean no decision could be reached
+/// at all. A backend that broke while trying to decide is a
+/// [`StorageError`](crate::StorageError), not one of these.
+///
+/// Variant names and `claimed`/`authorized` field naming follow
+/// `dialog_ucan_core::invocation::CheckFailed`, which classifies the same
+/// failures one layer down. This enum cannot reuse it -- that would invert
+/// the dependency, since the UCAN implementation must not depend on dialog
+/// types -- so it mirrors the vocabulary instead, and abilities arrive as
+/// `String` paths rather than a `Command` for the same reason.
+///
+/// The split matters because callers act differently on the reasons.
+/// [`Expired`](Self::Expired) means obtain a fresh proof and retry;
+/// [`Revoked`](Self::Revoked) means stop, since retrying presents the same
+/// withdrawn authority.
 #[derive(Debug, Error)]
 pub enum AuthorizeError {
-    /// Authorization was denied.
-    #[error("Authorization denied: {0}")]
-    Denied(String),
+    /// No delegation chain connects the authority to the subject.
+    ///
+    /// A real access decision: the delegations were searched and none of
+    /// them authorizes this. Distinct from
+    /// [`UnavailableProof`](Self::UnavailableProof), where a chain may well
+    /// exist but could not be evaluated.
+    ///
+    /// Mirrors `CheckFailed::UnprovenSubject`.
+    #[error("No delegation chain proves '{claimed}' may access '{authorized}'")]
+    UnprovenSubject {
+        /// The principal attempting access.
+        claimed: Did,
+        /// The subject it attempted to access.
+        authorized: Did,
+    },
 
-    /// Configuration error (e.g., missing delegation chain).
-    #[error("Authorization configuration error: {0}")]
-    Configuration(String),
+    /// A delegation exists but does not cover the requested ability.
+    ///
+    /// Abilities are paths (`/storage/get`), matching
+    /// [`Ability::ability`](crate::Ability::ability), which is how this crate
+    /// represents them everywhere else.
+    ///
+    /// Mirrors `CheckFailed::CommandEscalation`.
+    #[error("Claimed ability '{claimed}' is not authorized by ability '{authorized}'")]
+    CommandEscalation {
+        /// The ability the invocation asked for.
+        claimed: String,
+        /// The ability the delegation actually grants.
+        authorized: String,
+    },
+
+    /// A delegation covers the ability, but its policy rejected the arguments.
+    ///
+    /// Mirrors `CheckFailed::PolicyViolation`. That variant carries the
+    /// `Predicate` that failed; this one cannot name it without depending on
+    /// the UCAN types, so it carries the rendered predicate instead.
+    #[error("Invocation arguments violate delegation policy: {predicate}")]
+    PolicyViolation {
+        /// The predicate that evaluated to `false`, as rendered by the
+        /// protocol that evaluated it.
+        predicate: String,
+    },
+
+    /// The proof was issued for a different audience than the one presenting it.
+    ///
+    /// Mirrors `CheckFailed::DelegationAudienceMismatch`.
+    #[error("Claimed audience '{claimed}' does not match authorized audience '{authorized}'")]
+    InvalidAudience {
+        /// The audience the proof names.
+        claimed: Did,
+        /// The audience the invocation requires.
+        authorized: Did,
+    },
+
+    /// The proof's validity window has not opened yet.
+    ///
+    /// Mirrors the `TooEarly` side of `CheckFailed::TimeBound`.
+    #[error("Proof is not valid before {not_before}")]
+    NotValidBefore {
+        /// Unix timestamp the proof becomes valid at.
+        not_before: u64,
+        /// Unix timestamp the check was made at.
+        at: u64,
+    },
+
+    /// The proof's validity window has closed.
+    ///
+    /// Distinct from [`Revoked`](Self::Revoked): the authority was never
+    /// withdrawn, it simply lapsed, so obtaining a fresh proof is expected
+    /// to succeed.
+    ///
+    /// Mirrors the `Expired` side of `CheckFailed::TimeBound`.
+    #[error("Proof expired at {expiration}")]
+    Expired {
+        /// Unix timestamp the proof expired at.
+        expiration: u64,
+        /// Unix timestamp the check was made at.
+        at: u64,
+    },
+
+    /// Authority in the chain has been withdrawn.
+    ///
+    /// Terminal in a way [`Expired`](Self::Expired) is not: re-obtaining a
+    /// proof presents the same revoked authority, so callers should stop
+    /// rather than retry.
+    #[error("Authority for '{subject}' has been revoked")]
+    Revoked {
+        /// The subject whose authority was withdrawn.
+        subject: Did,
+    },
+
+    /// A proof's signature does not verify against its issuer's key.
+    #[error("Proof does not carry a valid signature from '{issuer}'")]
+    InvalidSignature {
+        /// The principal the proof claims to be signed by.
+        issuer: Did,
+    },
+
+    /// The chain referred to a proof that was not supplied.
+    ///
+    /// Not an access decision: the chain might well authorize this, but it
+    /// cannot be evaluated because a link it names is missing. Proofs travel
+    /// with the invocation here, so this is incomplete input rather than a
+    /// resolution failure.
+    ///
+    /// Mirrors the conformance suite's `UnavailableProof`.
+    #[error("Chain refers to proof '{link}', which was not supplied")]
+    UnavailableProof {
+        /// Identifier of the proof the chain referred to.
+        link: String,
+    },
+
+    /// The authorization could not be evaluated at all.
+    ///
+    /// Not an access decision: the chain was absent or undecodable, or the
+    /// material needed to decide could not be read. Distinct from the
+    /// decision variants above, which all mean "we understood the request
+    /// and the answer is no".
+    #[error("Authorization could not be evaluated: {0}")]
+    Malformed(String),
 }
 
 impl From<crate::StorageError> for AuthorizeError {
     fn from(e: crate::StorageError) -> Self {
-        AuthorizeError::Configuration(e.to_string())
+        AuthorizeError::Malformed(e.to_string())
     }
 }
 
@@ -550,6 +682,109 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::TimeRange;
+
+    mod reasons {
+        use crate::access::AuthorizeError;
+        use crate::did;
+
+        // The distinction the split exists for. Both mean "this proof does not
+        // authorize you right now", and a single `Denied(String)` could not
+        // tell them apart -- but a caller should re-authenticate on one and
+        // stop on the other, so they cannot share a variant.
+        #[dialog_common::test]
+        async fn it_separates_a_lapsed_proof_from_a_withdrawn_one() {
+            let lapsed = AuthorizeError::Expired {
+                expiration: 100,
+                at: 200,
+            };
+            let withdrawn = AuthorizeError::Revoked {
+                subject: did!("key:zSubject"),
+            };
+
+            assert!(matches!(lapsed, AuthorizeError::Expired { .. }));
+            assert!(matches!(withdrawn, AuthorizeError::Revoked { .. }));
+            assert_ne!(lapsed.to_string(), withdrawn.to_string());
+        }
+
+        // Operands are carried, not interpolated into prose, so a caller can
+        // read them back rather than parse a message.
+        #[dialog_common::test]
+        async fn it_carries_the_operands_of_a_denial() {
+            let claimed_did = did!("key:zAuthority");
+            let authorized_did = did!("key:zSubject");
+
+            match (AuthorizeError::UnprovenSubject {
+                claimed: claimed_did.clone(),
+                authorized: authorized_did.clone(),
+            }) {
+                AuthorizeError::UnprovenSubject {
+                    claimed,
+                    authorized,
+                } => {
+                    assert_eq!(claimed, claimed_did);
+                    assert_eq!(authorized, authorized_did);
+                }
+                other => panic!("expected UnprovenSubject, got {other:?}"),
+            }
+
+            match (AuthorizeError::CommandEscalation {
+                claimed: "/archive/put".into(),
+                authorized: "/archive/get".into(),
+            }) {
+                AuthorizeError::CommandEscalation {
+                    claimed,
+                    authorized,
+                } => {
+                    assert_eq!(claimed, "/archive/put");
+                    assert_eq!(authorized, "/archive/get");
+                }
+                other => panic!("expected CommandEscalation, got {other:?}"),
+            }
+        }
+
+        // Two failures that are not access decisions at all. Keeping them
+        // distinct from the decision variants is what stops either becoming
+        // the next catch-all -- and `UnavailableProof` specifically must not
+        // read as "denied", because the chain may well authorize once the
+        // caller supplies the link it refers to.
+        #[dialog_common::test]
+        async fn it_keeps_unevaluable_authorizations_out_of_the_denial_reasons() {
+            let undecodable = AuthorizeError::Malformed("chain did not decode".into());
+            assert!(
+                undecodable.to_string().contains("could not be evaluated"),
+                "an unevaluable authorization must not read as a refusal: {undecodable}"
+            );
+
+            let incomplete = AuthorizeError::UnavailableProof {
+                link: "bafyproof".into(),
+            };
+            match incomplete {
+                AuthorizeError::UnavailableProof { ref link } => assert_eq!(link, "bafyproof"),
+                other => panic!("expected UnavailableProof, got {other:?}"),
+            }
+            assert!(
+                incomplete.to_string().contains("not supplied"),
+                "a missing proof must name what is absent, not read as a denial: {incomplete}"
+            );
+        }
+
+        // A chain that was searched and found wanting is a decision; a chain
+        // that could not be evaluated is not. Both used to be `Denied`.
+        #[dialog_common::test]
+        async fn it_separates_an_absent_chain_from_an_unevaluable_one() {
+            let decided = AuthorizeError::UnprovenSubject {
+                claimed: did!("key:zAuthority"),
+                authorized: did!("key:zSubject"),
+            };
+            let undecided = AuthorizeError::UnavailableProof {
+                link: "bafyproof".into(),
+            };
+
+            assert!(matches!(decided, AuthorizeError::UnprovenSubject { .. }));
+            assert!(matches!(undecided, AuthorizeError::UnavailableProof { .. }));
+            assert_ne!(decided.to_string(), undecided.to_string());
+        }
+    }
 
     mod covers {
         use super::*;

--- a/rust/dialog-effects/src/credential.rs
+++ b/rust/dialog-effects/src/credential.rs
@@ -185,9 +185,11 @@ impl From<StorageError> for CredentialError {
     }
 }
 
+/// A credential that could not be loaded is not an access decision: nothing
+/// was weighed and refused, the material needed to decide was unavailable.
 impl From<CredentialError> for AuthorizeError {
     fn from(e: CredentialError) -> Self {
-        Self::Denied(e.to_string())
+        Self::Malformed(e.to_string())
     }
 }
 

--- a/rust/dialog-remote-fs/src/fs/address.rs
+++ b/rust/dialog-remote-fs/src/fs/address.rs
@@ -67,7 +67,7 @@ impl From<FsAddress> for SiteId {
 async fn open(address: &FsAddress) -> Result<FileSystem, AuthorizeError> {
     FileSystem::open(address.location())
         .await
-        .map_err(|e| AuthorizeError::Configuration(format!("opening directory: {e}")))
+        .map_err(|e| AuthorizeError::Malformed(format!("opening directory: {e}")))
 }
 
 /// Verify the resolved directory is the space for the invocation's subject:
@@ -97,7 +97,7 @@ where
         .perform(filesystem)
         .await
         .map_err(|e| {
-            AuthorizeError::Configuration(format!(
+            AuthorizeError::Malformed(format!(
                 "directory is not an initialized space (no readable credential/key/self): {e}"
             ))
         })?;
@@ -106,9 +106,10 @@ where
     let expected = capability.subject();
     let actual = credential.did();
     if &actual != expected {
-        return Err(AuthorizeError::Denied(format!(
-            "directory is the space for {actual}, not the invocation subject {expected}",
-        )));
+        return Err(AuthorizeError::InvalidAudience {
+            claimed: actual,
+            authorized: expected.clone(),
+        });
     }
     Ok(())
 }
@@ -133,7 +134,7 @@ where
     let identity = authority::Identify
         .perform(env)
         .await
-        .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+        .map_err(|e| AuthorizeError::Malformed(e.to_string()))?;
     let profile = identity.profile().clone();
     let operator = identity.did();
 

--- a/rust/dialog-remote-s3/src/error.rs
+++ b/rust/dialog-remote-s3/src/error.rs
@@ -113,6 +113,6 @@ impl From<AuthorizationFormatError> for dialog_effects::credential::CredentialEr
 
 impl From<AuthorizationFormatError> for dialog_capability::AuthorizeError {
     fn from(error: AuthorizationFormatError) -> Self {
-        Self::Configuration(error.to_string())
+        Self::Malformed(error.to_string())
     }
 }

--- a/rust/dialog-remote-s3/src/s3/address.rs
+++ b/rust/dialog-remote-s3/src/s3/address.rs
@@ -164,7 +164,7 @@ where
         let profile = authority::Identify
             .perform(env)
             .await
-            .map_err(|e| AuthorizeError::Configuration(e.to_string()))?
+            .map_err(|e| AuthorizeError::Malformed(e.to_string()))?
             .profile()
             .clone();
 

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -125,7 +125,7 @@ where
         let identity = authority::Identify
             .perform(env)
             .await
-            .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+            .map_err(|e| AuthorizeError::Malformed(e.to_string()))?;
         let profile = identity.profile().clone();
         let operator = identity.did();
 

--- a/rust/dialog-storage/src/storage/provider/fs/error.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/error.rs
@@ -32,6 +32,6 @@ impl From<FileSystemError> for CredentialError {
 
 impl From<FileSystemError> for AuthorizeError {
     fn from(e: FileSystemError) -> Self {
-        Self::Configuration(e.to_string())
+        Self::Malformed(e.to_string())
     }
 }

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -374,9 +374,11 @@ impl From<IndexedDbError> for CredentialError {
     }
 }
 
+/// A backend failure while reading certificates is not an access decision:
+/// the material needed to decide could not be fetched.
 impl From<IndexedDbError> for AuthorizeError {
     fn from(e: IndexedDbError) -> Self {
-        Self::Configuration(e.to_string())
+        Self::Malformed(e.to_string())
     }
 }
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
@@ -39,14 +39,14 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
         let lower = JsValue::from_str(&prefix);
         let upper = JsValue::from_str(&format!("{prefix}\u{ffff}"));
         let range = KeyRange::bound(&lower, &upper, None, None)
-            .map_err(|e| AuthorizeError::Configuration(format!("key range error: {e:?}")))?;
+            .map_err(|e| AuthorizeError::Malformed(format!("key range error: {e:?}")))?;
 
         store
             .query(|object_store| async move {
                 let values = object_store
                     .get_all(Some(range), None)
                     .await
-                    .map_err(|e| AuthorizeError::Configuration(format!("query: {e:?}")))?;
+                    .map_err(|e| AuthorizeError::Malformed(format!("query: {e:?}")))?;
 
                 let mut certs = Vec::new();
                 for value in values {
@@ -89,7 +89,7 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
                     object_store
                         .put(&js_val, Some(&js_key))
                         .await
-                        .map_err(|e| AuthorizeError::Configuration(format!("write: {e:?}")))?;
+                        .map_err(|e| AuthorizeError::Malformed(format!("write: {e:?}")))?;
                     Ok::<(), AuthorizeError>(())
                 })
                 .await?;

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -47,25 +47,26 @@ impl Certificate for UcanCertificate {
     fn verify(&self, access: &Scope) -> Result<TimeRange, AuthorizeError> {
         // Command attenuation: delegation command must be a prefix of requested command
         if !access.command.starts_with(self.0.command()) {
-            return Err(AuthorizeError::Denied(format!(
-                "command '{}' not covered by delegation '{}'",
-                access.command,
-                self.0.command()
-            )));
+            return Err(AuthorizeError::CommandEscalation {
+                claimed: access.command.to_string(),
+                authorized: self.0.command().to_string(),
+            });
         }
 
-        // Policy predicates: all must pass against the access parameters
+        // Policy predicates: all must pass against the access parameters.
+        // `find` rather than `all` so the failing predicate can be named --
+        // "policy rejected this" without saying which is hard to act on.
         let args = ipld_core::ipld::Ipld::Map(access.parameters.as_map().clone());
-        let all_pass = self
+        let failed = self
             .0
             .policy()
             .iter()
-            .all(|pred| pred.clone().run(&args).unwrap_or(false));
+            .find(|pred| !(*pred).clone().run(&args).unwrap_or(false));
 
-        if !all_pass {
-            return Err(AuthorizeError::Denied(
-                "policy predicates not satisfied".into(),
-            ));
+        if let Some(predicate) = failed {
+            return Err(AuthorizeError::PolicyViolation {
+                predicate: format!("{predicate:?}"),
+            });
         }
 
         Ok(TimeRange {
@@ -76,12 +77,12 @@ impl Certificate for UcanCertificate {
 
     fn encode(&self) -> Result<Vec<u8>, AuthorizeError> {
         serde_ipld_dagcbor::to_vec(&self.0)
-            .map_err(|e| AuthorizeError::Configuration(format!("Failed to encode proof: {e}")))
+            .map_err(|e| AuthorizeError::Malformed(format!("failed to encode proof: {e}")))
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, AuthorizeError> {
         serde_ipld_dagcbor::from_slice(bytes)
-            .map_err(|e| AuthorizeError::Configuration(format!("Failed to decode proof: {e}")))
+            .map_err(|e| AuthorizeError::Malformed(format!("failed to decode proof: {e}")))
     }
 }
 
@@ -155,7 +156,7 @@ impl Proof<Ucan> for UcanProof {
                 for proof in iter {
                     chain = chain
                         .push(proof.0)
-                        .map_err(|e| AuthorizeError::Configuration(e.to_string()))?;
+                        .map_err(|e| AuthorizeError::Malformed(e.to_string()))?;
                 }
                 Some(chain)
             }
@@ -196,9 +197,10 @@ impl Authorization<Ucan> for UcanAuthorization {
         if let Some(nbf) = self.duration.not_before
             && timestamp < nbf
         {
-            return Err(AuthorizeError::Denied(format!(
-                "cannot set not_before to {timestamp}, proof is not valid before {nbf}"
-            )));
+            return Err(AuthorizeError::NotValidBefore {
+                not_before: nbf,
+                at: timestamp,
+            });
         }
         self.duration.not_before = Some(timestamp);
         Ok(self)
@@ -208,9 +210,10 @@ impl Authorization<Ucan> for UcanAuthorization {
         if let Some(exp) = self.duration.expiration
             && timestamp > exp
         {
-            return Err(AuthorizeError::Denied(format!(
-                "cannot set expiration to {timestamp}, proof expires at {exp}"
-            )));
+            return Err(AuthorizeError::Expired {
+                expiration: exp,
+                at: timestamp,
+            });
         }
         self.duration.expiration = Some(timestamp);
         Ok(self)
@@ -238,12 +241,12 @@ impl Authorization<Ucan> for UcanAuthorization {
         let delegation = builder
             .try_build()
             .await
-            .map_err(|e| AuthorizeError::Configuration(format!("{e:?}")))?;
+            .map_err(|e| AuthorizeError::Malformed(format!("{e:?}")))?;
 
         let chain = match &self.chain {
             Some(chain) => chain
                 .push(delegation)
-                .map_err(|e| AuthorizeError::Configuration(format!("{e}")))?,
+                .map_err(|e| AuthorizeError::Malformed(format!("{e}")))?,
             None => DelegationChain::new(delegation),
         };
 
@@ -284,7 +287,7 @@ impl Authorization<Ucan> for UcanAuthorization {
             .proofs(proofs)
             .try_build()
             .await
-            .map_err(|e| AuthorizeError::Denied(format!("{e:?}")))?;
+            .map_err(|e| AuthorizeError::Malformed(format!("{e:?}")))?;
 
         let chain = InvocationChain::new(invocation, delegations_map);
 
@@ -363,14 +366,93 @@ mod tests {
         audience: &Did,
         subject: &Did,
     ) -> Delegation<Ed25519Signature> {
+        build_delegation_for(issuer, audience, subject, vec![]).await
+    }
+
+    async fn build_delegation_for(
+        issuer: Ed25519Signer,
+        audience: &Did,
+        subject: &Did,
+        command: Vec<String>,
+    ) -> Delegation<Ed25519Signature> {
         DelegationBuilder::new()
             .issuer(issuer)
             .audience(audience)
             .subject(UcanSubject::Specific(subject.clone()))
-            .command(vec![])
+            .command(command)
             .try_build()
             .await
             .unwrap()
+    }
+
+    // These drive a real `Certificate::verify` against a real delegation
+    // rather than constructing the error by hand, so they fail if the
+    // mapping from "what went wrong" to "which variant" is ever wrong --
+    // which asserting on hand-built values cannot catch.
+    mod verify_reports_why {
+        use super::*;
+        use dialog_ucan_core::command::Command;
+
+        /// A scope asking for `ability` against `subject`, with no policy.
+        fn scope_for(subject: &Did, ability: &str) -> crate::Scope {
+            crate::Scope {
+                subject: UcanSubject::Specific(subject.clone()),
+                command: Command::parse(ability).unwrap(),
+                parameters: Default::default(),
+            }
+        }
+
+        // A delegation granting `/archive/get` must not authorize
+        // `/archive/put`, and the error has to name both sides so a caller
+        // can see what it holds versus what it asked for.
+        #[dialog_common::test]
+        async fn it_names_both_abilities_when_one_does_not_cover_the_other() {
+            let issuer = signer(1).await;
+            let audience = signer(2).await.did();
+            let subject = signer(9).await.did();
+
+            let delegation = build_delegation_for(
+                issuer,
+                &audience,
+                &subject,
+                vec!["archive".into(), "get".into()],
+            )
+            .await;
+            let certificate = UcanCertificate(delegation);
+
+            // Ask for a sibling ability the delegation does not cover.
+            let scope = scope_for(&subject, "/archive/put");
+
+            match certificate.verify(&scope) {
+                Err(AuthorizeError::CommandEscalation {
+                    claimed,
+                    authorized,
+                }) => {
+                    assert_eq!(claimed, "/archive/put");
+                    assert_eq!(authorized, "/archive/get");
+                }
+                other => panic!("expected CommandEscalation, got {other:?}"),
+            }
+        }
+
+        // A delegation whose command the invocation *does* fall under must
+        // verify -- the guard above must not reject a legitimate narrowing.
+        #[dialog_common::test]
+        async fn it_accepts_an_ability_the_delegation_covers() {
+            let issuer = signer(1).await;
+            let audience = signer(2).await.did();
+            let subject = signer(9).await.did();
+
+            let delegation =
+                build_delegation_for(issuer, &audience, &subject, vec!["archive".into()]).await;
+            let certificate = UcanCertificate(delegation);
+
+            let scope = scope_for(&subject, "/archive/get");
+
+            certificate
+                .verify(&scope)
+                .expect("a delegation must authorize abilities beneath its own");
+        }
     }
 
     /// `UcanProof::from_chain` must yield proofs in root-to-leaf


### PR DESCRIPTION
`AuthorizeError::Denied(String)` was hiding six distinct failures behind one variant. The classification already existed — it was written in prose and then thrown away:

```
no delegation chain found for '{authority}' to access '{subject}'
command '{x}' not covered by delegation '{y}'
policy predicates not satisfied
cannot set not_before to {t}, proof is not valid before {nbf}
cannot set expiration to {t}, proof expires at {exp}
directory is the space for {actual}, not the subject {expected}
```

Each becomes a variant carrying its operands, so a caller reads them back rather than parsing a message.

## Why this matters now

The distinction that motivates it is **`Expired` versus `Revoked`**. Both mean "this proof does not authorize you right now", and a single `Denied` cannot tell them apart — but a caller should obtain a fresh proof on the first and *stop* on the second, since retrying presents the same withdrawn authority.

That distinction has a live consumer. The permit cache's retry (`dialog-remote-ucan-s3/src/provider.rs`) redeems and retries on any permit rejection; with these variants it can redeem on `Expired` and abandon on `Revoked`. Downstream, tonk's sync classifiers currently pattern-match magic strings (`"CREDENTIAL_REVOKED" | "DEVICE_REVOKED"`) across three crates to recover exactly this.

`Revoked` and `InvalidSignature` have no local constructor yet. They are where a transport maps a service's own classification — and the absence of anywhere to put revocation is why that detail has had to travel *beside* the error rather than inside it.

## Aligned with the UCAN vocabulary

Names and `claimed`/`authorized` field naming follow `dialog_ucan_core::invocation::CheckFailed`, which classifies the same failures one layer down: `UnprovenSubject`, `CommandEscalation`, `PolicyViolation`, `InvalidAudience`.

This enum cannot *reuse* `CheckFailed` — that would invert the dependency, since the UCAN implementation must not depend on dialog types. So it mirrors the vocabulary instead. Two consequences of that boundary:

- Abilities arrive as `String` paths rather than `Command`, matching how `Ability::ability` already represents them throughout `dialog-capability`.
- `PolicyViolation` carries the rendered predicate rather than the `Predicate` itself. `Certificate::verify` now uses `find` instead of folding with `all`, so it can name *which* predicate failed — "policy rejected this" without saying which is hard to act on.

## Two variants that are deliberately not denials

`UnavailableProof { link }` means the chain referred to a proof the caller did not supply, so nothing could be evaluated. Distinct from `UnprovenSubject`, where the delegations *were* searched and none authorizes this. The conformance fixtures already separate these (`"InvalidClaim"` vs `"UnavailableProof"`).

`Malformed(String)` (formerly `Configuration`) takes everything else that was never an access decision: encode/decode failures, credential loads, IndexedDB reads, delegation-builder errors.

Both say so in their docs, so neither quietly becomes the next catch-all.

## Tests

`verify_reports_why` drives `Certificate::verify` against **real delegations** rather than constructing errors by hand, so a wrong reason-to-variant mapping fails them. Verified non-vacuous by breaking the mapping and watching them catch it (`expected CommandEscalation, got Err(Malformed("nope"))`).

Unit tests additionally pin the `Expired`/`Revoked` split, that operands are readable rather than parsed, and that neither non-decision variant reads as a refusal.

**Coverage gap worth naming:** only `CommandEscalation` has a real-failure test. `InvalidAudience` and the time variants are constructed but not driven end-to-end, and nothing yet exercises a service returning 401/403 — that arrives with the transport mapping, since `Revoked`/`InvalidSignature` have no constructor until then.

## Notes for review

Three IndexedDB call sites are behind `cfg(wasm32)` and are invisible to a native-only check. They are converted too — worth knowing that `cargo check` alone would have shipped this broken.

`nix develop --command test:native:debug` green (2084 passed), `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, all libs compile for `wasm32-unknown-unknown`.

Stacked on #422 (`fix/storage-error-io`).
