### PR TITLE
feat(dialog-repository): cache resolved delegation chains

### DIFF
--- a/rust/dialog-repository/benches/delegation_prove.rs
+++ b/rust/dialog-repository/benches/delegation_prove.rs
@@ -21,8 +21,9 @@ use dialog_capability::access::{CertificateStore, Prove, TimeRange};
 use dialog_credentials::Ed25519Signer;
 use dialog_effects::storage::{Directory, Location};
 use dialog_network::Network;
+use dialog_operator::AccessProvider as _;
 use dialog_operator::{Operator, Profile};
-use dialog_repository::{Branch, RepositoryExt as _};
+use dialog_repository::{Branch, RepositoryExt as _, SyncedAccess};
 use dialog_storage::provider::storage::{Storage, VolatileSpace};
 use dialog_storage::provider::{FileSystem, Volatile};
 use dialog_storage::resource::Resource as _;
@@ -185,6 +186,22 @@ fn bench_prove(c: &mut Criterion) {
                     assert_eq!(result.is_ok(), expect_ok);
                 })
             });
+
+            // The resolved-chain cache over the same store: after the
+            // first iteration warms it, every prove is a verified hit.
+            // Only successful chains cache, so the miss shape is skipped.
+            if expect_ok {
+                let synced = SyncedAccess::new(backends.branch.clone(), backends.operator.clone());
+                group.bench_function(BenchmarkId::new("tree-cached", n), |b| {
+                    b.to_async(&rt).iter(|| {
+                        let mut claim = Prove::<Ucan>::new(principal.clone(), access.clone());
+                        claim.duration = TimeRange::unbounded();
+                        async {
+                            synced.prove(claim).await.unwrap();
+                        }
+                    })
+                });
+            }
         }
         group.finish();
     }

--- a/rust/dialog-repository/src/repository/access.rs
+++ b/rust/dialog-repository/src/repository/access.rs
@@ -30,9 +30,14 @@
 
 use std::sync::Arc;
 
+use std::collections::HashMap;
+
 use crate::Branch;
-use dialog_capability::access::{Access, AuthorizeError, Export, Prove};
-use dialog_capability::{Provider, Subject};
+use dialog_artifacts::history::Version;
+use dialog_capability::access::{
+    Access, AuthorizeError, Certificate as _, Export, Proof as _, Prove, TimeRange,
+};
+use dialog_capability::{Did, Provider, Subject};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify};
@@ -41,8 +46,11 @@ use dialog_effects::memory::{Publish, Resolve};
 use dialog_operator::{AccessProvider, Operator, Profile};
 use dialog_storage::provider::space::SpaceProvider;
 use dialog_storage::provider::storage::Storage;
+use dialog_ucan::UcanCertificate;
 use dialog_ucan::{Ucan, UcanDelegation, UcanProof};
 use dialog_ucan_core::DelegationChain;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use parking_lot::Mutex;
 
 use crate::RemoteSite;
 
@@ -51,22 +59,117 @@ use crate::RemoteSite;
 pub const ACCESS_BRANCH: &str = "main";
 
 /// An [`AccessProvider`] serving proofs and retains from a branch's
-/// delegation records.
+/// delegation records, with a resolved-chain cache.
+///
+/// The cache is what removes the per-effect amplification: a sync session
+/// authorizes every block get and put, and without it each one re-walks
+/// the delegation graph for an answer that cannot have changed mid-session.
+/// A resolved chain is cached under `(principal, subject, command)` and
+/// **re-verified on every hit** against the claim's full access (policy
+/// predicates run against the fresh parameters, and the chain's window
+/// must cover the requested duration), so a hit is as sound as a walk —
+/// it only skips the search, never the checks. The cache epoch is the
+/// branch head version: any commit, retain, retract, or pull moves the
+/// head and drops the cache, so staleness is impossible by construction.
+/// Failures are never cached; a claim the chain rejects falls through to
+/// a full walk.
 pub struct SyncedAccess<Env> {
     branch: Branch,
     env: Env,
+    cache: Mutex<ChainCache>,
+}
+
+/// Resolved chains, valid for one branch head version.
+#[derive(Default)]
+struct ChainCache {
+    /// The branch head the cached chains were resolved against.
+    epoch: Option<Version>,
+    /// Resolved chains by `(principal, subject, command)`.
+    chains: HashMap<(Did, Did, String), Vec<UcanCertificate>>,
 }
 
 impl<Env> SyncedAccess<Env> {
     /// Serve access from `branch`'s delegation records, performing the
     /// walk's effects against `env`.
     pub fn new(branch: Branch, env: Env) -> Self {
-        Self { branch, env }
+        Self {
+            branch,
+            env,
+            cache: Mutex::new(ChainCache::default()),
+        }
     }
 
     /// The branch this access provider serves from.
     pub fn branch(&self) -> &Branch {
         &self.branch
+    }
+
+    /// The number of chains currently cached (for tests).
+    #[cfg(test)]
+    fn cached_chains(&self) -> usize {
+        self.cache.lock().chains.len()
+    }
+
+    /// The cache key for a claim, or `None` when the claim is not
+    /// cacheable (wildcard subject or self-authorization resolve to an
+    /// empty proof without touching storage, so caching them buys
+    /// nothing).
+    fn cache_key(claim: &Prove<Ucan>) -> Option<(Did, Did, String)> {
+        let subject = match &claim.access.subject {
+            UcanSubject::Specific(did) => did.clone(),
+            UcanSubject::Any => return None,
+        };
+        if claim.principal == subject {
+            return None;
+        }
+        Some((
+            claim.principal.clone(),
+            subject,
+            claim.access.command.to_string(),
+        ))
+    }
+
+    /// Serve a claim from the cache: the chain resolved for this key at
+    /// the current epoch, re-verified against the claim's access and
+    /// duration. `None` on a miss or when the cached chain rejects this
+    /// particular claim (a fresh walk decides then).
+    fn cached(&self, key: &(Did, Did, String), claim: &Prove<Ucan>) -> Option<UcanProof> {
+        let epoch = self.branch.revision().map(|revision| revision.version());
+        let cache = self.cache.lock();
+        if cache.epoch != epoch {
+            return None;
+        }
+        let chain = cache.chains.get(key)?;
+
+        // Verify-on-hit: policy predicates run against THIS claim's
+        // parameters, and the chain's effective window must cover the
+        // requested duration. A hit skips the search, never the checks.
+        let mut effective = TimeRange::unbounded();
+        for certificate in chain {
+            let range = certificate.verify(&claim.access).ok()?;
+            effective = effective.intersect(&range);
+        }
+        if !effective.covers(&claim.duration) {
+            return None;
+        }
+
+        let mut proof = UcanProof::new(claim.access.clone());
+        for certificate in chain {
+            proof.push(certificate.clone());
+        }
+        proof.set_duration(effective);
+        Some(proof)
+    }
+
+    /// Record a resolved chain for this key at the current epoch.
+    fn record(&self, key: (Did, Did, String), proof: &UcanProof) {
+        let epoch = self.branch.revision().map(|revision| revision.version());
+        let mut cache = self.cache.lock();
+        if cache.epoch != epoch {
+            cache.chains.clear();
+            cache.epoch = epoch;
+        }
+        cache.chains.insert(key, proof.proofs().to_vec());
     }
 }
 
@@ -92,14 +195,26 @@ where
         + 'static,
 {
     async fn prove(&self, claim: Prove<Ucan>) -> Result<UcanProof, AuthorizeError> {
-        Box::pin(
+        let key = Self::cache_key(&claim);
+        if let Some(key) = &key
+            && let Some(proof) = self.cached(key, &claim)
+        {
+            return Ok(proof);
+        }
+
+        let proof = Box::pin(
             self.branch
                 .delegations()
-                .prove(claim.principal, claim.access)
+                .prove(claim.principal.clone(), claim.access.clone())
                 .during(claim.duration)
                 .perform(&self.env),
         )
-        .await
+        .await?;
+
+        if let Some(key) = key {
+            self.record(key, &proof);
+        }
+        Ok(proof)
     }
 
     async fn retain(&self, delegation: UcanDelegation) -> Result<(), AuthorizeError> {
@@ -186,9 +301,9 @@ mod tests {
     use crate::RepositoryExt as _;
     use anyhow::Result;
     use dialog_artifacts::{ArtifactSelector, Value};
-    use dialog_capability::access::{Proof as _, Retain, TimeRange};
+    use dialog_capability::access::Retain;
     use dialog_network::Network;
-    use dialog_storage::provider::storage::Storage;
+    use dialog_storage::provider::storage::{Storage, VolatileSpace};
     use dialog_ucan::Scope;
     use dialog_ucan_core::DelegationBuilder;
     use dialog_ucan_core::command::Command;
@@ -411,6 +526,172 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(facts.len(), 1);
 
+        Ok(())
+    }
+
+    /// A synced-access harness with direct hands on the [`SyncedAccess`]
+    /// instance, for cache assertions.
+    async fn cache_harness(
+        name: &str,
+    ) -> Result<(
+        SyncedAccess<Operator<VolatileSpace>>,
+        dialog_credentials::Ed25519Signer,
+        dialog_credentials::Ed25519Signer,
+    )> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name(name)).perform(&storage).await?;
+        let operator = profile
+            .derive(b"test")
+            .network(Network::default())
+            .build(storage)
+            .await?;
+        let repository = crate::Repository::from(&profile);
+        let branch = repository
+            .branch(ACCESS_BRANCH)
+            .open()
+            .perform(&operator)
+            .await?;
+
+        let space = dialog_credentials::Ed25519Signer::generate().await?;
+        let holder = dialog_credentials::Ed25519Signer::generate().await?;
+        let delegation = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&holder)
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await?;
+        branch
+            .delegations()
+            .retain(UcanDelegation::new(DelegationChain::new(delegation)))
+            .perform(&operator)
+            .await?;
+
+        Ok((SyncedAccess::new(branch, operator), space, holder))
+    }
+
+    fn storage_claim(
+        holder: &dialog_credentials::Ed25519Signer,
+        space: &dialog_credentials::Ed25519Signer,
+    ) -> Prove<Ucan> {
+        Prove::<Ucan>::new(
+            holder.did(),
+            Scope {
+                subject: UcanSubject::Specific(space.did()),
+                command: Command(vec!["storage".to_string()]),
+                parameters: dialog_ucan::Parameters::default(),
+            },
+        )
+    }
+
+    #[dialog_common::test]
+    async fn it_serves_repeat_proofs_from_the_cache() -> Result<()> {
+        let (access, space, holder) = cache_harness("cache-repeat").await?;
+
+        let first = access.prove(storage_claim(&holder, &space)).await?;
+        assert_eq!(access.cached_chains(), 1, "the walk's chain is cached");
+
+        let second = access.prove(storage_claim(&holder, &space)).await?;
+        assert_eq!(
+            first.proofs().len(),
+            second.proofs().len(),
+            "a hit serves the same chain the walk found"
+        );
+        assert_eq!(access.cached_chains(), 1);
+        Ok(())
+    }
+
+    /// Any head movement drops the cache: after retracting the delegation
+    /// through the same branch, a repeat claim must fail rather than serve
+    /// the stale chain.
+    #[dialog_common::test]
+    async fn it_invalidates_on_head_movement() -> Result<()> {
+        let (access, space, holder) = cache_harness("cache-invalidate").await?;
+
+        access.prove(storage_claim(&holder, &space)).await?;
+        assert_eq!(access.cached_chains(), 1);
+
+        // Rebuild the delegation deterministically? No — retract needs the
+        // chain; re-derive it from the branch's own record via the walk's
+        // proof instead.
+        let proof = access.prove(storage_claim(&holder, &space)).await?;
+        let chain = proof.proofs()[0].0.clone();
+        access
+            .branch()
+            .delegations()
+            .retract(UcanDelegation::new(DelegationChain::new(chain)))
+            .perform(&access.env)
+            .await?;
+
+        let refused = access.prove(storage_claim(&holder, &space)).await;
+        assert!(
+            matches!(refused, Err(AuthorizeError::UnprovenSubject { .. })),
+            "a retracted chain must not serve from the cache: {:?}",
+            refused.is_ok()
+        );
+        Ok(())
+    }
+
+    /// A hit is re-verified against the claim's duration: a cached chain
+    /// whose window cannot cover the request falls through to the walk,
+    /// which refuses it.
+    #[dialog_common::test]
+    async fn it_rejects_a_hit_outside_the_chain_window() -> Result<()> {
+        use dialog_common::time;
+        use dialog_ucan_core::time::timestamp::Timestamp;
+
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique_name("cache-window"))
+            .perform(&storage)
+            .await?;
+        let operator = profile
+            .derive(b"test")
+            .network(Network::default())
+            .build(storage)
+            .await?;
+        let repository = crate::Repository::from(&profile);
+        let branch = repository
+            .branch(ACCESS_BRANCH)
+            .open()
+            .perform(&operator)
+            .await?;
+
+        let now = time::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let space = dialog_credentials::Ed25519Signer::generate().await?;
+        let holder = dialog_credentials::Ed25519Signer::generate().await?;
+        let delegation = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&holder)
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec!["storage".to_string()])
+            .expiration(Timestamp::try_from((now + 3600) as i128).unwrap())
+            .try_build()
+            .await?;
+        branch
+            .delegations()
+            .retain(UcanDelegation::new(DelegationChain::new(delegation)))
+            .perform(&operator)
+            .await?;
+        let access = SyncedAccess::new(branch, operator);
+
+        // Warm the cache with an unbounded claim.
+        access.prove(storage_claim(&holder, &space)).await?;
+        assert_eq!(access.cached_chains(), 1);
+
+        // A claim needing validity past the chain's expiry must refuse.
+        let mut claim = storage_claim(&holder, &space);
+        claim.duration = TimeRange {
+            not_before: Some(now),
+            expiration: Some(now + 7200),
+        };
+        let refused = access.prove(claim).await;
+        assert!(
+            refused.is_err(),
+            "a hit must not outlive the chain's window"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Final slice of [delegations-as-data](https://github.com/dialog-db/dialog-db/blob/feat/access-cache/notes/delegations-as-data.md), stacked on #438. The resolved-chain cache removes the per-effect amplification: a sync session authorizes every block get and put, and without this each one re-walks the delegation graph for an answer that cannot have changed mid-session.

## Mechanism

`SyncedAccess` caches a successful walk's chain under `(principal, subject, command)` and **re-verifies it on every hit** against the claim's full access: policy predicates run against the fresh parameters and the chain's effective window must cover the requested duration, so a hit is as sound as a walk — it skips the search, never the checks. The cache epoch is the branch head version: any commit, retain, retract, or pull moves the head and drops the cache, so staleness is impossible by construction. Failures are never cached; a claim the cached chain rejects falls through to a full walk.

## Measurements

`prove_direct` with the same N certificates in every backend (verdicts asserted per iteration):

| N | legacy fs | legacy volatile | tree walk | **tree cached** |
|---:|---:|---:|---:|---:|
| 32 | 753 µs | 32 µs | 33 µs | **769 ns** |
| 512 | 13.4 ms | 516 µs | 24 µs | **737 ns** |
| 6144 | 208 ms | 6.4 ms | 24 µs | **730 ns** |

The steady-state per-effect authorization cost is ~730 ns flat, verify-on-hit included: from 208 ms on the legacy filesystem store at the field-reported accumulation scale, through 24 µs for the uncached tree walk, to sub-microsecond once the session's first prove has run.

## Tests

A repeat claim serves from the cache with the same chain; any head movement invalidates (a retracted chain refuses rather than serving stale); and a hit outside the chain's validity window falls through and refuses.