### PR TITLE
perf(search-tree): amortized flushing, columnar node format, and read-path memoization

### DIFF
--- a/rust/dialog-common/src/buffer.rs
+++ b/rust/dialog-common/src/buffer.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::fmt::{Formatter, Result as FmtResult};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -26,6 +26,7 @@ struct BufferInner {
     bytes: AlignedVec,
     hash: OnceLock<Blake3Hash>,
     decoded: OnceLock<Decoded>,
+    validated: OnceLock<TypeId>,
     touches: AtomicU32,
 }
 
@@ -113,6 +114,34 @@ impl Buffer {
         Ok(self.memoized())
     }
 
+    /// Whether these bytes have already been validated as archived type `T`
+    /// (see [`mark_validated`](Self::mark_validated)).
+    ///
+    /// The buffer is immutable and every clone shares one interior, so a
+    /// successful validation holds for the buffer's whole lifetime: a `true`
+    /// here lets a reader take rkyv's unchecked access path instead of
+    /// re-walking the archive's bytecheck on every touch. The slot stores the
+    /// [`TypeId`] of the archived type that was validated, so an access as a
+    /// *different* archived type never inherits another type's validation.
+    pub fn is_validated<T>(&self) -> bool
+    where
+        T: 'static,
+    {
+        self.0.validated.get() == Some(&TypeId::of::<T>())
+    }
+
+    /// Records that these bytes passed a full bytecheck validation as
+    /// archived type `T`. One validation per buffer: a later mark with a
+    /// different type is ignored (that access keeps re-validating, which is
+    /// correct, just not memoized — in practice a buffer plays exactly one
+    /// archived role).
+    pub fn mark_validated<T>(&self)
+    where
+        T: 'static,
+    {
+        let _ = self.0.validated.set(TypeId::of::<T>());
+    }
+
     /// Converts this [`Buffer`] into an owned `Vec<u8>`.
     ///
     /// This always copies: the bytes live in an [`AlignedVec`], whose
@@ -159,6 +188,7 @@ impl From<AlignedVec> for Buffer {
             bytes: value,
             hash: OnceLock::new(),
             decoded: OnceLock::new(),
+            validated: OnceLock::new(),
             touches: AtomicU32::new(0),
         }))
     }

--- a/rust/dialog-search-tree/src/delta.rs
+++ b/rust/dialog-search-tree/src/delta.rs
@@ -64,7 +64,7 @@ where
 
     /// Retrieves the value associated with a key from this delta.
     pub fn get(&self, key: &K) -> Option<V> {
-        let contents = self.contents.write();
+        let contents = self.contents.read();
         contents.get(key).cloned()
     }
 

--- a/rust/dialog-search-tree/src/distribution.rs
+++ b/rust/dialog-search-tree/src/distribution.rs
@@ -70,6 +70,7 @@ pub mod audit {
 mod hash_memo {
     use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::hash::{BuildHasherDefault, Hasher};
 
     use dialog_common::Blake3Hash;
 
@@ -78,9 +79,43 @@ mod hash_memo {
     /// cache's own footprint.
     const CAPACITY: usize = 1 << 17;
 
+    /// The memo's table hasher (FxHash): deterministic and a fraction of
+    /// SipHash's cost per byte, which matters because every shaping-path
+    /// hash pays one table lookup over the full key bytes — the lookups
+    /// were measured at a quarter of a large batch commit's instructions
+    /// under the default hasher. Collision quality is not load-bearing:
+    /// the map compares full keys on lookup, so a weak hash costs probes,
+    /// never correctness, and the memoized blake3 values (the only thing
+    /// shape decisions read) are unaffected.
+    #[derive(Default)]
+    struct FxHasher(u64);
+
+    impl Hasher for FxHasher {
+        fn write(&mut self, bytes: &[u8]) {
+            const SEED: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+            let mut chunks = bytes.chunks_exact(8);
+            for chunk in &mut chunks {
+                let word = u64::from_le_bytes(chunk.try_into().expect("8-byte chunk"));
+                self.0 = (self.0.rotate_left(5) ^ word).wrapping_mul(SEED);
+            }
+            let mut tail = 0u64;
+            for (at, byte) in chunks.remainder().iter().enumerate() {
+                tail |= u64::from(*byte) << (at * 8);
+            }
+            self.0 = (self.0.rotate_left(5) ^ tail).wrapping_mul(SEED);
+        }
+
+        fn finish(&self) -> u64 {
+            self.0
+        }
+    }
+
     thread_local! {
-        static MEMO: RefCell<HashMap<Vec<u8>, Blake3Hash>> =
-            RefCell::new(HashMap::with_capacity(1024));
+        static MEMO: RefCell<HashMap<Vec<u8>, Blake3Hash, BuildHasherDefault<FxHasher>>> =
+            RefCell::new(HashMap::with_capacity_and_hasher(
+                1024,
+                BuildHasherDefault::default(),
+            ));
     }
 
     /// The blake3 hash of `bytes`, memoized.
@@ -655,9 +690,27 @@ pub mod cap {
         cuts
     }
 
-    /// Longest common prefix length of two byte strings.
+    /// Longest common prefix length of two byte strings. Word-at-a-time:
+    /// the elections call this for every candidate seam on every regroup,
+    /// over keys that share long prefixes (an ordered key's neighbors agree
+    /// on most leading bytes), so the byte-wise scan was a measured
+    /// double-digit share of large batch commits.
     fn lcp(a: &[u8], b: &[u8]) -> usize {
-        a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+        let shared = a.len().min(b.len());
+        let mut at = 0;
+        while at + 8 <= shared {
+            let left = u64::from_le_bytes(a[at..at + 8].try_into().expect("8-byte window"));
+            let right = u64::from_le_bytes(b[at..at + 8].try_into().expect("8-byte window"));
+            if left != right {
+                // Little-endian: the lowest differing byte is the first.
+                return at + ((left ^ right).trailing_zeros() / 8) as usize;
+            }
+            at += 8;
+        }
+        while at < shared && a[at] == b[at] {
+            at += 1;
+        }
+        at
     }
 
     /// Whether the seam between adjacent keys `left < right` may carry a
@@ -806,7 +859,7 @@ pub mod cap {
     /// The shortest distinguishing separator length of the seam between
     /// adjacent keys `left < right`: `min(lcp + 1, len(right))`, the
     /// semantic-distance metric of the hybrid selector.
-    fn shortest_separator_len(left: &[u8], right: &[u8]) -> usize {
+    pub(crate) fn shortest_separator_len(left: &[u8], right: &[u8]) -> usize {
         (lcp(left, right) + 1).min(right.len())
     }
 
@@ -872,8 +925,47 @@ pub mod cap {
     /// than `max_separator` exists for it (see [`frame_separator`]), so the
     /// forced seam stays self-identifying in stored form and rank 0 at
     /// index levels, exactly like a stretch anchor.
+    ///
+    /// Decided without materializing the padded separator: this runs for
+    /// every accepted seam of every frame election, and the allocation plus
+    /// `max_separator + 1` zeroed bytes per probe was a measured double-digit
+    /// share of large batch commits. The branches below reproduce
+    /// `frame_separator(..).is_some()` exactly (pinned by the test assert).
     pub fn is_frame_candidate(left: &[u8], right: &[u8], manifest: &Manifest) -> bool {
-        frame_separator(left, right, manifest).is_some()
+        let bound = manifest.max_separator as usize;
+        let candidate = if right.len() > bound {
+            // The right-prefix form always exists for an over-bound right.
+            true
+        } else {
+            // The padded form `left ++ 0x00..` (to `max(bound, left.len())
+            // + 1` bytes) qualifies iff it sorts at or below `right`:
+            // resolved by comparing against `right` with the padding kept
+            // virtual.
+            let head = left.len().min(right.len());
+            match left[..head].cmp(&right[..head]) {
+                std::cmp::Ordering::Less => true,
+                std::cmp::Ordering::Greater => false,
+                // `right` no longer than `left` with an equal head: the
+                // padded string extends `left`, so it sorts above `right`.
+                std::cmp::Ordering::Equal if right.len() <= left.len() => false,
+                // `left` is a proper prefix of `right`: the padding (all
+                // zeros) sorts at or below the right tail unless the tail
+                // is a zero run shorter than the padding.
+                std::cmp::Ordering::Equal => {
+                    let padding = bound.max(left.len()) + 1 - left.len();
+                    let tail = &right[left.len()..];
+                    let probe = padding.min(tail.len());
+                    tail[..probe].iter().any(|&byte| byte != 0) || padding <= tail.len()
+                }
+            }
+        };
+        #[cfg(test)]
+        debug_assert_eq!(
+            candidate,
+            frame_separator(left, right, manifest).is_some(),
+            "allocation-free frame candidacy must match the separator construction"
+        );
+        candidate
     }
 
     /// The stored separator for a frame anchor at the accepted seam between
@@ -966,6 +1058,161 @@ pub mod cap {
             AnchorSelector::from_manifest(manifest),
         )
     }
+
+    /// Whether candidate `a` beats candidate `b` in an election under
+    /// `selector`. Candidates are `(separator_len, right-key hash, entry
+    /// position)`; equal order resolves to the smaller position, matching
+    /// [`choose_cuts`]'s `min_by` over the ascending candidate scan (the
+    /// first minimum wins).
+    pub(crate) fn anchor_precedes(
+        selector: AnchorSelector,
+        a: (usize, &Blake3Hash, usize),
+        b: (usize, &Blake3Hash, usize),
+    ) -> bool {
+        let order = match selector {
+            AnchorSelector::Rendezvous => anchor_order(a.1).cmp(anchor_order(b.1)),
+            AnchorSelector::Hybrid => {
+                a.0.cmp(&b.0)
+                    .then_with(|| anchor_order(a.1).cmp(anchor_order(b.1)))
+            }
+        };
+        match order {
+            std::cmp::Ordering::Less => true,
+            std::cmp::Ordering::Greater => false,
+            std::cmp::Ordering::Equal => a.2 < b.2,
+        }
+    }
+
+    /// One run piece in compressed form for
+    /// [`election_matches_boundaries`]: its entry count and summed
+    /// entry weight, plus its best INTERIOR forced-anchor candidate under
+    /// the manifest's selector — `(separator_len, right-key hash, entry
+    /// offset of the right key within the piece)` — or `None` when no
+    /// interior seam qualifies.
+    pub(crate) struct CompressedPiece {
+        /// Number of entries in the piece.
+        pub count: usize,
+        /// Summed entry weight of the piece.
+        pub weight: usize,
+        /// Best interior candidate seam, if any.
+        pub interior: Option<(usize, Blake3Hash, usize)>,
+    }
+
+    /// Whether a backstop election over a whole forced run reproduces
+    /// exactly the current piece boundaries, evaluated over per-piece
+    /// summaries without materializing any entry. One evaluation serves
+    /// both backstops — the caller passes the stretch backstop's
+    /// `max_segment` or the frame ceiling as `threshold`, with each
+    /// piece's `interior` filtered to the matching candidate kind
+    /// ([`is_forced_candidate`] seams for the stretch,
+    /// [`is_frame_candidate`] seams for the ceiling), and must have
+    /// verified every boundary seam is itself a candidate of that kind.
+    /// `boundaries[i]` carries the anchor identity of the seam between
+    /// pieces `i` and `i + 1`: its shortest-separator length and its
+    /// right key's hash.
+    ///
+    /// The verification mirrors [`choose_cuts`]'s recursive bisection at
+    /// piece granularity, which is exact: as long as every elected cut is
+    /// a piece boundary, every recursion range is a whole-piece union, so
+    /// prefix weights at boundaries suffice and the best interior
+    /// candidate of a range is the minimum of its member pieces' interior
+    /// minima. It returns `false` the moment the full election would
+    /// deviate from the stored partition: an interior candidate winning a
+    /// range (a cut would land inside a piece), an over-threshold
+    /// multi-piece range with no candidate at all, or an under-threshold
+    /// range still spanning a stored boundary (a cut would dissolve). A
+    /// `false` is therefore an exact "the plan changed", not a
+    /// "don't know".
+    pub(crate) fn election_matches_boundaries(
+        pieces: &[CompressedPiece],
+        boundaries: &[(usize, Blake3Hash)],
+        threshold: usize,
+        manifest: &Manifest,
+    ) -> bool {
+        let cap = threshold;
+        if cap == 0 || pieces.len() < 2 || boundaries.len() + 1 != pieces.len() {
+            return false;
+        }
+        let mut prefix_weight = Vec::with_capacity(pieces.len() + 1);
+        let mut prefix_count = Vec::with_capacity(pieces.len() + 1);
+        prefix_weight.push(0usize);
+        prefix_count.push(0usize);
+        for piece in pieces {
+            prefix_weight.push(prefix_weight.last().expect("seeded") + piece.weight);
+            prefix_count.push(prefix_count.last().expect("seeded") + piece.count);
+        }
+        if prefix_weight[pieces.len()] <= cap {
+            // The full election would place no cuts at all, dissolving
+            // every stored boundary.
+            return false;
+        }
+        let selector = AnchorSelector::from_manifest(manifest);
+
+        // Recursive bisection over piece-index ranges `[plo, phi)`.
+        let mut stack = vec![(0usize, pieces.len())];
+        while let Some((plo, phi)) = stack.pop() {
+            if prefix_weight[phi] - prefix_weight[plo] <= cap {
+                if phi - plo > 1 {
+                    // The election stops here, but stored boundaries exist
+                    // inside the range: they would dissolve.
+                    return false;
+                }
+                continue;
+            }
+            // The range's best candidate: boundary seams strictly inside,
+            // and every member piece's best interior seam (interior
+            // positions are strictly inside their piece, so strictly
+            // inside the range). Interior positions can never equal a
+            // boundary position, so the winner's kind is unambiguous.
+            let mut best: Option<(usize, &Blake3Hash, usize)> = None;
+            let mut best_boundary: Option<usize> = None;
+            for boundary in plo..phi.saturating_sub(1) {
+                let (separator_len, hash) = &boundaries[boundary];
+                let candidate = (*separator_len, hash, prefix_count[boundary + 1]);
+                if best.is_none_or(|current| anchor_precedes(selector, candidate, current)) {
+                    best = Some(candidate);
+                    best_boundary = Some(boundary);
+                }
+            }
+            for piece in plo..phi {
+                if let Some((separator_len, hash, offset)) = &pieces[piece].interior {
+                    let candidate = (*separator_len, hash, prefix_count[piece] + offset);
+                    if best.is_none_or(|current| anchor_precedes(selector, candidate, current)) {
+                        best = Some(candidate);
+                        best_boundary = None;
+                    }
+                }
+            }
+            match (best, best_boundary) {
+                // Over threshold with no candidate: the full election
+                // leaves the range whole, which matches the stored state
+                // only if it is a single piece.
+                (None, _) => {
+                    if phi - plo > 1 {
+                        return false;
+                    }
+                }
+                // An interior candidate wins: the full election would cut
+                // inside a piece the stored partition keeps whole.
+                (Some(_), None) => return false,
+                // A boundary wins: exactly the stored cut. Recurse.
+                (Some(_), Some(boundary)) => {
+                    stack.push((plo, boundary + 1));
+                    stack.push((boundary + 1, phi));
+                }
+            }
+        }
+        true
+    }
+}
+
+pub(crate) mod summary;
+
+/// The memoized anchor hash of a key — the same hash the elections use
+/// for candidate ordering — exposed for the compressed quiet check, whose
+/// boundary anchors are built outside this module.
+pub(crate) fn anchor_hash(key: &[u8]) -> dialog_common::Blake3Hash {
+    hash_memo::hash(key)
 }
 
 /// Geometric distribution for computing node ranks.
@@ -1057,6 +1304,51 @@ mod tests {
         // prove it.
         bytes[8..].fill(0xFF);
         Blake3Hash::from(bytes)
+    }
+
+    /// The allocation-free frame candidacy decision must agree with the
+    /// separator construction it stands in for, over every ordered pair of
+    /// short strings on a zero-heavy alphabet (padding is all zeros, so
+    /// zero runs and prefix relations are exactly the corner cases) and
+    /// across bounds that put keys under, at, and over `max_separator`.
+    #[dialog_common::test]
+    async fn it_decides_frame_candidacy_exactly_like_the_separator() -> Result<()> {
+        let mut strings: Vec<Vec<u8>> = vec![Vec::new()];
+        let alphabet = [0x00u8, 0x01, 0xFF];
+        let mut frontier = vec![Vec::new()];
+        for _ in 0..4 {
+            let mut next = Vec::new();
+            for prefix in &frontier {
+                for byte in alphabet {
+                    let mut string = prefix.clone();
+                    string.push(byte);
+                    next.push(string);
+                }
+            }
+            strings.extend(next.iter().cloned());
+            frontier = next;
+        }
+
+        for max_separator in [1u32, 2, 3, 5] {
+            let manifest = Manifest {
+                max_separator,
+                ..Manifest::default()
+            };
+            for left in &strings {
+                for right in &strings {
+                    if left >= right {
+                        continue;
+                    }
+                    assert_eq!(
+                        cap::is_frame_candidate(left, right, &manifest),
+                        cap::frame_separator(left, right, &manifest).is_some(),
+                        "candidacy diverged for left={left:?} right={right:?} bound={max_separator}"
+                    );
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// The threshold comparisons are exact, deterministic golden values: a

--- a/rust/dialog-search-tree/src/distribution/summary.rs
+++ b/rust/dialog-search-tree/src/distribution/summary.rs
@@ -1,0 +1,220 @@
+//! Per-piece summaries for the compressed forced-run quiet check.
+//!
+//! A forced run's pieces are content-addressed stored nodes, so everything
+//! the run-wide plan verification needs from an UNTOUCHED piece is a pure
+//! function of the piece's bytes: entry count and summed weight, edge keys
+//! and the last entry's weight (boundary seams and their coin verdicts are
+//! formed against these), the piece-local coin outcomes, the trailing
+//! bank, the heaviest interior vetoed stretch, and the best interior
+//! election candidate of each backstop kind. Summaries are memoized per
+//! node hash, so a piece is streamed once per content change instead of
+//! once per quiet check — the difference between the check costing
+//! O(run entries) and O(run pieces) on the hot path.
+//!
+//! Piece-local coin evaluation is exact in the regimes the compressed
+//! check accepts: the weight bank resets at every accepted seam, so when a
+//! piece's left boundary seam is accepted (the frame-ceiling regime) the
+//! bank entering the piece is zero, and when every seam is vetoed (the
+//! stretch regime) there are no coin verdicts at all.
+//!
+//! The memo is thread-local and bounded like the key-hash memo: entries
+//! are keyed by `(node hash, max_separator, anchor_selector)` — the only
+//! manifest knobs the summarized quantities read (coin verdicts also read
+//! `max_segment`, but through `D::leaf_cut`, whose manifest is the same
+//! one; a manifest change changes the key) — and the map is cleared
+//! wholesale at capacity.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dialog_common::Blake3Hash;
+
+use super::cap;
+use crate::{Distribution, Manifest};
+
+/// Everything the compressed quiet check needs from one run piece.
+#[derive(Debug, Clone)]
+pub(crate) struct PieceSummary {
+    /// Number of entries.
+    pub count: usize,
+    /// Summed entry weight ([`Entry::weight`](crate::Entry::weight)).
+    pub weight: usize,
+    /// The first entry's key bytes.
+    pub first_key: Vec<u8>,
+    /// The last entry's key bytes.
+    pub last_key: Vec<u8>,
+    /// The last entry's weight — the boundary seam's own coin charge reads
+    /// it together with `trailing_bank`.
+    pub last_weight: usize,
+    /// Whether every interior seam is vetoed (the stretch regime).
+    pub all_vetoed: bool,
+    /// Whether any interior accepted seam's coin verdict is a cut, under
+    /// piece-local banks. A stored piece is whole, so a cut
+    /// here means the plan does not reproduce the stored partition.
+    pub interior_coin_cut: bool,
+    /// The bank flowing into the seam after the piece's last entry: the
+    /// summed weights of the left partners of the trailing maximal run of
+    /// vetoed interior seams.
+    pub trailing_bank: usize,
+    /// The heaviest maximal interior vetoed stretch, measured as the
+    /// stretch election measures it (summed entry weights over the
+    /// stretch's full key range). Over `max_segment` the stretch backstop
+    /// could cut inside the piece, which the summary cannot decide.
+    pub max_stretch_weight: usize,
+    /// Best interior vetoed-seam candidate of the stretch backstop
+    /// ([`cap::is_forced_candidate`]): `(separator_len, right-key hash,
+    /// right-key offset)`.
+    pub stretch_interior: Option<(usize, Blake3Hash, usize)>,
+    /// Best interior accepted-seam candidate of the frame ceiling
+    /// ([`cap::is_frame_candidate`]), same shape.
+    pub frame_interior: Option<(usize, Blake3Hash, usize)>,
+}
+
+impl PieceSummary {
+    /// Builds a summary from a piece's keys (in entry order) and per-entry
+    /// weights, mirroring `cut_plan`'s seam walk at piece scope: vetoes
+    /// and banks left to right, coin verdicts at accepted seams, stretch
+    /// extents and both backstops' candidate minima.
+    pub(crate) fn build<D>(keys: &[&[u8]], weights: &[usize], manifest: &Manifest) -> Self
+    where
+        D: Distribution,
+    {
+        let count = keys.len();
+        let weight = weights.iter().sum();
+        let first_key = keys.first().map(|key| key.to_vec()).unwrap_or_default();
+        let last_key = keys.last().map(|key| key.to_vec()).unwrap_or_default();
+        let last_weight = weights.last().copied().unwrap_or_default();
+        let selector = cap::AnchorSelector::from_manifest(manifest);
+
+        let mut all_vetoed = true;
+        let mut interior_coin_cut = false;
+        let mut bank = 0usize;
+        let mut max_stretch_weight = 0usize;
+        // The open stretch's summed weight over its full key range
+        // `[start..=current]`, maintained incrementally: opening at seam
+        // `(at - 1, at)` seeds both partners' weights, each further vetoed
+        // seam adds its right partner.
+        let mut stretch_weight: Option<usize> = None;
+        let mut stretch_interior: Option<(usize, Blake3Hash, usize)> = None;
+        let mut frame_interior: Option<(usize, Blake3Hash, usize)> = None;
+
+        let consider = |slot: &mut Option<(usize, Blake3Hash, usize)>,
+                        candidate: (usize, Blake3Hash, usize)| {
+            let wins = match slot {
+                None => true,
+                Some(current) => cap::anchor_precedes(
+                    selector,
+                    (candidate.0, &candidate.1, candidate.2),
+                    (current.0, &current.1, current.2),
+                ),
+            };
+            if wins {
+                *slot = Some(candidate);
+            }
+        };
+
+        for at in 1..count {
+            let left = keys[at - 1];
+            let right = keys[at];
+            if D::vetoes(left, right, manifest) {
+                bank += weights[at - 1];
+                stretch_weight = Some(match stretch_weight {
+                    None => weights[at - 1] + weights[at],
+                    Some(sum) => sum + weights[at],
+                });
+                if cap::is_forced_candidate(left, right, manifest) {
+                    consider(
+                        &mut stretch_interior,
+                        (
+                            cap::shortest_separator_len(left, right),
+                            super::hash_memo::hash(right),
+                            at,
+                        ),
+                    );
+                }
+            } else {
+                all_vetoed = false;
+                if let Some(sum) = stretch_weight.take() {
+                    max_stretch_weight = max_stretch_weight.max(sum);
+                }
+                if D::leaf_cut(left, bank + weights[at - 1], manifest) {
+                    interior_coin_cut = true;
+                }
+                bank = 0;
+                if cap::is_frame_candidate(left, right, manifest) {
+                    consider(
+                        &mut frame_interior,
+                        (
+                            cap::shortest_separator_len(left, right),
+                            super::hash_memo::hash(right),
+                            at,
+                        ),
+                    );
+                }
+            }
+        }
+        if let Some(sum) = stretch_weight {
+            max_stretch_weight = max_stretch_weight.max(sum);
+        }
+
+        Self {
+            count,
+            weight,
+            first_key,
+            last_key,
+            last_weight,
+            all_vetoed,
+            interior_coin_cut,
+            trailing_bank: bank,
+            max_stretch_weight,
+            stretch_interior,
+            frame_interior,
+        }
+    }
+}
+
+/// Entries retained before the memo resets. Summaries are small (two edge
+/// keys plus a handful of scalars), so this bounds the memo well under the
+/// node cache's footprint.
+const CAPACITY: usize = 1 << 14;
+
+type MemoKey = (Blake3Hash, u32, u32);
+
+thread_local! {
+    /// The per-thread summary memo, keyed by node hash plus the manifest
+    /// knobs the summary reads.
+    static MEMO: RefCell<HashMap<MemoKey, Arc<PieceSummary>>> = RefCell::new(HashMap::new());
+}
+
+/// The memo key for `hash` under `manifest`.
+fn key(hash: &Blake3Hash, manifest: &Manifest) -> MemoKey {
+    (
+        hash.clone(),
+        manifest.max_separator,
+        manifest.anchor_selector,
+    )
+}
+
+/// The memoized summary for the piece stored under `hash`, if present.
+pub(crate) fn memoized(hash: &Blake3Hash, manifest: &Manifest) -> Option<Arc<PieceSummary>> {
+    MEMO.with(|memo| memo.borrow().get(&key(hash, manifest)).cloned())
+}
+
+/// Memoizes `summary` for the piece stored under `hash`, returning the
+/// shared handle.
+pub(crate) fn memoize(
+    hash: &Blake3Hash,
+    manifest: &Manifest,
+    summary: PieceSummary,
+) -> Arc<PieceSummary> {
+    MEMO.with(|memo| {
+        let mut memo = memo.borrow_mut();
+        if memo.len() >= CAPACITY {
+            memo.clear();
+        }
+        let summary = Arc::new(summary);
+        memo.insert(key(hash, manifest), summary.clone());
+        summary
+    })
+}

--- a/rust/dialog-search-tree/src/entry.rs
+++ b/rust/dialog-search-tree/src/entry.rs
@@ -10,6 +10,16 @@ pub struct Entry<Key, Value> {
     pub value: Value,
 }
 
+/// Per-entry encoding overhead charged by [`Entry::weight`], calibrated
+/// against measured leaf encodings on the real SE dataset: beyond key
+/// bytes and the value payload estimate, each entry costs ~64-72 encoded
+/// bytes of columnar bookkeeping (front-coding offsets, dictionary and
+/// value-table framing, polarity). Without this term the frame ceiling —
+/// which provably holds in weight — let encoded BYTES drift to 1.85x the
+/// metered weight at p90 (max 2.1x); charging it brings bytes/weight to
+/// p50 1.02 / p90 1.05, so the ceiling denominates in effective bytes.
+pub const ENTRY_ENCODING_OVERHEAD: usize = 64;
+
 impl<Key, Value> Entry<Key, Value>
 where
     Key: self::Key,
@@ -21,11 +31,12 @@ where
     }
 
     /// The weight this entry contributes toward `Manifest::max_segment`:
-    /// its key bytes plus its value's payload weight
-    /// ([`Value::payload_weight`]). The charge every byte-pacing decision
-    /// (the leaf coin's bank, stretch and frame budgets, the edit path's
-    /// ceiling gates) meters an entry by.
+    /// its key bytes, its value's payload weight
+    /// ([`Value::payload_weight`]), and the per-entry encoding overhead.
+    /// The charge every byte-pacing decision (the leaf coin's bank,
+    /// stretch and frame budgets, the edit path's ceiling gates) meters an
+    /// entry by.
     pub fn weight(&self) -> usize {
-        self.key.as_ref().len() + self.value.payload_weight()
+        self.key.as_ref().len() + self.value.payload_weight() + ENTRY_ENCODING_OVERHEAD
     }
 }

--- a/rust/dialog-search-tree/src/hitchhiker.rs
+++ b/rust/dialog-search-tree/src/hitchhiker.rs
@@ -62,6 +62,66 @@ use crate::{
 /// [`HitchhikerTree::with_op_buf_size`].
 pub const DEFAULT_OP_BUF_SIZE: usize = 256;
 
+/// The op-buffer capacity trees open under: [`DEFAULT_OP_BUF_SIZE`] unless
+/// `DIALOG_TREE_OP_BUF` overrides it (experiment plumbing, read once per
+/// process, native only). The capacity is the per-commit-cost knob: a
+/// commit re-encodes and re-hashes the root frame, whose size the buffer
+/// dominates, while a smaller buffer flushes (and pushes novelty toward
+/// the leaves) proportionally more often — so the optimum balances
+/// O(capacity) per commit against O(flush)/capacity amortized, and it is
+/// a measurement question, not a constant to guess.
+/// Default op-buffer WEIGHT cap: the buffer flushes when its buffered
+/// weight (key bytes + value payloads + per-entry encoding overhead, the
+/// calibrated byte metering) exceeds this, whatever the op count. The
+/// count cap bounds how many ops a buffer holds; this bounds their BYTES,
+/// which is what actually rides the root frame into every per-commit
+/// rewrite and every pushed operational block — a byte-heavy workload can
+/// pack ~200 KB into 256 ops. 64 KiB (the pacing target's scale) bounds
+/// the operational root block for a measured +17% replay cost on the
+/// byte-heavy real workload; the metering's per-op overhead charge means
+/// this cap also implies a hard op-count bound, so it is the primary
+/// knob and the count cap is secondary.
+pub const DEFAULT_OP_BUF_BYTES: usize = 64 * 1024;
+
+/// The op-buffer byte cap trees open under: [`DEFAULT_OP_BUF_BYTES`]
+/// unless `DIALOG_TREE_OP_BUF_BYTES` overrides it (experiment plumbing,
+/// read once per process, native only; explicit 0 disables the byte
+/// trigger).
+fn default_op_buf_bytes() -> usize {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        static BYTES: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        *BYTES.get_or_init(|| {
+            match std::env::var("DIALOG_TREE_OP_BUF_BYTES")
+                .ok()
+                .and_then(|raw| raw.parse().ok())
+            {
+                Some(0) => usize::MAX,
+                Some(bytes) => bytes,
+                None => DEFAULT_OP_BUF_BYTES,
+            }
+        })
+    }
+    #[cfg(target_arch = "wasm32")]
+    DEFAULT_OP_BUF_BYTES
+}
+
+fn default_op_buf_size() -> usize {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        static SIZE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        *SIZE.get_or_init(|| {
+            std::env::var("DIALOG_TREE_OP_BUF")
+                .ok()
+                .and_then(|raw| raw.parse().ok())
+                .filter(|&size| size > 0)
+                .unwrap_or(DEFAULT_OP_BUF_SIZE)
+        })
+    }
+    #[cfg(target_arch = "wasm32")]
+    DEFAULT_OP_BUF_SIZE
+}
+
 /// A boxed future returning an edited [`TransientNode`], the shape `enqueue`
 /// returns so its recursion can be expressed as a plain `async fn` body inside a
 /// `Box::pin`.
@@ -170,6 +230,7 @@ where
     root: HitchhikerRoot<Key, Value>,
     cache: Cache<Blake3Hash, Buffer>,
     op_buf_size: usize,
+    op_buf_bytes: usize,
     policy: FlushPolicy,
     trigger: FlushTrigger,
     /// The tree's format header, captured from the root node the first time a
@@ -207,7 +268,8 @@ where
         Self {
             root: HitchhikerRoot::Unloaded(tree.root().clone()),
             cache: tree.node_cache(),
-            op_buf_size: DEFAULT_OP_BUF_SIZE,
+            op_buf_size: default_op_buf_size(),
+            op_buf_bytes: default_op_buf_bytes(),
             policy: FlushPolicy::default(),
             trigger: FlushTrigger::default(),
             manifest: None,
@@ -220,7 +282,8 @@ where
         Self {
             root: HitchhikerRoot::Unloaded(NULL_BLAKE3_HASH.clone()),
             cache: Cache::new(),
-            op_buf_size: DEFAULT_OP_BUF_SIZE,
+            op_buf_size: default_op_buf_size(),
+            op_buf_bytes: default_op_buf_bytes(),
             policy: FlushPolicy::default(),
             trigger: FlushTrigger::default(),
             manifest: None,
@@ -228,9 +291,35 @@ where
         }
     }
 
+    /// Pins the format [`Manifest`] this session writes under, instead of
+    /// reading it from the tree's root on first load.
+    ///
+    /// The manifest normally travels IN the tree (every node carries it),
+    /// which leaves one gap: an EMPTY tree has no node to carry it, so a
+    /// session opened over an empty root writes under [`Manifest::default`]
+    /// — even when the tree held a different format before its last entry
+    /// was deleted. A caller that configures a non-default format must
+    /// therefore re-impose it whenever it opens over a possibly-empty
+    /// tree, or an empty-and-refill lifecycle silently reverts the store
+    /// to the default format (and two replicas that emptied at different
+    /// points diverge on identical facts). This was found by the
+    /// adversarial convergence soak's delete-to-empty pattern.
+    pub fn with_manifest(mut self, manifest: Manifest) -> Self {
+        self.manifest = Some(manifest);
+        self
+    }
+
     /// Sets the per-node novelty capacity (the write-amplification knob).
     pub fn with_op_buf_size(mut self, op_buf_size: usize) -> Self {
         self.op_buf_size = op_buf_size.max(1);
+        self
+    }
+
+    /// Sets the per-node novelty WEIGHT cap: the buffer flushes when its
+    /// buffered weight (key bytes + value payloads) exceeds this, whatever
+    /// the op count. `usize::MAX` (the default) disables the byte trigger.
+    pub fn with_op_buf_bytes(mut self, op_buf_bytes: usize) -> Self {
+        self.op_buf_bytes = op_buf_bytes.max(1);
         self
     }
 
@@ -287,6 +376,76 @@ where
         .await
     }
 
+    /// Buffers an insert WITHOUT evaluating the flush policy: the deferred
+    /// half of batch writing. The op is routed into the root's novelty and
+    /// left there however full the buffer gets; the caller runs
+    /// [`settle`](Self::settle) once after the whole batch, so a batch
+    /// cascades into any given child at most once instead of re-flushing it
+    /// on every overflow the batch crosses. Reads are novelty-aware wherever
+    /// ops sit, so a deferred tree reads exactly like a settled one.
+    pub async fn insert_deferred<Backend>(
+        self,
+        key: Key,
+        value: Value,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Self, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+    {
+        self.write_with(
+            vec![NoveltyEntry {
+                key: key.as_ref().to_vec(),
+                op: NoveltyOp::Assert(value),
+            }],
+            storage,
+            false,
+        )
+        .await
+    }
+
+    /// Buffers a delete WITHOUT evaluating the flush policy; see
+    /// [`insert_deferred`](Self::insert_deferred).
+    pub async fn delete_deferred<Backend>(
+        self,
+        key: Key,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Self, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+    {
+        self.write_with(
+            vec![NoveltyEntry {
+                key: key.as_ref().to_vec(),
+                op: NoveltyOp::Retract,
+            }],
+            storage,
+            false,
+        )
+        .await
+    }
+
+    /// Applies the flush policy once over everything the deferred writes
+    /// accumulated: the settle half of batch writing. Buffers that ended the
+    /// batch over their trigger cascade now, top-down, each child receiving
+    /// its whole accumulated share in one flush.
+    pub async fn settle<Backend>(
+        self,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Self, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+    {
+        match self.root {
+            // Nothing buffered in memory: nothing to settle. (A persisted
+            // root's stored buffers settle when a write next loads it.)
+            HitchhikerRoot::Unloaded(_) => Ok(self),
+            HitchhikerRoot::Loaded(_) => self.write_with(Vec::new(), storage, true).await,
+        }
+    }
+
     /// Enqueues a batch of ops into the tree, cascading buffers one level on
     /// overflow.
     ///
@@ -296,9 +455,27 @@ where
     /// [`TransientTree`] insert/delete path so leaf landings reshape exactly as
     /// a sequential edit would.
     async fn write<Backend>(
+        self,
+        msgs: Vec<NoveltyEntry<Value>>,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Self, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+    {
+        self.write_with(msgs, storage, true).await
+    }
+
+    /// [`write`](Self::write) with the flush policy made optional: `settle`
+    /// false routes the ops and returns (deferred batch writing), true is
+    /// the classic behavior. Leaf-bound ops (an empty or segment-rooted
+    /// tree, the `Immediate` policy) always go to the canonical edit path
+    /// immediately — a leaf has no buffer to defer into.
+    async fn write_with<Backend>(
         mut self,
         msgs: Vec<NoveltyEntry<Value>>,
         storage: &ContentAddressedStorage<Backend>,
+        settle: bool,
     ) -> Result<Self, DialogSearchTreeError>
     where
         Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
@@ -334,23 +511,100 @@ where
                 deferred = msgs;
                 Some(node)
             }
-            Some(node) => Some(
-                enqueue::<Key, Value, D, Backend>(
+            Some(node) => {
+                let node = enqueue::<Key, Value, D, Backend>(
                     node,
                     msgs,
-                    self.op_buf_size,
-                    self.policy,
-                    self.trigger,
+                    EnqueueConfig {
+                        op_buf_size: self.op_buf_size,
+                        op_buf_bytes: self.op_buf_bytes,
+                        policy: self.policy,
+                        trigger: self.trigger,
+                        settle,
+                    },
                     &mut deferred,
                     &accessor,
                 )
-                .await?,
-            ),
+                .await?;
+                Some(node)
+            }
             None => {
                 // No spine to buffer into yet: defer everything to the leaf path.
                 deferred = msgs;
                 None
             }
+        };
+
+        // Bulk-dominance rebuild: when the leaf-bound batch dwarfs the whole
+        // live tree — the bulk-load shape, where a batch's first instruction
+        // seeded a tiny root and everything since buffered behind it — the
+        // per-op canonical replay below is pure overhead. Resolve the tree's
+        // full logical state through the novelty-aware stream (bounded by
+        // the dominance ratio, so a genuinely large tree pays one aborted
+        // scan of at most `deferred/8` entries) and rebuild bottom-up with
+        // one plant. Exact: the stream yields the resolved pre-batch state,
+        // the deferred ops are strictly newer (a key's ops cascade as a
+        // whole link buffer, so no key straddles the two), and the plant's
+        // stable last-wins fold reproduces sequential application. History
+        // independence makes the bottom-up build byte-identical to the
+        // per-op replay's canonical outcome, which converge_check pins.
+        const PLANT_MIN: usize = 64;
+        const PLANT_DOMINANCE: usize = 8;
+        let node = if deferred.len() >= PLANT_MIN && node.is_some() {
+            let Some(live) = node else { unreachable!() };
+            self.root = HitchhikerRoot::Loaded(live);
+            let limit = deferred.len() / PLANT_DOMINANCE;
+            let existing = {
+                let stream = self.stream_range(.., storage);
+                futures_util::pin_mut!(stream);
+                let mut entries: Vec<Entry<Key, Value>> = Vec::new();
+                let mut small = true;
+                while let Some(entry) = futures_util::StreamExt::next(&mut stream).await {
+                    entries.push(entry?);
+                    if entries.len() > limit {
+                        small = false;
+                        break;
+                    }
+                }
+                small.then_some(entries)
+            };
+            match existing {
+                Some(entries) => {
+                    let mut oplist: Vec<NoveltyEntry<Value>> = entries
+                        .into_iter()
+                        .map(|entry| NoveltyEntry {
+                            key: entry.key.as_ref().to_vec(),
+                            op: NoveltyOp::Assert(entry.value),
+                        })
+                        .collect();
+                    oplist.extend(deferred);
+                    let edit = TransientTree::<Key, Value, D>::with_manifest(
+                        NULL_BLAKE3_HASH.clone(),
+                        self.cache.clone(),
+                        self.manifest.unwrap_or_default(),
+                    )
+                    .plant(oplist, storage)
+                    .await?;
+                    self.root = match edit.into_root() {
+                        TransientRootParts::Loaded(node) => HitchhikerRoot::Loaded(node),
+                        TransientRootParts::Unloaded(hash) => HitchhikerRoot::Unloaded(hash),
+                    };
+                    return Ok(self);
+                }
+                None => match std::mem::replace(
+                    &mut self.root,
+                    HitchhikerRoot::Unloaded(NULL_BLAKE3_HASH.clone()),
+                ) {
+                    HitchhikerRoot::Loaded(node) => Some(node),
+                    HitchhikerRoot::Unloaded(_) => {
+                        return Err(DialogSearchTreeError::Node(
+                            "The bulk-dominance check lost the live spine".into(),
+                        ));
+                    }
+                },
+            }
+        } else {
+            node
         };
 
         // Apply the deferred (leaf-bound) ops to the live spine in memory through
@@ -495,8 +749,11 @@ where
                     }
                 }
                 TransientNode::Segment(segment) => {
-                    return match segment.entries.binary_search_by(|entry| entry.key.cmp(key)) {
-                        Ok(at) => Ok(Some(segment.entries[at].value.clone())),
+                    return match segment
+                        .entries()
+                        .binary_search_by(|entry| entry.key.cmp(key))
+                    {
+                        Ok(at) => Ok(Some(segment.entries()[at].value.clone())),
                         Err(_) => Ok(None),
                     };
                 }
@@ -679,12 +936,58 @@ where
             // manifest; a tree born empty in this process has no stored header
             // yet and takes the default, which is exactly what its first
             // canonical write would stamp.
-            HitchhikerRoot::Loaded(node) => Ok(node
-                .persist(delta, &self.manifest.unwrap_or_default())?
-                .hash()
-                .clone()),
+            HitchhikerRoot::Loaded(node) => {
+                let manifest = self.manifest.unwrap_or_default();
+                let node = node.persist(delta, &manifest)?;
+                // Seed the shared node cache with the frame just produced:
+                // the very next read of this root (a manifest lookup, a
+                // query descent) otherwise misses, re-fetches the bytes
+                // from storage, and pays a full blake3 re-verification of
+                // a frame this process just hashed.
+                self.cache
+                    .insert(node.hash().clone(), node.buffer().clone());
+                Ok(node.hash().clone())
+            }
         }
     }
+
+    /// Serializes the buffered tree as-is (buffers intact) into `delta`
+    /// WITHOUT consuming it, returning its root hash.
+    ///
+    /// Byte- and hash-identical to [`persist`](Self::persist); the
+    /// difference is retention: the live spine survives, so the caller can
+    /// keep committing into it instead of re-opening the root frame from
+    /// bytes on every batch (see [`TransientNode::persist_mut`] for what is
+    /// kept live and what collapses back to links).
+    pub fn persist_mut(
+        &mut self,
+        delta: &mut Delta<Blake3Hash, Buffer>,
+    ) -> Result<Blake3Hash, DialogSearchTreeError> {
+        match &mut self.root {
+            HitchhikerRoot::Unloaded(hash) => Ok(hash.clone()),
+            HitchhikerRoot::Loaded(node) => {
+                let manifest = self.manifest.unwrap_or_default();
+                let node = node.persist_mut(delta, &manifest)?;
+                // Same cache seeding as `persist`: the frame this commit
+                // just produced is what the next read resolves the root to.
+                self.cache
+                    .insert(node.hash().clone(), node.buffer().clone());
+                Ok(node.hash().clone())
+            }
+        }
+    }
+}
+
+/// The knobs one `enqueue` pass runs under: the buffer capacity, how far
+/// an overflow cascades, what makes it fire, and whether it is evaluated
+/// at all (`settle` false = deferred batch routing).
+#[derive(Clone, Copy)]
+struct EnqueueConfig {
+    op_buf_size: usize,
+    op_buf_bytes: usize,
+    policy: FlushPolicy,
+    trigger: FlushTrigger,
+    settle: bool,
 }
 
 /// Routes `msgs` into the subtree rooted at `node`, cascading one level on
@@ -706,9 +1009,7 @@ where
 fn enqueue<'a, Key, Value, D, Backend>(
     node: TransientNode<Key, Value>,
     msgs: Vec<NoveltyEntry<Value>>,
-    op_buf_size: usize,
-    policy: FlushPolicy,
-    trigger: FlushTrigger,
+    config: EnqueueConfig,
     deferred: &'a mut Vec<NoveltyEntry<Value>>,
     accessor: &'a Accessor<Backend>,
 ) -> NodeFuture<'a, Key, Value>
@@ -742,69 +1043,110 @@ where
             index.novelty.route::<Key>(&bounds, msgs)?;
         }
 
+        // Deferred batch mode: the ops stay routed and the flush decision
+        // waits for the caller's single `settle` pass over the whole batch.
+        if !config.settle {
+            return Ok(node);
+        }
+
         // Does this node flush? `Capacity` asks whether the buffer
         // overflowed; `PerChild` asks whether any one child now has a batch
         // worth writing, which scales the decision to this node's own
         // fan-out. Both read lengths the grouped buffer already tracks.
-        let flushes = match trigger {
-            FlushTrigger::Capacity => index.novelty.len() > op_buf_size,
+        // The byte cap fires regardless of the count trigger: op counts
+        // bound how many ops ride the frame, the weight cap bounds how many
+        // BYTES do (a value-heavy workload can pack ~200 KB into 256 ops,
+        // and buffered weight rides every per-commit root rewrite and every
+        // pushed operational block).
+        let over_bytes = config.op_buf_bytes != usize::MAX
+            && index.novelty.weight::<Key>()? > config.op_buf_bytes;
+        let per_child_threshold = match config.trigger {
+            FlushTrigger::Capacity => None,
             FlushTrigger::PerChild { floor } => {
-                // Never exceed the buffer's capacity, whatever the per-child
-                // threshold works out to.
-                if index.novelty.len() > op_buf_size {
-                    true
-                } else {
-                    let children = index.children.len().max(1);
-                    let threshold = (op_buf_size / children).max(floor).max(1);
-                    index.novelty.peak() >= threshold
-                }
+                let children = index.children.len().max(1);
+                Some((config.op_buf_size / children).max(floor).max(1))
             }
         };
+        let over_count = index.novelty.len() > config.op_buf_size
+            || per_child_threshold.is_some_and(|threshold| index.novelty.peak() >= threshold);
 
         // Room: the ops stay where routing put them.
-        if !flushes {
+        if !over_bytes && !over_count {
             return Ok(node);
         }
 
-        // Overflow: cascade one level into the children — lifting ON
-        // DEMAND, only where a non-empty buffer actually descends. A child
-        // with nothing to take stays `Node::Persistent`: at persist,
-        // `into_link` passes its link through with no decode, no re-encode,
-        // no re-hash, and no delta entry, where lifting every child up
-        // front turned each untouched sibling into a byte-identical
-        // re-store (the measured 24-26% duplicate-block share of sealed
-        // bytes; see bead dialog-db-59). Provenance is the cheap, exact
-        // signal here — store identity is not observable at persist time.
-        let child_count = index.children.len();
-        for at in 0..child_count {
-            let took = index.novelty.take_link::<Key>(at)?;
-            if took.is_empty() {
+        // Overflow: shed the HEAVIEST link buffers first and stop once the
+        // buffer is back under half of whichever bound fired, leaving the
+        // light buffers in place. Draining every non-empty link paid a
+        // child rewrite per couple of ops once the ops scattered across a
+        // wide node (measured on the real workload: ~2.3 leaf rewrites of
+        // ~90 KB per commit to move ~20 KB of ops); heaviest-first
+        // shedding concentrates each child touch on the fattest batch
+        // available, and the halfway low-water mark keeps the next few
+        // enqueues from re-firing immediately. Under `PerChild`, any link
+        // at or over its threshold holds a batch worth writing by that
+        // trigger's own definition and is shed regardless.
+        //
+        // Each shed link cascades one level into its child — lifting ON
+        // DEMAND, only where a buffer actually descends. A child with
+        // nothing to take stays `Node::Persistent`: at persist, `into_link`
+        // passes its link through with no decode, no re-encode, no re-hash,
+        // and no delta entry, where lifting every child up front turned
+        // each untouched sibling into a byte-identical re-store (the
+        // measured 24-26% duplicate-block share of sealed bytes; see bead
+        // dialog-db-59). Provenance is the cheap, exact signal here — store
+        // identity is not observable at persist time.
+        let mut measures = index.novelty.link_measures::<Key>()?;
+        measures.sort_by_key(|&(_, weight, ops)| std::cmp::Reverse((weight, ops)));
+        let mut buffered_weight = index.novelty.weight::<Key>()?;
+        let mut buffered_ops = index.novelty.len();
+        let weight_target = if over_bytes {
+            config.op_buf_bytes / 2
+        } else {
+            usize::MAX
+        };
+        let count_target = if over_count {
+            config.op_buf_size / 2
+        } else {
+            usize::MAX
+        };
+        for (at, link_weight, link_ops) in measures {
+            let batch_worth = per_child_threshold.is_some_and(|threshold| link_ops >= threshold);
+            if !batch_worth && buffered_weight <= weight_target && buffered_ops <= count_target {
                 continue;
             }
+            let took = index.novelty.take_link::<Key>(at)?;
+            buffered_weight -= link_weight;
+            buffered_ops -= link_ops;
             lift_child(&mut index.children[at], accessor).await?;
 
             let child = std::mem::replace(
                 &mut index.children[at],
-                Node::Transient(TransientNode::Segment(TransientSegment {
-                    entries: Vec::new(),
-                    separator: Vec::new(),
-                })),
+                Node::Transient(TransientNode::Segment(TransientSegment::new(
+                    Vec::new(),
+                    Vec::new(),
+                ))),
             )
             .into_transient()?;
             // Amortized cascades one level: the child buffers normally. Recursive
             // flushes through to the leaves: the child gets a zero-size buffer so
             // it overflows immediately and keeps pushing down until the ops land
             // in leaves.
-            let child_buf_size = match policy {
+            let child_buf_size = match config.policy {
                 FlushPolicy::Recursive => 0,
-                _ => op_buf_size,
+                _ => config.op_buf_size,
             };
             let updated = enqueue::<Key, Value, D, Backend>(
                 child,
                 took,
-                child_buf_size,
-                policy,
-                trigger,
+                EnqueueConfig {
+                    op_buf_size: child_buf_size,
+                    // A cascade always settles the child it flushes into:
+                    // the deferral applies only to the arriving batch's
+                    // routing.
+                    settle: true,
+                    ..config
+                },
                 deferred,
                 accessor,
             )
@@ -978,7 +1320,7 @@ fn collect_stored_plan<Key, Value, R>(
             }
         }
         TransientNode::Segment(segment) => {
-            for entry in &segment.entries {
+            for entry in segment.entries() {
                 if bounds.contains(&entry.key) {
                     plan.push(StoredStep::Entry(entry.clone()));
                 }
@@ -1034,6 +1376,13 @@ where
     Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
         + ConditionalSync,
 {
+    // Bulk-load fast path: a batch landing in an EMPTY tree builds the
+    // canonical tree bottom-up in one pass instead of one canonical edit
+    // per op — history independence guarantees the same bytes, and
+    // converge_check's single-commit arm pins that equality.
+    if edit.is_unplanted() && !ops.is_empty() {
+        return edit.plant(ops, storage).await;
+    }
     for entry in ops {
         // A buffered op carries raw key bytes; the canonical edit path takes a
         // typed key, so reconstruct it here (the same round trip a leaf read
@@ -1283,6 +1632,217 @@ mod tests {
         Ok(())
     }
 
+    /// A non-consuming persist must leave a spine that keeps producing
+    /// exactly the roots the persist-and-reopen cycle produces: byte
+    /// identity of the persisted frames is the whole contract behind
+    /// reusing the live spine across commits.
+    #[dialog_common::test]
+    async fn it_persists_identically_when_the_spine_stays_live() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        // A canonical base wide enough for an index root with several
+        // children, so cascades touch subsets and re-sealed buffers mix
+        // with freshly encoded ones.
+        let keys: Vec<u32> = (0..1200).collect();
+        let base = sequential(&keys, &mut storage).await?;
+
+        // Live path: one spine held across every batch, serialized with
+        // `persist_mut` between batches. Oracle path: reopened from the
+        // persisted root before each batch, serialized with the consuming
+        // `persist`. The small buffer forces overflow cascades within the
+        // run, so both regimes (append and cascade) are covered.
+        let mut live = TestHitchhiker::open(&base).with_op_buf_size(8);
+        let mut oracle_root = base.root().clone();
+
+        for batch in 0..40u32 {
+            let batch_keys: Vec<u32> = (0..3).map(|i| (batch * 7 + i * 13) % 2000).collect();
+
+            let mut delta = Delta::zero();
+            for &k in &batch_keys {
+                live = live
+                    .insert(k.to_le_bytes(), vec![k as u8], &storage)
+                    .await?;
+            }
+            let live_root = live.persist_mut(&mut delta)?;
+            flush(&mut delta, &mut storage).await?;
+
+            let oracle_tree: TestTree = PersistentTree::seal(oracle_root, Cache::new());
+            let mut oracle = TestHitchhiker::open(&oracle_tree).with_op_buf_size(8);
+            for &k in &batch_keys {
+                oracle = oracle
+                    .insert(k.to_le_bytes(), vec![k as u8], &storage)
+                    .await?;
+            }
+            let mut delta = Delta::zero();
+            oracle_root = oracle.persist(&mut delta)?;
+            flush(&mut delta, &mut storage).await?;
+
+            assert_eq!(
+                live_root, oracle_root,
+                "live-spine persist diverged from persist-and-reopen at batch {batch}"
+            );
+        }
+
+        // The two paths must also agree on the canonical form.
+        let mut delta = Delta::zero();
+        let live_canonical = live.canonicalize(&storage, &mut delta).await?;
+        let oracle_tree: TestTree = PersistentTree::seal(oracle_root, Cache::new());
+        let mut delta = Delta::zero();
+        let oracle_canonical = TestHitchhiker::open(&oracle_tree)
+            .canonicalize(&storage, &mut delta)
+            .await?;
+        assert_eq!(live_canonical.root(), oracle_canonical.root());
+        Ok(())
+    }
+
+    /// A variable-length opaque key for the small-frame reshape fixture:
+    /// long shared prefixes past the separator bound are what veto seams
+    /// and push frames into the forced-split regime, which fixed-width
+    /// `[u8; 4]` keys can never reach.
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct VarKey(Vec<u8>);
+
+    impl AsRef<[u8]> for VarKey {
+        fn as_ref(&self) -> &[u8] {
+            &self.0
+        }
+    }
+
+    impl crate::Key for VarKey {
+        fn try_from_bytes(bytes: &[u8]) -> Result<Self, crate::DialogSearchTreeError> {
+            Ok(VarKey(bytes.to_vec()))
+        }
+        fn min() -> Self {
+            VarKey(Vec::new())
+        }
+        fn max() -> Self {
+            VarKey(vec![u8::MAX; 64])
+        }
+    }
+
+    type VarHitchhiker = HitchhikerTree<VarKey, Vec<u8>>;
+    type VarPersistent = PersistentTree<VarKey, Vec<u8>>;
+
+    /// One deterministic pseudo-random op for the small-frame fixture: keys
+    /// come from three long-prefix clusters (34 bytes sharing a 30-byte
+    /// prefix, past the 24-byte separator bound, so in-cluster seams are
+    /// vetoed and frames grow toward the forced-split ceiling) plus a short
+    /// tail; a slice of the writes are deletes of previously written keys
+    /// and the rest overwrite freely (the supersession shape).
+    fn cluster_key(cluster: u32, n: u32) -> VarKey {
+        // Forty distinct cluster labels: each head's left seam carries a
+        // distinct short separator, so across the labels the seam ranks
+        // vary — some punch index-level cuts, and those heads are where a
+        // delete can dissolve one.
+        let mut bytes = vec![b'L', b'A' + (cluster % 40) as u8];
+        bytes.extend(vec![b'p'; 40]);
+        bytes.extend(format!("{n:04}").into_bytes());
+        VarKey(bytes)
+    }
+
+    fn small_frame_op(rng: &mut Rng) -> (VarKey, Option<Vec<u8>>) {
+        let roll = rng.next_u32();
+        // Cluster HEADS churn hardest: a head's separator is short (the
+        // cluster's own long shared prefix starts at its successor), so the
+        // head is where index-level cuts punch — and deleting it re-derives
+        // the seam from the long vetoed successor, which is what DISSOLVES
+        // a punched cut and forces the leftward fusion under test.
+        if roll % 8 == 2 {
+            return (cluster_key(roll / 8, 0), None);
+        }
+        if roll % 8 == 6 {
+            let value = vec![b'v'; 8 + (rng.next_u32() % 64) as usize];
+            return (cluster_key(roll / 8, 0), Some(value));
+        }
+        let key = if roll % 4 == 3 {
+            VarKey(format!("s{:03}", roll % 96).into_bytes())
+        } else {
+            cluster_key(roll % 40, (roll / 8) % 24)
+        };
+        // A quarter of the remaining ops delete: supersession churn drives
+        // boundary deletes into the vetoed clusters, where the forced-run
+        // widenings cross the main path.
+        if roll % 4 == 1 {
+            (key, None)
+        } else {
+            let value = vec![b'v'; 8 + (rng.next_u32() % 64) as usize];
+            (key, Some(value))
+        }
+    }
+
+    /// Buffered commits over a small-frame manifest must keep every reshape
+    /// path consistent. This is the scaled-down deterministic form of a
+    /// field failure: replaying the real Stack Exchange log through the
+    /// buffered commit path with `max_segment = 16384` fails during a
+    /// commit with "Re-shape path child index out of range", and with
+    /// `max_segment = 8192` during canonicalize with "Re-shape path
+    /// descended into a node that was not lifted". Small frames make the
+    /// forced-split regime routine, and the buffered flush replays ops
+    /// through the canonical edit machinery against nodes carrying
+    /// novelty — the interaction under test.
+    #[dialog_common::test]
+    async fn it_survives_buffered_commits_under_a_small_frame_ceiling() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let manifest = Manifest {
+            fanout_n: 4,
+            max_separator: 24,
+            max_segment: 512,
+            // A tight ceiling makes FORCE-SPLIT INDEX frames routine: the
+            // field failure's stale path crossed an index-level forced-run
+            // merge, which needs index frames that exceed the ceiling.
+            frame_ceiling_factor: 1,
+            ..Manifest::default()
+        };
+
+        // Seed a canonical base under the small manifest so every stored
+        // node carries it and the buffered path below runs under it.
+        let mut delta = Delta::zero();
+        let mut seed = TransientTree::<VarKey, Vec<u8>>::with_manifest(
+            NULL_BLAKE3_HASH.clone(),
+            Cache::new(),
+            manifest,
+        );
+        let mut rng = Rng::new(11);
+        for _ in 0..96 {
+            let (key, value) = small_frame_op(&mut rng);
+            let value = value.unwrap_or_default();
+            seed = seed.insert(key, value, &storage).await?;
+        }
+        let base = seed.persist(&mut delta)?;
+        flush(&mut delta, &mut storage).await?;
+
+        // Buffered commits, exactly the store's commit lifecycle: open the
+        // buffered tree over the persisted root, apply a few ops, persist
+        // the buffered form, flush, reopen. The small op buffer makes the
+        // cascade (the flush into reshaping children) routine rather than
+        // rare.
+        let cache = Cache::new();
+        let mut root = base.root().clone();
+        for _ in 0..1500 {
+            let tree: VarPersistent = PersistentTree::seal(root.clone(), cache.clone());
+            let mut buffered = VarHitchhiker::open(&tree).with_op_buf_size(16);
+            for _ in 0..8 {
+                let (key, value) = small_frame_op(&mut rng);
+                buffered = match value {
+                    Some(value) => buffered.insert(key, value, &storage).await?,
+                    None => buffered.delete(key, &storage).await?,
+                };
+            }
+            let mut delta = Delta::zero();
+            root = buffered.persist(&mut delta)?;
+            flush(&mut delta, &mut storage).await?;
+        }
+
+        // The canonicalize half of the field failure: a full drain of every
+        // buffer through the same reshape machinery.
+        let tree: VarPersistent = PersistentTree::seal(root, cache);
+        let mut delta = Delta::zero();
+        VarHitchhiker::open(&tree)
+            .canonicalize(&storage, &mut delta)
+            .await?;
+        Ok(())
+    }
+
     /// Canonicalizing an empty buffered tree yields the null (empty) root.
     #[dialog_common::test]
     async fn it_canonicalizes_empty_to_null_root() -> Result<()> {
@@ -1510,7 +2070,7 @@ mod tests {
         for seed in 0..50u64 {
             let mut rng = Rng::new(seed);
             let mut ops: Vec<(bool, u32)> = Vec::new();
-            for _ in 0..400 {
+            for _ in 0..1500 {
                 let is_insert = !(rng.next_u32()).is_multiple_of(3);
                 let key = rng.next_u32() % 150;
                 ops.push((is_insert, key));
@@ -1570,7 +2130,7 @@ mod tests {
         for seed in 0..50u64 {
             let mut rng = Rng::new(seed);
             let mut ops: Vec<(bool, u32)> = Vec::new();
-            for _ in 0..400 {
+            for _ in 0..1500 {
                 let is_insert = !(rng.next_u32()).is_multiple_of(3);
                 let key = rng.next_u32() % 150;
                 ops.push((is_insert, key));
@@ -1634,7 +2194,7 @@ mod tests {
         for seed in 0..25u64 {
             let mut rng = Rng::new(seed);
             let mut ops: Vec<(bool, u32)> = Vec::new();
-            for _ in 0..400 {
+            for _ in 0..1500 {
                 let is_insert = !(rng.next_u32()).is_multiple_of(3);
                 ops.push((is_insert, rng.next_u32() % 150));
             }
@@ -2172,6 +2732,74 @@ mod tests {
             Some(5000u32.to_le_bytes().to_vec()),
             "canonicalizing first must reach the same result"
         );
+        Ok(())
+    }
+
+    /// Randomized reconcile convergence over DISJOINT key sets: replica A
+    /// edits even keys, replica B odd keys (inserts, rewrites, and deletes
+    /// of base keys), each with its own buffer size and possibly still
+    /// buffered at the sync boundary. Reconciling in either direction and
+    /// applying both op sets directly to the base must all canonicalize to
+    /// the same root — and that root must pass canonical-form validation.
+    /// (Overlapping key sets are deliberately out of scope here: the
+    /// integrate direction then decides winners, so order-independence is
+    /// not the property.)
+    #[dialog_common::test]
+    async fn it_reconciles_disjoint_replicas_order_independently() -> Result<()> {
+        for seed in 0..12u64 {
+            let mut rng = Rng::new(0x5851F42D4C957F2D ^ seed);
+            let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+            let base_keys: Vec<u32> = (0..200).map(|_| rng.next_u32() % 4000).collect();
+            let base = sequential(&base_keys, &mut storage).await?;
+
+            // Disjoint by parity: replica A touches even keys, B odd.
+            let mut a_ops: Vec<(bool, u32)> = Vec::new();
+            let mut b_ops: Vec<(bool, u32)> = Vec::new();
+            for _ in 0..80 {
+                let key = (rng.next_u32() % 4000) & !1;
+                a_ops.push((!rng.next_u32().is_multiple_of(3), key));
+                let key = (rng.next_u32() % 4000) | 1;
+                b_ops.push((!rng.next_u32().is_multiple_of(3), key));
+            }
+
+            // Replica A stays buffered at the sync boundary (large buffer);
+            // replica B cascades aggressively (tiny buffer).
+            let a = buffered_replica(&base, &a_ops, 100_000, &storage).await?;
+            let a_tree = persist_buffered(a, &mut storage).await?;
+            let b = buffered_replica(&base, &b_ops, 4, &storage).await?;
+            let b_tree = persist_buffered(b, &mut storage).await?;
+
+            let merged_ab = reconcile(&base, &a_tree, &b_tree, &mut storage).await?;
+            let merged_ba = reconcile(&base, &b_tree, &a_tree, &mut storage).await?;
+
+            // The reference: both op sets applied straight to the base.
+            let mut all_ops = a_ops.clone();
+            all_ops.extend(b_ops.iter().copied());
+            let direct = buffered_replica(&base, &all_ops, 64, &storage).await?;
+            let direct_tree = canonicalize_flushed(direct, &mut storage).await?;
+
+            let ab = canonicalize_flushed(TestHitchhiker::open(&merged_ab), &mut storage).await?;
+            let ba = canonicalize_flushed(TestHitchhiker::open(&merged_ba), &mut storage).await?;
+
+            assert_eq!(
+                ab.root(),
+                ba.root(),
+                "seed {seed}: reconcile direction changed the canonical result"
+            );
+            assert_eq!(
+                ab.root(),
+                direct_tree.root(),
+                "seed {seed}: reconcile disagrees with direct application"
+            );
+
+            let divergences = ab.canonical_divergences(&storage).await?;
+            assert_eq!(
+                divergences,
+                Vec::<String>::new(),
+                "seed {seed}: merged canonical tree failed canonical-form validation"
+            );
+        }
         Ok(())
     }
 

--- a/rust/dialog-search-tree/src/hitchhiker.rs
+++ b/rust/dialog-search-tree/src/hitchhiker.rs
@@ -291,8 +291,10 @@ where
         }
     }
 
-    /// Pins the format [`Manifest`] this session writes under, instead of
-    /// reading it from the tree's root on first load.
+    /// Pins the format [`Manifest`] this session writes under while the
+    /// tree is empty. A non-empty root's stored manifest still takes
+    /// precedence on first load: until adopt-on-edit exists, edits must
+    /// run under the format the nodes already carry.
     ///
     /// The manifest normally travels IN the tree (every node carries it),
     /// which leaves one gap: an EMPTY tree has no node to carry it, so a
@@ -617,9 +619,11 @@ where
                 self.cache.clone(),
                 self.manifest.unwrap_or_default(),
             ),
-            None => {
-                TransientTree::<Key, Value, D>::new(NULL_BLAKE3_HASH.clone(), self.cache.clone())
-            }
+            None => TransientTree::<Key, Value, D>::with_manifest(
+                NULL_BLAKE3_HASH.clone(),
+                self.cache.clone(),
+                self.manifest.unwrap_or_default(),
+            ),
         };
         let edit = replay_ops(edit, deferred, storage).await?;
         self.root = match edit.into_root() {
@@ -3428,6 +3432,60 @@ mod tests {
             canonical.root(),
             expected.root(),
             "canonicalize must replay and stamp under the tree's own manifest"
+        );
+        Ok(())
+    }
+
+    /// A session pinned to a non-default manifest must shape writes under
+    /// that manifest even when the tree is empty: the delete-to-empty and
+    /// refill lifecycle must produce the same root as a canonical build of
+    /// the surviving facts under the pinned format.
+    #[dialog_common::test]
+    async fn it_shapes_an_emptied_tree_under_the_pinned_manifest() -> Result<()> {
+        let custom = Manifest {
+            fanout_n: 2,
+            ..Manifest::default()
+        };
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+        // Fill a pinned session from empty, drain it back to empty, then
+        // refill: every write into the empty tree must shape under the pin.
+        let mut tree = HitchhikerTree::<[u8; 4], Vec<u8>>::empty().with_manifest(custom);
+        for k in 0..30u32 {
+            tree = tree
+                .insert(k.to_be_bytes(), k.to_be_bytes().to_vec(), &storage)
+                .await?;
+        }
+        for k in 0..30u32 {
+            tree = tree.delete(k.to_be_bytes(), &storage).await?;
+        }
+        for k in 100..150u32 {
+            tree = tree
+                .insert(k.to_be_bytes(), k.to_be_bytes().to_vec(), &storage)
+                .await?;
+        }
+        let mut delta = Delta::zero();
+        let refilled = tree.canonicalize(&storage, &mut delta).await?;
+        flush(&mut delta, &mut storage).await?;
+
+        let mut oracle = TransientTree::<[u8; 4], Vec<u8>>::with_manifest(
+            NULL_BLAKE3_HASH.clone(),
+            Cache::new(),
+            custom,
+        );
+        for k in 100..150u32 {
+            oracle = oracle
+                .insert(k.to_be_bytes(), k.to_be_bytes().to_vec(), &storage)
+                .await?;
+        }
+        let mut delta = Delta::zero();
+        let expected = oracle.persist(&mut delta)?;
+        flush(&mut delta, &mut storage).await?;
+
+        assert_eq!(
+            refilled.root(),
+            expected.root(),
+            "an empty pinned session must shape its writes under the pinned manifest"
         );
         Ok(())
     }

--- a/rust/dialog-search-tree/src/kv.rs
+++ b/rust/dialog-search-tree/src/kv.rs
@@ -143,7 +143,10 @@ impl<const N: usize> Key for [u8; N] {
 /// Trait for types that can be used as values in a search tree.
 ///
 /// Values must be cloneable and serializable.
-pub trait Value: Clone + Debug + Sized + Archive + ConditionalSend {
+// The `'static` admits keying a buffer's validation memo by the archived
+// type's `TypeId` (see `PersistentNode::body`); values are owned data, so
+// this constrains no implementor.
+pub trait Value: Clone + Debug + Sized + Archive + ConditionalSend + 'static {
     /// The weight this value's payload contributes to its entry for byte
     /// pacing (`Manifest::max_segment`): an estimate of the value's encoded
     /// footprint in a leaf, in bytes. A pure function of the value's

--- a/rust/dialog-search-tree/src/lib.rs
+++ b/rust/dialog-search-tree/src/lib.rs
@@ -165,6 +165,7 @@ mod storage;
 pub use storage::*;
 
 mod tree;
+mod validate;
 pub use tree::*;
 
 mod hitchhiker;

--- a/rust/dialog-search-tree/src/manifest.rs
+++ b/rust/dialog-search-tree/src/manifest.rs
@@ -129,7 +129,13 @@ impl Default for Manifest {
         // threading configuration through every layer. Unset variables leave
         // the shipped defaults untouched; existing trees always keep the
         // manifest their root node carries.
-        Self {
+        //
+        // Read once per process: `default()` sits on the per-commit persist
+        // path, and the environment scan (four variables) showed up as ~4%
+        // of a profiled commit before this memo. The environment of a
+        // running process does not change underneath it.
+        static DEFAULT: std::sync::OnceLock<Manifest> = std::sync::OnceLock::new();
+        *DEFAULT.get_or_init(|| Self {
             version: FORMAT_VERSION,
             fanout_n: DEFAULT_FANOUT_N,
             max_separator: DEFAULT_MAX_SEPARATOR,
@@ -141,7 +147,7 @@ impl Default for Manifest {
                 DEFAULT_FRAME_CEILING_FACTOR,
             ),
             anchor_selector: env_override("DIALOG_TREE_ANCHOR_SELECTOR", DEFAULT_ANCHOR_SELECTOR),
-        }
+        })
     }
 }
 

--- a/rust/dialog-search-tree/src/node.rs
+++ b/rust/dialog-search-tree/src/node.rs
@@ -14,7 +14,7 @@ pub fn encode_keys_public<K: AsRef<[u8]>>(keys: &[K]) -> (Vec<u8>, Vec<u8>) {
 pub(crate) mod columnar;
 pub use columnar::{ArchivedColumnData, ColumnData, ColumnSlices, StreamingLeaf};
 
-mod transient;
+pub(crate) mod transient;
 pub use transient::*;
 
 use dialog_common::Blake3Hash;

--- a/rust/dialog-search-tree/src/node/archive.rs
+++ b/rust/dialog-search-tree/src/node/archive.rs
@@ -356,20 +356,74 @@ where
     /// winners.
     pub fn op_at(&self, at: usize) -> Result<NoveltyOp<Value>, DialogSearchTreeError> {
         self.checked_count()?;
+        // The value table is aligned with the assert entries in entry order:
+        // this entry's slot is the number of asserts before it.
+        let slot = self.polarity[..at.min(self.polarity.len())]
+            .iter()
+            .filter(|&&p| p == 1)
+            .count();
+        self.op_with_slot(at, slot)
+    }
+
+    /// The op at entry `at` given its value-table `slot` (the number of
+    /// asserts before it), for readers that track the slot while streaming
+    /// the buffer instead of re-scanning the polarity column per op.
+    ///
+    /// The caller must have validated the buffer (every streaming read goes
+    /// through [`keys`](Self::keys), whose [`checked_count`](Self::checked_count)
+    /// pins the polarity and value tables), so a wrong slot can at worst
+    /// surface as an out-of-range error here, never a silent misread of a
+    /// well-formed buffer.
+    pub(crate) fn op_with_slot(
+        &self,
+        at: usize,
+        slot: usize,
+    ) -> Result<NoveltyOp<Value>, DialogSearchTreeError> {
         match self.polarity.get(at) {
             None => Err(malformed("Novelty entry out of range")),
             Some(0) => Ok(NoveltyOp::Retract),
-            _ => {
-                // The value table is aligned with the assert entries in entry
-                // order: this entry's slot is the number of asserts before it.
-                let slot = self.polarity[..at].iter().filter(|&&p| p == 1).count();
+            Some(1) => {
                 let value = self
                     .values
                     .get(slot)
                     .ok_or_else(|| malformed("Novelty value out of range"))?;
                 Ok(NoveltyOp::Assert(into_owned::<Value>(value)?))
             }
+            Some(_) => Err(malformed("Novelty polarity is neither assert nor retract")),
         }
+    }
+
+    /// The winning op for `key` in this buffer, or `None` when the key is not
+    /// buffered here: the archived counterpart of
+    /// [`NoveltyBuffer::resolve`](crate::NoveltyBuffer::resolve).
+    ///
+    /// One streaming pass: keys arrive in sorted order, so the walk stops at
+    /// the first key past the probe; within a key the last op wins (equal keys
+    /// are contiguous, newest last). The value-table slot is tracked as the
+    /// polarity column is walked, so resolving costs no per-op re-scan, and
+    /// only the winner's value is decoded.
+    pub fn resolve<Key: self::Key>(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<NoveltyOp<Value>>, DialogSearchTreeError> {
+        let mut keys = self.keys::<Key>()?;
+        let mut winner: Option<(usize, usize)> = None;
+        let mut asserts = 0usize;
+        while let Some((at, candidate)) = keys.next_key()? {
+            let slot = asserts;
+            // `keys()` validated every polarity byte as 0 or 1.
+            if self.polarity.get(at).copied() == Some(1) {
+                asserts += 1;
+            }
+            match candidate.cmp(key) {
+                Ordering::Less => {}
+                Ordering::Equal => winner = Some((at, slot)),
+                Ordering::Greater => break,
+            }
+        }
+        winner
+            .map(|(at, slot)| self.op_with_slot(at, slot))
+            .transpose()
     }
 
     /// Decodes the whole buffer to owned entries, in entry order.

--- a/rust/dialog-search-tree/src/node/persistent.rs
+++ b/rust/dialog-search-tree/src/node/persistent.rs
@@ -52,6 +52,41 @@ impl DecodedKeys {
     pub fn iter(&self) -> impl Iterator<Item = &[u8]> {
         (0..self.len()).map(|index| self.get(index).expect("index in range"))
     }
+
+    /// Position of the first key at or above `probe` (the partition
+    /// point): where a range starting at `probe` enters this leaf. O(log n)
+    /// key comparisons against the linear walk a front-coded stream needs.
+    pub fn lower_bound(&self, probe: &[u8]) -> usize {
+        let mut low = 0usize;
+        let mut high = self.len();
+        while low < high {
+            let middle = low + (high - low) / 2;
+            if self.get(middle).expect("index in range") < probe {
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+        low
+    }
+
+    /// Position of the key equal to `probe`, or `None`. Keys are stored in
+    /// entry (sorted) order, so this is a binary search — O(log n) key
+    /// comparisons against the linear front-coded stream a fresh decode
+    /// requires.
+    pub fn binary_search(&self, probe: &[u8]) -> Option<usize> {
+        let mut low = 0usize;
+        let mut high = self.len();
+        while low < high {
+            let middle = low + (high - low) / 2;
+            match self.get(middle).expect("index in range").cmp(probe) {
+                Ordering::Less => low = middle + 1,
+                Ordering::Greater => high = middle,
+                Ordering::Equal => return Some(middle),
+            }
+        }
+        None
+    }
 }
 
 /// A tree node in its serialized, content-addressed form.
@@ -373,6 +408,68 @@ where
         child: u32,
         entries: Vec<NoveltyEntry<Value>>,
     ) -> Result<Self, DialogSearchTreeError> {
+        let (count, layout, columns) = Self::key_columns::<Key>(&entries)?;
+
+        let mut polarity = Vec::with_capacity(entries.len());
+        let mut values = Vec::new();
+        for entry in entries {
+            match entry.op {
+                NoveltyOp::Assert(value) => {
+                    polarity.push(1);
+                    values.push(value);
+                }
+                NoveltyOp::Retract => polarity.push(0),
+            }
+        }
+
+        Ok(Self {
+            child,
+            count,
+            layout,
+            columns,
+            polarity,
+            values,
+        })
+    }
+
+    /// [`from_entries`](Self::from_entries) without consuming the op list:
+    /// the values are cloned into the buffer instead of moved. Exists for
+    /// the non-consuming persist, which must keep the decoded ops live for
+    /// later appends while embedding their encoding into the frame.
+    pub fn from_entries_ref<Key: self::Key>(
+        child: u32,
+        entries: &[NoveltyEntry<Value>],
+    ) -> Result<Self, DialogSearchTreeError> {
+        let (count, layout, columns) = Self::key_columns::<Key>(entries)?;
+
+        let mut polarity = Vec::with_capacity(entries.len());
+        let mut values = Vec::new();
+        for entry in entries {
+            match &entry.op {
+                NoveltyOp::Assert(value) => {
+                    polarity.push(1);
+                    values.push(value.clone());
+                }
+                NoveltyOp::Retract => polarity.push(0),
+            }
+        }
+
+        Ok(Self {
+            child,
+            count,
+            layout,
+            columns,
+            polarity,
+            values,
+        })
+    }
+
+    /// The key side of the buffer encoding, shared by the consuming and
+    /// borrowing constructors: layout classification plus the columnar
+    /// encode of every key.
+    fn key_columns<Key: self::Key>(
+        entries: &[NoveltyEntry<Value>],
+    ) -> Result<(u32, u8, Vec<ColumnData>), DialogSearchTreeError> {
         let count = entries.len() as u32;
         if entries.is_empty() {
             return Err(DialogSearchTreeError::Node(
@@ -419,26 +516,27 @@ where
             (MIXED_LAYOUT, vec![ColumnData::Arena { prefix, stream }])
         };
 
-        let mut polarity = Vec::with_capacity(entries.len());
-        let mut values = Vec::new();
-        for entry in entries {
-            match entry.op {
-                NoveltyOp::Assert(value) => {
-                    polarity.push(1);
-                    values.push(value);
-                }
-                NoveltyOp::Retract => polarity.push(0),
-            }
-        }
+        Ok((count, layout, columns))
+    }
 
-        Ok(Self {
-            child,
-            count,
-            layout,
-            columns,
-            polarity,
-            values,
-        })
+    /// The buffered weight this sealed buffer carries (key bytes plus value
+    /// payload weights, retracts charged at 16), for the byte-capped flush
+    /// trigger: computed by streaming the key columns, with no entry
+    /// materialization.
+    pub fn weight<Key: self::Key>(&self) -> Result<usize, DialogSearchTreeError> {
+        let mut weight = 0usize;
+        let mut keys = self.keys::<Key>()?;
+        while let Some((_, key)) = keys.next_key()? {
+            weight += key.len();
+        }
+        weight += self
+            .values
+            .iter()
+            .map(|value| value.payload_weight())
+            .sum::<usize>();
+        weight += 16 * self.polarity.iter().filter(|&&p| p == 0).count();
+        weight += crate::entry::ENTRY_ENCODING_OVERHEAD * self.count as usize;
+        Ok(weight)
     }
 
     /// The op count claimed by `count`, validated against the polarity and
@@ -489,13 +587,27 @@ where
     /// polarity column; an assert clones its value from the assert-aligned
     /// value table.
     pub fn op_at(&self, at: usize) -> Result<NoveltyOp<Value>, DialogSearchTreeError> {
+        let slot = self.polarity[..at.min(self.polarity.len())]
+            .iter()
+            .filter(|&&p| p == 1)
+            .count();
+        self.op_with_slot(at, slot)
+    }
+
+    /// The op at entry `at` given its value-table `slot` (the number of
+    /// asserts before it), for readers that track the slot while streaming
+    /// the buffer instead of re-scanning the polarity column per op.
+    pub(crate) fn op_with_slot(
+        &self,
+        at: usize,
+        slot: usize,
+    ) -> Result<NoveltyOp<Value>, DialogSearchTreeError> {
         match self.polarity.get(at) {
             None => Err(DialogSearchTreeError::Encoding(
                 "Novelty entry out of range".into(),
             )),
             Some(0) => Ok(NoveltyOp::Retract),
             Some(1) => {
-                let slot = self.polarity[..at].iter().filter(|&&p| p == 1).count();
                 let value = self.values.get(slot).ok_or_else(|| {
                     DialogSearchTreeError::Encoding("Novelty value out of range".into())
                 })?;
@@ -510,21 +622,30 @@ where
     /// The winning op for `key` in this buffer, or `None` when the key is not
     /// buffered here. The buffer is sorted by key with the newest op for a key
     /// last, so the scan keeps the last equal key and stops at the first
-    /// greater one; only the winner's value is decoded.
+    /// greater one; the winner's value-table slot is tracked as the polarity
+    /// column is walked, and only the winner's value is decoded.
     pub fn resolve<Key: self::Key>(
         &self,
         key: &[u8],
     ) -> Result<Option<NoveltyOp<Value>>, DialogSearchTreeError> {
         let mut keys = self.keys::<Key>()?;
-        let mut winner = None;
+        let mut winner: Option<(usize, usize)> = None;
+        let mut asserts = 0usize;
         while let Some((at, entry_key)) = keys.next_key()? {
+            let slot = asserts;
+            // `keys()` validated every polarity byte as 0 or 1.
+            if self.polarity.get(at).copied() == Some(1) {
+                asserts += 1;
+            }
             match entry_key.cmp(key) {
                 Ordering::Less => {}
-                Ordering::Equal => winner = Some(at),
+                Ordering::Equal => winner = Some((at, slot)),
                 Ordering::Greater => break,
             }
         }
-        winner.map(|at| self.op_at(at)).transpose()
+        winner
+            .map(|(at, slot)| self.op_with_slot(at, slot))
+            .transpose()
     }
 
     /// Decodes the whole buffer to owned entries, in entry order: the lift a

--- a/rust/dialog-search-tree/src/node/transient.rs
+++ b/rust/dialog-search-tree/src/node/transient.rs
@@ -8,7 +8,6 @@ use rkyv::{
     util::AlignedVec,
     validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
 };
-use std::collections::BTreeMap;
 use std::ops::Bound;
 
 use crate::{
@@ -78,8 +77,161 @@ pub struct TransientIndex<Key, Value> {
 enum LinkNovelty<Value> {
     /// The stored encoding, exactly as persisted, untouched since open.
     Sealed(NoveltyBuffer<Value>),
-    /// Decoded ops, sorted by key with the newest op for a key last.
-    Open(Vec<NoveltyEntry<Value>>),
+    /// Decoded ops as two sorted runs. `run` holds the settled majority;
+    /// `tail` holds recent arrivals, capped at [`NOVELTY_TAIL_LIMIT`] and
+    /// merged into `run` when full (and by any consumer that needs one flat
+    /// sorted list). Both runs are sorted by key with the newest op for a
+    /// key last, and every `tail` op is newer than every `run` op FOR THE
+    /// SAME KEY (arrivals only ever land in the tail), so the stable merge
+    /// that keeps `run` entries first on ties reproduces exactly the order
+    /// a single always-sorted buffer would hold.
+    ///
+    /// The split exists because enqueue inserts ops ONE AT A TIME (the
+    /// per-op cascade timing is deliberate — batching moved where flushes
+    /// fire and measured slower): insertion into one flat sorted vec walked
+    /// and shifted the whole accumulated buffer per op, O(n^2) per bulk
+    /// batch and the dominant cost of a bulk commit. Inserting into the
+    /// bounded tail is O(tail); point and range readers binary-search both
+    /// runs.
+    Open {
+        /// The settled ops, sorted by key, oldest ops first within a key.
+        run: Vec<NoveltyEntry<Value>>,
+        /// Recent arrivals, sorted by key, chronological within a key,
+        /// every one newer than any `run` op for its key.
+        tail: Vec<NoveltyEntry<Value>>,
+    },
+    /// Decoded ops WITH their current encoding alongside, the state a
+    /// non-consuming persist leaves an open link in: the next persist
+    /// re-embeds `buffer` verbatim (like a sealed link), while the next
+    /// mutation takes `entries` directly and drops the stale encoding (like
+    /// an open link) — so a link that ops keep landing in never re-decodes
+    /// its accumulated buffer, it only re-encodes it at each persist.
+    Cached {
+        /// The decoded ops, identical in content to `buffer`.
+        entries: Vec<NoveltyEntry<Value>>,
+        /// The encoding the last persist embedded.
+        buffer: NoveltyBuffer<Value>,
+    },
+}
+
+/// The size the tail run of an open link may grow to before it is merged
+/// into the main run. Bounds the linear share of every per-op insert and of
+/// every reader's tail probe; the merge amortizes to O(total / limit) full
+/// passes over the buffer.
+const NOVELTY_TAIL_LIMIT: usize = 128;
+
+/// Stably merges two sorted runs into one flat sorted list, keeping `run`
+/// entries before `tail` entries for equal keys — `tail` ops are newer, and
+/// the newest op for a key must sort last.
+fn merge_runs<Value>(
+    run: Vec<NoveltyEntry<Value>>,
+    tail: Vec<NoveltyEntry<Value>>,
+) -> Vec<NoveltyEntry<Value>> {
+    if tail.is_empty() {
+        return run;
+    }
+    if run.is_empty() {
+        return tail;
+    }
+    let mut merged = Vec::with_capacity(run.len() + tail.len());
+    let mut left = run.into_iter().peekable();
+    let mut right = tail.into_iter().peekable();
+    loop {
+        match (left.peek(), right.peek()) {
+            (Some(a), Some(b)) => {
+                if a.key <= b.key {
+                    merged.push(left.next().expect("peeked"));
+                } else {
+                    merged.push(right.next().expect("peeked"));
+                }
+            }
+            (Some(_), None) => merged.push(left.next().expect("peeked")),
+            (None, Some(_)) => merged.push(right.next().expect("peeked")),
+            (None, None) => break,
+        }
+    }
+    merged
+}
+
+/// Appends the winning op per key within `[start, end]` across two sorted
+/// runs, in ascending key order. The winner for a key is its last tail op
+/// when the tail holds the key at all (tail ops are newer than run ops for
+/// the same key), and its last run op otherwise. Both runs are sorted, so
+/// the in-range span of each is contiguous and sought by binary search; a
+/// flat single-run buffer passes an empty tail.
+fn winners_in_runs<Value>(
+    run: &[NoveltyEntry<Value>],
+    tail: &[NoveltyEntry<Value>],
+    start: Bound<&[u8]>,
+    end: Bound<&[u8]>,
+    out: &mut Vec<NoveltyEntry<Value>>,
+) where
+    Value: self::Value,
+{
+    let seek = |entries: &[NoveltyEntry<Value>]| match start {
+        Bound::Included(bound) => entries.partition_point(|entry| entry.key.as_slice() < bound),
+        Bound::Excluded(bound) => entries.partition_point(|entry| entry.key.as_slice() <= bound),
+        Bound::Unbounded => 0,
+    };
+    let past_end = |key: &[u8]| match end {
+        Bound::Included(bound) => key > bound,
+        Bound::Excluded(bound) => key >= bound,
+        Bound::Unbounded => false,
+    };
+    let mut r = seek(run);
+    let mut t = seek(tail);
+    while r < run.len() || t < tail.len() {
+        let key = match (run.get(r), tail.get(t)) {
+            (Some(a), Some(b)) => {
+                if a.key <= b.key {
+                    a.key.as_slice()
+                } else {
+                    b.key.as_slice()
+                }
+            }
+            (Some(a), None) => a.key.as_slice(),
+            (None, Some(b)) => b.key.as_slice(),
+            (None, None) => unreachable!("the loop condition holds a head"),
+        };
+        if past_end(key) {
+            break;
+        }
+        // Walk both heads past this key's contiguous span; the last tail
+        // entry seen wins over the last run entry (assigned after it).
+        let mut winner = None;
+        while let Some(entry) = run.get(r) {
+            if entry.key.as_slice() != key {
+                break;
+            }
+            winner = Some(entry);
+            r += 1;
+        }
+        while let Some(entry) = tail.get(t) {
+            if entry.key.as_slice() != key {
+                break;
+            }
+            winner = Some(entry);
+            t += 1;
+        }
+        out.push(winner.expect("some head held the key").clone());
+    }
+}
+
+/// The winning buffered op for `key` across an open link's two runs: the
+/// newest op for the key, which lives at the end of the key's contiguous
+/// span in the tail when the tail holds the key at all (tail ops are newer
+/// than run ops for the same key), and at the end of its span in the run
+/// otherwise.
+fn resolve_runs<'a, Value>(
+    run: &'a [NoveltyEntry<Value>],
+    tail: &'a [NoveltyEntry<Value>],
+    key: &[u8],
+) -> Option<&'a NoveltyOp<Value>> {
+    let last_for_key = |entries: &'a [NoveltyEntry<Value>]| {
+        let past = entries.partition_point(|entry| entry.key.as_slice() <= key);
+        (past > 0 && entries[past - 1].key.as_slice() == key).then(|| &entries[past - 1].op)
+    };
+    last_for_key(tail).or_else(|| last_for_key(run))
 }
 
 impl<Value> LinkNovelty<Value>
@@ -90,35 +242,105 @@ where
     fn len(&self) -> usize {
         match self {
             LinkNovelty::Sealed(buffer) => buffer.count as usize,
-            LinkNovelty::Open(entries) => entries.len(),
+            LinkNovelty::Open { run, tail } => run.len() + tail.len(),
+            LinkNovelty::Cached { entries, .. } => entries.len(),
         }
     }
 
-    /// Lifts this link to its decoded entries for mutation, decoding a sealed
-    /// buffer. The sealed encoding is discarded: from here on this link's
-    /// buffer is re-encoded at persist, which is exactly the invalidation the
-    /// cache needs.
+    /// An empty open link.
+    fn empty() -> Self {
+        LinkNovelty::Open {
+            run: Vec::new(),
+            tail: Vec::new(),
+        }
+    }
+
+    /// Merges an open link's tail into its run, so `run` is the one flat
+    /// sorted op list and `tail` is empty. A no-op for every other state
+    /// (sealed and cached entries are already flat and sorted).
+    fn consolidate(&mut self) {
+        if let LinkNovelty::Open { run, tail } = self
+            && !tail.is_empty()
+        {
+            let merged = merge_runs(std::mem::take(run), std::mem::take(tail));
+            *run = merged;
+        }
+    }
+
+    /// Lifts this link to ONE flat sorted list of decoded entries for
+    /// order-dependent mutation, decoding a sealed buffer and merging an
+    /// open link's tail. The encoding (sealed or cached) is discarded: from
+    /// here on this link's buffer is re-encoded at persist, which is exactly
+    /// the invalidation the cache needs.
     fn lift<K>(&mut self) -> Result<&mut Vec<NoveltyEntry<Value>>, DialogSearchTreeError>
     where
         K: self::Key,
     {
-        if let LinkNovelty::Sealed(buffer) = self {
-            *self = LinkNovelty::Open(buffer.entries::<K>()?);
+        match self {
+            LinkNovelty::Sealed(buffer) => {
+                *self = LinkNovelty::Open {
+                    run: buffer.entries::<K>()?,
+                    tail: Vec::new(),
+                };
+            }
+            LinkNovelty::Cached { entries, .. } => {
+                *self = LinkNovelty::Open {
+                    run: std::mem::take(entries),
+                    tail: Vec::new(),
+                };
+            }
+            LinkNovelty::Open { .. } => self.consolidate(),
         }
         match self {
-            LinkNovelty::Open(entries) => Ok(entries),
-            LinkNovelty::Sealed(_) => unreachable!("sealed buffer was lifted above"),
+            LinkNovelty::Open { run, .. } => Ok(run),
+            _ => unreachable!("the buffer was lifted above"),
         }
     }
 
-    /// Takes this link's ops, leaving it empty.
+    /// Inserts one arriving op, preserving every reader's invariants without
+    /// touching the settled run: the op binary-inserts into the bounded
+    /// sorted tail (after any equal keys, so chronological order within a
+    /// key holds), and a full tail merges into the run first. This is the
+    /// enqueue path's insertion — O(tail limit) per op instead of a re-sort
+    /// of the whole accumulated buffer.
+    fn insert<K>(&mut self, entry: NoveltyEntry<Value>) -> Result<(), DialogSearchTreeError>
+    where
+        K: self::Key,
+    {
+        match self {
+            LinkNovelty::Sealed(buffer) => {
+                *self = LinkNovelty::Open {
+                    run: buffer.entries::<K>()?,
+                    tail: vec![entry],
+                };
+            }
+            LinkNovelty::Cached { entries, .. } => {
+                *self = LinkNovelty::Open {
+                    run: std::mem::take(entries),
+                    tail: vec![entry],
+                };
+            }
+            LinkNovelty::Open { run, tail } => {
+                if tail.len() >= NOVELTY_TAIL_LIMIT {
+                    let merged = merge_runs(std::mem::take(run), std::mem::take(tail));
+                    *run = merged;
+                }
+                let at = tail.partition_point(|held| held.key <= entry.key);
+                tail.insert(at, entry);
+            }
+        }
+        Ok(())
+    }
+
+    /// Takes this link's ops as one flat sorted list, leaving it empty.
     fn take<K>(&mut self) -> Result<Vec<NoveltyEntry<Value>>, DialogSearchTreeError>
     where
         K: self::Key,
     {
-        match std::mem::replace(self, LinkNovelty::Open(Vec::new())) {
+        match std::mem::replace(self, LinkNovelty::empty()) {
             LinkNovelty::Sealed(buffer) => buffer.entries::<K>(),
-            LinkNovelty::Open(entries) => Ok(entries),
+            LinkNovelty::Open { run, tail } => Ok(merge_runs(run, tail)),
+            LinkNovelty::Cached { entries, .. } => Ok(entries),
         }
     }
 
@@ -130,7 +352,8 @@ where
     {
         match self {
             LinkNovelty::Sealed(buffer) => Ok(buffer.resolve::<K>(key)?.is_some()),
-            LinkNovelty::Open(entries) => Ok(resolve_pending(entries, key).is_some()),
+            LinkNovelty::Open { run, tail } => Ok(resolve_runs(run, tail, key).is_some()),
+            LinkNovelty::Cached { entries, .. } => Ok(resolve_pending(entries, key).is_some()),
         }
     }
 }
@@ -156,6 +379,27 @@ pub struct Novelty<Value> {
     /// Total buffered ops across every link, so capacity triggers read a
     /// number instead of scanning.
     total: usize,
+    /// Total buffered WEIGHT across every link (key bytes + value payload
+    /// weight per op, the same metering the frame ceiling uses), for the
+    /// byte-capped flush trigger. `None` until first asked for (a spine
+    /// opened from stored buffers computes it lazily by streaming the
+    /// sealed columns); once computed, every mutator keeps it exact.
+    weight: Option<usize>,
+}
+
+/// The weight one buffered op contributes toward the buffer byte cap: its
+/// key bytes plus its value's payload weight (a retract carries no value
+/// and is charged like [`State::Removed`]'s footprint).
+fn novelty_entry_weight<Value>(entry: &NoveltyEntry<Value>) -> usize
+where
+    Value: self::Value,
+{
+    entry.key.len()
+        + crate::entry::ENTRY_ENCODING_OVERHEAD
+        + match &entry.op {
+            NoveltyOp::Assert(value) => value.payload_weight(),
+            NoveltyOp::Retract => 16,
+        }
 }
 
 impl<Value> Default for Novelty<Value> {
@@ -170,6 +414,7 @@ impl<Value> Novelty<Value> {
         Self {
             links: Vec::new(),
             total: 0,
+            weight: Some(0),
         }
     }
 
@@ -223,8 +468,7 @@ where
     /// buffers as needed.
     fn link_mut(&mut self, at: usize) -> &mut LinkNovelty<Value> {
         if self.links.len() <= at {
-            self.links
-                .resize_with(at + 1, || LinkNovelty::Open(Vec::new()));
+            self.links.resize_with(at + 1, LinkNovelty::empty);
         }
         &mut self.links[at]
     }
@@ -232,9 +476,11 @@ where
     /// Routes `incoming` ops into their link buffers by the children's
     /// bounds (see [`link_bounds`]): one binary search per op, the same
     /// lower-bound rule stored routing uses, with a key below every bound
-    /// clamping into link 0. Only the touched links are lifted and re-sorted;
-    /// the stable sort keeps existing ops before incoming ones for equal
-    /// keys, so the newest op for a key stays last.
+    /// clamping into link 0. Each op inserts into its link's bounded sorted
+    /// tail in arrival order (see [`LinkNovelty::insert`]), so for equal
+    /// keys existing ops stay before incoming ones and the newest op for a
+    /// key stays last — the same order the old whole-buffer stable re-sort
+    /// produced, without its O(buffer) cost per op.
     pub(crate) fn route<K>(
         &mut self,
         bounds: &[&[u8]],
@@ -246,16 +492,13 @@ where
         if incoming.is_empty() {
             return Ok(());
         }
-        let mut buckets: BTreeMap<usize, Vec<NoveltyEntry<Value>>> = BTreeMap::new();
         for entry in incoming {
             let at = bounds.partition_point(|separator| *separator <= entry.key.as_slice());
-            buckets.entry(at).or_default().push(entry);
-        }
-        for (at, bucket) in buckets {
-            self.total += bucket.len();
-            let entries = self.link_mut(at).lift::<K>()?;
-            entries.extend(bucket);
-            entries.sort_by(|left, right| left.key.cmp(&right.key));
+            self.total += 1;
+            if let Some(weight) = self.weight.as_mut() {
+                *weight += novelty_entry_weight(&entry);
+            }
+            self.link_mut(at).insert::<K>(entry)?;
         }
         Ok(())
     }
@@ -274,8 +517,69 @@ where
         match self.links.get(at) {
             None => Ok(None),
             Some(LinkNovelty::Sealed(buffer)) => buffer.resolve::<K>(key),
-            Some(LinkNovelty::Open(entries)) => Ok(resolve_pending(entries, key).cloned()),
+            Some(LinkNovelty::Open { run, tail }) => Ok(resolve_runs(run, tail, key).cloned()),
+            Some(LinkNovelty::Cached { entries, .. }) => Ok(resolve_pending(entries, key).cloned()),
         }
+    }
+
+    /// Total buffered weight across every link (the byte-cap trigger's
+    /// quantity), computed lazily on first ask — a spine opened from stored
+    /// buffers streams their sealed columns once — and kept exact by every
+    /// mutator afterwards.
+    pub(crate) fn weight<K>(&mut self) -> Result<usize, DialogSearchTreeError>
+    where
+        K: self::Key,
+    {
+        if let Some(weight) = self.weight {
+            return Ok(weight);
+        }
+        let mut weight = 0usize;
+        for link in &self.links {
+            weight += match link {
+                LinkNovelty::Sealed(buffer) => buffer.weight::<K>()?,
+                LinkNovelty::Open { run, tail } => run
+                    .iter()
+                    .chain(tail.iter())
+                    .map(novelty_entry_weight)
+                    .sum(),
+                LinkNovelty::Cached { entries, .. } => {
+                    entries.iter().map(novelty_entry_weight).sum()
+                }
+            };
+        }
+        self.weight = Some(weight);
+        Ok(weight)
+    }
+
+    /// Per-link `(link, weight, ops)` for every non-empty link buffer, the
+    /// quantities a selective flush orders its shedding by. A sealed link
+    /// streams its encoded columns; nothing is lifted.
+    pub(crate) fn link_measures<K>(
+        &self,
+    ) -> Result<Vec<(usize, usize, usize)>, DialogSearchTreeError>
+    where
+        K: self::Key,
+    {
+        let mut measures = Vec::new();
+        for (at, link) in self.links.iter().enumerate() {
+            let ops = link.len();
+            if ops == 0 {
+                continue;
+            }
+            let weight = match link {
+                LinkNovelty::Sealed(buffer) => buffer.weight::<K>()?,
+                LinkNovelty::Open { run, tail } => run
+                    .iter()
+                    .chain(tail.iter())
+                    .map(novelty_entry_weight)
+                    .sum(),
+                LinkNovelty::Cached { entries, .. } => {
+                    entries.iter().map(novelty_entry_weight).sum()
+                }
+            };
+            measures.push((at, weight, ops));
+        }
+        Ok(measures)
     }
 
     /// Takes link `at`'s ops, leaving that buffer empty: what a flush hands
@@ -293,6 +597,9 @@ where
             Some(link) => {
                 let taken = link.take::<K>()?;
                 self.total -= taken.len();
+                if let Some(weight) = self.weight.as_mut() {
+                    *weight -= taken.iter().map(novelty_entry_weight).sum::<usize>();
+                }
                 Ok(taken)
             }
         }
@@ -312,6 +619,7 @@ where
         }
         self.links.clear();
         self.total = 0;
+        self.weight = Some(0);
         Ok(out)
     }
 
@@ -341,15 +649,26 @@ where
         };
         let present = match link {
             LinkNovelty::Sealed(buffer) => buffer.resolve::<K>(key)?.is_some(),
-            LinkNovelty::Open(entries) => resolve_pending(entries, key).is_some(),
+            LinkNovelty::Open { run, tail } => resolve_runs(run, tail, key).is_some(),
+            LinkNovelty::Cached { entries, .. } => resolve_pending(entries, key).is_some(),
         };
         if !present {
             return Ok(());
         }
         let entries = link.lift::<K>()?;
         let before = entries.len();
-        entries.retain(|entry| entry.key.as_slice() != key);
+        let mut removed_weight = 0usize;
+        entries.retain(|entry| {
+            let keep = entry.key.as_slice() != key;
+            if !keep {
+                removed_weight += novelty_entry_weight(entry);
+            }
+            keep
+        });
         self.total -= before - entries.len();
+        if let Some(weight) = self.weight.as_mut() {
+            *weight -= removed_weight;
+        }
         Ok(())
     }
 
@@ -377,10 +696,20 @@ where
             return Ok(());
         }
 
+        // The first/last probes and the partition splits below need each
+        // touched link as one flat sorted list; folding a pending tail in
+        // here is once-per-boundary-move, off every hot path.
+        for touched in [at - 1, at] {
+            if let Some(link) = self.links.get_mut(touched) {
+                link.consolidate();
+            }
+        }
+
         // A risen bound: the leading ops of link `at` fall below it now.
         let strays_below = match self.links.get(at) {
             None => false,
-            Some(LinkNovelty::Open(entries)) => entries
+            Some(LinkNovelty::Open { run, .. })
+            | Some(LinkNovelty::Cached { entries: run, .. }) => run
                 .first()
                 .is_some_and(|entry| entry.key.as_slice() < bound),
             Some(LinkNovelty::Sealed(buffer)) => match buffer.keys::<K>()?.next_key()? {
@@ -404,7 +733,8 @@ where
         // A dropped bound: the trailing ops of link `at - 1` reach it now.
         let strays_above = match self.links.get(at - 1) {
             None => false,
-            Some(LinkNovelty::Open(entries)) => entries
+            Some(LinkNovelty::Open { run, .. })
+            | Some(LinkNovelty::Cached { entries: run, .. }) => run
                 .last()
                 .is_some_and(|entry| entry.key.as_slice() >= bound),
             Some(LinkNovelty::Sealed(buffer)) => {
@@ -445,40 +775,26 @@ where
     {
         for link in &self.links {
             match link {
-                LinkNovelty::Open(entries) => {
-                    // Buffers are sorted by key, so the in-range ops are a
-                    // contiguous run: seek to its start rather than walking
-                    // the whole buffer.
-                    let from = match start {
-                        Bound::Included(bound) => {
-                            entries.partition_point(|entry| entry.key.as_slice() < bound)
-                        }
-                        Bound::Excluded(bound) => {
-                            entries.partition_point(|entry| entry.key.as_slice() <= bound)
-                        }
-                        Bound::Unbounded => 0,
-                    };
-                    let mut at = from;
-                    while at < entries.len() {
-                        match end {
-                            Bound::Included(bound) if entries[at].key.as_slice() > bound => break,
-                            Bound::Excluded(bound) if entries[at].key.as_slice() >= bound => break,
-                            _ => {}
-                        }
-                        let mut last = at;
-                        while last + 1 < entries.len() && entries[last + 1].key == entries[at].key {
-                            last += 1;
-                        }
-                        out.push(entries[last].clone());
-                        at = last + 1;
-                    }
+                LinkNovelty::Open { run, tail } => {
+                    winners_in_runs(run, tail, start, end, out);
+                }
+                LinkNovelty::Cached { entries, .. } => {
+                    winners_in_runs(entries, &[], start, end, out);
                 }
                 LinkNovelty::Sealed(buffer) => {
                     let mut keys = buffer.keys::<K>()?;
-                    // The pending winner: the last-seen index for the current
-                    // key, flushed when the key changes or the scan ends.
-                    let mut winner: Option<(usize, Vec<u8>)> = None;
+                    // The pending winner: the last-seen (index, value slot)
+                    // for the current key, flushed when the key changes or
+                    // the scan ends. The slot is tracked as the polarity
+                    // column is walked (`keys()` validated it), so decoding
+                    // a winner costs no per-op polarity re-scan.
+                    let mut winner: Option<(usize, usize, Vec<u8>)> = None;
+                    let mut asserts = 0usize;
                     while let Some((at, key)) = keys.next_key()? {
+                        let slot = asserts;
+                        if buffer.polarity.get(at).copied() == Some(1) {
+                            asserts += 1;
+                        }
                         let after_start = match start {
                             Bound::Included(bound) => key >= bound,
                             Bound::Excluded(bound) => key > bound,
@@ -496,22 +812,25 @@ where
                             break;
                         }
                         match &mut winner {
-                            Some((winning, current)) if current.as_slice() == key => *winning = at,
+                            Some((winning, winning_slot, current)) if current.as_slice() == key => {
+                                *winning = at;
+                                *winning_slot = slot;
+                            }
                             _ => {
-                                if let Some((winning, current)) = winner.take() {
+                                if let Some((winning, winning_slot, current)) = winner.take() {
                                     out.push(NoveltyEntry {
                                         key: current,
-                                        op: buffer.op_at(winning)?,
+                                        op: buffer.op_with_slot(winning, winning_slot)?,
                                     });
                                 }
-                                winner = Some((at, key.to_vec()));
+                                winner = Some((at, slot, key.to_vec()));
                             }
                         }
                     }
-                    if let Some((winning, current)) = winner {
+                    if let Some((winning, winning_slot, current)) = winner {
                         out.push(NoveltyEntry {
                             key: current,
-                            op: buffer.op_at(winning)?,
+                            op: buffer.op_with_slot(winning, winning_slot)?,
                         });
                     }
                 }
@@ -547,13 +866,17 @@ where
                 ));
             }
             let buffer = match link {
-                LinkNovelty::Open(entries) => {
+                LinkNovelty::Open { run, tail } => {
+                    let entries = merge_runs(run, tail);
                     if entries.is_empty() {
                         continue;
                     }
                     NoveltyBuffer::from_entries::<K>(at as u32, entries)?
                 }
-                LinkNovelty::Sealed(mut sealed) => {
+                LinkNovelty::Cached {
+                    buffer: mut sealed, ..
+                }
+                | LinkNovelty::Sealed(mut sealed) => {
                     sealed.child = at as u32;
                     // The cache's whole contract: the sealed bytes must be
                     // exactly what a fresh encode of the same ops produces.
@@ -574,6 +897,107 @@ where
                         );
                     }
                     sealed
+                }
+            };
+            #[cfg(debug_assertions)]
+            debug_assert_grouped::<K, Value>(&buffer, at, links)?;
+            buffers.push(buffer);
+        }
+        Ok(buffers)
+    }
+
+    /// The stored per-link buffers for a NON-consuming persist, leaving the
+    /// set intact so the live spine survives the persist and keeps taking
+    /// writes.
+    ///
+    /// The borrowed twin of [`into_buffers`](Self::into_buffers), with one
+    /// addition: an open link is encoded once and then held as
+    /// [`LinkNovelty::Cached`] — the decoded ops stay live for the next
+    /// append (no re-decode of the accumulated buffer) while the encoding
+    /// is re-embedded verbatim by any persist that arrives before the next
+    /// mutation. Encoding is a pure function of the op list, so a cached
+    /// buffer is bit-identical to what a fresh open of the persisted node
+    /// would carry.
+    pub(crate) fn persist_buffers<K>(
+        &mut self,
+        links: &[Link],
+    ) -> Result<Vec<NoveltyBuffer<Value>>, DialogSearchTreeError>
+    where
+        K: self::Key,
+        Value: for<'a> Serialize<
+            Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+        >,
+    {
+        let mut buffers = Vec::new();
+        for (at, link) in self.links.iter_mut().enumerate() {
+            if at >= links.len() {
+                if link.len() == 0 {
+                    continue;
+                }
+                return Err(DialogSearchTreeError::Node(
+                    "Novelty was buffered beyond the node's links".into(),
+                ));
+            }
+            let buffer = match link {
+                LinkNovelty::Open { run, tail } => {
+                    // Encoding needs the one flat sorted list; fold the tail
+                    // in first (once per persist, not per op).
+                    if !tail.is_empty() {
+                        let merged = merge_runs(std::mem::take(run), std::mem::take(tail));
+                        *run = merged;
+                    }
+                    if run.is_empty() {
+                        continue;
+                    }
+                    let buffer = NoveltyBuffer::from_entries_ref::<K>(at as u32, run)?;
+                    let emitted = buffer.clone();
+                    *link = LinkNovelty::Cached {
+                        entries: std::mem::take(run),
+                        buffer,
+                    };
+                    emitted
+                }
+                LinkNovelty::Cached { entries, buffer } => {
+                    // `entries` backs the debug-only identity check below;
+                    // release builds embed the cached encoding without it.
+                    #[cfg(not(debug_assertions))]
+                    let _ = entries;
+                    // Siblings may have shifted this buffer's child index;
+                    // restamp the retained copy too so it stays in sync with
+                    // what was just persisted.
+                    buffer.child = at as u32;
+                    #[cfg(debug_assertions)]
+                    {
+                        let fresh = NoveltyBuffer::from_entries_ref::<K>(buffer.child, entries)?;
+                        let cached_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(buffer)
+                            .map_err(|error| DialogSearchTreeError::Encoding(format!("{error}")))?;
+                        let fresh_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&fresh)
+                            .map_err(|error| DialogSearchTreeError::Encoding(format!("{error}")))?;
+                        debug_assert_eq!(
+                            cached_bytes.as_slice(),
+                            fresh_bytes.as_slice(),
+                            "a cached buffer must persist byte-identical to a fresh encode"
+                        );
+                    }
+                    buffer.clone()
+                }
+                LinkNovelty::Sealed(sealed) => {
+                    sealed.child = at as u32;
+                    #[cfg(debug_assertions)]
+                    {
+                        let fresh =
+                            NoveltyBuffer::from_entries::<K>(sealed.child, sealed.entries::<K>()?)?;
+                        let sealed_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(sealed)
+                            .map_err(|error| DialogSearchTreeError::Encoding(format!("{error}")))?;
+                        let fresh_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&fresh)
+                            .map_err(|error| DialogSearchTreeError::Encoding(format!("{error}")))?;
+                        debug_assert_eq!(
+                            sealed_bytes.as_slice(),
+                            fresh_bytes.as_slice(),
+                            "a sealed buffer must persist byte-identical to a fresh encode"
+                        );
+                    }
+                    sealed.clone()
                 }
             };
             #[cfg(debug_assertions)]
@@ -617,11 +1041,15 @@ where
             let sealed: NoveltyBuffer<Value> = rkyv::deserialize::<_, rkyv::rancor::Error>(buffer)
                 .map_err(|error| DialogSearchTreeError::Access(format!("{error}")))?;
             if links.len() <= child {
-                links.resize_with(child + 1, || LinkNovelty::Open(Vec::new()));
+                links.resize_with(child + 1, LinkNovelty::empty);
             }
             links[child] = LinkNovelty::Sealed(sealed);
         }
-        Ok(Self { links, total })
+        Ok(Self {
+            links,
+            total,
+            weight: None,
+        })
     }
 }
 
@@ -684,13 +1112,117 @@ pub(crate) fn link_bounds<Key, Value>(
 /// A leaf segment holding live key-value entries.
 #[derive(Debug)]
 pub struct TransientSegment<Key, Value> {
-    /// The key-value entries stored in this segment.
-    pub entries: Vec<Entry<Key, Value>>,
+    /// The key-value entries stored in this segment. Private so every
+    /// mutation flows through a method that keeps the cached total weight
+    /// exact; readers borrow through [`TransientSegment::entries`].
+    entries: Vec<Entry<Key, Value>>,
     /// The separator at this segment's left edge: the shortest byte string
     /// above everything left of the seam and at or below this segment's
     /// first key. Empty for the tree's global leftmost segment. This is the
     /// ground truth every index level above derives its separators from.
     pub separator: Vec<u8>,
+    /// Cached sum of the entries' weights ([`Entry::weight`]), `None` until
+    /// first queried or after a wholesale mutation invalidated it. The edit
+    /// path's frame-ceiling gate reads this once per edit; without the cache
+    /// it re-summed the whole leaf on every membership-changing edit, which
+    /// made batch commits quadratic in leaf size. The cached value must be
+    /// exact whenever it is `Some`: an under-report would let a segment
+    /// exceed the frame ceiling and change tree shape.
+    weight: Option<usize>,
+}
+
+impl<Key, Value> TransientSegment<Key, Value> {
+    /// Builds a segment from its entries and left-edge separator.
+    pub fn new(entries: Vec<Entry<Key, Value>>, separator: Vec<u8>) -> Self {
+        Self {
+            entries,
+            separator,
+            weight: None,
+        }
+    }
+
+    /// The key-value entries stored in this segment.
+    pub fn entries(&self) -> &[Entry<Key, Value>] {
+        &self.entries
+    }
+
+    /// Mutable access to the entries for wholesale edits (trims, pops).
+    /// Invalidates the cached total weight; the targeted edit methods
+    /// ([`upsert`](Self::upsert), [`delete`](Self::delete)) maintain it
+    /// incrementally instead and should be preferred on hot paths.
+    pub fn entries_mut(&mut self) -> &mut Vec<Entry<Key, Value>> {
+        self.weight = None;
+        &mut self.entries
+    }
+
+    /// Consumes the segment, returning its entries.
+    pub fn into_entries(self) -> Vec<Entry<Key, Value>> {
+        self.entries
+    }
+
+    /// Consumes the segment, returning its entries and separator.
+    pub fn into_parts(self) -> (Vec<Entry<Key, Value>>, Vec<u8>) {
+        (self.entries, self.separator)
+    }
+
+    /// Takes the entries out of the segment, leaving it empty.
+    pub fn take_entries(&mut self) -> Vec<Entry<Key, Value>> {
+        self.weight = None;
+        std::mem::take(&mut self.entries)
+    }
+}
+
+impl<Key, Value> TransientSegment<Key, Value>
+where
+    Key: self::Key,
+    Value: self::Value,
+{
+    /// The exact sum of the entries' weights ([`Entry::weight`]): the number
+    /// the frame-ceiling gate compares against `Manifest::frame_ceiling`.
+    /// Computed once per segment and maintained incrementally by
+    /// [`upsert`](Self::upsert) and [`delete`](Self::delete), so repeated
+    /// edits into the same leaf pay O(1) here instead of O(entries).
+    pub fn total_weight(&mut self) -> usize {
+        match self.weight {
+            Some(weight) => weight,
+            None => {
+                let weight = self.entries.iter().map(Entry::weight).sum();
+                self.weight = Some(weight);
+                weight
+            }
+        }
+    }
+
+    /// Inserts or replaces the entry for `entry.key`, keeping the cached
+    /// total weight exact: a replacement adjusts by the weight delta, an
+    /// insert adds the entry's weight.
+    pub fn upsert(&mut self, entry: Entry<Key, Value>) {
+        match self.entries.binary_search_by(|e| e.key.cmp(&entry.key)) {
+            Ok(at) => {
+                if let Some(weight) = self.weight.as_mut() {
+                    *weight = *weight + entry.weight() - self.entries[at].weight();
+                }
+                self.entries[at].value = entry.value;
+            }
+            Err(at) => {
+                if let Some(weight) = self.weight.as_mut() {
+                    *weight += entry.weight();
+                }
+                self.entries.insert(at, entry);
+            }
+        }
+    }
+
+    /// Removes the entry for `key` (a missing key is a no-op), keeping the
+    /// cached total weight exact.
+    pub fn delete(&mut self, key: &Key) {
+        if let Ok(at) = self.entries.binary_search_by(|e| e.key.cmp(key)) {
+            if let Some(weight) = self.weight.as_mut() {
+                *weight -= self.entries[at].weight();
+            }
+            self.entries.remove(at);
+        }
+    }
 }
 
 impl<Key, Value> TransientNode<Key, Value> {
@@ -859,10 +1391,9 @@ where
                         value: into_owned(segment.value_at(at)?)?,
                     });
                 }
-                Ok(TransientNode::Segment(TransientSegment {
-                    entries,
-                    separator,
-                }))
+                Ok(TransientNode::Segment(TransientSegment::new(
+                    entries, separator,
+                )))
             }
         }
     }
@@ -917,6 +1448,75 @@ where
                     .map(|child| child.into_link(delta, manifest))
                     .collect::<Result<Vec<Link>, DialogSearchTreeError>>()?;
                 let buffers = novelty.into_buffers::<Key>(&links)?;
+                PersistentNodeBody::index_from_buffers(links, buffers, *manifest)?
+            }
+        };
+
+        let node = PersistentNode::try_from(&body)?;
+        crate::distribution::audit::node(node.buffer().as_ref().len());
+        if let Some(kind) = audit_kind {
+            dialog_storage::dup_audit::note_seal(node.hash().as_bytes(), kind);
+        }
+        delta.add(node.hash().clone(), node.buffer().clone());
+        Ok(node)
+    }
+
+    /// Serializes this transient node into a [`PersistentNode`] WITHOUT
+    /// consuming it, so the live spine survives the persist and the next
+    /// write appends to it instead of re-opening the frame from bytes.
+    ///
+    /// Semantically identical to [`persist`](Self::persist) — same codec,
+    /// same bytes, same hash — with two retention rules: transient CHILDREN
+    /// are persisted and collapsed back to [`Node::Persistent`] links
+    /// (children are touched only by amortized cascades, so keeping them
+    /// live would re-encode untouched frames on every subsequent persist),
+    /// and open novelty buffers are re-sealed in place with the encoding
+    /// they just produced (see [`Novelty::persist_buffers`]), so only links a
+    /// later write touches pay a fresh encode next time.
+    pub fn persist_mut(
+        &mut self,
+        delta: &mut Delta<Blake3Hash, Buffer>,
+        manifest: &Manifest,
+    ) -> Result<PersistentNode<Key, Value>, DialogSearchTreeError> {
+        let audit_kind = if dialog_storage::dup_audit::enabled() {
+            Some(match &self {
+                TransientNode::Segment(_) => "segment",
+                TransientNode::Index(index) if index.novelty.is_empty() => "index-quiet",
+                TransientNode::Index(_) => "index-buffered",
+            })
+        } else {
+            None
+        };
+        let body = match self {
+            TransientNode::Segment(segment) => {
+                PersistentNodeBody::segment_from_entries(segment.entries().to_vec(), *manifest)?
+            }
+            TransientNode::Index(TransientIndex { children, novelty }) => {
+                // Collapse any live (cascade-touched) child back to its
+                // persisted link; an untouched persistent child passes
+                // through with no re-encode, exactly as in `persist`.
+                for child in children.iter_mut() {
+                    if matches!(child, Node::Transient(_)) {
+                        let lifted = std::mem::replace(
+                            child,
+                            Node::Transient(TransientNode::Segment(TransientSegment::new(
+                                Vec::new(),
+                                Vec::new(),
+                            ))),
+                        );
+                        *child = Node::Persistent(lifted.into_link(delta, manifest)?);
+                    }
+                }
+                let links = children
+                    .iter()
+                    .map(|child| match child {
+                        Node::Persistent(link) => Ok(link.clone()),
+                        Node::Transient(_) => Err(DialogSearchTreeError::Node(
+                            "A transient child survived link collapse".into(),
+                        )),
+                    })
+                    .collect::<Result<Vec<Link>, DialogSearchTreeError>>()?;
+                let buffers = novelty.persist_buffers::<Key>(&links)?;
                 PersistentNodeBody::index_from_buffers(links, buffers, *manifest)?
             }
         };
@@ -1188,55 +1788,36 @@ where
     regroup_entries_reusing::<Key, Value, D>(entries, floor, manifest, &[])
 }
 
-/// [`regroup_entries`] with piece provenance: any group that exactly
-/// reproduces an untouched origin piece — same entry range, same derived
-/// separator — is emitted as its original persistent link instead of a
-/// fresh transient segment. See [`PieceOrigin`].
-pub(crate) fn regroup_entries_reusing<Key, Value, D>(
-    entries: Vec<Entry<Key, Value>>,
-    floor: Vec<u8>,
+/// The regroup's complete cut-decision pipeline over a key sequence: the
+/// pair-aware coin pass (veto, bank), the vetoed-stretch
+/// backstop, and the frame ceiling, in that order. Returns
+/// `(cut_after, forced_start)`: `cut_after[i]` cuts after key `i`, and
+/// `forced_start[i]` marks key `i` as opening a group whose stored
+/// separator takes the long forced form.
+///
+/// Factored out of [`regroup_entries_reusing`] so the edit path's
+/// forced-run quiet check evaluates EXACTLY the decisions the regroup
+/// would make — the two must never drift, or the check would skip
+/// widenings whose outcome differs from its prediction. `weights` must be
+/// per-entry [`Entry::weight`] values when `manifest.max_segment` is
+/// non-zero, and may be empty otherwise (the entry-counted coin reads no
+/// weights).
+pub(crate) fn cut_plan<Key, D>(
+    keys: &[&Key],
+    weights: &[usize],
     manifest: &Manifest,
-    origins: &[PieceOrigin],
-) -> Vec<Node<Key, Value>>
+) -> (Vec<bool>, Vec<bool>)
 where
     Key: self::Key,
-    Value: self::Value,
     D: Distribution,
 {
-    let mut groups: Vec<Node<Key, Value>> = vec![];
-    let mut pending: Vec<Entry<Key, Value>> = vec![];
-    // The last key of the previously sealed group; None while sealing the
-    // first group, whose separator comes from the floor instead.
-    let mut previous_last: Option<Key> = None;
-
-    // Pair-aware cuts, decided before the entries move: the coin proposes a
-    // boundary after an entry, and the veto rejects the proposal when the
-    // seam to the successor cannot be told apart within the separator
-    // bound. Both partner keys are needed, so the decisions are computed
-    // over the borrowed list first. The veto verdicts are kept: they
-    // delimit the stretches the backstop below scans.
-    //
-    // The weight bank rides the same walk: a vetoed seam banks its left
-    // key's weight (no cut is possible there), and every ACCEPTED seam
-    // spends the bank into its cut decision and resets it — reset on every
-    // accepted seam, cut or no cut, so the bank is "weight since the last
-    // accepted seam" (a structural property of the key sequence) and never
-    // "weight since the last cut" (which would cascade decisions off coin
-    // outcomes and break convergence). See `Distribution::leaf_cut`.
-    let count = entries.len();
-    // Every pacing decision below meters entries by their full weight (key
-    // bytes plus the value's payload weight), computed once per window.
-    let weights: Vec<usize> = if manifest.max_segment == 0 {
-        Vec::new()
-    } else {
-        entries.iter().map(Entry::weight).collect()
-    };
+    let count = keys.len();
     let mut vetoed = vec![false; count.saturating_sub(1)];
     let mut cut_after = vec![false; count];
     let mut bank = 0usize;
     for at in 0..count.saturating_sub(1) {
-        let key = entries[at].key.as_ref();
-        vetoed[at] = D::vetoes(key, entries[at + 1].key.as_ref(), manifest);
+        let key = keys[at].as_ref();
+        vetoed[at] = D::vetoes(key, keys[at + 1].as_ref(), manifest);
         if vetoed[at] {
             // The coin is skipped entirely for vetoed seams: the veto
             // overrides whatever it would say, and the weight moves into
@@ -1284,8 +1865,8 @@ where
             }
             // The stretch covers keys `start..=at` (the last vetoed seam
             // joins keys `at - 1` and `at`).
-            let keys: Vec<&Key> = entries[start..=at].iter().map(|entry| &entry.key).collect();
-            for cut in cap::forced_cut_positions(&keys, &weights[start..=at], manifest) {
+            for cut in cap::forced_cut_positions(&keys[start..=at], &weights[start..=at], manifest)
+            {
                 cut_after[start + cut - 1] = true;
                 forced_start[start + cut] = true;
             }
@@ -1306,12 +1887,13 @@ where
                 continue;
             }
             if end > start {
-                let keys: Vec<&Key> = entries[start..=end]
-                    .iter()
-                    .map(|entry| &entry.key)
-                    .collect();
                 let seams = &vetoed[start..end];
-                for cut in cap::frame_cut_positions(&keys, &weights[start..=end], seams, manifest) {
+                for cut in cap::frame_cut_positions(
+                    &keys[start..=end],
+                    &weights[start..=end],
+                    seams,
+                    manifest,
+                ) {
                     cut_after[start + cut - 1] = true;
                     forced_start[start + cut] = true;
                 }
@@ -1320,11 +1902,67 @@ where
         }
     }
 
+    (cut_after, forced_start)
+}
+
+/// [`regroup_entries`] with piece provenance: any group that exactly
+/// reproduces an untouched origin piece — same entry range, same derived
+/// separator — is emitted as its original persistent link instead of a
+/// fresh transient segment. See [`PieceOrigin`].
+pub(crate) fn regroup_entries_reusing<Key, Value, D>(
+    entries: Vec<Entry<Key, Value>>,
+    floor: Vec<u8>,
+    manifest: &Manifest,
+    origins: &[PieceOrigin],
+) -> Vec<Node<Key, Value>>
+where
+    Key: self::Key,
+    Value: self::Value,
+    D: Distribution,
+{
+    let mut groups: Vec<Node<Key, Value>> = vec![];
+    let mut pending: Vec<Entry<Key, Value>> = vec![];
+    // The last key of the previously sealed group; None while sealing the
+    // first group, whose separator comes from the floor instead.
+    let mut previous_last: Option<Key> = None;
+
+    // Pair-aware cuts, decided before the entries move: the coin proposes a
+    // boundary after an entry, and the veto rejects the proposal when the
+    // seam to the successor cannot be told apart within the separator
+    // bound. Both partner keys are needed, so the decisions are computed
+    // over the borrowed list first. The veto verdicts are kept: they
+    // delimit the stretches the backstop below scans.
+    //
+    // The weight bank rides the same walk: a vetoed seam banks its left
+    // key's weight (no cut is possible there), and every ACCEPTED seam
+    // spends the bank into its cut decision and resets it — reset on every
+    // accepted seam, cut or no cut, so the bank is "weight since the last
+    // accepted seam" (a structural property of the key sequence) and never
+    // "weight since the last cut" (which would cascade decisions off coin
+    // outcomes and break convergence). See `Distribution::leaf_cut`.
+    let count = entries.len();
+    // Every pacing decision below meters entries by their full weight (key
+    // bytes plus the value's payload weight), computed once per window.
+    let weights: Vec<usize> = if manifest.max_segment == 0 {
+        Vec::new()
+    } else {
+        entries.iter().map(Entry::weight).collect()
+    };
+    let key_refs: Vec<&Key> = entries.iter().map(|entry| &entry.key).collect();
+    let (cut_after, forced_start) = cut_plan::<Key, D>(&key_refs, &weights, manifest);
+
     let origin_for = |start: usize, end: usize| -> Option<&Link> {
         origins
             .iter()
             .find(|origin| origin.start == start && origin.end == end)
             .map(|origin| &origin.link)
+    };
+    // The per-entry weights are already in hand, so each sealed group's
+    // exact total rides into the segment's weight cache: a freshly
+    // regrouped leaf then answers the edit path's frame-ceiling gate
+    // without re-summing its entries.
+    let group_weight = |start: usize, end: usize| -> Option<usize> {
+        (manifest.max_segment > 0).then(|| weights[start..end].iter().sum())
     };
     let mut group_start = 0usize;
     for (at, entry) in entries.into_iter().enumerate() {
@@ -1338,6 +1976,7 @@ where
                 forced_start[group_start],
                 manifest,
                 origin_for(group_start, at + 1),
+                group_weight(group_start, at + 1),
             );
             group_start = at + 1;
         }
@@ -1352,6 +1991,7 @@ where
             forced_start[group_start],
             manifest,
             origin_for(group_start, count),
+            group_weight(group_start, count),
         );
     }
 
@@ -1363,6 +2003,10 @@ where
 /// long forced form when the group starts at a backstop anchor, and the
 /// canonical shortest-distinguishing prefix against the previous group's
 /// last key everywhere else.
+///
+/// `weight`, when given, must be the exact sum of the group's entry weights
+/// (the caller sums the same per-entry weights its cut decisions read); it
+/// seeds the sealed segment's weight cache.
 #[allow(clippy::too_many_arguments)]
 fn seal<Key, Value, D>(
     pending: &mut Vec<Entry<Key, Value>>,
@@ -1372,6 +2016,7 @@ fn seal<Key, Value, D>(
     forced: bool,
     manifest: &Manifest,
     origin: Option<&Link>,
+    weight: Option<usize>,
 ) where
     Key: self::Key,
     Value: self::Value,
@@ -1389,6 +2034,16 @@ fn seal<Key, Value, D>(
         .key
         .clone();
     let separator = match previous_last.as_ref() {
+        // A window-start floor that is itself a forced mark (longer than
+        // the separator bound) is preserved verbatim: it is a valid
+        // separator for any minimum the window can hold (routing keeps
+        // `min >= floor`), and re-deriving through `reseparate` would
+        // collapse it to the short natural prefix — stripping the
+        // self-identifying mark that lets an edit rejoin the force-split
+        // run. Reachable when a non-membership edit (a value update)
+        // re-shapes a forced piece locally, which the widening does not
+        // intercept.
+        None if floor.len() > manifest.max_separator as usize => floor.to_vec(),
         None => D::reseparate(first.as_ref(), floor),
         Some(previous) if forced => {
             cap::forced_seam_separator(previous.as_ref(), first.as_ref(), manifest)
@@ -1406,7 +2061,22 @@ fn seal<Key, Value, D>(
         groups.push(Node::Persistent(link.clone()));
         return;
     }
-    groups.push(TransientNode::Segment(TransientSegment { entries, separator }).into());
+    #[cfg(test)]
+    if let Some(weight) = weight {
+        debug_assert_eq!(
+            weight,
+            entries.iter().map(Entry::weight).sum::<usize>(),
+            "a sealed group's cached weight must equal the sum of its entry weights"
+        );
+    }
+    groups.push(
+        TransientNode::Segment(TransientSegment {
+            entries,
+            separator,
+            weight,
+        })
+        .into(),
+    );
 }
 
 #[cfg(test)]
@@ -1554,5 +2224,289 @@ mod tests {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod novelty_model_tests {
+    #![allow(unexpected_cfgs)]
+
+    use std::collections::BTreeMap;
+
+    use super::{LinkNovelty, NOVELTY_TAIL_LIMIT, Novelty};
+    use crate::{NoveltyEntry, NoveltyOp};
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    type Val = Vec<u8>;
+
+    /// A reference model of one link's buffer: the chronological op log per
+    /// key. Everything the two-run structure must answer derives from it.
+    #[derive(Default)]
+    struct Model {
+        by_key: BTreeMap<Vec<u8>, Vec<NoveltyOp<Val>>>,
+        total: usize,
+    }
+
+    impl Model {
+        fn push(&mut self, key: Vec<u8>, op: NoveltyOp<Val>) {
+            self.by_key.entry(key).or_default().push(op);
+            self.total += 1;
+        }
+
+        fn newest(&self, key: &[u8]) -> Option<&NoveltyOp<Val>> {
+            self.by_key.get(key).and_then(|ops| ops.last())
+        }
+
+        /// The flat sorted op list the buffer must produce: ascending keys,
+        /// chronological order within a key (newest last).
+        fn flat(&self) -> Vec<NoveltyEntry<Val>> {
+            self.by_key
+                .iter()
+                .flat_map(|(key, ops)| {
+                    ops.iter().map(|op| NoveltyEntry {
+                        key: key.clone(),
+                        op: op.clone(),
+                    })
+                })
+                .collect()
+        }
+
+        /// The winner per key within `[start, end]`, ascending.
+        fn winners(&self, start: &[u8], end: &[u8]) -> Vec<NoveltyEntry<Val>> {
+            self.by_key
+                .range(start.to_vec()..=end.to_vec())
+                .map(|(key, ops)| NoveltyEntry {
+                    key: key.clone(),
+                    op: ops.last().expect("non-empty log").clone(),
+                })
+                .collect()
+        }
+    }
+
+    fn xorshift(state: &mut u64) -> u32 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        (*state >> 32) as u32
+    }
+
+    /// Single-op routing (the enqueue hot path) against the model, sweeping
+    /// seeds and op counts sized to cross the tail limit repeatedly, with a
+    /// small key pool so equal-key chains span run/tail boundaries.
+    #[dialog_common::test]
+    async fn it_matches_the_model_through_single_op_routing() {
+        for seed in 0..8u64 {
+            let mut rng = 0x9E3779B97F4A7C15u64 ^ seed;
+            let mut novelty: Novelty<Val> = Novelty::new();
+            let mut model = Model::default();
+
+            let ops = NOVELTY_TAIL_LIMIT * 3 + 17;
+            let pool = 24u32;
+            for at in 0..ops {
+                let key = (xorshift(&mut rng) % pool).to_be_bytes().to_vec();
+                let op = if xorshift(&mut rng).is_multiple_of(4) {
+                    NoveltyOp::Retract
+                } else {
+                    NoveltyOp::Assert(vec![at as u8, seed as u8])
+                };
+                model.push(key.clone(), op.clone());
+                novelty
+                    .route::<[u8; 4]>(&[], vec![NoveltyEntry { key, op }])
+                    .expect("route");
+
+                // Point-resolve a rotating probe against the model mid-run,
+                // so run/tail splits are checked at every phase, not only
+                // after the final consolidation.
+                if at.is_multiple_of(7) {
+                    let probe = (xorshift(&mut rng) % pool).to_be_bytes();
+                    assert_eq!(
+                        novelty.resolve::<[u8; 4]>(0, &probe).expect("resolve"),
+                        model.newest(&probe).cloned(),
+                        "seed {seed}, op {at}: resolve disagrees with the model"
+                    );
+                }
+            }
+
+            assert_eq!(novelty.len(), model.total, "seed {seed}: op count");
+            assert_eq!(novelty.peak(), model.total, "seed {seed}: single-link peak");
+
+            // Range winners while the tail is (very likely) non-empty.
+            for _ in 0..8 {
+                let mut lo = (xorshift(&mut rng) % pool).to_be_bytes().to_vec();
+                let mut hi = (xorshift(&mut rng) % pool).to_be_bytes().to_vec();
+                if lo > hi {
+                    std::mem::swap(&mut lo, &mut hi);
+                }
+                let mut got = Vec::new();
+                novelty
+                    .collect_winners_in_range::<[u8; 4]>(
+                        std::ops::Bound::Included(lo.as_slice()),
+                        std::ops::Bound::Included(hi.as_slice()),
+                        &mut got,
+                    )
+                    .expect("winners");
+                assert_eq!(
+                    got,
+                    model.winners(&lo, &hi),
+                    "seed {seed}: range winners [{lo:?}, {hi:?}] disagree"
+                );
+            }
+
+            // The drained flat list is the stored order: ascending keys,
+            // newest op for a key last. `NoveltyBuffer::from_entries` is a
+            // pure function of this list, so equality here IS sealed-bytes
+            // equality with a buffer built any other way.
+            assert_eq!(
+                novelty.take_all::<[u8; 4]>().expect("take_all"),
+                model.flat(),
+                "seed {seed}: flat drain order"
+            );
+            assert!(novelty.is_empty());
+        }
+    }
+
+    /// Multi-link routing partitions by the same lower-bound rule stored
+    /// routing uses, and each link's buffer independently matches the model.
+    #[dialog_common::test]
+    async fn it_routes_links_like_the_model_partition() {
+        let bounds: Vec<Vec<u8>> = vec![8u32.to_be_bytes().to_vec(), 16u32.to_be_bytes().to_vec()];
+        for seed in 0..4u64 {
+            let mut rng = 0xD1B54A32D192ED03u64 ^ seed;
+            let mut novelty: Novelty<Val> = Novelty::new();
+            let mut models: Vec<Model> = (0..3).map(|_| Model::default()).collect();
+
+            for at in 0..(NOVELTY_TAIL_LIMIT * 2 + 5) {
+                let key = (xorshift(&mut rng) % 24).to_be_bytes().to_vec();
+                let op = NoveltyOp::Assert(vec![at as u8]);
+                let slot = bounds
+                    .iter()
+                    .take_while(|bound| bound.as_slice() <= key.as_slice())
+                    .count();
+                models[slot].push(key.clone(), op.clone());
+                let borrowed: Vec<&[u8]> = bounds.iter().map(Vec::as_slice).collect();
+                novelty
+                    .route::<[u8; 4]>(&borrowed, vec![NoveltyEntry { key, op }])
+                    .expect("route");
+            }
+
+            let expected_peak = models.iter().map(|model| model.total).max().unwrap_or(0);
+            assert_eq!(novelty.peak(), expected_peak, "seed {seed}: peak");
+            for (slot, model) in models.iter().enumerate() {
+                assert_eq!(
+                    novelty.take_link::<[u8; 4]>(slot).expect("take_link"),
+                    model.flat(),
+                    "seed {seed}: link {slot} drain"
+                );
+            }
+            assert!(novelty.is_empty(), "seed {seed}: all links drained");
+        }
+    }
+
+    /// The tail-limit boundary exactly: inserting precisely at, below, and
+    /// above the limit keeps every reader consistent (the consolidation
+    /// fires between the limit-th and limit+1-th insert).
+    #[dialog_common::test]
+    async fn it_consolidates_exactly_at_the_tail_limit() {
+        for extra in [0usize, 1, 2] {
+            let mut novelty: Novelty<Val> = Novelty::new();
+            let mut model = Model::default();
+            // One shared key so every entry is one equal-key chain — the
+            // hardest shape for "newest last" across a consolidation.
+            let key = 7u32.to_be_bytes().to_vec();
+            for at in 0..(NOVELTY_TAIL_LIMIT + extra) {
+                let op = NoveltyOp::Assert(vec![at as u8, (at >> 8) as u8]);
+                model.push(key.clone(), op.clone());
+                novelty
+                    .route::<[u8; 4]>(
+                        &[],
+                        vec![NoveltyEntry {
+                            key: key.clone(),
+                            op,
+                        }],
+                    )
+                    .expect("route");
+                assert_eq!(
+                    novelty.resolve::<[u8; 4]>(0, &key).expect("resolve"),
+                    model.newest(&key).cloned(),
+                    "extra {extra}, op {at}: newest op must win across the limit"
+                );
+            }
+            assert_eq!(
+                novelty.take_all::<[u8; 4]>().expect("take_all"),
+                model.flat(),
+                "extra {extra}: chronological order within the key must survive"
+            );
+        }
+    }
+
+    /// `remove_key` drops every op for the key from BOTH runs and keeps the
+    /// accounting exact, without disturbing other keys.
+    #[dialog_common::test]
+    async fn it_removes_keys_across_both_runs() {
+        let mut novelty: Novelty<Val> = Novelty::new();
+        let mut model = Model::default();
+        // Interleave two keys so, after the limit crossing, the victim key
+        // holds ops in the run AND the tail.
+        let victim = 3u32.to_be_bytes().to_vec();
+        let keeper = 5u32.to_be_bytes().to_vec();
+        for at in 0..(NOVELTY_TAIL_LIMIT + NOVELTY_TAIL_LIMIT / 2) {
+            let key = if at.is_multiple_of(2) {
+                &victim
+            } else {
+                &keeper
+            };
+            let op = NoveltyOp::Assert(vec![at as u8]);
+            model.push(key.clone(), op.clone());
+            novelty
+                .route::<[u8; 4]>(
+                    &[],
+                    vec![NoveltyEntry {
+                        key: key.clone(),
+                        op,
+                    }],
+                )
+                .expect("route");
+        }
+        novelty
+            .remove_key::<[u8; 4]>(0, &victim)
+            .expect("remove_key");
+        let dropped = model.by_key.remove(&victim).expect("victim present");
+        model.total -= dropped.len();
+
+        assert_eq!(novelty.len(), model.total, "count after removal");
+        assert_eq!(
+            novelty.resolve::<[u8; 4]>(0, &victim).expect("resolve"),
+            None,
+            "removed key must not resolve"
+        );
+        assert_eq!(
+            novelty.take_all::<[u8; 4]>().expect("take_all"),
+            model.flat(),
+            "surviving ops must be untouched and ordered"
+        );
+    }
+
+    /// An empty-tail consolidation and a consolidation of a lifted sealed
+    /// buffer are both no-ops that leave the flat order intact.
+    #[dialog_common::test]
+    async fn it_consolidates_idempotently() {
+        let mut link: LinkNovelty<Val> = LinkNovelty::empty();
+        for at in 0..5u8 {
+            link.insert::<[u8; 4]>(NoveltyEntry {
+                key: vec![at],
+                op: NoveltyOp::Assert(vec![at]),
+            })
+            .expect("insert");
+        }
+        link.consolidate();
+        link.consolidate();
+        let drained = link.take::<[u8; 4]>().expect("take");
+        assert_eq!(drained.len(), 5);
+        assert!(
+            drained.windows(2).all(|pair| pair[0].key <= pair[1].key),
+            "consolidation must leave sorted order"
+        );
     }
 }

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -187,7 +187,16 @@ where
                 });
             }
             let segment = result.leaf.as_segment()?;
-            if let Some(at) = segment.find::<Key>(key.as_ref())? {
+            // A leaf probed once streams the front-coded keys (decode paid
+            // only as far as the probe); a leaf probed repeatedly — a hot key
+            // or a join landing on the same leaf per outer row — flips to the
+            // memoized flat decode and binary-searches it.
+            let at = if result.leaf.should_memoize_keys() {
+                result.leaf.memoized_keys()?.binary_search(key.as_ref())
+            } else {
+                segment.find::<Key>(key.as_ref())?
+            };
+            if let Some(at) = at {
                 into_owned(segment.value_at(at)?).map(Some)
             } else {
                 Ok(None)

--- a/rust/dialog-search-tree/src/tree/transient.rs
+++ b/rust/dialog-search-tree/src/tree/transient.rs
@@ -248,10 +248,9 @@ where
                 // empty separator there.
                 let separator = D::reseparate(entry.key.as_ref(), &[]);
                 TransientNode::Index(TransientIndex {
-                    children: vec![Node::Transient(TransientNode::Segment(TransientSegment {
-                        entries: vec![entry],
-                        separator,
-                    }))],
+                    children: vec![Node::Transient(TransientNode::Segment(
+                        TransientSegment::new(vec![entry], separator),
+                    ))],
                     novelty: Novelty::new(),
                 })
             }
@@ -292,6 +291,113 @@ where
             None => TransientRoot::Unloaded(NULL_BLAKE3_HASH.clone()),
         };
         Ok(self)
+    }
+
+    /// Whether this tree is empty and unedited — the bulk-load
+    /// precondition for [`plant`](Self::plant).
+    pub(crate) fn is_unplanted(&self) -> bool {
+        matches!(&self.root, TransientRoot::Unloaded(hash) if hash == NULL_BLAKE3_HASH)
+    }
+
+    /// Plants a whole batch into an EMPTY tree with one bottom-up build —
+    /// the bulk-load fast path. The ops are resolved last-wins per key
+    /// (the stable sort keeps a batch's temporal order within a key), the
+    /// surviving asserts become the sorted entry list, and the canonical
+    /// tree is built directly: [`regroup_entries`] for the leaf level,
+    /// then the same per-level grouping loop `seal_root` runs — instead of
+    /// one canonical edit per op, which is where a large batch into a
+    /// fresh store spends essentially all of its time.
+    ///
+    /// History independence makes this exact: the canonical form is a
+    /// pure function of the surviving fact set, so the bottom-up build
+    /// and the per-op replay produce the same bytes (converge_check's
+    /// single-commit arm pins exactly this equality against the per-txn
+    /// arms). A batch whose surviving set is empty leaves the tree empty.
+    pub(crate) async fn plant<Backend>(
+        mut self,
+        mut ops: Vec<NoveltyEntry<Value>>,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Self, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+    {
+        debug_assert!(self.is_unplanted(), "plant requires an empty tree");
+        ops.sort_by(|a, b| a.key.cmp(&b.key));
+
+        // Keep only each key's last op; a surviving retract on an empty
+        // tree is a no-op and drops out.
+        let mut entries: Vec<Entry<Key, Value>> = Vec::with_capacity(ops.len());
+        let mut push = |op: NoveltyEntry<Value>| -> Result<(), DialogSearchTreeError> {
+            if let NoveltyOp::Assert(value) = op.op {
+                entries.push(Entry {
+                    key: Key::try_from_bytes(&op.key)?,
+                    value,
+                });
+            }
+            Ok(())
+        };
+        let mut pending: Option<NoveltyEntry<Value>> = None;
+        for op in ops {
+            match &mut pending {
+                Some(previous) if previous.key == op.key => *previous = op,
+                Some(previous) => push(std::mem::replace(previous, op))?,
+                None => pending = Some(op),
+            }
+        }
+        if let Some(last) = pending {
+            push(last)?;
+        }
+        if entries.is_empty() {
+            return Ok(self);
+        }
+
+        let manifest = self.manifest;
+        let accessor = Accessor::new(self.cache.clone(), storage.clone());
+        let pieces = regroup_entries::<Key, Value, D>(entries, Vec::new(), &manifest);
+        self.root = match seal_root::<Key, Value, D, _>(pieces, 0, &manifest, &accessor).await? {
+            Some(node) => TransientRoot::Loaded(node),
+            None => TransientRoot::Unloaded(NULL_BLAKE3_HASH.clone()),
+        };
+        Ok(self)
+    }
+
+    /// The separator lists of every level below the root, top-down, for the
+    /// canonical-form validator: level `d` holds, in order, the separator of
+    /// every node at depth `d + 1`. A fully in-memory tree only (as
+    /// [`plant`](Self::plant) leaves it); a [`Node::Persistent`] child errors
+    /// rather than silently comparing an unloaded subtree.
+    pub(crate) fn level_separators(&self) -> Result<Vec<Vec<Vec<u8>>>, DialogSearchTreeError> {
+        let root = match &self.root {
+            TransientRoot::Unloaded(_) => return Ok(Vec::new()),
+            TransientRoot::Loaded(node) => node,
+        };
+        let mut levels = Vec::new();
+        let mut current: Vec<&TransientNode<Key, Value>> = vec![root];
+        loop {
+            let mut next: Vec<&TransientNode<Key, Value>> = Vec::new();
+            let mut separators: Vec<Vec<u8>> = Vec::new();
+            for node in &current {
+                let TransientNode::Index(index) = node else {
+                    continue;
+                };
+                for child in &index.children {
+                    let Node::Transient(child) = child else {
+                        return Err(DialogSearchTreeError::Node(
+                            "level_separators requires a fully in-memory tree".into(),
+                        ));
+                    };
+                    separators.push(child.separator()?.to_vec());
+                    next.push(child);
+                }
+            }
+            if separators.is_empty() {
+                break;
+            }
+            levels.push(separators);
+            current = next;
+        }
+        Ok(levels)
     }
 
     /// Retrieves the value associated with `key` from the in-flight transient
@@ -342,8 +448,11 @@ where
                     }
                 }
                 TransientNode::Segment(segment) => {
-                    return match segment.entries.binary_search_by(|entry| entry.key.cmp(key)) {
-                        Ok(at) => Ok(Some(segment.entries[at].value.clone())),
+                    return match segment
+                        .entries()
+                        .binary_search_by(|entry| entry.key.cmp(key))
+                    {
+                        Ok(at) => Ok(Some(segment.entries()[at].value.clone())),
                         Err(_) => Ok(None),
                     };
                 }
@@ -909,60 +1018,80 @@ where
         } else {
             match (&self, follow(&mut root, &path)?) {
                 (Edit::Upsert(entry), TransientNode::Segment(segment)) => {
-                    match segment.entries.binary_search_by(|e| e.key.cmp(&entry.key)) {
+                    match segment
+                        .entries()
+                        .binary_search_by(|e| e.key.cmp(&entry.key))
+                    {
                         // A value update with a changed payload weight moves
                         // pacing decisions just like a membership change.
                         Ok(at) => {
-                            segment.entries[at].value.payload_weight()
+                            segment.entries()[at].value.payload_weight()
                                 != entry.value.payload_weight()
                         }
                         Err(_) => true,
                     }
                 }
-                (Edit::Delete(key), TransientNode::Segment(segment)) => {
-                    segment.entries.binary_search_by(|e| e.key.cmp(key)).is_ok()
-                }
+                (Edit::Delete(key), TransientNode::Segment(segment)) => segment
+                    .entries()
+                    .binary_search_by(|e| e.key.cmp(key))
+                    .is_ok(),
                 _ => true,
             }
         };
-        let piece_origins = if changes_membership {
-            merge_forced_run::<Key, Value, Backend>(&mut root, &mut path, accessor, &manifest)
+        let mut piece_origins = if changes_membership {
+            let verdict = forced_run_quiet::<Key, Value, Backend, D>(
+                &mut root, &path, &self, accessor, &manifest,
+            )
+            .await?;
+            if let RunVerdict::SurgicalMin { separator } = verdict {
+                // A verified surgical min-insert: the run's post-edit plan
+                // reproduces every stored boundary and the piece's forced
+                // separator re-derives at the same length, so no election
+                // input changes at any level. Apply in place, swap the
+                // separator (the exact bytes a merged regroup's seal would
+                // store), and re-home the parent's buffered ops across the
+                // moved boundary — then the tree is byte-for-byte what the
+                // full merge-and-regroup path would have produced.
+                let TransientNode::Segment(leaf) = follow(&mut root, &path)? else {
+                    return Err(DialogSearchTreeError::Node(
+                        "Path did not reach a segment".into(),
+                    ));
+                };
+                apply_to_segment(leaf, self);
+                leaf.separator = separator;
+                reroute_moved_seam::<Key, Value>(&mut root, &path)?;
+                return Ok(Some(root));
+            }
+            if matches!(verdict, RunVerdict::Quiet) {
+                None
+            } else {
+                merge_forced_run::<Key, Value, Backend>(
+                    &mut root,
+                    &mut path,
+                    &mut [],
+                    accessor,
+                    &manifest,
+                )
                 .await?
+            }
         } else {
             None
         };
         let widened = piece_origins.is_some();
 
-        // The same widening, per INDEX level: a force-split index frame's
-        // pieces are separate stored nodes, and this level's regroup window
-        // is one node's children — so an edit descending through a piece
-        // must merge the frame's pieces first, or elections would re-derive
-        // anchors over a fragment and orders would diverge. A seam between
-        // siblings is a forced one exactly when its separator's seam rank
-        // fails the level threshold that grouped them (derived, no stored
-        // mark); ordinary paths see two rank probes per level and merge
-        // nothing.
-        let (index_widened, index_origins) = if changes_membership && manifest.frame_ceiling() > 0 {
-            merge_forced_index_runs::<Key, Value, D, Backend>(
-                &mut root, &mut path, accessor, &manifest,
-            )
-            .await?
-        } else {
-            (false, Vec::new())
-        };
-
         // The frame ceiling's fast-path gate: a membership-changing edit
         // that leaves its segment over the ceiling must reach the regroup,
         // which force-splits the frame — the in-place fast path would let
-        // the segment grow past the hard bound. The weight sum is paid only
-        // when a ceiling is armed and membership changes; an upsert of an
-        // existing key never gets here (weights are key-derived).
+        // the segment grow past the hard bound. The gate reads the segment's
+        // cached total weight (exact, maintained incrementally by the
+        // in-place edit methods), so a batch of edits into one leaf pays the
+        // O(entries) sum once instead of on every membership change.
         let over_ceiling = if !changes_membership || manifest.frame_ceiling() == 0 {
             false
         } else {
             match follow(&mut root, &path)? {
                 TransientNode::Segment(segment) => {
-                    let weight: usize = segment.entries.iter().map(Entry::weight).sum();
+                    let weight = segment.total_weight();
                     let weight = match &self {
                         Edit::Upsert(entry) => weight + entry.weight(),
                         Edit::Delete(_) => weight,
@@ -982,7 +1111,7 @@ where
         // yet must still fuse rightward, which the local check cannot see.
         let is_boundary_delete = match (&self, follow(&mut root, &path)?) {
             (Edit::Delete(_), TransientNode::Segment(segment)) => segment
-                .entries
+                .entries()
                 .last()
                 .map(|e| &e.key == key)
                 .unwrap_or(false),
@@ -1028,14 +1157,14 @@ where
                 // Cheapest test first: only a key sorting past the segment's
                 // last entry can be an orphan append, so the coin hashes are
                 // paid only on true appends.
-                match segment.entries.last() {
+                match segment.entries().last() {
                     Some(last) if entry.key > last.key => {
                         if manifest.max_segment == 0 {
                             D::rank(last.key.as_ref(), &manifest) > BOTTOM_RANK
                                 && D::rank(entry.key.as_ref(), &manifest) <= BOTTOM_RANK
                         } else if D::vetoes(last.key.as_ref(), entry.key.as_ref(), &manifest) {
                             let bank = trailing_stretch_weight::<Key, Value, D>(
-                                &segment.entries,
+                                segment.entries(),
                                 &manifest,
                             );
                             !D::leaf_cut(entry.key.as_ref(), bank + entry.weight(), &manifest)
@@ -1064,9 +1193,9 @@ where
         } else {
             match (&self, follow(&mut root, &path)?) {
                 (Edit::Delete(key), TransientNode::Segment(segment)) => {
-                    match segment.entries.binary_search_by(|e| e.key.cmp(key)) {
-                        Ok(at) if at + 1 < segment.entries.len() => {
-                            let entries = &segment.entries;
+                    match segment.entries().binary_search_by(|e| e.key.cmp(key)) {
+                        Ok(at) if at + 1 < segment.entries().len() => {
+                            let entries = segment.entries();
                             let beside_stretch = (at > 0
                                 && D::vetoes(
                                     entries[at - 1].key.as_ref(),
@@ -1093,6 +1222,43 @@ where
                         _ => false,
                     }
                 }
+                // A value UPDATE of the segment's terminal boundary entry can
+                // defund its cut just like a stretch-member delete: the coin
+                // charges the entry's payload weight, and payload weight
+                // moves with content (collapsed claims, causes, versions).
+                // Without this arm the stale boundary survives — the local
+                // re-shape has no right neighbor to fuse into, which is
+                // exactly the history-divergence converge_check caught (a
+                // stored leaf whose terminal coin no longer funds its cut).
+                (Edit::Upsert(entry), TransientNode::Segment(segment)) => {
+                    let entries = segment.entries();
+                    match entries.last() {
+                        Some(last)
+                            if last.key == entry.key
+                                && last.value.payload_weight() != entry.value.payload_weight() =>
+                        {
+                            // The bank the terminal coin sees: the summed
+                            // weight of the vetoed stretch immediately
+                            // before the terminal entry (weights of every
+                            // left partner of a vetoed seam), mirroring the
+                            // regroup's walk.
+                            let mut bank = 0usize;
+                            let mut at = entries.len() - 1;
+                            while at > 0
+                                && D::vetoes(
+                                    entries[at - 1].key.as_ref(),
+                                    entries[at].key.as_ref(),
+                                    &manifest,
+                                )
+                            {
+                                at -= 1;
+                                bank += entries[at].weight();
+                            }
+                            !D::leaf_cut(entry.key.as_ref(), bank + entry.weight(), &manifest)
+                        }
+                        _ => false,
+                    }
+                }
                 _ => false,
             }
         };
@@ -1105,7 +1271,10 @@ where
         // evaluated below, once the right neighbor's minimum is reachable.
         let min_move = match (&self, follow(&mut root, &path)?) {
             (Edit::Upsert(entry), TransientNode::Segment(segment)) => {
-                match segment.entries.binary_search_by(|e| e.key.cmp(&entry.key)) {
+                match segment
+                    .entries()
+                    .binary_search_by(|e| e.key.cmp(&entry.key))
+                {
                     Err(0) => Some((
                         segment.separator.clone(),
                         D::reseparate(entry.key.as_ref(), &segment.separator),
@@ -1114,10 +1283,10 @@ where
                 }
             }
             (Edit::Delete(key), TransientNode::Segment(segment)) => {
-                match segment.entries.binary_search_by(|e| e.key.cmp(key)) {
-                    Ok(0) if segment.entries.len() > 1 => Some((
+                match segment.entries().binary_search_by(|e| e.key.cmp(key)) {
+                    Ok(0) if segment.entries().len() > 1 => Some((
                         segment.separator.clone(),
-                        D::reseparate(segment.entries[1].key.as_ref(), &segment.separator),
+                        D::reseparate(segment.entries()[1].key.as_ref(), &segment.separator),
                     )),
                     _ => None,
                 }
@@ -1161,6 +1330,18 @@ where
         // Anything not provably canonical falls through to the re-shaping
         // paths. A widened window always re-shapes: the merge left the
         // stretch as one oversized segment that only the regroup re-splits.
+        //
+        // The forced-INDEX widening is deliberately NOT part of this gate:
+        // it is decided after the fast path, because a fast-path edit
+        // cannot need it. Index-level plans — seam ranks, link weights,
+        // frame elections — are pure functions of child SEPARATORS, and
+        // every gate here together proves the edit changes no separator
+        // and no membership anywhere (an in-place leaf edit with the
+        // minimum either untouched or re-deriving to identical bytes).
+        // Unchanged separators mean every level's stored partition is
+        // already the one a merged re-election would re-derive, so merging
+        // the frame's pieces would rebuild byte-identical nodes for
+        // nothing — which the widen census measured at once per op.
         if !is_boundary_delete
             && !is_orphan_append
             && !dissolves_terminal_cut
@@ -1168,7 +1349,6 @@ where
             && !raises_left_cut
             && !moves_seam_under_ceiling
             && !widened
-            && !index_widened
             && !over_ceiling
         {
             let TransientNode::Segment(segment) = follow(&mut root, &path)? else {
@@ -1176,14 +1356,26 @@ where
                     "Path did not reach a segment".into(),
                 ));
             };
-            if fast_path_keeps_canonical::<Key, Value, D>(&segment.entries, &self, &manifest) {
-                apply_to_segment(&mut segment.entries, self);
+            if fast_path_keeps_canonical::<Key, Value, D>(segment.entries(), &self, &manifest) {
+                apply_to_segment(segment, self);
                 // The seam at the segment's left edge moves with its first
-                // key. Re-derive the separator from the new minimum against
-                // the old separator as the floor; the rule is idempotent
-                // when the minimum did not change.
-                if let Some(first) = segment.entries.first() {
-                    segment.separator = D::reseparate(first.key.as_ref(), &segment.separator);
+                // key: only a min-move re-derives the separator. Re-deriving
+                // unconditionally was NOT the no-op its idempotence argument
+                // assumed — a force-split piece stores the long forced form
+                // (left neighbor's key plus 0x00 padding), which is not a
+                // prefix of the minimum, so `reseparate` collapsed it to
+                // the short natural prefix and silently stripped the
+                // self-identifying mark. The orphaned piece then never
+                // rejoined its run, and whether its boundary existed at all
+                // depended on edit history (the converge_check divergence).
+                // A min-move can never see a forced floor here: it changes
+                // membership, and membership changes into a forced piece
+                // are widened before the fast path is reachable.
+                if min_move.is_some()
+                    && let Some(first) = segment.entries().first()
+                {
+                    let separator = D::reseparate(first.key.as_ref(), &segment.separator);
+                    segment.separator = separator;
                 }
                 // A moved separator moves a link boundary in the deepest
                 // ancestor where this leaf is not on the leftmost edge, and
@@ -1199,6 +1391,32 @@ where
             }
         }
 
+        // The same widening as the leaf backstop, per INDEX level: a
+        // force-split index frame's pieces are separate stored nodes, and
+        // this level's regroup window is one node's children — so an edit
+        // descending through a piece must merge the frame's pieces first,
+        // or elections would re-derive anchors over a fragment and orders
+        // would diverge. A seam between siblings is a forced one exactly
+        // when its separator's seam rank fails the level threshold that
+        // grouped them (derived, no stored mark); ordinary paths see two
+        // rank probes per level and merge nothing. Runs only when the edit
+        // fell through the fast path above: an in-place edit changes no
+        // separator, so no index-level plan can move and the merge would
+        // be an identity rebuild.
+        let (index_widened, mut index_origins) =
+            if changes_membership && manifest.frame_ceiling() > 0 {
+                merge_forced_index_runs::<Key, Value, D, Backend>(
+                    &mut root,
+                    &mut path,
+                    &mut [],
+                    accessor,
+                    &manifest,
+                )
+                .await?
+            } else {
+                (false, Vec::new())
+            };
+
         let neighbor_path = if is_boundary_delete || is_orphan_append || dissolves_terminal_cut {
             lift_right_neighbor_spine(&mut root, &path, accessor).await?
         } else {
@@ -1212,23 +1430,32 @@ where
         // index frames alike — so the fusion regroups against complete
         // membership. For any non-cluster neighbor the scan reads one
         // separator length and joins nothing.
-        let neighbor_path = match neighbor_path {
+        let mut neighbor_path = match neighbor_path {
             Some(mut neighbor_path) if manifest.max_segment > 0 => {
-                merge_forced_run::<Key, Value, Backend>(
+                let merged_leaf = merge_forced_run::<Key, Value, Backend>(
                     &mut root,
                     &mut neighbor_path,
+                    &mut [&mut path],
                     accessor,
                     &manifest,
                 )
-                .await?;
+                .await?
+                .is_some();
+                let mut merged_index = false;
                 if manifest.frame_ceiling() > 0 {
-                    merge_forced_index_runs::<Key, Value, D, Backend>(
+                    merged_index = merge_forced_index_runs::<Key, Value, D, Backend>(
                         &mut root,
                         &mut neighbor_path,
+                        &mut [&mut path],
                         accessor,
                         &manifest,
                     )
-                    .await?;
+                    .await?
+                    .0;
+                }
+                if merged_leaf || merged_index {
+                    piece_origins = None;
+                    index_origins.clear();
                 }
                 Some(neighbor_path)
             }
@@ -1236,19 +1463,15 @@ where
         };
 
         // The right-LCA: the deepest level where the main and right-neighbor
-        // paths diverge (for a boundary delete).
-        let lca_depth = match &neighbor_path {
-            Some(neighbor_path) => Some(
-                path.iter()
-                    .zip(neighbor_path.iter())
-                    .position(|(a, b)| a != b)
-                    .ok_or_else(|| {
-                        DialogSearchTreeError::Node(
-                            "Boundary delete had no diverging neighbor path".into(),
-                        )
-                    })?,
-            ),
-            None => None,
+        // paths diverge (for a boundary delete). `None` with a neighbor
+        // present means a widening merged the two paths into the same nodes
+        // all the way down (the run swallowed the edited leaf); the fusion
+        // the neighbor existed for has then already happened structurally,
+        // and the edit falls back to the plain re-shape below.
+        let lca_of = |path: &[usize], neighbor: &Option<Vec<usize>>| {
+            neighbor
+                .as_ref()
+                .and_then(|neighbor| path.iter().zip(neighbor.iter()).position(|(a, b)| a != b))
         };
 
         // A single-entry boundary delete removes the whole segment, joining
@@ -1259,14 +1482,14 @@ where
             || match &neighbor_path {
                 Some(neighbor_path) => {
                     let floor = match follow(&mut root, &path)? {
-                        TransientNode::Segment(segment) if segment.entries.len() == 1 => {
+                        TransientNode::Segment(segment) if segment.entries().len() == 1 => {
                             Some(segment.separator.clone())
                         }
                         _ => None,
                     };
                     match floor {
                         Some(floor) => match follow(&mut root, neighbor_path)? {
-                            TransientNode::Segment(neighbor) => match neighbor.entries.first() {
+                            TransientNode::Segment(neighbor) => match neighbor.entries().first() {
                                 Some(first) => seam_cut_dissolves::<D>(
                                     &floor,
                                     &D::reseparate(first.key.as_ref(), &floor),
@@ -1295,40 +1518,52 @@ where
                     // level, so any of them that is a force-split piece
                     // must first rejoin its run — leaf runs and index
                     // frames alike — or the fold regroups against
-                    // fragments. Forced seams between the left spine and
-                    // the main path were already dissolved by the main
-                    // path's own widening, so these scans stop before
-                    // touching path-tracked nodes.
+                    // fragments. These merges splice ancestors the MAIN
+                    // (and neighbor) paths share with the left spine —
+                    // merging pieces left of them shifts their child
+                    // indices, and a run can even absorb their own nodes —
+                    // so both ride along as co-paths and are remapped
+                    // through every splice.
                     if manifest.max_segment > 0 {
-                        merge_forced_run::<Key, Value, Backend>(
+                        let mut co_paths: Vec<&mut Vec<usize>> = Vec::new();
+                        co_paths.push(&mut path);
+                        if let Some(neighbor) = neighbor_path.as_mut() {
+                            co_paths.push(neighbor);
+                        }
+                        let merged_leaf = merge_forced_run::<Key, Value, Backend>(
                             &mut root,
                             &mut left_path,
+                            &mut co_paths,
                             accessor,
                             &manifest,
                         )
-                        .await?;
+                        .await?
+                        .is_some();
+                        let mut merged_index = false;
                         if manifest.frame_ceiling() > 0 {
-                            merge_forced_index_runs::<Key, Value, D, Backend>(
+                            merged_index = merge_forced_index_runs::<Key, Value, D, Backend>(
                                 &mut root,
                                 &mut left_path,
+                                &mut co_paths,
                                 accessor,
                                 &manifest,
                             )
-                            .await?;
+                            .await?
+                            .0;
+                        }
+                        if merged_leaf || merged_index {
+                            piece_origins = None;
+                            index_origins.clear();
                         }
                     }
-                    let depth = path
-                        .iter()
-                        .zip(left_path.iter())
-                        .position(|(a, b)| a != b)
-                        .ok_or_else(|| {
-                            DialogSearchTreeError::Node(
-                                "Left fusion had no diverging neighbor path".into(),
-                            )
-                        })?;
-                    match lca_depth {
-                        Some(lca) if depth > lca => None,
-                        _ => Some(depth),
+                    // `None` means the widenings merged the left spine and
+                    // the main path into the same nodes all the way down:
+                    // the leftward fusion has already happened structurally
+                    // and the regroup below re-derives the joined region.
+                    let depth = path.iter().zip(left_path.iter()).position(|(a, b)| a != b);
+                    match (depth, lca_of(&path, &neighbor_path)) {
+                        (Some(depth), Some(lca)) if depth > lca => None,
+                        (depth, _) => depth,
                     }
                 }
                 None => None,
@@ -1336,6 +1571,10 @@ where
         } else {
             None
         };
+
+        // The left widenings can remap both paths, so the LCA gating the
+        // fused re-shape below must be re-derived from their final values.
+        let lca_depth = lca_of(&path, &neighbor_path);
 
         // Phase two: synchronous re-shape. The whole touched region is transient, so
         // the re-shape needs no further loads and runs without any borrow spanning
@@ -1357,7 +1596,7 @@ where
                                 "Path did not reach a segment".into(),
                             ));
                         };
-                        apply_to_segment(&mut segment.entries, edit);
+                        apply_to_segment(segment, edit);
                         None
                     }
                 };
@@ -1381,6 +1620,7 @@ where
                 &manifest,
                 piece_origins.as_deref().unwrap_or(&[]),
                 &index_origins,
+                widened || index_widened,
             )?,
         };
         seal_root::<Key, Value, D, _>(replacement, height, &manifest, accessor).await
@@ -1528,6 +1768,7 @@ where
 async fn merge_forced_index_runs<Key, Value, D, Backend>(
     root: &mut TransientNode<Key, Value>,
     path: &mut [usize],
+    co_paths: &mut [&mut Vec<usize>],
     accessor: &Accessor<Backend>,
     manifest: &Manifest,
 ) -> Result<(bool, Vec<(usize, Vec<IndexPieceOrigin>)>), DialogSearchTreeError>
@@ -1604,6 +1845,7 @@ where
         let mut merged_children: Vec<Node<Key, Value>> = Vec::new();
         let mut carried: Vec<NoveltyEntry<Value>> = Vec::new();
         let mut origins: Vec<IndexPieceOrigin> = Vec::new();
+        let mut member_starts: Vec<usize> = Vec::new();
         let mut lead = 0usize;
         for (offset, member) in members.into_iter().enumerate() {
             let TransientNode::Index(mut piece) = member.into_transient()? else {
@@ -1613,6 +1855,7 @@ where
             };
             let piece_novelty = piece.novelty.take_all::<Key>()?;
             let start = merged_children.len();
+            member_starts.push(start);
             // A piece with a stored link and no buffered ops of its own can be
             // passed through if the regroup reproduces its exact child range:
             // draining a quiet piece takes nothing, so its stored bytes still
@@ -1652,6 +1895,12 @@ where
         }
         path[d - 1] = lo;
         path[d] += lead;
+        // Any other live path routed through the same parent recorded its
+        // index against the pre-splice child list; remap it through the
+        // merge, including into the merged node when the run absorbed it.
+        for co_path in co_paths.iter_mut() {
+            remap_through_merge(co_path, &parent_path, lo, hi, &member_starts);
+        }
         merged_any = true;
         // `reshape_path` regroups the merged node's children when it is the
         // recursion's current `node` — reached after consuming the `d` path
@@ -1663,6 +1912,656 @@ where
         }
     }
     Ok((merged_any, origins_by_remaining))
+}
+
+/// The forced-run check's verdict.
+enum RunVerdict {
+    /// The run's post-edit plan is byte-identical to the stored partition:
+    /// skip the widening, the ordinary edit machinery handles the piece.
+    Quiet,
+    /// Not provably quiet: widen as before.
+    Widen,
+    /// A verified surgical min-insert: the run's election reproduces every
+    /// stored boundary with the new minimum applied, and the edited
+    /// piece's forced separator re-derives to `separator` — the SAME
+    /// LENGTH as the stored one. Forced-long separators are never index
+    /// anchors (`index_frame_cut_positions` excludes over-bound seams) and
+    /// a link's weight reads only its separator's length, so a
+    /// length-preserving rewrite changes no index-level election input at
+    /// any ancestor — the edit may apply in place with the separator
+    /// swapped and the parent's buffered ops re-homed, and every level
+    /// above stays exactly as a full merge-and-regroup would leave it.
+    SurgicalMin {
+        /// The re-derived forced separator for the edited piece.
+        separator: Vec<u8>,
+    },
+}
+
+/// Whether a membership edit into a forced-run piece provably leaves the
+/// run's stored partition byte-identical, so the backstop widening can be
+/// skipped and the ordinary edit machinery applied to the edited piece
+/// alone.
+///
+/// The check re-evaluates the regroup's complete decision pipeline
+/// ([`cut_plan`](crate::node::transient::cut_plan)) over the run's
+/// post-edit key sequence — streamed read-only, without lifting any piece
+/// into the tree — and demands the predicted cuts land exactly on the
+/// current piece boundaries, each carrying the forced mark it carries
+/// today. On top of that exact-outcome test the edit must be strictly
+/// interior to its piece (no new minimum, no boundary or terminal-entry
+/// change, so none of the seam-rewriting gates downstream can fire), and
+/// a delete must not sit beside a vetoed seam (the terminal-cut fusion
+/// gates key off those). Any doubt returns `false`, which widens as
+/// before.
+///
+/// Buffered novelty on the parent does not block the skip: the widening
+/// itself elects anchors over STORED keys only — `merge_forced_run`
+/// re-routes buffered ops by link boundary without ever feeding them to
+/// the election — so when the plan check proves the boundaries
+/// unchanged, that re-route is an identity and the buffers may stay
+/// exactly where they are.
+///
+/// The point is cost: a passing check trades the merge's full
+/// rebuild-and-re-encode of every piece in the run — plus the new blocks
+/// that rebuild ships to every replica — for piece decodes and memoized
+/// key hashes, leaving the untouched pieces byte-identical in the store.
+async fn forced_run_quiet<Key, Value, Backend, D>(
+    root: &mut TransientNode<Key, Value>,
+    path: &[usize],
+    edit: &Edit<Key, Value>,
+    accessor: &Accessor<Backend>,
+    manifest: &Manifest,
+) -> Result<RunVerdict, DialogSearchTreeError>
+where
+    Key: self::Key + ConditionalSync + 'static,
+    Value: self::Value + ConditionalSync + 'static,
+    Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+        + ConditionalSync,
+    D: Distribution,
+{
+    if path.is_empty() || manifest.max_segment == 0 {
+        return Ok(RunVerdict::Widen);
+    }
+    let at = path[path.len() - 1];
+    let parent_path = &path[..path.len() - 1];
+    let bound = manifest.max_separator as usize;
+
+    // Run detection mirroring `merge_forced_run`: the maximal stretch of
+    // children joined by forced (over-bound) separators around the edited
+    // child.
+    let (lo, hi) = {
+        let children = &follow(root, parent_path)?.as_index()?.children;
+        let mut lo = at;
+        while lo > 0 && children[lo].separator()?.len() > bound {
+            lo -= 1;
+        }
+        let mut hi = at;
+        while hi + 1 < children.len() && children[hi + 1].separator()?.len() > bound {
+            hi += 1;
+        }
+        (lo, hi)
+    };
+    if lo == hi {
+        return Ok(RunVerdict::Widen);
+    }
+
+    // The edit must be strictly interior to its piece: a new minimum, a
+    // first/last-entry change, or an append would engage the boundary
+    // machinery (min-move separator rewrites, boundary-delete fusion,
+    // terminal-cut checks), which re-decides seams without the election.
+    //
+    // ONE boundary shape gets a verified escape hatch instead of an
+    // instant reject: an insert of a new minimum into a non-first piece
+    // (`Err(0)`, the dominant reject on the SE replay at 83%). Its plan is
+    // evaluated by the same compressed election — the simulation handles
+    // any position — and on a full boundary match the piece's forced
+    // separator is re-derived; if the new form has the SAME LENGTH as the
+    // stored one, the edit is a `SurgicalMin`: forced-long separators are
+    // never index anchors and link weights read only separator length, so
+    // nothing above the parent's link bytes changes, exactly as a full
+    // merge-and-regroup would leave it (which rebuilds the piece with the
+    // same entries and this same separator, reusing everything else).
+    let mut min_insert = false;
+    {
+        let TransientNode::Segment(leaf) = follow(root, path)? else {
+            return Ok(RunVerdict::Widen);
+        };
+        let entries = leaf.entries();
+        // Whether this boundary case must reject: a new minimum, a
+        // first/last-entry change, or an append engages the boundary
+        // machinery, which re-decides seams without the election.
+        let reject = match edit {
+            Edit::Upsert(entry) => match entries.binary_search_by(|e| e.key.cmp(&entry.key)) {
+                Ok(0) => true,
+                Ok(i) if i + 1 >= entries.len() => true,
+                Ok(_) => false,
+                Err(0) => {
+                    min_insert = true;
+                    false
+                }
+                Err(i) if i >= entries.len() => true,
+                Err(_) => false,
+            },
+            Edit::Delete(key) => match entries.binary_search_by(|e| e.key.cmp(key)) {
+                Ok(0) => true,
+                Ok(i) if i + 1 >= entries.len() => true,
+                Ok(i)
+                    if D::vetoes(
+                        entries[i - 1].key.as_ref(),
+                        entries[i].key.as_ref(),
+                        manifest,
+                    ) || D::vetoes(
+                        entries[i].key.as_ref(),
+                        entries[i + 1].key.as_ref(),
+                        manifest,
+                    ) =>
+                {
+                    true
+                }
+                Ok(_) => false,
+                Err(_) => true,
+            },
+        };
+        if reject {
+            return Ok(RunVerdict::Widen);
+        }
+    }
+    if min_insert && at == lo {
+        // The run's first piece carries a NATURAL (short) separator whose
+        // rewrite is rank-relevant: no surgical escape.
+        return Ok(RunVerdict::Widen);
+    }
+
+    // The compressed evaluation: verify the post-edit plan at piece
+    // granularity over memoized summaries, streaming no untouched piece.
+    // `None` (regime not met) falls back to the full entry stream for
+    // interior edits, and widens for the min-insert shape (the stream
+    // cannot license a surgical apply). In debug builds every compressed
+    // interior verdict is pinned against the full stream's.
+    let compressed = compressed_run_quiet::<Key, Value, Backend, D>(
+        root, path, lo, hi, edit, accessor, manifest,
+    )
+    .await?;
+
+    if min_insert {
+        #[cfg(debug_assertions)]
+        if let Some(verdict) = compressed {
+            let full = streamed_run_quiet::<Key, Value, Backend, D>(
+                root, path, lo, hi, edit, accessor, manifest,
+            )
+            .await?;
+            debug_assert_eq!(
+                verdict, full,
+                "the compressed min-insert verdict must match the full streamed plan check"
+            );
+        }
+        // A new minimum often flips its boundary seam's veto status (it
+        // shares a longer prefix with the left neighbor than the old first
+        // key did), putting the run outside the compressed regimes — the
+        // measured dominant case. The full stream handles any regime and
+        // gives the identical plan-and-marks guarantee, so it licenses the
+        // surgical apply whenever the compressed evaluation cannot.
+        let verdict = match compressed {
+            Some(verdict) => verdict,
+            None => {
+                streamed_run_quiet::<Key, Value, Backend, D>(
+                    root, path, lo, hi, edit, accessor, manifest,
+                )
+                .await?
+            }
+        };
+        if !verdict {
+            return Ok(RunVerdict::Widen);
+        }
+        let Edit::Upsert(entry) = edit else {
+            return Ok(RunVerdict::Widen);
+        };
+        // The boundary's re-derived forced separator: previous piece's
+        // last key (its summary is in hand after the compressed pass)
+        // against the new minimum, exactly as the regroup's seal would
+        // derive it. Only a LENGTH-preserving rewrite is surgical.
+        let (previous_last, stored_len) = {
+            let children = &follow(root, parent_path)?.as_index()?.children;
+            let previous_last = match &children[at - 1] {
+                Node::Transient(TransientNode::Segment(segment)) => segment
+                    .entries()
+                    .last()
+                    .map(|entry| entry.key.as_ref().to_vec()),
+                Node::Persistent(link) => {
+                    crate::distribution::summary::memoized(&link.node, manifest)
+                        .map(|summary| summary.last_key.clone())
+                }
+                Node::Transient(_) => None,
+            };
+            (previous_last, children[at].separator()?.len())
+        };
+        let Some(previous_last) = previous_last else {
+            return Ok(RunVerdict::Widen);
+        };
+        let separator =
+            crate::distribution::cap::frame_separator(&previous_last, entry.key.as_ref(), manifest);
+        return Ok(match separator {
+            Some(separator) if separator.len() == stored_len => {
+                RunVerdict::SurgicalMin { separator }
+            }
+            _ => RunVerdict::Widen,
+        });
+    }
+
+    if let Some(verdict) = compressed {
+        #[cfg(debug_assertions)]
+        {
+            let full = streamed_run_quiet::<Key, Value, Backend, D>(
+                root, path, lo, hi, edit, accessor, manifest,
+            )
+            .await?;
+            debug_assert_eq!(
+                verdict, full,
+                "the compressed quiet verdict must match the full streamed plan check"
+            );
+        }
+        return Ok(if verdict {
+            RunVerdict::Quiet
+        } else {
+            RunVerdict::Widen
+        });
+    }
+
+    Ok(
+        if streamed_run_quiet::<Key, Value, Backend, D>(
+            root, path, lo, hi, edit, accessor, manifest,
+        )
+        .await?
+        {
+            RunVerdict::Quiet
+        } else {
+            RunVerdict::Widen
+        },
+    )
+}
+
+/// The full entry-streamed forced-run plan check: streams every piece's
+/// keys and weights, simulates the edit, re-runs `cut_plan` and demands
+/// the exact stored partition. The authoritative fallback (and debug
+/// oracle) for `compressed_run_quiet`.
+#[allow(clippy::too_many_arguments)]
+async fn streamed_run_quiet<Key, Value, Backend, D>(
+    root: &mut TransientNode<Key, Value>,
+    path: &[usize],
+    lo: usize,
+    hi: usize,
+    edit: &Edit<Key, Value>,
+    accessor: &Accessor<Backend>,
+    manifest: &Manifest,
+) -> Result<bool, DialogSearchTreeError>
+where
+    Key: self::Key + ConditionalSync + 'static,
+    Value: self::Value + ConditionalSync + 'static,
+    Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+        + ConditionalSync,
+    D: Distribution,
+{
+    let at = path[path.len() - 1];
+    let parent_path = &path[..path.len() - 1];
+    let run_at = at - lo;
+
+    // Per-piece sources for the read-only stream: transient siblings give
+    // up their keys and weights immediately, persistent ones contribute
+    // their link.
+    enum PieceSource<Key> {
+        Fetch(Link),
+        Ready(Vec<Key>, Vec<usize>),
+    }
+    let sources: Vec<PieceSource<Key>> = {
+        let children = &follow(root, parent_path)?.as_index()?.children;
+        let mut sources = Vec::with_capacity(hi - lo + 1);
+        for child in children.iter().take(hi + 1).skip(lo) {
+            sources.push(match child {
+                Node::Persistent(link) => PieceSource::Fetch(link.clone()),
+                Node::Transient(TransientNode::Segment(segment)) => PieceSource::Ready(
+                    segment.entries().iter().map(|e| e.key.clone()).collect(),
+                    segment.entries().iter().map(Entry::weight).collect(),
+                ),
+                Node::Transient(_) => return Ok(false),
+            });
+        }
+        sources
+    };
+
+    // Stream the run's keys and weights in key order, remembering each
+    // piece's length so the current partition can be compared against the
+    // recomputed plan.
+    let mut keys: Vec<Key> = Vec::new();
+    let mut weights: Vec<usize> = Vec::new();
+    let mut piece_lens: Vec<usize> = Vec::with_capacity(sources.len());
+    for source in sources {
+        match source {
+            PieceSource::Ready(piece_keys, piece_weights) => {
+                piece_lens.push(piece_keys.len());
+                keys.extend(piece_keys);
+                weights.extend(piece_weights);
+            }
+            PieceSource::Fetch(link) => {
+                let persistent = accessor.get_node(&link.node).await?;
+                let TransientNode::Segment(segment) =
+                    TransientNode::<Key, Value>::open(&persistent, link.separator.clone())?
+                else {
+                    return Ok(false);
+                };
+                let entries = segment.entries();
+                piece_lens.push(entries.len());
+                keys.extend(entries.iter().map(|e| e.key.clone()));
+                weights.extend(entries.iter().map(Entry::weight));
+            }
+        }
+    }
+
+    // Simulate the edit on the streamed sequence. The edit always lands in
+    // the descent piece (`run_at`) — routing put it there — so that
+    // piece's length adjusts directly.
+    match edit {
+        Edit::Upsert(entry) => match keys.binary_search(&entry.key) {
+            Ok(i) => weights[i] = entry.weight(),
+            Err(i) => {
+                piece_lens[run_at] += 1;
+                keys.insert(i, entry.key.clone());
+                weights.insert(i, entry.weight());
+            }
+        },
+        Edit::Delete(key) => {
+            let Ok(i) = keys.binary_search(key) else {
+                return Ok(false);
+            };
+            piece_lens[run_at] -= 1;
+            keys.remove(i);
+            weights.remove(i);
+        }
+    }
+
+    // Re-run the regroup's decision pipeline and demand the exact current
+    // partition: every predicted cut on a current boundary, every current
+    // boundary predicted, and every boundary still carrying its forced
+    // mark (a coin cut landing on a boundary would flip the stored
+    // separator to its natural form — different bytes, so widen).
+    let key_refs: Vec<&Key> = keys.iter().collect();
+    let (cut_after, forced_start) =
+        crate::node::transient::cut_plan::<Key, D>(&key_refs, &weights, manifest);
+    let count = keys.len();
+    let mut boundary = vec![false; count];
+    let mut acc = 0usize;
+    for len in &piece_lens[..piece_lens.len() - 1] {
+        acc += len;
+        if acc == 0 || acc > count {
+            return Ok(false);
+        }
+        boundary[acc - 1] = true;
+    }
+    for j in 0..count.saturating_sub(1) {
+        if cut_after[j] != boundary[j] {
+            return Ok(false);
+        }
+        if boundary[j] && !forced_start[j + 1] {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// The compressed forced-run plan check: verifies the post-edit plan at
+/// piece granularity over memoized `PieceSummary` data
+/// (`distribution::summary`), streaming no untouched piece.
+///
+/// Exact within two regimes, selected by the boundary seams' veto status:
+///
+/// - **Stretch** (every boundary vetoed): with every piece fully vetoed
+///   inside, the window is one maximal stretch — no coin verdicts, no
+///   ceiling candidates — and the plan reduces to the stretch backstop's
+///   election at `max_segment`.
+/// - **Ceiling** (every boundary accepted): banks reset at every
+///   boundary, so coin verdicts are piece-local and carried by the
+///   summaries (`interior_coin_cut` must be clear, and each boundary's
+///   own verdict — `leaf_cut(last key, trailing bank + last weight)` —
+///   must be no-cut); interior vetoed stretches must stay under
+///   `max_segment` (the summary bounds them), and the plan reduces to the
+///   frame ceiling's election over the window's single frame.
+///
+/// Both elections are evaluated by `cap::election_matches_boundaries` at
+/// piece granularity. The edited piece's post-edit summary is built live
+/// from the open leaf with the edit applied (its edge keys are unchanged
+/// by the strict-interior guard, so the boundary seams stand).
+///
+/// Returns `Some(verdict)` — an EXACT quiet/widen answer — or `None` when
+/// the run falls outside both regimes (mixed boundaries, a non-candidate
+/// boundary, an over-weight interior stretch, a transient index sibling),
+/// in which case the full entry stream decides.
+#[allow(clippy::too_many_arguments)]
+async fn compressed_run_quiet<Key, Value, Backend, D>(
+    root: &mut TransientNode<Key, Value>,
+    path: &[usize],
+    lo: usize,
+    hi: usize,
+    edit: &Edit<Key, Value>,
+    accessor: &Accessor<Backend>,
+    manifest: &Manifest,
+) -> Result<Option<bool>, DialogSearchTreeError>
+where
+    Key: self::Key + ConditionalSync + 'static,
+    Value: self::Value + ConditionalSync + 'static,
+    Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
+    Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+        + ConditionalSync,
+    D: Distribution,
+{
+    use crate::distribution::summary::{self, PieceSummary};
+    use crate::distribution::{anchor_hash, cap};
+    use std::sync::Arc;
+
+    let at = path[path.len() - 1];
+    let parent_path = &path[..path.len() - 1];
+
+    // Pass 1 (sync, under the tree borrow): per piece, either a ready
+    // summary — transient segments and the edited piece, summarized in
+    // place — or the stored link to resolve against the memo. The edited
+    // piece gets its POST-EDIT summary, built from the open leaf with the
+    // edit applied, mirroring the full check's simulation.
+    enum Pending {
+        Ready(Arc<PieceSummary>),
+        Fetch(Link),
+    }
+    let mut pieces: Vec<Pending> = Vec::with_capacity(hi - lo + 1);
+    {
+        let children = &follow(root, parent_path)?.as_index()?.children;
+        for (index, child) in children.iter().enumerate().take(hi + 1).skip(lo) {
+            if index == at {
+                let Node::Transient(TransientNode::Segment(leaf)) = child else {
+                    return Ok(None);
+                };
+                let entries = leaf.entries();
+                let mut keys: Vec<&[u8]> = Vec::with_capacity(entries.len() + 1);
+                let mut weights: Vec<usize> = Vec::with_capacity(entries.len() + 1);
+                for entry in entries {
+                    keys.push(entry.key.as_ref());
+                    weights.push(entry.weight());
+                }
+                match edit {
+                    Edit::Upsert(entry) => {
+                        match entries.binary_search_by(|e| e.key.cmp(&entry.key)) {
+                            Ok(i) => weights[i] = entry.weight(),
+                            Err(i) => {
+                                keys.insert(i, entry.key.as_ref());
+                                weights.insert(i, entry.weight());
+                            }
+                        }
+                    }
+                    Edit::Delete(key) => match entries.binary_search_by(|e| e.key.cmp(key)) {
+                        Ok(i) => {
+                            keys.remove(i);
+                            weights.remove(i);
+                        }
+                        Err(_) => return Ok(None),
+                    },
+                }
+                pieces.push(Pending::Ready(Arc::new(PieceSummary::build::<D>(
+                    &keys, &weights, manifest,
+                ))));
+            } else {
+                match child {
+                    Node::Persistent(link) => match summary::memoized(&link.node, manifest) {
+                        Some(ready) => pieces.push(Pending::Ready(ready)),
+                        None => pieces.push(Pending::Fetch(link.clone())),
+                    },
+                    Node::Transient(TransientNode::Segment(segment)) => {
+                        let entries = segment.entries();
+                        let keys: Vec<&[u8]> =
+                            entries.iter().map(|entry| entry.key.as_ref()).collect();
+                        let weights: Vec<usize> = entries.iter().map(Entry::weight).collect();
+                        pieces.push(Pending::Ready(Arc::new(PieceSummary::build::<D>(
+                            &keys, &weights, manifest,
+                        ))));
+                    }
+                    Node::Transient(_) => return Ok(None),
+                }
+            }
+        }
+    }
+
+    // Pass 2 (async): resolve stored pieces through the memo, streaming a
+    // piece only on its first touch per content change.
+    let mut summaries: Vec<Arc<PieceSummary>> = Vec::with_capacity(pieces.len());
+    for pending in pieces {
+        summaries.push(match pending {
+            Pending::Ready(summary) => summary,
+            Pending::Fetch(link) => {
+                let persistent = accessor.get_node(&link.node).await?;
+                let TransientNode::Segment(segment) =
+                    TransientNode::<Key, Value>::open(&persistent, link.separator.clone())?
+                else {
+                    return Ok(None);
+                };
+                let entries = segment.entries();
+                let keys: Vec<&[u8]> = entries.iter().map(|entry| entry.key.as_ref()).collect();
+                let weights: Vec<usize> = entries.iter().map(Entry::weight).collect();
+                summary::memoize(
+                    &link.node,
+                    manifest,
+                    PieceSummary::build::<D>(&keys, &weights, manifest),
+                )
+            }
+        });
+    }
+
+    // Regime selection by the boundary seams' veto status: all vetoed is
+    // the stretch regime, all accepted the ceiling regime, and a mix
+    // falls back to the full stream.
+    if summaries.iter().any(|summary| summary.count == 0) {
+        return Ok(None);
+    }
+    let mut vetoed_boundaries = 0usize;
+    for pair in summaries.windows(2) {
+        if D::vetoes(
+            pair[0].last_key.as_slice(),
+            pair[1].first_key.as_slice(),
+            manifest,
+        ) {
+            vetoed_boundaries += 1;
+        }
+    }
+
+    let (threshold, boundaries) = if vetoed_boundaries == summaries.len() - 1 {
+        // Stretch regime: every piece fully vetoed inside, every boundary
+        // a forced candidate; the plan is the stretch election alone.
+        if summaries.iter().any(|summary| !summary.all_vetoed) {
+            return Ok(None);
+        }
+        let mut boundaries = Vec::with_capacity(summaries.len() - 1);
+        for pair in summaries.windows(2) {
+            let left = pair[0].last_key.as_slice();
+            let right = pair[1].first_key.as_slice();
+            if !cap::is_forced_candidate(left, right, manifest) {
+                return Ok(None);
+            }
+            boundaries.push((cap::shortest_separator_len(left, right), anchor_hash(right)));
+        }
+        let compressed: Vec<cap::CompressedPiece> = summaries
+            .iter()
+            .map(|summary| cap::CompressedPiece {
+                count: summary.count,
+                weight: summary.weight,
+                interior: summary.stretch_interior.clone(),
+            })
+            .collect();
+        return Ok(Some(cap::election_matches_boundaries(
+            &compressed,
+            &boundaries,
+            manifest.max_segment as usize,
+            manifest,
+        )));
+    } else if vetoed_boundaries == 0 {
+        // Ceiling regime: banks reset at every (accepted) boundary, so
+        // the summaries' piece-local coin verdicts are exact. A stored
+        // piece is whole, so any interior coin cut means the plan does
+        // not reproduce the stored partition — but only for verdicts the
+        // edit cannot have changed; the edited piece's summary is
+        // post-edit, so the claim holds uniformly. Interior vetoed
+        // stretches over `max_segment` could hide stretch-backstop cuts
+        // the summary cannot decide: fall back.
+        if manifest.frame_ceiling() == 0 {
+            return Ok(None);
+        }
+        if summaries
+            .iter()
+            .any(|summary| summary.max_stretch_weight > manifest.max_segment as usize)
+        {
+            return Ok(None);
+        }
+        if summaries.iter().any(|summary| summary.interior_coin_cut) {
+            return Ok(Some(false));
+        }
+        let mut boundaries = Vec::with_capacity(summaries.len() - 1);
+        for pair in summaries.windows(2) {
+            let left = pair[0].last_key.as_slice();
+            let right = pair[1].first_key.as_slice();
+            if !cap::is_frame_candidate(left, right, manifest) {
+                return Ok(None);
+            }
+            // The boundary seam's own coin verdict must be no-cut: a
+            // natural cut here would store the short separator, not the
+            // long forced form the stored partition carries.
+            if D::leaf_cut(left, pair[0].trailing_bank + pair[0].last_weight, manifest) {
+                return Ok(Some(false));
+            }
+            boundaries.push((cap::shortest_separator_len(left, right), anchor_hash(right)));
+        }
+        (manifest.frame_ceiling(), boundaries)
+    } else {
+        return Ok(None);
+    };
+
+    let compressed: Vec<cap::CompressedPiece> = summaries
+        .iter()
+        .map(|summary| cap::CompressedPiece {
+            count: summary.count,
+            weight: summary.weight,
+            interior: summary.frame_interior.clone(),
+        })
+        .collect();
+    Ok(Some(cap::election_matches_boundaries(
+        &compressed,
+        &boundaries,
+        threshold,
+        manifest,
+    )))
 }
 
 /// Widens an edit's window to the whole force-split run around the leaf at
@@ -1695,6 +2594,7 @@ where
 async fn merge_forced_run<Key, Value, Backend>(
     root: &mut TransientNode<Key, Value>,
     path: &mut [usize],
+    co_paths: &mut [&mut Vec<usize>],
     accessor: &Accessor<Backend>,
     manifest: &Manifest,
 ) -> Result<Option<Vec<PieceOrigin>>, DialogSearchTreeError>
@@ -1769,24 +2669,24 @@ where
                 "Vetoed-stretch window member was not a leaf segment".into(),
             ));
         };
+        let (segment_entries, segment_separator) = segment.into_parts();
         if offset == 0 {
-            separator = segment.separator;
+            separator = segment_separator;
         }
         if let Some(link) = piece_links[offset].take() {
             origins.push(PieceOrigin {
                 start: entries.len(),
-                end: entries.len() + segment.entries.len(),
+                end: entries.len() + segment_entries.len(),
                 link,
             });
         }
-        entries.extend(segment.entries);
+        entries.extend(segment_entries);
     }
     parent.children.insert(
         lo,
-        Node::Transient(TransientNode::Segment(TransientSegment {
-            entries,
-            separator,
-        })),
+        Node::Transient(TransientNode::Segment(TransientSegment::new(
+            entries, separator,
+        ))),
     );
     if !pending.is_empty() {
         let bounds = link_bounds(&parent.children)?;
@@ -1794,7 +2694,55 @@ where
     }
     let leaf = path.len() - 1;
     path[leaf] = lo;
+    // Any other live path routed through the same parent recorded its leaf
+    // index against the pre-splice child list; remap it through the merge
+    // (no member starts: a path cannot descend below a leaf).
+    for co_path in co_paths {
+        remap_through_merge(co_path, &parent_path, lo, hi, &[]);
+    }
     Ok(Some(origins))
+}
+
+/// Remaps a recorded descent path through a forced-run merge that just
+/// spliced the children `lo..=hi` of the node at `parent_path` into ONE
+/// merged node inserted back at `lo`.
+///
+/// The widenings splice ancestors that OTHER live paths (the main edit
+/// path, the right-neighbor path) may share with the path being widened;
+/// without this remap those paths keep indices recorded against the
+/// pre-splice child list and the later re-shape descends into the wrong —
+/// or a nonexistent — child ("Re-shape path child index out of range" /
+/// "descended into a node that was not lifted").
+///
+/// A path that does not route through `parent_path` is untouched. One
+/// whose child index at that level sits right of the merged range shifts
+/// left by the removed count. One inside the range now descends through
+/// the merged node: `member_starts[k]` gives the number of children the
+/// merged node had accumulated before absorbing member `lo + k`, which is
+/// the offset the path's next-deeper index moves by (empty for a leaf
+/// merge, where there is no deeper index to shift).
+fn remap_through_merge(
+    path: &mut [usize],
+    parent_path: &[usize],
+    lo: usize,
+    hi: usize,
+    member_starts: &[usize],
+) {
+    let depth = parent_path.len();
+    if path.len() <= depth || &path[..depth] != parent_path {
+        return;
+    }
+    let at = path[depth];
+    if at > hi {
+        path[depth] = at - (hi - lo);
+    } else if at >= lo {
+        path[depth] = lo;
+        if let Some(&start) = member_starts.get(at - lo)
+            && depth + 1 < path.len()
+        {
+            path[depth + 1] += start;
+        }
+    }
 }
 
 /// Walks `root` down the recorded child indices in `path`, lifting the node at
@@ -2016,6 +2964,7 @@ fn reshape_path<Key, Value, D>(
     manifest: &Manifest,
     origins: &[PieceOrigin],
     index_origins: &[(usize, Vec<IndexPieceOrigin>)],
+    widened: bool,
 ) -> Result<Vec<Node<Key, Value>>, DialogSearchTreeError>
 where
     Key: self::Key,
@@ -2038,17 +2987,20 @@ where
             // shift by the entry-count delta, earlier ones stand.
             let (landed, shift) = match &edit {
                 Edit::Upsert(entry) => {
-                    match segment.entries.binary_search_by(|e| e.key.cmp(&entry.key)) {
+                    match segment
+                        .entries()
+                        .binary_search_by(|e| e.key.cmp(&entry.key))
+                    {
                         Ok(at) => (at, 0isize),
                         Err(at) => (at, 1),
                     }
                 }
-                Edit::Delete(key) => match segment.entries.binary_search_by(|e| e.key.cmp(key)) {
+                Edit::Delete(key) => match segment.entries().binary_search_by(|e| e.key.cmp(key)) {
                     Ok(at) => (at, -1isize),
                     Err(at) => (at, 0),
                 },
             };
-            apply_to_segment(&mut segment.entries, edit);
+            apply_to_segment(segment, edit);
             let adjusted: Vec<PieceOrigin> = origins
                 .iter()
                 .filter_map(|origin| {
@@ -2085,7 +3037,7 @@ where
             // paths, which have the neighbor's keys in memory.
             let floor = std::mem::take(&mut segment.separator);
             Ok(regroup_entries_reusing::<Key, Value, D>(
-                std::mem::take(&mut segment.entries),
+                segment.take_entries(),
                 floor,
                 manifest,
                 &adjusted,
@@ -2093,6 +3045,7 @@ where
         }
         Some((&at, rest)) => {
             let child = node.child_mut(at)?;
+            let child_separator = child.separator()?.to_vec();
             let replacement = reshape_path::<Key, Value, D>(
                 child,
                 rest,
@@ -2102,7 +3055,45 @@ where
                 manifest,
                 origins,
                 index_origins,
+                widened,
             )?;
+            // Identity fast path: the child re-cut to exactly one piece whose
+            // left-edge separator is unchanged. This node's separator SET is
+            // then identical, and every index-level decision — seam ranks,
+            // link weights, frame ceilings, anchor elections — reads only
+            // separators, so the splice-and-regroup below would reproduce
+            // this node verbatim (regrouping is deterministic and this node
+            // is itself the output of a prior regroup over the same
+            // separators). Skip it: put the piece back and keep every
+            // buffered link — and its sealed or cached encoding — exactly
+            // where it is, instead of decoding, re-routing, and re-encoding
+            // the whole buffer for a shape that cannot change. (Measured:
+            // per-edit `take_all` of en-route buffers was the dominant term
+            // of the at-scale commit cost under fat caps.)
+            //
+            // A widened edit is excluded outright: the forced-run merges
+            // fused stored pieces into one deliberately oversized window
+            // that ONLY the regroup re-splits, so on those paths the
+            // regroup must run even when the child re-cut to itself.
+            if !widened
+                && left_fuse != Some(0)
+                && replacement.len() == 1
+                && replacement[0]
+                    .separator()
+                    .map(|separator| separator == child_separator.as_slice())
+                    .unwrap_or(false)
+            {
+                let index = node.as_index_mut()?;
+                index.children[at] = replacement
+                    .into_iter()
+                    .next()
+                    .expect("the replacement has exactly one piece");
+                let kept = std::mem::replace(
+                    node,
+                    TransientNode::Segment(TransientSegment::new(Vec::new(), Vec::new())),
+                );
+                return Ok(vec![Node::Transient(kept)]);
+            }
             // Regrouping replaces `node` with a run of new nodes, so the ops
             // buffered here have nowhere to live unless they are carried over:
             // they are pending against this subtree, and the run covers exactly
@@ -2216,10 +3207,10 @@ where
             // node in an index that can. The wrapper keeps the same key range,
             // so routing is unchanged; its single link takes every op.
             other => {
-                let placeholder = Node::Transient(TransientNode::Segment(TransientSegment {
-                    entries: Vec::new(),
-                    separator: Vec::new(),
-                }));
+                let placeholder = Node::Transient(TransientNode::Segment(TransientSegment::new(
+                    Vec::new(),
+                    Vec::new(),
+                )));
                 let wrapped = std::mem::replace(other, placeholder);
                 let mut novelty = Novelty::new();
                 novelty.route::<Key>(&[], bucket)?;
@@ -2447,12 +3438,16 @@ where
             // nothing, so there is nothing to lift here.
             let floor = std::mem::take(&mut main.separator);
             if let Some(key) = key
-                && main.entries.last().map(|e| &e.key == key).unwrap_or(false)
+                && main
+                    .entries()
+                    .last()
+                    .map(|e| &e.key == key)
+                    .unwrap_or(false)
             {
-                main.entries.pop();
+                main.entries_mut().pop();
             }
-            let mut entries = main.entries;
-            entries.extend(neighbor.entries);
+            let mut entries = main.into_entries();
+            entries.extend(neighbor.into_entries());
             Ok((
                 regroup_entries::<Key, Value, D>(entries, floor, manifest),
                 Vec::new(),
@@ -2665,10 +3660,7 @@ where
     // Strip a non-canonical chain of single-child index nodes over indices. A
     // persistent single child is lifted first: its kind (index or segment)
     // decides whether the wrapper above it is canonical.
-    loop {
-        let TransientNode::Index(index) = &mut root else {
-            break;
-        };
+    while let TransientNode::Index(index) = &mut root {
         if index.children.len() != 1 {
             break;
         }
@@ -2825,14 +3817,14 @@ where
 {
     match node {
         TransientNode::Segment(segment) => {
-            let before = segment.entries.len();
-            segment.entries.retain(|entry| {
+            let before = segment.entries().len();
+            segment.entries_mut().retain(|entry| {
                 (!trim_start || &entry.key >= range.start())
                     && (!trim_end || &entry.key <= range.end())
             });
-            Ok(if segment.entries.is_empty() {
+            Ok(if segment.entries().is_empty() {
                 Trim::Empty
-            } else if segment.entries.len() == before {
+            } else if segment.entries().len() == before {
                 Trim::Unchanged
             } else {
                 Trim::Trimmed
@@ -3097,12 +4089,13 @@ where
     D: Distribution,
 {
     match (left, right) {
-        (TransientNode::Segment(mut left), TransientNode::Segment(right)) => {
+        (TransientNode::Segment(left), TransientNode::Segment(right)) => {
             // Leaves buffer nothing.
             let floor = left.separator.clone();
-            left.entries.extend(right.entries);
+            let mut entries = left.into_entries();
+            entries.extend(right.into_entries());
             Ok((
-                regroup_entries::<Key, Value, D>(left.entries, floor, manifest),
+                regroup_entries::<Key, Value, D>(entries, floor, manifest),
                 Vec::new(),
             ))
         }
@@ -3286,21 +4279,16 @@ where
     }
 }
 
-/// Applies one edit to a sorted segment in place.
-fn apply_to_segment<Key, Value>(entries: &mut Vec<Entry<Key, Value>>, edit: Edit<Key, Value>)
+/// Applies one edit to a sorted segment in place, through the segment's own
+/// edit methods so its cached total weight stays exact.
+fn apply_to_segment<Key, Value>(segment: &mut TransientSegment<Key, Value>, edit: Edit<Key, Value>)
 where
-    Key: Ord,
+    Key: self::Key,
+    Value: self::Value,
 {
     match edit {
-        Edit::Upsert(entry) => match entries.binary_search_by(|e| e.key.cmp(&entry.key)) {
-            Ok(at) => entries[at].value = entry.value,
-            Err(at) => entries.insert(at, entry),
-        },
-        Edit::Delete(key) => {
-            if let Ok(at) = entries.binary_search_by(|e| e.key.cmp(&key)) {
-                entries.remove(at);
-            }
-        }
+        Edit::Upsert(entry) => segment.upsert(entry),
+        Edit::Delete(key) => segment.delete(&key),
     }
 }
 
@@ -3397,7 +4385,7 @@ fn collect_stream_plan<Key, Value>(
             }
         }
         TransientNode::Segment(segment) => {
-            for entry in &segment.entries {
+            for entry in segment.entries() {
                 if bounds.contains(&entry.key) {
                     plan.push(StreamStep::Entry(entry.clone()));
                 }
@@ -5627,9 +6615,10 @@ mod tests {
         let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
         let manifest = ceiling_manifest(2, 0);
 
-        // A small vetoed cluster (under the 512 stretch target, so the
-        // stretch backstop stays out of the picture) whose terminal seam
-        // coin is tails, found deterministically over cluster tags.
+        // A small vetoed cluster (under the 512 stretch target — three
+        // 34-byte keys at the calibrated per-entry weight, so the stretch
+        // backstop stays out of the picture) whose terminal seam coin is
+        // tails, found deterministically over cluster tags.
         let cluster = {
             let mut tag = b'a';
             loop {
@@ -5639,14 +6628,19 @@ mod tests {
                     bytes.extend(format!("{n:04}").into_bytes());
                     VarKey(bytes)
                 };
-                let keys: Vec<VarKey> = (0..5u32).map(make).collect();
+                let keys: Vec<VarKey> = (0..3u32).map(make).collect();
                 // The terminal coin's charge mirrors production: the vetoed
-                // stretch's bank plus the terminal entry's own full weight.
+                // stretch's bank plus the terminal entry's own full weight,
+                // both metered by `Entry::weight` (payload plus the
+                // calibrated encoding overhead on top of the key bytes).
                 let charge: usize = keys
                     .iter()
-                    .map(|key| distribution::cap::entry_weight(&key.0))
+                    .map(|key| {
+                        distribution::cap::entry_weight(&key.0)
+                            + crate::entry::ENTRY_ENCODING_OVERHEAD
+                    })
                     .sum();
-                let last = &keys[4];
+                let last = &keys[2];
                 if !<Geometric as Distribution>::leaf_cut(&last.0, charge, &manifest) {
                     break keys;
                 }
@@ -5680,6 +6674,106 @@ mod tests {
                 String::from_utf8_lossy(anchor)
             );
         }
+
+        Ok(())
+    }
+
+    /// A force-split frame's pieces are self-identified by their long
+    /// forced separators, and every edit path must preserve that mark. A
+    /// weight-neutral value update into a piece rides the in-place fast
+    /// path, which used to re-derive the piece's separator
+    /// unconditionally: the long forced form is not a prefix of the
+    /// piece's minimum, so `reseparate` collapsed it to the short natural
+    /// prefix and silently stripped the mark. The orphaned piece then
+    /// never rejoined its run, and canonical shapes came to depend on
+    /// edit history — the real-workload converge harness caught it as
+    /// same-facts-different-roots. Pinned at both layers: the stored
+    /// marks survive the update byte-for-byte, and the updated tree
+    /// matches the sequential build that carried the final value from
+    /// the start.
+    #[dialog_common::test]
+    async fn it_keeps_forced_marks_through_fast_path_updates() -> Result<()> {
+        let mut storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let manifest = ceiling_manifest(2, 0);
+
+        // An all-tails run over the ceiling: no natural cut anywhere, so
+        // the frame machinery must force-split it at marked anchors.
+        let sorted: Vec<VarKey> = tails_keys("e", 24, &manifest);
+        let tree = build_incremental(&sorted, manifest, &mut storage).await?;
+        let bound = manifest.max_separator as usize;
+        let marked: Vec<(usize, Vec<u8>)> = leaf_piece_heads(tree.root(), &storage)
+            .await?
+            .into_iter()
+            .filter(|(separator, _)| *separator > bound)
+            .collect();
+        assert!(
+            !marked.is_empty(),
+            "the all-tails run exceeds the ceiling and must be force-split"
+        );
+
+        // Update a key inside a marked piece with a same-weight value:
+        // eligible for the in-place fast path, which must leave every
+        // stored mark in place.
+        let head = &marked[0].1;
+        let at = sorted
+            .iter()
+            .position(|key| &key.0 == head)
+            .expect("the marked head is one of the built keys");
+        let target = sorted.get(at + 1).unwrap_or(&sorted[at]).clone();
+        let mut delta = Delta::zero();
+        let updated = tree
+            .edit_with_manifest(&storage)
+            .await?
+            .insert(target.clone(), b"rewritten".to_vec(), &storage)
+            .await?
+            .persist(&mut delta)?;
+        for (hash, buffer) in delta.flush() {
+            storage.store(buffer.as_ref().to_vec(), &hash).await?;
+        }
+
+        let after: Vec<(usize, Vec<u8>)> = leaf_piece_heads(updated.root(), &storage)
+            .await?
+            .into_iter()
+            .filter(|(separator, _)| *separator > bound)
+            .collect();
+        assert_eq!(
+            marked, after,
+            "a weight-neutral update stripped a forced mark"
+        );
+
+        // History-independence: a sequential build carrying the final
+        // value from the start lands on the same root.
+        let mut fresh_storage = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut fresh: Option<VarTree> = None;
+        let mut delta = Delta::zero();
+        for key in &sorted {
+            let transient = match &fresh {
+                None => {
+                    TransientTree::with_manifest(NULL_BLAKE3_HASH.clone(), Cache::new(), manifest)
+                }
+                Some(tree) => tree.edit_with_manifest(&fresh_storage).await?,
+            };
+            let value = if key == &target {
+                b"rewritten".to_vec()
+            } else {
+                key.0.clone()
+            };
+            let next = transient
+                .insert(key.clone(), value, &fresh_storage)
+                .await?
+                .persist(&mut delta)?;
+            for (hash, buffer) in delta.flush() {
+                fresh_storage.store(buffer.as_ref().to_vec(), &hash).await?;
+            }
+            delta = Delta::zero();
+            fresh = Some(next);
+        }
+        let fresh = fresh.expect("the sequential build is non-empty");
+        assert_eq!(
+            updated.root(),
+            fresh.root(),
+            "the update's history leaked into the canonical shape"
+        );
 
         Ok(())
     }
@@ -6128,7 +7222,7 @@ mod tests {
     /// of 15 near-duplicate keys sharing a 24-byte cluster prefix.
     fn semantic_cluster() -> Vec<VarKey> {
         let mut keys = Vec::new();
-        for sub in [b'A', b'B', b'C'] {
+        for sub in *b"ABC" {
             for n in 0..15u32 {
                 let mut bytes = vec![b'W'];
                 bytes.extend(vec![b'q'; 23]);

--- a/rust/dialog-search-tree/src/validate.rs
+++ b/rust/dialog-search-tree/src/validate.rs
@@ -1,0 +1,328 @@
+//! Canonical-form validation for real, stored trees.
+//!
+//! # The property being checked
+//!
+//! The convergence guarantee this crate makes is precisely this: for a
+//! given format [`Manifest`], the CANONICAL, FULLY-PERSISTED form of a tree
+//! is a pure function of its entry set — the same `(key, value)` set
+//! canonicalizes to the same node graph, byte for byte, regardless of the
+//! order, grouping, or path (edits, buffered writes, plants, flushes) by
+//! which the entries arrived. Two boundary clauses matter:
+//!
+//! - the function is PARAMETERIZED BY THE MANIFEST, and the manifest
+//!   travels in the tree's nodes — so an EMPTY tree carries none. A
+//!   lifecycle that deletes every entry and writes again re-stamps
+//!   whatever manifest the writer imposes ([`Manifest::default`] unless
+//!   pinned via `HitchhikerTree::with_manifest`); convergence claims hold
+//!   only among writers imposing the same manifest across such gaps. The
+//!   adversarial soak's delete-to-empty pattern found exactly this seam.
+//! - the property does NOT cover in-flight buffered state: a hitchhiker
+//!   root with pending novelty is valid and publishable, but its shape
+//!   deliberately depends on where ops currently sit, and two such roots
+//!   holding the same facts may differ until canonicalized.
+//!
+//! # What the validator does
+//!
+//! Because the shape rules are history-independent they are locally
+//! re-derivable: the canonical partition at every level is a function of
+//! the entry sequence and the manifest alone. The validator exploits the
+//! fact that the crate already contains the canonical constructor — the
+//! bottom-up plant path (`regroup_entries` + `seal_root`) — and reuses it
+//! verbatim rather than re-deriving seam rules (coins, vetoed stretches,
+//! frame ceilings, forced-long separators, anchor elections) in a second
+//! implementation that could drift:
+//!
+//! 1. walk the stored tree, flagging any non-empty novelty buffer (a
+//!    canonical tree is fully flushed) and collecting its entries and its
+//!    per-level separator lists;
+//! 2. replant the same entries in memory through the production plant path
+//!    (no persist, no hashing);
+//! 3. lockstep-compare the two shapes level by level, reporting the FIRST
+//!    divergence at each level with its position and separators.
+//!
+//! A clean report on every commit's canonicalized root upgrades "root
+//! differs after 3,000 commits" into "level 2, node 17, seam misplaced at
+//! key …" at the causing edit. Cost is O(n) in entries plus one in-memory
+//! rebuild; no reference store, no second persist.
+
+use dialog_common::{Blake3Hash, ConditionalSync, NULL_BLAKE3_HASH};
+use dialog_storage::{DialogStorageError, StorageBackend};
+use rkyv::{
+    Deserialize, Serialize,
+    bytecheck::CheckBytes,
+    de::Pool,
+    rancor::Strategy,
+    ser::{Serializer, allocator::ArenaHandle, sharing::Share},
+    util::AlignedVec,
+    validation::{Validator, archive::ArchiveValidator, shared::SharedValidator},
+};
+
+use crate::{
+    Accessor, ArchivedNodeBody, ContentAddressedStorage, DialogSearchTreeError, Distribution, Key,
+    NoveltyEntry, NoveltyOp, PersistentNode, PersistentTree, TransientTree, Value, into_owned,
+};
+
+/// Renders a separator for a violation message: a bounded hex prefix, so
+/// reports stay readable for long keys.
+fn hex_prefix(bytes: &[u8]) -> String {
+    let shown: String = bytes.iter().take(20).map(|b| format!("{b:02x}")).collect();
+    if bytes.len() > 20 {
+        format!("{shown}… ({} bytes)", bytes.len())
+    } else {
+        shown
+    }
+}
+
+impl<K, V, D> PersistentTree<K, V, D>
+where
+    K: Key + ConditionalSync + 'static,
+    V: Value
+        + ConditionalSync
+        + 'static
+        + for<'a> Serialize<
+            Strategy<Serializer<AlignedVec, ArenaHandle<'a>, Share>, rkyv::rancor::Error>,
+        >,
+    V::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        > + Deserialize<V, Strategy<Pool, rkyv::rancor::Error>>
+        + ConditionalSync,
+    D: Distribution + ConditionalSync + 'static,
+{
+    /// Validates that this tree is in canonical form: fully flushed, and
+    /// shaped exactly as the canonical constructor shapes its entry set
+    /// under the tree's own manifest. Returns one message per divergence
+    /// (empty = canonical); each message names the level and position, so
+    /// a failure localizes to a node instead of a differing root hash.
+    ///
+    /// See the module docs for the precise property statement — this is
+    /// meaningful for canonicalized roots, and will (correctly) report a
+    /// buffered hitchhiker root as non-canonical.
+    pub async fn canonical_divergences<Backend>(
+        &self,
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Vec<String>, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync,
+    {
+        if self.root() == NULL_BLAKE3_HASH {
+            return Ok(Vec::new());
+        }
+        let manifest = self.manifest(storage).await?;
+        let accessor: Accessor<Backend> = Accessor::new(Default::default(), storage.clone());
+
+        let mut violations = Vec::new();
+
+        // Level-order walk of the stored tree: per-level separator lists
+        // (children of every level's nodes, in order), entry collection in
+        // key order, and the fully-flushed check.
+        let mut stored_levels: Vec<Vec<Vec<u8>>> = Vec::new();
+        let mut entries: Vec<NoveltyEntry<V>> = Vec::new();
+        let mut current: Vec<Blake3Hash> = vec![self.root().clone()];
+        while !current.is_empty() {
+            let mut next: Vec<Blake3Hash> = Vec::new();
+            let mut separators: Vec<Vec<u8>> = Vec::new();
+            for hash in &current {
+                let node: PersistentNode<K, V> = accessor.get_node(hash).await?;
+                match node.body() {
+                    ArchivedNodeBody::Index(index) => {
+                        for at in 0..index.len() {
+                            if index.buffer_for(at).is_some() {
+                                violations.push(format!(
+                                    "buffered novelty at level {} link {at}: the tree is \
+                                     not fully flushed, so it is not in canonical form",
+                                    stored_levels.len(),
+                                ));
+                            }
+                            separators.push(index.separator(at)?);
+                            next.push(index.hash_at(at)?.clone());
+                        }
+                    }
+                    ArchivedNodeBody::Segment(segment) => {
+                        let mut keys = segment.keys::<K>()?;
+                        while let Some((at, key)) = keys.next_key()? {
+                            entries.push(NoveltyEntry {
+                                key: key.to_vec(),
+                                op: NoveltyOp::Assert(into_owned(segment.value_at(at)?)?),
+                            });
+                        }
+                    }
+                }
+            }
+            if !separators.is_empty() {
+                stored_levels.push(separators);
+            }
+            current = next;
+        }
+        // Buffered novelty means the replant below would fold ops the
+        // stored shape has not absorbed; the report above already says
+        // everything useful.
+        if !violations.is_empty() {
+            return Ok(violations);
+        }
+
+        // The canonical constructor, over the same entries, in memory.
+        let expected = TransientTree::<K, V, D>::with_manifest(
+            NULL_BLAKE3_HASH.clone(),
+            Default::default(),
+            manifest,
+        )
+        .plant(entries, storage)
+        .await?;
+        let expected_levels = expected.level_separators()?;
+
+        if stored_levels.len() != expected_levels.len() {
+            violations.push(format!(
+                "tree height diverges: stored {} levels below the root, canonical {}",
+                stored_levels.len(),
+                expected_levels.len(),
+            ));
+        }
+        for (depth, (stored, expected)) in
+            stored_levels.iter().zip(expected_levels.iter()).enumerate()
+        {
+            if stored.len() != expected.len() {
+                violations.push(format!(
+                    "level {depth}: stored {} nodes, canonical {}",
+                    stored.len(),
+                    expected.len(),
+                ));
+            }
+            if let Some(at) =
+                (0..stored.len().min(expected.len())).find(|at| stored[*at] != expected[*at])
+            {
+                violations.push(format!(
+                    "level {depth}, node {at}: seam diverges — stored separator {} vs \
+                     canonical {}",
+                    hex_prefix(&stored[at]),
+                    hex_prefix(&expected[at]),
+                ));
+            }
+        }
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unexpected_cfgs)]
+
+    use anyhow::Result;
+    use dialog_common::Blake3Hash;
+    use dialog_storage::MemoryStorageBackend;
+
+    use crate::{Buffer, ContentAddressedStorage, Delta, HitchhikerTree, PersistentTree};
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    type Store = ContentAddressedStorage<MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
+    type Tree = PersistentTree<[u8; 4], Vec<u8>>;
+
+    async fn settle(delta: &mut Delta<Blake3Hash, Buffer>, storage: &mut Store) -> Result<()> {
+        for (_, buffer) in delta.flush() {
+            storage
+                .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// A tree built by canonical edits validates clean at EVERY step — the
+    /// edit path's whole contract is that it maintains canonical form
+    /// incrementally, and the validator re-derives that form through the
+    /// independent plant constructor.
+    #[dialog_common::test]
+    async fn it_validates_canonically_edited_trees_clean() -> Result<()> {
+        let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut tree = Tree::empty();
+        for i in 0..250u32 {
+            let key = (i * 37 % 1000).to_be_bytes();
+            let mut delta = Delta::zero();
+            tree = tree
+                .edit()
+                .insert(key, vec![i as u8; (i % 60) as usize + 1], &storage)
+                .await?
+                .persist(&mut delta)?;
+            settle(&mut delta, &mut storage).await?;
+
+            if i % 50 == 49 {
+                let divergences = tree.canonical_divergences(&storage).await?;
+                assert_eq!(
+                    divergences,
+                    Vec::<String>::new(),
+                    "canonical edit left a non-canonical tree after {} inserts",
+                    i + 1
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// A canonicalized buffered tree validates clean: the flush cascade must
+    /// settle every op into the same shape the plant constructor derives.
+    #[dialog_common::test]
+    async fn it_validates_canonicalized_buffered_trees_clean() -> Result<()> {
+        let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        let mut buffered = HitchhikerTree::open(&Tree::empty()).with_op_buf_size(8);
+        for i in 0..300u32 {
+            let key = (i * 17 % 700).to_be_bytes();
+            buffered = buffered.insert(key, vec![i as u8, 3], &storage).await?;
+        }
+        let mut delta = Delta::zero();
+        let canonical = buffered.canonicalize(&storage, &mut delta).await?;
+        settle(&mut delta, &mut storage).await?;
+
+        let divergences = canonical.canonical_divergences(&storage).await?;
+        assert_eq!(
+            divergences,
+            Vec::<String>::new(),
+            "canonicalize left divergences"
+        );
+        Ok(())
+    }
+
+    /// The validator is not vacuous: a published BUFFERED root — valid,
+    /// publishable, deliberately not canonical — must be reported, via the
+    /// fully-flushed check.
+    #[dialog_common::test]
+    async fn it_flags_buffered_roots_as_non_canonical() -> Result<()> {
+        let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+        // Seed enough entries through the canonical path that the tree has
+        // real depth, then buffer a few writes with the DEFAULT op buffer:
+        // they stay parked in the root's novelty, which is exactly the
+        // published-but-not-canonical form the property excludes. (A tiny
+        // op buffer would cascade every op to the leaves and publish a form
+        // that genuinely IS canonical — the validator correctly accepts it.)
+        let mut tree = Tree::empty();
+        for i in 0..200u32 {
+            let key = (i * 13 % 400).to_be_bytes();
+            let mut delta = Delta::zero();
+            tree = tree
+                .edit()
+                .insert(key, vec![i as u8], &storage)
+                .await?
+                .persist(&mut delta)?;
+            settle(&mut delta, &mut storage).await?;
+        }
+        let mut buffered = HitchhikerTree::open(&tree);
+        for i in 0..10u32 {
+            let key = (900 + i).to_be_bytes();
+            buffered = buffered.insert(key, vec![i as u8], &storage).await?;
+        }
+        let mut delta = Delta::zero();
+        let root = buffered.persist(&mut delta)?;
+        settle(&mut delta, &mut storage).await?;
+        let tree = Tree::from_hash_with_cache(root, Default::default());
+
+        let divergences = tree.canonical_divergences(&storage).await?;
+        assert!(
+            divergences
+                .iter()
+                .any(|violation| violation.contains("buffered novelty")),
+            "a buffered root must be reported as not in canonical form, got: {divergences:?}"
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -21,21 +21,72 @@ use crate::{
     Value, into_owned,
 };
 
-/// Whether `key` lies at or above `range`'s upper bound: once one does, no
-/// later key (keys stream in order) can be in range, so a walk can stop even
-/// if the range was never entered. Without this, a range lying entirely below
-/// a subtree's keys would walk every leaf to the subtree's right edge
-/// yielding nothing.
-fn past_end<Key: Ord, R: RangeBounds<Key>>(range: &R, key: &Key) -> bool {
-    match range.end_bound() {
-        Bound::Included(end) => key > end,
-        Bound::Excluded(end) => key >= end,
+/// A buffered op that won its key during [`pending_for_leaf`]'s collection
+/// pass, located by position instead of decoded: `level` names the path layer
+/// whose descended link buffers it, `at` its entry index there, and `slot` its
+/// value-table slot (tracked while streaming, so decoding it later costs no
+/// polarity re-scan). Values are decoded only for the winners that survive
+/// every narrowing and shadowing step, in the final decode pass.
+struct PendingWinner {
+    key: Vec<u8>,
+    level: usize,
+    at: usize,
+    slot: usize,
+}
+
+/// Merges two key-sorted winner lists, keeping the `shallow` entry where both
+/// hold a key: across the path the root-most layer's op is the newest. Runs
+/// linear in the combined length, replacing the per-key membership scan that
+/// made accumulation quadratic in the buffered-op count.
+fn merge_winners(shallow: Vec<PendingWinner>, deeper: Vec<PendingWinner>) -> Vec<PendingWinner> {
+    if deeper.is_empty() {
+        return shallow;
+    }
+    if shallow.is_empty() {
+        return deeper;
+    }
+    let mut merged = Vec::with_capacity(shallow.len() + deeper.len());
+    let mut left = shallow.into_iter().peekable();
+    let mut right = deeper.into_iter().peekable();
+    loop {
+        match (left.peek(), right.peek()) {
+            (Some(l), Some(r)) => match l.key.cmp(&r.key) {
+                std::cmp::Ordering::Less => merged.push(left.next().expect("peeked")),
+                std::cmp::Ordering::Greater => merged.push(right.next().expect("peeked")),
+                std::cmp::Ordering::Equal => {
+                    merged.push(left.next().expect("peeked"));
+                    right.next();
+                }
+            },
+            (Some(_), None) => merged.push(left.next().expect("peeked")),
+            (None, Some(_)) => merged.push(right.next().expect("peeked")),
+            (None, None) => break,
+        }
+    }
+    merged
+}
+
+/// Whether `key` lies below `start`, i.e. before the walk's range begins.
+fn below_start(start: &Bound<&[u8]>, key: &[u8]) -> bool {
+    match start {
+        Bound::Included(bound) => key < *bound,
+        Bound::Excluded(bound) => key <= *bound,
+        Bound::Unbounded => false,
+    }
+}
+
+/// Whether `key` lies past `end`, i.e. beyond the walk's range.
+fn past_end_bytes(end: &Bound<&[u8]>, key: &[u8]) -> bool {
+    match end {
+        Bound::Included(bound) => key > *bound,
+        Bound::Excluded(bound) => key >= *bound,
         Bound::Unbounded => false,
     }
 }
 
 /// The buffered ops covering the leaf a walk currently sits on, resolved to one
-/// winning op per key and sorted by key.
+/// winning op per key and sorted by key, restricted to the walk's `[start, end]`
+/// byte bounds.
 ///
 /// `path` is the walk's ancestor stack, root first, each entry paired with the
 /// index of the child it descended into. Novelty is stored per child link, so
@@ -47,6 +98,12 @@ fn past_end<Key: Ord, R: RangeBounds<Key>>(range: &R, key: &Key) -> bool {
 /// leaves, at the leaf, exactly the ops a flush would deliver to it — no
 /// cross-level span inheritance exists to get wrong.
 ///
+/// The range restriction is sound because the walker only ever surfaces a
+/// buffered op after an in-range check: an op outside the bounds can never
+/// yield, so collecting it (let alone decoding its value) is pure waste — and
+/// for a point read it was most of the buffered-path cost, since the root
+/// buffer holds ops for the whole subtree while the probe wants one key.
+///
 /// Precedence: WITHIN one link's buffer the last entry for a key is the newest
 /// and wins; ACROSS the path the first (root-most) layer holding the key wins,
 /// because writes land in the root buffer and a flush only moves ops downward,
@@ -54,6 +111,8 @@ fn past_end<Key: Ord, R: RangeBounds<Key>>(range: &R, key: &Key) -> bool {
 #[allow(clippy::type_complexity)]
 fn pending_for_leaf<Key, Value>(
     path: &[(PersistentNode<Key, Value>, Option<usize>)],
+    start: Bound<&[u8]>,
+    end: Bound<&[u8]>,
 ) -> Result<Vec<(Vec<u8>, NoveltyOp<Value>)>, DialogSearchTreeError>
 where
     Key: self::Key + 'static,
@@ -63,8 +122,8 @@ where
         > + Deserialize<Value, Strategy<Pool, rkyv::rancor::Error>>
         + ConditionalSync,
 {
-    let mut winners: Vec<(Vec<u8>, NoveltyOp<Value>)> = Vec::new();
-    for (node, descended) in path {
+    let mut winners: Vec<PendingWinner> = Vec::new();
+    for (level, (node, descended)) in path.iter().enumerate() {
         let ArchivedNodeBody::Index(index) = node.body() else {
             continue;
         };
@@ -84,42 +143,75 @@ where
             } else {
                 None
             };
-            winners.retain(|(key, _)| {
+            winners.retain(|winner| {
                 lower
                     .as_ref()
-                    .is_none_or(|lower| key.as_slice() >= lower.as_slice())
+                    .is_none_or(|lower| winner.key.as_slice() >= lower.as_slice())
                     && upper
                         .as_ref()
-                        .is_none_or(|upper| key.as_slice() < upper.as_slice())
+                        .is_none_or(|upper| winner.key.as_slice() < upper.as_slice())
             });
         }
 
         // This level's buffer is deeper (older) than everything accumulated,
-        // so only keys no shallower layer claimed enter. Within the buffer
-        // equal keys are contiguous and the last op of a run is the newest;
-        // values are decoded only for the ops that win.
+        // so on a shared key the shallower layer's op wins the merge. Within
+        // the buffer equal keys are contiguous and the last op of a run is
+        // the newest. One streaming pass collects the in-range run winners
+        // by position; no key outside the walk's bounds is materialized and
+        // no value is decoded here at all.
         let Some(buffer) = index.buffer_for(at) else {
             continue;
         };
+        let mut runs: Vec<PendingWinner> = Vec::new();
+        // `keys()` validates the buffer (count vs polarity vs value tables),
+        // so the polarity reads below cannot misread a well-formed buffer.
         let mut keys = buffer.keys::<Key>()?;
-        let mut runs: Vec<(Vec<u8>, usize)> = Vec::new();
+        let mut asserts = 0usize;
         while let Some((entry_at, key)) = keys.next_key()? {
-            match runs.last_mut() {
-                Some((last_key, last_at)) if last_key.as_slice() == key => *last_at = entry_at,
-                _ => runs.push((key.to_vec(), entry_at)),
+            let slot = asserts;
+            if buffer.polarity.get(entry_at).copied() == Some(1) {
+                asserts += 1;
             }
-        }
-        for (key, entry_at) in runs {
-            if winners.iter().any(|(candidate, _)| *candidate == key) {
+            // Keys stream in sorted order: everything past the end bound
+            // stays out of range for the rest of the buffer.
+            if past_end_bytes(&end, key) {
+                break;
+            }
+            if below_start(&start, key) {
                 continue;
             }
-            let op = buffer.op_at(entry_at)?;
-            winners.push((key, op));
+            match runs.last_mut() {
+                Some(last) if last.key.as_slice() == key => {
+                    last.at = entry_at;
+                    last.slot = slot;
+                }
+                _ => runs.push(PendingWinner {
+                    key: key.to_vec(),
+                    level,
+                    at: entry_at,
+                    slot,
+                }),
+            }
         }
+        winners = merge_winners(winners, runs);
     }
 
-    winners.sort_by(|(left, _), (right, _)| left.cmp(right));
-    Ok(winners)
+    // Decode values only for the ops that actually won: everything narrowed
+    // away or shadowed by a shallower layer cost a position, not a decode.
+    winners
+        .into_iter()
+        .map(|winner| {
+            let (node, descended) = &path[winner.level];
+            let at = descended.ok_or_else(|| {
+                DialogSearchTreeError::Node("pending winner on an undescended layer".into())
+            })?;
+            let buffer = node.as_index()?.buffer_for(at).ok_or_else(|| {
+                DialogSearchTreeError::Node("pending winner on a bufferless link".into())
+            })?;
+            let op = buffer.op_with_slot(winner.at, winner.slot)?;
+            Ok((winner.key, op))
+        })
+        .collect()
 }
 
 /// The winning buffered op for `key` along a root-to-leaf search path, or
@@ -152,23 +244,14 @@ where
         let Some(buffer) = index.buffer_for(layer.index) else {
             continue;
         };
-        // Keys stream in sorted order, so the walk stops at the first key
-        // past the probe; within a key the last op wins, and equal keys are
-        // contiguous. Only a winning op's value is decoded.
-        let mut keys = buffer.keys::<Key>()?;
-        let mut found: Option<usize> = None;
-        while let Some((at, candidate)) = keys.next_key()? {
-            match candidate.cmp(key) {
-                std::cmp::Ordering::Less => {}
-                std::cmp::Ordering::Equal => found = Some(at),
-                std::cmp::Ordering::Greater => break,
-            }
-        }
-        if let Some(at) = found {
+        // One streaming pass per buffer: the walk stops at the first key past
+        // the probe, the winner's value-table slot is tracked as the polarity
+        // column is walked, and only a winning op's value is decoded.
+        if let Some(op) = buffer.resolve::<Key>(key)? {
             // The path is root first, so this is the shallowest layer holding
             // the key: its op is the newest, and any deeper hit is an older
             // copy a flush pushed down before this one was buffered.
-            return Ok(Some(buffer.op_at(at)?));
+            return Ok(Some(op));
         }
     }
     Ok(None)
@@ -268,8 +351,20 @@ where
                 // reaches a leaf when that buffer overflows, so a walk that
                 // reads segments alone misses every recent write. Merge the
                 // covering ops over the stored entries, exactly as a flush
-                // would resolve them.
-                let pending = pending_for_leaf::<Key, Value>(&search_path)?;
+                // would resolve them — restricted to the walk's own range,
+                // since an out-of-range op can never yield (`Key`'s order
+                // agrees with its bytes, so bounds compare through `as_ref`).
+                let start_bytes = match range.start_bound() {
+                    Bound::Included(bound) => Bound::Included(bound.as_ref()),
+                    Bound::Excluded(bound) => Bound::Excluded(bound.as_ref()),
+                    Bound::Unbounded => Bound::Unbounded,
+                };
+                let end_bytes = match range.end_bound() {
+                    Bound::Included(bound) => Bound::Included(bound.as_ref()),
+                    Bound::Excluded(bound) => Bound::Excluded(bound.as_ref()),
+                    Bound::Unbounded => Bound::Unbounded,
+                };
+                let pending = pending_for_leaf::<Key, Value>(&search_path, start_bytes, end_bytes)?;
                 let mut buffered = pending.into_iter().peekable();
 
                 // A leaf re-touched across selects (a join re-selects the same
@@ -283,6 +378,18 @@ where
                 // stored keys are obtained differs.
                 if node.should_memoize_keys() {
                     let keys = node.memoized_keys()?;
+                    // The memoized decode has random access, so enter the leaf
+                    // at the range's partition point instead of visiting every
+                    // entry before it — the difference between O(leaf) and
+                    // O(log leaf + hits) per point-shaped read. Buffered ops
+                    // are already range-restricted, so none sort below the
+                    // entry point's range.
+                    let start_at = match &start_bytes {
+                        Bound::Included(bound) | Bound::Excluded(bound) => {
+                            keys.lower_bound(bound)
+                        }
+                        Bound::Unbounded => 0,
+                    };
                     // Resolve the segment at most once per leaf, and only when
                     // an entry actually yields: `body()` is a full bytecheck
                     // validation of the node buffer, so resolving per yielded
@@ -290,7 +397,8 @@ where
                     // (join) hot path, while resolving eagerly taxes leaves
                     // the range never enters.
                     let mut segment = None;
-                    for (at, key) in keys.iter().enumerate() {
+                    for at in start_at..keys.len() {
+                        let key = keys.get(at).expect("index in range");
                         // Buffered inserts sorting before this entry.
                         while let Some((buffered_key, _)) = buffered.peek() {
                             if buffered_key.as_slice() >= key {
@@ -298,11 +406,9 @@ where
                             }
                             let (buffered_key, op) = buffered.next().expect("peeked");
                             if let NoveltyOp::Assert(value) = op {
+                                entered_range = true;
                                 let entry_key = Key::try_from_bytes(&buffered_key)?;
-                                if range.contains(&entry_key) {
-                                    entered_range = true;
-                                    yield Entry { key: entry_key, value };
-                                }
+                                yield Entry { key: entry_key, value };
                             }
                         }
 
@@ -310,17 +416,17 @@ where
                         if matches!(buffered.peek(), Some((buffered_key, _)) if buffered_key.as_slice() == key) {
                             let (buffered_key, op) = buffered.next().expect("peeked");
                             if let NoveltyOp::Assert(value) = op {
+                                entered_range = true;
                                 let entry_key = Key::try_from_bytes(&buffered_key)?;
-                                if range.contains(&entry_key) {
-                                    entered_range = true;
-                                    yield Entry { key: entry_key, value };
-                                }
+                                yield Entry { key: entry_key, value };
                             }
                             continue;
                         }
 
-                        let entry_key = Key::try_from_bytes(key)?;
-                        if range.contains(&entry_key) {
+                        // Byte-level range check: `Key`'s order agrees with
+                        // its bytes, so the typed key is only materialized
+                        // for entries that actually yield.
+                        if !below_start(&start_bytes, key) && !past_end_bytes(&end_bytes, key) {
                             entered_range = true;
                             let segment = match &segment {
                                 Some(segment) => segment,
@@ -332,14 +438,15 @@ where
                                 }
                             };
                             let value = into_owned(segment.value_at(at)?)?;
+                            let entry_key = Key::try_from_bytes(key)?;
                             yield Entry { key: entry_key, value };
                         // Entries only ascend, so a key past the range's end
-                        // ends the walk. The `past_end` half must NOT be gated
-                        // on `entered_range`: a scan whose range hits no stored
-                        // entry would otherwise never exit and would walk the
-                        // rest of the tree, making an empty lookup cost the
-                        // size of the database.
-                        } else if entered_range || past_end(&range, &entry_key) {
+                        // ends the walk. The `past_end_bytes` half must NOT be
+                        // gated on `entered_range`: a scan whose range hits no
+                        // stored entry would otherwise never exit and would
+                        // walk the rest of the tree, making an empty lookup
+                        // cost the size of the database.
+                        } else if entered_range || past_end_bytes(&end_bytes, key) {
                             return;
                         }
                     }
@@ -356,11 +463,9 @@ where
                             }
                             let (buffered_key, op) = buffered.next().expect("peeked");
                             if let NoveltyOp::Assert(value) = op {
+                                entered_range = true;
                                 let entry_key = Key::try_from_bytes(&buffered_key)?;
-                                if range.contains(&entry_key) {
-                                    entered_range = true;
-                                    yield Entry { key: entry_key, value };
-                                }
+                                yield Entry { key: entry_key, value };
                             }
                         }
 
@@ -368,37 +473,37 @@ where
                         if matches!(buffered.peek(), Some((buffered_key, _)) if buffered_key.as_slice() == key) {
                             let (buffered_key, op) = buffered.next().expect("peeked");
                             if let NoveltyOp::Assert(value) = op {
+                                entered_range = true;
                                 let entry_key = Key::try_from_bytes(&buffered_key)?;
-                                if range.contains(&entry_key) {
-                                    entered_range = true;
-                                    yield Entry { key: entry_key, value };
-                                }
+                                yield Entry { key: entry_key, value };
                             }
                             continue;
                         }
 
-                        let entry_key = Key::try_from_bytes(key)?;
-                        if range.contains(&entry_key) {
+                        // Byte-level range check, as in the memoized arm.
+                        if !below_start(&start_bytes, key) && !past_end_bytes(&end_bytes, key) {
                             entered_range = true;
                             let value = into_owned(segment.value_at(at)?)?;
+                            let entry_key = Key::try_from_bytes(key)?;
                             yield Entry { key: entry_key, value };
-                        // See the memoized arm above: the `past_end` half must
-                        // not be gated on `entered_range`, or a range matching
-                        // no stored entry walks the rest of the tree.
-                        } else if entered_range || past_end(&range, &entry_key) {
+                        // See the memoized arm above: the `past_end_bytes`
+                        // half must not be gated on `entered_range`, or a
+                        // range matching no stored entry walks the rest of
+                        // the tree.
+                        } else if entered_range || past_end_bytes(&end_bytes, key) {
                             return;
                         }
                     }
                 }
 
                 // Buffered inserts past the last stored entry of this leaf.
+                // Already range-restricted by `pending_for_leaf`, so every
+                // assert yields.
                 for (buffered_key, op) in buffered {
                     if let NoveltyOp::Assert(value) = op {
+                        entered_range = true;
                         let entry_key = Key::try_from_bytes(&buffered_key)?;
-                        if range.contains(&entry_key) {
-                            entered_range = true;
-                            yield Entry { key: entry_key, value };
-                        }
+                        yield Entry { key: entry_key, value };
                     }
                 }
             }
@@ -754,7 +859,7 @@ mod walker_novelty_tests {
             expected.push((key, value));
 
             // Every write so far must be readable, by scan and by point read.
-            expected.sort_by(|(a, _), (b, _)| a.cmp(b));
+            expected.sort_by_key(|(a, _)| *a);
             let mut seen = Vec::new();
             {
                 let stream = tree.stream_range(.., &storage);

--- a/rust/dialog-search-tree/tests/adversarial.rs
+++ b/rust/dialog-search-tree/tests/adversarial.rs
@@ -1,0 +1,518 @@
+//! Adversarial convergence soak: the program harness pointed at the parts
+//! of the shape machinery that ordinary workloads barely touch.
+//!
+//! The default-manifest workloads (SE replay, the program harness) run
+//! with `max_separator = 512`, so forced-long separators — and with them
+//! the forced-run merge, the widen/quiet-check regimes, and the anchor
+//! election edge cases — are rare events. This soak drives them
+//! CONSTANTLY: keys are long (40 bytes) with deep shared prefixes, and the
+//! manifest matrix includes `max_separator` values far below the key
+//! length, so most seams derive forced-long separators; `max_segment` is
+//! shrunk so trees get real depth at test-sized op counts.
+//!
+//! Executors and oracles are the program harness's: canonical sequential
+//! edits vs buffered writes across op-buffer sizes and persist cadences,
+//! canonical roots compared at checkpoints, the canonical-form validator
+//! run on every checkpoint tree first.
+//!
+//! Scale knobs: `DIALOG_ADVERSARIAL_SEEDS`, `DIALOG_ADVERSARIAL_OPS`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use anyhow::Result;
+use dialog_common::{Blake3Hash, NULL_BLAKE3_HASH};
+use dialog_search_tree::{
+    Buffer, ContentAddressedStorage, Delta, HitchhikerTree, Manifest, PersistentTree, TransientTree,
+};
+use dialog_storage::MemoryStorageBackend;
+
+type Store = ContentAddressedStorage<MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
+type TreeKey = [u8; 40];
+type Tree = PersistentTree<TreeKey, Vec<u8>>;
+
+#[derive(Clone, Copy, Debug)]
+enum Op {
+    Insert(TreeKey, u8),
+    Delete(TreeKey),
+}
+
+struct Program {
+    ops: Vec<Op>,
+    checkpoints: Vec<usize>,
+}
+
+fn xorshift(state: &mut u64) -> u32 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    (*state >> 32) as u32
+}
+
+/// A 40-byte key with a deep shared prefix: `band` picks the first byte
+/// (a short-separator seam between bands), `cluster` a 3-byte middle, and
+/// only the final 4 bytes vary within a cluster — so separators between
+/// same-cluster neighbors need 37+ bytes and exceed every small
+/// `max_separator` in the matrix.
+fn make_key(band: u8, cluster: u32, suffix: u32) -> TreeKey {
+    let mut key = [0x61u8; 40];
+    key[0] = band;
+    key[1..4].copy_from_slice(&cluster.to_be_bytes()[1..]);
+    key[36..40].copy_from_slice(&suffix.to_be_bytes());
+    key
+}
+
+/// Conjunction-sampled ops over the long-key space: scatter across bands,
+/// deep clusters, churn of recent keys, min-churn of the smallest.
+fn generate(seed: u64, op_count: usize) -> Program {
+    let mut rng = 0xA24BAED4963EE407u64 ^ seed;
+    let mut ops = Vec::with_capacity(op_count);
+    let mut live: Vec<TreeKey> = Vec::new();
+    for _ in 0..op_count {
+        let pattern = xorshift(&mut rng) % 10;
+        let op = match pattern {
+            // scatter: any band, any cluster, any suffix
+            0..=2 => Op::Insert(
+                make_key(
+                    (xorshift(&mut rng) % 4) as u8,
+                    xorshift(&mut rng) % 8,
+                    xorshift(&mut rng) % 10_000,
+                ),
+                (xorshift(&mut rng) % 60) as u8,
+            ),
+            // deep cluster: one band, one cluster, dense suffixes — the
+            // forced-run factory
+            3..=6 => Op::Insert(
+                make_key(1, seed as u32 % 4, xorshift(&mut rng) % 400),
+                (xorshift(&mut rng) % 60) as u8,
+            ),
+            // churn: rewrite or delete a recent key
+            7 | 8 if !live.is_empty() => {
+                let victim = live[(xorshift(&mut rng) as usize) % live.len()];
+                if xorshift(&mut rng).is_multiple_of(2) {
+                    Op::Delete(victim)
+                } else {
+                    Op::Insert(victim, (xorshift(&mut rng) % 60) as u8)
+                }
+            }
+            // min-churn: delete the smallest live key (boundary moves)
+            9 if !live.is_empty() && xorshift(&mut rng).is_multiple_of(2) => {
+                Op::Delete(*live.iter().min().expect("non-empty"))
+            }
+            // absent-churn: delete a key that was never inserted — a
+            // buffered retract with nothing to hit must vanish without
+            // trace on every surface
+            9 => Op::Delete(make_key(3, 7, 999_000 + xorshift(&mut rng) % 50)),
+            // idempotent rewrite: same key, same value — the no-change
+            // edit that quiet checks and fast paths key on
+            _ if !live.is_empty() => {
+                let victim = live[(xorshift(&mut rng) as usize) % live.len()];
+                Op::Insert(victim, 7)
+            }
+            _ => Op::Insert(make_key(0, 0, xorshift(&mut rng) % 100), 1),
+        };
+        match op {
+            Op::Insert(key, _) => {
+                if !live.contains(&key) {
+                    live.push(key);
+                }
+            }
+            Op::Delete(key) => live.retain(|held| *held != key),
+        }
+        ops.push(op);
+    }
+    let checkpoints = vec![op_count / 3, (op_count * 2) / 3, op_count];
+    Program { ops, checkpoints }
+}
+
+/// The manifest matrix: `max_separator` far below the key length so most
+/// seams force, and small segments so depth appears fast. The default
+/// manifest rides along as the control arm.
+fn manifests() -> Vec<(&'static str, Manifest)> {
+    let tight = Manifest {
+        max_separator: 8,
+        max_segment: 2048,
+        ..Manifest::default()
+    };
+    let mid = Manifest {
+        max_separator: 32,
+        max_segment: 4096,
+        ..Manifest::default()
+    };
+    // Small separator bound with DEFAULT segments: long forced runs inside
+    // few, large leaves — the widen windows at their longest.
+    let long_runs = Manifest {
+        max_separator: 8,
+        ..Manifest::default()
+    };
+    vec![
+        ("max_sep=8/seg=2k", tight),
+        ("max_sep=32/seg=4k", mid),
+        ("max_sep=8/seg=default", long_runs),
+        ("default", Manifest::default()),
+    ]
+}
+
+async fn settle(delta: &mut Delta<Blake3Hash, Buffer>, storage: &mut Store) -> Result<()> {
+    for (_, buffer) in delta.flush() {
+        storage
+            .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+            .await?;
+    }
+    Ok(())
+}
+
+async fn checkpoint_root(tree: &Tree, storage: &Store, label: &str) -> Result<Blake3Hash> {
+    let divergences = tree.canonical_divergences(storage).await?;
+    assert_eq!(
+        divergences,
+        Vec::<String>::new(),
+        "{label}: canonical-form validation failed"
+    );
+    Ok(tree.root().clone())
+}
+
+/// Canonical sequential edits under `manifest`: the first write stamps it,
+/// every later edit recovers it from the root.
+async fn run_canonical(program: &Program, manifest: Manifest) -> Result<Vec<Blake3Hash>> {
+    let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+    let mut tree = Tree::empty();
+    let mut roots = Vec::new();
+    for (at, op) in program.ops.iter().enumerate() {
+        let mut delta = Delta::zero();
+        let edit = if tree.root() == NULL_BLAKE3_HASH {
+            TransientTree::with_manifest(NULL_BLAKE3_HASH.clone(), Default::default(), manifest)
+        } else {
+            tree.edit_with_manifest(&storage).await?
+        };
+        tree = match *op {
+            Op::Insert(key, len) => {
+                edit.insert(key, vec![key[39]; len as usize + 1], &storage)
+                    .await?
+            }
+            Op::Delete(key) => edit.delete(&key, &storage).await?,
+        }
+        .persist(&mut delta)?;
+        settle(&mut delta, &mut storage).await?;
+        if program.checkpoints.contains(&(at + 1)) {
+            roots.push(checkpoint_root(&tree, &storage, "canonical").await?);
+        }
+    }
+    Ok(roots)
+}
+
+/// Buffered writes under `manifest` with periodic persist + reopen,
+/// canonicalizing (and continuing) at checkpoints.
+async fn run_buffered(
+    program: &Program,
+    manifest: Manifest,
+    // One entry per session: each persist-and-reopen advances to the next
+    // buffer size (wrapping), so a single lifecycle can change its op
+    // buffer between sessions — the upgrade scenario.
+    op_bufs: &[Option<usize>],
+    persist_every: usize,
+) -> Result<Vec<Blake3Hash>> {
+    let mut session = 0usize;
+    let mut next_buf = move || {
+        let chosen = op_bufs[session % op_bufs.len()];
+        session += 1;
+        chosen
+    };
+    let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+
+    // Stamp the manifest with the first op through a canonical edit, so the
+    // buffered session opens over a root that carries it.
+    let mut ops = program.ops.iter();
+    let first = *ops.next().expect("programs are non-empty");
+    let mut delta = Delta::zero();
+    let seed_edit =
+        TransientTree::with_manifest(NULL_BLAKE3_HASH.clone(), Default::default(), manifest);
+    let mut tree = match first {
+        Op::Insert(key, len) => {
+            seed_edit
+                .insert(key, vec![key[39]; len as usize + 1], &storage)
+                .await?
+        }
+        Op::Delete(key) => seed_edit.delete(&key, &storage).await?,
+    }
+    .persist(&mut delta)?;
+    settle(&mut delta, &mut storage).await?;
+
+    // Pin the manifest on every session: the manifest travels in the tree,
+    // and a session opened over an EMPTIED tree would otherwise silently
+    // write under the default — the divergence this soak caught.
+    let open = |tree: &Tree, op_buf: Option<usize>| {
+        let buffered = HitchhikerTree::open(tree).with_manifest(manifest);
+        match op_buf {
+            Some(size) => buffered.with_op_buf_size(size),
+            None => buffered,
+        }
+    };
+    let mut roots = Vec::new();
+    if program.checkpoints.contains(&1) {
+        roots.push(checkpoint_root(&tree, &storage, "buffered/first").await?);
+    }
+    let mut buffered = open(&tree, next_buf());
+    for (at, op) in ops.enumerate() {
+        buffered = match *op {
+            Op::Insert(key, len) => {
+                buffered
+                    .insert(key, vec![key[39]; len as usize + 1], &storage)
+                    .await?
+            }
+            Op::Delete(key) => buffered.delete(key, &storage).await?,
+        };
+        let done = at + 2;
+        if program.checkpoints.contains(&done) {
+            let mut delta = Delta::zero();
+            tree = buffered.canonicalize(&storage, &mut delta).await?;
+            settle(&mut delta, &mut storage).await?;
+            roots.push(checkpoint_root(&tree, &storage, "buffered checkpoint").await?);
+            buffered = open(&tree, next_buf());
+        } else if done.is_multiple_of(persist_every) {
+            let mut delta = Delta::zero();
+            let root = buffered.persist(&mut delta)?;
+            settle(&mut delta, &mut storage).await?;
+            tree = Tree::from_hash_with_cache(root, Default::default());
+            buffered = open(&tree, next_buf());
+        }
+    }
+    Ok(roots)
+}
+
+fn knob(name: &str, fallback: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(fallback)
+}
+
+/// Under every manifest in the matrix, every executor surface must agree
+/// on every checkpoint's canonical root, and every checkpoint tree must be
+/// THE canonical tree — with forced-long separators the common case, not
+/// the exception.
+#[tokio::test]
+async fn it_converges_under_adversarial_manifests() -> Result<()> {
+    let seeds = knob("DIALOG_ADVERSARIAL_SEEDS", 3) as u64;
+    let op_count = knob("DIALOG_ADVERSARIAL_OPS", 180);
+    for (label, manifest) in manifests() {
+        for seed in 0..seeds {
+            let program = generate(seed, op_count);
+            let canonical = run_canonical(&program, manifest).await?;
+            let tiny = run_buffered(&program, manifest, &[Some(4)], 13).await?;
+            let medium = run_buffered(&program, manifest, &[Some(32)], 7).await?;
+            let default_buf = run_buffered(&program, manifest, &[None], 50).await?;
+            let mixed = run_buffered(&program, manifest, &[Some(4), Some(32), None], 11).await?;
+            for (arm, roots) in [
+                ("buffered(4)/persist-13", &tiny),
+                ("buffered(32)/persist-7", &medium),
+                ("buffered(default)/persist-50", &default_buf),
+                ("buffered(mixed 4/32/default)/persist-11", &mixed),
+            ] {
+                assert_eq!(
+                    roots, &canonical,
+                    "manifest {label}, seed {seed}: {arm} diverged from canonical"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Minimizer for a caught divergence: finds the shortest op prefix where
+/// an executor arm's canonicalized entry set differs from canonical, then
+/// prints the entry-level diff. Ignored by default; run explicitly while
+/// hunting.
+#[tokio::test]
+#[ignore]
+async fn minimize_caught_divergence() -> Result<()> {
+    use dialog_search_tree::ContentAddressedStorage as Cas;
+    use futures_util::StreamExt as _;
+
+    let manifest = manifests()
+        .into_iter()
+        .find(|(label, _)| *label == "max_sep=8/seg=2k")
+        .expect("manifest present")
+        .1;
+    let seed = 14u64;
+    let full = generate(seed, 1200);
+
+    async fn entries_of(tree: &Tree, storage: &Store) -> Result<Vec<(TreeKey, Vec<u8>)>> {
+        let mut out = Vec::new();
+        let stream = tree.stream_range(.., storage);
+        futures_util::pin_mut!(stream);
+        while let Some(entry) = stream.next().await {
+            let entry = entry?;
+            out.push((entry.key, entry.value));
+        }
+        Ok(out)
+    }
+
+    let _ = |storage: &Cas<MemoryStorageBackend<Blake3Hash, Vec<u8>>>| storage.clone();
+
+    // Find the shortest prefix (scanning coarsely then finely) where the
+    // mixed arm diverges.
+    let mut bad = None;
+    let mut len = 8;
+    while len <= full.ops.len() {
+        let program = Program {
+            ops: full.ops[..len].to_vec(),
+            checkpoints: vec![len],
+        };
+        let canonical = run_canonical(&program, manifest).await?;
+        let mixed = run_buffered(&program, manifest, &[Some(4), Some(32), None], 11).await?;
+        if canonical != mixed {
+            bad = Some(len);
+            break;
+        }
+        len += 8;
+    }
+    let Some(bad_len) = bad else {
+        println!("no divergence up to {} ops", full.ops.len());
+        return Ok(());
+    };
+    // Tighten to the exact op.
+    let mut lo = bad_len - 8;
+    while lo < bad_len {
+        let probe = lo + 1;
+        let program = Program {
+            ops: full.ops[..probe].to_vec(),
+            checkpoints: vec![probe],
+        };
+        let canonical = run_canonical(&program, manifest).await?;
+        let mixed = run_buffered(&program, manifest, &[Some(4), Some(32), None], 11).await?;
+        if canonical != mixed {
+            break;
+        }
+        lo = probe;
+    }
+    let minimal = lo + 1;
+    println!("first divergent prefix: {minimal} ops");
+    for (at, op) in full.ops[..minimal].iter().enumerate() {
+        match op {
+            Op::Insert(key, len) => println!(
+                "  {at}: INSERT band={} cluster={:?} suffix={:?} len={len}",
+                key[0],
+                &key[1..4],
+                &key[36..40]
+            ),
+            Op::Delete(key) => println!(
+                "  {at}: DELETE band={} cluster={:?} suffix={:?}",
+                key[0],
+                &key[1..4],
+                &key[36..40]
+            ),
+        }
+    }
+
+    // Entry-level diff at the divergent prefix.
+    let program = Program {
+        ops: full.ops[..minimal].to_vec(),
+        checkpoints: vec![minimal],
+    };
+    // Re-run both arms, retaining the trees this time.
+    let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+    let mut tree = Tree::empty();
+    for op in &program.ops {
+        let mut delta = Delta::zero();
+        let edit = if tree.root() == NULL_BLAKE3_HASH {
+            TransientTree::with_manifest(NULL_BLAKE3_HASH.clone(), Default::default(), manifest)
+        } else {
+            tree.edit_with_manifest(&storage).await?
+        };
+        tree = match *op {
+            Op::Insert(key, len) => {
+                edit.insert(key, vec![key[39]; len as usize + 1], &storage)
+                    .await?
+            }
+            Op::Delete(key) => edit.delete(&key, &storage).await?,
+        }
+        .persist(&mut delta)?;
+        settle(&mut delta, &mut storage).await?;
+    }
+    let canonical_entries = entries_of(&tree, &storage).await?;
+
+    // Mixed arm, retaining the final canonicalized tree: reuse run_buffered
+    // by reading back its root through a fresh replay with the same store
+    // is intrusive; instead re-run its logic inline at this small size.
+    let mut storage2: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+    let mut ops2 = program.ops.iter();
+    let first = *ops2.next().expect("non-empty");
+    let mut delta = Delta::zero();
+    let seed_edit =
+        TransientTree::with_manifest(NULL_BLAKE3_HASH.clone(), Default::default(), manifest);
+    let mut tree2 = match first {
+        Op::Insert(key, len) => {
+            seed_edit
+                .insert(key, vec![key[39]; len as usize + 1], &storage2)
+                .await?
+        }
+        Op::Delete(key) => seed_edit.delete(&key, &storage2).await?,
+    }
+    .persist(&mut delta)?;
+    settle(&mut delta, &mut storage2).await?;
+    let bufs = [Some(4usize), Some(32), None];
+    let mut session = 0usize;
+    let open = |tree: &Tree, buf: Option<usize>| {
+        let buffered = HitchhikerTree::open(tree).with_manifest(manifest);
+        match buf {
+            Some(size) => buffered.with_op_buf_size(size),
+            None => buffered,
+        }
+    };
+    let mut buffered = open(&tree2, bufs[session % bufs.len()]);
+    session += 1;
+    for (at, op) in ops2.enumerate() {
+        buffered = match *op {
+            Op::Insert(key, len) => {
+                buffered
+                    .insert(key, vec![key[39]; len as usize + 1], &storage2)
+                    .await?
+            }
+            Op::Delete(key) => buffered.delete(key, &storage2).await?,
+        };
+        let done = at + 2;
+        if done == program.ops.len() {
+            let mut delta = Delta::zero();
+            tree2 = buffered.canonicalize(&storage2, &mut delta).await?;
+            settle(&mut delta, &mut storage2).await?;
+            break;
+        } else if done.is_multiple_of(11) {
+            let mut delta = Delta::zero();
+            let root = buffered.persist(&mut delta)?;
+            settle(&mut delta, &mut storage2).await?;
+            tree2 = Tree::from_hash_with_cache(root, Default::default());
+            buffered = open(&tree2, bufs[session % bufs.len()]);
+            session += 1;
+        }
+    }
+    let mixed_entries = entries_of(&tree2, &storage2).await?;
+
+    println!(
+        "canonical entries: {}, mixed entries: {}",
+        canonical_entries.len(),
+        mixed_entries.len()
+    );
+    for entry in &canonical_entries {
+        if !mixed_entries.contains(entry) {
+            println!(
+                "  MISSING from mixed: band={} cluster={:?} suffix={:?} value_len={}",
+                entry.0[0],
+                &entry.0[1..4],
+                &entry.0[36..40],
+                entry.1.len()
+            );
+        }
+    }
+    for entry in &mixed_entries {
+        if !canonical_entries.contains(entry) {
+            println!(
+                "  PHANTOM in mixed: band={} cluster={:?} suffix={:?} value_len={}",
+                entry.0[0],
+                &entry.0[1..4],
+                &entry.0[36..40],
+                entry.1.len()
+            );
+        }
+    }
+    Ok(())
+}

--- a/rust/dialog-search-tree/tests/program.rs
+++ b/rust/dialog-search-tree/tests/program.rs
@@ -1,0 +1,248 @@
+//! Program-convergence harness (v1): one serializable op program run
+//! through several executor surfaces, with the oracles checked at every
+//! checkpoint.
+//!
+//! This is the "one convergence harness" the campaign's hardening feedback
+//! called for: instead of hand-compiling each regression as its own test,
+//! a `Program` — seeded ops drawn from the known stress-pattern vocabulary
+//! plus lifecycle markers — is executed by every write surface, and at
+//! each checkpoint every executor's canonicalized tree must agree on the
+//! root AND pass the canonical-form validator (which localizes any break
+//! to a level and node). Adding a future bug's pattern to the vocabulary
+//! institutionalizes its regression test.
+//!
+//! Executor surfaces covered here (all public API):
+//! - canonical sequential edits, persisted and settled per op;
+//! - buffered (hitchhiker) writes with small, medium, and default op
+//!   buffers — different cascade timings, same canonical outcome;
+//! - buffered writes with periodic persist + reopen (the commit-shaped
+//!   lifecycle), including canonicalize-and-continue at checkpoints.
+//!
+//! Not yet covered (future harness growth): stitch/differential merges and
+//! replica reconciliation orders.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use anyhow::Result;
+use dialog_common::Blake3Hash;
+use dialog_search_tree::{Buffer, ContentAddressedStorage, Delta, HitchhikerTree, PersistentTree};
+use dialog_storage::MemoryStorageBackend;
+
+type Store = ContentAddressedStorage<MemoryStorageBackend<Blake3Hash, Vec<u8>>>;
+type Tree = PersistentTree<[u8; 4], Vec<u8>>;
+
+/// One write op. Keys are `u32` big-endian so byte order is key order;
+/// values vary in length so weight-sensitive seams are exercised.
+#[derive(Clone, Copy, Debug)]
+enum Op {
+    Insert(u32, u8),
+    Delete(u32),
+}
+
+/// A deterministic program: ops plus checkpoint positions (after which
+/// every executor's canonical form must agree).
+struct Program {
+    ops: Vec<Op>,
+    checkpoints: Vec<usize>,
+}
+
+fn xorshift(state: &mut u64) -> u32 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    (*state >> 32) as u32
+}
+
+/// Draws a program by SAMPLING CONJUNCTIONS of the stress-pattern
+/// vocabulary — every op picks a pattern, so patterns interleave rather
+/// than run as separate phases (bugs live in the conjunctions):
+///
+/// - `scatter`: uniform keys across the space;
+/// - `cluster`: keys concentrated in a narrow prefix band (deep shared
+///   prefixes stress separator derivation);
+/// - `churn`: delete-then-reinsert of recently written keys (boundary
+///   re-decisions);
+/// - `min-churn`: deletes of the smallest live key (min-move edits, the
+///   boundary-reroute path).
+fn generate(seed: u64, op_count: usize) -> Program {
+    let mut rng = 0x9E3779B97F4A7C15u64 ^ seed;
+    let mut ops = Vec::with_capacity(op_count);
+    let mut live: Vec<u32> = Vec::new();
+    for _ in 0..op_count {
+        let pattern = xorshift(&mut rng) % 10;
+        let op = match pattern {
+            // scatter (4/10)
+            0..=3 => Op::Insert(
+                xorshift(&mut rng) % 100_000,
+                (xorshift(&mut rng) % 60) as u8,
+            ),
+            // cluster (3/10): a narrow band around a per-seed anchor
+            4..=6 => {
+                let anchor = ((seed as u32) * 7919) % 90_000;
+                Op::Insert(
+                    anchor + xorshift(&mut rng) % 64,
+                    (xorshift(&mut rng) % 60) as u8,
+                )
+            }
+            // churn (2/10): rewrite or delete a recent key
+            7 | 8 if !live.is_empty() => {
+                let victim = live[(xorshift(&mut rng) as usize) % live.len()];
+                if xorshift(&mut rng).is_multiple_of(2) {
+                    Op::Delete(victim)
+                } else {
+                    Op::Insert(victim, (xorshift(&mut rng) % 60) as u8)
+                }
+            }
+            // min-churn (1/10): delete the smallest live key
+            9 if !live.is_empty() => Op::Delete(*live.iter().min().expect("non-empty")),
+            _ => Op::Insert(xorshift(&mut rng) % 100_000, 1),
+        };
+        match op {
+            Op::Insert(key, _) => {
+                if !live.contains(&key) {
+                    live.push(key);
+                }
+            }
+            Op::Delete(key) => live.retain(|held| *held != key),
+        }
+        ops.push(op);
+    }
+    let checkpoints = vec![op_count / 3, (op_count * 2) / 3, op_count];
+    Program { ops, checkpoints }
+}
+
+async fn settle(delta: &mut Delta<Blake3Hash, Buffer>, storage: &mut Store) -> Result<()> {
+    for (_, buffer) in delta.flush() {
+        storage
+            .store(buffer.as_ref().to_vec(), buffer.blake3_hash())
+            .await?;
+    }
+    Ok(())
+}
+
+/// What one executor reports at a checkpoint: the canonical root, checked
+/// clean by the canonical-form validator before being compared.
+async fn checkpoint_root(tree: &Tree, storage: &Store, label: &str) -> Result<Blake3Hash> {
+    let divergences = tree.canonical_divergences(storage).await?;
+    assert_eq!(
+        divergences,
+        Vec::<String>::new(),
+        "{label}: canonical-form validation failed"
+    );
+    Ok(tree.root().clone())
+}
+
+/// Canonical sequential edits: persist + settle every op.
+async fn run_canonical(program: &Program) -> Result<Vec<Blake3Hash>> {
+    let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+    let mut tree = Tree::empty();
+    let mut roots = Vec::new();
+    for (at, op) in program.ops.iter().enumerate() {
+        let mut delta = Delta::zero();
+        let edit = tree.edit();
+        tree = match *op {
+            Op::Insert(key, len) => {
+                edit.insert(
+                    key.to_be_bytes(),
+                    vec![key as u8; len as usize + 1],
+                    &storage,
+                )
+                .await?
+            }
+            Op::Delete(key) => edit.delete(&key.to_be_bytes(), &storage).await?,
+        }
+        .persist(&mut delta)?;
+        settle(&mut delta, &mut storage).await?;
+        if program.checkpoints.contains(&(at + 1)) {
+            roots.push(checkpoint_root(&tree, &storage, "canonical").await?);
+        }
+    }
+    Ok(roots)
+}
+
+/// Buffered writes with the given op buffer, persisting + reopening every
+/// `persist_every` ops (the commit-shaped lifecycle), canonicalizing at
+/// checkpoints and continuing from the canonical tree.
+async fn run_buffered(
+    program: &Program,
+    op_buf: Option<usize>,
+    persist_every: usize,
+) -> Result<Vec<Blake3Hash>> {
+    let mut storage: Store = ContentAddressedStorage::new(MemoryStorageBackend::default());
+    let mut tree = Tree::empty();
+    let mut roots = Vec::new();
+    let open = |tree: &Tree, op_buf: Option<usize>| {
+        let buffered = HitchhikerTree::open(tree);
+        match op_buf {
+            Some(size) => buffered.with_op_buf_size(size),
+            None => buffered,
+        }
+    };
+    let mut buffered = open(&tree, op_buf);
+    for (at, op) in program.ops.iter().enumerate() {
+        buffered = match *op {
+            Op::Insert(key, len) => {
+                buffered
+                    .insert(
+                        key.to_be_bytes(),
+                        vec![key as u8; len as usize + 1],
+                        &storage,
+                    )
+                    .await?
+            }
+            Op::Delete(key) => buffered.delete(key.to_be_bytes(), &storage).await?,
+        };
+        let done = at + 1;
+        if program.checkpoints.contains(&done) {
+            // Canonicalize, check, and continue from the canonical tree —
+            // a legitimate lifecycle, and the only point the property
+            // makes a claim about.
+            let mut delta = Delta::zero();
+            tree = buffered.canonicalize(&storage, &mut delta).await?;
+            settle(&mut delta, &mut storage).await?;
+            roots.push(
+                checkpoint_root(&tree, &storage, &format!("buffered(buf {op_buf:?})")).await?,
+            );
+            buffered = open(&tree, op_buf);
+        } else if done.is_multiple_of(persist_every) {
+            // Publish the buffered form and reopen over it: the persisted
+            // spine round-trip every real commit performs.
+            let mut delta = Delta::zero();
+            let root = buffered.persist(&mut delta)?;
+            settle(&mut delta, &mut storage).await?;
+            tree = Tree::from_hash_with_cache(root, Default::default());
+            buffered = open(&tree, op_buf);
+        }
+    }
+    Ok(roots)
+}
+
+/// Every executor surface must produce the same canonical root at every
+/// checkpoint, and every checkpoint tree must be THE canonical tree.
+#[tokio::test]
+async fn it_converges_across_executor_surfaces() -> Result<()> {
+    let op_count: usize = std::env::var("DIALOG_PROGRAM_OPS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(240);
+    for seed in 0..4u64 {
+        let program = generate(seed, op_count);
+
+        let canonical = run_canonical(&program).await?;
+        let tiny = run_buffered(&program, Some(4), 13).await?;
+        let medium = run_buffered(&program, Some(32), 7).await?;
+        let default_buf = run_buffered(&program, None, 50).await?;
+
+        for (arm, roots) in [
+            ("buffered(4)/persist-13", &tiny),
+            ("buffered(32)/persist-7", &medium),
+            ("buffered(default)/persist-50", &default_buf),
+        ] {
+            assert_eq!(
+                roots, &canonical,
+                "seed {seed}: {arm} diverged from canonical sequential edits"
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Distills the search-tree engine wins from the performance campaign into the lowest layer of the stack. The whole workspace builds with only this PR applied, so it can be reviewed and measured in isolation.

## What changes

- **Amortized flushing** — deferred inserts accumulate in a byte-capped novelty buffer and settle in bulk, instead of reshaping the tree on every write.
- **Compressed quiet-check node shaping** — the run/quiet split that decides node boundaries now works over a compressed summary of the incoming piece set.
- **Bulk plant** — a batch of ops plants the spine bottom-up in one pass.
- **Slot-tracked reads** — the walker carries pending winners per leaf and merges them, avoiding redundant re-reads on the read path.
- **Memoized decoded keys** — persistent nodes cache their decoded key arena (`DecodedKeys` with `lower_bound` / `binary_search`) so repeated lookups don't re-parse.
- **Node validity as a construction invariant** — `PersistentNode` is built only through `TryFrom<Buffer>` (validates untrusted bytes) or `TryFrom<&PersistentNodeBody>` (serializes typed, valid-by-construction data), so `body()` is infallible and the validation proof rides the type rather than a runtime marker.
- **Validation harness + property suites** — `validate.rs` plus `tests/adversarial.rs` and `tests/program.rs` pin tree-shape convergence.

## Measurement

Criterion A/B, this branch vs `main`, on a quiesced machine (load average low single digits, both sides pre-built, measured back to back). Every row below is `p < 0.05` with a 95% confidence interval; negative = faster.

**Point lookups (`get`)** collapse, and this also clears the large-tree point-lookup regression that #399's 64 KiB leaves had introduced on `main`:

| size | change | 95% CI |
| --- | --- | --- |
| 10 | -43.3% | [-43.7%, -42.9%] |
| 100 | -81.2% | [-81.3%, -81.1%] |
| 1000 | -65.5% | [-65.8%, -65.2%] |
| 10000 | **-97.7%** | [-97.7%, -97.7%] |

**Writes at scale** (the 10 000-row cases, across sequential / random / batched / mixed):

| bench | change | 95% CI |
| --- | --- | --- |
| insert_sequential/10000 | -44.3% | [-44.7%, -44.0%] |
| insert_random/10000 | -54.7% | [-55.0%, -54.4%] |
| insert_batch/sequential/10000 | -53.7% | [-53.9%, -53.4%] |
| insert_batch/batched/10000 | **-92.5%** | [-92.7%, -92.4%] |
| mixed_batch/sequential/10000 | -68.1% | [-68.2%, -67.9%] |
| mixed_batch/batched/10000 | **-96.5%** | [-96.6%, -96.5%] |

**Small-batch tradeoff.** The only regressions are tiny sequential batches below the amortization threshold, where the byte-capped buffer's bookkeeping does not yet pay for itself: `insert_batch/sequential/100` +1.9% [+1.4%, +2.3%], `/1000` +3.9% [+3.3%, +4.6%], `mixed_batch/sequential/100` +1.3% [+0.6%, +1.9%]. Sub-4%, and the same paths turn into 44-96% wins by size 10 000.

Full table across all sizes (get, insert_sequential, insert_random, insert_batch, mixed_batch) confirms the shape: micro-overhead on tiny sequential ops, large wins at scale and on the read path.

This PR is the base of a three-PR stack; the artifacts/query/repository migration and the dev-baseline measurement crate build on top.