### PR TITLE
feat(dialog-repository): prove chains over retained delegations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base58",
+ "criterion",
  "dialog-artifacts",
  "dialog-capability",
  "dialog-common",

--- a/rust/dialog-repository/Cargo.toml
+++ b/rust/dialog-repository/Cargo.toml
@@ -69,6 +69,7 @@ wasm-bindgen-futures = { workspace = true }
 wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [
@@ -79,6 +80,10 @@ tokio = { workspace = true, features = [
     "rt",
     "rt-multi-thread",
 ] }
+
+[[bench]]
+name = "delegation_prove"
+harness = false
 
 [lints.rust]
 # This cfg is used by the dialog_common::test proc macro for wasm inner tests

--- a/rust/dialog-repository/benches/delegation_prove.rs
+++ b/rust/dialog-repository/benches/delegation_prove.rs
@@ -1,0 +1,247 @@
+//! Chain-search cost: legacy certificate stores vs the tree-backed walk.
+//!
+//! Populates the legacy filesystem and volatile certificate stores and a
+//! branch's delegation region with the same N certificates, then measures
+//! `prove` on each backend under two shapes:
+//!
+//! - `direct`: every certificate is a direct grant to the principal for the
+//!   subject (the accumulation pathology observed in the field). The legacy
+//!   stores read and decode all N before the first direct grant wins; the
+//!   tree walk admits its first candidate.
+//! - `miss`: every certificate is an indirect grant whose issuer holds
+//!   nothing further, so the walk must exhaust all N candidates and fail.
+//!   Worst case for every backend.
+//!
+//! Plus `chain3`: a clean three-hop powerline chain, the intended topology,
+//! at a single size.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dialog_capability::Subject;
+use dialog_capability::access::{CertificateStore, Prove, TimeRange};
+use dialog_credentials::Ed25519Signer;
+use dialog_effects::storage::{Directory, Location};
+use dialog_network::Network;
+use dialog_operator::{Operator, Profile};
+use dialog_repository::{Branch, RepositoryExt as _};
+use dialog_storage::provider::storage::{Storage, VolatileSpace};
+use dialog_storage::provider::{FileSystem, Volatile};
+use dialog_storage::resource::Resource as _;
+use dialog_ucan::{Parameters, Scope, Ucan, UcanDelegation};
+use dialog_ucan_core::command::Command;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+use dialog_varsig::{Did, Principal as _};
+
+const SIZES: &[usize] = &[32, 512, 6144];
+
+async fn delegate(issuer: &Ed25519Signer, audience: &Did, subject: UcanSubject) -> UcanDelegation {
+    let delegation = DelegationBuilder::new()
+        .issuer(issuer.clone())
+        .audience(audience)
+        .subject(subject)
+        .command(vec!["storage".to_string()])
+        .try_build()
+        .await
+        .unwrap();
+    UcanDelegation::new(DelegationChain::new(delegation))
+}
+
+fn scope(subject: &Did) -> Scope {
+    Scope {
+        subject: UcanSubject::Specific(subject.clone()),
+        command: Command(vec!["storage".to_string()]),
+        parameters: Parameters::default(),
+    }
+}
+
+async fn open_branch(name: &str) -> (Branch, Operator<VolatileSpace>) {
+    let storage = Storage::volatile();
+    let profile = Profile::open(name.to_string())
+        .perform(&storage)
+        .await
+        .unwrap();
+    let operator = profile
+        .derive(b"bench")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(storage)
+        .await
+        .unwrap();
+    let repo = profile
+        .repository(format!("{name}-repo"))
+        .open()
+        .perform(&operator)
+        .await
+        .unwrap();
+    let branch = repo.branch("main").open().perform(&operator).await.unwrap();
+    (branch, operator)
+}
+
+/// All three backends holding the same delegations.
+struct Backends {
+    fs: FileSystem,
+    volatile: Volatile,
+    branch: Branch,
+    operator: Operator<VolatileSpace>,
+}
+
+async fn populate(name: &str, chains: Vec<UcanDelegation>) -> Backends {
+    let location = Location::new(
+        Directory::Temp,
+        format!("delegation-prove-{name}-{}", std::process::id()),
+    );
+    let fs = FileSystem::open(&location).await.unwrap();
+    let volatile = Volatile::new();
+    let (branch, operator) = open_branch(&format!("delegation-prove-{name}")).await;
+
+    for chain in &chains {
+        CertificateStore::<Ucan>::save(&fs, chain).await.unwrap();
+        CertificateStore::<Ucan>::save(&volatile, chain)
+            .await
+            .unwrap();
+    }
+    branch
+        .delegations()
+        .retain_all(chains)
+        .perform(&operator)
+        .await
+        .unwrap();
+
+    Backends {
+        fs,
+        volatile,
+        branch,
+        operator,
+    }
+}
+
+fn bench_prove(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    for (shape, expect_ok) in [("direct", true), ("miss", false)] {
+        let mut group = c.benchmark_group(format!("prove_{shape}"));
+        group.sample_size(10);
+
+        for &n in SIZES {
+            let (backends, principal, access) = rt.block_on(async {
+                let space = Ed25519Signer::generate().await.unwrap();
+                let holder = Ed25519Signer::generate().await.unwrap();
+                let mut chains = Vec::with_capacity(n);
+                for _ in 0..n {
+                    let chain = match shape {
+                        // Direct grant: issuer is the subject itself.
+                        "direct" => {
+                            delegate(&space, &holder.did(), UcanSubject::Specific(space.did()))
+                                .await
+                        }
+                        // Indirect dead end: issued by a stranger who holds
+                        // nothing, so the walk must exhaust everything.
+                        _ => {
+                            let stranger = Ed25519Signer::generate().await.unwrap();
+                            delegate(&stranger, &holder.did(), UcanSubject::Specific(space.did()))
+                                .await
+                        }
+                    };
+                    chains.push(chain);
+                }
+                let backends = populate(&format!("{shape}-{n}"), chains).await;
+                (backends, holder.did(), scope(&space.did()))
+            });
+
+            group.bench_function(BenchmarkId::new("legacy-fs", n), |b| {
+                b.to_async(&rt).iter(|| {
+                    let mut claim = Prove::<Ucan>::new(principal.clone(), access.clone());
+                    claim.duration = TimeRange::unbounded();
+                    async {
+                        let result = CertificateStore::<Ucan>::prove(&backends.fs, claim).await;
+                        assert_eq!(result.is_ok(), expect_ok);
+                    }
+                })
+            });
+
+            group.bench_function(BenchmarkId::new("legacy-volatile", n), |b| {
+                b.to_async(&rt).iter(|| {
+                    let mut claim = Prove::<Ucan>::new(principal.clone(), access.clone());
+                    claim.duration = TimeRange::unbounded();
+                    async {
+                        let result =
+                            CertificateStore::<Ucan>::prove(&backends.volatile, claim).await;
+                        assert_eq!(result.is_ok(), expect_ok);
+                    }
+                })
+            });
+
+            group.bench_function(BenchmarkId::new("tree", n), |b| {
+                b.to_async(&rt).iter(|| async {
+                    let result = backends
+                        .branch
+                        .delegations()
+                        .prove(principal.clone(), access.clone())
+                        .perform(&backends.operator)
+                        .await;
+                    assert_eq!(result.is_ok(), expect_ok);
+                })
+            });
+        }
+        group.finish();
+    }
+
+    // The intended topology: space -> account -> profile -> operator, all
+    // powerlines except the root grant. Depth cost with no accumulation.
+    let mut group = c.benchmark_group("prove_chain3");
+    group.sample_size(10);
+    let (backends, principal, access) = rt.block_on(async {
+        let space = Ed25519Signer::generate().await.unwrap();
+        let account = Ed25519Signer::generate().await.unwrap();
+        let profile = Ed25519Signer::generate().await.unwrap();
+        let operator = Ed25519Signer::generate().await.unwrap();
+        let chains = vec![
+            delegate(&space, &account.did(), UcanSubject::Specific(space.did())).await,
+            delegate(&account, &profile.did(), UcanSubject::Any).await,
+            delegate(&profile, &operator.did(), UcanSubject::Any).await,
+        ];
+        let backends = populate("chain3", chains).await;
+        (backends, operator.did(), scope(&space.did()))
+    });
+
+    group.bench_function("legacy-fs", |b| {
+        b.to_async(&rt).iter(|| {
+            let mut claim = Prove::<Ucan>::new(principal.clone(), access.clone());
+            claim.duration = TimeRange::unbounded();
+            async {
+                CertificateStore::<Ucan>::prove(&backends.fs, claim)
+                    .await
+                    .unwrap();
+            }
+        })
+    });
+    group.bench_function("legacy-volatile", |b| {
+        b.to_async(&rt).iter(|| {
+            let mut claim = Prove::<Ucan>::new(principal.clone(), access.clone());
+            claim.duration = TimeRange::unbounded();
+            async {
+                CertificateStore::<Ucan>::prove(&backends.volatile, claim)
+                    .await
+                    .unwrap();
+            }
+        })
+    });
+    group.bench_function("tree", |b| {
+        b.to_async(&rt).iter(|| async {
+            backends
+                .branch
+                .delegations()
+                .prove(principal.clone(), access.clone())
+                .perform(&backends.operator)
+                .await
+                .unwrap();
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_prove);
+criterion_main!(benches);

--- a/rust/dialog-repository/src/repository/branch/delegation.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation.rs
@@ -57,6 +57,9 @@
 //! # }
 //! ```
 
+mod prove;
+pub use prove::*;
+
 use crate::repository::branch::blob::index_store;
 use crate::{Branch, CommitError, Index, RemoteSite};
 use dialog_artifacts::{
@@ -74,6 +77,7 @@ use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_ucan::{UcanCertificate, UcanDelegation};
 use futures_util::stream;
+use std::collections::HashSet;
 
 /// Attribute naming who receives the delegated authority.
 pub const DELEGATION_AUDIENCE: &str = "dialog.ucan/audience";
@@ -112,9 +116,15 @@ impl<'a> Delegations<'a> {
     /// Retain a delegation chain: decompose every certificate into its
     /// `dialog.ucan/*` facts plus its envelope blob, in one commit.
     pub fn retain(self, chain: UcanDelegation) -> RetainDelegation<'a> {
+        self.retain_all(vec![chain])
+    }
+
+    /// Retain many delegation chains in one commit — the bulk form of
+    /// [`retain`](Delegations::retain), for imports.
+    pub fn retain_all(self, chains: Vec<UcanDelegation>) -> RetainDelegation<'a> {
         RetainDelegation {
             branch: self.branch,
-            chain,
+            chains,
         }
     }
 
@@ -195,11 +205,11 @@ fn encode(certificate: &UcanCertificate) -> Result<Vec<u8>, CommitError> {
     })
 }
 
-/// Retain a delegation chain as one commit. Created by
-/// [`Delegations::retain`].
+/// Retain one or many delegation chains as one commit. Created by
+/// [`Delegations::retain`] or [`Delegations::retain_all`].
 pub struct RetainDelegation<'a> {
     branch: &'a Branch,
-    chain: UcanDelegation,
+    chains: Vec<UcanDelegation>,
 }
 
 impl RetainDelegation<'_> {
@@ -231,7 +241,8 @@ impl RetainDelegation<'_> {
         let mut instructions = Vec::new();
         let mut entries = Vec::new();
         let mut retained = Vec::new();
-        for certificate in self.chain.certificates() {
+        let mut batched = HashSet::new();
+        for certificate in self.chains.iter().flat_map(|chain| chain.certificates()) {
             let bytes = encode(&certificate)?;
 
             // The envelope bytes must be durable before the revision minted
@@ -245,7 +256,11 @@ impl RetainDelegation<'_> {
 
             // Idempotence: a certificate the tree already references was
             // retained with its facts in one commit, so there is nothing to
-            // add for it.
+            // add for it. Chains sharing a certificate (common: they share
+            // a proof prefix) contribute it to this batch once.
+            if !batched.insert(index_hash) {
+                continue;
+            }
             if let Some(tree) = &tree
                 && tree.get_blob(&store, &index_hash).await?.is_some()
             {

--- a/rust/dialog-repository/src/repository/branch/delegation/prove.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation/prove.rs
@@ -1,0 +1,781 @@
+//! Chain search over retained delegations.
+//!
+//! The tree-backed counterpart of the certificate store's
+//! [`prove`](dialog_capability::access::CertificateStore::prove), searching
+//! the `dialog.ucan/*` facts instead of listing and decoding stored
+//! certificate files. The walk considers **slim candidates** read from the
+//! facts (issuer, subject, command, validity bounds) and only fetches and
+//! decodes an envelope at admission time:
+//!
+//! - a **direct** candidate (issuer = subject) is admitted the moment it is
+//!   seen, so the common case reads one envelope no matter how many
+//!   delegations are retained;
+//! - an **indirect** candidate is deferred until every direct candidate of
+//!   the hop has been tried, preserving the direct-first preference of the
+//!   certificate-store walk;
+//! - a candidate whose subject, command cover, or validity window already
+//!   fails on the facts is skipped without touching its envelope.
+//!
+//! Each queue entry carries the principals already on its path, so a cyclic
+//! delegation graph cannot loop the walk; `MAX_DEPTH` still bounds honest
+//! depth exactly like the certificate-store walk.
+
+use dialog_artifacts::{Artifact, ArtifactSelector, Entity, Value};
+use dialog_capability::access::{AuthorizeError, Certificate as _, Proof as _, TimeRange};
+use dialog_capability::{ANY_SUBJECT, Did, Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::blob::{Import as BlobImport, Read as BlobRead};
+use dialog_effects::memory::Resolve;
+use dialog_ucan::{Scope, UcanCertificate, UcanProof};
+use dialog_ucan_core::command::Command;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use futures_util::StreamExt as _;
+use std::collections::HashSet;
+use std::fmt::Display;
+
+use super::{
+    DELEGATION_AUDIENCE, DELEGATION_COMMAND, DELEGATION_EXPIRATION, DELEGATION_ISSUER,
+    DELEGATION_NOT_BEFORE, DELEGATION_SUBJECT, Delegations,
+};
+use crate::repository::branch::blob::index_store;
+use crate::{Blob, Branch, RemoteSite, Select};
+
+/// Maximum chain depth, matching
+/// [`CertificateStore::MAX_DEPTH`](dialog_capability::access::CertificateStore::MAX_DEPTH).
+const MAX_DEPTH: usize = 10;
+
+impl<'a> Delegations<'a> {
+    /// Search the retained delegations for a chain proving `principal` may
+    /// access `access`, mirroring the certificate store's
+    /// [`prove`](dialog_capability::access::CertificateStore::prove)
+    /// semantics over the branch's `dialog.ucan/*` facts.
+    pub fn prove(self, principal: Did, access: Scope) -> ProveDelegation<'a> {
+        ProveDelegation {
+            branch: self.branch,
+            principal,
+            access,
+            duration: TimeRange::unbounded(),
+        }
+    }
+}
+
+/// A chain search over retained delegations. Created by
+/// [`Delegations::prove`].
+pub struct ProveDelegation<'a> {
+    branch: &'a Branch,
+    principal: Did,
+    access: Scope,
+    duration: TimeRange,
+}
+
+/// A delegation considered by the walk, read entirely from its facts; the
+/// envelope is untouched until admission.
+struct Candidate {
+    entity: Entity,
+    issuer: Did,
+    /// The certificate's own validity window, from the fact bounds.
+    range: TimeRange,
+}
+
+/// One pending hop of the walk.
+struct Hop {
+    audience: Did,
+    chain: Vec<(UcanCertificate, TimeRange)>,
+    /// Every principal already on this path, for cycle prevention.
+    path: HashSet<Did>,
+    depth: usize,
+}
+
+fn malformed(context: &str, error: impl Display) -> AuthorizeError {
+    AuthorizeError::Malformed {
+        detail: format!("{context}: {error}"),
+    }
+}
+
+impl ProveDelegation<'_> {
+    /// Constrain the proof to a time range the chain must cover.
+    pub fn during(mut self, duration: TimeRange) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Execute the search, returning the proof chain.
+    pub async fn perform<Env>(self, env: &Env) -> Result<UcanProof, AuthorizeError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<BlobRead>
+            + Provider<BlobImport>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + Provider<Fork<RemoteSite, BlobRead>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let access = &self.access;
+        let duration = &self.duration;
+
+        let subject = match &access.subject {
+            UcanSubject::Specific(did) => did.clone(),
+            // An `Any` subject needs no proof, exactly as the
+            // certificate-store walk decides it.
+            UcanSubject::Any => return Ok(UcanProof::new(access.clone())),
+        };
+        if self.principal == subject {
+            return Ok(UcanProof::new(access.clone()));
+        }
+
+        let store = index_store(branch, env).await;
+
+        let mut queue: Vec<Hop> = vec![Hop {
+            audience: self.principal.clone(),
+            chain: Vec::new(),
+            path: HashSet::from([self.principal.clone()]),
+            depth: 0,
+        }];
+
+        while let Some(hop) = queue.pop() {
+            if hop.depth >= MAX_DEPTH {
+                continue;
+            }
+
+            // One audience-scoped scan yields the hop's candidate entities;
+            // their facts filter and order them without a single decode.
+            let candidates = Select::new(
+                branch,
+                ArtifactSelector::new()
+                    .the(DELEGATION_AUDIENCE.parse().expect("valid attribute"))
+                    .is(Value::String(hop.audience.to_string())),
+            )
+            .execute(store.clone())
+            .await
+            .map_err(|error| malformed("candidate scan failed", error))?;
+            futures_util::pin_mut!(candidates);
+
+            let mut deferred: Vec<Candidate> = Vec::new();
+            let mut admitted_direct = None;
+
+            while let Some(item) = candidates.next().await {
+                let fact = item.map_err(|error| malformed("candidate fact undecodable", error))?;
+                let Some(candidate) = self.candidate(branch, &store, fact.of, &subject).await?
+                else {
+                    continue;
+                };
+
+                if candidate.issuer == subject {
+                    // Direct grant: admit immediately. The first one whose
+                    // envelope verifies completes the chain.
+                    if let Some(admitted) = self
+                        .admit(branch, env, &candidate, access, duration)
+                        .await?
+                    {
+                        admitted_direct = Some(admitted);
+                        break;
+                    }
+                } else if !hop.path.contains(&candidate.issuer) {
+                    deferred.push(candidate);
+                }
+            }
+
+            if let Some((certificate, range)) = admitted_direct {
+                let mut chain = hop.chain;
+                chain.insert(0, (certificate, range));
+                let effective = chain
+                    .iter()
+                    .fold(TimeRange::unbounded(), |acc, (_, r)| acc.intersect(r));
+                let mut proof = UcanProof::new(access.clone());
+                for (certificate, _) in chain {
+                    proof.push(certificate);
+                }
+                proof.set_duration(effective);
+                return Ok(proof);
+            }
+
+            // No direct grant at this hop: admit the deferred indirect
+            // candidates and queue the next hops.
+            for candidate in deferred {
+                let Some((certificate, range)) = self
+                    .admit(branch, env, &candidate, access, duration)
+                    .await?
+                else {
+                    continue;
+                };
+                let issuer = candidate.issuer.clone();
+                let mut chain = hop.chain.clone();
+                chain.insert(0, (certificate, range));
+                let mut path = hop.path.clone();
+                path.insert(issuer.clone());
+                queue.push(Hop {
+                    audience: issuer,
+                    chain,
+                    path,
+                    depth: hop.depth + 1,
+                });
+            }
+        }
+
+        Err(AuthorizeError::UnprovenSubject {
+            claimed: self.principal.clone(),
+            authorized: subject,
+        })
+    }
+
+    /// Read a candidate's slim facts and filter on them: subject match,
+    /// command cover, validity window. `None` means the candidate cannot
+    /// serve this claim and its envelope is never touched.
+    async fn candidate<S>(
+        &self,
+        branch: &Branch,
+        store: &S,
+        entity: Entity,
+        subject: &Did,
+    ) -> Result<Option<Candidate>, AuthorizeError>
+    where
+        S: dialog_storage::StorageBackend<
+                Key = dialog_storage::Blake3Hash,
+                Value = Vec<u8>,
+                Error = dialog_storage::DialogStorageError,
+            > + Clone
+            + ConditionalSync,
+    {
+        let facts = Select::new(branch, ArtifactSelector::new().of(entity.clone()))
+            .execute(store.clone())
+            .await
+            .map_err(|error| malformed("candidate read failed", error))?;
+        futures_util::pin_mut!(facts);
+
+        let mut issuer = None;
+        let mut candidate_subject = None;
+        let mut command = None;
+        let mut not_before = None;
+        let mut expiration = None;
+        while let Some(item) = facts.next().await {
+            let fact: Artifact =
+                item.map_err(|error| malformed("candidate fact undecodable", error))?;
+            match (fact.the.as_str(), fact.is) {
+                (DELEGATION_ISSUER, Value::String(did)) => issuer = Some(did),
+                (DELEGATION_SUBJECT, Value::String(did)) => candidate_subject = Some(did),
+                (DELEGATION_COMMAND, Value::String(path)) => command = Some(path),
+                (DELEGATION_NOT_BEFORE, Value::UnsignedInt(seconds)) => {
+                    not_before = Some(seconds as u64)
+                }
+                (DELEGATION_EXPIRATION, Value::UnsignedInt(seconds)) => {
+                    expiration = Some(seconds as u64)
+                }
+                _ => {}
+            }
+        }
+        let (Some(issuer), Some(candidate_subject), Some(command)) =
+            (issuer, candidate_subject, command)
+        else {
+            // Not a complete delegation record (foreign facts on a blob
+            // entity, or a partially visible one): not a candidate.
+            return Ok(None);
+        };
+
+        // Subject: specific match or powerline.
+        if candidate_subject != subject.to_string() && candidate_subject != ANY_SUBJECT {
+            return Ok(None);
+        }
+
+        // Command cover: the requested command must fall under the
+        // delegated one. The envelope's authoritative verify re-checks
+        // this at admission; failing here just skips the fetch.
+        match Command::parse(&command) {
+            Ok(delegated) if self.access.command.starts_with(&delegated) => {}
+            _ => return Ok(None),
+        }
+
+        // Validity window, from the fact bounds.
+        let range = TimeRange {
+            not_before,
+            expiration,
+        };
+        if !range.covers(&self.duration) {
+            return Ok(None);
+        }
+
+        let issuer: Did = issuer
+            .parse()
+            .map_err(|_| malformed("candidate issuer is not a DID", issuer.clone()))?;
+
+        Ok(Some(Candidate {
+            entity,
+            issuer,
+            range,
+        }))
+    }
+
+    /// Fetch and decode a candidate's envelope and run the authoritative
+    /// verification (command cover and policy). `None` means the envelope
+    /// rejected a claim its facts admitted; the walk moves on.
+    async fn admit<Env>(
+        &self,
+        branch: &Branch,
+        env: &Env,
+        candidate: &Candidate,
+        access: &Scope,
+        duration: &TimeRange,
+    ) -> Result<Option<(UcanCertificate, TimeRange)>, AuthorizeError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<BlobRead>
+            + Provider<BlobImport>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + Provider<Fork<RemoteSite, BlobRead>>
+            + ConditionalSync
+            + 'static,
+    {
+        let mut reader = Blob::from(candidate.entity.clone())
+            .read(branch.into())
+            .perform(env)
+            .await
+            .map_err(|error| malformed("envelope unavailable", error))?;
+        let mut bytes = Vec::new();
+        while let Some(chunk) = reader
+            .next()
+            .await
+            .map_err(|error| malformed("envelope read failed", error))?
+        {
+            bytes.extend(chunk);
+        }
+
+        let certificate = UcanCertificate::decode(&bytes)?;
+        let Ok(range) = certificate.verify(access) else {
+            return Ok(None);
+        };
+        if !range.covers(duration) {
+            return Ok(None);
+        }
+        debug_assert_eq!(
+            (range.not_before, range.expiration),
+            (candidate.range.not_before, candidate.range.expiration),
+            "fact bounds must mirror the envelope's"
+        );
+        Ok(Some((certificate, range)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::RepositoryExt as _;
+    use crate::helpers::unique_name;
+    use anyhow::Result;
+    use dialog_capability::Subject;
+    use dialog_capability::access::{CertificateStore, Prove};
+    use dialog_credentials::Ed25519Signer;
+    use dialog_network::Network;
+    use dialog_operator::{Operator, Profile};
+    use dialog_storage::provider::Volatile;
+    use dialog_storage::provider::storage::{Storage, VolatileSpace};
+    use dialog_ucan::{Parameters, Ucan, UcanDelegation};
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal as _;
+
+    /// Both stores, populated identically: every scenario proves against
+    /// the legacy certificate store AND the tree-backed walk, and the two
+    /// must agree.
+    struct Harness {
+        branch: crate::Branch,
+        operator: Operator<VolatileSpace>,
+        legacy: Volatile,
+    }
+
+    impl Harness {
+        async fn new(name: &str) -> Result<Self> {
+            let storage = Storage::volatile();
+            let profile = Profile::open(unique_name(name)).perform(&storage).await?;
+            let operator = profile
+                .derive(b"test")
+                .allow(Subject::any())
+                .network(Network::default())
+                .build(storage)
+                .await?;
+            let repo = profile
+                .repository(unique_name("repo"))
+                .open()
+                .perform(&operator)
+                .await?;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+            Ok(Self {
+                branch,
+                operator,
+                legacy: Volatile::new(),
+            })
+        }
+
+        async fn retain(&self, chain: UcanDelegation) -> Result<()> {
+            CertificateStore::<Ucan>::save(&self.legacy, &chain)
+                .await
+                .unwrap();
+            self.branch
+                .delegations()
+                .retain(chain)
+                .perform(&self.operator)
+                .await?;
+            Ok(())
+        }
+
+        /// Prove against both stores and assert they agree on success and
+        /// chain length; return the tree walk's verdict.
+        async fn parity(
+            &self,
+            principal: &Did,
+            scope: Scope,
+            duration: TimeRange,
+        ) -> Result<UcanProof, AuthorizeError> {
+            let mut legacy_claim = Prove::<Ucan>::new(principal.clone(), scope.clone());
+            legacy_claim.duration = duration;
+            let legacy = CertificateStore::<Ucan>::prove(&self.legacy, legacy_claim).await;
+
+            let tree = self
+                .branch
+                .delegations()
+                .prove(principal.clone(), scope)
+                .during(duration)
+                .perform(&self.operator)
+                .await;
+
+            match (&legacy, &tree) {
+                (Ok(expected), Ok(actual)) => assert_eq!(
+                    expected.proofs().len(),
+                    actual.proofs().len(),
+                    "both walks must find chains of the same length"
+                ),
+                (Err(_), Err(_)) => {}
+                (expected, actual) => panic!(
+                    "walks disagree: legacy ok={} tree ok={}",
+                    expected.is_ok(),
+                    actual.is_ok()
+                ),
+            }
+            tree
+        }
+    }
+
+    async fn signer() -> Ed25519Signer {
+        Ed25519Signer::generate().await.unwrap()
+    }
+
+    async fn delegate(
+        issuer: &Ed25519Signer,
+        audience: &Ed25519Signer,
+        subject: UcanSubject,
+    ) -> UcanDelegation {
+        let delegation = DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(audience)
+            .subject(subject)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+        UcanDelegation::new(DelegationChain::new(delegation))
+    }
+
+    fn scope(subject: &Ed25519Signer, command: &[&str]) -> Scope {
+        Scope {
+            subject: UcanSubject::Specific(subject.did()),
+            command: Command(command.iter().map(|s| s.to_string()).collect()),
+            parameters: Parameters::default(),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_proves_with_direct_delegation() -> Result<()> {
+        let harness = Harness::new("prove-direct").await?;
+        let space = signer().await;
+        let holder = signer().await;
+        harness
+            .retain(delegate(&space, &holder, UcanSubject::Specific(space.did())).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert_eq!(proof.expect("direct grant proves").proofs().len(), 1);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_proves_with_powerline_delegation() -> Result<()> {
+        let harness = Harness::new("prove-powerline").await?;
+        let space = signer().await;
+        let holder = signer().await;
+        harness
+            .retain(delegate(&space, &holder, UcanSubject::Any).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert!(proof.is_ok(), "powerline proves: {:?}", proof.err());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_without_delegation() -> Result<()> {
+        let harness = Harness::new("prove-none").await?;
+        let space = signer().await;
+        let holder = signer().await;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert!(matches!(proof, Err(AuthorizeError::UnprovenSubject { .. })));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_for_wrong_audience() -> Result<()> {
+        let harness = Harness::new("prove-wrong-aud").await?;
+        let space = signer().await;
+        let holder = signer().await;
+        let stranger = signer().await;
+        harness
+            .retain(delegate(&space, &holder, UcanSubject::Specific(space.did())).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &stranger.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert!(proof.is_err());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_for_wrong_subject() -> Result<()> {
+        let harness = Harness::new("prove-wrong-subj").await?;
+        let space = signer().await;
+        let other_space = signer().await;
+        let holder = signer().await;
+        harness
+            .retain(delegate(&space, &holder, UcanSubject::Specific(space.did())).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&other_space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert!(proof.is_err());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_for_uncovered_command() -> Result<()> {
+        let harness = Harness::new("prove-command").await?;
+        let space = signer().await;
+        let holder = signer().await;
+        harness
+            .retain(delegate(&space, &holder, UcanSubject::Specific(space.did())).await)
+            .await?;
+
+        // The delegation grants /storage; /archive is not beneath it.
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["archive"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert!(proof.is_err());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_an_expired_delegation() -> Result<()> {
+        use dialog_common::time;
+        use dialog_ucan_core::time::timestamp::Timestamp;
+
+        let harness = Harness::new("prove-expired").await?;
+        let space = signer().await;
+        let holder = signer().await;
+
+        let now = time::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let past = Timestamp::try_from((now - 3600) as i128).unwrap();
+        let delegation = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&holder)
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec!["storage".to_string()])
+            .expiration(past)
+            .try_build()
+            .await
+            .unwrap();
+        harness
+            .retain(UcanDelegation::new(DelegationChain::new(delegation)))
+            .await?;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange {
+                    not_before: Some(now),
+                    expiration: Some(now + 60),
+                },
+            )
+            .await;
+        assert!(proof.is_err(), "an expired delegation must not prove");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_proves_via_powerline_chain() -> Result<()> {
+        let harness = Harness::new("prove-powerline-chain").await?;
+        let space = signer().await;
+        let intermediary = signer().await;
+        let holder = signer().await;
+
+        harness
+            .retain(delegate(&space, &intermediary, UcanSubject::Any).await)
+            .await?;
+        harness
+            .retain(delegate(&intermediary, &holder, UcanSubject::Specific(space.did())).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert_eq!(proof.expect("chain proves").proofs().len(), 2);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_proves_through_powerline_middle_link() -> Result<()> {
+        let harness = Harness::new("prove-mid-powerline").await?;
+        let space = signer().await;
+        let intermediary = signer().await;
+        let holder = signer().await;
+
+        harness
+            .retain(delegate(&space, &intermediary, UcanSubject::Specific(space.did())).await)
+            .await?;
+        harness
+            .retain(delegate(&intermediary, &holder, UcanSubject::Any).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert_eq!(proof.expect("chain proves").proofs().len(), 2);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_proves_through_powerline_powerline_chain() -> Result<()> {
+        let harness = Harness::new("prove-powerline-powerline").await?;
+        let space = signer().await;
+        let intermediary = signer().await;
+        let holder = signer().await;
+
+        harness
+            .retain(delegate(&space, &intermediary, UcanSubject::Any).await)
+            .await?;
+        harness
+            .retain(delegate(&intermediary, &holder, UcanSubject::Any).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert_eq!(proof.expect("chain proves").proofs().len(), 2);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_proves_self_authorization_without_certificates() -> Result<()> {
+        let harness = Harness::new("prove-self").await?;
+        let space = signer().await;
+
+        let proof = harness
+            .parity(
+                &space.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert!(
+            proof
+                .expect("self-authorization proves")
+                .proofs()
+                .is_empty(),
+            "self-authorization needs no chain"
+        );
+        Ok(())
+    }
+
+    /// A cyclic delegation graph (A grants B, B grants A, neither reaching
+    /// the subject) must terminate with a denial rather than loop. The
+    /// certificate-store walk survives this only through its depth bound;
+    /// the tree walk's per-path visited set prunes it outright, and both
+    /// must agree on the verdict.
+    #[dialog_common::test]
+    async fn it_terminates_on_a_cyclic_delegation_graph() -> Result<()> {
+        let harness = Harness::new("prove-cycle").await?;
+        let space = signer().await;
+        let alpha = signer().await;
+        let beta = signer().await;
+
+        harness
+            .retain(delegate(&alpha, &beta, UcanSubject::Specific(space.did())).await)
+            .await?;
+        harness
+            .retain(delegate(&beta, &alpha, UcanSubject::Specific(space.did())).await)
+            .await?;
+
+        let proof = harness
+            .parity(
+                &beta.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert!(matches!(proof, Err(AuthorizeError::UnprovenSubject { .. })));
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/delegation/prove.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation/prove.rs
@@ -116,7 +116,6 @@ impl ProveDelegation<'_> {
     {
         let branch = self.branch;
         let access = &self.access;
-        let duration = &self.duration;
 
         let subject = match &access.subject {
             UcanSubject::Specific(did) => did.clone(),
@@ -169,7 +168,7 @@ impl ProveDelegation<'_> {
                     // Direct grant: admit immediately. The first one whose
                     // envelope verifies completes the chain.
                     if let Some(admitted) = self
-                        .admit(branch, env, &candidate, access, duration)
+                        .admit(branch, env, &candidate, &hop.audience, &subject)
                         .await?
                     {
                         admitted_direct = Some(admitted);
@@ -198,7 +197,7 @@ impl ProveDelegation<'_> {
             // candidates and queue the next hops.
             for candidate in deferred {
                 let Some((certificate, range)) = self
-                    .admit(branch, env, &candidate, access, duration)
+                    .admit(branch, env, &candidate, &hop.audience, &subject)
                     .await?
                 else {
                     continue;
@@ -310,15 +309,17 @@ impl ProveDelegation<'_> {
     }
 
     /// Fetch and decode a candidate's envelope and run the authoritative
-    /// verification (command cover and policy). `None` means the envelope
-    /// rejected a claim its facts admitted; the walk moves on.
+    /// verification (identity linkage, command cover and policy). `None`
+    /// means the envelope is unavailable, undecodable, inconsistent with
+    /// the facts that routed it here, or rejected a claim its facts
+    /// admitted; the walk moves on to the next candidate.
     async fn admit<Env>(
         &self,
         branch: &Branch,
         env: &Env,
         candidate: &Candidate,
-        access: &Scope,
-        duration: &TimeRange,
+        audience: &Did,
+        subject: &Did,
     ) -> Result<Option<(UcanCertificate, TimeRange)>, AuthorizeError>
     where
         Env: Provider<Get>
@@ -332,32 +333,73 @@ impl ProveDelegation<'_> {
             + ConditionalSync
             + 'static,
     {
-        let mut reader = Blob::from(candidate.entity.clone())
+        // An unavailable or unreadable envelope skips the candidate rather
+        // than aborting the walk: another candidate, or a later direct
+        // grant, can still prove the claim. The certificate-store walk has
+        // no such failure mode (a listed certificate's bytes are always
+        // present), but a replica that pulled the facts without hydrating
+        // an envelope does.
+        let mut bytes = Vec::new();
+        let mut reader = match Blob::from(candidate.entity.clone())
             .read(branch.into())
             .perform(env)
             .await
-            .map_err(|error| malformed("envelope unavailable", error))?;
-        let mut bytes = Vec::new();
-        while let Some(chunk) = reader
-            .next()
-            .await
-            .map_err(|error| malformed("envelope read failed", error))?
         {
-            bytes.extend(chunk);
+            Ok(reader) => reader,
+            Err(error) => {
+                tracing::warn!(%error, "delegation envelope unavailable; skipping candidate");
+                return Ok(None);
+            }
+        };
+        loop {
+            match reader.next().await {
+                Ok(Some(chunk)) => bytes.extend(chunk),
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::warn!(%error, "delegation envelope unreadable; skipping candidate");
+                    return Ok(None);
+                }
+            }
+        }
+        let certificate = match UcanCertificate::decode(&bytes) {
+            Ok(certificate) => certificate,
+            Err(error) => {
+                tracing::warn!(%error, "delegation envelope undecodable; skipping candidate");
+                return Ok(None);
+            }
+        };
+
+        // The facts routed this envelope here, but the envelope is the
+        // authority: a drifted record (any peer with push access can write
+        // `dialog.ucan/*` facts the envelope does not back) must not
+        // splice a broken link into the chain.
+        if certificate.issuer() != &candidate.issuer
+            || certificate.audience() != audience
+            || certificate.subject().is_some_and(|did| did != subject)
+        {
+            tracing::warn!(
+                entity = %candidate.entity,
+                "delegation facts disagree with their envelope; skipping candidate"
+            );
+            return Ok(None);
         }
 
-        let certificate = UcanCertificate::decode(&bytes)?;
-        let Ok(range) = certificate.verify(access) else {
+        let Ok(range) = certificate.verify(&self.access) else {
             return Ok(None);
         };
-        if !range.covers(duration) {
+        if !range.covers(&self.duration) {
             return Ok(None);
         }
-        debug_assert_eq!(
-            (range.not_before, range.expiration),
-            (candidate.range.not_before, candidate.range.expiration),
-            "fact bounds must mirror the envelope's"
-        );
+        if (range.not_before, range.expiration)
+            != (candidate.range.not_before, candidate.range.expiration)
+        {
+            // The envelope's bounds prevail (they just passed the cover
+            // check); drifted fact bounds only mis-prefilter candidates.
+            tracing::warn!(
+                entity = %candidate.entity,
+                "delegation fact bounds drifted from their envelope"
+            );
+        }
         Ok(Some((certificate, range)))
     }
 }
@@ -372,7 +414,7 @@ mod tests {
     use crate::helpers::unique_name;
     use anyhow::Result;
     use dialog_capability::Subject;
-    use dialog_capability::access::{CertificateStore, Prove};
+    use dialog_capability::access::{CertificateStore, Delegation as _, Prove};
     use dialog_credentials::Ed25519Signer;
     use dialog_network::Network;
     use dialog_operator::{Operator, Profile};
@@ -776,6 +818,218 @@ mod tests {
             )
             .await;
         assert!(matches!(proof, Err(AuthorizeError::UnprovenSubject { .. })));
+        Ok(())
+    }
+
+    /// Assert hand-crafted `dialog.ucan/*` facts on `entity` — the shape a
+    /// peer with push access can plant without a matching envelope, since
+    /// the namespace write gate holds only on the local write path.
+    async fn plant_facts(
+        harness: &Harness,
+        entity: &Entity,
+        issuer: &Did,
+        audience: &Did,
+        subject: &Did,
+    ) -> Result<()> {
+        use dialog_artifacts::{Attribute, Instruction};
+        use futures_util::stream;
+
+        let fact = |attribute: &str, value: &str| -> Result<Instruction> {
+            Ok(Instruction::Assert(Artifact {
+                the: Attribute::try_from(attribute.to_string())?,
+                of: entity.clone(),
+                is: Value::String(value.to_string()),
+                cause: None,
+            }))
+        };
+        let command = Command(vec!["storage".to_string()]).to_string();
+        let instructions = vec![
+            fact(DELEGATION_AUDIENCE, audience.as_ref())?,
+            fact(DELEGATION_SUBJECT, subject.as_ref())?,
+            fact(DELEGATION_ISSUER, issuer.as_ref())?,
+            fact(DELEGATION_COMMAND, &command)?,
+        ];
+        harness
+            .branch
+            .commit(stream::iter(instructions))
+            .machinery()
+            .perform(&harness.operator)
+            .await?;
+        Ok(())
+    }
+
+    /// A retracted delegation must stop proving: retraction is the closest
+    /// thing this system has to revocation.
+    #[dialog_common::test]
+    async fn it_stops_proving_after_a_retract() -> Result<()> {
+        let harness = Harness::new("prove-retract").await?;
+        let space = signer().await;
+        let holder = signer().await;
+        let chain = delegate(&space, &holder, UcanSubject::Specific(space.did())).await;
+
+        harness.retain(chain.clone()).await?;
+        let proven = harness
+            .branch
+            .delegations()
+            .prove(holder.did(), scope(&space, &["storage"]))
+            .perform(&harness.operator)
+            .await;
+        assert!(proven.is_ok(), "the grant proves before the retract");
+
+        harness
+            .branch
+            .delegations()
+            .retract(chain)
+            .perform(&harness.operator)
+            .await?;
+        let verdict = harness
+            .branch
+            .delegations()
+            .prove(holder.did(), scope(&space, &["storage"]))
+            .perform(&harness.operator)
+            .await;
+        assert!(
+            matches!(verdict, Err(AuthorizeError::UnprovenSubject { .. })),
+            "a retracted delegation must stop proving: {:?}",
+            verdict.err()
+        );
+        Ok(())
+    }
+
+    /// A single retained chain of several certificates decomposes into one
+    /// candidate per certificate and proves end to end — every other test
+    /// retains single-certificate chains, leaving the decomposition loop
+    /// unexercised.
+    #[dialog_common::test]
+    async fn it_retains_and_proves_a_multi_certificate_chain() -> Result<()> {
+        let harness = Harness::new("prove-chain-retain").await?;
+        let space = signer().await;
+        let mid = signer().await;
+        let holder = signer().await;
+
+        let root = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&mid)
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+        let leaf = DelegationBuilder::new()
+            .issuer(mid.clone())
+            .audience(&holder)
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await
+            .unwrap();
+        let chain = UcanDelegation::new(DelegationChain::try_from(vec![root, leaf])?);
+
+        harness.retain(chain).await?;
+        let proof = harness
+            .parity(
+                &holder.did(),
+                scope(&space, &["storage"]),
+                TimeRange::unbounded(),
+            )
+            .await;
+        assert_eq!(
+            proof.expect("the decomposed chain proves").proofs().len(),
+            2,
+            "both certificates of the chain assemble into the proof"
+        );
+        Ok(())
+    }
+
+    /// Facts with no envelope bytes behind them (a replica that pulled the
+    /// facts but never hydrated the blob, or a merge that split the retain
+    /// commit) must be skipped, not abort the walk — and must not stop a
+    /// healthy candidate from proving.
+    #[dialog_common::test]
+    async fn it_skips_a_candidate_whose_envelope_is_unavailable() -> Result<()> {
+        let harness = Harness::new("prove-missing-envelope").await?;
+        let space = signer().await;
+        let holder = signer().await;
+
+        let ghost_hash: dialog_storage::Blake3Hash = [7u8; 32];
+        let ghost = Entity::from_blob(&ghost_hash)?;
+        plant_facts(&harness, &ghost, &space.did(), &holder.did(), &space.did()).await?;
+
+        let verdict = harness
+            .branch
+            .delegations()
+            .prove(holder.did(), scope(&space, &["storage"]))
+            .perform(&harness.operator)
+            .await;
+        assert!(
+            matches!(verdict, Err(AuthorizeError::UnprovenSubject { .. })),
+            "a dangling candidate is a skip, not an abort: {:?}",
+            verdict.err()
+        );
+
+        harness
+            .retain(delegate(&space, &holder, UcanSubject::Specific(space.did())).await)
+            .await?;
+        let proof = harness
+            .branch
+            .delegations()
+            .prove(holder.did(), scope(&space, &["storage"]))
+            .perform(&harness.operator)
+            .await;
+        assert!(
+            proof.is_ok(),
+            "the healthy grant proves despite the dangling candidate: {:?}",
+            proof.err()
+        );
+        Ok(())
+    }
+
+    /// Facts that disagree with the envelope they point at — here spoofing
+    /// the issuer as the subject itself, turning an unrelated certificate
+    /// into an apparent direct grant — must not assemble into a proof: the
+    /// envelope is the authority.
+    #[dialog_common::test]
+    async fn it_rejects_facts_that_disagree_with_their_envelope() -> Result<()> {
+        let harness = Harness::new("prove-drifted-facts").await?;
+        let space = signer().await;
+        let mid = signer().await;
+        let holder = signer().await;
+
+        // A real envelope issued by `mid`, stored as a blob without retain.
+        let certificate = delegate(&mid, &holder, UcanSubject::Specific(space.did()))
+            .await
+            .certificates()
+            .remove(0);
+        use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
+        let bytes: Vec<u8> = certificate
+            .encode()
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        let mut sink = harness
+            .branch
+            .archive()
+            .blob()
+            .write()
+            .perform(&harness.operator)
+            .await?;
+        sink.write_all(&bytes).await?;
+        let hash = sink.finish().await?;
+        let index_hash: dialog_storage::Blake3Hash = *hash.as_bytes();
+        let entity = Entity::from_blob(&index_hash)?;
+
+        // Facts claiming `space` itself issued it: an apparent direct grant.
+        plant_facts(&harness, &entity, &space.did(), &holder.did(), &space.did()).await?;
+
+        let verdict = harness
+            .branch
+            .delegations()
+            .prove(holder.did(), scope(&space, &["storage"]))
+            .perform(&harness.operator)
+            .await;
+        assert!(
+            matches!(verdict, Err(AuthorizeError::UnprovenSubject { .. })),
+            "spoofed facts must not assemble a proof from a mismatched envelope: {:?}",
+            verdict.err()
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Third slice of [delegations-as-data](https://github.com/dialog-db/dialog-db/blob/feat/delegation-prover/notes/delegations-as-data.md), stacked on #436. The chain search moves onto the retained-delegation facts, with measurements demonstrating the expected behavior.

## Mechanism

`branch.delegations().prove(principal, scope)` replaces the certificate-store shape of list-and-decode-everything with a slim-candidate walk:

- candidates are filtered on their facts (subject match, command cover, validity window) without touching an envelope;
- a **direct grant** (issuer = subject) is admitted the moment it is seen, so the common case reads and decodes exactly one envelope no matter how many delegations are retained;
- **indirect** candidates are deferred until the hop's direct candidates are exhausted, preserving the certificate-store walk's direct-first preference;
- each queue entry carries the principals on its path, so a cyclic delegation graph terminates by pruning rather than by depth bound alone.

## Parity

Twelve scenarios (direct, powerline, three chain shapes, wrong audience/subject/command, expired, self-auth, cyclic) each prove against **both** the legacy volatile certificate store and the tree walk, asserting agreement on verdict and chain length.

## Measurements

`benches/delegation_prove.rs` populates the legacy filesystem store, the legacy volatile store, and the delegation region with the same N certificates (verdicts asserted every iteration):

| scenario | legacy fs | legacy volatile | tree |
|---|---:|---:|---:|
| direct, N=32 | 751 µs | 31 µs | 23 µs |
| direct, N=512 | 12.2 ms | 492 µs | **21 µs** |
| direct, N=6144 | 210 ms | 6.0 ms | **25 µs** |
| miss (exhaustive), N=32 | 1.5 ms | 43 µs | 780 µs |
| miss, N=512 | 24 ms | 1.8 ms | 13 ms |
| miss, N=6144 | 308 ms | 187 ms | 180 ms |
| chain3 (intended topology) | 174 µs | 4.6 µs | 89 µs |

The accumulation pathology observed in the field (thousands of same-audience grants, every remote effect re-decoding all of them) goes from O(N) to O(1): flat ~25 µs at 6144 certificates vs 210 ms on the filesystem store. The tree walk beats the store native actually persists to in every scenario. Honest caveat the data surfaced: at small-N exhaustive misses the in-memory store wins on per-candidate constant factors (~25 µs of select machinery per candidate; a batching target, irrelevant at sub-ms absolutes).

The certificate store still serves the operator's prove path; switching it over with migration, and the resolved-chain cache that amortizes repeat proves per effect, are the remaining slices.