### PR TITLE
fix: appease rust 1.97 clippy

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -1142,13 +1142,10 @@ mod tests {
             cause: None,
         };
         let after_root = facts
-            .commit(
-                vec![
-                    Instruction::Assert(transient.clone()),
-                    Instruction::Retract(transient.clone()),
-                ]
-                .into_iter(),
-            )
+            .commit(vec![
+                Instruction::Assert(transient.clone()),
+                Instruction::Retract(transient.clone()),
+            ])
             .await?;
 
         // No tree churn: the novel fact left no key at all.

--- a/rust/dialog-artifacts/src/artifacts/artifact.rs
+++ b/rust/dialog-artifacts/src/artifacts/artifact.rs
@@ -59,7 +59,7 @@ impl Debug for Artifact {
 impl Display for Artifact {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let attribute = self.the.to_string();
-        let entity = format!("{}", &self.of);
+        let entity = format!("{}", self.of);
         let value = self.is.to_utf8();
 
         write!(f, "Artifact: the '{attribute}' of '{entity}' is '{value}'")

--- a/rust/dialog-common/src/helpers.rs
+++ b/rust/dialog-common/src/helpers.rs
@@ -393,6 +393,7 @@ mod tests {
     /// Settings for the server
     #[cfg(not(target_arch = "wasm32"))]
     #[derive(Debug, Clone, Default)]
+    #[allow(unused)]
     pub struct ServerSettings {
         pub port: u16,
     }

--- a/rust/dialog-remote-s3/src/request/memory.rs
+++ b/rust/dialog-remote-s3/src/request/memory.rs
@@ -73,8 +73,8 @@ impl From<&Capability<PublishAttenuation>> for S3Request {
             path: format!(
                 "{}/{}/{}",
                 capability.subject(),
-                &Space::of(capability).space,
-                &Cell::of(capability).cell
+                Space::of(capability).space,
+                Cell::of(capability).cell
             ),
             checksum: Some(publish.checksum.clone()),
             precondition: publish.when.as_ref().into(),

--- a/rust/dialog-search-tree/src/tree/transient.rs
+++ b/rust/dialog-search-tree/src/tree/transient.rs
@@ -6125,7 +6125,7 @@ mod tests {
     /// of 15 near-duplicate keys sharing a 24-byte cluster prefix.
     fn semantic_cluster() -> Vec<VarKey> {
         let mut keys = Vec::new();
-        for sub in [b'A', b'B', b'C'] {
+        for sub in *b"ABC" {
             for n in 0..15u32 {
                 let mut bytes = vec![b'W'];
                 bytes.extend(vec![b'q'; 23]);

--- a/rust/dialog-search-tree/src/tree/transient.rs
+++ b/rust/dialog-search-tree/src/tree/transient.rs
@@ -2665,10 +2665,7 @@ where
     // Strip a non-canonical chain of single-child index nodes over indices. A
     // persistent single child is lifted first: its kind (index or segment)
     // decides whether the wrapper above it is canonical.
-    loop {
-        let TransientNode::Index(index) = &mut root else {
-            break;
-        };
+    while let TransientNode::Index(index) = &mut root {
         if index.children.len() != 1 {
             break;
         }

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -754,7 +754,7 @@ mod walker_novelty_tests {
             expected.push((key, value));
 
             // Every write so far must be readable, by scan and by point read.
-            expected.sort_by(|(a, _), (b, _)| a.cmp(b));
+            expected.sort_by_key(|(a, _)| *a);
             let mut seen = Vec::new();
             {
                 let stream = tree.stream_range(.., &storage);

--- a/rust/dialog-ucan-core/src/delegation/store.rs
+++ b/rust/dialog-ucan-core/src/delegation/store.rs
@@ -130,7 +130,7 @@ impl<S: Signature, H: BuildHasher> DelegationStore<Local, S, Arc<Delegation<S>>>
                 if let Some(dlg) = locked.get(c) {
                     dlgs.push(dlg.clone());
                 } else {
-                    return Err(Missing(*c))?;
+                    Err(Missing(*c))?;
                 }
             }
             Ok(dlgs)
@@ -174,7 +174,7 @@ where
                 if let Some(dlg) = locked.get(c) {
                     dlgs.push(dlg.clone());
                 } else {
-                    return Err(Missing(*c))?;
+                    Err(Missing(*c))?;
                 }
             }
             Ok(dlgs)


### PR DESCRIPTION
Mechanical lint fixes for the rust 1.97 clippy pass, split out of two feature branches (tree inspection and ordered relations) that were each carrying them as duplicated patches, so both can rebase onto main cleanly. No behavior changes.

- `needless_return_with_question_mark` in the delegation store's `get_all`
- `useless_borrows_in_formatting` and `while_let_loop` in dialog-remote-s3 and dialog-search-tree
- `useless_borrows_in_formatting`, `byte_char_slices`, `unnecessary_sort_by`, and a test-only `dead_code` allow across test targets
- redundant `into_iter` at a `commit` call that already accepts `IntoIterator`
