### PR TITLE
fix(dialog-csv): flush the serializer on close

### DIFF
--- a/rust/dialog-csv/src/exporter.rs
+++ b/rust/dialog-csv/src/exporter.rs
@@ -40,6 +40,14 @@ impl<W: AsyncWrite + Unpin + Send> Exporter for CsvExporter<W> {
     }
 
     async fn close(&mut self) -> Result<(), DialogArtifactsError> {
-        Ok(())
+        // Push everything the serializer buffered down to the underlying
+        // writer. Without this the tail of an export sits in the internal
+        // buffer, so a reader that opens the destination right after close
+        // sees a truncated file — the `it_roundtrips_via_file` flake, where
+        // release-mode timing dropped the last row.
+        self.writer
+            .flush()
+            .await
+            .map_err(|e| DialogArtifactsError::Export(e.to_string()))
     }
 }


### PR DESCRIPTION
`CsvExporter::close` was a no-op (`Ok(())`), so the tail of an export stayed in `csv_async::AsyncSerializer`'s internal buffer. Any reader opening the destination right after close raced the buffer: the release-mode CI job on #439 caught `it_roundtrips_via_file` importing 2 of the 3 rows it exported (the debug jobs in that run were canceled by the matrix, not failed — the flake predates the branch and is unrelated to its diff; #438, its direct parent, passed the same job). Close now flushes before reporting success.