### PR TITLE
feat(dialog-repository): retain delegations as data

### DIFF
--- a/rust/dialog-artifacts/src/blob_index.rs
+++ b/rust/dialog-artifacts/src/blob_index.rs
@@ -70,6 +70,20 @@ impl BlobRecord {
         })
     }
 
+    /// The tree entry recording this blob reference, for callers appending
+    /// machinery entries to an open batch (see `BufferedBatch::record`) rather
+    /// than editing the tree directly through
+    /// [`put_blob`](BlobIndexExt::put_blob).
+    pub fn entry(self, hash: &Blake3Hash) -> (crate::Key, State<Datum>) {
+        (BlobKey::new(hash).into_key(), self.into_state())
+    }
+
+    /// The tombstone entry retracting a blob reference, the batch-entry
+    /// counterpart of [`retract_blob`](BlobIndexExt::retract_blob).
+    pub fn retract_entry(hash: &Blake3Hash) -> (crate::Key, State<Datum>) {
+        (BlobKey::new(hash).into_key(), State::Removed)
+    }
+
     /// Decode a blob record from a tree value. `Removed` (a retracted entry)
     /// decodes to `None`.
     pub(crate) fn from_state(state: &State<Datum>) -> Result<Option<Self>, DialogArtifactsError> {

--- a/rust/dialog-artifacts/src/buffered.rs
+++ b/rust/dialog-artifacts/src/buffered.rs
@@ -42,7 +42,7 @@ use futures_util::Stream;
 use std::ops::RangeInclusive;
 
 use crate::history::Version;
-use crate::tree::{ArtifactTree, TreeStorageBridge, write_instructions};
+use crate::tree::{ArtifactTree, TreeStorageBridge, WriteScope, write_instructions};
 use crate::{Datum, DialogArtifactsError, Instruction, Key, State};
 
 /// The buffered counterpart of [`ArtifactTree`].
@@ -267,6 +267,7 @@ impl BufferedBatch {
         store: &mut S,
         version: Option<Version>,
         instructions: I,
+        scope: WriteScope,
     ) -> Result<Self, DialogArtifactsError>
     where
         S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
@@ -287,6 +288,7 @@ impl BufferedBatch {
             version,
             &manifest,
             instructions,
+            scope,
         )
         .await?;
         Ok(Self {
@@ -408,7 +410,8 @@ where
         + ConditionalSync,
     I: Stream<Item = Instruction> + ConditionalSend,
 {
-    let batch = BufferedBatch::apply(tree, store, version, instructions).await?;
+    let batch =
+        BufferedBatch::apply(tree, store, version, instructions, WriteScope::Application).await?;
     let changed = batch.changed();
     *tree = batch.seal(store, delta, canonicalize).await?;
     Ok(changed)
@@ -424,7 +427,7 @@ mod tests {
     use dialog_storage::{CborEncoder, MemoryStorageBackend, Storage, StorageBackend as _};
     use futures_util::stream;
 
-    use super::{BufferedBatch, apply_buffered};
+    use super::{BufferedBatch, WriteScope, apply_buffered};
     use crate::history::{Edition, Origin, Version};
     use crate::key::{FromKey as _, default_manifest};
     use crate::tree::{ArtifactTree, ArtifactTreeExt as _};
@@ -790,6 +793,7 @@ mod tests {
             &mut batch_store,
             Some(version()),
             stream::iter(data()),
+            WriteScope::Application,
         )
         .await?;
         assert!(batch.changed(), "the data writes change the indexes");
@@ -815,6 +819,7 @@ mod tests {
             &mut buffered_store,
             Some(version()),
             stream::iter(data()),
+            WriteScope::Application,
         )
         .await?;
         let batch = batch.record(&buffered_store, entries()).await?;

--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -773,9 +773,16 @@ impl ArtifactTreeExt for ArtifactTree {
         // Open one transient edit batch over this tree's spine and apply every
         // instruction's writes to it in flight, so the whole instruction stream
         // costs a single persist instead of one full tree rebuild per key.
-        let (transient, changed) =
-            write_instructions(transient, store, &storage, version, &manifest, instructions)
-                .await?;
+        let (transient, changed) = write_instructions(
+            transient,
+            store,
+            &storage,
+            version,
+            &manifest,
+            instructions,
+            WriteScope::Application,
+        )
+        .await?;
         // Seal the whole batch with a single bottom-up persist into the
         // caller's delta.
         *self = transient.persist(delta)?;
@@ -1048,6 +1055,23 @@ pub fn selector_range(
     }
 }
 
+/// Which attribute namespaces an instruction stream may write.
+///
+/// The `dialog.` namespace is reserved for machinery-written facts (revision
+/// records, delegation records): [`Application`](WriteScope::Application)
+/// writes reject it, so at the library level such facts cannot be corrupted
+/// through the ordinary write path. Machinery write paths pass
+/// [`Machinery`](WriteScope::Machinery) and take responsibility for what they
+/// write — the same trust level as [`ArtifactTreeExt::record`], which appends
+/// reserved entries without instructions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WriteScope {
+    /// Ordinary application data: reserved attributes are rejected.
+    Application,
+    /// Machinery-written facts: reserved attributes are permitted.
+    Machinery,
+}
+
 /// Applies an instruction stream to any [`ArtifactWriter`], returning the
 /// written target and whether the batch changed the indexes.
 ///
@@ -1086,6 +1110,7 @@ pub async fn write_instructions<W, S, I>(
     version: Option<Version>,
     manifest: &Manifest,
     instructions: I,
+    scope: WriteScope,
 ) -> Result<(W, bool), DialogArtifactsError>
 where
     W: ArtifactWriter,
@@ -1132,13 +1157,13 @@ where
 
     tokio::pin!(instructions);
     while let Some(instruction) = instructions.next().await {
-        // The `dialog.` namespace is reserved for version-control
-        // machinery (revision records — see
-        // `history::RevisionRecord`), which writes through
-        // [`ArtifactTreeExt::record`] rather than instructions. At the
-        // library level lineage therefore cannot be corrupted through
-        // the ordinary write path.
-        {
+        // The `dialog.` namespace is reserved for machinery (revision
+        // records — see `history::RevisionRecord` — and delegation
+        // records), written through [`ArtifactTreeExt::record`] or a
+        // [`WriteScope::Machinery`] stream. At the library level such
+        // facts therefore cannot be corrupted through the ordinary
+        // write path.
+        if scope == WriteScope::Application {
             let (Instruction::Assert(artifact)
             | Instruction::Replace(artifact)
             | Instruction::Retract(artifact)) = &instruction;

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -31,6 +31,9 @@ pub use claims::*;
 mod commit;
 pub use commit::*;
 
+mod delegation;
+pub use delegation::*;
+
 mod export;
 pub use export::*;
 

--- a/rust/dialog-repository/src/repository/branch/blob.rs
+++ b/rust/dialog-repository/src/repository/branch/blob.rs
@@ -198,7 +198,7 @@ fn blob_hash(entity: &Entity) -> Result<Blake3Hash, BlobError> {
 /// local, and the index nodes hydrate lazily. Fall back to the remote archive
 /// on a local miss (caching what lands), as `commit` does. With no remote
 /// upstream this degrades to a plain local index.
-async fn index_store<'e, Env>(branch: &Branch, env: &'e Env) -> NetworkedIndex<'e, Env>
+pub(crate) async fn index_store<'e, Env>(branch: &Branch, env: &'e Env) -> NetworkedIndex<'e, Env>
 where
     Env: Provider<Resolve> + ConditionalSync + 'static,
 {

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -3,7 +3,8 @@ use crate::{
     RepositoryArchiveExt as _, RepositoryMemoryExt, Revision, TreeReference,
 };
 use dialog_artifacts::history::{Context, Edition, TreeHistory, Version, context_of, extend_skips};
-use dialog_artifacts::{DialogArtifactsError, Instruction};
+use dialog_artifacts::tree::WriteScope;
+use dialog_artifacts::{Datum, DialogArtifactsError, Instruction, Key, State};
 use dialog_capability::{Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::{ConditionalSend, ConditionalSync};
@@ -22,6 +23,8 @@ pub struct Commit<'a, Changes> {
     changes: Changes,
     allow_empty: bool,
     canonicalize: bool,
+    scope: WriteScope,
+    entries: Vec<(Key, State<Datum>)>,
 }
 
 impl<'a, Changes> Commit<'a, Changes> {
@@ -31,7 +34,27 @@ impl<'a, Changes> Commit<'a, Changes> {
             changes,
             allow_empty: false,
             canonicalize: false,
+            scope: WriteScope::Application,
+            entries: Vec::new(),
         }
+    }
+
+    /// Permit reserved `dialog.*` attributes in the change stream.
+    ///
+    /// For machinery-written facts (delegation records); application
+    /// commits keep the default [`WriteScope::Application`] rejection.
+    pub(crate) fn machinery(mut self) -> Self {
+        self.scope = WriteScope::Machinery;
+        self
+    }
+
+    /// Append pre-built machinery entries (blob-index edits) to the same
+    /// batch, so they seal, persist, and publish with the commit's data in
+    /// one revision. Entries make the commit non-empty even when the change
+    /// stream is all no-ops.
+    pub(crate) fn with_entries(mut self, entries: Vec<(Key, State<Datum>)>) -> Self {
+        self.entries = entries;
+        self
     }
 
     /// Flush the write buffers to the leaves before publishing, so the
@@ -196,10 +219,17 @@ where
         // for callers that want the history-independent form (see
         // `Commit::canonicalize`).
         let mut delta = Delta::zero();
-        let batch =
-            dialog_artifacts::BufferedBatch::apply(&tree, &mut store, Some(version), changes)
-                .await?;
-        let changed = batch.changed();
+        let batch = dialog_artifacts::BufferedBatch::apply(
+            &tree,
+            &mut store,
+            Some(version),
+            changes,
+            self.scope,
+        )
+        .await?;
+        // Machinery entries count as changes: a commit carrying only a
+        // blob-index edit still advances the head.
+        let changed = batch.changed() || !self.entries.is_empty();
 
         // A batch that left the indexes untouched (e.g. a transaction
         // re-asserting metadata that is already in place) is a no-op:
@@ -304,6 +334,10 @@ where
         // they ride the same buffered write as the data, so the record costs
         // a buffer append instead of a second canonical spine-to-leaf edit.
         let entries = record.entries(batch.manifest())?;
+        // The caller's machinery entries (blob-index edits) ride the same
+        // batch as the revision record, so one seal covers data, record,
+        // and entries together.
+        let batch = batch.record(&store, self.entries).await?;
         let batch = batch.record(&store, entries).await?;
         // Seed the verified-record memo with what we just minted. The next
         // commit's skip-table walk starts at this very record, so without this

--- a/rust/dialog-repository/src/repository/branch/delegation.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation.rs
@@ -1,0 +1,637 @@
+//! UCAN delegations as data in the branch tree.
+//!
+//! A retained delegation decomposes into two synced pieces:
+//!
+//! - **Slim facts** under the reserved `dialog.ucan/*` attributes, one per
+//!   queried field (audience, subject, issuer, command, and the validity
+//!   bounds when present), on the entity `blob:<hash>` of the certificate's
+//!   encoded envelope. They are ordinary version-controlled facts: they ride
+//!   the fact indexes, replicate with the tree, merge with observed-remove
+//!   semantics, and answer datalog queries.
+//! - **The signed envelope as a blob**, addressed by that same hash and
+//!   recorded in the blob index so push ships the bytes and a replica
+//!   hydrates them on demand. The envelope is never decomposed: policy,
+//!   meta, nonce, and signature live only there, and proof assembly reads
+//!   it back byte-identical.
+//!
+//! Both land in ONE commit, so the denormalized fields cannot drift from the
+//! envelope. Retraction mirrors it: the facts are retracted and the blob
+//! reference tombstoned in one commit; the bytes stay in the blob store
+//! (reclaiming unreferenced bytes is the deferred GC concern).
+//!
+//! The surface is a [`Delegations`] handle on the branch:
+//!
+//! ```no_run
+//! # use dialog_capability::{Fork, Provider};
+//! # use dialog_effects::archive::{Get, Import, Put};
+//! # use dialog_effects::authority::{Attest, Identify};
+//! # use dialog_effects::blob::Write as BlobWrite;
+//! # use dialog_effects::memory::{Publish, Resolve};
+//! # use dialog_repository::{Branch, CommitError, RemoteSite};
+//! # use dialog_ucan::UcanDelegation;
+//! # async fn example<Env>(
+//! #     branch: &Branch,
+//! #     env: &Env,
+//! #     chain: UcanDelegation,
+//! # ) -> Result<(), CommitError>
+//! # where
+//! #     Env: Provider<Get>
+//! #         + Provider<Put>
+//! #         + Provider<Import>
+//! #         + Provider<Resolve>
+//! #         + Provider<Publish>
+//! #         + Provider<Identify>
+//! #         + Provider<Attest>
+//! #         + Provider<BlobWrite>
+//! #         + Provider<Fork<RemoteSite, Get>>
+//! #         + Provider<Fork<RemoteSite, Resolve>>
+//! #         + dialog_common::ConditionalSync
+//! #         + 'static,
+//! # {
+//! // retain: every certificate in the chain becomes facts + an envelope blob
+//! let entities = branch.delegations().retain(chain.clone()).perform(env).await?;
+//!
+//! // retract: facts retracted, blob reference tombstoned, bytes untouched
+//! branch.delegations().retract(chain).perform(env).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::repository::branch::blob::index_store;
+use crate::{Branch, CommitError, Index, RemoteSite};
+use dialog_artifacts::{
+    Artifact, Attribute, BlobIndexExt as _, BlobRecord, DialogArtifactsError, Entity, Instruction,
+    Value,
+};
+use dialog_capability::access::{Certificate as _, Delegation as _};
+use dialog_capability::{ANY_SUBJECT, Fork, Provider};
+use dialog_common::Blake3Hash as NodeHash;
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Import, Put};
+use dialog_effects::authority::{Attest, Identify};
+use dialog_effects::blob::Write as BlobWrite;
+use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
+use dialog_effects::memory::{Publish, Resolve};
+use dialog_ucan::{UcanCertificate, UcanDelegation};
+use futures_util::stream;
+
+/// Attribute naming who receives the delegated authority.
+pub const DELEGATION_AUDIENCE: &str = "dialog.ucan/audience";
+/// Attribute naming the subject the delegation applies to.
+/// A [powerline](https://github.com/ucan-wg/delegation#powerline) delegation
+/// (any subject) carries [`ANY_SUBJECT`] as its value, keeping the lookup a
+/// plain equality.
+pub const DELEGATION_SUBJECT: &str = "dialog.ucan/subject";
+/// Attribute naming who issued (signed) the delegation.
+pub const DELEGATION_ISSUER: &str = "dialog.ucan/issuer";
+/// Attribute carrying the delegated command path (`/storage/get`).
+pub const DELEGATION_COMMAND: &str = "dialog.ucan/command";
+/// Attribute carrying the expiration as unix seconds, absent when the
+/// delegation never expires.
+pub const DELEGATION_EXPIRATION: &str = "dialog.ucan/expiration";
+/// Attribute carrying the earliest validity as unix seconds, absent when
+/// unbounded.
+pub const DELEGATION_NOT_BEFORE: &str = "dialog.ucan/notBefore";
+
+/// A branch's retained delegations: the target that delegation retain and
+/// retract bind to. Obtain one with [`Branch::delegations`].
+#[derive(Clone, Copy)]
+pub struct Delegations<'a> {
+    branch: &'a Branch,
+}
+
+impl Branch {
+    /// This branch's retained delegations, the target for
+    /// [`Delegations::retain`] and [`Delegations::retract`].
+    pub fn delegations(&self) -> Delegations<'_> {
+        Delegations { branch: self }
+    }
+}
+
+impl<'a> Delegations<'a> {
+    /// Retain a delegation chain: decompose every certificate into its
+    /// `dialog.ucan/*` facts plus its envelope blob, in one commit.
+    pub fn retain(self, chain: UcanDelegation) -> RetainDelegation<'a> {
+        RetainDelegation {
+            branch: self.branch,
+            chain,
+        }
+    }
+
+    /// Retract a delegation chain: retract every certificate's facts and
+    /// tombstone its blob reference, in one commit. The envelope bytes stay
+    /// in the blob store.
+    pub fn retract(self, chain: UcanDelegation) -> RetractDelegation<'a> {
+        RetractDelegation {
+            branch: self.branch,
+            chain,
+        }
+    }
+}
+
+/// One fact on the delegation's entity.
+fn field(entity: &Entity, attribute: &str, value: Value) -> Result<Artifact, DialogArtifactsError> {
+    Ok(Artifact {
+        the: Attribute::try_from(attribute.to_string())?,
+        of: entity.clone(),
+        is: value,
+        cause: None,
+    })
+}
+
+/// The slim facts a certificate decomposes into, on `entity`.
+///
+/// Exactly the queried fields: policy, meta, and nonce stay inside the
+/// envelope, which the entity's blob carries byte-identical.
+fn field_artifacts(
+    entity: &Entity,
+    certificate: &UcanCertificate,
+) -> Result<Vec<Artifact>, DialogArtifactsError> {
+    let subject = match certificate.subject() {
+        Some(did) => did.to_string(),
+        None => ANY_SUBJECT.to_string(),
+    };
+    let mut artifacts = vec![
+        field(
+            entity,
+            DELEGATION_AUDIENCE,
+            Value::String(certificate.audience().to_string()),
+        )?,
+        field(entity, DELEGATION_SUBJECT, Value::String(subject))?,
+        field(
+            entity,
+            DELEGATION_ISSUER,
+            Value::String(certificate.issuer().to_string()),
+        )?,
+        field(
+            entity,
+            DELEGATION_COMMAND,
+            Value::String(certificate.0.command().to_string()),
+        )?,
+    ];
+    if let Some(expiration) = certificate.0.expiration() {
+        artifacts.push(field(
+            entity,
+            DELEGATION_EXPIRATION,
+            Value::UnsignedInt(expiration.to_unix() as u128),
+        )?);
+    }
+    if let Some(not_before) = certificate.0.not_before() {
+        artifacts.push(field(
+            entity,
+            DELEGATION_NOT_BEFORE,
+            Value::UnsignedInt(not_before.to_unix() as u128),
+        )?);
+    }
+    Ok(artifacts)
+}
+
+/// A certificate's encoded envelope, as [`CommitError`].
+fn encode(certificate: &UcanCertificate) -> Result<Vec<u8>, CommitError> {
+    certificate.encode().map_err(|error| {
+        CommitError::Artifact(DialogArtifactsError::InvalidValue(format!(
+            "failed to encode delegation envelope: {error}"
+        )))
+    })
+}
+
+/// Retain a delegation chain as one commit. Created by
+/// [`Delegations::retain`].
+pub struct RetainDelegation<'a> {
+    branch: &'a Branch,
+    chain: UcanDelegation,
+}
+
+impl RetainDelegation<'_> {
+    /// Execute the retain, returning the entity of every certificate this
+    /// commit newly retained (empty when the whole chain was already
+    /// retained: content-addressed entities make a re-retain a no-op that
+    /// mints no revision).
+    pub async fn perform<Env>(self, env: &Env) -> Result<Vec<Entity>, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<BlobWrite>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let store = index_store(branch, env).await;
+        let tree = branch
+            .revision()
+            .map(|revision| Index::from_hash(NodeHash::from(*revision.tree.hash())));
+
+        let mut instructions = Vec::new();
+        let mut entries = Vec::new();
+        let mut retained = Vec::new();
+        for certificate in self.chain.certificates() {
+            let bytes = encode(&certificate)?;
+
+            // The envelope bytes must be durable before the revision minted
+            // below references them (the `WriteBlob` invariant). The sink is
+            // also the hashing authority: the entity is derived from the
+            // digest the blob store reports, never computed on the side.
+            let mut sink = branch.archive().blob().write().perform(env).await?;
+            sink.write_all(&bytes).await?;
+            let hash = sink.finish().await?;
+            let index_hash: dialog_storage::Blake3Hash = *hash.as_bytes();
+
+            // Idempotence: a certificate the tree already references was
+            // retained with its facts in one commit, so there is nothing to
+            // add for it.
+            if let Some(tree) = &tree
+                && tree.get_blob(&store, &index_hash).await?.is_some()
+            {
+                continue;
+            }
+
+            let entity = Entity::from_blob(&index_hash)?;
+            for artifact in field_artifacts(&entity, &certificate)? {
+                instructions.push(Instruction::Assert(artifact));
+            }
+            entries.push(BlobRecord::new(bytes.len() as u64).entry(&index_hash));
+            retained.push(entity);
+        }
+
+        if retained.is_empty() {
+            return Ok(retained);
+        }
+
+        Box::pin(
+            branch
+                .commit(stream::iter(instructions))
+                .machinery()
+                .with_entries(entries)
+                .perform(env),
+        )
+        .await?;
+
+        Ok(retained)
+    }
+}
+
+/// Retract a delegation chain as one commit. Created by
+/// [`Delegations::retract`].
+pub struct RetractDelegation<'a> {
+    branch: &'a Branch,
+    chain: UcanDelegation,
+}
+
+impl RetractDelegation<'_> {
+    /// Execute the retract, returning the entity of every certificate this
+    /// commit retracted (empty when none were retained: retracting an
+    /// unretained chain is a no-op that mints no revision).
+    ///
+    /// The envelope bytes are not touched — a replica that hydrated them
+    /// keeps reading its local copy; reclaiming unreferenced bytes is a
+    /// separate, local concern. (The bytes are in fact re-written through
+    /// the blob sink here: the sink is the hashing authority the entity is
+    /// derived from, and a content-addressed re-write of bytes this store
+    /// holds — or is about to stop referencing — is idempotent.)
+    pub async fn perform<Env>(self, env: &Env) -> Result<Vec<Entity>, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<BlobWrite>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let Some(revision) = branch.revision() else {
+            return Ok(Vec::new());
+        };
+        let store = index_store(branch, env).await;
+        let tree = Index::from_hash(NodeHash::from(*revision.tree.hash()));
+
+        let mut instructions = Vec::new();
+        let mut entries = Vec::new();
+        let mut retracted = Vec::new();
+        for certificate in self.chain.certificates() {
+            let bytes = encode(&certificate)?;
+            let mut sink = branch.archive().blob().write().perform(env).await?;
+            sink.write_all(&bytes).await?;
+            let hash = sink.finish().await?;
+            let index_hash: dialog_storage::Blake3Hash = *hash.as_bytes();
+
+            // A certificate the tree does not reference has nothing to
+            // retract.
+            if tree.get_blob(&store, &index_hash).await?.is_none() {
+                continue;
+            }
+
+            let entity = Entity::from_blob(&index_hash)?;
+            for artifact in field_artifacts(&entity, &certificate)? {
+                instructions.push(Instruction::Retract(artifact));
+            }
+            entries.push(BlobRecord::retract_entry(&index_hash));
+            retracted.push(entity);
+        }
+
+        if retracted.is_empty() {
+            return Ok(retracted);
+        }
+
+        Box::pin(
+            branch
+                .commit(stream::iter(instructions))
+                .machinery()
+                .with_entries(entries)
+                .perform(env),
+        )
+        .await?;
+
+        Ok(retracted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::{Blob, RepositoryExt as _};
+    use anyhow::Result;
+    use dialog_artifacts::ArtifactSelector;
+    use dialog_capability::Subject;
+    use dialog_credentials::Ed25519Signer;
+    use dialog_effects::blob::BlobReader;
+    use dialog_network::Network;
+    use dialog_operator::{Operator, Profile};
+    use dialog_storage::provider::storage::{Storage, VolatileSpace};
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal as _;
+    use futures_util::StreamExt as _;
+
+    use crate::helpers::unique_name;
+
+    async fn delegate(
+        issuer: &Ed25519Signer,
+        audience: &Ed25519Signer,
+        subject: UcanSubject,
+    ) -> UcanDelegation {
+        let delegation = DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(subject)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+        UcanDelegation::new(DelegationChain::new(delegation))
+    }
+
+    async fn open_branch(name: &str) -> Result<(crate::Branch, Operator<VolatileSpace>)> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name(name)).perform(&storage).await?;
+        let operator = profile
+            .derive(b"test")
+            .allow(Subject::any())
+            .network(Network::default())
+            .build(storage)
+            .await?;
+        let repo = profile
+            .repository(unique_name("repo"))
+            .open()
+            .perform(&operator)
+            .await?;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+        Ok((branch, operator))
+    }
+
+    async fn drain(mut reader: BlobReader) -> Vec<u8> {
+        let mut out = Vec::new();
+        while let Some(chunk) = reader.next().await.unwrap() {
+            out.extend(chunk);
+        }
+        out
+    }
+
+    #[dialog_common::test]
+    async fn it_retains_a_delegation_as_facts_and_envelope() -> Result<()> {
+        let (branch, operator) = open_branch("delegation-retain").await?;
+        let space = Ed25519Signer::generate().await?;
+        let holder = Ed25519Signer::generate().await?;
+        let chain = delegate(&space, &holder, UcanSubject::Specific(space.did())).await;
+        let certificate = chain.certificates().pop().unwrap();
+        let envelope = certificate.encode().unwrap();
+
+        let entities = branch
+            .delegations()
+            .retain(chain.clone())
+            .perform(&operator)
+            .await?;
+        assert_eq!(entities.len(), 1);
+        let entity = entities[0].clone();
+
+        // The slim facts stand on the envelope's entity.
+        let facts: Vec<Artifact> = branch
+            .claims()
+            .select(ArtifactSelector::new().of(entity.clone()))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        let get = |attribute: &str| {
+            facts
+                .iter()
+                .find(|fact| fact.the.as_str() == attribute)
+                .map(|fact| fact.is.clone())
+        };
+        assert_eq!(
+            get(DELEGATION_AUDIENCE),
+            Some(Value::String(holder.did().to_string()))
+        );
+        assert_eq!(
+            get(DELEGATION_SUBJECT),
+            Some(Value::String(space.did().to_string()))
+        );
+        assert_eq!(
+            get(DELEGATION_ISSUER),
+            Some(Value::String(space.did().to_string()))
+        );
+        assert_eq!(
+            get(DELEGATION_COMMAND),
+            Some(Value::String("/storage".to_string()))
+        );
+        assert_eq!(get(DELEGATION_NOT_BEFORE), None);
+
+        // The envelope reads back byte-identical and decodes to the same
+        // certificate.
+        let reader = Blob::from(entity.clone())
+            .read((&branch).into())
+            .perform(&operator)
+            .await?;
+        let bytes = drain(reader).await;
+        assert_eq!(bytes, envelope);
+        let decoded = UcanCertificate::decode(&bytes).unwrap();
+        assert_eq!(decoded.issuer(), certificate.issuer());
+        assert_eq!(decoded.audience(), certificate.audience());
+        assert_eq!(decoded.subject(), certificate.subject());
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_records_a_powerline_subject_as_the_wildcard_did() -> Result<()> {
+        let (branch, operator) = open_branch("delegation-powerline").await?;
+        let space = Ed25519Signer::generate().await?;
+        let holder = Ed25519Signer::generate().await?;
+        let chain = delegate(&space, &holder, UcanSubject::Any).await;
+
+        let entities = branch
+            .delegations()
+            .retain(chain)
+            .perform(&operator)
+            .await?;
+        let facts: Vec<Artifact> = branch
+            .claims()
+            .select(ArtifactSelector::new().of(entities[0].clone()))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        let subject = facts
+            .iter()
+            .find(|fact| fact.the.as_str() == DELEGATION_SUBJECT)
+            .unwrap();
+        assert_eq!(subject.is, Value::String(ANY_SUBJECT.to_string()));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_retains_idempotently() -> Result<()> {
+        let (branch, operator) = open_branch("delegation-idempotent").await?;
+        let space = Ed25519Signer::generate().await?;
+        let holder = Ed25519Signer::generate().await?;
+        let chain = delegate(&space, &holder, UcanSubject::Specific(space.did())).await;
+
+        let first = branch
+            .delegations()
+            .retain(chain.clone())
+            .perform(&operator)
+            .await?;
+        assert_eq!(first.len(), 1);
+        let head = branch.revision();
+
+        let second = branch
+            .delegations()
+            .retain(chain)
+            .perform(&operator)
+            .await?;
+        assert!(second.is_empty(), "a re-retain retains nothing new");
+        assert_eq!(
+            branch.revision().map(|revision| revision.version()),
+            head.map(|revision| revision.version()),
+            "a no-op retain mints no revision"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_retracts_facts_and_reference_but_not_bytes() -> Result<()> {
+        let (branch, operator) = open_branch("delegation-retract").await?;
+        let space = Ed25519Signer::generate().await?;
+        let holder = Ed25519Signer::generate().await?;
+        let chain = delegate(&space, &holder, UcanSubject::Specific(space.did())).await;
+
+        let entities = branch
+            .delegations()
+            .retain(chain.clone())
+            .perform(&operator)
+            .await?;
+        let entity = entities[0].clone();
+
+        let retracted = branch
+            .delegations()
+            .retract(chain.clone())
+            .perform(&operator)
+            .await?;
+        assert_eq!(retracted, entities);
+
+        // Facts gone, index reference gone...
+        let facts: Vec<Artifact> = branch
+            .claims()
+            .select(ArtifactSelector::new().of(entity.clone()))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        assert!(facts.is_empty(), "retract removes the facts: {facts:?}");
+        assert_eq!(
+            Blob::from(entity.clone())
+                .size((&branch).into())
+                .perform(&operator)
+                .await?,
+            None
+        );
+
+        // ...bytes untouched.
+        let reader = Blob::from(entity)
+            .read((&branch).into())
+            .perform(&operator)
+            .await?;
+        assert!(!drain(reader).await.is_empty());
+
+        // Retracting again is a no-op that mints no revision.
+        let head = branch.revision();
+        let again = branch
+            .delegations()
+            .retract(chain)
+            .perform(&operator)
+            .await?;
+        assert!(again.is_empty());
+        assert_eq!(
+            branch.revision().map(|revision| revision.version()),
+            head.map(|revision| revision.version()),
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_the_namespace_reserved_for_applications() -> Result<()> {
+        let (branch, operator) = open_branch("delegation-reserved").await?;
+
+        let result = branch
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: DELEGATION_AUDIENCE.parse()?,
+                of: "user:mallory".parse()?,
+                is: Value::String("did:key:zForged".to_string()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(CommitError::Artifact(
+                    DialogArtifactsError::ReservedAttribute(_)
+                ))
+            ),
+            "application commits must not write dialog.ucan facts"
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -479,6 +479,184 @@ async fn it_replicates_a_blob_retraction_on_pull(s3: S3Address) -> Result<()> {
     Ok(())
 }
 
+/// A retained delegation replicates like any data: site A retains a chain
+/// (facts + envelope blob in one commit) and pushes; site B pulls, finds the
+/// delegation by an ordinary value-bound query on `dialog.ucan/audience` (the
+/// shape a prover uses), and reads the envelope back byte-identical through
+/// blob hydration. A retraction then replicates the same way: after B pulls
+/// it, the facts and the blob reference are gone.
+// Native only, feature-gated: same reasoning as
+// `it_ships_blobs_on_push_and_hydrates_on_read` above.
+#[cfg(not(feature = "web-integration-tests"))]
+#[dialog_common::test]
+async fn it_replicates_retained_delegations(s3: S3Address) -> Result<()> {
+    use crate::DELEGATION_AUDIENCE;
+    use dialog_capability::access::{Certificate as _, Delegation as _};
+    use dialog_credentials::Ed25519Signer;
+
+    // --- Site A: retain a delegation, push. ---
+    let storage_a = Storage::temp();
+    let profile_a = Profile::open(unique_name("delegation-ship-a"))
+        .perform(&storage_a)
+        .await?;
+    let operator_a = profile_a
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage_a)
+        .await?;
+    let repo_a = profile_a
+        .repository(unique_name("delegation-ship"))
+        .create()
+        .perform(&operator_a)
+        .await?;
+    let site_a = s3_site_address(&s3);
+    profile_a
+        .credential()
+        .site(&site_a)
+        .save(S3Credential::new(&s3.access_key_id, &s3.secret_access_key))
+        .perform(&operator_a)
+        .await?;
+    let origin_a = repo_a
+        .remote("origin")
+        .create(site_a)
+        .perform(&operator_a)
+        .await?;
+    let branch_a = repo_a.branch("main").open().perform(&operator_a).await?;
+    let remote_branch_a = origin_a.branch("main").open().perform(&operator_a).await?;
+    branch_a
+        .set_upstream(remote_branch_a)
+        .perform(&operator_a)
+        .await?;
+
+    let space = Ed25519Signer::generate().await?;
+    let holder = Ed25519Signer::generate().await?;
+    let delegation = dialog_ucan_core::DelegationBuilder::new()
+        .issuer(space.clone())
+        .audience(&holder)
+        .subject(dialog_ucan_core::subject::Subject::Specific(
+            dialog_varsig::Principal::did(&space),
+        ))
+        .command(vec!["storage".to_string()])
+        .try_build()
+        .await?;
+    let chain =
+        dialog_ucan::UcanDelegation::new(dialog_ucan_core::DelegationChain::new(delegation));
+    let certificate = chain.certificates().pop().unwrap();
+    let envelope = certificate.encode().unwrap();
+
+    let entities = branch_a
+        .delegations()
+        .retain(chain.clone())
+        .perform(&operator_a)
+        .await?;
+    assert_eq!(entities.len(), 1);
+    let entity = entities[0].clone();
+    assert!(branch_a.push().perform(&operator_a).await?.is_some());
+
+    // --- Site B: pull, query by audience, read the envelope. ---
+    let storage_b = Storage::temp();
+    let profile_b = Profile::open(unique_name("delegation-ship-b"))
+        .perform(&storage_b)
+        .await?;
+    let operator_b = profile_b
+        .derive(b"test")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage_b)
+        .await?;
+    let repo_b = profile_b
+        .repository(unique_name("delegation-ship-b-repo"))
+        .open()
+        .perform(&operator_b)
+        .await?;
+    let site_b = s3_site_address(&s3);
+    profile_b
+        .credential()
+        .site(&site_b)
+        .save(S3Credential::new(&s3.access_key_id, &s3.secret_access_key))
+        .perform(&operator_b)
+        .await?;
+    let origin_b = repo_b
+        .remote("origin")
+        .create(site_b)
+        .subject(repo_a.did())
+        .perform(&operator_b)
+        .await?;
+    let branch_b = repo_b.branch("main").open().perform(&operator_b).await?;
+    let remote_branch_b = origin_b.branch("main").open().perform(&operator_b).await?;
+    branch_b
+        .set_upstream(remote_branch_b)
+        .perform(&operator_b)
+        .await?;
+
+    branch_b.pull().perform(&operator_b).await?;
+
+    // Value-bound query on the audience: the shape a prover's candidate
+    // lookup takes, over facts site B never wrote.
+    let holder_did = dialog_varsig::Principal::did(&holder).to_string();
+    let found: Vec<_> = branch_b
+        .claims()
+        .select(
+            ArtifactSelector::new()
+                .the(DELEGATION_AUDIENCE.parse()?)
+                .is(Value::String(holder_did.clone())),
+        )
+        .perform(&operator_b)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(found.len(), 1, "site B finds the delegation by audience");
+    assert_eq!(found[0].of, entity);
+
+    // The envelope hydrates from the remote and reads back byte-identical.
+    let mut reader = Blob::from(entity.clone())
+        .read((&branch_b).into())
+        .perform(&operator_b)
+        .await?;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = reader.next().await? {
+        bytes.extend(chunk);
+    }
+    assert_eq!(bytes, envelope, "the envelope replicates byte-identical");
+
+    // --- Site A retracts and pushes; B pulls the retraction. ---
+    branch_a
+        .delegations()
+        .retract(chain)
+        .perform(&operator_a)
+        .await?;
+    assert!(branch_a.push().perform(&operator_a).await?.is_some());
+    branch_b.pull().perform(&operator_b).await?;
+
+    let after: Vec<_> = branch_b
+        .claims()
+        .select(
+            ArtifactSelector::new()
+                .the(DELEGATION_AUDIENCE.parse()?)
+                .is(Value::String(holder_did)),
+        )
+        .perform(&operator_b)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+    assert!(after.is_empty(), "a pulled retraction removes the facts");
+    assert_eq!(
+        Blob::from(entity)
+            .size((&branch_b).into())
+            .perform(&operator_b)
+            .await?,
+        None,
+        "a pulled retraction removes the blob reference"
+    );
+
+    Ok(())
+}
+
 /// Push ships a spilling scalar value's block to the remote before publishing.
 ///
 /// A value larger than the tree's inline threshold does not travel in the key

--- a/rust/dialog-repository/src/repository/branch/read_amplification.rs
+++ b/rust/dialog-repository/src/repository/branch/read_amplification.rs
@@ -355,7 +355,7 @@ async fn measure_shape(depth: usize) -> Result<()> {
 async fn measure_write_paths(depth: usize, batches: usize) -> Result<()> {
     use crate::RepositoryArchiveExt as _;
     use dialog_artifacts::tree::ArtifactTreeExt as _;
-    use dialog_artifacts::tree::write_instructions;
+    use dialog_artifacts::tree::{WriteScope, write_instructions};
     use dialog_artifacts::{Instruction as I, apply_buffered};
     use dialog_effects::prelude::CatalogExt as _;
     use dialog_search_tree::Delta;
@@ -439,6 +439,7 @@ async fn measure_write_paths(depth: usize, batches: usize) -> Result<()> {
             // The bench tree carries the default manifest.
             &dialog_search_tree::Manifest::default(),
             stream::iter(batch(i)),
+            WriteScope::Application,
         )
         .await?;
         deferred = next;


### PR DESCRIPTION
Second slice of [delegations-as-data](https://github.com/dialog-db/dialog-db/blob/feat/delegations-as-data/notes/delegations-as-data.md), stacked on #433. UCAN delegations become synced data: retained into the branch tree, replicated by ordinary push/pull, queryable with the query engine.

## Mechanism

`branch.delegations().retain(chain)` decomposes every certificate into two synced pieces, landing in **one commit** so they cannot drift:

- **Slim facts** under reserved `dialog.ucan/*` attributes (audience, subject, issuer, command, and validity bounds when present) on the entity `blob:<hash>` of the encoded envelope. Ordinary version-controlled facts: all three orderings, history records, observed-remove merge, datalog-queryable. Powerline subjects store `ANY_SUBJECT` so lookups stay equalities.
- **The signed envelope as a blob** addressed by that same hash and recorded in the blob index, so push ships the bytes and replicas hydrate on demand. Policy, meta, nonce, and the signature are never decomposed; proof assembly reads the envelope back byte-identical.

`retract(chain)` mirrors it: fact retractions through the versioned apply path plus the blob-reference tombstone from #433, one commit, bytes untouched. Both operations are idempotent by content address (a re-retain/re-retract mints no revision). `retain_all` is the bulk one-commit form for imports.

## Plumbing

- `write_instructions`/`BufferedBatch::apply` gain a `WriteScope`: `Application` (default everywhere existing) keeps rejecting `dialog.*`; `Machinery` permits it, at the same trust level as the public `record()` path, so the decomposition is the only writer of these facts.
- `Commit` gains crate-private `machinery()` / `with_entries()` so blob-index edits seal in the same revision as the facts (entries also make a commit non-empty).
- `BlobRecord::entry()` / `retract_entry()` let blob-index edits ride a batch instead of editing the tree directly.

## Tests

Unit: decompose-and-read-back (facts via select, envelope via blob read, decode roundtrip), powerline encoding, idempotence, retract semantics, and a pin that application commits still cannot write `dialog.ucan/*`. Integration (`it_replicates_retained_delegations`): site B pulls, finds the delegation by a value-bound audience query, hydrates the envelope byte-identical, and sees the retraction after a second pull.

The certificate store still serves the operator's prove path; the prover switch is the next PR in the stack.