### PR TITLE
test(dialog-repository): descend the resolver fixture to any depth

### DIFF
--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -1671,10 +1671,13 @@ mod resolver_tests {
             );
         }
 
-        // Descend every child; leaves must carry the committed entries.
+        // Descend to the leaves whatever the depth: the fixture's
+        // entities are random, so the tree's shape is probabilistic and
+        // a child may itself be an index (the depth-3 draw that made
+        // the one-level version of this walk flaky).
         let mut entries = 0usize;
-        for span in &spans {
-            let child = text(span, "node");
+        let mut frontier: Vec<String> = spans.iter().map(|span| text(span, "node")).collect();
+        while let Some(child) = frontier.pop() {
             let child_node: Vec<ResolverConclusion> = branch
                 .query()
                 .select(tree_node(&child))
@@ -1695,6 +1698,14 @@ mod resolver_tests {
                     "one key row per segment entry"
                 );
                 entries += keys.len();
+            } else {
+                let child_spans: Vec<ResolverConclusion> = branch
+                    .query()
+                    .select(tree_span(&child))
+                    .perform(&operator)
+                    .try_vec()
+                    .await?;
+                frontier.extend(child_spans.iter().map(|span| text(span, "node")));
             }
         }
         assert!(


### PR DESCRIPTION
Fixes the main-branch flake in `it_descends_a_multi_level_tree` (first tripped on the #442 merge run): the fixture's random entities make the tree shape probabilistic, and a depth-3 draw left the one-level descent counting zero segment keys. The walk now follows a frontier to the leaves whatever the depth, keeping the per-segment key-row check at every leaf.