### PR TITLE
feat: login by pulling the account, on-demand proving, branch download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/rust/dialog-operator/Cargo.toml
+++ b/rust/dialog-operator/Cargo.toml
@@ -43,6 +43,7 @@ signature = { workspace = true }
 serde_ipld_dagcbor = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "io-util"] }
+tracing = { workspace = true }
 [dev-dependencies]
 dialog-storage = { workspace = true, features = ["helpers"] }
 dialog-remote-s3 = { workspace = true, features = ["helpers"] }

--- a/rust/dialog-operator/src/operator.rs
+++ b/rust/dialog-operator/src/operator.rs
@@ -15,7 +15,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
-use dialog_repository::{Branch, CommitError};
+use dialog_repository::Branch;
 use dialog_ucan::UcanCertificate;
 use parking_lot::Mutex;
 
@@ -31,26 +31,44 @@ use dialog_network::Network;
 use dialog_storage::provider::storage::Storage;
 use dialog_varsig::{Did, Principal};
 
-/// One hydration run over the access branch: fetch the delegation
-/// records and envelopes the current head references that are not yet
-/// local, through the full network-capable environment.
+/// A boxed effect dispatch: one remote fork effect's input to its output.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) type HydrationFuture = Pin<Box<dyn Future<Output = Result<usize, CommitError>> + Send>>;
-/// One hydration run over the access branch (single-threaded wasm form).
+pub(crate) type ReachFuture<Output> = Pin<Box<dyn Future<Output = Output> + Send>>;
+/// A boxed effect dispatch (single-threaded wasm form).
 #[cfg(target_arch = "wasm32")]
-pub(crate) type HydrationFuture = Pin<Box<dyn Future<Output = Result<usize, CommitError>>>>;
+pub(crate) type ReachFuture<Output> = Pin<Box<dyn Future<Output = Output>>>;
 
-/// The dyn-erased delegation hydrator installed at build time.
-///
-/// Erased because naming the remote fork providers as bounds on the
-/// `Prove` provider itself would close the trait cycle the local-only
-/// walk exists to break (Prove -> Fork -> Authorize -> Prove); at the
-/// build site the concrete operator satisfies them without any cycle.
+/// One remote fork effect the authorization walk may dispatch.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) type Hydrator = Box<dyn Fn() -> HydrationFuture + Send + Sync>;
-/// The dyn-erased delegation hydrator (single-threaded wasm form).
+pub(crate) type ReachFn<Fx> =
+    Box<dyn Fn(Fx) -> ReachFuture<<Fx as dialog_capability::Command>::Output> + Send + Sync>;
+/// One remote fork effect (single-threaded wasm form).
 #[cfg(target_arch = "wasm32")]
-pub(crate) type Hydrator = Box<dyn Fn() -> HydrationFuture>;
+pub(crate) type ReachFn<Fx> =
+    Box<dyn Fn(Fx) -> ReachFuture<<Fx as dialog_capability::Command>::Output>>;
+
+/// The remote reach of the authorization walk: the fork effects a proof's
+/// tree and envelope reads may dispatch to replicate content on demand,
+/// exactly as any other read does.
+///
+/// Dyn-erased and installed at build time because naming the remote fork
+/// providers as bounds on the `Prove` provider itself would close the
+/// trait cycle authorization must not enter (Prove -> Fork -> Authorize
+/// -> Prove); at the build site the concrete operator satisfies them
+/// without any cycle. The operator clone captured inside these closures
+/// carries NO reach of its own, so the proof that authorizes a fetch
+/// resolves from what is already local — that is what bounds the
+/// recursion.
+pub(crate) struct WalkReach {
+    /// Remote block read for the walk's tree scans.
+    pub(crate) get: ReachFn<dialog_capability::Fork<dialog_repository::RemoteSite, archive::Get>>,
+    /// Remote head resolution for the walk's index store.
+    pub(crate) resolve:
+        ReachFn<dialog_capability::Fork<dialog_repository::RemoteSite, memory::Resolve>>,
+    /// Remote envelope read for candidate admission.
+    pub(crate) blob_read:
+        ReachFn<dialog_capability::Fork<dialog_repository::RemoteSite, blob::Read>>,
+}
 
 /// An operating environment built from a [`Profile`](crate::profile::Profile).
 ///
@@ -104,13 +122,11 @@ pub struct Operator<S: Clone> {
     /// Resolved-chain cache (see `operator/access.rs`).
     chains: Arc<Mutex<access::ChainCache>>,
 
-    /// Hydrates the access branch when its head moves: the authorization
-    /// walk reads only local state, and this is what brings that state
-    /// local after a pull. Deliberately EMPTY on the operator clone the
-    /// hydrator itself runs against — proving the hydration fetches must
-    /// resolve from what is already local, or the recursion would never
-    /// bottom out.
-    hydrator: Arc<OnceLock<Hydrator>>,
+    /// The authorization walk's remote reach (see [`WalkReach`]).
+    /// Deliberately EMPTY on the operator clone captured inside the reach
+    /// closures — the proof that authorizes a fetch must resolve from
+    /// what is already local, or the recursion would never bottom out.
+    reach: Arc<OnceLock<WalkReach>>,
 }
 
 impl<S: Clone> Operator<S> {

--- a/rust/dialog-operator/src/operator.rs
+++ b/rust/dialog-operator/src/operator.rs
@@ -11,9 +11,11 @@ mod test;
 
 pub use builder::{DeriveOperator, OperatorBuilder, OperatorError};
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
-use dialog_repository::Branch;
+use dialog_repository::{Branch, CommitError};
 use dialog_ucan::UcanCertificate;
 use parking_lot::Mutex;
 
@@ -28,6 +30,27 @@ use dialog_identity::Authority;
 use dialog_network::Network;
 use dialog_storage::provider::storage::Storage;
 use dialog_varsig::{Did, Principal};
+
+/// One hydration run over the access branch: fetch the delegation
+/// records and envelopes the current head references that are not yet
+/// local, through the full network-capable environment.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type HydrationFuture = Pin<Box<dyn Future<Output = Result<usize, CommitError>> + Send>>;
+/// One hydration run over the access branch (single-threaded wasm form).
+#[cfg(target_arch = "wasm32")]
+pub(crate) type HydrationFuture = Pin<Box<dyn Future<Output = Result<usize, CommitError>>>>;
+
+/// The dyn-erased delegation hydrator installed at build time.
+///
+/// Erased because naming the remote fork providers as bounds on the
+/// `Prove` provider itself would close the trait cycle the local-only
+/// walk exists to break (Prove -> Fork -> Authorize -> Prove); at the
+/// build site the concrete operator satisfies them without any cycle.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type Hydrator = Box<dyn Fn() -> HydrationFuture + Send + Sync>;
+/// The dyn-erased delegation hydrator (single-threaded wasm form).
+#[cfg(target_arch = "wasm32")]
+pub(crate) type Hydrator = Box<dyn Fn() -> HydrationFuture>;
 
 /// An operating environment built from a [`Profile`](crate::profile::Profile).
 ///
@@ -80,6 +103,14 @@ pub struct Operator<S: Clone> {
 
     /// Resolved-chain cache (see `operator/access.rs`).
     chains: Arc<Mutex<access::ChainCache>>,
+
+    /// Hydrates the access branch when its head moves: the authorization
+    /// walk reads only local state, and this is what brings that state
+    /// local after a pull. Deliberately EMPTY on the operator clone the
+    /// hydrator itself runs against — proving the hydration fetches must
+    /// resolve from what is already local, or the recursion would never
+    /// bottom out.
+    hydrator: Arc<OnceLock<Hydrator>>,
 }
 
 impl<S: Clone> Operator<S> {

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -22,6 +22,15 @@
 //! hit is as sound as a walk — it skips the search, never the checks. The
 //! epoch is the branch head version: any commit, retain, retract, or pull
 //! drops the cache. Failures are never cached.
+//!
+//! The walk's reads replicate content on demand like any other read: a
+//! delegation record or envelope the local store does not hold is fetched
+//! from the branch's upstream through the operator's [`WalkReach`](super::WalkReach)
+//! and cached locally. The proof authorizing such a fetch resolves from
+//! what is already local (bounding the recursion — see [`AccessEnv`]);
+//! offline, the walk simply skips what it cannot read. An embedder that
+//! does not want proving to pay download latency materializes the branch
+//! up front with `Branch::download`.
 
 use super::Operator;
 use dialog_capability::access::{
@@ -49,9 +58,6 @@ pub(crate) struct ChainCache {
     epoch: Option<Version>,
     /// Resolved chains by `(principal, subject, command)`.
     chains: HashMap<(Did, Did, String), Vec<UcanCertificate>>,
-    /// The branch head the last hydration ran against — `None` until the
-    /// first prove, reset when a run fails so the next prove retries.
-    hydrated: Option<Option<Version>>,
 }
 
 /// The local provider set the delegation walk needs from the operator.
@@ -91,12 +97,17 @@ impl<T> LocalEnv for T where
 
 /// The environment the delegation walk and retain run against.
 ///
-/// Local effects delegate to the operator (storage and authority); the
-/// remote fork providers are stubs that report content as unavailable.
-/// Authorization therefore reads only locally hydrated state — it never
-/// reaches for a remote mid-proof, which would require authorizing the
-/// reach itself. Sync (pull through the ordinary flows) is what brings
-/// access-branch state local.
+/// Local effects delegate to the operator (storage and authority). The
+/// remote fork providers dispatch through the operator's [`WalkReach`] —
+/// dyn-erased fork effects installed at build — so the walk's tree and
+/// envelope reads replicate content on demand exactly as any other read
+/// does. The operator clone captured inside the reach closures carries
+/// no reach of its own: the proof that authorizes such a fetch resolves
+/// from what is already local (the retained cross-party grants and the
+/// in-memory session), which bounds the recursion a fork-inside-a-proof
+/// would otherwise open. Before the reach is installed (during build)
+/// and offline, the forks degrade to reporting content unavailable, and
+/// the walk skips what it cannot read.
 struct AccessEnv<S: Clone> {
     operator: Operator<S>,
 }
@@ -134,11 +145,14 @@ where
 {
     async fn execute(
         &self,
-        _input: <Fork<RemoteSite, Get> as Command>::Input,
+        input: <Fork<RemoteSite, Get> as Command>::Input,
     ) -> <Fork<RemoteSite, Get> as Command>::Output {
-        // Remote content is unavailable during authorization; a block the
-        // walk needs must already be local (sync hydrates it).
-        Ok(None)
+        match self.operator.reach.get() {
+            Some(reach) => (reach.get)(input).await,
+            // No reach installed (mid-build, or the recursion-bounding
+            // inner clone): the block must already be local.
+            None => Ok(None),
+        }
     }
 }
 
@@ -151,9 +165,12 @@ where
 {
     async fn execute(
         &self,
-        _input: <Fork<RemoteSite, Resolve> as Command>::Input,
+        input: <Fork<RemoteSite, Resolve> as Command>::Input,
     ) -> <Fork<RemoteSite, Resolve> as Command>::Output {
-        Ok(None)
+        match self.operator.reach.get() {
+            Some(reach) => (reach.resolve)(input).await,
+            None => Ok(None),
+        }
     }
 }
 
@@ -166,11 +183,14 @@ where
 {
     async fn execute(
         &self,
-        _input: <Fork<RemoteSite, BlobRead> as Command>::Input,
+        input: <Fork<RemoteSite, BlobRead> as Command>::Input,
     ) -> <Fork<RemoteSite, BlobRead> as Command>::Output {
-        Err(BlobError::NotFound(
-            "remote content is unavailable during authorization".to_string(),
-        ))
+        match self.operator.reach.get() {
+            Some(reach) => (reach.blob_read)(input).await,
+            None => Err(BlobError::NotFound(
+                "remote content is unavailable while the walk's reach is not installed".to_string(),
+            )),
+        }
     }
 }
 
@@ -251,25 +271,13 @@ impl<S: Clone> Operator<S> {
             .find(|grant| grant.verify(&claim.access).is_ok())
     }
 
-    /// Refresh the access branch head and, when it moved since the last
-    /// hydration, fetch the delegation records and envelopes it
-    /// references through the full environment.
-    ///
-    /// The refresh is what makes a pull through ANOTHER handle of the
+    /// Re-resolve the access branch handle's head and upstream from
+    /// storage. This is what makes a pull through ANOTHER handle of the
     /// branch visible here: a pull moves the head in storage, not in
     /// this handle's cache, and both the walk and the chain-cache epoch
-    /// read the cache. The hydration then brings the moved head's
-    /// delegation state local — a pulled tree adopts subtrees by link
-    /// and envelope bytes replicate lazily, while the walk deliberately
-    /// reads only local state.
-    ///
-    /// Best-effort on both counts: on a failure the walk still runs over
-    /// whatever is local, and a failed hydration retries on the next
-    /// prove. The operator clone the hydrator runs against carries no
-    /// hydrator of its own, which is what bounds the recursion
-    /// (hydration fetches are authorized by proofs that must already be
-    /// local — the retained login grant and the in-memory session).
-    async fn rehydrate(&self)
+    /// read the cache. Best-effort: on a failure the walk still runs
+    /// over the last resolved head.
+    async fn refresh(&self)
     where
         Self: LocalEnv,
         S: ConditionalSend + ConditionalSync + 'static,
@@ -280,21 +288,6 @@ impl<S: Clone> Operator<S> {
         if let Err(error) = branch.refresh(self).await {
             tracing::warn!(%error, "failed to refresh the access branch head");
         }
-        let Some(hydrator) = self.hydrator.get() else {
-            return;
-        };
-        let epoch = branch.revision().map(|revision| revision.version());
-        {
-            let mut cache = self.chains.lock();
-            if cache.hydrated.as_ref() == Some(&epoch) {
-                return;
-            }
-            cache.hydrated = Some(epoch);
-        }
-        if let Err(error) = hydrator().await {
-            tracing::warn!(%error, "failed to hydrate the access branch delegations");
-            self.chains.lock().hydrated = None;
-        }
     }
 
     /// Resolve a proof for `claim` from the access branch, with the
@@ -304,7 +297,7 @@ impl<S: Clone> Operator<S> {
         Self: LocalEnv,
         S: ConditionalSend + ConditionalSync + 'static,
     {
-        self.rehydrate().await;
+        self.refresh().await;
 
         let key = Self::cache_key(&claim);
         if let Some(key) = &key

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -49,6 +49,9 @@ pub(crate) struct ChainCache {
     epoch: Option<Version>,
     /// Resolved chains by `(principal, subject, command)`.
     chains: HashMap<(Did, Did, String), Vec<UcanCertificate>>,
+    /// The branch head the last hydration ran against — `None` until the
+    /// first prove, reset when a run fails so the next prove retries.
+    hydrated: Option<Option<Version>>,
 }
 
 /// The local provider set the delegation walk needs from the operator.
@@ -248,6 +251,52 @@ impl<S: Clone> Operator<S> {
             .find(|grant| grant.verify(&claim.access).is_ok())
     }
 
+    /// Refresh the access branch head and, when it moved since the last
+    /// hydration, fetch the delegation records and envelopes it
+    /// references through the full environment.
+    ///
+    /// The refresh is what makes a pull through ANOTHER handle of the
+    /// branch visible here: a pull moves the head in storage, not in
+    /// this handle's cache, and both the walk and the chain-cache epoch
+    /// read the cache. The hydration then brings the moved head's
+    /// delegation state local — a pulled tree adopts subtrees by link
+    /// and envelope bytes replicate lazily, while the walk deliberately
+    /// reads only local state.
+    ///
+    /// Best-effort on both counts: on a failure the walk still runs over
+    /// whatever is local, and a failed hydration retries on the next
+    /// prove. The operator clone the hydrator runs against carries no
+    /// hydrator of its own, which is what bounds the recursion
+    /// (hydration fetches are authorized by proofs that must already be
+    /// local — the retained login grant and the in-memory session).
+    async fn rehydrate(&self)
+    where
+        Self: LocalEnv,
+        S: ConditionalSend + ConditionalSync + 'static,
+    {
+        let Ok(branch) = self.delegations() else {
+            return;
+        };
+        if let Err(error) = branch.refresh(self).await {
+            tracing::warn!(%error, "failed to refresh the access branch head");
+        }
+        let Some(hydrator) = self.hydrator.get() else {
+            return;
+        };
+        let epoch = branch.revision().map(|revision| revision.version());
+        {
+            let mut cache = self.chains.lock();
+            if cache.hydrated.as_ref() == Some(&epoch) {
+                return;
+            }
+            cache.hydrated = Some(epoch);
+        }
+        if let Err(error) = hydrator().await {
+            tracing::warn!(%error, "failed to hydrate the access branch delegations");
+            self.chains.lock().hydrated = None;
+        }
+    }
+
     /// Resolve a proof for `claim` from the access branch, with the
     /// session composition when the principal is this operator.
     async fn resolve(&self, claim: Prove<Ucan>) -> Result<UcanProof, AuthorizeError>
@@ -255,6 +304,8 @@ impl<S: Clone> Operator<S> {
         Self: LocalEnv,
         S: ConditionalSend + ConditionalSync + 'static,
     {
+        self.rehydrate().await;
+
         let key = Self::cache_key(&claim);
         if let Some(key) = &key
             && let Some(proof) = self.cached(key, &claim)

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -2,10 +2,12 @@
 
 use std::sync::{Arc, OnceLock};
 
-use super::Operator;
-use dialog_capability::{Ability, Capability, Constraint};
+use super::{Hydrator, Operator};
+use dialog_capability::{Ability, Capability, Constraint, Provider};
+use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_credentials::key::KeyExport;
 use dialog_credentials::{Ed25519Signer, SignerCredential};
+use dialog_effects::blob;
 use dialog_effects::storage::Directory;
 use dialog_identity::Authority;
 use dialog_identity::Profile;
@@ -93,7 +95,14 @@ impl OperatorBuilder {
     /// which every proof of cross-party authority resolves.
     pub async fn build<S>(self, storage: Storage<S>) -> Result<Operator<S>, OperatorError>
     where
-        S: SpaceProvider + Clone + 'static,
+        S: SpaceProvider
+            + Provider<blob::Read>
+            + Provider<blob::Write>
+            + Provider<blob::Import>
+            + Clone
+            + ConditionalSend
+            + ConditionalSync
+            + 'static,
     {
         let operator_signer = derive_operator(&self.credential, &self.context).await?;
         let credentials = Authority::new(
@@ -126,6 +135,7 @@ impl OperatorBuilder {
             session: Arc::new(session),
             delegations: Arc::new(OnceLock::new()),
             chains: Arc::default(),
+            hydrator: Arc::new(OnceLock::new()),
         };
 
         // Open the profile repository's access branch: the store every
@@ -139,8 +149,28 @@ impl OperatorBuilder {
             .map_err(|e| OperatorError::Delegation(format!("{e}")))?;
         operator
             .delegations
-            .set(branch)
+            .set(branch.clone())
             .expect("freshly built operator has no access branch yet");
+
+        // Install the hydrator: when the branch head moves, the operator
+        // fetches the delegation records and envelopes the new head
+        // references, through this full network-capable environment. The
+        // captured operator clone carries NO hydrator of its own — the
+        // proofs authorizing the hydration fetches resolve from what is
+        // already local, bounding the recursion.
+        let anchor = Operator {
+            hydrator: Arc::new(OnceLock::new()),
+            ..operator.clone()
+        };
+        let hydrator: Hydrator = Box::new(move || {
+            let operator = anchor.clone();
+            let branch = branch.clone();
+            Box::pin(async move { branch.delegations().hydrate().perform(&operator).await })
+        });
+        operator
+            .hydrator
+            .set(hydrator)
+            .unwrap_or_else(|_| unreachable!("freshly built operator has no hydrator yet"));
 
         Ok(operator)
     }

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -2,17 +2,17 @@
 
 use std::sync::{Arc, OnceLock};
 
-use super::{Hydrator, Operator};
-use dialog_capability::{Ability, Capability, Constraint, Provider};
+use super::{Operator, WalkReach};
+use dialog_capability::{Ability, Capability, Constraint, Fork, Provider};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_credentials::key::KeyExport;
 use dialog_credentials::{Ed25519Signer, SignerCredential};
-use dialog_effects::blob;
 use dialog_effects::storage::Directory;
+use dialog_effects::{archive, blob, memory};
 use dialog_identity::Authority;
 use dialog_identity::Profile;
 use dialog_network::Network;
-use dialog_repository::ACCESS_BRANCH;
+use dialog_repository::{ACCESS_BRANCH, RemoteSite};
 use dialog_storage::provider::space::SpaceProvider;
 use dialog_storage::provider::storage::Storage;
 use dialog_ucan::{Scope, UcanCertificate};
@@ -135,7 +135,7 @@ impl OperatorBuilder {
             session: Arc::new(session),
             delegations: Arc::new(OnceLock::new()),
             chains: Arc::default(),
-            hydrator: Arc::new(OnceLock::new()),
+            reach: Arc::new(OnceLock::new()),
         };
 
         // Open the profile repository's access branch: the store every
@@ -149,28 +149,52 @@ impl OperatorBuilder {
             .map_err(|e| OperatorError::Delegation(format!("{e}")))?;
         operator
             .delegations
-            .set(branch.clone())
+            .set(branch)
             .expect("freshly built operator has no access branch yet");
 
-        // Install the hydrator: when the branch head moves, the operator
-        // fetches the delegation records and envelopes the new head
-        // references, through this full network-capable environment. The
-        // captured operator clone carries NO hydrator of its own — the
-        // proofs authorizing the hydration fetches resolve from what is
-        // already local, bounding the recursion.
+        // Install the walk's remote reach: the authorization walk's tree
+        // and envelope reads replicate content on demand through these
+        // fork effects, like any other read. The captured operator clone
+        // carries NO reach of its own — the proof that authorizes such a
+        // fetch resolves from what is already local, which bounds the
+        // recursion a fork-inside-a-proof would otherwise open.
         let anchor = Operator {
-            hydrator: Arc::new(OnceLock::new()),
+            reach: Arc::new(OnceLock::new()),
             ..operator.clone()
         };
-        let hydrator: Hydrator = Box::new(move || {
-            let operator = anchor.clone();
-            let branch = branch.clone();
-            Box::pin(async move { branch.delegations().hydrate().perform(&operator).await })
-        });
+        let reach = WalkReach {
+            get: {
+                let anchor = anchor.clone();
+                Box::new(move |input| {
+                    let anchor = anchor.clone();
+                    Box::pin(async move {
+                        Provider::<Fork<RemoteSite, archive::Get>>::execute(&anchor, input).await
+                    })
+                })
+            },
+            resolve: {
+                let anchor = anchor.clone();
+                Box::new(move |input| {
+                    let anchor = anchor.clone();
+                    Box::pin(async move {
+                        Provider::<Fork<RemoteSite, memory::Resolve>>::execute(&anchor, input).await
+                    })
+                })
+            },
+            blob_read: {
+                let anchor = anchor.clone();
+                Box::new(move |input| {
+                    let anchor = anchor.clone();
+                    Box::pin(async move {
+                        Provider::<Fork<RemoteSite, blob::Read>>::execute(&anchor, input).await
+                    })
+                })
+            },
+        };
         operator
-            .hydrator
-            .set(hydrator)
-            .unwrap_or_else(|_| unreachable!("freshly built operator has no hydrator yet"));
+            .reach
+            .set(reach)
+            .unwrap_or_else(|_| unreachable!("freshly built operator has no reach yet"));
 
         Ok(operator)
     }

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -37,6 +37,9 @@ pub use commit::*;
 mod delegation;
 pub use delegation::*;
 
+mod download;
+pub use download::*;
+
 mod export;
 pub use export::*;
 

--- a/rust/dialog-repository/src/repository/branch/delegation.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation.rs
@@ -74,7 +74,6 @@ use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify};
 use dialog_effects::blob::Write as BlobWrite;
 use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
-use dialog_effects::blob::{Import as EnvelopeImport, Read as EnvelopeRead};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_ucan::{UcanCertificate, UcanDelegation};
 use futures_util::stream;
@@ -137,107 +136,6 @@ impl<'a> Delegations<'a> {
             branch: self.branch,
             chain,
         }
-    }
-
-    /// Hydrate every retained delegation into local storage: the tree
-    /// blocks its facts live in (a pulled tree adopts subtrees by link,
-    /// leaving their blocks remote until read) and its envelope blob.
-    /// The operator runs this when the branch head moves — the
-    /// authorization walk deliberately reads only local state, so this
-    /// is the step that brings that state local.
-    pub fn hydrate(self) -> HydrateDelegations<'a> {
-        HydrateDelegations {
-            branch: self.branch,
-        }
-    }
-}
-
-/// Hydrate retained delegation envelopes from the branch's remote.
-/// Created by [`Delegations::hydrate`].
-pub struct HydrateDelegations<'a> {
-    branch: &'a Branch,
-}
-
-impl HydrateDelegations<'_> {
-    /// Fetch every retained delegation's fact blocks and envelope that
-    /// are not yet local, returning how many delegations are locally
-    /// provable afterward. The scan warms exactly what the walk reads:
-    /// the audience index it discovers candidates through, each
-    /// delegation entity's own facts, and the envelope bytes admission
-    /// decodes. A delegation the remote cannot serve is skipped: the
-    /// prover treats it as no candidate, and a later attempt can
-    /// complete it.
-    pub async fn perform<Env>(self, env: &Env) -> Result<usize, CommitError>
-    where
-        Env: Provider<Get>
-            + Provider<Put>
-            + Provider<Resolve>
-            + Provider<EnvelopeRead>
-            + Provider<EnvelopeImport>
-            + Provider<Fork<RemoteSite, Get>>
-            + Provider<Fork<RemoteSite, Resolve>>
-            + Provider<Fork<RemoteSite, EnvelopeRead>>
-            + ConditionalSync
-            + 'static,
-    {
-        use dialog_artifacts::ArtifactSelector;
-        use futures_util::StreamExt as _;
-
-        let branch = self.branch;
-        let store = index_store(branch, env).await;
-        let facts = crate::Select::new(
-            branch,
-            ArtifactSelector::new().the(
-                DELEGATION_AUDIENCE
-                    .parse()
-                    .expect("the audience attribute is valid"),
-            ),
-        )
-        .execute(store.clone())
-        .await
-        .map_err(DialogArtifactsError::from)?;
-        futures_util::pin_mut!(facts);
-
-        let mut entities = Vec::new();
-        {
-            let mut seen = HashSet::new();
-            while let Some(fact) = facts.next().await {
-                let Ok(artifact) = fact.and_then(|view| view.to_owned()) else {
-                    continue;
-                };
-                if seen.insert(artifact.of.to_string()) {
-                    entities.push(artifact.of);
-                }
-            }
-        }
-
-        let mut hydrated = 0;
-        for entity in entities {
-            // Warm the entity's own fact blocks: the walk reads them
-            // through the entity ordering, which the audience scan above
-            // does not touch.
-            let entity_facts =
-                crate::Select::new(branch, ArtifactSelector::new().of(entity.clone()))
-                    .execute(store.clone())
-                    .await
-                    .map_err(DialogArtifactsError::from)?;
-            futures_util::pin_mut!(entity_facts);
-            while entity_facts.next().await.is_some() {}
-
-            // Local-first read with remote fallback: a hit caches the
-            // bytes locally, a miss (remote cannot serve it either) is
-            // skipped.
-            let Ok(mut reader) = crate::Blob::from(entity)
-                .read(branch.into())
-                .perform(env)
-                .await
-            else {
-                continue;
-            };
-            while let Ok(Some(_)) = reader.next().await {}
-            hydrated += 1;
-        }
-        Ok(hydrated)
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/delegation.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation.rs
@@ -74,6 +74,7 @@ use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify};
 use dialog_effects::blob::Write as BlobWrite;
 use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
+use dialog_effects::blob::{Import as EnvelopeImport, Read as EnvelopeRead};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_ucan::{UcanCertificate, UcanDelegation};
 use futures_util::stream;
@@ -136,6 +137,81 @@ impl<'a> Delegations<'a> {
             branch: self.branch,
             chain,
         }
+    }
+
+    /// Hydrate every retained delegation's envelope into the local blob
+    /// store. Pull runs this after adopting an upstream: facts arrive with
+    /// the tree, but envelope bytes replicate lazily, and the
+    /// authorization walk deliberately reads only local state — sync is
+    /// what brings the state.
+    pub fn hydrate(self) -> HydrateDelegations<'a> {
+        HydrateDelegations {
+            branch: self.branch,
+        }
+    }
+}
+
+/// Hydrate retained delegation envelopes from the branch's remote.
+/// Created by [`Delegations::hydrate`].
+pub struct HydrateDelegations<'a> {
+    branch: &'a Branch,
+}
+
+impl HydrateDelegations<'_> {
+    /// Fetch every retained delegation's envelope that is not yet local,
+    /// returning how many envelopes are locally readable afterward. An
+    /// envelope the remote cannot serve is skipped: the prover treats it
+    /// as no candidate, and a later pull can complete it.
+    pub async fn perform<Env>(self, env: &Env) -> Result<usize, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<EnvelopeRead>
+            + Provider<EnvelopeImport>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + Provider<Fork<RemoteSite, EnvelopeRead>>
+            + ConditionalSync
+            + 'static,
+    {
+        use dialog_artifacts::ArtifactSelector;
+        use futures_util::StreamExt as _;
+
+        let branch = self.branch;
+        let store = index_store(branch, env).await;
+        let facts = crate::Select::new(
+            branch,
+            ArtifactSelector::new().the(
+                DELEGATION_AUDIENCE
+                    .parse()
+                    .expect("the audience attribute is valid"),
+            ),
+        )
+        .execute(store)
+        .await
+        .map_err(DialogArtifactsError::from)?;
+        futures_util::pin_mut!(facts);
+
+        let mut hydrated = 0;
+        while let Some(fact) = facts.next().await {
+            let Ok(artifact) = fact.and_then(|view| view.to_owned()) else {
+                continue;
+            };
+            // Local-first read with remote fallback: a hit caches the
+            // bytes locally, a miss (remote cannot serve it either) is
+            // skipped.
+            let Ok(mut reader) = crate::Blob::from(artifact.of)
+                .read(branch.into())
+                .perform(env)
+                .await
+            else {
+                continue;
+            };
+            while let Ok(Some(_)) = reader.next().await {}
+            hydrated += 1;
+        }
+        Ok(hydrated)
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/delegation.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation.rs
@@ -139,11 +139,12 @@ impl<'a> Delegations<'a> {
         }
     }
 
-    /// Hydrate every retained delegation's envelope into the local blob
-    /// store. Pull runs this after adopting an upstream: facts arrive with
-    /// the tree, but envelope bytes replicate lazily, and the
-    /// authorization walk deliberately reads only local state — sync is
-    /// what brings the state.
+    /// Hydrate every retained delegation into local storage: the tree
+    /// blocks its facts live in (a pulled tree adopts subtrees by link,
+    /// leaving their blocks remote until read) and its envelope blob.
+    /// The operator runs this when the branch head moves — the
+    /// authorization walk deliberately reads only local state, so this
+    /// is the step that brings that state local.
     pub fn hydrate(self) -> HydrateDelegations<'a> {
         HydrateDelegations {
             branch: self.branch,
@@ -158,10 +159,14 @@ pub struct HydrateDelegations<'a> {
 }
 
 impl HydrateDelegations<'_> {
-    /// Fetch every retained delegation's envelope that is not yet local,
-    /// returning how many envelopes are locally readable afterward. An
-    /// envelope the remote cannot serve is skipped: the prover treats it
-    /// as no candidate, and a later pull can complete it.
+    /// Fetch every retained delegation's fact blocks and envelope that
+    /// are not yet local, returning how many delegations are locally
+    /// provable afterward. The scan warms exactly what the walk reads:
+    /// the audience index it discovers candidates through, each
+    /// delegation entity's own facts, and the envelope bytes admission
+    /// decodes. A delegation the remote cannot serve is skipped: the
+    /// prover treats it as no candidate, and a later attempt can
+    /// complete it.
     pub async fn perform<Env>(self, env: &Env) -> Result<usize, CommitError>
     where
         Env: Provider<Get>
@@ -188,20 +193,41 @@ impl HydrateDelegations<'_> {
                     .expect("the audience attribute is valid"),
             ),
         )
-        .execute(store)
+        .execute(store.clone())
         .await
         .map_err(DialogArtifactsError::from)?;
         futures_util::pin_mut!(facts);
 
+        let mut entities = Vec::new();
+        {
+            let mut seen = HashSet::new();
+            while let Some(fact) = facts.next().await {
+                let Ok(artifact) = fact.and_then(|view| view.to_owned()) else {
+                    continue;
+                };
+                if seen.insert(artifact.of.to_string()) {
+                    entities.push(artifact.of);
+                }
+            }
+        }
+
         let mut hydrated = 0;
-        while let Some(fact) = facts.next().await {
-            let Ok(artifact) = fact.and_then(|view| view.to_owned()) else {
-                continue;
-            };
+        for entity in entities {
+            // Warm the entity's own fact blocks: the walk reads them
+            // through the entity ordering, which the audience scan above
+            // does not touch.
+            let entity_facts =
+                crate::Select::new(branch, ArtifactSelector::new().of(entity.clone()))
+                    .execute(store.clone())
+                    .await
+                    .map_err(DialogArtifactsError::from)?;
+            futures_util::pin_mut!(entity_facts);
+            while entity_facts.next().await.is_some() {}
+
             // Local-first read with remote fallback: a hit caches the
             // bytes locally, a miss (remote cannot serve it either) is
             // skipped.
-            let Ok(mut reader) = crate::Blob::from(artifact.of)
+            let Ok(mut reader) = crate::Blob::from(entity)
                 .read(branch.into())
                 .perform(env)
                 .await

--- a/rust/dialog-repository/src/repository/branch/download.rs
+++ b/rust/dialog-repository/src/repository/branch/download.rs
@@ -1,0 +1,146 @@
+//! Materialize a branch's content locally.
+//!
+//! A pull adopts an upstream head by reference: subtrees the local
+//! replica never changed stay remote and hydrate lazily as reads touch
+//! them, and blob bytes replicate on first read. That laziness is the
+//! right default for sync cost, but sometimes the caller wants the
+//! opposite guarantee — everything the head references present locally,
+//! before going offline or before latency-sensitive reads (the
+//! authorization walk over an access branch is the motivating case).
+//!
+//! [`Branch::download`] provides it: one walk of the current revision
+//! through the snapshot export machinery with download reach, fetching
+//! every block and blob the revision references that the local store
+//! does not hold, caching each as it lands. [`Pull::download`] chains
+//! the two acts — adopt the upstream head, then materialize it.
+
+use dialog_capability::{Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Import, Put};
+use dialog_effects::authority::{Attest, Identify};
+use dialog_effects::blob::{Import as BlobImport, Read as BlobRead};
+use dialog_effects::memory::{Publish, Resolve};
+use futures_util::StreamExt as _;
+
+use crate::repository::snapshot::Snapshot;
+use crate::{
+    Branch, DownloadError, Pull, PullError, RemoteSite, RepositoryMemoryExt as _, Revision,
+    Upstream,
+};
+
+/// Command struct for materializing a branch's content locally. Created
+/// by [`Branch::download`].
+pub struct Download<'a> {
+    branch: &'a Branch,
+    from: Option<Upstream>,
+}
+
+impl Branch {
+    /// Fetch every block and blob the current revision references that
+    /// the local store does not hold, from the branch's upstream.
+    ///
+    /// A no-op without a remote upstream (a local upstream shares the
+    /// store, so there is nothing to fetch) or before the first
+    /// revision.
+    pub fn download(&self) -> Download<'_> {
+        Download {
+            branch: self,
+            from: None,
+        }
+    }
+}
+
+impl Download<'_> {
+    /// Materialize the branch's current revision locally.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), DownloadError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<BlobRead>
+            + Provider<BlobImport>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, BlobRead>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.branch;
+        let Some(revision) = branch.revision() else {
+            return Ok(());
+        };
+        let upstream = self.from.or_else(|| branch.upstream());
+        let Some(Upstream::Remote { remote: name, .. }) = upstream else {
+            return Ok(());
+        };
+        let remote = branch
+            .subject()
+            .remote(name)
+            .load()
+            .perform(env)
+            .await
+            .map_err(DownloadError::LoadRemote)?;
+
+        // One walk with download reach: a read-miss falls through to the
+        // remote and is cached locally on the way through, and a missing
+        // blob is imported (digest-verified) before its reader is served.
+        // The items themselves carry nothing the local store does not
+        // already hold by the time they are yielded, so draining the
+        // stream is the whole job.
+        let items = Snapshot::of(branch.subject(), revision)
+            .export()
+            .download(remote)
+            .perform(env);
+        futures_util::pin_mut!(items);
+        while let Some(item) = items.next().await {
+            item.map_err(DownloadError::Snapshot)?;
+        }
+        Ok(())
+    }
+}
+
+/// Command struct for a pull followed by a download of the adopted head.
+/// Created by [`Pull::download`].
+pub struct PullDownload<'a>(Pull<'a>);
+
+impl<'a> Pull<'a> {
+    /// After the pull, fetch every block and blob the adopted head
+    /// references that the local store does not hold.
+    ///
+    /// The pull itself stays byte-frugal — it adopts by reference — and
+    /// this chains the materialization the caller opted into. The login
+    /// flow is the motivating case: pull the account's access branch,
+    /// download it, and proofs read entirely locally.
+    pub fn download(self) -> PullDownload<'a> {
+        PullDownload(self)
+    }
+}
+
+impl PullDownload<'_> {
+    /// Pull, then materialize the adopted head locally. Returns what the
+    /// pull returned.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Option<Revision>, PullError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<BlobRead>
+            + Provider<BlobImport>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + Provider<Fork<RemoteSite, BlobRead>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.0.branch();
+        let from = self.0.source().cloned();
+        let pulled = self.0.perform(env).await?;
+        if pulled.is_some() {
+            Download { branch, from }.perform(env).await?;
+        }
+        Ok(pulled)
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -1296,18 +1296,18 @@ async fn it_two_party_convergence(s3: S3Address) -> Result<()> {
 use dialog_remote_ucan_s3::UcanAddress;
 use dialog_remote_ucan_s3::helpers::UcanS3Address;
 
-/// Alice creates a repo, delegates to Bob, Bob pulls, commits, pushes,
-/// then Alice pulls Bob's changes.
 /// The login flow: the ACCOUNT repository is the durable home of
 /// delegations, and a device regains access by pulling it. A space
 /// delegates to the account; the account's access branch (holding that
 /// grant) is pushed to the access service. A device profile "logs in":
 /// it retains the account-to-profile powerline locally, adds the account
 /// as the upstream of its own access branch, and pulls. The pull adopts
-/// the account's delegation records and hydrates their envelopes, and
-/// the operator then proves access to the space through the three-hop
-/// chain: space to account (pulled), account to profile (retained at
-/// login), profile to operator (in-memory session).
+/// the account's delegation records; on the first prove after the head
+/// moves the operator hydrates their blocks and envelopes (authorized by
+/// the retained powerline plus the in-memory session — the proofs that
+/// are already local), then proves access to the space through the
+/// three-hop chain: space to account (pulled), account to profile
+/// (retained at login), profile to operator (in-memory session).
 #[dialog_common::test]
 async fn it_regains_access_by_pulling_the_account(ucan: UcanS3Address) -> Result<()> {
     use dialog_capability::access::{

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -1298,6 +1298,189 @@ use dialog_remote_ucan_s3::helpers::UcanS3Address;
 
 /// Alice creates a repo, delegates to Bob, Bob pulls, commits, pushes,
 /// then Alice pulls Bob's changes.
+/// The login flow: the ACCOUNT repository is the durable home of
+/// delegations, and a device regains access by pulling it. A space
+/// delegates to the account; the account's access branch (holding that
+/// grant) is pushed to the access service. A device profile "logs in":
+/// it retains the account-to-profile powerline locally, adds the account
+/// as the upstream of its own access branch, and pulls. The pull adopts
+/// the account's delegation records and hydrates their envelopes, and
+/// the operator then proves access to the space through the three-hop
+/// chain: space to account (pulled), account to profile (retained at
+/// login), profile to operator (in-memory session).
+#[dialog_common::test]
+async fn it_regains_access_by_pulling_the_account(ucan: UcanS3Address) -> Result<()> {
+    use dialog_capability::access::{
+        Access as AccessAttenuation, Proof as _, Prove, Retain, TimeRange,
+    };
+    use dialog_credentials::{Credential as RawCredential, Ed25519Signer, SignerCredential};
+    use dialog_effects::storage::{LocationExt as _, Storage as StorageFx};
+    use dialog_operator::DeriveOperator as _;
+    use dialog_ucan::{Parameters, Scope, Ucan, UcanDelegation};
+    use dialog_ucan_core::command::Command as UcanCommand;
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal as _;
+
+    let ucan_site = SiteAddress::Ucan(UcanAddress::new(&ucan.access_service_url));
+
+    // --- The account: its own identity, its own repository, the durable
+    // home of delegations. ---
+    let account_storage = Storage::volatile();
+    let account_signer = Ed25519Signer::generate().await?;
+    let account_name = unique_name("account");
+    StorageFx::profile(account_name.clone())
+        .create(RawCredential::Signer(SignerCredential::from(
+            account_signer.clone(),
+        )))
+        .perform(&account_storage)
+        .await?;
+    let account_profile = Profile::load(account_name)
+        .perform(&account_storage)
+        .await?;
+    let account_operator = account_profile
+        .derive(b"account-device")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(account_storage)
+        .await?;
+
+    // A space grants the ACCOUNT (not a profile): the durable direction,
+    // so a compromised device profile cannot cost the access.
+    let space = Ed25519Signer::generate().await?;
+    let space_grant = DelegationBuilder::new()
+        .issuer(space.clone())
+        .audience(&account_signer)
+        .subject(UcanSubject::Specific(space.did()))
+        .command(vec!["storage".to_string()])
+        .try_build()
+        .await?;
+    Subject::from(account_profile.did())
+        .attenuate(AccessAttenuation)
+        .invoke(Retain::<Ucan>::new(UcanDelegation::new(
+            DelegationChain::new(space_grant),
+        )))
+        .perform(&account_operator)
+        .await?;
+
+    // Publish the account's access branch to the access service.
+    let account_repo = crate::Repository::from(&account_profile);
+    let account_origin = account_repo
+        .remote("origin")
+        .create(ucan_site.clone())
+        .perform(&account_operator)
+        .await?;
+    let account_branch = account_repo
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&account_operator)
+        .await?;
+    let account_remote_branch = account_origin
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&account_operator)
+        .await?;
+    account_branch
+        .set_upstream(account_remote_branch)
+        .perform(&account_operator)
+        .await?;
+    assert!(
+        account_branch
+            .push()
+            .perform(&account_operator)
+            .await?
+            .is_some()
+    );
+
+    // --- The device: fresh profile and operator. "Login" retains the
+    // account-to-profile powerline locally (handed over out of band) and
+    // points the profile's access branch at the account. ---
+    let device_storage = Storage::volatile();
+    let device_profile = Profile::open(unique_name("device"))
+        .perform(&device_storage)
+        .await?;
+    let device_operator = device_profile
+        .derive(b"device")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(device_storage)
+        .await?;
+
+    let login_grant = DelegationBuilder::new()
+        .issuer(account_signer.clone())
+        .audience(&device_profile.did())
+        .subject(UcanSubject::Any)
+        .command(vec![])
+        .try_build()
+        .await?;
+    Subject::from(device_profile.did())
+        .attenuate(AccessAttenuation)
+        .invoke(Retain::<Ucan>::new(UcanDelegation::new(
+            DelegationChain::new(login_grant),
+        )))
+        .perform(&device_operator)
+        .await?;
+
+    let device_repo = crate::Repository::from(&device_profile);
+    let device_origin = device_repo
+        .remote("account")
+        .create(ucan_site)
+        .subject(account_profile.did())
+        .perform(&device_operator)
+        .await?;
+    let device_branch = device_repo
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&device_operator)
+        .await?;
+    let device_remote_branch = device_origin
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&device_operator)
+        .await?;
+    device_branch
+        .set_upstream(device_remote_branch)
+        .perform(&device_operator)
+        .await?;
+
+    // The pull IS the login's data path: authorized by the retained
+    // powerline plus the in-memory session, it adopts the account's
+    // delegation records and hydrates their envelopes.
+    assert!(
+        device_branch
+            .pull()
+            .perform(&device_operator)
+            .await?
+            .is_some(),
+        "the login pull adopts the account's delegations"
+    );
+
+    // The device now proves access to the space through the full ladder:
+    // space -> account (pulled), account -> profile (login), profile ->
+    // operator (session).
+    let mut claim = Prove::<Ucan>::new(
+        device_operator.did(),
+        Scope {
+            subject: UcanSubject::Specific(space.did()),
+            command: UcanCommand(vec!["storage".to_string()]),
+            parameters: Parameters::default(),
+        },
+    );
+    claim.duration = TimeRange::unbounded();
+    let proof = Subject::from(device_profile.did())
+        .attenuate(AccessAttenuation)
+        .invoke(claim)
+        .perform(&device_operator)
+        .await?;
+    assert_eq!(
+        proof.proofs().len(),
+        3,
+        "space -> account -> profile -> operator"
+    );
+
+    Ok(())
+}
+
 /// The upgrade path, end to end over the access service and local S3:
 /// a delegation sitting in the LEGACY certificate store (as an old
 /// install left it) no longer authorizes anything — the operator serves

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -1302,12 +1302,14 @@ use dialog_remote_ucan_s3::helpers::UcanS3Address;
 /// grant) is pushed to the access service. A device profile "logs in":
 /// it retains the account-to-profile powerline locally, adds the account
 /// as the upstream of its own access branch, and pulls. The pull adopts
-/// the account's delegation records; on the first prove after the head
-/// moves the operator hydrates their blocks and envelopes (authorized by
-/// the retained powerline plus the in-memory session — the proofs that
-/// are already local), then proves access to the space through the
-/// three-hop chain: space to account (pulled), account to profile
-/// (retained at login), profile to operator (in-memory session).
+/// the account's delegation records by reference; the prove then reads
+/// them like any other read, replicating record blocks and envelope
+/// bytes on demand through the walk's reach (each fetch authorized by
+/// the retained powerline plus the in-memory session — proofs that are
+/// already local). The chain proved is the three-hop ladder: space to
+/// account (pulled), account to profile (retained at login), profile to
+/// operator (in-memory session). No explicit download: this test pins
+/// that proving works on-demand right after a bare pull.
 #[dialog_common::test]
 async fn it_regains_access_by_pulling_the_account(ucan: UcanS3Address) -> Result<()> {
     use dialog_capability::access::{
@@ -1477,6 +1479,184 @@ async fn it_regains_access_by_pulling_the_account(ucan: UcanS3Address) -> Result
         3,
         "space -> account -> profile -> operator"
     );
+
+    Ok(())
+}
+
+/// The embedder's eager form of the login pull: `pull().download()`
+/// materializes the adopted head locally — every delegation record
+/// block and envelope blob — before any prove runs. Pinned by reading
+/// an envelope's bytes straight from the device's local blob provider,
+/// with no remote reach in the environment: only a download could have
+/// put them there, since a bare pull adopts by reference and envelope
+/// bytes otherwise replicate on first read.
+#[dialog_common::test]
+async fn it_downloads_the_account_branch_on_login(ucan: UcanS3Address) -> Result<()> {
+    use dialog_capability::access::{Access as AccessAttenuation, Retain};
+    use dialog_credentials::{Credential as RawCredential, Ed25519Signer, SignerCredential};
+    use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+    use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
+    use dialog_effects::storage::{LocationExt as _, Storage as StorageFx};
+    use dialog_operator::DeriveOperator as _;
+    use dialog_ucan::{Ucan, UcanDelegation};
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal as _;
+    use futures_util::StreamExt as _;
+
+    let ucan_site = SiteAddress::Ucan(UcanAddress::new(&ucan.access_service_url));
+
+    // The account, holding a space's grant in its pushed access branch.
+    let account_storage = Storage::volatile();
+    let account_signer = Ed25519Signer::generate().await?;
+    let account_name = unique_name("account");
+    StorageFx::profile(account_name.clone())
+        .create(RawCredential::Signer(SignerCredential::from(
+            account_signer.clone(),
+        )))
+        .perform(&account_storage)
+        .await?;
+    let account_profile = Profile::load(account_name)
+        .perform(&account_storage)
+        .await?;
+    let account_operator = account_profile
+        .derive(b"account-device")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(account_storage)
+        .await?;
+    let space = Ed25519Signer::generate().await?;
+    let space_grant = DelegationBuilder::new()
+        .issuer(space.clone())
+        .audience(&account_signer)
+        .subject(UcanSubject::Specific(space.did()))
+        .command(vec!["storage".to_string()])
+        .try_build()
+        .await?;
+    Subject::from(account_profile.did())
+        .attenuate(AccessAttenuation)
+        .invoke(Retain::<Ucan>::new(UcanDelegation::new(
+            DelegationChain::new(space_grant),
+        )))
+        .perform(&account_operator)
+        .await?;
+    let account_repo = crate::Repository::from(&account_profile);
+    let account_origin = account_repo
+        .remote("origin")
+        .create(ucan_site.clone())
+        .perform(&account_operator)
+        .await?;
+    let account_branch = account_repo
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&account_operator)
+        .await?;
+    let account_remote_branch = account_origin
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&account_operator)
+        .await?;
+    account_branch
+        .set_upstream(account_remote_branch)
+        .perform(&account_operator)
+        .await?;
+    assert!(
+        account_branch
+            .push()
+            .perform(&account_operator)
+            .await?
+            .is_some()
+    );
+
+    // The device logs in: retain the powerline, point at the account,
+    // pull WITH download.
+    let device_storage = Storage::volatile();
+    let device_profile = Profile::open(unique_name("device"))
+        .perform(&device_storage)
+        .await?;
+    let device_operator = device_profile
+        .derive(b"device")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(device_storage.clone())
+        .await?;
+    let login_grant = DelegationBuilder::new()
+        .issuer(account_signer.clone())
+        .audience(&device_profile.did())
+        .subject(UcanSubject::Any)
+        .command(vec![])
+        .try_build()
+        .await?;
+    Subject::from(device_profile.did())
+        .attenuate(AccessAttenuation)
+        .invoke(Retain::<Ucan>::new(UcanDelegation::new(
+            DelegationChain::new(login_grant),
+        )))
+        .perform(&device_operator)
+        .await?;
+    let device_repo = crate::Repository::from(&device_profile);
+    let device_origin = device_repo
+        .remote("account")
+        .create(ucan_site)
+        .subject(account_profile.did())
+        .perform(&device_operator)
+        .await?;
+    let device_branch = device_repo
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&device_operator)
+        .await?;
+    let device_remote_branch = device_origin
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&device_operator)
+        .await?;
+    device_branch
+        .set_upstream(device_remote_branch)
+        .perform(&device_operator)
+        .await?;
+    assert!(
+        device_branch
+            .pull()
+            .download()
+            .perform(&device_operator)
+            .await?
+            .is_some(),
+        "the login pull adopts the account's delegations"
+    );
+
+    // Every retained delegation's envelope must now be readable from the
+    // device's LOCAL blob provider — no remote reach in this env.
+    use dialog_artifacts::ArtifactSelector;
+    let store = super::blob::index_store(&device_branch, &device_operator).await;
+    let facts: Vec<_> = crate::Select::new(
+        &device_branch,
+        ArtifactSelector::new().the(crate::DELEGATION_AUDIENCE.parse().unwrap()),
+    )
+    .execute(store)
+    .await?
+    .collect()
+    .await;
+    assert_eq!(facts.len(), 2, "the powerline and the space grant");
+    for fact in facts {
+        let artifact = fact?.to_owned()?;
+        let digest = artifact
+            .of
+            .blob_hash()
+            .expect("delegation entities are blob entities");
+        let mut reader = device_branch
+            .subject()
+            .archive()
+            .blob()
+            .read(digest)
+            .perform(&device_storage)
+            .await?;
+        let mut bytes = 0;
+        while let Some(chunk) = reader.next().await? {
+            bytes += chunk.len();
+        }
+        assert!(bytes > 0, "the envelope's bytes are local after download");
+    }
 
     Ok(())
 }

--- a/rust/dialog-repository/src/repository/branch/pull.rs
+++ b/rust/dialog-repository/src/repository/branch/pull.rs
@@ -40,6 +40,16 @@ impl<'a> Pull<'a> {
         Self { branch, from: None }
     }
 
+    /// The branch this pull targets.
+    pub(crate) fn branch(&self) -> &'a Branch {
+        self.branch
+    }
+
+    /// The explicit source set through [`Pull::from`], if any.
+    pub(crate) fn source(&self) -> Option<&Upstream> {
+        self.from.as_ref()
+    }
+
     /// Pull from the given branch instead of the default upstream.
     ///
     /// Accepts either a `&Branch` or a `&RemoteBranch` — the same inputs as

--- a/rust/dialog-repository/src/repository/branch/pull.rs
+++ b/rust/dialog-repository/src/repository/branch/pull.rs
@@ -14,7 +14,6 @@ use dialog_common::ConditionalSync;
 use dialog_effects::archive::prelude::CatalogExt as _;
 use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify, OperatorExt};
-use dialog_effects::blob::{Import as BlobImport, Read as BlobRead};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_search_tree::{ContentAddressedStorage as TreeStorage, Delta};
 
@@ -103,30 +102,12 @@ impl<'a> Pull<'a> {
             + Provider<Publish>
             + Provider<Identify>
             + Provider<Attest>
-            + Provider<BlobRead>
-            + Provider<BlobImport>
             + Provider<Fork<RemoteSite, Get>>
             + Provider<Fork<RemoteSite, Resolve>>
-            + Provider<Fork<RemoteSite, BlobRead>>
             + ConditionalSync
             + 'static,
     {
-        let branch = self.branch;
-        let pulled = Box::pin(self.prepare(env)).await?.commit(env).await?;
-
-        // Hydrate the retained delegation envelopes the adopted tree
-        // references: facts arrive with the tree, envelope bytes replicate
-        // lazily, and the authorization walk deliberately reads only local
-        // state — this is where sync brings that state. Best-effort: a
-        // delegation the remote cannot serve yet is simply not a usable
-        // candidate until a later pull completes it.
-        if pulled.is_some()
-            && let Err(error) = branch.delegations().hydrate().perform(env).await
-        {
-            tracing::warn!(%error, "failed to hydrate delegation envelopes after pull");
-        }
-
-        Ok(pulled)
+        Box::pin(self.prepare(env)).await?.commit(env).await
     }
 
     /// Phase one: fetch the upstream, rebase local changes onto it, and persist

--- a/rust/dialog-repository/src/repository/branch/pull.rs
+++ b/rust/dialog-repository/src/repository/branch/pull.rs
@@ -14,6 +14,7 @@ use dialog_common::ConditionalSync;
 use dialog_effects::archive::prelude::CatalogExt as _;
 use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify, OperatorExt};
+use dialog_effects::blob::{Import as BlobImport, Read as BlobRead};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_search_tree::{ContentAddressedStorage as TreeStorage, Delta};
 
@@ -102,12 +103,30 @@ impl<'a> Pull<'a> {
             + Provider<Publish>
             + Provider<Identify>
             + Provider<Attest>
+            + Provider<BlobRead>
+            + Provider<BlobImport>
             + Provider<Fork<RemoteSite, Get>>
             + Provider<Fork<RemoteSite, Resolve>>
+            + Provider<Fork<RemoteSite, BlobRead>>
             + ConditionalSync
             + 'static,
     {
-        Box::pin(self.prepare(env)).await?.commit(env).await
+        let branch = self.branch;
+        let pulled = Box::pin(self.prepare(env)).await?.commit(env).await?;
+
+        // Hydrate the retained delegation envelopes the adopted tree
+        // references: facts arrive with the tree, envelope bytes replicate
+        // lazily, and the authorization walk deliberately reads only local
+        // state — this is where sync brings that state. Best-effort: a
+        // delegation the remote cannot serve yet is simply not a usable
+        // candidate until a later pull completes it.
+        if pulled.is_some()
+            && let Err(error) = branch.delegations().hydrate().perform(env).await
+        {
+            tracing::warn!(%error, "failed to hydrate delegation envelopes after pull");
+        }
+
+        Ok(pulled)
     }
 
     /// Phase one: fetch the upstream, rebase local changes onto it, and persist

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -289,6 +289,11 @@ pub enum PullError {
     /// An artifact decode during pull failed.
     #[error("Artifact decode failed during pull: {0}")]
     Artifact(#[from] DialogArtifactsError),
+
+    /// Materializing the adopted head after the pull failed
+    /// ([`Pull::download`](crate::Pull::download)).
+    #[error("Download after pull failed: {0}")]
+    Download(#[from] DownloadError),
 }
 
 /// Errors specific to a push operation.
@@ -572,6 +577,19 @@ mod tests {
         assert!(matches!(reason, AuthorizeError::Revoked { .. }));
         assert_revoked(&push.to_string());
     }
+}
+
+/// Errors from materializing a branch's content locally
+/// ([`Branch::download`](crate::Branch::download)).
+#[derive(Error, Debug)]
+pub enum DownloadError {
+    /// Loading the branch's configured remote failed.
+    #[error("Failed to load remote for download: {0}")]
+    LoadRemote(#[from] LoadRemoteError),
+
+    /// The materializing walk failed.
+    #[error("Download walk failed: {0}")]
+    Snapshot(#[from] SnapshotError),
 }
 
 /// Errors from snapshot export and import.

--- a/rust/dialog-repository/src/repository/snapshot.rs
+++ b/rust/dialog-repository/src/repository/snapshot.rs
@@ -52,9 +52,10 @@ use dialog_effects::archive::{Catalog, Get, Put};
 use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
 use dialog_effects::blob::{BlobError, BlobReader, Import as BlobImport, Read as BlobRead};
 use dialog_search_tree::{
-    ArchivedNodeBody, ContentAddressedStorage as TreeStorage, Traversable as _, Visit, into_owned,
+    ArchivedNodeBody, ContentAddressedStorage as TreeStorage, NoveltyOp, Traversable as _, Visit,
+    into_owned,
 };
-use futures_util::{Stream, StreamExt as _};
+use futures_util::{Stream, StreamExt as _, stream};
 
 use dialog_credentials::Credential;
 use dialog_varsig::Principal;
@@ -63,6 +64,13 @@ use crate::{
     Index, NetworkedIndex, RemoteRepository, RemoteSite, Repository, RepositoryArchiveExt as _,
     Revision, SnapshotError,
 };
+
+/// How many spill or blob fetches an export keeps in flight at once.
+///
+/// Concurrency, not parallelism: one task drives them, so this holds on
+/// wasm too. Sized to overlap remote round-trips under a downloading
+/// reach without swamping a local store or a remote's connection limits.
+const FETCH_CONCURRENCY: usize = 16;
 
 /// A block of a snapshot: content plus the digest it must hash to.
 ///
@@ -300,6 +308,10 @@ impl<C: Principal> SnapshotExport<'_, C> {
 
             let mut spills: HashSet<[u8; 32]> = HashSet::new();
             let mut blobs: Vec<NodeHash> = Vec::new();
+            // A key may surface twice — its stored leaf entry plus a
+            // buffered op riding an ancestor index node — naming the same
+            // content; ship each blob once.
+            let mut blob_seen: HashSet<NodeHash> = HashSet::new();
 
             let visits = tree.traverse_available(&storage);
             futures_util::pin_mut!(visits);
@@ -315,16 +327,34 @@ impl<C: Principal> SnapshotExport<'_, C> {
                     }
                 };
 
-                // A leaf is already decoded here, so its entries are lifted
-                // in this visit. The closure only collects: classification
-                // returns artifact errors, which do not belong in a
-                // tree-walk callback.
+                // A node is already decoded here, so the entries it holds
+                // are lifted in this visit — and every entry a node
+                // physically holds is in the revision's closure. For a
+                // leaf that includes entries a buffered op upstream has
+                // superseded: reads screen those, but their bytes (and
+                // the spill blocks and blobs they reference) are still
+                // stored and still served to history reads. For an index
+                // node it is the buffered asserts riding its novelty
+                // buffers, whose keys and values reference content
+                // exactly like stored entries (a buffered retract
+                // references nothing of its own). The closure only
+                // collects: classification returns artifact errors,
+                // which do not belong in a tree-walk callback.
                 let mut entries: Vec<(Key, State<Datum>)> = Vec::new();
-                if let ArchivedNodeBody::Segment(segment) = node.body() {
-                    segment.for_each_entry::<Key, _>(|key, value| {
-                        entries.push((Key::from(key.to_vec()), into_owned(value)?));
-                        Ok(())
-                    })?;
+                match node.body() {
+                    ArchivedNodeBody::Segment(segment) => {
+                        segment.for_each_entry::<Key, _>(|key, value| {
+                            entries.push((Key::from(key.to_vec()), into_owned(value)?));
+                            Ok(())
+                        })?;
+                    }
+                    ArchivedNodeBody::Index(index) => {
+                        for entry in index.all_novelty::<Key>()? {
+                            if let NoveltyOp::Assert(value) = entry.op {
+                                entries.push((Key::from(entry.key), value));
+                            }
+                        }
+                    }
                 }
                 for (key, value) in entries {
                     match shipment_ref(&key, &value, false)? {
@@ -332,7 +362,10 @@ impl<C: Principal> SnapshotExport<'_, C> {
                             spills.insert(reference);
                         }
                         Some(ShipmentRef::Blob(BlobChange::Added(hash))) => {
-                            blobs.push(NodeHash::from(hash));
+                            let hash = NodeHash::from(hash);
+                            if blob_seen.insert(hash.clone()) {
+                                blobs.push(hash);
+                            }
                         }
                         _ => {}
                     }
@@ -341,10 +374,24 @@ impl<C: Principal> SnapshotExport<'_, C> {
                 yield Item::Block(Block::new(node.buffer().clone()));
             }
 
-            // Spilled value blocks, discovered above.
-            for reference in spills {
-                let digest = NodeHash::from(reference);
-                match storage.retrieve(&digest).await? {
+            // Spilled value blocks, discovered above. Their reads are
+            // independent, so they run concurrently (bounded) and yield
+            // as they complete — against a downloading reach this
+            // overlaps the remote round-trips instead of paying them one
+            // after another.
+            let mut spill_reads = stream::iter(spills.into_iter().map(
+                |reference| {
+                    let storage = &storage;
+                    async move {
+                        let digest = NodeHash::from(reference);
+                        let bytes = storage.retrieve(&digest).await;
+                        (digest, bytes)
+                    }
+                },
+            ))
+            .buffer_unordered(FETCH_CONCURRENCY);
+            while let Some((digest, bytes)) = spill_reads.next().await {
+                match bytes? {
                     Some(bytes) => {
                         yield Item::Block(Block { digest, content: Buffer::from(bytes) });
                     }
@@ -352,75 +399,89 @@ impl<C: Principal> SnapshotExport<'_, C> {
                     None => Err(SnapshotError::MissingBlock { digest })?,
                 }
             }
+            drop(spill_reads);
 
             // Blob bytes, discovered above. The size comes from the tree's
             // own blob index rather than the traversal: `import` is opened
-            // with it, and reading it costs no byte fetch.
-            for digest in blobs {
-                let record = tree.get_blob(&index, digest.as_bytes()).await?;
-                let Some(record) = record else {
-                    if !sparse {
-                        Err(SnapshotError::MissingBlob { digest })?;
-                    }
-                    continue;
-                };
-                let reader = subject
-                    .clone()
-                    .archive()
-                    .blob()
-                    .read(digest.clone())
-                    .perform(env)
-                    .await;
-                let reader = match (reader, &hydrate) {
-                    // A local miss the reach says to resolve. The index
-                    // cannot serve this one -- blocks fall through to the
-                    // remote via `Get`, blob bytes travel their own
-                    // channel -- so fetch the whole blob through a local
-                    // digest-verified import first (a lying remote
-                    // surfaces as `DigestMismatch` at `finish`, and the
-                    // bytes are cached like every other download), then
-                    // serve the read from the now-local copy.
-                    (Err(BlobError::NotFound(_)), Some(remote)) => {
-                        let address = remote.address();
-                        let mut source = address
-                            .subject
-                            .clone()
-                            .archive()
-                            .blob()
-                            .read(digest.clone())
-                            .fork(address.site())
-                            .perform(env)
-                            .await?;
-                        let mut sink = subject
-                            .clone()
-                            .archive()
-                            .blob()
-                            .import(digest.clone(), record.size)
-                            .perform(env)
-                            .await?;
-                        while let Some(chunk) = source.next().await? {
-                            sink.write_all(&chunk).await?;
+            // with it, and reading it costs no byte fetch. Each blob's
+            // whole fetch (and, under a downloading reach, its local
+            // import) is one future; they run concurrently (bounded) and
+            // yield as they complete. `None` from a future means the blob
+            // is unavailable — no index record, or no bytes anywhere the
+            // reach extends — which sparse tolerates and complete refuses.
+            let mut blob_reads = stream::iter(blobs.into_iter().map(|digest| {
+                let tree = &tree;
+                let index = &index;
+                let hydrate = &hydrate;
+                let subject = subject.clone();
+                async move {
+                    let Some(record) = tree.get_blob(index, digest.as_bytes()).await? else {
+                        return Ok((digest, None));
+                    };
+                    let reader = subject
+                        .clone()
+                        .archive()
+                        .blob()
+                        .read(digest.clone())
+                        .perform(env)
+                        .await;
+                    let reader = match (reader, hydrate) {
+                        // A local miss the reach says to resolve. The index
+                        // cannot serve this one -- blocks fall through to the
+                        // remote via `Get`, blob bytes travel their own
+                        // channel -- so fetch the whole blob through a local
+                        // digest-verified import first (a lying remote
+                        // surfaces as `DigestMismatch` at `finish`, and the
+                        // bytes are cached like every other download), then
+                        // serve the read from the now-local copy.
+                        (Err(BlobError::NotFound(_)), Some(remote)) => {
+                            let address = remote.address();
+                            let mut source = address
+                                .subject
+                                .clone()
+                                .archive()
+                                .blob()
+                                .read(digest.clone())
+                                .fork(address.site())
+                                .perform(env)
+                                .await?;
+                            let mut sink = subject
+                                .clone()
+                                .archive()
+                                .blob()
+                                .import(digest.clone(), record.size)
+                                .perform(env)
+                                .await?;
+                            while let Some(chunk) = source.next().await? {
+                                sink.write_all(&chunk).await?;
+                            }
+                            sink.finish().await?;
+                            subject
+                                .clone()
+                                .archive()
+                                .blob()
+                                .read(digest.clone())
+                                .perform(env)
+                                .await
                         }
-                        sink.finish().await?;
-                        subject
-                            .clone()
-                            .archive()
-                            .blob()
-                            .read(digest.clone())
-                            .perform(env)
-                            .await
+                        (reader, _) => reader,
+                    };
+                    match reader {
+                        Ok(chunks) => Ok((digest, Some((record.size, chunks)))),
+                        Err(BlobError::NotFound(_)) => Ok((digest, None)),
+                        Err(error) => Err(SnapshotError::from(error)),
                     }
-                    (reader, _) => reader,
-                };
-                match reader {
-                    Ok(chunks) => {
-                        yield Item::Blob { digest, size: record.size, chunks };
+                }
+            }))
+            .buffer_unordered(FETCH_CONCURRENCY);
+            while let Some(fetched) = blob_reads.next().await {
+                let (digest, available) = fetched?;
+                match available {
+                    Some((size, chunks)) => {
+                        yield Item::Blob { digest, size, chunks };
                     }
-                    Err(BlobError::NotFound(_)) if sparse => {}
-                    Err(BlobError::NotFound(_)) => {
-                        Err(SnapshotError::MissingBlob { digest })?;
-                    }
-                    Err(error) => Err(SnapshotError::from(error))?,
+                    None if sparse => {}
+                    None => Err(SnapshotError::MissingBlob { digest })?,
                 }
             }
         }

--- a/rust/dialog-repository/src/repository/snapshot.rs
+++ b/rust/dialog-repository/src/repository/snapshot.rs
@@ -38,6 +38,7 @@
 //! upstream as the walk proceeds, which is what makes the result complete.
 
 use std::collections::HashSet;
+use std::marker::PhantomData;
 
 use async_stream::try_stream;
 use dialog_artifacts::tree::TreeStorageBridge;
@@ -93,9 +94,16 @@ impl Block {
 }
 
 /// An immutable view of a repository at one revision.
+///
+/// Holds the repository's subject rather than the repository itself:
+/// everything an export touches — the archive catalog, the blob channel —
+/// derives from the subject, which lets a [`Branch`](crate::Branch) mint
+/// a snapshot of its own repository too (see
+/// [`Branch::download`](crate::Branch::download)).
 pub struct Snapshot<'a, C: Principal = Credential> {
-    repository: &'a Repository<C>,
+    subject: Subject,
     revision: Revision,
+    repository: PhantomData<&'a C>,
 }
 
 impl<C: Principal> Repository<C> {
@@ -108,8 +116,21 @@ impl<C: Principal> Repository<C> {
     /// from an upstream (see [`SnapshotExport::download`]).
     pub fn snapshot(&self, revision: Revision) -> Snapshot<'_, C> {
         Snapshot {
-            repository: self,
+            subject: self.subject(),
             revision,
+            repository: PhantomData,
+        }
+    }
+}
+
+impl Snapshot<'static> {
+    /// An immutable view of `subject`'s repository at `revision`, for
+    /// callers that hold a branch rather than a repository.
+    pub(crate) fn of(subject: Subject, revision: Revision) -> Self {
+        Snapshot {
+            subject,
+            revision,
+            repository: PhantomData,
         }
     }
 }
@@ -122,7 +143,7 @@ impl<C: Principal> Snapshot<'_, C> {
 
     /// The archive catalog this snapshot's blocks live in.
     pub(crate) fn index(&self) -> Capability<Catalog> {
-        self.repository.subject().archive().index()
+        self.subject.clone().archive().index()
     }
 }
 
@@ -258,7 +279,7 @@ impl<C: Principal> SnapshotExport<'_, C> {
             + 'static,
     {
         let catalog = self.snapshot.index();
-        let subject = self.snapshot.repository.subject();
+        let subject = self.snapshot.subject.clone();
         let upstream = match &self.reach {
             Reach::Download(remote) => Some(remote.clone()),
             Reach::Complete | Reach::Sparse => None,

--- a/rust/dialog-search-tree/src/traversal.rs
+++ b/rust/dialog-search-tree/src/traversal.rs
@@ -36,6 +36,13 @@ use crate::{
     PersistentNode, PersistentTree, Value,
 };
 
+/// How many block reads one traversal level issues concurrently.
+///
+/// Sized for a backend that reaches a remote on a miss: enough in flight
+/// to hide round-trips, small enough not to swamp a local store or a
+/// remote's connection limits.
+const FETCH_CONCURRENCY: usize = 16;
+
 /// What a gap-tolerant traversal found at one position in the tree.
 #[derive(Debug, Clone)]
 pub enum Visit<K, V> {
@@ -97,31 +104,50 @@ where
         Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
             + ConditionalSend,
     {
+        use futures_util::StreamExt as _;
+
         let root = self.root().clone();
 
         try_stream! {
             if &root != NULL_BLAKE3_HASH {
-                let mut queue = vec![root];
+                // Level order with the whole frontier fetched concurrently:
+                // a level's reads are independent, so against a backend
+                // that reaches a remote on a miss the wall clock is depth
+                // round-trips, not node-count round-trips.
+                let mut frontier = vec![root];
 
-                while let Some(hash) = queue.pop() {
-                    // `retrieve` verifies stored bytes against the hash it
-                    // was asked for, so `None` here is genuinely "not
-                    // stored" -- a corrupt block raises instead, and still
-                    // fails the walk.
-                    let Some(bytes) = storage.retrieve(&hash).await? else {
-                        yield Visit::Absent(hash);
-                        continue;
-                    };
-                    let node: PersistentNode<Key, Value> =
-                        PersistentNode::try_from(Buffer::from(bytes))?;
+                while !frontier.is_empty() {
+                    let level = std::mem::take(&mut frontier);
+                    let mut reads = futures_util::stream::iter(level.into_iter().map(
+                        |hash| async move {
+                            // `retrieve` verifies stored bytes against the
+                            // hash it was asked for, so `None` here is
+                            // genuinely "not stored" -- a corrupt block
+                            // raises instead, and still fails the walk.
+                            let bytes = storage.retrieve(&hash).await;
+                            (hash, bytes)
+                        },
+                    ))
+                    .buffer_unordered(FETCH_CONCURRENCY);
 
-                    if let ArchivedNodeBody::Index(index) = node.body() {
-                        for link in index.links()? {
-                            queue.push(link.node);
+                    let mut next = Vec::new();
+                    while let Some((hash, bytes)) = reads.next().await {
+                        let Some(bytes) = bytes? else {
+                            yield Visit::Absent(hash);
+                            continue;
+                        };
+                        let node: PersistentNode<Key, Value> =
+                            PersistentNode::try_from(Buffer::from(bytes))?;
+
+                        if let ArchivedNodeBody::Index(index) = node.body() {
+                            for link in index.links()? {
+                                next.push(link.node);
+                            }
                         }
-                    }
 
-                    yield Visit::Present(node);
+                        yield Visit::Present(node);
+                    }
+                    frontier = next;
                 }
             }
         }


### PR DESCRIPTION
The account repository is the durable home of delegations, and a device regains access by pulling it. This PR makes that flow real, end to end, and fixes what it exposed along the way.

## Proving replicates on demand

The authorization walk now reads the access branch like any other read: a delegation record or envelope the local store does not hold is fetched from the branch's upstream and cached locally. The walk's env dispatches remote fork effects through the operator's `WalkReach` — dyn-erased closures installed at build time, because naming the fork providers as bounds on the `Prove` impl would close the trait cycle authorization must not enter (Prove → Fork → Authorize → Prove). The operator clone captured inside those closures carries no reach of its own, so the proof authorizing a fetch resolves from what is already local (the retained cross-party grants and the in-memory session), which bounds the recursion. Offline, a fetch fails and the walk skips that candidate — exactly the previous local-only behavior.

Resolve also refreshes the branch handle first: a pull through another handle moves the head in storage, not in every handle's cache, and both the walk and the chain-cache epoch read the cache. Without this, a login pull was invisible to the prover (and a retraction arriving by pull could not invalidate cached chains).

## `branch.download()` and `pull().download()`

Pull stays byte-frugal — it adopts an upstream head by reference, reading none of its tree (the pinned property). For embedders that do not want proving to pay download latency, `branch.download()` materializes the current revision locally — every block and blob the head references — through the snapshot export's download reach, and `pull().download()` chains the two acts. `Snapshot` now carries the repository's subject rather than a repository borrow (all an export ever used), which is what lets a branch mint one.

## Concurrent fetches

Snapshot export and everything on it overlap their fetches — concurrency, not parallelism: one task, up to 16 in-flight futures, wasm-safe. The tree traversal fetches each level's nodes concurrently (wall clock becomes depth round-trips instead of node-count round-trips, for every `traverse_available` caller), and the export's spilled-value and blob legs fan out the same way, yielding items as they complete.

## Buffered ops belong to the export closure

The login test caught a blind spot: a merged tree carries part of its state as buffered ops riding index nodes' novelty buffers (readers overlay them on descent), and the export enumerated referenced spills and blobs from stored leaf entries alone — a blob whose only reference rode a buffer was never shipped or downloaded. Blocks always traveled correctly (ops live inside the index node's bytes); only discovery was blind. The export now lifts buffered asserts as reference sources alongside stored entries — additively, since a leaf entry superseded by a buffered op still physically holds its bytes and serves history reads, the semantics `it_downloads_spilled_values_a_pull_never_shipped` pins.

## Tests

- `it_regains_access_by_pulling_the_account`: the login flow against the access service — a space grants the account, the account branch is pushed; a device retains the account→profile powerline, points its access branch at the account, bare-pulls, and proves the three-hop ladder (space → account → profile → operator) with the walk replicating on demand.
- `it_downloads_the_account_branch_on_login`: the eager form — after `pull().download()`, every envelope's bytes are readable from the local blob provider alone, no remote reach in the environment.

The delegation-specific `hydrate` pass from the interim design is gone; `download()` subsumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141p6y4o2HK8qxLdVnaBXXQ