### PR TITLE
feat(dialog-repository): retract blobs from the index

### DIFF
--- a/rust/dialog-artifacts/src/blob_index.rs
+++ b/rust/dialog-artifacts/src/blob_index.rs
@@ -174,6 +174,27 @@ pub trait BlobIndexExt {
             + Clone
             + ConditionalSync;
 
+    /// Retract a blob reference from the index.
+    ///
+    /// Writes a tombstone ([`State::Removed`]) at the blob's key rather than
+    /// deleting the entry, so the removal replicates and merges like a fact
+    /// retraction instead of being resurrected by a union with an older tree.
+    /// The blob's bytes are not touched; reclaiming bytes no index references
+    /// is a separate, local concern.
+    ///
+    /// Idempotent: retracting an unreferenced hash writes the same tombstone.
+    /// A later [`put_blob`](BlobIndexExt::put_blob) re-references the blob.
+    async fn retract_blob<S>(
+        &mut self,
+        store: &mut S,
+        delta: &mut Delta<NodeHash, Buffer>,
+        hash: &Blake3Hash,
+    ) -> Result<(), DialogArtifactsError>
+    where
+        S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync;
+
     /// Look up a blob's record, or `None` if it is not in the index.
     async fn get_blob<S>(
         &self,
@@ -232,6 +253,24 @@ impl BlobIndexExt for ArtifactTree {
             .edit()
             .insert(key, record.into_state(), &storage)
             .await?;
+        *self = transient.persist(delta)?;
+        Ok(())
+    }
+
+    async fn retract_blob<S>(
+        &mut self,
+        store: &mut S,
+        delta: &mut Delta<NodeHash, Buffer>,
+        hash: &Blake3Hash,
+    ) -> Result<(), DialogArtifactsError>
+    where
+        S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync,
+    {
+        let storage = ContentAddressedStorage::new(TreeStorageBridge(store.clone()));
+        let key = BlobKey::new(hash).into_key();
+        let transient = self.edit().insert(key, State::Removed, &storage).await?;
         *self = transient.persist(delta)?;
         Ok(())
     }
@@ -349,6 +388,151 @@ mod tests {
                 (hash(3), BlobRecord::new(3)),
             ]
         );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_retracts_a_blob_reference() -> Result<(), DialogArtifactsError> {
+        let mut store = MemoryStorageBackend::<Blake3Hash, Vec<u8>>::default();
+        let mut delta = Delta::zero();
+        let mut tree = ArtifactTree::empty();
+
+        for seed in [1u8, 2] {
+            tree.put_blob(
+                &mut store,
+                &mut delta,
+                &hash(seed),
+                BlobRecord::new(seed as u64),
+            )
+            .await?;
+            for (_, buffer) in delta.flush() {
+                store
+                    .set(*buffer.blake3_hash().as_bytes(), buffer.as_ref().to_vec())
+                    .await?;
+            }
+        }
+
+        tree.retract_blob(&mut store, &mut delta, &hash(1)).await?;
+        for (_, buffer) in delta.flush() {
+            store
+                .set(*buffer.blake3_hash().as_bytes(), buffer.as_ref().to_vec())
+                .await?;
+        }
+
+        assert_eq!(tree.get_blob(&store, &hash(1)).await?, None);
+        assert!(!tree.has_blob(&store, &hash(1)).await?);
+
+        // The other reference is untouched, and listing skips the tombstone.
+        assert_eq!(
+            tree.get_blob(&store, &hash(2)).await?,
+            Some(BlobRecord::new(2))
+        );
+        let listed: Vec<_> = tree.list_blobs(store).try_collect().await?;
+        assert_eq!(listed, vec![(hash(2), BlobRecord::new(2))]);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_re_references_a_blob_after_retraction() -> Result<(), DialogArtifactsError> {
+        let mut store = MemoryStorageBackend::<Blake3Hash, Vec<u8>>::default();
+        let mut delta = Delta::zero();
+        let mut tree = ArtifactTree::empty();
+
+        let flush = |store: &mut MemoryStorageBackend<Blake3Hash, Vec<u8>>,
+                     delta: &mut Delta<NodeHash, Buffer>| {
+            let buffers: Vec<_> = delta.flush().collect();
+            let mut store = store.clone();
+            async move {
+                for (_, buffer) in buffers {
+                    store
+                        .set(*buffer.blake3_hash().as_bytes(), buffer.as_ref().to_vec())
+                        .await?;
+                }
+                Ok::<_, DialogArtifactsError>(())
+            }
+        };
+
+        tree.put_blob(&mut store, &mut delta, &hash(1), BlobRecord::new(10))
+            .await?;
+        flush(&mut store, &mut delta).await?;
+        tree.retract_blob(&mut store, &mut delta, &hash(1)).await?;
+        flush(&mut store, &mut delta).await?;
+        tree.put_blob(&mut store, &mut delta, &hash(1), BlobRecord::new(10))
+            .await?;
+        flush(&mut store, &mut delta).await?;
+
+        assert_eq!(
+            tree.get_blob(&store, &hash(1)).await?,
+            Some(BlobRecord::new(10))
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_surfaces_a_retraction_as_removed_in_the_differential()
+    -> Result<(), DialogArtifactsError> {
+        let mut store = MemoryStorageBackend::<Blake3Hash, Vec<u8>>::default();
+        let mut delta = Delta::zero();
+
+        let flush = |store: &mut MemoryStorageBackend<Blake3Hash, Vec<u8>>,
+                     delta: &mut Delta<NodeHash, Buffer>| {
+            let buffers: Vec<_> = delta.flush().collect();
+            let mut store = store.clone();
+            async move {
+                for (_, buffer) in buffers {
+                    store
+                        .set(*buffer.blake3_hash().as_bytes(), buffer.as_ref().to_vec())
+                        .await?;
+                }
+                Ok::<_, DialogArtifactsError>(())
+            }
+        };
+
+        let mut checkpoint = ArtifactTree::empty();
+        checkpoint
+            .put_blob(&mut store, &mut delta, &hash(1), BlobRecord::new(10))
+            .await?;
+        flush(&mut store, &mut delta).await?;
+
+        let mut current = checkpoint.clone();
+        current
+            .retract_blob(&mut store, &mut delta, &hash(1))
+            .await?;
+        flush(&mut store, &mut delta).await?;
+
+        let changes: Vec<_> = blob_changes(checkpoint, current, store)
+            .try_collect()
+            .await?;
+        assert_eq!(changes, vec![BlobChange::Removed(hash(1))]);
+        Ok(())
+    }
+
+    /// Retracting a hash the index never referenced writes a tombstone and
+    /// stays a no-op for readers and for shipment: the differential's added
+    /// tombstone decodes to `None`, which `shipment_ref` classifies as
+    /// nothing to ship.
+    #[dialog_common::test]
+    async fn it_ships_nothing_for_a_retraction_of_an_unreferenced_blob()
+    -> Result<(), DialogArtifactsError> {
+        let mut store = MemoryStorageBackend::<Blake3Hash, Vec<u8>>::default();
+        let mut delta = Delta::zero();
+
+        let checkpoint = ArtifactTree::empty();
+        let mut current = checkpoint.clone();
+        current
+            .retract_blob(&mut store, &mut delta, &hash(9))
+            .await?;
+        for (_, buffer) in delta.flush() {
+            store
+                .set(*buffer.blake3_hash().as_bytes(), buffer.as_ref().to_vec())
+                .await?;
+        }
+
+        assert_eq!(current.get_blob(&store, &hash(9)).await?, None);
+        let changes: Vec<_> = blob_changes(checkpoint, current, store)
+            .try_collect()
+            .await?;
+        assert!(changes.is_empty(), "nothing to un-ship: {changes:?}");
         Ok(())
     }
 

--- a/rust/dialog-repository/src/repository/branch/blob.rs
+++ b/rust/dialog-repository/src/repository/branch/blob.rs
@@ -55,6 +55,10 @@
 //! // write: stream chunks in, get the blob's entity back (recorded in the
 //! // index so `push` replicates it)
 //! let entity = Blob::import(chunks).write(branch.into()).perform(env).await?;
+//!
+//! // retract: drop the index reference (the removal replicates like any
+//! // commit); the bytes stay in the blob store
+//! Blob::from(entity).retract(branch.into()).perform(env).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -149,6 +153,14 @@ impl Blob {
     /// Look up the blob's size from `archive`'s index, without fetching bytes.
     pub fn size<'a>(self, archive: BlobArchive<'a>) -> BlobSize<'a> {
         BlobSize {
+            archive,
+            entity: self.entity,
+        }
+    }
+
+    /// Retract the blob from `archive`'s index, without touching its bytes.
+    pub fn retract<'a>(self, archive: BlobArchive<'a>) -> RetractBlob<'a> {
+        RetractBlob {
             archive,
             entity: self.entity,
         }
@@ -401,126 +413,226 @@ where
         }
         let hash = sink.finish().await?;
 
-        // 2. Record the blob in the index. Mirror `commit`: checkpoint the head
-        //    so the publish below CAS's against it, walk from the current tree
-        //    root (or the empty tree), put the record, flush the new nodes, then
-        //    publish the advanced revision.
-        let head = branch.revision.checkpoint();
-        let base_revision = branch.revision();
-
-        // Same remote-fallback selection as `commit`: the first remote among
-        // ALL tracked upstreams, not only a remote default — a branch whose
-        // default upstream is local but which tracks a remote must still be
-        // able to hydrate blocks it holds by reference.
-        let upstreams = branch.upstreams();
-        let remote = match upstreams.remote_name() {
-            Some(name) => branch
-                .subject()
-                .remote(name.to_string())
-                .load()
-                .perform(env)
-                .await
-                .ok(),
-            None => None,
-        };
-        let mut store = NetworkedIndex::new(env, branch.archive().index(), remote);
-
-        let base_tree_hash = base_revision
-            .as_ref()
-            .map(|rev| *rev.tree.hash())
-            .unwrap_or(EMPTY_TREE_HASH);
-        let mut tree = Index::from_hash(NodeHash::from(base_tree_hash));
-
-        let mut delta = Delta::zero();
+        // 2. Record the blob in the index and advance the head.
         let index_hash: dialog_storage::Blake3Hash = *hash.as_bytes();
-        tree.put_blob(&mut store, &mut delta, &index_hash, BlobRecord::new(size))
-            .await?;
-
-        // A blob write advances the branch like any commit, so its revision
-        // gets the full version-control treatment: a DAG edge and skip table
-        // in a signed revision record, and an issuer-signed head — otherwise
-        // the published head would fail pull-side verification and leave a
-        // hole in the ancestry walk.
-        let authority = Identify.perform(env).await?;
-        let issuer = authority.did();
-        let profile = authority.profile().clone();
-
-        let parent = base_revision.as_ref().map(Revision::version);
-        let skips = match &parent {
-            Some(parent) => {
-                let history = TreeHistory::from_root_with_cache(
-                    &base_tree_hash,
-                    store.clone(),
-                    branch.node_cache(),
-                )
-                .with_record_cache(branch.records());
-                extend_skips(&history, parent).await?
-            }
-            None => Vec::new(),
-        };
-        let base_context = base_revision.as_ref().and_then(|base| base.context.clone());
-        let branch_entity = crate::branch_of(branch.of(), &profile, branch.name());
-        let mut revision = match base_revision {
-            Some(base) => base.advance(TreeReference::default(), branch_entity.clone(), issuer),
-            None => Revision::new(TreeReference::default(), branch_entity.clone(), issuer),
-        };
-        let mut record = revision.record(&profile, parent.into_iter().collect(), skips);
-        record.signature = Attest::new(record.payload()?).perform(env).await?;
-        // The record's key carries its value through the tree's own
-        // inline-vs-spill threshold, so read it off the tree rather than
-        // assuming the default.
-        let manifest = tree.format_manifest(store.clone(), &delta).await?;
-        tree.record(&mut store, &mut delta, record.entries(&manifest)?)
-            .await?;
-
-        // Persist the tree's pending nodes before referencing the root in a
-        // revision; a revision must only point at durable blocks.
-        branch
-            .archive()
-            .index()
-            .import(delta.flush().map(|(_, buffer)| buffer))
-            .perform(env)
-            .await
-            .map_err(DialogArtifactsError::from)?;
-
-        // The new head's causal context: the parent's plus this write's
-        // own version, exactly as `Commit` derives it — a blob write
-        // advances the head like any commit and publishes its watermark
-        // the same way.
-        let contexts = branch.contexts();
-        let minted = revision.version();
-        let context = {
-            let mut context = match (&parent, base_context) {
-                (None, _) => Context::new(),
-                (Some(_), Some(context)) => context,
-                (Some(parent), None) => match contexts.cached(parent).await {
-                    Some(context) => context,
-                    None => {
-                        let history = TreeHistory::from_root_with_cache(
-                            &base_tree_hash,
-                            store.clone(),
-                            branch.node_cache(),
-                        )
-                        .with_record_cache(branch.records());
-                        context_of(parent, &history).await?
-                    }
-                },
-            };
-            context.record(minted);
-            context
-        };
-
-        revision.tree = TreeReference::from(*tree.root().as_bytes());
-        revision.context = Some(context.clone());
-        revision.signature = Attest::new(revision.payload()).perform(env).await?;
-
-        head.publish(revision, env).await?;
-
-        // Advance the branch memo so later pulls through this handle
-        // answer the context from memory.
-        contexts.insert(minted, context);
+        advance_blob_index(
+            branch,
+            env,
+            BlobIndexEdit::Put {
+                hash: index_hash,
+                record: BlobRecord::new(size),
+            },
+        )
+        .await?;
 
         Ok(Entity::from_blob(&index_hash)?)
+    }
+}
+
+/// The single blob-index edit [`advance_blob_index`] applies while minting a
+/// revision.
+enum BlobIndexEdit {
+    /// Record a blob reference (see [`WriteBlob`]).
+    Put {
+        hash: dialog_storage::Blake3Hash,
+        record: BlobRecord,
+    },
+    /// Tombstone a blob reference (see [`RetractBlob`]).
+    Retract { hash: dialog_storage::Blake3Hash },
+}
+
+/// Apply one blob-index edit as a new revision. Mirrors `commit`: checkpoint
+/// the head so the publish CAS's against it, walk from the current tree root
+/// (or the empty tree), apply the edit, flush the new nodes, then publish the
+/// advanced revision with the full version-control treatment (signed record,
+/// skip table, causal context).
+async fn advance_blob_index<Env>(
+    branch: &Branch,
+    env: &Env,
+    edit: BlobIndexEdit,
+) -> Result<(), CommitError>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Import>
+        + Provider<Resolve>
+        + Provider<Publish>
+        + Provider<Identify>
+        + Provider<Attest>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let head = branch.revision.checkpoint();
+    let base_revision = branch.revision();
+
+    // Same remote-fallback selection as `commit`: the first remote among
+    // ALL tracked upstreams, not only a remote default — a branch whose
+    // default upstream is local but which tracks a remote must still be
+    // able to hydrate blocks it holds by reference.
+    let upstreams = branch.upstreams();
+    let remote = match upstreams.remote_name() {
+        Some(name) => branch
+            .subject()
+            .remote(name.to_string())
+            .load()
+            .perform(env)
+            .await
+            .ok(),
+        None => None,
+    };
+    let mut store = NetworkedIndex::new(env, branch.archive().index(), remote);
+
+    let base_tree_hash = base_revision
+        .as_ref()
+        .map(|rev| *rev.tree.hash())
+        .unwrap_or(EMPTY_TREE_HASH);
+    let mut tree = Index::from_hash(NodeHash::from(base_tree_hash));
+
+    let mut delta = Delta::zero();
+    match &edit {
+        BlobIndexEdit::Put { hash, record } => {
+            tree.put_blob(&mut store, &mut delta, hash, *record).await?;
+        }
+        BlobIndexEdit::Retract { hash } => {
+            tree.retract_blob(&mut store, &mut delta, hash).await?;
+        }
+    }
+
+    // A blob-index edit advances the branch like any commit, so its
+    // revision gets the full version-control treatment: a DAG edge and
+    // skip table in a signed revision record, and an issuer-signed head —
+    // otherwise the published head would fail pull-side verification and
+    // leave a hole in the ancestry walk.
+    let authority = Identify.perform(env).await?;
+    let issuer = authority.did();
+    let profile = authority.profile().clone();
+
+    let parent = base_revision.as_ref().map(Revision::version);
+    let skips = match &parent {
+        Some(parent) => {
+            let history = TreeHistory::from_root_with_cache(
+                &base_tree_hash,
+                store.clone(),
+                branch.node_cache(),
+            )
+            .with_record_cache(branch.records());
+            extend_skips(&history, parent).await?
+        }
+        None => Vec::new(),
+    };
+    let base_context = base_revision.as_ref().and_then(|base| base.context.clone());
+    let branch_entity = crate::branch_of(branch.of(), &profile, branch.name());
+    let mut revision = match base_revision {
+        Some(base) => base.advance(TreeReference::default(), branch_entity.clone(), issuer),
+        None => Revision::new(TreeReference::default(), branch_entity.clone(), issuer),
+    };
+    let mut record = revision.record(&profile, parent.into_iter().collect(), skips);
+    record.signature = Attest::new(record.payload()?).perform(env).await?;
+    // The record's key carries its value through the tree's own
+    // inline-vs-spill threshold, so read it off the tree rather than
+    // assuming the default.
+    let manifest = tree.format_manifest(store.clone(), &delta).await?;
+    tree.record(&mut store, &mut delta, record.entries(&manifest)?)
+        .await?;
+
+    // Persist the tree's pending nodes before referencing the root in a
+    // revision; a revision must only point at durable blocks.
+    branch
+        .archive()
+        .index()
+        .import(delta.flush().map(|(_, buffer)| buffer))
+        .perform(env)
+        .await
+        .map_err(DialogArtifactsError::from)?;
+
+    // The new head's causal context: the parent's plus this write's
+    // own version, exactly as `Commit` derives it — a blob write
+    // advances the head like any commit and publishes its watermark
+    // the same way.
+    let contexts = branch.contexts();
+    let minted = revision.version();
+    let context = {
+        let mut context = match (&parent, base_context) {
+            (None, _) => Context::new(),
+            (Some(_), Some(context)) => context,
+            (Some(parent), None) => match contexts.cached(parent).await {
+                Some(context) => context,
+                None => {
+                    let history = TreeHistory::from_root_with_cache(
+                        &base_tree_hash,
+                        store.clone(),
+                        branch.node_cache(),
+                    )
+                    .with_record_cache(branch.records());
+                    context_of(parent, &history).await?
+                }
+            },
+        };
+        context.record(minted);
+        context
+    };
+
+    revision.tree = TreeReference::from(*tree.root().as_bytes());
+    revision.context = Some(context.clone());
+    revision.signature = Attest::new(revision.payload()).perform(env).await?;
+
+    head.publish(revision, env).await?;
+
+    // Advance the branch memo so later pulls through this handle
+    // answer the context from memory.
+    contexts.insert(minted, context);
+
+    Ok(())
+}
+
+/// Retract a blob's index reference as one new revision. Created by
+/// [`Blob::retract`].
+///
+/// Removes the blob from the index only: the bytes stay in the blob store,
+/// so a replica that already holds them can still read them locally.
+/// Reclaiming bytes no index references is a separate, local concern. The
+/// removal travels with the tree like any commit, so replicas that pull it
+/// stop referencing the blob and can no longer hydrate it from a remote.
+pub struct RetractBlob<'a> {
+    archive: BlobArchive<'a>,
+    entity: Entity,
+}
+
+impl RetractBlob<'_> {
+    /// Execute the retraction.
+    ///
+    /// Idempotent at the branch level: when the index does not reference the
+    /// blob (never written, or already retracted), this is a no-op that mints
+    /// no revision.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.archive.branch;
+        let hash = blob_hash(&self.entity)?;
+        if index_size(branch, &hash, env).await?.is_none() {
+            return Ok(());
+        }
+        advance_blob_index(
+            branch,
+            env,
+            BlobIndexEdit::Retract {
+                hash: *hash.as_bytes(),
+            },
+        )
+        .await
     }
 }
 
@@ -605,6 +717,79 @@ mod tests {
             .perform(&operator)
             .await?;
         assert_eq!(drain(reader).await, payload[10..19]);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_retracts_a_blob_from_the_index_but_not_the_store() -> Result<()> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name("blob-retract"))
+            .perform(&storage)
+            .await?;
+        let operator = profile
+            .derive(b"test")
+            .allow(Subject::any())
+            .network(Network::default())
+            .build(storage)
+            .await?;
+        let repo = profile
+            .repository(unique_name("repo"))
+            .open()
+            .perform(&operator)
+            .await?;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let payload: Vec<u8> = (0..10_000u32).map(|i| (i % 251) as u8).collect();
+        let chunks: Vec<Result<Vec<u8>, BlobError>> =
+            payload.chunks(4096).map(|c| Ok(c.to_vec())).collect();
+        let entity = Blob::import(stream::iter(chunks))
+            .write((&branch).into())
+            .perform(&operator)
+            .await?;
+
+        Blob::from(entity.clone())
+            .retract((&branch).into())
+            .perform(&operator)
+            .await?;
+
+        // The index no longer references the blob...
+        assert_eq!(
+            Blob::from(entity.clone())
+                .size((&branch).into())
+                .perform(&operator)
+                .await?,
+            None
+        );
+
+        // ...but the bytes were not touched: a local read still serves them.
+        let reader = Blob::from(entity.clone())
+            .read((&branch).into())
+            .perform(&operator)
+            .await?;
+        assert_eq!(drain(reader).await, payload);
+
+        // Retracting again is a no-op, not an error.
+        Blob::from(entity.clone())
+            .retract((&branch).into())
+            .perform(&operator)
+            .await?;
+
+        // Re-importing the same bytes re-references the blob.
+        let chunks: Vec<Result<Vec<u8>, BlobError>> =
+            payload.chunks(4096).map(|c| Ok(c.to_vec())).collect();
+        let again = Blob::import(stream::iter(chunks))
+            .write((&branch).into())
+            .perform(&operator)
+            .await?;
+        assert_eq!(again, entity);
+        assert_eq!(
+            Blob::from(entity)
+                .size((&branch).into())
+                .perform(&operator)
+                .await?,
+            Some(payload.len() as u64)
+        );
 
         Ok(())
     }

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -281,6 +281,204 @@ async fn it_ships_blobs_on_push_and_hydrates_on_read(s3: S3Address) -> Result<()
     Ok(())
 }
 
+/// A blob retraction replicates on pull: the tombstoned index entry travels
+/// with the tree nodes, so a replica that pulls it stops referencing the
+/// blob (`size` answers `None`) and a replica that never hydrated the bytes
+/// can no longer fetch them from the remote. Bytes already held locally are
+/// untouched: retraction removes the reference, not the content, so a
+/// replica that hydrated before the retraction still reads its local copy.
+// Native only, feature-gated: same reasoning as
+// `it_ships_blobs_on_push_and_hydrates_on_read` above.
+#[cfg(not(feature = "web-integration-tests"))]
+#[dialog_common::test]
+async fn it_replicates_a_blob_retraction_on_pull(s3: S3Address) -> Result<()> {
+    // --- Site A: write a blob, push. ---
+    let storage_a = Storage::temp();
+    let profile_a = Profile::open(unique_name("blob-retract-a"))
+        .perform(&storage_a)
+        .await?;
+    let operator_a = profile_a
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage_a)
+        .await?;
+
+    let repo_a = profile_a
+        .repository(unique_name("blob-retract"))
+        .create()
+        .perform(&operator_a)
+        .await?;
+
+    let site_a = s3_site_address(&s3);
+    profile_a
+        .credential()
+        .site(&site_a)
+        .save(S3Credential::new(&s3.access_key_id, &s3.secret_access_key))
+        .perform(&operator_a)
+        .await?;
+
+    let origin_a = repo_a
+        .remote("origin")
+        .create(site_a)
+        .perform(&operator_a)
+        .await?;
+    let branch_a = repo_a.branch("main").open().perform(&operator_a).await?;
+    let remote_branch_a = origin_a.branch("main").open().perform(&operator_a).await?;
+    branch_a
+        .set_upstream(remote_branch_a)
+        .perform(&operator_a)
+        .await?;
+
+    let payload: Vec<u8> = (0..50_000u32).map(|i| (i % 199) as u8).collect();
+    let chunks: Vec<Result<Vec<u8>, BlobError>> =
+        payload.chunks(8192).map(|c| Ok(c.to_vec())).collect();
+    let blob = Blob::import(stream::iter(chunks))
+        .write((&branch_a).into())
+        .perform(&operator_a)
+        .await?;
+    assert!(branch_a.push().perform(&operator_a).await?.is_some());
+
+    // --- Site B: pull and hydrate the bytes while still referenced. ---
+    let storage_b = Storage::temp();
+    let profile_b = Profile::open(unique_name("blob-retract-b"))
+        .perform(&storage_b)
+        .await?;
+    let operator_b = profile_b
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage_b)
+        .await?;
+    let repo_b = profile_b
+        .repository(unique_name("blob-retract-b-repo"))
+        .open()
+        .perform(&operator_b)
+        .await?;
+    let site_b = s3_site_address(&s3);
+    profile_b
+        .credential()
+        .site(&site_b)
+        .save(S3Credential::new(&s3.access_key_id, &s3.secret_access_key))
+        .perform(&operator_b)
+        .await?;
+    let origin_b = repo_b
+        .remote("origin")
+        .create(site_b)
+        .subject(repo_a.did())
+        .perform(&operator_b)
+        .await?;
+    let branch_b = repo_b.branch("main").open().perform(&operator_b).await?;
+    let remote_branch_b = origin_b.branch("main").open().perform(&operator_b).await?;
+    branch_b
+        .set_upstream(remote_branch_b)
+        .perform(&operator_b)
+        .await?;
+
+    branch_b.pull().perform(&operator_b).await?;
+    let mut reader = Blob::from(blob.clone())
+        .read((&branch_b).into())
+        .perform(&operator_b)
+        .await?;
+    let mut out = Vec::new();
+    while let Some(chunk) = reader.next().await? {
+        out.extend(chunk);
+    }
+    assert_eq!(out, payload, "site B hydrates the bytes before retraction");
+
+    // --- Site A retracts the blob and pushes the retraction. ---
+    Blob::from(blob.clone())
+        .retract((&branch_a).into())
+        .perform(&operator_a)
+        .await?;
+    assert!(branch_a.push().perform(&operator_a).await?.is_some());
+
+    // --- Site B pulls the retraction: the reference is gone, the hydrated
+    // bytes are not. ---
+    branch_b.pull().perform(&operator_b).await?;
+    assert_eq!(
+        Blob::from(blob.clone())
+            .size((&branch_b).into())
+            .perform(&operator_b)
+            .await?,
+        None,
+        "a pulled retraction removes the index reference"
+    );
+    let mut reader = Blob::from(blob.clone())
+        .read((&branch_b).into())
+        .perform(&operator_b)
+        .await?;
+    let mut out = Vec::new();
+    while let Some(chunk) = reader.next().await? {
+        out.extend(chunk);
+    }
+    assert_eq!(
+        out, payload,
+        "locally hydrated bytes survive the retraction"
+    );
+
+    // --- Site C: fresh replica, pulls after the retraction; it can neither
+    // see the reference nor hydrate the bytes. ---
+    let storage_c = Storage::temp();
+    let profile_c = Profile::open(unique_name("blob-retract-c"))
+        .perform(&storage_c)
+        .await?;
+    let operator_c = profile_c
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage_c)
+        .await?;
+    let repo_c = profile_c
+        .repository(unique_name("blob-retract-c-repo"))
+        .open()
+        .perform(&operator_c)
+        .await?;
+    let site_c = s3_site_address(&s3);
+    profile_c
+        .credential()
+        .site(&site_c)
+        .save(S3Credential::new(&s3.access_key_id, &s3.secret_access_key))
+        .perform(&operator_c)
+        .await?;
+    let origin_c = repo_c
+        .remote("origin")
+        .create(site_c)
+        .subject(repo_a.did())
+        .perform(&operator_c)
+        .await?;
+    let branch_c = repo_c.branch("main").open().perform(&operator_c).await?;
+    let remote_branch_c = origin_c.branch("main").open().perform(&operator_c).await?;
+    branch_c
+        .set_upstream(remote_branch_c)
+        .perform(&operator_c)
+        .await?;
+
+    branch_c.pull().perform(&operator_c).await?;
+    assert_eq!(
+        Blob::from(blob.clone())
+            .size((&branch_c).into())
+            .perform(&operator_c)
+            .await?,
+        None,
+        "a fresh replica pulls no reference to the retracted blob"
+    );
+    let refused = Blob::from(blob)
+        .read((&branch_c).into())
+        .perform(&operator_c)
+        .await;
+    assert!(
+        matches!(
+            refused,
+            Err(crate::CommitError::Blob(BlobError::NotFound(_)))
+        ),
+        "an unreferenced blob cannot hydrate: {:?}",
+        refused.as_ref().err()
+    );
+
+    Ok(())
+}
+
 /// Push ships a spilling scalar value's block to the remote before publishing.
 ///
 /// A value larger than the tree's inline threshold does not travel in the key


### PR DESCRIPTION
Blob retraction removes a blob's index entry and leaves its bytes in the blob store. First slice of the [delegations-as-data](https://github.com/dialog-db/dialog-db/blob/feat/blob-retract/notes/delegations-as-data.md) direction, but useful on its own.

## Mechanism

The tag-4 index entry is the synced, authoritative statement that a blob belongs to the branch, so retraction is an ordinary tree edit: a `State::Removed` tombstone at the `BlobKey`, not a raw delete, so the removal replicates on push/pull and merges like a fact retraction instead of being resurrected by a union with an older tree. The shipment classifier already decoded a tombstoned blob entry as `BlobChange::Removed` (and ships nothing for it); this adds the writer it anticipated.

Reclaiming the now-unreferenced bytes is deliberately out of scope (the general GC problem). Retraction keeps the reference honest so a future sweep has correct information; replicas that already hydrated the bytes keep reading their local copy, and replicas that never did can no longer hydrate.

## Surface

- `BlobIndexExt::retract_blob(store, delta, hash)` in dialog-artifacts, same delta-accumulating contract as `put_blob`. Idempotent; a later `put_blob` re-references the blob.
- `Blob::from(entity).retract(branch.into()).perform(env)` in dialog-repository, minting one revision with the full version-control treatment (signed record, skip table, causal context). The revision-minting tail of `WriteBlob::perform` is factored into a shared `advance_blob_index` helper with a `Put`/`Retract` edit enum, so write and retract share one code path. Retracting an unreferenced blob is a no-op that mints no revision.

## Tests

Unit: retraction hides the entry from `get`/`has`/`list` while neighbors survive; re-put resurrects; the differential surfaces `Removed`; retracting a never-referenced hash ships nothing. Branch: size answers `None`, local bytes still readable, double retract is a no-op, re-import re-references. Integration (`it_replicates_a_blob_retraction_on_pull`): three sites over a shared S3 remote prove the retraction replicates, hydrated bytes survive, and a fresh replica can neither see nor hydrate the retracted blob.