### PR TITLE
feat(dialog-repository): serve operator access from the profile branch

### DIFF
--- a/rust/dialog-capability/src/access.rs
+++ b/rust/dialog-capability/src/access.rs
@@ -19,6 +19,7 @@
 use crate::{Ability, Attenuate, Capability, Constraint, Did, Effect};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use thiserror::Error;
 
 /// Describes the scope of access being requested or granted.
@@ -429,6 +430,43 @@ where
     type Output = Result<(), AuthorizeError>;
 }
 
+/// Export effect — enumerates every retained certificate.
+///
+/// An [`Effect`](crate::Effect) on [`Access`]. The subject DID in the
+/// capability chain determines which store is enumerated. Exists for
+/// migration: a caller moving certificates from one store to another
+/// (the legacy per-provider certificate stores into the synced
+/// delegation records) reads them all through this rather than knowing
+/// each store's layout.
+#[derive(Serialize, Deserialize, Attenuate)]
+pub struct Export<P: Protocol> {
+    #[serde(skip)]
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<P: Protocol> Export<P> {
+    /// Create a new export request.
+    pub fn new() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P: Protocol> Default for Export<P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<P: Protocol> crate::Effect for Export<P>
+where
+    P::Certificate: 'static,
+{
+    type Of = Access;
+    type Output = Result<Vec<P::Certificate>, AuthorizeError>;
+}
+
 /// Storage backend for delegation proofs.
 ///
 /// Each storage backend (FileStore, Volatile, IndexedDb) implements this
@@ -452,6 +490,10 @@ pub trait CertificateStore<P: Protocol> {
 
     /// Store a delegation for future authorization lookups.
     async fn save(&self, delegation: &P::Delegation) -> Result<(), AuthorizeError>;
+
+    /// Enumerate every certificate this store retains, for migration into
+    /// another store (see [`Export`]).
+    async fn export(&self) -> Result<Vec<P::Certificate>, AuthorizeError>;
 
     /// Resolve a delegation chain for the given claim.
     ///

--- a/rust/dialog-operator/src/operator.rs
+++ b/rust/dialog-operator/src/operator.rs
@@ -9,7 +9,10 @@ mod space;
 #[cfg(test)]
 mod test;
 
+pub use access::AccessProvider;
 pub use builder::{OperatorBuilder, OperatorError};
+
+use std::sync::Arc;
 
 use crate::Authority;
 use dialog_capability::{Capability, Provider};
@@ -29,7 +32,7 @@ use dialog_varsig::{Did, Principal};
 /// - [`Storage`] for DID-routed effects
 /// - Base directory for resolving space names to storage locations
 /// - Remote for fork invocations
-#[derive(Provider)]
+#[derive(Provider, Clone)]
 pub struct Operator<S: Clone> {
     #[provide(Identify, Attest)]
     /// Provider for authority effects (identity and attestation).
@@ -58,9 +61,27 @@ pub struct Operator<S: Clone> {
 
     /// Network dispatch for fork invocations.
     network: Network,
+
+    /// Optional override for where proofs are resolved and delegations
+    /// retained (see [`AccessProvider`]). `None` routes access effects to
+    /// the storage certificate provider.
+    access: Option<Arc<dyn AccessProvider>>,
 }
 
 impl<S: Clone> Operator<S> {
+    /// Install an [`AccessProvider`], returning an operator whose access
+    /// effects (prove, retain) resolve through it instead of the storage
+    /// certificate provider.
+    pub fn with_access(mut self, access: Arc<dyn AccessProvider>) -> Self {
+        self.access = Some(access);
+        self
+    }
+
+    /// The installed access override, if any.
+    pub(crate) fn access(&self) -> Option<&Arc<dyn AccessProvider>> {
+        self.access.as_ref()
+    }
+
     /// The operator's DID (the ephemeral/derived session key).
     pub fn did(&self) -> Did {
         self.authority.operator_did()

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -1,74 +1,121 @@
 //! Access capability providers for Operator.
+//!
+//! By default the access effects ([`Prove`], [`Retain`], [`Export`]) route
+//! through [`Storage`] to the subject space's certificate provider. An
+//! installed [`AccessProvider`] (see [`Operator::with_access`]) overrides
+//! where proofs are resolved and delegations retained — the hook the
+//! repository layer uses to serve access from the synced delegation
+//! records of a branch, which this crate cannot construct itself (the
+//! repository sits above it in the crate graph).
 
 use super::Operator;
 use dialog_capability::Provider;
 use dialog_capability::access::{
-    Access, Authorize, AuthorizeError, Proof as _, Protocol, Prove, Retain,
+    Access, Authorize, AuthorizeError, Export, Proof as _, Protocol, Prove, Retain,
 };
-use dialog_capability::{Capability, Subject};
+use dialog_capability::{Capability, Policy as _, Subject};
 use dialog_common::{ConditionalSend, ConditionalSync};
-use dialog_credentials::Ed25519Signer;
 use dialog_storage::provider::storage::Storage;
+use dialog_ucan::{Ucan, UcanDelegation, UcanProof};
+
+/// Overrides where the operator resolves and retains UCAN delegations.
+///
+/// Installed with [`Operator::with_access`]; without one, access effects
+/// route to the storage certificate provider.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait AccessProvider: ConditionalSend + ConditionalSync {
+    /// Resolve a proof chain for the claim.
+    async fn prove(&self, claim: Prove<Ucan>) -> Result<UcanProof, AuthorizeError>;
+
+    /// Retain a delegation for future claims.
+    async fn retain(&self, delegation: UcanDelegation) -> Result<(), AuthorizeError>;
+}
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<S, P> Provider<Prove<P>> for Operator<S>
+impl<S> Provider<Prove<Ucan>> for Operator<S>
 where
     S: Clone + ConditionalSend + ConditionalSync + 'static,
-    P: Protocol,
-    P::Access: Clone + ConditionalSend + ConditionalSync,
-    P::Certificate: Clone + ConditionalSend + ConditionalSync,
-    P::Proof: ConditionalSend,
-    Storage<S>: Provider<Prove<P>>,
+    Storage<S>: Provider<Prove<Ucan>>,
     Self: ConditionalSend + ConditionalSync,
 {
-    async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
-        input.perform(&self.storage).await
+    async fn execute(&self, input: Capability<Prove<Ucan>>) -> Result<UcanProof, AuthorizeError> {
+        match self.access() {
+            Some(access) => {
+                let claim = Prove::<Ucan>::of(&input);
+                let mut prove = Prove::<Ucan>::new(claim.principal.clone(), claim.access.clone());
+                prove.duration = claim.duration;
+                access.prove(prove).await
+            }
+            None => input.perform(&self.storage).await,
+        }
     }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<S, P> Provider<Retain<P>> for Operator<S>
+impl<S> Provider<Retain<Ucan>> for Operator<S>
 where
     S: Clone + ConditionalSend + ConditionalSync + 'static,
-    P: Protocol,
-    P::Delegation: ConditionalSend + ConditionalSync,
-    Storage<S>: Provider<Retain<P>>,
+    Storage<S>: Provider<Retain<Ucan>>,
     Self: ConditionalSend + ConditionalSync,
 {
-    async fn execute(&self, input: Capability<Retain<P>>) -> Result<(), AuthorizeError> {
-        input.perform(&self.storage).await
+    async fn execute(&self, input: Capability<Retain<Ucan>>) -> Result<(), AuthorizeError> {
+        match self.access() {
+            Some(access) => {
+                let delegation = Retain::<Ucan>::of(&input).delegation.clone();
+                access.retain(delegation).await
+            }
+            None => input.perform(&self.storage).await,
+        }
     }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<S, P> Provider<Authorize<P>> for Operator<S>
+impl<S, P> Provider<Export<P>> for Operator<S>
 where
     S: Clone + ConditionalSend + ConditionalSync + 'static,
     P: Protocol,
-    P::Access: Clone + ConditionalSend + ConditionalSync,
-    P::Certificate: Clone + ConditionalSend + ConditionalSync,
-    P::Proof: ConditionalSend,
-    P::Signer: From<Ed25519Signer>,
-    P::Authorization: ConditionalSend,
-    Storage<S>: Provider<Prove<P>>,
+    P::Certificate: ConditionalSend + ConditionalSync,
+    Storage<S>: Provider<Export<P>>,
     Self: ConditionalSend + ConditionalSync,
 {
     async fn execute(
         &self,
-        input: Capability<Authorize<P>>,
-    ) -> Result<P::Authorization, AuthorizeError> {
-        let subject = input.subject().clone();
-        let prove: Prove<P> = input.into_effect().into();
+        input: Capability<Export<P>>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        // Enumeration always reads the storage certificate provider: it
+        // exists to migrate certificates OUT of it, so an installed access
+        // override must not redirect it.
+        input.perform(&self.storage).await
+    }
+}
 
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<S> Provider<Authorize<Ucan>> for Operator<S>
+where
+    S: Clone + ConditionalSend + ConditionalSync + 'static,
+    Storage<S>: Provider<Prove<Ucan>>,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        input: Capability<Authorize<Ucan>>,
+    ) -> Result<<Ucan as Protocol>::Authorization, AuthorizeError> {
+        let subject = input.subject().clone();
+        let prove: Prove<Ucan> = input.into_effect().into();
+
+        // Route the proof through this operator's own Prove provider, so
+        // an installed access override serves it.
         let proof = Subject::from(subject)
             .attenuate(Access)
             .invoke(prove)
-            .perform(&self.storage)
+            .perform(self)
             .await?;
 
-        proof.claim(self.authority.operator_signer().clone().into())
+        proof.claim(self.authority.operator_signer().clone())
     }
 }

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -84,6 +84,7 @@ impl OperatorBuilder {
             storage,
             directory: self.directory,
             network: self.network,
+            access: None,
         };
 
         // Create delegations for allowed capabilities

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -13,6 +13,9 @@ use dialog_operator::access::Access as ProfileAccess;
 use dialog_operator::{Profile, SpaceHandle};
 use dialog_varsig::Principal;
 
+mod access;
+pub use access::*;
+
 mod archive;
 pub use archive::*;
 

--- a/rust/dialog-repository/src/repository/access.rs
+++ b/rust/dialog-repository/src/repository/access.rs
@@ -1,0 +1,416 @@
+//! Synced access: the operator's delegations served from a branch.
+//!
+//! [`SyncedAccess`] implements the operator's
+//! [`AccessProvider`](dialog_operator::AccessProvider) over a branch's
+//! retained delegations, so proofs resolve through the tree walk
+//! ([`Delegations::prove`](crate::Delegations::prove)) and retains land as
+//! synced `dialog.ucan/*` facts — replicated by ordinary push/pull instead
+//! of living in a per-device certificate store.
+//!
+//! [`synced_access`] is the installer: it opens the profile's own
+//! repository branch (the store that is always locally present — proving
+//! access to it needs only the profile-to-operator delegation the builder
+//! mints locally, so a fresh device can pull it before it holds anything
+//! else), migrates every certificate the legacy store retains into the
+//! branch, and returns an operator with the override installed:
+//!
+//! ```no_run
+//! # use dialog_operator::{Operator, Profile};
+//! # use dialog_repository::synced_access;
+//! # use dialog_storage::provider::storage::VolatileSpace;
+//! # async fn example(
+//! #     profile: &Profile,
+//! #     operator: Operator<VolatileSpace>,
+//! # ) -> anyhow::Result<()> {
+//! let operator = synced_access(profile, operator).await?;
+//! // proofs now resolve from the profile branch's delegation records
+//! # Ok(())
+//! # }
+//! ```
+
+use std::sync::Arc;
+
+use crate::Branch;
+use dialog_capability::access::{Access, AuthorizeError, Export, Prove};
+use dialog_capability::{Provider, Subject};
+use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_effects::archive::{Get, Import, Put};
+use dialog_effects::authority::{Attest, Identify};
+use dialog_effects::blob::{Import as BlobImport, Read as BlobRead, Write as BlobWrite};
+use dialog_effects::memory::{Publish, Resolve};
+use dialog_operator::{AccessProvider, Operator, Profile};
+use dialog_storage::provider::space::SpaceProvider;
+use dialog_storage::provider::storage::Storage;
+use dialog_ucan::{Ucan, UcanDelegation, UcanProof};
+use dialog_ucan_core::DelegationChain;
+
+use crate::RemoteSite;
+
+/// The branch name delegations are retained under in the profile's own
+/// repository.
+pub const ACCESS_BRANCH: &str = "main";
+
+/// An [`AccessProvider`] serving proofs and retains from a branch's
+/// delegation records.
+pub struct SyncedAccess<Env> {
+    branch: Branch,
+    env: Env,
+}
+
+impl<Env> SyncedAccess<Env> {
+    /// Serve access from `branch`'s delegation records, performing the
+    /// walk's effects against `env`.
+    pub fn new(branch: Branch, env: Env) -> Self {
+        Self { branch, env }
+    }
+
+    /// The branch this access provider serves from.
+    pub fn branch(&self) -> &Branch {
+        &self.branch
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<Env> AccessProvider for SyncedAccess<Env>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Import>
+        + Provider<Resolve>
+        + Provider<Publish>
+        + Provider<Identify>
+        + Provider<Attest>
+        + Provider<BlobRead>
+        + Provider<BlobWrite>
+        + Provider<BlobImport>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + Provider<Fork<RemoteSite, BlobRead>>
+        + ConditionalSend
+        + ConditionalSync
+        + 'static,
+{
+    async fn prove(&self, claim: Prove<Ucan>) -> Result<UcanProof, AuthorizeError> {
+        Box::pin(
+            self.branch
+                .delegations()
+                .prove(claim.principal, claim.access)
+                .during(claim.duration)
+                .perform(&self.env),
+        )
+        .await
+    }
+
+    async fn retain(&self, delegation: UcanDelegation) -> Result<(), AuthorizeError> {
+        self.branch
+            .delegations()
+            .retain(delegation)
+            .perform(&self.env)
+            .await
+            .map(|_| ())
+            .map_err(|error| AuthorizeError::Malformed {
+                detail: format!("failed to retain delegation: {error}"),
+            })
+    }
+}
+
+use dialog_capability::Fork;
+
+/// Serve the operator's access from the profile's own repository branch.
+///
+/// Opens the profile repository's [`ACCESS_BRANCH`], migrates every
+/// certificate the legacy store retains into it (idempotent by content
+/// address, so repeated installs re-import nothing), and returns the
+/// operator with a [`SyncedAccess`] override installed. From then on
+/// proofs resolve through the tree walk over the branch's `dialog.ucan/*`
+/// facts and retained delegations land as synced facts.
+pub async fn synced_access<S>(
+    profile: &Profile,
+    operator: Operator<S>,
+) -> Result<Operator<S>, AuthorizeError>
+where
+    S: SpaceProvider
+        + Provider<BlobRead>
+        + Provider<BlobWrite>
+        + Provider<BlobImport>
+        + Clone
+        + 'static,
+    Operator<S>: ConditionalSend + ConditionalSync,
+    Storage<S>: Provider<Prove<Ucan>> + Provider<Export<Ucan>>,
+{
+    let repository = crate::Repository::from(profile);
+    let branch = repository
+        .branch(ACCESS_BRANCH)
+        .open()
+        .perform(&operator)
+        .await
+        .map_err(|error| AuthorizeError::Malformed {
+            detail: format!("failed to open the profile access branch: {error}"),
+        })?;
+
+    // Migrate the legacy certificate store: enumerate everything it holds
+    // and retain it into the branch as one commit. Content-addressed
+    // idempotence makes this a no-op when nothing is new.
+    let certificates = Subject::from(profile.did())
+        .attenuate(Access)
+        .invoke(Export::<Ucan>::new())
+        .perform(&operator)
+        .await?;
+    if !certificates.is_empty() {
+        let chains = certificates
+            .into_iter()
+            .map(|certificate| UcanDelegation::new(DelegationChain::new(certificate.0)))
+            .collect();
+        branch
+            .delegations()
+            .retain_all(chains)
+            .perform(&operator)
+            .await
+            .map_err(|error| AuthorizeError::Malformed {
+                detail: format!("failed to migrate legacy certificates: {error}"),
+            })?;
+    }
+
+    let access = SyncedAccess::new(branch, operator.clone());
+    Ok(operator.with_access(Arc::new(access)))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::DELEGATION_AUDIENCE;
+    use crate::RepositoryExt as _;
+    use anyhow::Result;
+    use dialog_artifacts::{ArtifactSelector, Value};
+    use dialog_capability::access::{Proof as _, Retain, TimeRange};
+    use dialog_network::Network;
+    use dialog_storage::provider::storage::Storage;
+    use dialog_ucan::Scope;
+    use dialog_ucan_core::DelegationBuilder;
+    use dialog_ucan_core::command::Command;
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_varsig::Principal as _;
+    use futures_util::StreamExt as _;
+
+    use crate::helpers::unique_name;
+
+    fn scope(subject: dialog_capability::Did) -> Scope {
+        Scope {
+            subject: UcanSubject::Specific(subject),
+            command: Command(vec![]),
+            parameters: dialog_ucan::Parameters::default(),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_migrates_legacy_certificates_and_serves_proofs_from_the_branch() -> Result<()> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name("synced-access"))
+            .perform(&storage)
+            .await?;
+        // `allow` retains a profile-to-operator delegation through the
+        // LEGACY certificate store at build time.
+        let operator = profile
+            .derive(b"test")
+            .allow(dialog_capability::Subject::any())
+            .network(Network::default())
+            .build(storage)
+            .await?;
+
+        let operator = synced_access(&profile, operator).await?;
+
+        // The migrated delegation stands as facts in the profile branch.
+        let repository = crate::Repository::from(&profile);
+        let branch = repository
+            .branch(ACCESS_BRANCH)
+            .open()
+            .perform(&operator)
+            .await?;
+        let facts: Vec<_> = branch
+            .claims()
+            .select(
+                ArtifactSelector::new()
+                    .the(DELEGATION_AUDIENCE.parse()?)
+                    .is(Value::String(operator.did().to_string())),
+            )
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(facts.len(), 1, "the legacy delegation migrated: {facts:?}");
+
+        // Proofs resolve through the branch: the operator proves the
+        // migrated powerline against the profile's own space (the
+        // powerline's issuer IS that subject, so the chain is one direct
+        // grant; a subject the profile holds no grant for would rightly
+        // refuse on either store).
+        let mut claim = Prove::<Ucan>::new(operator.did(), scope(profile.did()));
+        claim.duration = TimeRange::unbounded();
+        let proof = Subject::from(profile.did())
+            .attenuate(Access)
+            .invoke(claim)
+            .perform(&operator)
+            .await?;
+        assert_eq!(proof.proofs().len(), 1, "proved via the migrated grant");
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_retains_through_the_branch_not_the_legacy_store() -> Result<()> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name("synced-retain"))
+            .perform(&storage)
+            .await?;
+        let operator = profile
+            .derive(b"test")
+            .network(Network::default())
+            .build(storage)
+            .await?;
+        let operator = synced_access(&profile, operator).await?;
+
+        // Retain a fresh delegation through the operator's Retain effect.
+        let space = dialog_credentials::Ed25519Signer::generate().await?;
+        let holder = dialog_credentials::Ed25519Signer::generate().await?;
+        let delegation = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&holder)
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await?;
+        let chain = UcanDelegation::new(DelegationChain::new(delegation));
+        Subject::from(profile.did())
+            .attenuate(Access)
+            .invoke(Retain::<Ucan>::new(chain))
+            .perform(&operator)
+            .await?;
+
+        // The legacy store never saw it: enumeration is empty.
+        let exported = Subject::from(profile.did())
+            .attenuate(Access)
+            .invoke(Export::<Ucan>::new())
+            .perform(&operator)
+            .await?;
+        assert!(
+            exported.is_empty(),
+            "retains route to the branch, not the legacy store"
+        );
+
+        // The branch proves it.
+        let mut claim = Prove::<Ucan>::new(
+            holder.did(),
+            Scope {
+                subject: UcanSubject::Specific(space.did()),
+                command: Command(vec!["storage".to_string()]),
+                parameters: dialog_ucan::Parameters::default(),
+            },
+        );
+        claim.duration = TimeRange::unbounded();
+        let proof = Subject::from(profile.did())
+            .attenuate(Access)
+            .invoke(claim)
+            .perform(&operator)
+            .await?;
+        assert_eq!(proof.proofs().len(), 1);
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_installs_idempotently() -> Result<()> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name("synced-idempotent"))
+            .perform(&storage)
+            .await?;
+        let operator = profile
+            .derive(b"test")
+            .allow(dialog_capability::Subject::any())
+            .network(Network::default())
+            .build(storage)
+            .await?;
+
+        let operator = synced_access(&profile, operator).await?;
+        let repository = crate::Repository::from(&profile);
+        let branch = repository
+            .branch(ACCESS_BRANCH)
+            .open()
+            .perform(&operator)
+            .await?;
+        let head = branch.revision().map(|revision| revision.version());
+
+        // Installing again re-migrates nothing: the branch head is
+        // unchanged.
+        let operator = synced_access(&profile, operator).await?;
+        let branch = repository
+            .branch(ACCESS_BRANCH)
+            .open()
+            .perform(&operator)
+            .await?;
+        assert_eq!(
+            branch.revision().map(|revision| revision.version()),
+            head,
+            "a second install migrates nothing new"
+        );
+
+        Ok(())
+    }
+
+    /// The full repository flow works with synced access installed: create
+    /// a repository (whose delegations now land in the profile branch),
+    /// open a branch, commit and read back — every authorize along the way
+    /// resolves through the tree walk.
+    #[dialog_common::test]
+    async fn it_serves_the_repository_flow() -> Result<()> {
+        use dialog_artifacts::{Artifact, Instruction};
+        use futures_util::stream;
+
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name("synced-repo-flow"))
+            .perform(&storage)
+            .await?;
+        let operator = profile
+            .derive(b"test")
+            .allow(dialog_capability::Subject::any())
+            .network(Network::default())
+            .build(storage)
+            .await?;
+        let operator = synced_access(&profile, operator).await?;
+
+        let repo = profile
+            .repository(unique_name("repo"))
+            .open()
+            .perform(&operator)
+            .await?;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        branch
+            .commit(stream::iter(vec![Instruction::Assert(Artifact {
+                the: "user/name".parse()?,
+                of: "user:1".parse()?,
+                is: Value::String("Alice".into()),
+                cause: None,
+            })]))
+            .perform(&operator)
+            .await?;
+
+        let facts: Vec<_> = branch
+            .claims()
+            .select(ArtifactSelector::new().the("user/name".parse()?))
+            .perform(&operator)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(facts.len(), 1);
+
+        Ok(())
+    }
+}

--- a/rust/dialog-storage/src/storage/provider/fs/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/fs/certificate.rs
@@ -4,7 +4,7 @@
 
 use base58::ToBase58;
 use dialog_capability::access::{
-    AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
+    AuthorizeError, Certificate, CertificateStore, Delegation, Export, Protocol, Prove, Retain,
 };
 use dialog_capability::{Capability, Policy, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
@@ -69,6 +69,45 @@ where
         Ok(certificates)
     }
 
+    /// Walk `certificate/{audience}/{subject}/` and decode every stored
+    /// certificate, for migration.
+    async fn export(&self) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        let root = match self.certificate() {
+            Ok(root) => root,
+            Err(_) => return Ok(Vec::new()),
+        };
+        let audiences = match root.list().await {
+            Ok(entries) => entries,
+            Err(_) => return Ok(Vec::new()),
+        };
+
+        let mut certificates = Vec::new();
+        for audience in audiences {
+            let audience_dir = root.resolve(&audience)?;
+            let subjects = match audience_dir.list().await {
+                Ok(entries) => entries,
+                Err(_) => continue,
+            };
+            for subject in subjects {
+                let subject_dir = audience_dir.resolve(&subject)?;
+                let entries = match subject_dir.list().await {
+                    Ok(entries) => entries,
+                    Err(_) => continue,
+                };
+                for entry in entries {
+                    let handle = subject_dir.resolve(&entry)?;
+                    if let Ok(bytes) = handle.read().await
+                        && let Ok(cert) = <P::Certificate as Certificate>::decode(&bytes)
+                    {
+                        certificates.push(cert);
+                    }
+                }
+            }
+        }
+
+        Ok(certificates)
+    }
+
     /// Store a delegation's certificates as files for future lookups.
     async fn save(&self, delegation: &P::Delegation) -> Result<(), AuthorizeError> {
         for cert in delegation.certificates() {
@@ -94,6 +133,21 @@ where
         }
 
         Ok(())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<P> Provider<Export<P>> for FileSystem
+where
+    P: Protocol,
+    P::Certificate: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        _input: Capability<Export<P>>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        CertificateStore::<P>::export(self).await
     }
 }
 

--- a/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 use base58::ToBase58;
 use dialog_capability::access::{
-    AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
+    AuthorizeError, Certificate, CertificateStore, Delegation, Export, Protocol, Prove, Retain,
 };
 use dialog_capability::{Capability, Policy, Provider};
 use dialog_varsig::Did;
@@ -65,6 +65,34 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
             .await
     }
 
+    async fn export(&self) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        let has_store = self.connection.borrow().stores.contains(CERTIFICATE);
+        if !has_store {
+            return Ok(Vec::new());
+        }
+
+        let store = self.store(CERTIFICATE).await?;
+        store
+            .query(|object_store| async move {
+                let values = object_store.get_all(None, None).await.map_err(|e| {
+                    AuthorizeError::Unavailable {
+                        detail: format!("query: {e:?}"),
+                    }
+                })?;
+
+                let mut certs = Vec::new();
+                for value in values {
+                    let array = js_sys::Uint8Array::new(&value);
+                    let bytes = array.to_vec();
+                    if let Ok(cert) = <P::Certificate as Certificate>::decode(&bytes) {
+                        certs.push(cert);
+                    }
+                }
+                Ok(certs)
+            })
+            .await
+    }
+
     async fn save(&self, delegation: &P::Delegation) -> Result<(), AuthorizeError> {
         let certs = delegation.certificates();
         if certs.is_empty() {
@@ -102,6 +130,19 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
         }
 
         Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl<P> Provider<Export<P>> for IndexedDb
+where
+    P: Protocol,
+{
+    async fn execute(
+        &self,
+        _input: Capability<Export<P>>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        CertificateStore::<P>::export(self).await
     }
 }
 

--- a/rust/dialog-storage/src/storage/provider/space.rs
+++ b/rust/dialog-storage/src/storage/provider/space.rs
@@ -41,7 +41,7 @@
 //! how higher-level runtimes (`Storage`) can construct mounted spaces
 //! without knowing the concrete provider types.
 
-use dialog_capability::access::{AuthorizeError, Protocol, Prove, Retain as AccessRetain};
+use dialog_capability::access::{AuthorizeError, Export, Protocol, Prove, Retain as AccessRetain};
 use dialog_capability::{Capability, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_credentials::Credential;
@@ -141,6 +141,27 @@ where
     Blob: ConditionalSend + ConditionalSync,
 {
     async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
+        input.perform(&self.certificate).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<Archive, Memory, Credential, Certificate, Blob, P> Provider<Export<P>>
+    for Space<Archive, Memory, Credential, Certificate, Blob>
+where
+    P: Protocol,
+    P::Certificate: ConditionalSend + ConditionalSync,
+    Certificate: Provider<Export<P>> + ConditionalSend + ConditionalSync,
+    Archive: ConditionalSend + ConditionalSync,
+    Memory: ConditionalSend + ConditionalSync,
+    Credential: ConditionalSend + ConditionalSync,
+    Blob: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        input: Capability<Export<P>>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
         input.perform(&self.certificate).await
     }
 }

--- a/rust/dialog-storage/src/storage/provider/storage.rs
+++ b/rust/dialog-storage/src/storage/provider/storage.rs
@@ -10,7 +10,7 @@ mod web;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use dialog_capability::access::{AuthorizeError, Protocol, Prove, Retain};
+use dialog_capability::access::{AuthorizeError, Export, Protocol, Prove, Retain};
 use dialog_capability::{Capability, Did, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_credentials::Credential;
@@ -83,6 +83,24 @@ where
     Self: ConditionalSend + ConditionalSync,
 {
     async fn execute(&self, input: Capability<Prove<P>>) -> Result<P::Proof, AuthorizeError> {
+        input.perform(&self.router).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S, P> Provider<Export<P>> for Storage<S>
+where
+    S: Clone + ConditionalSync,
+    P: Protocol,
+    P::Certificate: ConditionalSend + ConditionalSync,
+    Router<S>: Provider<Export<P>>,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        input: Capability<Export<P>>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
         input.perform(&self.router).await
     }
 }

--- a/rust/dialog-storage/src/storage/provider/volatile/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/certificate.rs
@@ -6,7 +6,7 @@
 
 use base58::ToBase58;
 use dialog_capability::access::{
-    AuthorizeError, Certificate, CertificateStore, Delegation, Protocol, Prove, Retain,
+    AuthorizeError, Certificate, CertificateStore, Delegation, Export, Protocol, Prove, Retain,
 };
 use dialog_capability::{Capability, Policy, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
@@ -50,6 +50,20 @@ where
         Ok(certificates)
     }
 
+    /// Decode every stored certificate across all sessions, for migration.
+    async fn export(&self) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        let sessions = self.sessions.read();
+        let mut certificates = Vec::new();
+        for session in sessions.values() {
+            for bytes in session.certificates.values() {
+                if let Ok(cert) = <P::Certificate as Certificate>::decode(bytes) {
+                    certificates.push(cert);
+                }
+            }
+        }
+        Ok(certificates)
+    }
+
     /// Store a delegation's certificates for future lookups.
     ///
     /// Each certificate is stored keyed by
@@ -75,6 +89,22 @@ where
         }
 
         Ok(())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<P> Provider<Export<P>> for Volatile
+where
+    P: Protocol,
+    P::Certificate: ConditionalSend + ConditionalSync,
+    Self: ConditionalSend + ConditionalSync,
+{
+    async fn execute(
+        &self,
+        _input: Capability<Export<P>>,
+    ) -> Result<Vec<P::Certificate>, AuthorizeError> {
+        CertificateStore::<P>::export(self).await
     }
 }
 


### PR DESCRIPTION
Fourth slice of [delegations-as-data](https://github.com/dialog-db/dialog-db/blob/feat/synced-access/notes/delegations-as-data.md), stacked on #437. The operator's authorization switches over to the synced delegation store, with migration from the legacy certificate stores.

## Mechanism

The crate graph forces an inversion: the tree-backed store lives in dialog-repository, which sits **above** dialog-operator, so the operator cannot construct it. Instead:

- **dialog-operator** gains a pluggable `AccessProvider`: by default `Prove`/`Retain` route to the storage certificate provider exactly as before; an installed override routes them elsewhere. `Authorize` now routes its proof through the operator's own `Prove` provider so the override serves the per-effect hot path. The access providers narrow from generic protocols to `Ucan` (the only protocol implemented).
- **dialog-repository** provides the override: `SyncedAccess` serves proofs through the tree walk over a branch's `dialog.ucan/*` facts and lands retains as synced facts. `synced_access(profile, operator)` installs it: opens the profile repository's own branch (always locally present, provable with the locally-minted profile-to-operator delegation, so a fresh device can pull it before holding anything else), migrates the legacy store's certificates into it, and returns the operator with the override installed.
- **Migration** rides a new `Export` access effect: `CertificateStore::export` enumerates a legacy store (filesystem walk, volatile scan, IndexedDb `get_all`), forwarded through Space/Storage/Router like `Prove`. It always reads the legacy store even with an override installed, since it exists to migrate certificates out of it. `retain_all` makes the import one commit, idempotent by content address.

The legacy certificate providers stay: they serve operators without the override and the migration read path. Retiring them means inverting the operator/repository layering, a separate refactor.

## Tests

Migration imports the builder's `allow` delegation and proofs resolve from the branch; retains route to the branch and never touch the legacy store (enumeration stays empty); repeated installs migrate nothing (branch head unchanged); and the full repository flow (create, open, commit, select) runs with every authorize resolving through the tree walk.