### PR TITLE
feat: algorithm-agnostic signing and authorization (ed25519 + P-256)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,7 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.2.16",
  "js-sys",
+ "p256",
  "serde",
  "signature",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_bytes",
+ "serde_ipld_dagcbor",
  "signature",
  "testresult",
  "thiserror 2.0.18",

--- a/rust/dialog-credentials/Cargo.toml
+++ b/rust/dialog-credentials/Cargo.toml
@@ -7,7 +7,8 @@ authors.workspace = true
 license.workspace = true
 
 [features]
-default = ["ed25519", "es256"]
+# ed25519 is the always-on default. Other algorithms are opt-in.
+default = ["ed25519"]
 ed25519 = [
     "dep:ed25519-dalek",
     "dep:getrandom",

--- a/rust/dialog-credentials/Cargo.toml
+++ b/rust/dialog-credentials/Cargo.toml
@@ -7,13 +7,20 @@ authors.workspace = true
 license.workspace = true
 
 [features]
-default = ["ed25519"]
+default = ["ed25519", "es256"]
 ed25519 = [
     "dep:ed25519-dalek",
     "dep:getrandom",
     "dep:base58",
     "dialog-varsig/edwards25519",
     "dialog-varsig/sha2_512",
+]
+es256 = [
+    "dep:p256",
+    "dep:getrandom",
+    "dep:base58",
+    "dialog-varsig/secp256r1",
+    "dialog-varsig/sha2_256",
 ]
 
 [dependencies]
@@ -29,6 +36,11 @@ signature = { workspace = true }
 ed25519-dalek = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 base58 = { workspace = true, optional = true }
+
+# es256 (p256) feature deps
+# `pkcs8` is used by the browser WebCrypto arm to encode the private scalar as
+# PKCS#8 for `SubtleCrypto.importKey`; it is inert on native builds.
+p256 = { workspace = true, optional = true, features = ["ecdsa", "pkcs8"] }
 
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/rust/dialog-credentials/src/any.rs
+++ b/rust/dialog-credentials/src/any.rs
@@ -1,0 +1,393 @@
+//! Algorithm-agnostic signer, verifier, and signature types.
+//!
+//! The varsig [`Signer`](dialog_varsig::Signer) and
+//! [`Verifier`](dialog_varsig::Verifier) traits are each generic over a single
+//! concrete signature type. To hold an identity without committing to an
+//! algorithm, we wrap the per-algorithm types in enums and implement the varsig
+//! traits over a single [`AnySignature`] enum that carries an algorithm tag
+//! alongside the raw signature bytes.
+//!
+//! The concrete arms stay authoritative: `AnyVerifier::Ed25519` verifies only
+//! ed25519 signatures, `AnyVerifier::Es256` only P-256, and a signature whose
+//! tag does not match the verifier's arm is rejected. This keeps the
+//! ed25519 path byte-identical while making room for P-256 and future
+//! algorithms.
+
+use dialog_capability::Issuer;
+use dialog_varsig::{
+    Did, Principal, SignatureAlgorithm, Signer, Verifier, ecdsa::Es256, ecdsa::Es256Signature,
+    eddsa::Ed25519, eddsa::Ed25519Signature, signature::Signature,
+};
+use signature::SignatureEncoding;
+
+use crate::{Ed25519Signer, Ed25519Verifier, Es256Signer, Es256Verifier};
+
+/// The algorithm tag carried by [`AnySignature`] and [`AnyAlgorithm`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Algorithm {
+    /// Ed25519 (`EdDSA` over Edwards25519).
+    Ed25519,
+    /// ES256 (ECDSA over P-256).
+    Es256,
+}
+
+/// Algorithm-agnostic [`SignatureAlgorithm`].
+///
+/// Wraps the concrete varsig algorithm descriptors. `Default` resolves to
+/// Ed25519 to satisfy the trait bound; the meaningful tag always travels with
+/// an [`AnySignature`] value, so the default is never used to interpret bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AnyAlgorithm(pub Algorithm);
+
+impl Default for AnyAlgorithm {
+    fn default() -> Self {
+        AnyAlgorithm(Algorithm::Ed25519)
+    }
+}
+
+impl SignatureAlgorithm for AnyAlgorithm {
+    fn prefix(&self) -> u64 {
+        match self.0 {
+            Algorithm::Ed25519 => Ed25519::default().prefix(),
+            Algorithm::Es256 => Es256::default().prefix(),
+        }
+    }
+
+    fn config_tags(&self) -> Vec<u64> {
+        match self.0 {
+            Algorithm::Ed25519 => Ed25519::default().config_tags(),
+            Algorithm::Es256 => Es256::default().config_tags(),
+        }
+    }
+
+    fn try_from_tags(bytes: &[u64]) -> Option<(Self, &[u64])> {
+        if let Some((_, rest)) = Ed25519::try_from_tags(bytes) {
+            Some((AnyAlgorithm(Algorithm::Ed25519), rest))
+        } else if let Some((_, rest)) = Es256::try_from_tags(bytes) {
+            Some((AnyAlgorithm(Algorithm::Es256), rest))
+        } else {
+            None
+        }
+    }
+}
+
+/// Algorithm-agnostic signature: an algorithm tag plus the raw signature bytes.
+///
+/// Both supported algorithms use a 64-byte fixed-width signature, so the bytes
+/// are stored inline. The tag lets [`AnyVerifier`] reject a signature produced
+/// by a different algorithm than it holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnySignature {
+    algorithm: Algorithm,
+    bytes: [u8; 64],
+}
+
+impl AnySignature {
+    /// The algorithm that produced this signature.
+    #[must_use]
+    pub const fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
+    /// The raw 64-byte signature.
+    #[must_use]
+    pub const fn to_bytes(&self) -> [u8; 64] {
+        self.bytes
+    }
+}
+
+impl From<Ed25519Signature> for AnySignature {
+    fn from(sig: Ed25519Signature) -> Self {
+        Self {
+            algorithm: Algorithm::Ed25519,
+            bytes: sig.to_bytes(),
+        }
+    }
+}
+
+impl From<Es256Signature> for AnySignature {
+    fn from(sig: Es256Signature) -> Self {
+        Self {
+            algorithm: Algorithm::Es256,
+            bytes: sig.to_bytes(),
+        }
+    }
+}
+
+/// `AnySignature` encodes as its raw 64-byte body. The algorithm tag is carried
+/// out of band (by the verifier's arm), matching how a varsig header already
+/// names the algorithm separately from the signature body.
+impl SignatureEncoding for AnySignature {
+    type Repr = [u8; 64];
+}
+
+impl From<AnySignature> for [u8; 64] {
+    fn from(sig: AnySignature) -> Self {
+        sig.bytes
+    }
+}
+
+impl TryFrom<&[u8]> for AnySignature {
+    type Error = signature::Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 64] = bytes.try_into().map_err(|_| signature::Error::new())?;
+        // With no header, default to Ed25519; callers that know the algorithm
+        // construct via the typed `From` impls instead.
+        Ok(Self {
+            algorithm: Algorithm::Ed25519,
+            bytes,
+        })
+    }
+}
+
+impl Signature for AnySignature {
+    type Algorithm = AnyAlgorithm;
+}
+
+/// Algorithm-agnostic verifier.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnyVerifier {
+    /// An Ed25519 verifier.
+    Ed25519(Ed25519Verifier),
+    /// An ES256 (P-256) verifier.
+    Es256(Es256Verifier),
+}
+
+impl From<Ed25519Verifier> for AnyVerifier {
+    fn from(v: Ed25519Verifier) -> Self {
+        Self::Ed25519(v)
+    }
+}
+
+impl From<Es256Verifier> for AnyVerifier {
+    fn from(v: Es256Verifier) -> Self {
+        Self::Es256(v)
+    }
+}
+
+impl AnyVerifier {
+    /// The algorithm this verifier checks.
+    #[must_use]
+    pub const fn algorithm(&self) -> Algorithm {
+        match self {
+            Self::Ed25519(_) => Algorithm::Ed25519,
+            Self::Es256(_) => Algorithm::Es256,
+        }
+    }
+
+    /// Get the ed25519 verifier, if this is an ed25519 arm.
+    #[must_use]
+    pub const fn as_ed25519(&self) -> Option<&Ed25519Verifier> {
+        match self {
+            Self::Ed25519(v) => Some(v),
+            Self::Es256(_) => None,
+        }
+    }
+
+    /// Get the es256 verifier, if this is an es256 arm.
+    #[must_use]
+    pub const fn as_es256(&self) -> Option<&Es256Verifier> {
+        match self {
+            Self::Es256(v) => Some(v),
+            Self::Ed25519(_) => None,
+        }
+    }
+
+    /// Parse a `did:key` string into an algorithm-agnostic verifier, trying
+    /// ed25519 first, then es256.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string is not a supported `did:key`.
+    pub fn from_did_key(s: &str) -> Result<Self, AnyDidFromStrError> {
+        if let Ok(v) = s.parse::<Ed25519Verifier>() {
+            return Ok(Self::Ed25519(v));
+        }
+        if let Ok(v) = s.parse::<Es256Verifier>() {
+            return Ok(Self::Es256(v));
+        }
+        Err(AnyDidFromStrError)
+    }
+}
+
+impl std::str::FromStr for AnyVerifier {
+    type Err = AnyDidFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_did_key(s)
+    }
+}
+
+impl std::fmt::Display for AnyVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ed25519(v) => write!(f, "{v}"),
+            Self::Es256(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+impl Principal for AnyVerifier {
+    fn did(&self) -> Did {
+        match self {
+            Self::Ed25519(v) => v.did(),
+            Self::Es256(v) => v.did(),
+        }
+    }
+}
+
+impl Verifier<AnySignature> for AnyVerifier {
+    async fn verify(&self, msg: &[u8], signature: &AnySignature) -> Result<(), signature::Error> {
+        if signature.algorithm() != self.algorithm() {
+            return Err(signature::Error::new());
+        }
+        match self {
+            Self::Ed25519(v) => {
+                let sig = Ed25519Signature::from_bytes(signature.to_bytes());
+                v.verify(msg, &sig).await
+            }
+            Self::Es256(v) => {
+                let sig = Es256Signature::from_bytes(signature.to_bytes());
+                v.verify(msg, &sig).await
+            }
+        }
+    }
+}
+
+/// Error returned when a `did:key` string is not a supported algorithm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
+#[error("unsupported or invalid did:key")]
+pub struct AnyDidFromStrError;
+
+/// Algorithm-agnostic signer: a wrapped local key that can sign.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone)]
+pub enum AnySigner {
+    /// An Ed25519 signer.
+    Ed25519(Ed25519Signer),
+    /// An ES256 (P-256) signer.
+    Es256(Es256Signer),
+}
+
+impl From<Ed25519Signer> for AnySigner {
+    fn from(s: Ed25519Signer) -> Self {
+        Self::Ed25519(s)
+    }
+}
+
+impl From<Es256Signer> for AnySigner {
+    fn from(s: Es256Signer) -> Self {
+        Self::Es256(s)
+    }
+}
+
+impl AnySigner {
+    /// The algorithm this signer produces.
+    #[must_use]
+    pub const fn algorithm(&self) -> Algorithm {
+        match self {
+            Self::Ed25519(_) => Algorithm::Ed25519,
+            Self::Es256(_) => Algorithm::Es256,
+        }
+    }
+
+    /// Get the ed25519 signer, if this is an ed25519 arm.
+    #[must_use]
+    pub const fn as_ed25519(&self) -> Option<&Ed25519Signer> {
+        match self {
+            Self::Ed25519(s) => Some(s),
+            Self::Es256(_) => None,
+        }
+    }
+
+    /// Get the es256 signer, if this is an es256 arm.
+    #[must_use]
+    pub const fn as_es256(&self) -> Option<&Es256Signer> {
+        match self {
+            Self::Es256(s) => Some(s),
+            Self::Ed25519(_) => None,
+        }
+    }
+
+    /// The algorithm-agnostic verifier for this signer's public key.
+    #[must_use]
+    pub fn verifier(&self) -> AnyVerifier {
+        match self {
+            Self::Ed25519(s) => AnyVerifier::Ed25519(s.ed25519_did().clone()),
+            Self::Es256(s) => AnyVerifier::Es256(s.es256_did().clone()),
+        }
+    }
+}
+
+impl Principal for AnySigner {
+    fn did(&self) -> Did {
+        match self {
+            Self::Ed25519(s) => s.did(),
+            Self::Es256(s) => s.did(),
+        }
+    }
+}
+
+impl Signer<AnySignature> for AnySigner {
+    async fn sign(&self, msg: &[u8]) -> Result<AnySignature, signature::Error> {
+        match self {
+            Self::Ed25519(s) => Ok(AnySignature::from(Signer::sign(s, msg).await?)),
+            Self::Es256(s) => Ok(AnySignature::from(Signer::sign(s, msg).await?)),
+        }
+    }
+}
+
+impl Issuer for AnySigner {
+    type Signature = AnySignature;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn any_ed25519_sign_verify() {
+        let signer = AnySigner::from(Ed25519Signer::generate().await.unwrap());
+        let verifier = signer.verifier();
+        let msg = b"agnostic";
+        let sig = Signer::sign(&signer, msg).await.unwrap();
+        assert_eq!(sig.algorithm(), Algorithm::Ed25519);
+        verifier.verify(msg, &sig).await.unwrap();
+    }
+
+    #[dialog_common::test]
+    async fn any_es256_sign_verify() {
+        let signer = AnySigner::from(Es256Signer::generate().await.unwrap());
+        let verifier = signer.verifier();
+        let msg = b"agnostic";
+        let sig = Signer::sign(&signer, msg).await.unwrap();
+        assert_eq!(sig.algorithm(), Algorithm::Es256);
+        verifier.verify(msg, &sig).await.unwrap();
+    }
+
+    #[dialog_common::test]
+    async fn any_cross_algorithm_rejected() {
+        // A signature from an ed25519 signer must not verify against an es256
+        // verifier, even though both signature bodies are 64 bytes.
+        let ed = AnySigner::from(Ed25519Signer::generate().await.unwrap());
+        let es_verifier = AnySigner::from(Es256Signer::generate().await.unwrap()).verifier();
+        let msg = b"agnostic";
+        let sig = Signer::sign(&ed, msg).await.unwrap();
+        assert!(es_verifier.verify(msg, &sig).await.is_err());
+    }
+
+    #[dialog_common::test]
+    async fn any_verifier_did_key_roundtrip() {
+        for signer in [
+            AnySigner::from(Ed25519Signer::generate().await.unwrap()),
+            AnySigner::from(Es256Signer::generate().await.unwrap()),
+        ] {
+            let verifier = signer.verifier();
+            let did = verifier.did();
+            let parsed = AnyVerifier::from_did_key(did.as_str()).unwrap();
+            assert_eq!(parsed.did(), did);
+            assert_eq!(parsed.algorithm(), verifier.algorithm());
+        }
+    }
+}

--- a/rust/dialog-credentials/src/credential.rs
+++ b/rust/dialog-credentials/src/credential.rs
@@ -14,7 +14,7 @@ pub use export::{
 pub use signer::SignerCredential;
 pub use verifier::VerifierCredential;
 
-use crate::{Ed25519Signer, Ed25519Verifier};
+use crate::{Signer, Verifier};
 use dialog_varsig::{Did, Principal};
 use serde::ser::Error as SerError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -34,15 +34,41 @@ pub enum Credential {
     Verifier(VerifierCredential),
 }
 
-impl From<Ed25519Signer> for Credential {
-    fn from(signer: Ed25519Signer) -> Self {
+impl From<Signer> for Credential {
+    fn from(signer: Signer) -> Self {
         Self::Signer(SignerCredential(signer))
     }
 }
 
-impl From<Ed25519Verifier> for Credential {
-    fn from(verifier: Ed25519Verifier) -> Self {
+impl From<crate::Ed25519Signer> for Credential {
+    fn from(signer: crate::Ed25519Signer) -> Self {
+        Self::Signer(SignerCredential(Signer::Ed25519(signer)))
+    }
+}
+
+#[cfg(feature = "es256")]
+impl From<crate::Es256Signer> for Credential {
+    fn from(signer: crate::Es256Signer) -> Self {
+        Self::Signer(SignerCredential(Signer::Es256(signer)))
+    }
+}
+
+impl From<Verifier> for Credential {
+    fn from(verifier: Verifier) -> Self {
         Self::Verifier(VerifierCredential(verifier))
+    }
+}
+
+impl From<crate::Ed25519Verifier> for Credential {
+    fn from(verifier: crate::Ed25519Verifier) -> Self {
+        Self::Verifier(VerifierCredential(Verifier::Ed25519(verifier)))
+    }
+}
+
+#[cfg(feature = "es256")]
+impl From<crate::Es256Verifier> for Credential {
+    fn from(verifier: crate::Es256Verifier) -> Self {
+        Self::Verifier(VerifierCredential(Verifier::Es256(verifier)))
     }
 }
 
@@ -63,7 +89,7 @@ impl From<Credential> for Did {
 
 impl Credential {
     /// Get a reference to the signer, if this credential holds one.
-    pub fn signer(&self) -> Option<&Ed25519Signer> {
+    pub fn signer(&self) -> Option<&Signer> {
         match self {
             Self::Signer(s) => Some(&s.0),
             Self::Verifier(_) => None,
@@ -89,63 +115,141 @@ impl Credential {
     /// Recover a verifier-only credential (public key, hence DID) from the
     /// byte-compatible on-disk storage form, on any target.
     ///
-    /// The stored form is multicodec-tagged bytes — `{PUBLIC_TAG|pubkey}` for a
-    /// verifier, `{PRIVATE_TAG|seed|PUBLIC_TAG|pubkey}` for a signer. Only the
-    /// public key is read, so this works in the browser too (no WebCrypto
-    /// import of a non-extractable signing key). The result can verify and
-    /// yields the credential's [`Did`](dialog_varsig::Did), which is all that
-    /// subject checks need; it cannot sign.
+    /// The stored form is multicodec-tagged bytes — `{public_tag|pubkey}` for a
+    /// verifier, `{private_tag|priv|public_tag|pubkey}` for a signer, with the
+    /// tags naming the algorithm. Only the public key is read, so this works in
+    /// the browser too (no WebCrypto import of a non-extractable signing key).
+    /// The result can verify and yields the credential's [`Did`], which is all
+    /// that subject checks need; it cannot sign.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn identity(bytes: &[u8]) -> Result<Self, CredentialExportError> {
-        use constants::{
-            KEY_SIZE, PRIVATE_TAG, PUBLIC_KEY_OFFSET, PUBLIC_TAG, PUBLIC_TAG_SIZE,
-            SIGNER_EXPORT_SIZE, VERIFIER_EXPORT_SIZE,
-        };
+        Self::identity_native(bytes)
+    }
 
-        let pubkey: &[u8] = if bytes.len() == VERIFIER_EXPORT_SIZE && bytes.starts_with(PUBLIC_TAG)
-        {
-            &bytes[PUBLIC_TAG_SIZE..]
-        } else if bytes.len() == SIGNER_EXPORT_SIZE
-            && bytes.starts_with(PRIVATE_TAG)
+    /// Recover a verifier-only credential from tagged bytes (any target).
+    #[cfg(target_arch = "wasm32")]
+    pub fn identity(bytes: &[u8]) -> Result<Self, CredentialExportError> {
+        Self::identity_any(bytes)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn identity_native(bytes: &[u8]) -> Result<Self, CredentialExportError> {
+        use constants::{PRIVATE_TAG, PUBLIC_KEY_OFFSET, PUBLIC_TAG, PUBLIC_TAG_SIZE};
+
+        // ed25519 verifier form.
+        if bytes.starts_with(PUBLIC_TAG) && bytes.len() == PUBLIC_TAG_SIZE + constants::KEY_SIZE {
+            return Self::ed25519_verifier_from_pubkey(&bytes[PUBLIC_TAG_SIZE..]);
+        }
+        // ed25519 signer form: read only the trailing public key.
+        if bytes.starts_with(PRIVATE_TAG)
+            && bytes.len() == constants::SIGNER_EXPORT_SIZE
             && bytes[PUBLIC_KEY_OFFSET..].starts_with(PUBLIC_TAG)
         {
-            &bytes[PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE..]
-        } else {
-            return Err(CredentialExportError::InvalidFormat(format!(
-                "unrecognized credential format: length={}",
-                bytes.len()
-            )));
-        };
+            return Self::ed25519_verifier_from_pubkey(
+                &bytes[PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE..],
+            );
+        }
 
-        let key: [u8; KEY_SIZE] = pubkey
+        #[cfg(feature = "es256")]
+        {
+            use constants::{
+                ES256_PRIVATE_TAG, ES256_PUBLIC_KEY_OFFSET, ES256_PUBLIC_TAG,
+                ES256_PUBLIC_TAG_SIZE, ES256_SIGNER_EXPORT_SIZE, ES256_VERIFIER_EXPORT_SIZE,
+            };
+            if bytes.starts_with(ES256_PUBLIC_TAG) && bytes.len() == ES256_VERIFIER_EXPORT_SIZE {
+                return Self::es256_verifier_from_pubkey(&bytes[ES256_PUBLIC_TAG_SIZE..]);
+            }
+            if bytes.starts_with(ES256_PRIVATE_TAG)
+                && bytes.len() == ES256_SIGNER_EXPORT_SIZE
+                && bytes[ES256_PUBLIC_KEY_OFFSET..].starts_with(ES256_PUBLIC_TAG)
+            {
+                return Self::es256_verifier_from_pubkey(
+                    &bytes[ES256_PUBLIC_KEY_OFFSET + ES256_PUBLIC_TAG_SIZE..],
+                );
+            }
+        }
+
+        Err(CredentialExportError::InvalidFormat(format!(
+            "unrecognized credential format: length={}",
+            bytes.len()
+        )))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn identity_any(bytes: &[u8]) -> Result<Self, CredentialExportError> {
+        use constants::{PUBLIC_TAG, PUBLIC_TAG_SIZE};
+        if bytes.starts_with(PUBLIC_TAG) && bytes.len() == PUBLIC_TAG_SIZE + constants::KEY_SIZE {
+            return Self::ed25519_verifier_from_pubkey(&bytes[PUBLIC_TAG_SIZE..]);
+        }
+        #[cfg(feature = "es256")]
+        {
+            use constants::{ES256_PUBLIC_TAG, ES256_PUBLIC_TAG_SIZE, ES256_VERIFIER_EXPORT_SIZE};
+            if bytes.starts_with(ES256_PUBLIC_TAG) && bytes.len() == ES256_VERIFIER_EXPORT_SIZE {
+                return Self::es256_verifier_from_pubkey(&bytes[ES256_PUBLIC_TAG_SIZE..]);
+            }
+        }
+        Err(CredentialExportError::InvalidFormat(format!(
+            "unrecognized credential format: length={}",
+            bytes.len()
+        )))
+    }
+
+    fn ed25519_verifier_from_pubkey(pubkey: &[u8]) -> Result<Self, CredentialExportError> {
+        let key: [u8; 32] = pubkey
             .try_into()
             .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
         let vk = ed25519_dalek::VerifyingKey::from_bytes(&key)
             .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
-        Ok(Self::Verifier(VerifierCredential::from(
+        Ok(Self::Verifier(VerifierCredential(Verifier::Ed25519(
             crate::Ed25519Verifier(crate::ed25519::Ed25519VerifyingKey::Native(vk)),
-        )))
+        ))))
+    }
+
+    #[cfg(feature = "es256")]
+    fn es256_verifier_from_pubkey(pubkey: &[u8]) -> Result<Self, CredentialExportError> {
+        let vk = p256::ecdsa::VerifyingKey::from_sec1_bytes(pubkey)
+            .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+        Ok(Self::Verifier(VerifierCredential(Verifier::Es256(
+            crate::Es256Verifier(crate::es256::Es256VerifyingKey::Native(vk)),
+        ))))
     }
 
     /// The identity (public-key) bytes for this credential, in the
-    /// byte-compatible verifier storage form `{PUBLIC_TAG|pubkey}`, on any
+    /// byte-compatible verifier storage form `{public_tag|pubkey}`, on any
     /// target.
     ///
     /// This is the inverse of [`identity`](Self::identity): writing these bytes
     /// to a directory's `credential/key/self` is what makes that directory the
-    /// space for this credential's [`Did`](dialog_varsig::Did). Only the public
-    /// key is emitted, so it works in the browser too.
+    /// space for this credential's [`Did`]. Only the public key is emitted, so
+    /// it works in the browser too.
     pub fn to_identity_bytes(&self) -> Vec<u8> {
-        use constants::{KEY_SIZE, PUBLIC_TAG, PUBLIC_TAG_SIZE, VERIFIER_EXPORT_SIZE};
-
-        let pubkey: [u8; KEY_SIZE] = match self {
-            Self::Signer(s) => s.0.ed25519_did().0.to_bytes(),
-            Self::Verifier(v) => v.0.0.to_bytes(),
+        let verifier = match self {
+            Self::Signer(s) => s.0.verifier(),
+            Self::Verifier(v) => v.0.clone(),
         };
-        let mut buffer = Vec::with_capacity(VERIFIER_EXPORT_SIZE);
-        buffer.extend_from_slice(PUBLIC_TAG);
-        buffer.extend_from_slice(&pubkey);
-        debug_assert_eq!(buffer.len(), PUBLIC_TAG_SIZE + KEY_SIZE);
-        buffer
+        tagged_public_bytes(&verifier)
+    }
+}
+
+/// Serialize a verifier's public key in the tagged `{public_tag|pubkey}` form.
+fn tagged_public_bytes(verifier: &Verifier) -> Vec<u8> {
+    use constants::PUBLIC_TAG;
+    match verifier {
+        Verifier::Ed25519(v) => {
+            let mut buffer = Vec::with_capacity(PUBLIC_TAG.len() + 32);
+            buffer.extend_from_slice(PUBLIC_TAG);
+            buffer.extend_from_slice(&v.0.to_bytes());
+            buffer
+        }
+        #[cfg(feature = "es256")]
+        Verifier::Es256(v) => {
+            use constants::ES256_PUBLIC_TAG;
+            let compressed = v.0.to_compressed_bytes();
+            let mut buffer = Vec::with_capacity(ES256_PUBLIC_TAG.len() + compressed.len());
+            buffer.extend_from_slice(ES256_PUBLIC_TAG);
+            buffer.extend_from_slice(&compressed);
+            buffer
+        }
     }
 }
 
@@ -155,14 +259,15 @@ impl Serialize for Credential {
             Self::Signer(_) => Err(SerError::custom(
                 "Serialization of secret key material is not supported",
             )),
-            Self::Verifier(v) => v.0.serialize(serializer),
+            Self::Verifier(v) => v.did().serialize(serializer),
         }
     }
 }
 
 impl<'de> Deserialize<'de> for Credential {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let verifier = Ed25519Verifier::deserialize(deserializer)?;
+        let did = Did::deserialize(deserializer)?;
+        let verifier = Verifier::from_did_key(did.as_str()).map_err(serde::de::Error::custom)?;
         Ok(Self::Verifier(VerifierCredential(verifier)))
     }
 }

--- a/rust/dialog-credentials/src/credential/constants.rs
+++ b/rust/dialog-credentials/src/credential/constants.rs
@@ -1,8 +1,12 @@
 //! Shared multicodec constants and sizes for credential export formats.
+//!
+//! The stored form is self-describing: a multicodec tag names the algorithm,
+//! so the reader dispatches on the tag rather than assuming ed25519. ed25519
+//! constants are unchanged, keeping existing stored credentials byte-identical.
 
-/// Multicodec varint for ed25519 private key (0x1300).
+/// Multicodec varint for ed25519 private key (`0x1300`).
 pub const PRIVATE_TAG: &[u8] = &[0x80, 0x26];
-/// Multicodec varint for ed25519 public key (0xed).
+/// Multicodec varint for ed25519 public key (`0xed`).
 pub const PUBLIC_TAG: &[u8] = &[0xed, 0x01];
 /// Length of an ed25519 key (private seed or public key) in bytes.
 pub const KEY_SIZE: usize = 32;
@@ -10,11 +14,41 @@ pub const KEY_SIZE: usize = 32;
 pub const PRIVATE_TAG_SIZE: usize = PRIVATE_TAG.len();
 /// Byte length of the ed25519 public key multicodec tag prefix.
 pub const PUBLIC_TAG_SIZE: usize = PUBLIC_TAG.len();
-/// Total size of a serialized signer credential
+/// Total size of a serialized ed25519 signer credential
 /// (private tag + private seed + public tag + public key).
 pub const SIGNER_EXPORT_SIZE: usize = PRIVATE_TAG_SIZE + KEY_SIZE + PUBLIC_TAG_SIZE + KEY_SIZE;
-/// Total size of a serialized verifier credential (public tag + public key).
+/// Total size of a serialized ed25519 verifier credential (public tag + public key).
 pub const VERIFIER_EXPORT_SIZE: usize = PUBLIC_TAG_SIZE + KEY_SIZE;
-/// Offset within a serialized signer credential at which the public key
+/// Offset within a serialized ed25519 signer credential at which the public key
 /// section begins.
 pub const PUBLIC_KEY_OFFSET: usize = PRIVATE_TAG_SIZE + KEY_SIZE;
+
+/// Multicodec varint for p256 private key (`0x1306`).
+#[cfg(feature = "es256")]
+pub const ES256_PRIVATE_TAG: &[u8] = &[0x86, 0x26];
+/// Multicodec varint for p256 public key (`0x1200`).
+#[cfg(feature = "es256")]
+pub const ES256_PUBLIC_TAG: &[u8] = &[0x80, 0x24];
+/// Length of a p256 private scalar in bytes.
+#[cfg(feature = "es256")]
+pub const ES256_PRIVATE_KEY_SIZE: usize = 32;
+/// Length of a p256 compressed public point in bytes.
+#[cfg(feature = "es256")]
+pub const ES256_PUBLIC_KEY_SIZE: usize = 33;
+/// Byte length of the p256 private key multicodec tag prefix.
+#[cfg(feature = "es256")]
+pub const ES256_PRIVATE_TAG_SIZE: usize = ES256_PRIVATE_TAG.len();
+/// Byte length of the p256 public key multicodec tag prefix.
+#[cfg(feature = "es256")]
+pub const ES256_PUBLIC_TAG_SIZE: usize = ES256_PUBLIC_TAG.len();
+/// Total size of a serialized p256 signer credential.
+#[cfg(feature = "es256")]
+pub const ES256_SIGNER_EXPORT_SIZE: usize =
+    ES256_PRIVATE_TAG_SIZE + ES256_PRIVATE_KEY_SIZE + ES256_PUBLIC_TAG_SIZE + ES256_PUBLIC_KEY_SIZE;
+/// Total size of a serialized p256 verifier credential.
+#[cfg(feature = "es256")]
+pub const ES256_VERIFIER_EXPORT_SIZE: usize = ES256_PUBLIC_TAG_SIZE + ES256_PUBLIC_KEY_SIZE;
+/// Offset within a serialized p256 signer credential at which the public key
+/// section begins.
+#[cfg(feature = "es256")]
+pub const ES256_PUBLIC_KEY_OFFSET: usize = ES256_PRIVATE_TAG_SIZE + ES256_PRIVATE_KEY_SIZE;

--- a/rust/dialog-credentials/src/credential/export.rs
+++ b/rust/dialog-credentials/src/credential/export.rs
@@ -2,12 +2,22 @@
 //!
 //! These are plain data containers for serialized credential material.
 //! Import/export logic lives on the credential types themselves.
+//!
+//! On native the stored form is variable-length, multicodec-tagged bytes: the
+//! leading tag names the algorithm, so ed25519 and p256 credentials round-trip
+//! through the same container. ed25519's byte layout is unchanged.
 
 use thiserror::Error;
 
 #[cfg(not(target_arch = "wasm32"))]
+use super::constants::{PRIVATE_TAG, PUBLIC_KEY_OFFSET, PUBLIC_TAG, SIGNER_EXPORT_SIZE};
+
+#[cfg(not(target_arch = "wasm32"))]
+use super::constants::VERIFIER_EXPORT_SIZE;
+#[cfg(all(not(target_arch = "wasm32"), feature = "es256"))]
 use super::constants::{
-    PRIVATE_TAG, PUBLIC_KEY_OFFSET, PUBLIC_TAG, SIGNER_EXPORT_SIZE, VERIFIER_EXPORT_SIZE,
+    ES256_PRIVATE_TAG, ES256_PUBLIC_KEY_OFFSET, ES256_PUBLIC_TAG, ES256_SIGNER_EXPORT_SIZE,
+    ES256_VERIFIER_EXPORT_SIZE,
 };
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -29,11 +39,12 @@ pub enum CredentialExportError {
 
 /// Platform-specific serialized form of a signer credential.
 ///
-/// On native: multicodec-tagged fixed-size bytes (68 bytes).
+/// On native: variable-length multicodec-tagged bytes (68 bytes for ed25519,
+/// 70 for p256).
 /// On web: JsValue wrapping a CryptoKeyPair.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
-pub struct SignerCredentialExport(pub [u8; SIGNER_EXPORT_SIZE]);
+pub struct SignerCredentialExport(pub Vec<u8>);
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #[derive(Debug, Clone)]
@@ -41,11 +52,12 @@ pub struct SignerCredentialExport(pub JsValue);
 
 /// Platform-specific serialized form of a verifier credential.
 ///
-/// On native: multicodec-tagged fixed-size bytes (34 bytes).
+/// On native: variable-length multicodec-tagged bytes (34 bytes for ed25519,
+/// 35 for p256).
 /// On web: JsValue wrapping a Uint8Array of public key bytes.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
-pub struct VerifierCredentialExport(pub [u8; VERIFIER_EXPORT_SIZE]);
+pub struct VerifierCredentialExport(pub Vec<u8>);
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #[derive(Debug, Clone)]
@@ -54,65 +66,35 @@ pub struct VerifierCredentialExport(pub JsValue);
 /// Platform-specific serialized form of a credential (signer or verifier).
 #[derive(Debug, Clone)]
 pub enum CredentialExport {
+    /// A serialized signing credential.
     Signer(SignerCredentialExport),
+    /// A serialized verifying credential.
     Verifier(VerifierCredentialExport),
 }
 
-/// Raw byte type for a serialized signer credential.
 #[cfg(not(target_arch = "wasm32"))]
-pub type SignerExport = [u8; SIGNER_EXPORT_SIZE];
-
-/// Raw byte type for a serialized verifier credential.
-#[cfg(not(target_arch = "wasm32"))]
-pub type VerifierExport = [u8; VERIFIER_EXPORT_SIZE];
-
-#[cfg(not(target_arch = "wasm32"))]
-impl TryFrom<Vec<u8>> for SignerCredentialExport {
-    type Error = CredentialExportError;
-
-    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        let arr: SignerExport = bytes.try_into().map_err(|_| {
-            CredentialExportError::InvalidFormat("invalid signer export length".into())
-        })?;
-        Ok(Self(arr))
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl TryFrom<Vec<u8>> for VerifierCredentialExport {
-    type Error = CredentialExportError;
-
-    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        let arr: VerifierExport = bytes.try_into().map_err(|_| {
-            CredentialExportError::InvalidFormat("invalid verifier export length".into())
-        })?;
-        Ok(Self(arr))
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl From<SignerExport> for SignerCredentialExport {
-    fn from(bytes: SignerExport) -> Self {
+impl From<Vec<u8>> for SignerCredentialExport {
+    fn from(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl From<SignerCredentialExport> for SignerExport {
+impl From<SignerCredentialExport> for Vec<u8> {
     fn from(export: SignerCredentialExport) -> Self {
         export.0
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl From<VerifierExport> for VerifierCredentialExport {
-    fn from(bytes: VerifierExport) -> Self {
+impl From<Vec<u8>> for VerifierCredentialExport {
+    fn from(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl From<VerifierCredentialExport> for VerifierExport {
+impl From<VerifierCredentialExport> for Vec<u8> {
     fn from(export: VerifierCredentialExport) -> Self {
         export.0
     }
@@ -132,24 +114,47 @@ impl AsRef<[u8]> for VerifierCredentialExport {
     }
 }
 
+/// Whether these bytes are a signer export for some supported algorithm.
+#[cfg(not(target_arch = "wasm32"))]
+fn is_signer_export(bytes: &[u8]) -> bool {
+    if bytes.len() == SIGNER_EXPORT_SIZE
+        && bytes.starts_with(PRIVATE_TAG)
+        && bytes[PUBLIC_KEY_OFFSET..].starts_with(PUBLIC_TAG)
+    {
+        return true;
+    }
+    #[cfg(feature = "es256")]
+    if bytes.len() == ES256_SIGNER_EXPORT_SIZE
+        && bytes.starts_with(ES256_PRIVATE_TAG)
+        && bytes[ES256_PUBLIC_KEY_OFFSET..].starts_with(ES256_PUBLIC_TAG)
+    {
+        return true;
+    }
+    false
+}
+
+/// Whether these bytes are a verifier export for some supported algorithm.
+#[cfg(not(target_arch = "wasm32"))]
+fn is_verifier_export(bytes: &[u8]) -> bool {
+    if bytes.len() == VERIFIER_EXPORT_SIZE && bytes.starts_with(PUBLIC_TAG) {
+        return true;
+    }
+    #[cfg(feature = "es256")]
+    if bytes.len() == ES256_VERIFIER_EXPORT_SIZE && bytes.starts_with(ES256_PUBLIC_TAG) {
+        return true;
+    }
+    false
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl TryFrom<Vec<u8>> for CredentialExport {
     type Error = CredentialExportError;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        if bytes.len() == SIGNER_EXPORT_SIZE
-            && bytes.starts_with(PRIVATE_TAG)
-            && bytes[PUBLIC_KEY_OFFSET..].starts_with(PUBLIC_TAG)
-        {
-            let arr: SignerExport = bytes.try_into().map_err(|_| {
-                CredentialExportError::InvalidFormat("invalid signer length".into())
-            })?;
-            Ok(Self::Signer(arr.into()))
-        } else if bytes.len() == VERIFIER_EXPORT_SIZE && bytes.starts_with(PUBLIC_TAG) {
-            let arr: VerifierExport = bytes.try_into().map_err(|_| {
-                CredentialExportError::InvalidFormat("invalid verifier length".into())
-            })?;
-            Ok(Self::Verifier(arr.into()))
+        if is_signer_export(&bytes) {
+            Ok(Self::Signer(SignerCredentialExport(bytes)))
+        } else if is_verifier_export(&bytes) {
+            Ok(Self::Verifier(VerifierCredentialExport(bytes)))
         } else {
             Err(CredentialExportError::InvalidFormat(format!(
                 "unrecognized credential format: length={}",

--- a/rust/dialog-credentials/src/credential/signer.rs
+++ b/rust/dialog-credentials/src/credential/signer.rs
@@ -1,6 +1,6 @@
-//! Signer credential — wraps a full Ed25519 keypair.
+//! Signer credential — wraps an algorithm-agnostic signing key.
 
-use crate::Ed25519Signer;
+use crate::Signer;
 use dialog_capability::Issuer;
 use dialog_varsig::{Did, Principal};
 
@@ -11,13 +11,26 @@ use super::constants::{
 };
 use super::export::{CredentialExportError, SignerCredentialExport};
 
-/// A signer credential — wraps an `Ed25519Signer` (full keypair).
+/// A signer credential — wraps a [`Signer`] (a full keypair for some algorithm).
 #[derive(Debug, Clone)]
-pub struct SignerCredential(pub Ed25519Signer);
+pub struct SignerCredential(pub Signer);
 
-impl From<Ed25519Signer> for SignerCredential {
-    fn from(signer: Ed25519Signer) -> Self {
+impl From<Signer> for SignerCredential {
+    fn from(signer: Signer) -> Self {
         Self(signer)
+    }
+}
+
+impl From<crate::Ed25519Signer> for SignerCredential {
+    fn from(signer: crate::Ed25519Signer) -> Self {
+        Self(Signer::Ed25519(signer))
+    }
+}
+
+#[cfg(feature = "es256")]
+impl From<crate::Es256Signer> for SignerCredential {
+    fn from(signer: crate::Es256Signer) -> Self {
+        Self(Signer::Es256(signer))
     }
 }
 
@@ -35,83 +48,158 @@ impl From<SignerCredential> for Did {
 
 impl SignerCredential {
     /// Get a reference to the underlying signer.
-    pub fn signer(&self) -> &Ed25519Signer {
+    pub fn signer(&self) -> &Signer {
         &self.0
     }
 
     /// Consume and return the underlying signer.
-    pub fn into_signer(self) -> Ed25519Signer {
+    pub fn into_signer(self) -> Signer {
         self.0
     }
 }
 
-impl From<SignerCredential> for Ed25519Signer {
+impl From<SignerCredential> for Signer {
     fn from(credential: SignerCredential) -> Self {
         credential.0
     }
 }
 
-impl dialog_varsig::Signer<dialog_varsig::eddsa::Ed25519Signature> for SignerCredential {
-    async fn sign(
-        &self,
-        msg: &[u8],
-    ) -> Result<dialog_varsig::eddsa::Ed25519Signature, signature::Error> {
+impl dialog_varsig::Signer<crate::Signature> for SignerCredential {
+    async fn sign(&self, msg: &[u8]) -> Result<crate::Signature, signature::Error> {
         dialog_varsig::Signer::sign(&self.0, msg).await
     }
 }
 
 impl Issuer for SignerCredential {
-    type Signature = dialog_varsig::eddsa::Ed25519Signature;
+    type Signature = crate::Signature;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl SignerCredential {
     /// Export to multicodec-tagged bytes for native storage.
+    ///
+    /// The layout is `{private_tag|seed|public_tag|pubkey}`, with the tags and
+    /// key sizes chosen per algorithm. ed25519 is byte-identical to prior
+    /// releases.
     pub async fn export(&self) -> Result<SignerCredentialExport, CredentialExportError> {
-        let crate::key::KeyExport::Extractable(ref seed) = self
-            .0
+        match &self.0 {
+            Signer::Ed25519(signer) => {
+                let crate::key::KeyExport::Extractable(ref seed) = signer
+                    .export()
+                    .await
+                    .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+
+                let public_key = signer.ed25519_did().0.to_bytes();
+                let mut buffer = vec![0u8; SIGNER_EXPORT_SIZE];
+                buffer[..PRIVATE_TAG_SIZE].copy_from_slice(PRIVATE_TAG);
+                buffer[PRIVATE_TAG_SIZE..PUBLIC_KEY_OFFSET].copy_from_slice(seed);
+                buffer[PUBLIC_KEY_OFFSET..PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE]
+                    .copy_from_slice(PUBLIC_TAG);
+                buffer[PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE..].copy_from_slice(&public_key);
+                Ok(SignerCredentialExport(buffer))
+            }
+            #[cfg(feature = "es256")]
+            Signer::Es256(signer) => {
+                Ok(SignerCredentialExport(es256_native::export(signer).await?))
+            }
+        }
+    }
+
+    /// Import from multicodec-tagged bytes, dispatching on the leading tag.
+    pub async fn import(export: SignerCredentialExport) -> Result<Self, CredentialExportError> {
+        let data = &export.0;
+
+        if data.len() == SIGNER_EXPORT_SIZE
+            && data.starts_with(PRIVATE_TAG)
+            && data[PUBLIC_KEY_OFFSET..].starts_with(PUBLIC_TAG)
+        {
+            let seed: &[u8; KEY_SIZE] = data[PRIVATE_TAG_SIZE..PUBLIC_KEY_OFFSET]
+                .try_into()
+                .map_err(|_| CredentialExportError::InvalidFormat("invalid seed".into()))?;
+            let stored_pubkey: &[u8; KEY_SIZE] = data[PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE..]
+                .try_into()
+                .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
+            let signer = crate::Ed25519Signer::import(seed)
+                .await
+                .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+
+            // Verify the stored public key matches the one derived from the
+            // seed. A mismatch indicates either corruption or tampering.
+            let derived_pubkey = signer.ed25519_did().0.to_bytes();
+            if *stored_pubkey != derived_pubkey {
+                return Err(CredentialExportError::InvalidFormat(
+                    "public key does not match seed".into(),
+                ));
+            }
+
+            return Ok(Self(Signer::Ed25519(signer)));
+        }
+
+        #[cfg(feature = "es256")]
+        if let Some(signer) = es256_native::try_import(data).await? {
+            return Ok(Self(Signer::Es256(signer)));
+        }
+
+        Err(CredentialExportError::InvalidFormat(
+            "unrecognized signer credential tags".into(),
+        ))
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "es256"))]
+mod es256_native {
+    use super::CredentialExportError;
+    use crate::Es256Signer;
+    use crate::credential::constants::{
+        ES256_PRIVATE_KEY_SIZE, ES256_PRIVATE_TAG, ES256_PRIVATE_TAG_SIZE, ES256_PUBLIC_KEY_OFFSET,
+        ES256_PUBLIC_KEY_SIZE, ES256_PUBLIC_TAG, ES256_PUBLIC_TAG_SIZE, ES256_SIGNER_EXPORT_SIZE,
+    };
+
+    pub(super) async fn export(signer: &Es256Signer) -> Result<Vec<u8>, CredentialExportError> {
+        let crate::key::KeyExport::Extractable(ref scalar) = signer
             .export()
             .await
             .map_err(|e| CredentialExportError::Key(e.to_string()))?;
 
-        let public_key = self.0.ed25519_did().0.to_bytes();
-        let mut buffer = [0u8; SIGNER_EXPORT_SIZE];
-        buffer[..PRIVATE_TAG_SIZE].copy_from_slice(PRIVATE_TAG);
-        buffer[PRIVATE_TAG_SIZE..PUBLIC_KEY_OFFSET].copy_from_slice(seed);
-        buffer[PUBLIC_KEY_OFFSET..PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE].copy_from_slice(PUBLIC_TAG);
-        buffer[PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE..].copy_from_slice(&public_key);
-        Ok(SignerCredentialExport(buffer))
+        let public_key = signer.es256_did().0.to_compressed_bytes();
+        let mut buffer = vec![0u8; ES256_SIGNER_EXPORT_SIZE];
+        buffer[..ES256_PRIVATE_TAG_SIZE].copy_from_slice(ES256_PRIVATE_TAG);
+        buffer[ES256_PRIVATE_TAG_SIZE..ES256_PUBLIC_KEY_OFFSET].copy_from_slice(scalar);
+        buffer[ES256_PUBLIC_KEY_OFFSET..ES256_PUBLIC_KEY_OFFSET + ES256_PUBLIC_TAG_SIZE]
+            .copy_from_slice(ES256_PUBLIC_TAG);
+        buffer[ES256_PUBLIC_KEY_OFFSET + ES256_PUBLIC_TAG_SIZE..].copy_from_slice(&public_key);
+        Ok(buffer)
     }
 
-    /// Import from multicodec-tagged bytes.
-    pub async fn import(export: SignerCredentialExport) -> Result<Self, CredentialExportError> {
-        let data = &export.0;
-        if !data.starts_with(PRIVATE_TAG) || !data[PUBLIC_KEY_OFFSET..].starts_with(PUBLIC_TAG) {
-            return Err(CredentialExportError::InvalidFormat(
-                "invalid multicodec tags".into(),
-            ));
+    pub(super) async fn try_import(
+        data: &[u8],
+    ) -> Result<Option<Es256Signer>, CredentialExportError> {
+        if data.len() != ES256_SIGNER_EXPORT_SIZE
+            || !data.starts_with(ES256_PRIVATE_TAG)
+            || !data[ES256_PUBLIC_KEY_OFFSET..].starts_with(ES256_PUBLIC_TAG)
+        {
+            return Ok(None);
         }
 
-        let seed: &[u8; KEY_SIZE] = data[PRIVATE_TAG_SIZE..PUBLIC_KEY_OFFSET]
+        let scalar: &[u8; ES256_PRIVATE_KEY_SIZE] = data
+            [ES256_PRIVATE_TAG_SIZE..ES256_PUBLIC_KEY_OFFSET]
             .try_into()
-            .map_err(|_| CredentialExportError::InvalidFormat("invalid seed".into()))?;
-        let stored_pubkey: &[u8; KEY_SIZE] = data[PUBLIC_KEY_OFFSET + PUBLIC_TAG_SIZE..]
+            .map_err(|_| CredentialExportError::InvalidFormat("invalid es256 scalar".into()))?;
+        let stored_pubkey: &[u8; ES256_PUBLIC_KEY_SIZE] = data
+            [ES256_PUBLIC_KEY_OFFSET + ES256_PUBLIC_TAG_SIZE..]
             .try_into()
-            .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
-        let signer = Ed25519Signer::import(seed)
+            .map_err(|_| CredentialExportError::InvalidFormat("invalid es256 public key".into()))?;
+        let signer = Es256Signer::import(scalar)
             .await
             .map_err(|e| CredentialExportError::Key(e.to_string()))?;
 
-        // Verify the stored public key matches the one derived from the seed.
-        // A mismatch indicates either corruption or tampering.
-        let derived_pubkey = signer.ed25519_did().0.to_bytes();
+        let derived_pubkey = signer.es256_did().0.to_compressed_bytes();
         if *stored_pubkey != derived_pubkey {
             return Err(CredentialExportError::InvalidFormat(
-                "public key does not match seed".into(),
+                "es256 public key does not match scalar".into(),
             ));
         }
-
-        Ok(Self(signer))
+        Ok(Some(signer))
     }
 }
 
@@ -119,28 +207,44 @@ impl SignerCredential {
 impl SignerCredential {
     /// Export to a JsValue (CryptoKeyPair) for web storage.
     pub async fn export(&self) -> Result<SignerCredentialExport, CredentialExportError> {
-        let key_export = self
-            .0
-            .export()
-            .await
-            .map_err(|e| CredentialExportError::Key(e.to_string()))?;
-        Ok(SignerCredentialExport(key_export.into()))
+        match &self.0 {
+            Signer::Ed25519(signer) => {
+                let key_export = signer
+                    .export()
+                    .await
+                    .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+                Ok(SignerCredentialExport(key_export.into()))
+            }
+            #[cfg(feature = "es256")]
+            Signer::Es256(signer) => {
+                let key_export = signer
+                    .export()
+                    .await
+                    .map_err(|e| CredentialExportError::Key(e.to_string()))?;
+                Ok(SignerCredentialExport(key_export.into()))
+            }
+        }
     }
 
     /// Import from a JsValue (CryptoKeyPair).
+    ///
+    /// The web `CryptoKeyPair` does not carry an algorithm tag we can read
+    /// synchronously, so the ed25519 arm is tried; a future multi-algorithm web
+    /// store would probe the key's algorithm before dispatch.
     pub async fn import(export: SignerCredentialExport) -> Result<Self, CredentialExportError> {
         let key_export = crate::key::KeyExport::try_from(export.0)
             .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
-        let signer = Ed25519Signer::import(key_export)
+        let signer = crate::Ed25519Signer::import(key_export)
             .await
             .map_err(|e| CredentialExportError::Key(e.to_string()))?;
-        Ok(Self(signer))
+        Ok(Self(Signer::Ed25519(signer)))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Ed25519Signer;
 
     #[dialog_common::test]
     async fn it_roundtrips_export_import() {
@@ -152,6 +256,21 @@ mod tests {
         let imported = SignerCredential::import(export).await.unwrap();
 
         assert_eq!(imported.did(), original_did);
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "es256"))]
+    #[dialog_common::test]
+    async fn it_roundtrips_es256_export_import() {
+        use crate::Es256Signer;
+        let signer = Es256Signer::generate().await.unwrap();
+        let original_did = Principal::did(&signer);
+        let cred = SignerCredential::from(signer);
+
+        let export = cred.export().await.unwrap();
+        let imported = SignerCredential::import(export).await.unwrap();
+
+        assert_eq!(imported.did(), original_did);
+        assert_eq!(imported.0.algorithm(), crate::AlgorithmTag::Es256);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -189,13 +308,35 @@ mod tests {
 
         #[dialog_common::test]
         async fn it_rejects_invalid_tags() {
-            let mut bytes = [0u8; SIGNER_EXPORT_SIZE];
+            let mut bytes = vec![0u8; SIGNER_EXPORT_SIZE];
             // Wrong private key tag
             bytes[0] = 0x00;
             bytes[1] = 0x00;
 
             let result = SignerCredential::import(bytes.into()).await;
             assert!(result.is_err(), "should reject invalid multicodec tags");
+        }
+
+        // The exact bytes an ed25519 signer credential serialized to before the
+        // algorithm-agnostic change: {0x80,0x26 | 32-byte seed | 0xed,0x01 |
+        // 32-byte pubkey}. Deterministic seed of all 0x07 so the vector is
+        // stable. This asserts old on-disk credentials still import.
+        #[dialog_common::test]
+        async fn it_imports_legacy_ed25519_credential() {
+            let seed = [0x07u8; 32];
+            let signer = Ed25519Signer::import(&seed).await.unwrap();
+            let expected_did = Principal::did(&signer);
+            let pubkey = signer.ed25519_did().0.to_bytes();
+
+            let mut legacy = Vec::new();
+            legacy.extend_from_slice(&[0x80, 0x26]);
+            legacy.extend_from_slice(&seed);
+            legacy.extend_from_slice(&[0xed, 0x01]);
+            legacy.extend_from_slice(&pubkey);
+            assert_eq!(legacy.len(), SIGNER_EXPORT_SIZE);
+
+            let imported = SignerCredential::import(legacy.into()).await.unwrap();
+            assert_eq!(imported.did(), expected_did);
         }
     }
 

--- a/rust/dialog-credentials/src/credential/verifier.rs
+++ b/rust/dialog-credentials/src/credential/verifier.rs
@@ -1,21 +1,32 @@
-//! Verifier credential — wraps an Ed25519 public key.
+//! Verifier credential — wraps an algorithm-agnostic public key.
 
-use crate::Ed25519Verifier;
-use crate::ed25519::Ed25519VerifyingKey;
+use crate::Verifier;
 use dialog_varsig::{Did, Principal};
 
-use super::constants::KEY_SIZE;
 #[cfg(not(target_arch = "wasm32"))]
-use super::constants::{PUBLIC_TAG, PUBLIC_TAG_SIZE, VERIFIER_EXPORT_SIZE};
+use super::constants::{KEY_SIZE, PUBLIC_TAG, PUBLIC_TAG_SIZE, VERIFIER_EXPORT_SIZE};
 use super::export::{CredentialExportError, VerifierCredentialExport};
 
-/// A verifier credential — wraps an `Ed25519Verifier` (public key only).
+/// A verifier credential — wraps a [`Verifier`] (public key only).
 #[derive(Debug, Clone)]
-pub struct VerifierCredential(pub Ed25519Verifier);
+pub struct VerifierCredential(pub Verifier);
 
-impl From<Ed25519Verifier> for VerifierCredential {
-    fn from(verifier: Ed25519Verifier) -> Self {
+impl From<Verifier> for VerifierCredential {
+    fn from(verifier: Verifier) -> Self {
         Self(verifier)
+    }
+}
+
+impl From<crate::Ed25519Verifier> for VerifierCredential {
+    fn from(verifier: crate::Ed25519Verifier) -> Self {
+        Self(Verifier::Ed25519(verifier))
+    }
+}
+
+#[cfg(feature = "es256")]
+impl From<crate::Es256Verifier> for VerifierCredential {
+    fn from(verifier: crate::Es256Verifier) -> Self {
+        Self(Verifier::Es256(verifier))
     }
 }
 
@@ -35,27 +46,72 @@ impl From<VerifierCredential> for Did {
 impl VerifierCredential {
     /// Export to multicodec-tagged bytes for native storage.
     pub fn export(&self) -> VerifierCredentialExport {
-        let mut buffer = [0u8; VERIFIER_EXPORT_SIZE];
-        buffer[..PUBLIC_TAG_SIZE].copy_from_slice(PUBLIC_TAG);
-        buffer[PUBLIC_TAG_SIZE..].copy_from_slice(&self.0.0.to_bytes());
-        VerifierCredentialExport(buffer)
+        match &self.0 {
+            Verifier::Ed25519(verifier) => {
+                let mut buffer = vec![0u8; VERIFIER_EXPORT_SIZE];
+                buffer[..PUBLIC_TAG_SIZE].copy_from_slice(PUBLIC_TAG);
+                buffer[PUBLIC_TAG_SIZE..].copy_from_slice(&verifier.0.to_bytes());
+                VerifierCredentialExport(buffer)
+            }
+            #[cfg(feature = "es256")]
+            Verifier::Es256(verifier) => VerifierCredentialExport(es256_native::export(verifier)),
+        }
     }
 
-    /// Import from multicodec-tagged bytes.
+    /// Import from multicodec-tagged bytes, dispatching on the leading tag.
     pub fn import(export: VerifierCredentialExport) -> Result<Self, CredentialExportError> {
+        use crate::ed25519::Ed25519VerifyingKey;
         let data = &export.0;
-        if !data.starts_with(PUBLIC_TAG) {
-            return Err(CredentialExportError::InvalidFormat(
-                "invalid ed25519-pub multicodec tag".into(),
-            ));
+
+        if data.len() == VERIFIER_EXPORT_SIZE && data.starts_with(PUBLIC_TAG) {
+            let key_arr: &[u8; KEY_SIZE] = data[PUBLIC_TAG_SIZE..]
+                .try_into()
+                .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
+            let vk = ed25519_dalek::VerifyingKey::from_bytes(key_arr)
+                .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+            return Ok(Self(Verifier::Ed25519(crate::Ed25519Verifier(
+                Ed25519VerifyingKey::Native(vk),
+            ))));
         }
 
-        let key_arr: &[u8; KEY_SIZE] = data[PUBLIC_TAG_SIZE..]
+        #[cfg(feature = "es256")]
+        if let Some(verifier) = es256_native::try_import(data)? {
+            return Ok(Self(Verifier::Es256(verifier)));
+        }
+
+        Err(CredentialExportError::InvalidFormat(
+            "unrecognized verifier credential tag".into(),
+        ))
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "es256"))]
+mod es256_native {
+    use super::CredentialExportError;
+    use crate::Es256Verifier;
+    use crate::credential::constants::{
+        ES256_PUBLIC_KEY_SIZE, ES256_PUBLIC_TAG, ES256_PUBLIC_TAG_SIZE, ES256_VERIFIER_EXPORT_SIZE,
+    };
+    use crate::es256::Es256VerifyingKey;
+
+    pub(super) fn export(verifier: &Es256Verifier) -> Vec<u8> {
+        let compressed = verifier.0.to_compressed_bytes();
+        let mut buffer = vec![0u8; ES256_VERIFIER_EXPORT_SIZE];
+        buffer[..ES256_PUBLIC_TAG_SIZE].copy_from_slice(ES256_PUBLIC_TAG);
+        buffer[ES256_PUBLIC_TAG_SIZE..].copy_from_slice(&compressed);
+        buffer
+    }
+
+    pub(super) fn try_import(data: &[u8]) -> Result<Option<Es256Verifier>, CredentialExportError> {
+        if data.len() != ES256_VERIFIER_EXPORT_SIZE || !data.starts_with(ES256_PUBLIC_TAG) {
+            return Ok(None);
+        }
+        let key_arr: &[u8; ES256_PUBLIC_KEY_SIZE] = data[ES256_PUBLIC_TAG_SIZE..]
             .try_into()
-            .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
-        let vk = ed25519_dalek::VerifyingKey::from_bytes(key_arr)
+            .map_err(|_| CredentialExportError::InvalidFormat("invalid es256 public key".into()))?;
+        let vk = p256::ecdsa::VerifyingKey::from_sec1_bytes(key_arr)
             .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
-        Ok(Self(Ed25519Verifier(Ed25519VerifyingKey::Native(vk))))
+        Ok(Some(Es256Verifier(Es256VerifyingKey::Native(vk))))
     }
 }
 
@@ -67,8 +123,11 @@ use wasm_bindgen::JsCast;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl VerifierCredential {
     /// Export to a JsValue (Uint8Array) for web storage.
+    ///
+    /// The bytes are the algorithm-tagged public key form, so a reader can
+    /// dispatch on the tag.
     pub fn export(&self) -> VerifierCredentialExport {
-        let bytes = self.0.0.to_bytes();
+        let bytes = self.to_tagged_public_bytes();
         VerifierCredentialExport(Uint8Array::from(bytes.as_slice()).into())
     }
 
@@ -79,11 +138,75 @@ impl VerifierCredential {
             .dyn_ref()
             .ok_or_else(|| CredentialExportError::InvalidFormat("expected Uint8Array".into()))?;
         let bytes = array.to_vec();
-        let key_arr: [u8; KEY_SIZE] = bytes.as_slice().try_into().map_err(|_| {
-            CredentialExportError::InvalidFormat(format!("invalid verifier length={}", bytes.len()))
-        })?;
-        let vk = ed25519_dalek::VerifyingKey::from_bytes(&key_arr)
-            .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
-        Ok(Self(Ed25519Verifier(Ed25519VerifyingKey::Native(vk))))
+        Self::from_tagged_public_bytes(&bytes)
+    }
+
+    fn to_tagged_public_bytes(&self) -> Vec<u8> {
+        use crate::credential::constants::PUBLIC_TAG;
+        match &self.0 {
+            Verifier::Ed25519(verifier) => {
+                let mut buffer = Vec::with_capacity(PUBLIC_TAG.len() + 32);
+                buffer.extend_from_slice(PUBLIC_TAG);
+                buffer.extend_from_slice(&verifier.0.to_bytes());
+                buffer
+            }
+            #[cfg(feature = "es256")]
+            Verifier::Es256(verifier) => {
+                use crate::credential::constants::ES256_PUBLIC_TAG;
+                let compressed = verifier.0.to_compressed_bytes();
+                let mut buffer = Vec::with_capacity(ES256_PUBLIC_TAG.len() + compressed.len());
+                buffer.extend_from_slice(ES256_PUBLIC_TAG);
+                buffer.extend_from_slice(&compressed);
+                buffer
+            }
+        }
+    }
+
+    fn from_tagged_public_bytes(bytes: &[u8]) -> Result<Self, CredentialExportError> {
+        use crate::credential::constants::PUBLIC_TAG;
+        use crate::ed25519::Ed25519VerifyingKey;
+
+        // Historic web verifier exports were raw 32-byte ed25519 keys with no
+        // tag. Accept them for backward compatibility.
+        if bytes.len() == 32 {
+            let key_arr: [u8; 32] = bytes
+                .try_into()
+                .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
+            let vk = ed25519_dalek::VerifyingKey::from_bytes(&key_arr)
+                .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+            return Ok(Self(Verifier::Ed25519(crate::Ed25519Verifier(
+                Ed25519VerifyingKey::Native(vk),
+            ))));
+        }
+
+        if bytes.starts_with(PUBLIC_TAG) && bytes.len() == PUBLIC_TAG.len() + 32 {
+            let key_arr: [u8; 32] = bytes[PUBLIC_TAG.len()..]
+                .try_into()
+                .map_err(|_| CredentialExportError::InvalidFormat("invalid public key".into()))?;
+            let vk = ed25519_dalek::VerifyingKey::from_bytes(&key_arr)
+                .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+            return Ok(Self(Verifier::Ed25519(crate::Ed25519Verifier(
+                Ed25519VerifyingKey::Native(vk),
+            ))));
+        }
+
+        #[cfg(feature = "es256")]
+        {
+            use crate::credential::constants::ES256_PUBLIC_TAG;
+            use crate::es256::Es256VerifyingKey;
+            if bytes.starts_with(ES256_PUBLIC_TAG) && bytes.len() == ES256_PUBLIC_TAG.len() + 33 {
+                let key = &bytes[ES256_PUBLIC_TAG.len()..];
+                let vk = p256::ecdsa::VerifyingKey::from_sec1_bytes(key)
+                    .map_err(|e| CredentialExportError::InvalidFormat(e.to_string()))?;
+                return Ok(Self(Verifier::Es256(crate::Es256Verifier(
+                    Es256VerifyingKey::Native(vk),
+                ))));
+            }
+        }
+
+        Err(CredentialExportError::InvalidFormat(format!(
+            "invalid verifier bytes length={}",
+            bytes.len()
+        )))
     }
 }

--- a/rust/dialog-credentials/src/es256.rs
+++ b/rust/dialog-credentials/src/es256.rs
@@ -1,0 +1,243 @@
+//! ES256 (ECDSA P-256) key types, DID, and signer implementations.
+
+use dialog_varsig::ecdsa::Es256Signature;
+
+// WebCrypto is only available in web browsers (wasm32 + unknown OS). Kept
+// private (a `mod`, not `pub mod`) so the crate-root glob re-export does not
+// collide with the `ed25519::web` module of the same name; siblings reach it
+// via `super::web`.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod web;
+
+// Submodules
+mod error;
+mod resolver;
+mod signer;
+mod verifier;
+
+// Re-export public types
+pub use crate::key::KeyExport;
+pub use error::{Es256DidFromStrError, Es256KeyError, Es256ResolveError, Es256SignerError};
+pub use resolver::Es256KeyResolver;
+pub use signer::Es256Signer;
+pub use verifier::Es256Verifier;
+
+// Re-export WebCrypto helpers on WASM.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub use crate::key::{ExtractableKey, WebCryptoError};
+
+/// ES256 verifying (public) key.
+///
+/// Mirrors the `Ed25519VerifyingKey` shape:
+/// - `Native`: uses the `p256` crate for non-WASM platforms.
+/// - `WebCrypto`: uses the browser's `WebCrypto` API (web WASM only).
+#[derive(Debug, Clone)]
+#[allow(missing_copy_implementations)] // CryptoKey is not Copy on WASM
+pub enum Es256VerifyingKey {
+    /// Native verifying key using the `p256` crate.
+    Native(p256::ecdsa::VerifyingKey),
+
+    /// WebCrypto verifying key (web WASM only).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    WebCrypto(web::VerifyingKey),
+}
+
+impl From<p256::ecdsa::VerifyingKey> for Es256VerifyingKey {
+    fn from(key: p256::ecdsa::VerifyingKey) -> Self {
+        Self::Native(key)
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<web::VerifyingKey> for Es256VerifyingKey {
+    fn from(key: web::VerifyingKey) -> Self {
+        Self::WebCrypto(key)
+    }
+}
+
+impl Es256VerifyingKey {
+    /// Get the SEC1 compressed public key bytes (33 bytes).
+    ///
+    /// This is the encoding used inside a P-256 `did:key`. The `WebCrypto` arm
+    /// caches the same compressed representation, so `did:key` output is
+    /// identical across arms for the same key.
+    #[must_use]
+    pub fn to_compressed_bytes(&self) -> [u8; 33] {
+        match self {
+            Self::Native(key) => {
+                let point = key.to_encoded_point(true);
+                let mut bytes = [0u8; 33];
+                bytes.copy_from_slice(point.as_bytes());
+                bytes
+            }
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Self::WebCrypto(key) => key.to_compressed_bytes(),
+        }
+    }
+
+    /// Verify a signature for the given message.
+    ///
+    /// # Errors
+    ///
+    /// Returns `signature::Error` if verification fails.
+    #[allow(clippy::unused_async)]
+    pub async fn verify_signature(
+        &self,
+        msg: &[u8],
+        signature: &Es256Signature,
+    ) -> Result<(), signature::Error> {
+        match self {
+            Self::Native(key) => {
+                use signature::Verifier;
+                let sig = p256::ecdsa::Signature::try_from(*signature)?;
+                key.verify(msg, &sig)
+            }
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Self::WebCrypto(key) => key.verify_signature(msg, signature).await,
+        }
+    }
+}
+
+impl PartialEq for Es256VerifyingKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_compressed_bytes() == other.to_compressed_bytes()
+    }
+}
+
+impl Eq for Es256VerifyingKey {}
+
+/// ES256 signing key.
+///
+/// Enum-shaped like [`Es256VerifyingKey`]:
+/// - `Native`: uses the `p256` crate for non-WASM platforms.
+/// - `WebCrypto`: uses the browser's `WebCrypto` API (web WASM only), with
+///   non-extractable keys by default.
+#[derive(Debug, Clone)]
+pub enum Es256SigningKey {
+    /// Native signing key using the `p256` crate.
+    Native(p256::ecdsa::SigningKey),
+
+    /// WebCrypto signing key (web WASM only).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    WebCrypto(web::SigningKey),
+}
+
+impl Es256SigningKey {
+    /// Get the verifying (public) key.
+    #[must_use]
+    pub fn verifying_key(&self) -> Es256VerifyingKey {
+        match self {
+            Self::Native(key) => Es256VerifyingKey::Native(*key.verifying_key()),
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Self::WebCrypto(key) => Es256VerifyingKey::WebCrypto(key.verifying_key()),
+        }
+    }
+
+    /// Generate a new ES256 signing key.
+    ///
+    /// On WASM, uses the `WebCrypto` API (non-extractable key by default).
+    /// On native, uses the `p256` crate with random bytes from `getrandom`.
+    ///
+    /// # Errors
+    ///
+    /// On WASM, returns an error if key generation fails or the browser does
+    /// not support ECDSA P-256. On native, returns an error if the RNG fails.
+    #[allow(clippy::unused_async)]
+    pub async fn generate() -> Result<Self, Es256KeyError> {
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        {
+            Ok(Self::WebCrypto(web::SigningKey::generate().await?))
+        }
+
+        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+        {
+            let mut seed = [0u8; 32];
+            getrandom::getrandom(&mut seed).map_err(Es256KeyError::Rng)?;
+            let key = p256::ecdsa::SigningKey::from_slice(&seed)
+                .map_err(|_| Es256KeyError::InvalidSeedLength(seed.len()))?;
+            Ok(Self::Native(key))
+        }
+    }
+
+    /// Export the key material.
+    ///
+    /// For `Native` keys, returns `KeyExport::Extractable` with the raw 32-byte
+    /// scalar. For `WebCrypto` keys, delegates to [`web::SigningKey::export`],
+    /// which yields `NonExtractable` for a non-extractable key.
+    ///
+    /// # Errors
+    ///
+    /// On WASM, returns an error if the `WebCrypto` export fails.
+    #[allow(clippy::unused_async)]
+    pub async fn export(&self) -> Result<KeyExport, Es256KeyError> {
+        match self {
+            Self::Native(key) => Ok(KeyExport::Extractable(key.to_bytes().to_vec())),
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Self::WebCrypto(key) => Ok(key.export().await?),
+        }
+    }
+
+    /// Import from a [`KeyExport`].
+    ///
+    /// On native, `Extractable(bytes)` constructs a `p256::ecdsa::SigningKey`
+    /// from the 32-byte scalar.
+    ///
+    /// On WASM, both variants route through [`web::SigningKey::import`] so an
+    /// `Extractable` scalar produces a non-extractable `WebCrypto` key.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the scalar is invalid or the `WebCrypto` import
+    /// fails.
+    #[allow(clippy::unused_async)]
+    pub async fn import(key: impl Into<KeyExport>) -> Result<Self, Es256KeyError> {
+        let key = key.into();
+
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        {
+            Ok(Self::WebCrypto(web::SigningKey::import(key).await?))
+        }
+
+        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+        {
+            match key {
+                KeyExport::Extractable(ref bytes) => {
+                    let signing_key = p256::ecdsa::SigningKey::from_slice(bytes)
+                        .map_err(|_| Es256KeyError::InvalidSeedLength(bytes.len()))?;
+                    Ok(Self::Native(signing_key))
+                }
+            }
+        }
+    }
+
+    /// Sign a message.
+    ///
+    /// # Errors
+    ///
+    /// Returns `signature::Error` if signing fails.
+    #[allow(clippy::unused_async)]
+    pub async fn sign_bytes(&self, msg: &[u8]) -> Result<Es256Signature, signature::Error> {
+        match self {
+            Self::Native(key) => {
+                use signature::Signer;
+                let sig: p256::ecdsa::Signature = key.try_sign(msg)?;
+                Ok(Es256Signature::from(sig))
+            }
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Self::WebCrypto(key) => key.sign_bytes(msg).await,
+        }
+    }
+}
+
+impl From<p256::ecdsa::SigningKey> for Es256SigningKey {
+    fn from(key: p256::ecdsa::SigningKey) -> Self {
+        Self::Native(key)
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<web::SigningKey> for Es256SigningKey {
+    fn from(key: web::SigningKey) -> Self {
+        Self::WebCrypto(key)
+    }
+}

--- a/rust/dialog-credentials/src/es256/error.rs
+++ b/rust/dialog-credentials/src/es256/error.rs
@@ -1,0 +1,102 @@
+//! Error types for ES256 (P-256) key operations.
+
+use thiserror::Error;
+
+/// Errors from [`super::Es256SigningKey::import`] or [`super::Es256SigningKey::export`].
+#[derive(Debug, Clone)]
+#[allow(missing_copy_implementations)]
+pub enum Es256KeyError {
+    /// The seed bytes have the wrong length or are not a valid P-256 scalar.
+    InvalidSeedLength(usize),
+
+    /// Random number generation failed (native only).
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    Rng(getrandom::Error),
+
+    /// A `WebCrypto` operation failed (WASM only).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    WebCrypto(crate::key::WebCryptoError),
+}
+
+impl std::fmt::Display for Es256KeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidSeedLength(n) => write!(f, "invalid P-256 scalar, got {n} bytes"),
+            #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+            Self::Rng(e) => write!(f, "RNG error: {e}"),
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Self::WebCrypto(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for Es256KeyError {}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<crate::key::WebCryptoError> for Es256KeyError {
+    fn from(e: crate::key::WebCryptoError) -> Self {
+        Self::WebCrypto(e)
+    }
+}
+
+/// Error type for [`super::signer::Es256Signer`] operations.
+#[derive(Debug, Clone)]
+#[allow(missing_copy_implementations)]
+pub enum Es256SignerError {
+    /// Random number generation failed (from `generate`).
+    Rng(getrandom::Error),
+
+    /// Key import/export error.
+    Key(Es256KeyError),
+}
+
+impl std::fmt::Display for Es256SignerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rng(e) => write!(f, "RNG error: {e}"),
+            Self::Key(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for Es256SignerError {}
+
+impl From<getrandom::Error> for Es256SignerError {
+    fn from(e: getrandom::Error) -> Self {
+        Self::Rng(e)
+    }
+}
+
+impl From<Es256KeyError> for Es256SignerError {
+    fn from(e: Es256KeyError) -> Self {
+        Self::Key(e)
+    }
+}
+
+/// Errors that can occur when parsing an `Es256Verifier` from a string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Error)]
+pub enum Es256DidFromStrError {
+    /// The DID header is invalid.
+    #[error("invalid did header")]
+    InvalidDidHeader,
+
+    /// The base58 prefix 'z' is missing.
+    #[error("missing base58 prefix 'z'")]
+    MissingBase58Prefix,
+
+    /// The base58 encoding is invalid.
+    #[error("invalid base58 encoding")]
+    InvalidBase58,
+
+    /// The key bytes are invalid.
+    #[error("invalid key bytes")]
+    InvalidKey,
+}
+
+/// Error type for ES256 DID resolution.
+#[derive(Debug, Clone, Copy, Error)]
+pub enum Es256ResolveError {
+    /// The DID could not be parsed as an ES256 did:key.
+    #[error("invalid es256 did:key: {0}")]
+    InvalidDid(#[from] Es256DidFromStrError),
+}

--- a/rust/dialog-credentials/src/es256/resolver.rs
+++ b/rust/dialog-credentials/src/es256/resolver.rs
@@ -1,0 +1,17 @@
+//! ES256 DID key resolver.
+
+use super::{error::Es256ResolveError, verifier::Es256Verifier};
+use dialog_varsig::{Did, Verifier, ecdsa::Es256Signature};
+
+/// Resolves `did:key` strings to ES256 verifiers.
+#[derive(Debug, Clone, Copy)]
+pub struct Es256KeyResolver;
+
+impl dialog_varsig::resolver::Resolver<Es256Signature> for Es256KeyResolver {
+    type Error = Es256ResolveError;
+
+    async fn resolve(&self, did: &Did) -> Result<impl Verifier<Es256Signature>, Self::Error> {
+        let es_did: Es256Verifier = did.as_str().parse()?;
+        Ok(es_did)
+    }
+}

--- a/rust/dialog-credentials/src/es256/signer.rs
+++ b/rust/dialog-credentials/src/es256/signer.rs
@@ -1,0 +1,175 @@
+//! ES256 signer implementation.
+
+use super::{Es256SigningKey, error::Es256SignerError, verifier::Es256Verifier};
+use crate::key::KeyExport;
+use dialog_varsig::{Did, Principal, Signer, ecdsa::Es256Signature};
+use serde::Serialize;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use super::web;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use crate::key::{ExtractableKey, WebCryptoError};
+
+/// An `ES256` (`P-256`) `did:key` signer.
+///
+/// On native platforms this wraps a `p256::ecdsa::SigningKey`. On WASM it can
+/// also wrap a `WebCrypto` `CryptoKey` for non-extractable key support.
+#[derive(Debug, Clone)]
+pub struct Es256Signer {
+    did: Es256Verifier,
+    signer: Es256SigningKey,
+}
+
+impl From<Es256SigningKey> for Es256Signer {
+    fn from(signer: Es256SigningKey) -> Self {
+        let did = Es256Verifier::from(signer.verifying_key());
+        Self { did, signer }
+    }
+}
+
+impl Es256Signer {
+    /// Generate a new ES256 keypair.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the RNG fails.
+    pub async fn generate() -> Result<Self, Es256SignerError> {
+        Ok(Es256SigningKey::generate().await?.into())
+    }
+
+    /// Import a keypair from a [`KeyExport`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bytes are not a valid P-256 scalar.
+    pub async fn import(key: impl Into<KeyExport>) -> Result<Self, Es256SignerError> {
+        let signing_key = Es256SigningKey::import(key).await?;
+        Ok(signing_key.into())
+    }
+
+    /// Export the key material.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible for the native arm.
+    pub async fn export(&self) -> Result<KeyExport, Es256SignerError> {
+        Ok(self.signer.export().await?)
+    }
+
+    /// Get the associated ES256 DID (verifier).
+    #[must_use]
+    pub const fn es256_did(&self) -> &Es256Verifier {
+        &self.did
+    }
+
+    /// Get the inner signing key.
+    #[must_use]
+    pub const fn signing_key(&self) -> &Es256SigningKey {
+        &self.signer
+    }
+}
+
+impl From<p256::ecdsa::SigningKey> for Es256Signer {
+    fn from(key: p256::ecdsa::SigningKey) -> Self {
+        Es256SigningKey::from(key).into()
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<web::SigningKey> for Es256Signer {
+    fn from(key: web::SigningKey) -> Self {
+        Es256SigningKey::from(key).into()
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl ExtractableKey for Es256Signer {
+    async fn generate() -> Result<Self, WebCryptoError> {
+        let key = <web::SigningKey as ExtractableKey>::generate().await?;
+        Ok(Es256SigningKey::from(key).into())
+    }
+
+    async fn import(key: impl Into<KeyExport>) -> Result<Self, WebCryptoError> {
+        let key = <web::SigningKey as ExtractableKey>::import(key).await?;
+        Ok(Es256SigningKey::from(key).into())
+    }
+
+    async fn export(&self) -> Result<KeyExport, WebCryptoError> {
+        match &self.signer {
+            Es256SigningKey::WebCrypto(key) => {
+                <web::SigningKey as ExtractableKey>::export(key).await
+            }
+            Es256SigningKey::Native(key) => Ok(KeyExport::Extractable(key.to_bytes().to_vec())),
+        }
+    }
+}
+
+impl std::fmt::Display for Es256Signer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.did)
+    }
+}
+
+impl Signer<Es256Signature> for Es256Signer {
+    async fn sign(&self, msg: &[u8]) -> Result<Es256Signature, signature::Error> {
+        self.signer.sign_bytes(msg).await
+    }
+}
+
+impl Principal for Es256Signer {
+    fn did(&self) -> Did {
+        self.did.did()
+    }
+}
+
+use dialog_capability::Issuer;
+
+impl Issuer for Es256Signer {
+    type Signature = Es256Signature;
+}
+
+impl Serialize for Es256Signer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.did.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn es256_sign_verify_roundtrip() {
+        use dialog_varsig::Verifier as _;
+
+        let signer = Es256Signer::generate().await.unwrap();
+        let verifier = signer.es256_did().clone();
+        let msg = b"hello p256";
+
+        let sig = Signer::sign(&signer, msg).await.unwrap();
+        verifier.verify(msg, &sig).await.unwrap();
+
+        // A tampered message must not verify.
+        assert!(verifier.verify(b"other", &sig).await.is_err());
+    }
+
+    #[dialog_common::test]
+    async fn es256_did_is_stable() {
+        let signer = Es256Signer::generate().await.unwrap();
+        let did1 = Principal::did(&signer);
+        let did2 = signer.es256_did().did();
+        assert_eq!(did1, did2);
+    }
+
+    #[dialog_common::test]
+    async fn es256_export_import_roundtrip() {
+        let signer = Es256Signer::generate().await.unwrap();
+        let did = Principal::did(&signer);
+        let export = signer.export().await.unwrap();
+        let restored = Es256Signer::import(export).await.unwrap();
+        assert_eq!(Principal::did(&restored), did);
+    }
+}

--- a/rust/dialog-credentials/src/es256/verifier.rs
+++ b/rust/dialog-credentials/src/es256/verifier.rs
@@ -1,0 +1,154 @@
+//! ES256 DID principal and verifier.
+
+use super::{Es256VerifyingKey, error::Es256DidFromStrError};
+use base58::ToBase58;
+use dialog_varsig::{Did, Principal, Verifier, ecdsa::Es256Signature};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::str::FromStr;
+
+/// The `p256-pub` multicodec code `0x1200`, encoded as an unsigned varint.
+const P256_PUB_MULTICODEC: [u8; 2] = [0x80, 0x24];
+
+/// An `ES256` (`P-256`) `did:key`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Es256Verifier(pub Es256VerifyingKey);
+
+impl From<Es256VerifyingKey> for Es256Verifier {
+    fn from(key: Es256VerifyingKey) -> Self {
+        Es256Verifier(key)
+    }
+}
+
+impl From<p256::ecdsa::VerifyingKey> for Es256Verifier {
+    fn from(key: p256::ecdsa::VerifyingKey) -> Self {
+        Es256Verifier(Es256VerifyingKey::Native(key))
+    }
+}
+
+impl std::fmt::Display for Es256Verifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let compressed = self.0.to_compressed_bytes();
+        let mut raw_bytes = Vec::with_capacity(P256_PUB_MULTICODEC.len() + compressed.len());
+        raw_bytes.extend_from_slice(&P256_PUB_MULTICODEC);
+        raw_bytes.extend_from_slice(&compressed);
+        let b58 = ToBase58::to_base58(raw_bytes.as_slice());
+        write!(f, "did:key:z{b58}")
+    }
+}
+
+impl FromStr for Es256Verifier {
+    type Err = Es256DidFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(':').collect();
+        let did_tag = *parts
+            .first()
+            .ok_or(Es256DidFromStrError::InvalidDidHeader)?;
+        let key_tag = *parts.get(1).ok_or(Es256DidFromStrError::InvalidDidHeader)?;
+
+        if parts.len() != 3 || did_tag != "did" || key_tag != "key" {
+            return Err(Es256DidFromStrError::InvalidDidHeader);
+        }
+        let b58 = parts
+            .get(2)
+            .ok_or(Es256DidFromStrError::InvalidDidHeader)?
+            .strip_prefix('z')
+            .ok_or(Es256DidFromStrError::MissingBase58Prefix)?;
+        let raw = base58::FromBase58::from_base58(b58)
+            .map_err(|_| Es256DidFromStrError::InvalidBase58)?;
+        let raw_arr =
+            <[u8; 35]>::try_from(raw.as_slice()).map_err(|_| Es256DidFromStrError::InvalidKey)?;
+        if raw_arr[0..2] != P256_PUB_MULTICODEC {
+            return Err(Es256DidFromStrError::InvalidKey);
+        }
+        let key = p256::ecdsa::VerifyingKey::from_sec1_bytes(&raw_arr[2..])
+            .map_err(|_| Es256DidFromStrError::InvalidKey)?;
+        Ok(Es256Verifier(Es256VerifyingKey::Native(key)))
+    }
+}
+
+impl Verifier<Es256Signature> for Es256Verifier {
+    async fn verify(&self, msg: &[u8], signature: &Es256Signature) -> Result<(), signature::Error> {
+        self.0.verify_signature(msg, signature).await
+    }
+}
+
+impl Principal for Es256Verifier {
+    fn did(&self) -> Did {
+        self.to_string().parse().expect("valid DID string")
+    }
+}
+
+impl Serialize for Es256Verifier {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Es256Verifier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DidKeyVisitor;
+
+        impl serde::de::Visitor<'_> for DidKeyVisitor {
+            type Value = Es256Verifier;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a did:key string containing a P-256 public key")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                v.parse()
+                    .map_err(|e| E::custom(format!("invalid es256 did:key: {e}")))
+            }
+        }
+
+        deserializer.deserialize_str(DidKeyVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_verifying_key(seed: u8) -> Es256VerifyingKey {
+        let signing_key = p256::ecdsa::SigningKey::from_slice(&[seed; 32]).unwrap();
+        Es256VerifyingKey::Native(*signing_key.verifying_key())
+    }
+
+    #[dialog_common::test]
+    fn es256_did_display_roundtrip() {
+        let vk = test_verifying_key(1);
+        let principal = Es256Verifier(vk);
+        let did_string = principal.to_string();
+        assert!(did_string.starts_with("did:key:z"));
+        let parsed: Es256Verifier = did_string.parse().unwrap();
+        assert_eq!(parsed, principal);
+    }
+
+    #[dialog_common::test]
+    fn es256_did_from_str_invalid_header() {
+        let result: Result<Es256Verifier, _> = "not:a:did".parse();
+        assert!(matches!(
+            result,
+            Err(Es256DidFromStrError::InvalidDidHeader)
+        ));
+    }
+
+    #[dialog_common::test]
+    fn es256_did_from_str_missing_prefix() {
+        let result: Result<Es256Verifier, _> = "did:key:abc".parse();
+        assert!(matches!(
+            result,
+            Err(Es256DidFromStrError::MissingBase58Prefix)
+        ));
+    }
+}

--- a/rust/dialog-credentials/src/es256/web.rs
+++ b/rust/dialog-credentials/src/es256/web.rs
@@ -577,8 +577,9 @@ mod tests {
         );
 
         // And therefore on the did:key string.
-        let web_verifier =
-            Es256Verifier::from(crate::es256::Es256VerifyingKey::WebCrypto(web_key.verifying_key()));
+        let web_verifier = Es256Verifier::from(crate::es256::Es256VerifyingKey::WebCrypto(
+            web_key.verifying_key(),
+        ));
         assert_eq!(web_verifier.to_string(), native_verifier.to_string());
     }
 
@@ -592,7 +593,9 @@ mod tests {
         .to_string();
 
         let export = signing.export().await.unwrap();
-        let restored = <SigningKey as ExtractableKey>::import(export).await.unwrap();
+        let restored = <SigningKey as ExtractableKey>::import(export)
+            .await
+            .unwrap();
         let did_after = Es256Verifier::from(crate::es256::Es256VerifyingKey::WebCrypto(
             restored.verifying_key(),
         ))

--- a/rust/dialog-credentials/src/es256/web.rs
+++ b/rust/dialog-credentials/src/es256/web.rs
@@ -1,0 +1,603 @@
+//! WebCrypto-based ES256 (ECDSA P-256) signing implementation.
+//!
+//! This module provides P-256 signing for browser WASM environments using
+//! the Web Crypto API (`SubtleCrypto` with `ECDSA` over `P-256`). It supports
+//! non-extractable keys for enhanced security, matching the ed25519 web arm.
+//!
+//! # Security
+//!
+//! By default, keys are created as **non-extractable**, meaning the private
+//! key material cannot be read from JavaScript/WASM code. This is the same
+//! defense-in-depth posture the ed25519 WebCrypto arm uses.
+//!
+//! # Why P-256 on the web matters
+//!
+//! Browser `SubtleCrypto` supports ECDSA P-256 broadly, and WebAuthn/passkeys
+//! produce P-256 keys, so a passkey-derived signer belongs on this arm.
+
+use crate::key::KeyExport;
+use dialog_varsig::ecdsa::Es256Signature;
+use js_sys::{Object, Reflect, Uint8Array};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::pkcs8::EncodePrivateKey;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{CryptoKey, SubtleCrypto};
+
+pub use crate::key::{ExtractableKey, WebCryptoError};
+
+/// WebCrypto-based ES256 signing key.
+///
+/// Wraps a WebCrypto `CryptoKey` pair, non-extractable by default. The cached
+/// public key bytes are the 33-byte SEC1 compressed point, matching the native
+/// arm's `to_compressed_bytes` so that the `did:key` encoding is identical on
+/// both arms.
+#[derive(Debug, Clone)]
+pub struct SigningKey {
+    private_key: CryptoKey,
+    public_key: CryptoKey,
+    public_key_bytes: [u8; 33],
+}
+
+impl SigningKey {
+    fn new(private_key: CryptoKey, public_key: CryptoKey, public_key_bytes: [u8; 33]) -> Self {
+        Self {
+            private_key,
+            public_key,
+            public_key_bytes,
+        }
+    }
+
+    /// Generate a new P-256 keypair using WebCrypto.
+    ///
+    /// The private key is created as **non-extractable** for security.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key generation fails or the browser does not
+    /// support ECDSA P-256.
+    pub async fn generate() -> Result<Self, WebCryptoError> {
+        generate(false).await
+    }
+
+    /// Import a keypair from a [`KeyExport`].
+    ///
+    /// - `Extractable(bytes)` treats the bytes as a 32-byte P-256 scalar,
+    ///   imports it via PKCS#8 (non-extractable), and derives the public key.
+    /// - `NonExtractable { private_key, public_key }` wraps the supplied
+    ///   `CryptoKey`s and re-exports the public key to cache its bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the scalar is invalid or the import fails.
+    pub async fn import(key: impl Into<KeyExport>) -> Result<Self, WebCryptoError> {
+        let key = key.into();
+        match key {
+            KeyExport::Extractable(ref bytes) => {
+                let scalar: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                    WebCryptoError::KeyImport(format!(
+                        "expected 32 scalar bytes, got {}",
+                        bytes.len()
+                    ))
+                })?;
+                import(&scalar, false).await
+            }
+            KeyExport::NonExtractable {
+                private_key,
+                public_key,
+            } => {
+                let subtle = get_subtle_crypto()?;
+                let public_key_bytes = export_public_key_compressed(&subtle, &public_key).await?;
+                Ok(SigningKey::new(private_key, public_key, public_key_bytes))
+            }
+        }
+    }
+
+    /// Export the key material.
+    ///
+    /// If the private key is extractable, returns `KeyExport::Extractable`
+    /// with the raw 32-byte scalar recovered from the PKCS#8 encoding.
+    /// Otherwise returns `KeyExport::NonExtractable` with both `CryptoKey`s.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the PKCS#8 export fails.
+    pub async fn export(&self) -> Result<KeyExport, WebCryptoError> {
+        if self.private_key.extractable() {
+            let subtle = get_subtle_crypto()?;
+            let promise = subtle
+                .export_key("pkcs8", &self.private_key)
+                .map_err(|e| WebCryptoError::KeyExport(format!("{e:?}")))?;
+            let exported = JsFuture::from(promise)
+                .await
+                .map_err(|e| WebCryptoError::KeyExport(format!("{e:?}")))?;
+            let array = Uint8Array::new(&exported);
+            let mut pkcs8_bytes = vec![0u8; array.length() as usize];
+            array.copy_to(&mut pkcs8_bytes);
+            let scalar = scalar_from_pkcs8(&pkcs8_bytes)?;
+            Ok(KeyExport::Extractable(scalar.to_vec()))
+        } else {
+            Ok(KeyExport::NonExtractable {
+                private_key: self.private_key.clone(),
+                public_key: self.public_key.clone(),
+            })
+        }
+    }
+
+    /// Get the verifying (public) key.
+    #[must_use]
+    pub fn verifying_key(&self) -> VerifyingKey {
+        VerifyingKey::new(self.public_key.clone(), self.public_key_bytes)
+    }
+
+    /// Sign a message using the WebCrypto API.
+    ///
+    /// # Errors
+    ///
+    /// Returns `signature::Error` if signing fails.
+    pub async fn sign_bytes(&self, msg: &[u8]) -> Result<Es256Signature, signature::Error> {
+        sign(&self.private_key, msg).await
+    }
+}
+
+/// Generate a keypair with the specified extractability.
+async fn generate(extractable: bool) -> Result<SigningKey, WebCryptoError> {
+    let subtle = get_subtle_crypto()?;
+
+    let algorithm = ecdsa_key_algorithm()?;
+
+    let key_usages = js_sys::Array::new();
+    key_usages.push(&"sign".into());
+    key_usages.push(&"verify".into());
+
+    let promise = subtle
+        .generate_key_with_object(&algorithm, extractable, &key_usages)
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+
+    let key_pair = JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyGeneration(format!("{e:?}")))?;
+
+    let private_key: CryptoKey = Reflect::get(&key_pair, &"privateKey".into())
+        .map_err(|e| WebCryptoError::KeyGeneration(format!("failed to get privateKey: {e:?}")))?
+        .unchecked_into();
+
+    let public_key: CryptoKey = Reflect::get(&key_pair, &"publicKey".into())
+        .map_err(|e| WebCryptoError::KeyGeneration(format!("failed to get publicKey: {e:?}")))?
+        .unchecked_into();
+
+    let public_key_bytes = export_public_key_compressed(&subtle, &public_key).await?;
+
+    Ok(SigningKey::new(private_key, public_key, public_key_bytes))
+}
+
+/// Import a keypair from a 32-byte scalar with the specified extractability.
+async fn import(scalar: &[u8; 32], extractable: bool) -> Result<SigningKey, WebCryptoError> {
+    let subtle = get_subtle_crypto()?;
+
+    let secret = p256::SecretKey::from_bytes(scalar.into())
+        .map_err(|e| WebCryptoError::KeyImport(format!("invalid P-256 scalar: {e}")))?;
+    let pkcs8 = secret
+        .to_pkcs8_der()
+        .map_err(|e| WebCryptoError::KeyImport(format!("PKCS#8 encode failed: {e}")))?;
+
+    let algorithm = ecdsa_key_algorithm()?;
+
+    let key_usages = js_sys::Array::new();
+    key_usages.push(&"sign".into());
+
+    let pkcs8_array = Uint8Array::from(pkcs8.as_bytes());
+
+    let promise = subtle
+        .import_key_with_object(
+            "pkcs8",
+            &pkcs8_array.buffer(),
+            &algorithm,
+            extractable,
+            &key_usages,
+        )
+        .map_err(|e| WebCryptoError::KeyImport(format!("{e:?}")))?;
+
+    let private_key: CryptoKey = JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyImport(format!("{e:?}")))?
+        .unchecked_into();
+
+    let public_key_bytes = compressed_public_from_secret(&secret);
+    let public_key = import_public_key_compressed(&subtle, &public_key_bytes).await?;
+
+    Ok(SigningKey::new(private_key, public_key, public_key_bytes))
+}
+
+/// Sign a message using WebCrypto ECDSA P-256 with SHA-256.
+async fn sign(key: &CryptoKey, msg: &[u8]) -> Result<Es256Signature, signature::Error> {
+    let subtle = subtle_from_global()?;
+
+    let algorithm = ecdsa_sign_algorithm()
+        .map_err(|e| signature::Error::from_source(format!("algorithm setup failed: {e}")))?;
+
+    let msg_array = Uint8Array::from(msg);
+
+    let promise = subtle
+        .sign_with_object_and_buffer_source(&algorithm, key, &msg_array)
+        .map_err(|e| signature::Error::from_source(format!("sign failed: {e:?}")))?;
+
+    let signature_buffer = JsFuture::from(promise)
+        .await
+        .map_err(|e| signature::Error::from_source(format!("sign await failed: {e:?}")))?;
+
+    let signature_array = Uint8Array::new(&signature_buffer);
+
+    if signature_array.length() != 64 {
+        return Err(signature::Error::from_source(format!(
+            "expected 64 signature bytes (r||s), got {}",
+            signature_array.length()
+        )));
+    }
+
+    let mut signature_bytes = [0u8; 64];
+    signature_array.copy_to(&mut signature_bytes);
+
+    Ok(Es256Signature::from_bytes(signature_bytes))
+}
+
+/// Verify a signature using WebCrypto ECDSA P-256 with SHA-256.
+pub(crate) async fn verify(
+    key: &CryptoKey,
+    msg: &[u8],
+    sig: &Es256Signature,
+) -> Result<(), signature::Error> {
+    let subtle = subtle_from_global()?;
+
+    let algorithm = ecdsa_sign_algorithm()
+        .map_err(|e| signature::Error::from_source(format!("algorithm setup failed: {e}")))?;
+
+    let sig_array = Uint8Array::from(sig.to_bytes().as_slice());
+    let msg_array = Uint8Array::from(msg);
+
+    let promise = subtle
+        .verify_with_object_and_buffer_source_and_buffer_source(
+            &algorithm, key, &sig_array, &msg_array,
+        )
+        .map_err(|e| signature::Error::from_source(format!("verify failed: {e:?}")))?;
+
+    let result = JsFuture::from(promise)
+        .await
+        .map_err(|e| signature::Error::from_source(format!("verify await failed: {e:?}")))?;
+
+    if result.as_bool() == Some(true) {
+        Ok(())
+    } else {
+        Err(signature::Error::new())
+    }
+}
+
+/// WebCrypto-based ES256 verifying key.
+///
+/// Wraps a WebCrypto public `CryptoKey` alongside a cached 33-byte SEC1
+/// compressed point for synchronous `did:key` encoding.
+#[derive(Debug, Clone)]
+pub struct VerifyingKey {
+    crypto_key: CryptoKey,
+    public_key_bytes: [u8; 33],
+}
+
+impl VerifyingKey {
+    fn new(crypto_key: CryptoKey, public_key_bytes: [u8; 33]) -> Self {
+        Self {
+            crypto_key,
+            public_key_bytes,
+        }
+    }
+
+    /// Get a reference to the inner `CryptoKey`.
+    #[must_use]
+    pub const fn crypto_key(&self) -> &CryptoKey {
+        &self.crypto_key
+    }
+
+    /// Get the 33-byte SEC1 compressed public key bytes.
+    #[must_use]
+    pub const fn to_compressed_bytes(&self) -> [u8; 33] {
+        self.public_key_bytes
+    }
+
+    /// Create a `VerifyingKey` from a WebCrypto `CryptoKey`.
+    ///
+    /// Validates that the key is an ECDSA P-256 key with `verify` usage, and
+    /// exports the compressed public point for `did:key` encoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the key's algorithm or curve is not ECDSA P-256,
+    /// the key lacks the `verify` usage, or the export fails.
+    pub async fn from_crypto_key(key: CryptoKey) -> Result<Self, WebCryptoError> {
+        let algo = key
+            .algorithm()
+            .map_err(|e| WebCryptoError::InvalidPublicKey(format!("{e:?}")))?;
+
+        let name = Reflect::get(&algo, &"name".into())
+            .ok()
+            .and_then(|v| v.as_string());
+        if name.as_deref() != Some("ECDSA") {
+            return Err(WebCryptoError::InvalidPublicKey(format!(
+                "expected ECDSA algorithm, got {name:?}"
+            )));
+        }
+
+        let curve = Reflect::get(&algo, &"namedCurve".into())
+            .ok()
+            .and_then(|v| v.as_string());
+        if curve.as_deref() != Some("P-256") {
+            return Err(WebCryptoError::InvalidPublicKey(format!(
+                "expected P-256 curve, got {curve:?}"
+            )));
+        }
+
+        let usages = key.usages();
+        if !usages.includes(&"verify".into(), 0) {
+            return Err(WebCryptoError::InvalidPublicKey(
+                "key does not have 'verify' usage".into(),
+            ));
+        }
+
+        let subtle = get_subtle_crypto()?;
+        let public_key_bytes = export_public_key_compressed(&subtle, &key).await?;
+
+        Ok(Self {
+            crypto_key: key,
+            public_key_bytes,
+        })
+    }
+
+    /// Verify a signature for the given message.
+    ///
+    /// # Errors
+    ///
+    /// Returns `signature::Error` if verification fails.
+    pub async fn verify_signature(
+        &self,
+        msg: &[u8],
+        signature: &Es256Signature,
+    ) -> Result<(), signature::Error> {
+        verify(&self.crypto_key, msg, signature).await
+    }
+}
+
+/// Build the `{ name: "ECDSA", namedCurve: "P-256" }` algorithm object used for
+/// key generation and import.
+fn ecdsa_key_algorithm() -> Result<Object, WebCryptoError> {
+    let algorithm = Object::new();
+    Reflect::set(&algorithm, &"name".into(), &"ECDSA".into())
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+    Reflect::set(&algorithm, &"namedCurve".into(), &"P-256".into())
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+    Ok(algorithm)
+}
+
+/// Build the `{ name: "ECDSA", hash: "SHA-256" }` algorithm object used for
+/// signing and verification.
+fn ecdsa_sign_algorithm() -> Result<Object, WebCryptoError> {
+    let algorithm = Object::new();
+    Reflect::set(&algorithm, &"name".into(), &"ECDSA".into())
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+    Reflect::set(&algorithm, &"hash".into(), &"SHA-256".into())
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+    Ok(algorithm)
+}
+
+/// Get the `SubtleCrypto` interface, returning a `WebCryptoError` on failure.
+fn get_subtle_crypto() -> Result<SubtleCrypto, WebCryptoError> {
+    let global = js_sys::global();
+
+    let crypto = Reflect::get(&global, &"crypto".into())
+        .map_err(|_| WebCryptoError::NotAvailable("crypto not found on global".into()))?;
+
+    if crypto.is_undefined() {
+        return Err(WebCryptoError::NotAvailable("crypto is undefined".into()));
+    }
+
+    let subtle = Reflect::get(&crypto, &"subtle".into())
+        .map_err(|_| WebCryptoError::NotAvailable("subtle not found on crypto".into()))?;
+
+    if subtle.is_undefined() {
+        return Err(WebCryptoError::NotAvailable(
+            "crypto.subtle is undefined".into(),
+        ));
+    }
+
+    Ok(subtle.unchecked_into())
+}
+
+/// Get the `SubtleCrypto` interface, returning a `signature::Error` on failure
+/// (used on the sign/verify paths).
+fn subtle_from_global() -> Result<SubtleCrypto, signature::Error> {
+    let global = js_sys::global();
+
+    let crypto = Reflect::get(&global, &"crypto".into())
+        .map_err(|e| signature::Error::from_source(format!("crypto not found: {e:?}")))?;
+
+    let subtle = Reflect::get(&crypto, &"subtle".into())
+        .map_err(|e| signature::Error::from_source(format!("subtle not found: {e:?}")))?;
+
+    Ok(subtle.unchecked_into())
+}
+
+/// Export a public `CryptoKey` and return its 33-byte SEC1 compressed point.
+///
+/// WebCrypto exports ECDSA public keys as a 65-byte uncompressed SEC1 point
+/// (`0x04 || X || Y`); we compress it via the `p256` crate so the bytes match
+/// the native arm's `did:key` encoding exactly.
+async fn export_public_key_compressed(
+    subtle: &SubtleCrypto,
+    public_key: &CryptoKey,
+) -> Result<[u8; 33], WebCryptoError> {
+    let promise = subtle
+        .export_key("raw", public_key)
+        .map_err(|e| WebCryptoError::KeyExport(format!("{e:?}")))?;
+
+    let exported = JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyExport(format!("{e:?}")))?;
+
+    let array = Uint8Array::new(&exported);
+    let mut raw = vec![0u8; array.length() as usize];
+    array.copy_to(&mut raw);
+
+    compress_sec1(&raw)
+}
+
+/// Import a 33-byte compressed public point as a verify-only WebCrypto
+/// `CryptoKey`. WebCrypto's `raw` import accepts both compressed and
+/// uncompressed SEC1 points for ECDSA.
+async fn import_public_key_compressed(
+    subtle: &SubtleCrypto,
+    compressed: &[u8; 33],
+) -> Result<CryptoKey, WebCryptoError> {
+    let algorithm = ecdsa_key_algorithm()?;
+
+    let key_usages = js_sys::Array::new();
+    key_usages.push(&"verify".into());
+
+    let key_data = Uint8Array::from(compressed.as_slice());
+
+    let promise = subtle
+        .import_key_with_object("raw", &key_data.buffer(), &algorithm, true, &key_usages)
+        .map_err(|e| WebCryptoError::KeyImport(format!("{e:?}")))?;
+
+    let key = JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyImport(format!("{e:?}")))?;
+
+    Ok(key.unchecked_into())
+}
+
+/// Compress a SEC1 public point (accepts a 65-byte uncompressed or an
+/// already-33-byte compressed point) to its 33-byte compressed form.
+fn compress_sec1(bytes: &[u8]) -> Result<[u8; 33], WebCryptoError> {
+    let public = p256::PublicKey::from_sec1_bytes(bytes)
+        .map_err(|e| WebCryptoError::InvalidPublicKey(format!("invalid SEC1 point: {e}")))?;
+    let point = public.to_encoded_point(true);
+    let mut out = [0u8; 33];
+    let point_bytes = point.as_bytes();
+    if point_bytes.len() != 33 {
+        return Err(WebCryptoError::InvalidPublicKey(format!(
+            "expected 33 compressed bytes, got {}",
+            point_bytes.len()
+        )));
+    }
+    out.copy_from_slice(point_bytes);
+    Ok(out)
+}
+
+/// Derive the 33-byte compressed public point from a P-256 secret key.
+fn compressed_public_from_secret(secret: &p256::SecretKey) -> [u8; 33] {
+    let point = secret.public_key().to_encoded_point(true);
+    let mut out = [0u8; 33];
+    out.copy_from_slice(point.as_bytes());
+    out
+}
+
+/// Recover the 32-byte P-256 scalar from a PKCS#8 DER private key.
+fn scalar_from_pkcs8(der: &[u8]) -> Result<[u8; 32], WebCryptoError> {
+    use p256::pkcs8::DecodePrivateKey;
+    let secret = p256::SecretKey::from_pkcs8_der(der)
+        .map_err(|e| WebCryptoError::KeyExport(format!("PKCS#8 decode failed: {e}")))?;
+    Ok(secret.to_bytes().into())
+}
+
+impl ExtractableKey for SigningKey {
+    async fn generate() -> Result<Self, WebCryptoError> {
+        generate(true).await
+    }
+
+    async fn import(key: impl Into<KeyExport>) -> Result<Self, WebCryptoError> {
+        let key = key.into();
+        match key {
+            KeyExport::Extractable(ref bytes) => {
+                let scalar: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                    WebCryptoError::KeyImport(format!(
+                        "expected 32 scalar bytes, got {}",
+                        bytes.len()
+                    ))
+                })?;
+                import(&scalar, true).await
+            }
+            KeyExport::NonExtractable {
+                private_key,
+                public_key,
+            } => {
+                let subtle = get_subtle_crypto()?;
+                let public_key_bytes = export_public_key_compressed(&subtle, &public_key).await?;
+                Ok(SigningKey::new(private_key, public_key, public_key_bytes))
+            }
+        }
+    }
+
+    async fn export(&self) -> Result<KeyExport, WebCryptoError> {
+        self.export().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::es256::Es256Verifier;
+
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[dialog_common::test]
+    async fn web_generate_sign_verify_roundtrip() {
+        let signing = SigningKey::generate().await.unwrap();
+        let verifying = signing.verifying_key();
+        let msg = b"hello webcrypto p256";
+
+        let sig = signing.sign_bytes(msg).await.unwrap();
+        verifying.verify_signature(msg, &sig).await.unwrap();
+        assert!(verifying.verify_signature(b"other", &sig).await.is_err());
+    }
+
+    #[dialog_common::test]
+    async fn web_did_key_matches_native_encoding() {
+        // A key imported from a fixed scalar must produce the same did:key on
+        // the web arm as the native arm would, since both encode the 33-byte
+        // compressed point behind the same multicodec.
+        let scalar = [7u8; 32];
+        let web_key = import(&scalar, true).await.unwrap();
+        let web_compressed = web_key.verifying_key().to_compressed_bytes();
+
+        let native = p256::ecdsa::SigningKey::from_slice(&scalar).unwrap();
+        let native_verifier = Es256Verifier::from(*native.verifying_key());
+        let native_compressed =
+            crate::es256::Es256VerifyingKey::from(*native.verifying_key()).to_compressed_bytes();
+
+        assert_eq!(
+            web_compressed, native_compressed,
+            "web and native must agree on the compressed public point"
+        );
+
+        // And therefore on the did:key string.
+        let web_verifier =
+            Es256Verifier::from(crate::es256::Es256VerifyingKey::WebCrypto(web_key.verifying_key()));
+        assert_eq!(web_verifier.to_string(), native_verifier.to_string());
+    }
+
+    #[dialog_common::test]
+    async fn web_export_import_preserves_did() {
+        // Extractable web key: export the scalar and re-import; the DID is stable.
+        let signing = <SigningKey as ExtractableKey>::generate().await.unwrap();
+        let did_before = Es256Verifier::from(crate::es256::Es256VerifyingKey::WebCrypto(
+            signing.verifying_key(),
+        ))
+        .to_string();
+
+        let export = signing.export().await.unwrap();
+        let restored = <SigningKey as ExtractableKey>::import(export).await.unwrap();
+        let did_after = Es256Verifier::from(crate::es256::Es256VerifyingKey::WebCrypto(
+            restored.verifying_key(),
+        ))
+        .to_string();
+
+        assert_eq!(did_before, did_after);
+    }
+}

--- a/rust/dialog-credentials/src/lib.rs
+++ b/rust/dialog-credentials/src/lib.rs
@@ -3,16 +3,19 @@
 //! This crate provides credential implementations that satisfy the
 //! [`Principal`] and [`Issuer`] traits from `dialog-capability`.
 //!
-//! Ed25519 (`ed25519` feature) and ES256 / P-256 (`es256` feature) are both
-//! available and on by default. The algorithm-agnostic [`AnySigner`],
-//! [`AnyVerifier`], and [`AnySignature`] enums let callers hold an identity
-//! without committing to a signature algorithm.
+//! The crate's default identity types are algorithm-agnostic: [`Signer`],
+//! [`Verifier`], and [`Signature`] are enums that hold whichever algorithm a
+//! credential was created with. ed25519 is always available (the `ed25519`
+//! feature, on by default); other algorithms are feature-gated and add arms to
+//! those enums when enabled. Today the only additional algorithm is ES256 /
+//! P-256 (the `es256` feature).
 //!
 //! [`Principal`]: dialog_capability::Principal
 //! [`Issuer`]: dialog_capability::Issuer
 
 pub mod credential;
 pub mod key;
+pub mod signature;
 
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
@@ -24,11 +27,9 @@ pub mod es256;
 #[cfg(feature = "es256")]
 pub use es256::*;
 
-// The algorithm-agnostic `Any*` types span both supported algorithms, so they
-// require both features. Both are on by default.
-#[cfg(all(feature = "ed25519", feature = "es256"))]
-pub mod any;
-#[cfg(all(feature = "ed25519", feature = "es256"))]
-pub use any::*;
+// The algorithm-agnostic identity types. Available whenever ed25519 is (the
+// always-on default); enabling further algorithms adds arms to the enums.
+#[cfg(feature = "ed25519")]
+pub use signature::{Algorithm, AlgorithmTag, DidFromStrError, Signature, Signer, Verifier};
 
 pub use credential::*;

--- a/rust/dialog-credentials/src/lib.rs
+++ b/rust/dialog-credentials/src/lib.rs
@@ -3,8 +3,10 @@
 //! This crate provides credential implementations that satisfy the
 //! [`Principal`] and [`Issuer`] traits from `dialog-capability`.
 //!
-//! Currently the only implementation is Ed25519 (enabled by the `ed25519`
-//! feature, which is on by default).
+//! Ed25519 (`ed25519` feature) and ES256 / P-256 (`es256` feature) are both
+//! available and on by default. The algorithm-agnostic [`AnySigner`],
+//! [`AnyVerifier`], and [`AnySignature`] enums let callers hold an identity
+//! without committing to a signature algorithm.
 //!
 //! [`Principal`]: dialog_capability::Principal
 //! [`Issuer`]: dialog_capability::Issuer
@@ -16,5 +18,17 @@ pub mod key;
 pub mod ed25519;
 #[cfg(feature = "ed25519")]
 pub use ed25519::*;
+
+#[cfg(feature = "es256")]
+pub mod es256;
+#[cfg(feature = "es256")]
+pub use es256::*;
+
+// The algorithm-agnostic `Any*` types span both supported algorithms, so they
+// require both features. Both are on by default.
+#[cfg(all(feature = "ed25519", feature = "es256"))]
+pub mod any;
+#[cfg(all(feature = "ed25519", feature = "es256"))]
+pub use any::*;
 
 pub use credential::*;

--- a/rust/dialog-credentials/src/lib.rs
+++ b/rust/dialog-credentials/src/lib.rs
@@ -30,6 +30,10 @@ pub use es256::*;
 // The algorithm-agnostic identity types. Available whenever ed25519 is (the
 // always-on default); enabling further algorithms adds arms to the enums.
 #[cfg(feature = "ed25519")]
+pub mod resolver;
+#[cfg(feature = "ed25519")]
+pub use resolver::{DidKeyResolveError, DidKeyResolver};
+#[cfg(feature = "ed25519")]
 pub use signature::{Algorithm, AlgorithmTag, DidFromStrError, Signature, Signer, Verifier};
 
 pub use credential::*;

--- a/rust/dialog-credentials/src/resolver.rs
+++ b/rust/dialog-credentials/src/resolver.rs
@@ -1,0 +1,103 @@
+//! Algorithm-agnostic `did:key` resolver.
+//!
+//! Resolves a `did:key` string to the agnostic [`Verifier`], dispatching to the
+//! right algorithm by the DID's multicodec. This is what verifies the
+//! algorithm-agnostic [`Signature`](crate::Signature): a UCAN signed by an
+//! ed25519 or a P-256 key resolves through the same resolver.
+//!
+//! This handles `did:key` only. Network methods (`did:web`, `did:plc`) are
+//! separate resolvers that compose with this one.
+
+use crate::{Ed25519Verifier, Verifier};
+use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::{AnySignature, Did, resolver::Resolver};
+
+/// Resolves `did:key` strings to a verifier, dispatching to the right algorithm
+/// by the DID's multicodec.
+///
+/// It resolves the algorithm-agnostic [`AnySignature`] (returning the agnostic
+/// [`Verifier`]), and also the concrete per-algorithm signature types, so the
+/// same resolver serves both agnostic and concretely-typed verification paths.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DidKeyResolver;
+
+/// Error returned when a `did:key` string cannot be resolved to a supported
+/// verifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
+#[error("could not resolve did:key to a supported verifier")]
+pub struct DidKeyResolveError;
+
+impl Resolver<AnySignature> for DidKeyResolver {
+    type Error = DidKeyResolveError;
+
+    async fn resolve(
+        &self,
+        did: &Did,
+    ) -> Result<impl dialog_varsig::Verifier<AnySignature>, Self::Error> {
+        Verifier::from_did_key(did.as_str()).map_err(|_| DidKeyResolveError)
+    }
+}
+
+impl Resolver<Ed25519Signature> for DidKeyResolver {
+    type Error = DidKeyResolveError;
+
+    async fn resolve(
+        &self,
+        did: &Did,
+    ) -> Result<impl dialog_varsig::Verifier<Ed25519Signature>, Self::Error> {
+        let verifier: Ed25519Verifier = did.as_str().parse().map_err(|_| DidKeyResolveError)?;
+        Ok(verifier)
+    }
+}
+
+#[cfg(feature = "es256")]
+impl Resolver<dialog_varsig::ecdsa::Es256Signature> for DidKeyResolver {
+    type Error = DidKeyResolveError;
+
+    async fn resolve(
+        &self,
+        did: &Did,
+    ) -> Result<impl dialog_varsig::Verifier<dialog_varsig::ecdsa::Es256Signature>, Self::Error>
+    {
+        let verifier: crate::Es256Verifier =
+            did.as_str().parse().map_err(|_| DidKeyResolveError)?;
+        Ok(verifier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Ed25519Signer, Signer};
+    use dialog_varsig::{
+        AnySignature, Principal, Signer as VarsigSigner, Verifier as VarsigVerifier,
+    };
+
+    #[dialog_common::test]
+    async fn it_resolves_ed25519_did_key() {
+        let signer = Signer::from(Ed25519Signer::generate().await.unwrap());
+        let did = signer.did();
+        let msg = b"resolve me";
+        let sig = VarsigSigner::sign(&signer, msg).await.unwrap();
+
+        let verifier = Resolver::<AnySignature>::resolve(&DidKeyResolver, &did)
+            .await
+            .unwrap();
+        verifier.verify(msg, &sig).await.unwrap();
+    }
+
+    #[cfg(feature = "es256")]
+    #[dialog_common::test]
+    async fn it_resolves_es256_did_key() {
+        use crate::Es256Signer;
+        let signer = Signer::from(Es256Signer::generate().await.unwrap());
+        let did = signer.did();
+        let msg = b"resolve me";
+        let sig = VarsigSigner::sign(&signer, msg).await.unwrap();
+
+        let verifier = Resolver::<AnySignature>::resolve(&DidKeyResolver, &did)
+            .await
+            .unwrap();
+        verifier.verify(msg, &sig).await.unwrap();
+    }
+}

--- a/rust/dialog-credentials/src/signature.rs
+++ b/rust/dialog-credentials/src/signature.rs
@@ -3,89 +3,107 @@
 //! The varsig [`Signer`](dialog_varsig::Signer) and
 //! [`Verifier`](dialog_varsig::Verifier) traits are each generic over a single
 //! concrete signature type. To hold an identity without committing to an
-//! algorithm, we wrap the per-algorithm types in enums and implement the varsig
-//! traits over a single [`AnySignature`] enum that carries an algorithm tag
-//! alongside the raw signature bytes.
+//! algorithm, this module wraps the per-algorithm types in enums and implements
+//! the varsig traits over a single [`Signature`] value that carries an
+//! algorithm tag alongside the raw signature bytes.
 //!
-//! The concrete arms stay authoritative: `AnyVerifier::Ed25519` verifies only
-//! ed25519 signatures, `AnyVerifier::Es256` only P-256, and a signature whose
-//! tag does not match the verifier's arm is rejected. This keeps the
-//! ed25519 path byte-identical while making room for P-256 and future
-//! algorithms.
+//! These enums are the crate's default identity types: `dialog-credentials`
+//! deals in [`Signer`] / [`Verifier`] / [`Signature`], not in any one algorithm.
+//! ed25519 is always available; other algorithms (currently ES256 / P-256) are
+//! feature-gated and add arms to the enums when enabled.
+//!
+//! The concrete arms stay authoritative: an [`Verifier::Ed25519`] verifies only
+//! ed25519 signatures, and a signature whose tag does not match the verifier's
+//! arm is rejected. This keeps the ed25519 path byte-identical while making room
+//! for further algorithms.
+
+// With only the `ed25519` feature the enums below are single-arm. That is
+// intentional: they are always enums so that enabling another algorithm is
+// purely additive. Silence the lints that fire for the single-arm shape.
+#![allow(clippy::single_match_else)]
 
 use dialog_capability::Issuer;
 use dialog_varsig::{
-    Did, Principal, SignatureAlgorithm, Signer, Verifier, ecdsa::Es256, ecdsa::Es256Signature,
-    eddsa::Ed25519, eddsa::Ed25519Signature, signature::Signature,
+    Did, Principal, SignatureAlgorithm, Signer as VarsigSigner, Verifier as VarsigVerifier,
+    eddsa::Ed25519, eddsa::Ed25519Signature, signature::Signature as VarsigSignature,
 };
 use signature::SignatureEncoding;
 
-use crate::{Ed25519Signer, Ed25519Verifier, Es256Signer, Es256Verifier};
+use crate::{Ed25519Signer, Ed25519Verifier};
 
-/// The algorithm tag carried by [`AnySignature`] and [`AnyAlgorithm`].
+#[cfg(feature = "es256")]
+use crate::{Es256Signer, Es256Verifier};
+#[cfg(feature = "es256")]
+use dialog_varsig::ecdsa::{Es256, Es256Signature};
+
+/// The algorithm tag carried by [`Signature`] and [`Algorithm`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Algorithm {
+pub enum AlgorithmTag {
     /// Ed25519 (`EdDSA` over Edwards25519).
     Ed25519,
     /// ES256 (ECDSA over P-256).
+    #[cfg(feature = "es256")]
     Es256,
 }
 
 /// Algorithm-agnostic [`SignatureAlgorithm`].
 ///
 /// Wraps the concrete varsig algorithm descriptors. `Default` resolves to
-/// Ed25519 to satisfy the trait bound; the meaningful tag always travels with
-/// an [`AnySignature`] value, so the default is never used to interpret bytes.
+/// Ed25519 to satisfy the trait bound; the meaningful tag always travels with a
+/// [`Signature`] value, so the default is never used to interpret bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AnyAlgorithm(pub Algorithm);
+pub struct Algorithm(pub AlgorithmTag);
 
-impl Default for AnyAlgorithm {
+impl Default for Algorithm {
     fn default() -> Self {
-        AnyAlgorithm(Algorithm::Ed25519)
+        Algorithm(AlgorithmTag::Ed25519)
     }
 }
 
-impl SignatureAlgorithm for AnyAlgorithm {
+impl SignatureAlgorithm for Algorithm {
     fn prefix(&self) -> u64 {
         match self.0 {
-            Algorithm::Ed25519 => Ed25519::default().prefix(),
-            Algorithm::Es256 => Es256::default().prefix(),
+            AlgorithmTag::Ed25519 => Ed25519::default().prefix(),
+            #[cfg(feature = "es256")]
+            AlgorithmTag::Es256 => Es256::default().prefix(),
         }
     }
 
     fn config_tags(&self) -> Vec<u64> {
         match self.0 {
-            Algorithm::Ed25519 => Ed25519::default().config_tags(),
-            Algorithm::Es256 => Es256::default().config_tags(),
+            AlgorithmTag::Ed25519 => Ed25519::default().config_tags(),
+            #[cfg(feature = "es256")]
+            AlgorithmTag::Es256 => Es256::default().config_tags(),
         }
     }
 
     fn try_from_tags(bytes: &[u64]) -> Option<(Self, &[u64])> {
         if let Some((_, rest)) = Ed25519::try_from_tags(bytes) {
-            Some((AnyAlgorithm(Algorithm::Ed25519), rest))
-        } else if let Some((_, rest)) = Es256::try_from_tags(bytes) {
-            Some((AnyAlgorithm(Algorithm::Es256), rest))
-        } else {
-            None
+            return Some((Algorithm(AlgorithmTag::Ed25519), rest));
         }
+        #[cfg(feature = "es256")]
+        if let Some((_, rest)) = Es256::try_from_tags(bytes) {
+            return Some((Algorithm(AlgorithmTag::Es256), rest));
+        }
+        None
     }
 }
 
 /// Algorithm-agnostic signature: an algorithm tag plus the raw signature bytes.
 ///
 /// Both supported algorithms use a 64-byte fixed-width signature, so the bytes
-/// are stored inline. The tag lets [`AnyVerifier`] reject a signature produced
-/// by a different algorithm than it holds.
+/// are stored inline. The tag lets [`Verifier`] reject a signature produced by a
+/// different algorithm than it holds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AnySignature {
-    algorithm: Algorithm,
+pub struct Signature {
+    algorithm: AlgorithmTag,
     bytes: [u8; 64],
 }
 
-impl AnySignature {
+impl Signature {
     /// The algorithm that produced this signature.
     #[must_use]
-    pub const fn algorithm(&self) -> Algorithm {
+    pub const fn algorithm(&self) -> AlgorithmTag {
         self.algorithm
     }
 
@@ -96,38 +114,39 @@ impl AnySignature {
     }
 }
 
-impl From<Ed25519Signature> for AnySignature {
+impl From<Ed25519Signature> for Signature {
     fn from(sig: Ed25519Signature) -> Self {
         Self {
-            algorithm: Algorithm::Ed25519,
+            algorithm: AlgorithmTag::Ed25519,
             bytes: sig.to_bytes(),
         }
     }
 }
 
-impl From<Es256Signature> for AnySignature {
+#[cfg(feature = "es256")]
+impl From<Es256Signature> for Signature {
     fn from(sig: Es256Signature) -> Self {
         Self {
-            algorithm: Algorithm::Es256,
+            algorithm: AlgorithmTag::Es256,
             bytes: sig.to_bytes(),
         }
     }
 }
 
-/// `AnySignature` encodes as its raw 64-byte body. The algorithm tag is carried
+/// [`Signature`] encodes as its raw 64-byte body. The algorithm tag is carried
 /// out of band (by the verifier's arm), matching how a varsig header already
 /// names the algorithm separately from the signature body.
-impl SignatureEncoding for AnySignature {
+impl SignatureEncoding for Signature {
     type Repr = [u8; 64];
 }
 
-impl From<AnySignature> for [u8; 64] {
-    fn from(sig: AnySignature) -> Self {
+impl From<Signature> for [u8; 64] {
+    fn from(sig: Signature) -> Self {
         sig.bytes
     }
 }
 
-impl TryFrom<&[u8]> for AnySignature {
+impl TryFrom<&[u8]> for Signature {
     type Error = signature::Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -135,44 +154,47 @@ impl TryFrom<&[u8]> for AnySignature {
         // With no header, default to Ed25519; callers that know the algorithm
         // construct via the typed `From` impls instead.
         Ok(Self {
-            algorithm: Algorithm::Ed25519,
+            algorithm: AlgorithmTag::Ed25519,
             bytes,
         })
     }
 }
 
-impl Signature for AnySignature {
-    type Algorithm = AnyAlgorithm;
+impl VarsigSignature for Signature {
+    type Algorithm = Algorithm;
 }
 
 /// Algorithm-agnostic verifier.
 #[derive(Debug, Clone, PartialEq)]
-pub enum AnyVerifier {
+pub enum Verifier {
     /// An Ed25519 verifier.
     Ed25519(Ed25519Verifier),
     /// An ES256 (P-256) verifier.
+    #[cfg(feature = "es256")]
     Es256(Es256Verifier),
 }
 
-impl From<Ed25519Verifier> for AnyVerifier {
+impl From<Ed25519Verifier> for Verifier {
     fn from(v: Ed25519Verifier) -> Self {
         Self::Ed25519(v)
     }
 }
 
-impl From<Es256Verifier> for AnyVerifier {
+#[cfg(feature = "es256")]
+impl From<Es256Verifier> for Verifier {
     fn from(v: Es256Verifier) -> Self {
         Self::Es256(v)
     }
 }
 
-impl AnyVerifier {
+impl Verifier {
     /// The algorithm this verifier checks.
     #[must_use]
-    pub const fn algorithm(&self) -> Algorithm {
+    pub const fn algorithm(&self) -> AlgorithmTag {
         match self {
-            Self::Ed25519(_) => Algorithm::Ed25519,
-            Self::Es256(_) => Algorithm::Es256,
+            Self::Ed25519(_) => AlgorithmTag::Ed25519,
+            #[cfg(feature = "es256")]
+            Self::Es256(_) => AlgorithmTag::Es256,
         }
     }
 
@@ -181,11 +203,13 @@ impl AnyVerifier {
     pub const fn as_ed25519(&self) -> Option<&Ed25519Verifier> {
         match self {
             Self::Ed25519(v) => Some(v),
+            #[cfg(feature = "es256")]
             Self::Es256(_) => None,
         }
     }
 
     /// Get the es256 verifier, if this is an es256 arm.
+    #[cfg(feature = "es256")]
     #[must_use]
     pub const fn as_es256(&self) -> Option<&Es256Verifier> {
         match self {
@@ -195,50 +219,53 @@ impl AnyVerifier {
     }
 
     /// Parse a `did:key` string into an algorithm-agnostic verifier, trying
-    /// ed25519 first, then es256.
+    /// each enabled algorithm in turn.
     ///
     /// # Errors
     ///
     /// Returns an error if the string is not a supported `did:key`.
-    pub fn from_did_key(s: &str) -> Result<Self, AnyDidFromStrError> {
+    pub fn from_did_key(s: &str) -> Result<Self, DidFromStrError> {
         if let Ok(v) = s.parse::<Ed25519Verifier>() {
             return Ok(Self::Ed25519(v));
         }
+        #[cfg(feature = "es256")]
         if let Ok(v) = s.parse::<Es256Verifier>() {
             return Ok(Self::Es256(v));
         }
-        Err(AnyDidFromStrError)
+        Err(DidFromStrError)
     }
 }
 
-impl std::str::FromStr for AnyVerifier {
-    type Err = AnyDidFromStrError;
+impl std::str::FromStr for Verifier {
+    type Err = DidFromStrError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::from_did_key(s)
     }
 }
 
-impl std::fmt::Display for AnyVerifier {
+impl std::fmt::Display for Verifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Ed25519(v) => write!(f, "{v}"),
+            #[cfg(feature = "es256")]
             Self::Es256(v) => write!(f, "{v}"),
         }
     }
 }
 
-impl Principal for AnyVerifier {
+impl Principal for Verifier {
     fn did(&self) -> Did {
         match self {
             Self::Ed25519(v) => v.did(),
+            #[cfg(feature = "es256")]
             Self::Es256(v) => v.did(),
         }
     }
 }
 
-impl Verifier<AnySignature> for AnyVerifier {
-    async fn verify(&self, msg: &[u8], signature: &AnySignature) -> Result<(), signature::Error> {
+impl VarsigVerifier<Signature> for Verifier {
+    async fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), signature::Error> {
         if signature.algorithm() != self.algorithm() {
             return Err(signature::Error::new());
         }
@@ -247,6 +274,7 @@ impl Verifier<AnySignature> for AnyVerifier {
                 let sig = Ed25519Signature::from_bytes(signature.to_bytes());
                 v.verify(msg, &sig).await
             }
+            #[cfg(feature = "es256")]
             Self::Es256(v) => {
                 let sig = Es256Signature::from_bytes(signature.to_bytes());
                 v.verify(msg, &sig).await
@@ -258,37 +286,40 @@ impl Verifier<AnySignature> for AnyVerifier {
 /// Error returned when a `did:key` string is not a supported algorithm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
 #[error("unsupported or invalid did:key")]
-pub struct AnyDidFromStrError;
+pub struct DidFromStrError;
 
 /// Algorithm-agnostic signer: a wrapped local key that can sign.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
-pub enum AnySigner {
+pub enum Signer {
     /// An Ed25519 signer.
     Ed25519(Ed25519Signer),
     /// An ES256 (P-256) signer.
+    #[cfg(feature = "es256")]
     Es256(Es256Signer),
 }
 
-impl From<Ed25519Signer> for AnySigner {
+impl From<Ed25519Signer> for Signer {
     fn from(s: Ed25519Signer) -> Self {
         Self::Ed25519(s)
     }
 }
 
-impl From<Es256Signer> for AnySigner {
+#[cfg(feature = "es256")]
+impl From<Es256Signer> for Signer {
     fn from(s: Es256Signer) -> Self {
         Self::Es256(s)
     }
 }
 
-impl AnySigner {
+impl Signer {
     /// The algorithm this signer produces.
     #[must_use]
-    pub const fn algorithm(&self) -> Algorithm {
+    pub const fn algorithm(&self) -> AlgorithmTag {
         match self {
-            Self::Ed25519(_) => Algorithm::Ed25519,
-            Self::Es256(_) => Algorithm::Es256,
+            Self::Ed25519(_) => AlgorithmTag::Ed25519,
+            #[cfg(feature = "es256")]
+            Self::Es256(_) => AlgorithmTag::Es256,
         }
     }
 
@@ -297,11 +328,13 @@ impl AnySigner {
     pub const fn as_ed25519(&self) -> Option<&Ed25519Signer> {
         match self {
             Self::Ed25519(s) => Some(s),
+            #[cfg(feature = "es256")]
             Self::Es256(_) => None,
         }
     }
 
     /// Get the es256 signer, if this is an es256 arm.
+    #[cfg(feature = "es256")]
     #[must_use]
     pub const fn as_es256(&self) -> Option<&Es256Signer> {
         match self {
@@ -312,34 +345,37 @@ impl AnySigner {
 
     /// The algorithm-agnostic verifier for this signer's public key.
     #[must_use]
-    pub fn verifier(&self) -> AnyVerifier {
+    pub fn verifier(&self) -> Verifier {
         match self {
-            Self::Ed25519(s) => AnyVerifier::Ed25519(s.ed25519_did().clone()),
-            Self::Es256(s) => AnyVerifier::Es256(s.es256_did().clone()),
+            Self::Ed25519(s) => Verifier::Ed25519(s.ed25519_did().clone()),
+            #[cfg(feature = "es256")]
+            Self::Es256(s) => Verifier::Es256(s.es256_did().clone()),
         }
     }
 }
 
-impl Principal for AnySigner {
+impl Principal for Signer {
     fn did(&self) -> Did {
         match self {
             Self::Ed25519(s) => s.did(),
+            #[cfg(feature = "es256")]
             Self::Es256(s) => s.did(),
         }
     }
 }
 
-impl Signer<AnySignature> for AnySigner {
-    async fn sign(&self, msg: &[u8]) -> Result<AnySignature, signature::Error> {
+impl VarsigSigner<Signature> for Signer {
+    async fn sign(&self, msg: &[u8]) -> Result<Signature, signature::Error> {
         match self {
-            Self::Ed25519(s) => Ok(AnySignature::from(Signer::sign(s, msg).await?)),
-            Self::Es256(s) => Ok(AnySignature::from(Signer::sign(s, msg).await?)),
+            Self::Ed25519(s) => Ok(Signature::from(VarsigSigner::sign(s, msg).await?)),
+            #[cfg(feature = "es256")]
+            Self::Es256(s) => Ok(Signature::from(VarsigSigner::sign(s, msg).await?)),
         }
     }
 }
 
-impl Issuer for AnySigner {
-    type Signature = AnySignature;
+impl Issuer for Signer {
+    type Signature = Signature;
 }
 
 #[cfg(test)]
@@ -347,45 +383,50 @@ mod tests {
     use super::*;
 
     #[dialog_common::test]
-    async fn any_ed25519_sign_verify() {
-        let signer = AnySigner::from(Ed25519Signer::generate().await.unwrap());
+    async fn ed25519_sign_verify() {
+        let signer = Signer::from(Ed25519Signer::generate().await.unwrap());
         let verifier = signer.verifier();
         let msg = b"agnostic";
-        let sig = Signer::sign(&signer, msg).await.unwrap();
-        assert_eq!(sig.algorithm(), Algorithm::Ed25519);
+        let sig = VarsigSigner::sign(&signer, msg).await.unwrap();
+        assert_eq!(sig.algorithm(), AlgorithmTag::Ed25519);
         verifier.verify(msg, &sig).await.unwrap();
     }
 
+    #[cfg(feature = "es256")]
     #[dialog_common::test]
-    async fn any_es256_sign_verify() {
-        let signer = AnySigner::from(Es256Signer::generate().await.unwrap());
+    async fn es256_sign_verify() {
+        let signer = Signer::from(Es256Signer::generate().await.unwrap());
         let verifier = signer.verifier();
         let msg = b"agnostic";
-        let sig = Signer::sign(&signer, msg).await.unwrap();
-        assert_eq!(sig.algorithm(), Algorithm::Es256);
+        let sig = VarsigSigner::sign(&signer, msg).await.unwrap();
+        assert_eq!(sig.algorithm(), AlgorithmTag::Es256);
         verifier.verify(msg, &sig).await.unwrap();
     }
 
+    #[cfg(feature = "es256")]
     #[dialog_common::test]
-    async fn any_cross_algorithm_rejected() {
+    async fn cross_algorithm_rejected() {
         // A signature from an ed25519 signer must not verify against an es256
         // verifier, even though both signature bodies are 64 bytes.
-        let ed = AnySigner::from(Ed25519Signer::generate().await.unwrap());
-        let es_verifier = AnySigner::from(Es256Signer::generate().await.unwrap()).verifier();
+        let ed = Signer::from(Ed25519Signer::generate().await.unwrap());
+        let es_verifier = Signer::from(Es256Signer::generate().await.unwrap()).verifier();
         let msg = b"agnostic";
-        let sig = Signer::sign(&ed, msg).await.unwrap();
+        let sig = VarsigSigner::sign(&ed, msg).await.unwrap();
         assert!(es_verifier.verify(msg, &sig).await.is_err());
     }
 
     #[dialog_common::test]
-    async fn any_verifier_did_key_roundtrip() {
-        for signer in [
-            AnySigner::from(Ed25519Signer::generate().await.unwrap()),
-            AnySigner::from(Es256Signer::generate().await.unwrap()),
-        ] {
+    async fn verifier_did_key_roundtrip() {
+        let signers = {
+            let mut v = vec![Signer::from(Ed25519Signer::generate().await.unwrap())];
+            #[cfg(feature = "es256")]
+            v.push(Signer::from(Es256Signer::generate().await.unwrap()));
+            v
+        };
+        for signer in signers {
             let verifier = signer.verifier();
             let did = verifier.did();
-            let parsed = AnyVerifier::from_did_key(did.as_str()).unwrap();
+            let parsed = Verifier::from_did_key(did.as_str()).unwrap();
             assert_eq!(parsed.did(), did);
             assert_eq!(parsed.algorithm(), verifier.algorithm());
         }

--- a/rust/dialog-credentials/src/signature.rs
+++ b/rust/dialog-credentials/src/signature.rs
@@ -24,174 +24,17 @@
 
 use dialog_capability::Issuer;
 use dialog_varsig::{
-    Did, Principal, SignatureAlgorithm, Signer as VarsigSigner, Verifier as VarsigVerifier,
-    eddsa::Ed25519, eddsa::Ed25519Signature, signature::Signature as VarsigSignature,
+    Did, Principal, Signer as VarsigSigner, Verifier as VarsigVerifier, eddsa::Ed25519Signature,
 };
-use signature::SignatureEncoding;
+
+pub use dialog_varsig::{AlgorithmTag, AnyAlgorithm as Algorithm, AnySignature as Signature};
 
 use crate::{Ed25519Signer, Ed25519Verifier};
 
 #[cfg(feature = "es256")]
 use crate::{Es256Signer, Es256Verifier};
 #[cfg(feature = "es256")]
-use dialog_varsig::ecdsa::{Es256, Es256Signature};
-
-/// The algorithm tag carried by [`Signature`] and [`Algorithm`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum AlgorithmTag {
-    /// Ed25519 (`EdDSA` over Edwards25519).
-    Ed25519,
-    /// ES256 (ECDSA over P-256).
-    #[cfg(feature = "es256")]
-    Es256,
-}
-
-/// Algorithm-agnostic [`SignatureAlgorithm`].
-///
-/// Wraps the concrete varsig algorithm descriptors. `Default` resolves to
-/// Ed25519 to satisfy the trait bound; the meaningful tag always travels with a
-/// [`Signature`] value, so the default is never used to interpret bytes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Algorithm(pub AlgorithmTag);
-
-impl Default for Algorithm {
-    fn default() -> Self {
-        Algorithm(AlgorithmTag::Ed25519)
-    }
-}
-
-impl SignatureAlgorithm for Algorithm {
-    fn prefix(&self) -> u64 {
-        match self.0 {
-            AlgorithmTag::Ed25519 => Ed25519::default().prefix(),
-            #[cfg(feature = "es256")]
-            AlgorithmTag::Es256 => Es256::default().prefix(),
-        }
-    }
-
-    fn config_tags(&self) -> Vec<u64> {
-        match self.0 {
-            AlgorithmTag::Ed25519 => Ed25519::default().config_tags(),
-            #[cfg(feature = "es256")]
-            AlgorithmTag::Es256 => Es256::default().config_tags(),
-        }
-    }
-
-    fn try_from_tags(bytes: &[u64]) -> Option<(Self, &[u64])> {
-        if let Some((_, rest)) = Ed25519::try_from_tags(bytes) {
-            return Some((Algorithm(AlgorithmTag::Ed25519), rest));
-        }
-        #[cfg(feature = "es256")]
-        if let Some((_, rest)) = Es256::try_from_tags(bytes) {
-            return Some((Algorithm(AlgorithmTag::Es256), rest));
-        }
-        None
-    }
-}
-
-/// Algorithm-agnostic signature: an algorithm tag plus the raw signature bytes.
-///
-/// Both supported algorithms use a 64-byte fixed-width signature, so the bytes
-/// are stored inline. The tag lets [`Verifier`] reject a signature produced by a
-/// different algorithm than it holds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Signature {
-    algorithm: AlgorithmTag,
-    bytes: [u8; 64],
-}
-
-impl Signature {
-    /// The algorithm that produced this signature.
-    #[must_use]
-    pub const fn algorithm(&self) -> AlgorithmTag {
-        self.algorithm
-    }
-
-    /// The raw 64-byte signature.
-    #[must_use]
-    pub const fn to_bytes(&self) -> [u8; 64] {
-        self.bytes
-    }
-
-    /// Reconstruct a signature from the algorithm named by a varsig header and
-    /// the raw signature body.
-    ///
-    /// The header is the single source of truth for the algorithm; the 64-byte
-    /// body alone cannot distinguish algorithms that share a signature width.
-    /// This refuses (rather than defaulting) when the header names an algorithm
-    /// this build does not support, or when the body is not 64 bytes.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `bytes` is not exactly 64 bytes.
-    pub fn from_algorithm_and_bytes(
-        algorithm: &Algorithm,
-        bytes: &[u8],
-    ) -> Result<Self, signature::Error> {
-        let bytes: [u8; 64] = bytes.try_into().map_err(|_| signature::Error::new())?;
-        Ok(Self {
-            algorithm: algorithm.0,
-            bytes,
-        })
-    }
-}
-
-impl From<Ed25519Signature> for Signature {
-    fn from(sig: Ed25519Signature) -> Self {
-        Self {
-            algorithm: AlgorithmTag::Ed25519,
-            bytes: sig.to_bytes(),
-        }
-    }
-}
-
-#[cfg(feature = "es256")]
-impl From<Es256Signature> for Signature {
-    fn from(sig: Es256Signature) -> Self {
-        Self {
-            algorithm: AlgorithmTag::Es256,
-            bytes: sig.to_bytes(),
-        }
-    }
-}
-
-/// [`Signature`] encodes as its raw 64-byte body. The algorithm tag is carried
-/// out of band (by the verifier's arm), matching how a varsig header already
-/// names the algorithm separately from the signature body.
-impl SignatureEncoding for Signature {
-    type Repr = [u8; 64];
-}
-
-impl From<Signature> for [u8; 64] {
-    fn from(sig: Signature) -> Self {
-        sig.bytes
-    }
-}
-
-impl TryFrom<&[u8]> for Signature {
-    type Error = signature::Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let bytes: [u8; 64] = bytes.try_into().map_err(|_| signature::Error::new())?;
-        // With no header, default to Ed25519; callers that know the algorithm
-        // construct via the typed `From` impls instead.
-        Ok(Self {
-            algorithm: AlgorithmTag::Ed25519,
-            bytes,
-        })
-    }
-}
-
-impl VarsigSignature for Signature {
-    type Algorithm = Algorithm;
-
-    fn from_algorithm_bytes(
-        algorithm: &Self::Algorithm,
-        bytes: &[u8],
-    ) -> Result<Self, signature::Error> {
-        Self::from_algorithm_and_bytes(algorithm, bytes)
-    }
-}
+use dialog_varsig::ecdsa::Es256Signature;
 
 /// Algorithm-agnostic verifier.
 #[derive(Debug, Clone, PartialEq)]
@@ -419,45 +262,6 @@ mod tests {
         let sig = VarsigSigner::sign(&signer, msg).await.unwrap();
         assert_eq!(sig.algorithm(), AlgorithmTag::Ed25519);
         verifier.verify(msg, &sig).await.unwrap();
-    }
-
-    #[dialog_common::test]
-    fn from_algorithm_bytes_takes_tag_from_header_not_bytes() {
-        // The 64-byte body cannot name its algorithm. Reconstruction must take
-        // the tag from the (header-provided) algorithm, never guess from bytes.
-        let bytes = [7u8; 64];
-
-        let ed = <Signature as VarsigSignature>::from_algorithm_bytes(
-            &Algorithm(AlgorithmTag::Ed25519),
-            &bytes,
-        )
-        .unwrap();
-        assert_eq!(ed.algorithm(), AlgorithmTag::Ed25519);
-
-        #[cfg(feature = "es256")]
-        {
-            let es = <Signature as VarsigSignature>::from_algorithm_bytes(
-                &Algorithm(AlgorithmTag::Es256),
-                &bytes,
-            )
-            .unwrap();
-            assert_eq!(es.algorithm(), AlgorithmTag::Es256);
-            // Same bytes, different header algorithm, different tag: the header
-            // is authoritative.
-            assert_ne!(ed.algorithm(), es.algorithm());
-        }
-    }
-
-    #[dialog_common::test]
-    fn from_algorithm_bytes_refuses_wrong_length() {
-        let short = [0u8; 32];
-        assert!(
-            <Signature as VarsigSignature>::from_algorithm_bytes(
-                &Algorithm(AlgorithmTag::Ed25519),
-                &short,
-            )
-            .is_err()
-        );
     }
 
     #[cfg(feature = "es256")]

--- a/rust/dialog-credentials/src/signature.rs
+++ b/rust/dialog-credentials/src/signature.rs
@@ -143,12 +143,16 @@ impl VarsigVerifier<Signature> for Verifier {
         }
         match self {
             Self::Ed25519(v) => {
-                let sig = Ed25519Signature::from_bytes(signature.to_bytes());
+                // The body is variable-length; reconstruct the concrete
+                // fixed-width signature, refusing a body of the wrong length.
+                let sig = Ed25519Signature::try_from(signature.to_bytes())
+                    .map_err(|_| signature::Error::new())?;
                 v.verify(msg, &sig).await
             }
             #[cfg(feature = "es256")]
             Self::Es256(v) => {
-                let sig = Es256Signature::from_bytes(signature.to_bytes());
+                let sig = Es256Signature::try_from(signature.to_bytes())
+                    .map_err(|_| signature::Error::new())?;
                 v.verify(msg, &sig).await
             }
         }

--- a/rust/dialog-credentials/src/signature.rs
+++ b/rust/dialog-credentials/src/signature.rs
@@ -112,6 +112,28 @@ impl Signature {
     pub const fn to_bytes(&self) -> [u8; 64] {
         self.bytes
     }
+
+    /// Reconstruct a signature from the algorithm named by a varsig header and
+    /// the raw signature body.
+    ///
+    /// The header is the single source of truth for the algorithm; the 64-byte
+    /// body alone cannot distinguish algorithms that share a signature width.
+    /// This refuses (rather than defaulting) when the header names an algorithm
+    /// this build does not support, or when the body is not 64 bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is not exactly 64 bytes.
+    pub fn from_algorithm_and_bytes(
+        algorithm: &Algorithm,
+        bytes: &[u8],
+    ) -> Result<Self, signature::Error> {
+        let bytes: [u8; 64] = bytes.try_into().map_err(|_| signature::Error::new())?;
+        Ok(Self {
+            algorithm: algorithm.0,
+            bytes,
+        })
+    }
 }
 
 impl From<Ed25519Signature> for Signature {
@@ -162,6 +184,13 @@ impl TryFrom<&[u8]> for Signature {
 
 impl VarsigSignature for Signature {
     type Algorithm = Algorithm;
+
+    fn from_algorithm_bytes(
+        algorithm: &Self::Algorithm,
+        bytes: &[u8],
+    ) -> Result<Self, signature::Error> {
+        Self::from_algorithm_and_bytes(algorithm, bytes)
+    }
 }
 
 /// Algorithm-agnostic verifier.
@@ -390,6 +419,45 @@ mod tests {
         let sig = VarsigSigner::sign(&signer, msg).await.unwrap();
         assert_eq!(sig.algorithm(), AlgorithmTag::Ed25519);
         verifier.verify(msg, &sig).await.unwrap();
+    }
+
+    #[dialog_common::test]
+    fn from_algorithm_bytes_takes_tag_from_header_not_bytes() {
+        // The 64-byte body cannot name its algorithm. Reconstruction must take
+        // the tag from the (header-provided) algorithm, never guess from bytes.
+        let bytes = [7u8; 64];
+
+        let ed = <Signature as VarsigSignature>::from_algorithm_bytes(
+            &Algorithm(AlgorithmTag::Ed25519),
+            &bytes,
+        )
+        .unwrap();
+        assert_eq!(ed.algorithm(), AlgorithmTag::Ed25519);
+
+        #[cfg(feature = "es256")]
+        {
+            let es = <Signature as VarsigSignature>::from_algorithm_bytes(
+                &Algorithm(AlgorithmTag::Es256),
+                &bytes,
+            )
+            .unwrap();
+            assert_eq!(es.algorithm(), AlgorithmTag::Es256);
+            // Same bytes, different header algorithm, different tag: the header
+            // is authoritative.
+            assert_ne!(ed.algorithm(), es.algorithm());
+        }
+    }
+
+    #[dialog_common::test]
+    fn from_algorithm_bytes_refuses_wrong_length() {
+        let short = [0u8; 32];
+        assert!(
+            <Signature as VarsigSignature>::from_algorithm_bytes(
+                &Algorithm(AlgorithmTag::Ed25519),
+                &short,
+            )
+            .is_err()
+        );
     }
 
     #[cfg(feature = "es256")]

--- a/rust/dialog-identity/src/authority.rs
+++ b/rust/dialog-identity/src/authority.rs
@@ -4,9 +4,9 @@
 //! the provider traits needed by `Operator` for identity effects.
 
 use dialog_capability::{Capability, Provider, Subject};
-use dialog_credentials::Ed25519Signer;
+use dialog_credentials::Signer;
 use dialog_effects::authority::{self, AuthorityError, Operator as AuthOperator};
-use dialog_varsig::{Did, Principal};
+use dialog_varsig::{Did, Principal, Signer as _};
 
 // Authority always answers for the current session, regardless of which
 // repository we're operating on. We use the profile DID as the subject
@@ -20,18 +20,22 @@ use dialog_varsig::{Did, Principal};
 #[derive(Debug, Clone)]
 pub struct Authority {
     name: String,
-    profile: Ed25519Signer,
-    operator: Ed25519Signer,
+    profile: Signer,
+    operator: Signer,
     account: Option<Did>,
 }
 
 impl Authority {
     /// Create an opened profile from existing signers.
-    pub fn new(name: impl Into<String>, profile: Ed25519Signer, operator: Ed25519Signer) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        profile: impl Into<Signer>,
+        operator: impl Into<Signer>,
+    ) -> Self {
         Self {
             name: name.into(),
-            profile,
-            operator,
+            profile: profile.into(),
+            operator: operator.into(),
             account: None,
         }
     }
@@ -63,12 +67,12 @@ impl Authority {
     }
 
     /// Get a reference to the profile signer.
-    pub fn profile_signer(&self) -> &Ed25519Signer {
+    pub fn profile_signer(&self) -> &Signer {
         &self.profile
     }
 
     /// Get a reference to the operator signer.
-    pub fn operator_signer(&self) -> &Ed25519Signer {
+    pub fn operator_signer(&self) -> &Signer {
         &self.operator
     }
 
@@ -108,11 +112,10 @@ impl Provider<authority::Attest> for Authority {
     async fn execute(&self, input: authority::Attest) -> Result<Vec<u8>, AuthorityError> {
         // Sign with the operator key: the session identity `Identify`
         // reports as the issuer, so verifiers can resolve the operator's
-        // did:key to check the signature.
+        // did to check the signature.
         let signature = self
             .operator
-            .signing_key()
-            .sign_bytes(&input.payload)
+            .sign(&input.payload)
             .await
             .map_err(|error| AuthorityError::Attestation(format!("{error}")))?;
         Ok(signature.to_bytes().to_vec())
@@ -124,6 +127,8 @@ impl serde::Serialize for Authority {
     where
         S: serde::Serializer,
     {
-        self.operator.serialize(serializer)
+        // Serialize as the operator DID, mirroring the operator signer's own
+        // did:key serialization.
+        self.operator_did().serialize(serializer)
     }
 }

--- a/rust/dialog-identity/src/profile/access.rs
+++ b/rust/dialog-identity/src/profile/access.rs
@@ -152,28 +152,19 @@ where
     where
         Env: Provider<access::Prove<Ucan>> + ConditionalSync,
     {
-        let signer = ed25519_signer(self.claim.by)?;
+        let signer = signer_of(self.claim.by);
         let proof_chain = self.claim.perform(env).await?;
         let authorization = proof_chain.claim(signer)?;
         authorization.invoke().await
     }
 }
 
-/// Extract the ed25519 signer from a credential for UCAN signing.
+/// The algorithm-agnostic signer for UCAN signing.
 ///
-/// The UCAN authorization chain currently signs with a concrete ed25519 key; a
-/// profile backed by another algorithm is rejected here rather than silently
-/// mis-signing.
-fn ed25519_signer(
-    credential: &SignerCredential,
-) -> Result<dialog_credentials::Ed25519Signer, AuthorizeError> {
-    credential
-        .signer()
-        .as_ed25519()
-        .cloned()
-        .ok_or_else(|| AuthorizeError::Malformed {
-            detail: "authorization requires an ed25519 profile signer".into(),
-        })
+/// The UCAN authorization chain signs with the agnostic
+/// [`Signer`](dialog_credentials::Signer), so any supported algorithm works.
+fn signer_of(credential: &SignerCredential) -> dialog_credentials::Signer {
+    credential.signer().clone()
 }
 
 /// A delegation request combining a claim with a target audience.
@@ -194,7 +185,7 @@ where
     where
         Env: Provider<access::Prove<Ucan>> + ConditionalSync,
     {
-        let signer = ed25519_signer(self.claim.by)?;
+        let signer = signer_of(self.claim.by);
         let duration = self.claim.duration();
         let proof_chain = self.claim.perform(env).await?;
         let mut authorization = proof_chain.claim(signer)?;

--- a/rust/dialog-identity/src/profile/access.rs
+++ b/rust/dialog-identity/src/profile/access.rs
@@ -152,11 +152,28 @@ where
     where
         Env: Provider<access::Prove<Ucan>> + ConditionalSync,
     {
-        let signer = self.claim.by.signer().clone();
+        let signer = ed25519_signer(self.claim.by)?;
         let proof_chain = self.claim.perform(env).await?;
         let authorization = proof_chain.claim(signer)?;
         authorization.invoke().await
     }
+}
+
+/// Extract the ed25519 signer from a credential for UCAN signing.
+///
+/// The UCAN authorization chain currently signs with a concrete ed25519 key; a
+/// profile backed by another algorithm is rejected here rather than silently
+/// mis-signing.
+fn ed25519_signer(
+    credential: &SignerCredential,
+) -> Result<dialog_credentials::Ed25519Signer, AuthorizeError> {
+    credential
+        .signer()
+        .as_ed25519()
+        .cloned()
+        .ok_or_else(|| AuthorizeError::Malformed {
+            detail: "authorization requires an ed25519 profile signer".into(),
+        })
 }
 
 /// A delegation request combining a claim with a target audience.
@@ -177,7 +194,7 @@ where
     where
         Env: Provider<access::Prove<Ucan>> + ConditionalSync,
     {
-        let signer = self.claim.by.signer().clone();
+        let signer = ed25519_signer(self.claim.by)?;
         let duration = self.claim.duration();
         let proof_chain = self.claim.perform(env).await?;
         let mut authorization = proof_chain.claim(signer)?;

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -489,7 +489,15 @@ where
             .perform(self)
             .await?;
 
-        proof.claim(self.authority.operator_signer().clone())
+        let operator_signer = self
+            .authority
+            .operator_signer()
+            .as_ed25519()
+            .cloned()
+            .ok_or_else(|| AuthorizeError::Malformed {
+                detail: "authorization requires an ed25519 operator signer".into(),
+            })?;
+        proof.claim(operator_signer)
     }
 }
 

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -489,14 +489,7 @@ where
             .perform(self)
             .await?;
 
-        let operator_signer = self
-            .authority
-            .operator_signer()
-            .as_ed25519()
-            .cloned()
-            .ok_or_else(|| AuthorizeError::Malformed {
-                detail: "authorization requires an ed25519 operator signer".into(),
-            })?;
+        let operator_signer = self.authority.operator_signer().clone();
         proof.claim(operator_signer)
     }
 }
@@ -553,7 +546,7 @@ mod tests {
         expiration: Option<Timestamp>,
     ) -> UcanDelegation {
         let mut builder = DelegationBuilder::new()
-            .issuer(space.clone())
+            .issuer(dialog_credentials::Signer::from(space.clone()))
             .audience(holder)
             .subject(UcanSubject::Specific(space.did()))
             .command(vec!["storage".to_string()]);
@@ -716,7 +709,7 @@ mod tests {
         let holder = Ed25519Signer::generate().await?;
 
         let constrained = DelegationBuilder::new()
-            .issuer(space.clone())
+            .issuer(dialog_credentials::Signer::from(space.clone()))
             .audience(&holder)
             .subject(UcanSubject::Specific(space.did()))
             .command(vec!["storage".to_string()])
@@ -875,7 +868,7 @@ mod tests {
 
         // space -> profile, retained (the explicit, synced act).
         let delegation = DelegationBuilder::new()
-            .issuer(space.clone())
+            .issuer(dialog_credentials::Signer::from(space.clone()))
             .audience(&profile.did())
             .subject(UcanSubject::Specific(space.did()))
             .command(vec![])

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -104,15 +104,12 @@ impl OperatorBuilder {
             + ConditionalSync
             + 'static,
     {
-        let operator_signer = derive_operator(&self.credential, &self.context).await?;
-        let credentials = Authority::new(
-            "operator",
-            Ed25519Signer::from(self.credential.clone()),
-            operator_signer.clone(),
-        );
+        let profile_signer = ed25519_signer(&self.credential)?;
+        let operator_signer = derive_operator(&profile_signer, &self.context).await?;
+        let credentials =
+            Authority::new("operator", profile_signer.clone(), operator_signer.clone());
 
         // Mint the session: one in-memory grant per allowed scope.
-        let profile_signer = Ed25519Signer::from(self.credential.clone());
         let mut session = Vec::with_capacity(self.allowed.len());
         for scope in &self.allowed {
             let delegation = DelegationBuilder::new()
@@ -200,11 +197,24 @@ impl OperatorBuilder {
     }
 }
 
+/// Extract the ed25519 signer from a credential.
+///
+/// Operator derivation currently assumes an ed25519 profile key (the blake3
+/// derivation and `did:key` operator identity are ed25519-specific). A profile
+/// backed by another algorithm is rejected here rather than deriving a wrong
+/// operator.
+fn ed25519_signer(credential: &SignerCredential) -> Result<Ed25519Signer, OperatorError> {
+    credential
+        .signer()
+        .as_ed25519()
+        .cloned()
+        .ok_or_else(|| OperatorError::Key("operator derivation requires an ed25519 profile".into()))
+}
+
 async fn derive_operator(
-    credential: &SignerCredential,
+    signer: &Ed25519Signer,
     context: &[u8],
 ) -> Result<Ed25519Signer, OperatorError> {
-    let signer = Ed25519Signer::from(credential.clone());
     let export = signer
         .export()
         .await

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -113,7 +113,7 @@ impl OperatorBuilder {
         let mut session = Vec::with_capacity(self.allowed.len());
         for scope in &self.allowed {
             let delegation = DelegationBuilder::new()
-                .issuer(profile_signer.clone())
+                .issuer(dialog_credentials::Signer::from(profile_signer.clone()))
                 .audience(&operator_signer)
                 .subject(scope.subject.clone())
                 .command(scope.command.segments().clone())

--- a/rust/dialog-operator/src/operator/test.rs
+++ b/rust/dialog-operator/src/operator/test.rs
@@ -274,7 +274,6 @@ mod tests {
         use crate::Operator;
         use dialog_capability::Subject;
         use dialog_capability::access::{Authorization as _, Proof as _};
-        use dialog_credentials::Ed25519Signer;
         use dialog_effects::archive::prelude::{ArchiveExt, ArchiveSubjectExt};
         use dialog_identity::Profile;
         use dialog_ucan_core::time::Timestamp;
@@ -515,7 +514,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let signer = Ed25519Signer::from(profile.signer().clone());
+            let signer = profile.signer().signer().as_ed25519().unwrap().clone();
             let authorization = proof.claim(signer).unwrap();
 
             // Try to set expiration beyond proof bounds
@@ -555,7 +554,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let signer = Ed25519Signer::from(profile.signer().clone());
+            let signer = profile.signer().signer().as_ed25519().unwrap().clone();
             let authorization = proof.claim(signer).unwrap();
 
             // Try to set not_before earlier than proof bounds
@@ -596,7 +595,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let signer = Ed25519Signer::from(profile.signer().clone());
+            let signer = profile.signer().signer().as_ed25519().unwrap().clone();
             let authorization = proof.claim(signer).unwrap();
 
             // Narrow the window - should succeed

--- a/rust/dialog-operator/src/operator/test.rs
+++ b/rust/dialog-operator/src/operator/test.rs
@@ -514,7 +514,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let signer = profile.signer().signer().as_ed25519().unwrap().clone();
+            let signer = profile.signer().signer().clone();
             let authorization = proof.claim(signer).unwrap();
 
             // Try to set expiration beyond proof bounds
@@ -554,7 +554,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let signer = profile.signer().signer().as_ed25519().unwrap().clone();
+            let signer = profile.signer().signer().clone();
             let authorization = proof.claim(signer).unwrap();
 
             // Try to set not_before earlier than proof bounds
@@ -595,7 +595,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let signer = profile.signer().signer().as_ed25519().unwrap().clone();
+            let signer = profile.signer().signer().clone();
             let authorization = proof.claim(signer).unwrap();
 
             // Narrow the window - should succeed

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -57,7 +57,7 @@ use dialog_ucan_core::ContainerError;
 use std::collections::BTreeMap;
 
 use dialog_capability::{Capability, Constraint, Did, Policy};
-use dialog_credentials::Ed25519KeyResolver;
+use dialog_credentials::DidKeyResolver;
 use dialog_effects::{archive, blob, memory};
 use dialog_remote_s3::{Address, Permit, S3Credential, S3Error};
 use dialog_ucan_core::InvocationChain;
@@ -295,7 +295,7 @@ impl UcanAuthorizer {
                 detail: e.to_string(),
             })
         })?;
-        chain.verify(&Ed25519KeyResolver).await.map_err(|e| {
+        chain.verify(&DidKeyResolver).await.map_err(|e| {
             // Two different failures arrive here: their material not
             // verifying, and our own setup being unable to check it.
             // Only the first is a statement about their request, so only

--- a/rust/dialog-remote-ucan-s3/src/provider.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider.rs
@@ -112,7 +112,7 @@ mod tests {
     async fn self_authorization(signer: &Ed25519Signer) -> UcanAuthorization {
         let did = signer.did();
         let invocation = InvocationBuilder::new()
-            .issuer(signer.clone())
+            .issuer(dialog_credentials::Signer::from(signer.clone()))
             .audience(&did)
             .subject(&did)
             .command(vec!["archive".to_string(), "get".to_string()])

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -310,7 +310,7 @@ mod tests {
             .expect("operator key");
         let command = vec!["memory".to_string(), "resolve".to_string()];
         let delegation = DelegationBuilder::new()
-            .issuer(subject.clone())
+            .issuer(dialog_credentials::Signer::from(subject.clone()))
             .audience(&operator)
             .subject(DelegatedSubject::Specific(subject.did()))
             .command(command.clone())
@@ -319,7 +319,7 @@ mod tests {
             .expect("delegation");
         let delegation_cid = delegation.to_cid();
         let invocation = InvocationBuilder::new()
-            .issuer(operator)
+            .issuer(dialog_credentials::Signer::from(operator))
             .audience(&subject.did())
             .subject(&subject.did())
             .command(command)

--- a/rust/dialog-repository/benches/delegation_prove.rs
+++ b/rust/dialog-repository/benches/delegation_prove.rs
@@ -38,7 +38,7 @@ const SIZES: &[usize] = &[32, 512, 6144];
 
 async fn delegate(issuer: &Ed25519Signer, audience: &Did, subject: UcanSubject) -> UcanDelegation {
     let delegation = DelegationBuilder::new()
-        .issuer(issuer.clone())
+        .issuer(dialog_credentials::Signer::from(issuer.clone()))
         .audience(audience)
         .subject(subject)
         .command(vec!["storage".to_string()])

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -154,6 +154,12 @@ impl From<Ed25519Signer> for Repository<SignerCredential> {
     }
 }
 
+impl From<dialog_credentials::Signer> for Repository<SignerCredential> {
+    fn from(signer: dialog_credentials::Signer) -> Self {
+        SignerCredential::from(signer).into()
+    }
+}
+
 impl From<Profile> for Repository<SignerCredential> {
     fn from(profile: Profile) -> Self {
         Self::new(profile.signer().clone())

--- a/rust/dialog-repository/src/repository/access.rs
+++ b/rust/dialog-repository/src/repository/access.rs
@@ -46,7 +46,6 @@ use dialog_capability::access::{
 };
 use dialog_capability::{Command, Fork, Provider, Subject};
 use dialog_common::{ConditionalSend, ConditionalSync};
-use dialog_credentials::Ed25519Signer;
 use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify};
 use dialog_effects::blob::Write as BlobWrite;
@@ -77,14 +76,14 @@ pub trait MigrateAccess {
 impl MigrateAccess for Access<'_> {
     fn migrate(&self) -> MigrateCertificates {
         MigrateCertificates {
-            credential: Ed25519Signer::from(self.signer().clone()),
+            credential: self.signer().signer().clone(),
         }
     }
 }
 
 /// The migration command. Created by [`MigrateAccess::migrate`].
 pub struct MigrateCertificates {
-    credential: Ed25519Signer,
+    credential: dialog_credentials::Signer,
 }
 
 /// The environment migration commits with: the profile identifies and
@@ -290,6 +289,7 @@ mod tests {
     use anyhow::Result;
     use dialog_artifacts::{ArtifactSelector, Value};
     use dialog_capability::access::Retain;
+    use dialog_credentials::Ed25519Signer;
     use dialog_identity::Profile;
     use dialog_operator::helpers::unique_name;
     use dialog_storage::provider::storage::{Storage, VolatileSpace};
@@ -344,7 +344,7 @@ mod tests {
             .await?;
         let space = signer().await;
         let other_space = signer().await;
-        let profile_signer = Ed25519Signer::from(profile.signer().clone());
+        let profile_signer = profile.signer().signer().as_ed25519().unwrap().clone();
 
         // Legacy store: two interchangeable space->profile grants (same
         // payload, different nonce), one distinct grant, and one
@@ -502,7 +502,7 @@ mod tests {
             .perform(&storage)
             .await?;
         let space = signer().await;
-        let profile_signer = Ed25519Signer::from(profile.signer().clone());
+        let profile_signer = profile.signer().signer().as_ed25519().unwrap().clone();
 
         // One migratable grant, one self-issued survivor.
         let seed = |issuer: Ed25519Signer, audience: dialog_capability::Did, subject| {
@@ -563,7 +563,7 @@ mod tests {
             .perform(&storage)
             .await?;
         let space = signer().await;
-        let profile_signer = Ed25519Signer::from(profile.signer().clone());
+        let profile_signer = profile.signer().signer().as_ed25519().unwrap().clone();
 
         let certificate = seed_legacy(
             &storage,

--- a/rust/dialog-repository/src/repository/access.rs
+++ b/rust/dialog-repository/src/repository/access.rs
@@ -310,7 +310,7 @@ mod tests {
         subject: UcanSubject,
     ) -> UcanCertificate {
         let delegation = DelegationBuilder::new()
-            .issuer(issuer.clone())
+            .issuer(dialog_credentials::Signer::from(issuer.clone()))
             .audience(&audience)
             .subject(subject)
             .command(vec!["storage".to_string()])
@@ -510,7 +510,7 @@ mod tests {
             let profile = &profile;
             async move {
                 let delegation = DelegationBuilder::new()
-                    .issuer(issuer)
+                    .issuer(dialog_credentials::Signer::from(issuer))
                     .audience(&audience)
                     .subject(subject)
                     .command(vec!["storage".to_string()])

--- a/rust/dialog-repository/src/repository/branch/delegation.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation.rs
@@ -401,7 +401,7 @@ mod tests {
         subject: UcanSubject,
     ) -> UcanDelegation {
         let delegation = DelegationBuilder::new()
-            .issuer(issuer.clone())
+            .issuer(dialog_credentials::Signer::from(issuer.clone()))
             .audience(audience)
             .subject(subject)
             .command(vec!["storage".to_string()])

--- a/rust/dialog-repository/src/repository/branch/delegation/prove.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation/prove.rs
@@ -396,7 +396,7 @@ impl ProveDelegation<'_> {
         // a cheap check at admission.
         if let Err(error) = certificate
             .0
-            .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+            .verify_signature(&dialog_credentials::DidKeyResolver)
             .await
         {
             tracing::warn!(
@@ -1074,7 +1074,7 @@ mod tests {
             audience.did(),
             UcanSubject::Specific(subject.did()),
             Command(vec!["storage".to_string()]),
-            actual_signer,
+            &dialog_credentials::Signer::from(actual_signer.clone()),
         )
         .await
         .expect("forge a delegation");

--- a/rust/dialog-repository/src/repository/branch/delegation/prove.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation/prove.rs
@@ -539,7 +539,7 @@ mod tests {
         subject: UcanSubject,
     ) -> UcanDelegation {
         let delegation = DelegationBuilder::new()
-            .issuer(issuer.clone())
+            .issuer(dialog_credentials::Signer::from(issuer.clone()))
             .audience(audience)
             .subject(subject)
             .command(vec!["storage".to_string()])
@@ -692,7 +692,7 @@ mod tests {
             .as_secs();
         let past = Timestamp::try_from((now - 3600) as i128).unwrap();
         let delegation = DelegationBuilder::new()
-            .issuer(space.clone())
+            .issuer(dialog_credentials::Signer::from(space.clone()))
             .audience(&holder)
             .subject(UcanSubject::Specific(space.did()))
             .command(vec!["storage".to_string()])
@@ -932,7 +932,7 @@ mod tests {
         let holder = signer().await;
 
         let root = DelegationBuilder::new()
-            .issuer(space.clone())
+            .issuer(dialog_credentials::Signer::from(space.clone()))
             .audience(&mid)
             .subject(UcanSubject::Specific(space.did()))
             .command(vec!["storage".to_string()])
@@ -940,7 +940,7 @@ mod tests {
             .await
             .unwrap();
         let leaf = DelegationBuilder::new()
-            .issuer(mid.clone())
+            .issuer(dialog_credentials::Signer::from(mid.clone()))
             .audience(&holder)
             .subject(UcanSubject::Specific(space.did()))
             .command(vec!["storage".to_string()])

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -533,7 +533,7 @@ async fn it_replicates_retained_delegations(s3: S3Address) -> Result<()> {
     let space = Ed25519Signer::generate().await?;
     let holder = Ed25519Signer::generate().await?;
     let delegation = dialog_ucan_core::DelegationBuilder::new()
-        .issuer(space.clone())
+        .issuer(dialog_credentials::Signer::from(space.clone()))
         .audience(&holder)
         .subject(dialog_ucan_core::subject::Subject::Specific(
             dialog_varsig::Principal::did(&space),
@@ -1351,7 +1351,7 @@ async fn it_regains_access_by_pulling_the_account(ucan: UcanS3Address) -> Result
     // so a compromised device profile cannot cost the access.
     let space = Ed25519Signer::generate().await?;
     let space_grant = DelegationBuilder::new()
-        .issuer(space.clone())
+        .issuer(dialog_credentials::Signer::from(space.clone()))
         .audience(&account_signer)
         .subject(UcanSubject::Specific(space.did()))
         .command(vec!["storage".to_string()])
@@ -1409,7 +1409,7 @@ async fn it_regains_access_by_pulling_the_account(ucan: UcanS3Address) -> Result
         .await?;
 
     let login_grant = DelegationBuilder::new()
-        .issuer(account_signer.clone())
+        .issuer(dialog_credentials::Signer::from(account_signer.clone()))
         .audience(&device_profile.did())
         .subject(UcanSubject::Any)
         .command(vec![])
@@ -1527,7 +1527,7 @@ async fn it_downloads_the_account_branch_on_login(ucan: UcanS3Address) -> Result
         .await?;
     let space = Ed25519Signer::generate().await?;
     let space_grant = DelegationBuilder::new()
-        .issuer(space.clone())
+        .issuer(dialog_credentials::Signer::from(space.clone()))
         .audience(&account_signer)
         .subject(UcanSubject::Specific(space.did()))
         .command(vec!["storage".to_string()])
@@ -1581,7 +1581,7 @@ async fn it_downloads_the_account_branch_on_login(ucan: UcanS3Address) -> Result
         .build(device_storage.clone())
         .await?;
     let login_grant = DelegationBuilder::new()
-        .issuer(account_signer.clone())
+        .issuer(dialog_credentials::Signer::from(account_signer.clone()))
         .audience(&device_profile.did())
         .subject(UcanSubject::Any)
         .command(vec![])

--- a/rust/dialog-ucan-core/Cargo.toml
+++ b/rust/dialog-ucan-core/Cargo.toml
@@ -42,7 +42,7 @@ wasm-bindgen = { workspace = true }
 arbitrary = { workspace = true }
 base64 = { workspace = true }
 dialog-common = { workspace = true, features = ["helpers"] }
-dialog-credentials = { workspace = true }
+dialog-credentials = { workspace = true, features = ["ed25519", "es256"] }
 ipld-core = { workspace = true, features = ["arb"] }
 pretty_assertions = { workspace = true }
 quickcheck = { workspace = true }

--- a/rust/dialog-ucan-core/src/container/delegation.rs
+++ b/rust/dialog-ucan-core/src/container/delegation.rs
@@ -13,8 +13,8 @@ use super::{Container, ContainerError};
 use crate::Delegation;
 use crate::subject::Subject;
 use crate::time::Timestamp;
+use dialog_varsig::AnySignature;
 use dialog_varsig::Did;
-use dialog_varsig::eddsa::Ed25519Signature;
 use ipld_core::cid::Cid;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
@@ -32,7 +32,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct DelegationChain {
     /// The delegation proofs keyed by CID.
-    delegations: HashMap<Cid, Arc<Delegation<Ed25519Signature>>>,
+    delegations: HashMap<Cid, Arc<Delegation<AnySignature>>>,
     /// The CIDs of the delegation proofs in subject-first (root-to-leaf) order.
     /// This is guaranteed to be non-empty.
     proof_cids: Vec<Cid>,
@@ -53,7 +53,7 @@ impl DelegationChain {
     ///
     /// This is the primary constructor for creating a delegation chain from a single
     /// root delegation (typically subject -> operator).
-    pub fn new(delegation: Delegation<Ed25519Signature>) -> Self {
+    pub fn new(delegation: Delegation<AnySignature>) -> Self {
         let cid = delegation.to_cid();
         let mut delegations = HashMap::with_capacity(1);
         delegations.insert(cid, Arc::new(delegation));
@@ -81,7 +81,7 @@ impl DelegationChain {
 
         let mut delegations_vec = Vec::with_capacity(proof_bytes.len());
         for (i, bytes) in proof_bytes.iter().enumerate() {
-            let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
+            let delegation: Delegation<AnySignature> = serde_ipld_dagcbor::from_slice(bytes)
                 .map_err(|e| {
                     ContainerError::Invocation(format!("failed to decode delegation {}: {}", i, e))
                 })?;
@@ -104,7 +104,7 @@ impl DelegationChain {
     }
 
     /// Iterate the chain's delegations in root-to-leaf order.
-    pub fn proofs(&self) -> impl Iterator<Item = &Delegation<Ed25519Signature>> {
+    pub fn proofs(&self) -> impl Iterator<Item = &Delegation<AnySignature>> {
         self.proof_cids
             .iter()
             .map(|cid| self.proof_for_cid(cid).as_ref())
@@ -116,13 +116,13 @@ impl DelegationChain {
     /// For constructing a delegation lookup table — most commonly to
     /// hand to `InvocationChain::new`. Collect into a `HashMap` at
     /// the call site.
-    pub fn export(&self) -> impl Iterator<Item = (Cid, Arc<Delegation<Ed25519Signature>>)> + '_ {
+    pub fn export(&self) -> impl Iterator<Item = (Cid, Arc<Delegation<AnySignature>>)> + '_ {
         self.proof_cids
             .iter()
             .map(|cid| (*cid, self.proof_for_cid(cid).clone()))
     }
 
-    fn proof_for_cid(&self, cid: &Cid) -> &Arc<Delegation<Ed25519Signature>> {
+    fn proof_for_cid(&self, cid: &Cid) -> &Arc<Delegation<AnySignature>> {
         self.delegations
             .get(cid)
             .expect("proof_cids and delegations are kept in sync by construction")
@@ -201,7 +201,7 @@ impl DelegationChain {
     /// Push a delegation onto the chain (closer to invoker).
     ///
     /// Its issuer must match the current chain's audience.
-    pub fn push(&self, delegation: Delegation<Ed25519Signature>) -> Result<Self, ContainerError> {
+    pub fn push(&self, delegation: Delegation<AnySignature>) -> Result<Self, ContainerError> {
         let current_audience = self.audience();
         let new_issuer = delegation.issuer();
         if new_issuer != current_audience {
@@ -226,7 +226,7 @@ impl DelegationChain {
     }
 }
 
-impl TryFrom<Vec<Delegation<Ed25519Signature>>> for DelegationChain {
+impl TryFrom<Vec<Delegation<AnySignature>>> for DelegationChain {
     type Error = ContainerError;
 
     /// Create a delegation chain from a vector of delegations.
@@ -243,7 +243,7 @@ impl TryFrom<Vec<Delegation<Ed25519Signature>>> for DelegationChain {
     /// # Errors
     ///
     /// Returns an error if the vector is empty or if principal alignment fails.
-    fn try_from(delegations_vec: Vec<Delegation<Ed25519Signature>>) -> Result<Self, Self::Error> {
+    fn try_from(delegations_vec: Vec<Delegation<AnySignature>>) -> Result<Self, Self::Error> {
         if delegations_vec.is_empty() {
             return Err(ContainerError::Configuration(
                 "DelegationChain requires at least one delegation".to_string(),
@@ -282,8 +282,8 @@ impl TryFrom<Vec<Delegation<Ed25519Signature>>> for DelegationChain {
     }
 }
 
-impl From<Delegation<Ed25519Signature>> for DelegationChain {
-    fn from(delegation: Delegation<Ed25519Signature>) -> Self {
+impl From<Delegation<AnySignature>> for DelegationChain {
+    fn from(delegation: Delegation<AnySignature>) -> Self {
         Self::new(delegation)
     }
 }
@@ -306,10 +306,10 @@ impl TryFrom<Container> for DelegationChain {
         let token_bytes = container.into_tokens();
 
         // Deserialize delegations and verify principal alignment
-        let mut delegations_vec: Vec<Delegation<Ed25519Signature>> =
+        let mut delegations_vec: Vec<Delegation<AnySignature>> =
             Vec::with_capacity(token_bytes.len());
         for (i, bytes) in token_bytes.iter().enumerate() {
-            let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
+            let delegation: Delegation<AnySignature> = serde_ipld_dagcbor::from_slice(bytes)
                 .map_err(|e| {
                     ContainerError::Invocation(format!("failed to decode delegation {}: {}", i, e))
                 })?;

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -21,10 +21,10 @@ use crate::{
     Delegation, Invocation,
     invocation::{InvocationCheckError, StoredCheckError},
 };
+use dialog_varsig::AnySignature;
 use dialog_varsig::Did;
 use dialog_varsig::Resolver;
 use dialog_varsig::Signature;
-use dialog_varsig::eddsa::Ed25519Signature;
 use ipld_core::cid::Cid;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl TryFrom<&[u8]> for InvocationChain<Ed25519Signature> {
+impl TryFrom<&[u8]> for InvocationChain<AnySignature> {
     type Error = ContainerError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -156,7 +156,7 @@ impl TryFrom<&[u8]> for InvocationChain<Ed25519Signature> {
     }
 }
 
-impl TryFrom<Container> for InvocationChain<Ed25519Signature> {
+impl TryFrom<Container> for InvocationChain<AnySignature> {
     type Error = ContainerError;
 
     /// Convert a container to an invocation chain.
@@ -172,16 +172,16 @@ impl TryFrom<Container> for InvocationChain<Ed25519Signature> {
         }
 
         // First token is the invocation
-        let invocation: Invocation<Ed25519Signature> =
-            serde_ipld_dagcbor::from_slice(&token_bytes[0]).map_err(|e| {
+        let invocation: Invocation<AnySignature> = serde_ipld_dagcbor::from_slice(&token_bytes[0])
+            .map_err(|e| {
                 ContainerError::Invocation(format!("failed to decode invocation: {}", e))
             })?;
 
         // Remaining tokens are delegations - build a map keyed by CID
-        let mut delegations: HashMap<Cid, Arc<Delegation<Ed25519Signature>>> =
+        let mut delegations: HashMap<Cid, Arc<Delegation<AnySignature>>> =
             HashMap::with_capacity(token_bytes.len() - 1);
         for (i, bytes) in token_bytes.iter().skip(1).enumerate() {
-            let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
+            let delegation: Delegation<AnySignature> = serde_ipld_dagcbor::from_slice(bytes)
                 .map_err(|e| {
                     ContainerError::Invocation(format!("failed to decode delegation {}: {}", i, e))
                 })?;
@@ -232,7 +232,7 @@ where
     }
 }
 
-impl<'de> Deserialize<'de> for InvocationChain<Ed25519Signature> {
+impl<'de> Deserialize<'de> for InvocationChain<AnySignature> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -249,11 +249,11 @@ mod tests {
     use crate::helpers::{create_delegation, generate_signer};
     use crate::subject::Subject;
     use crate::{DelegationBuilder, InvocationBuilder};
-    use dialog_credentials::Ed25519KeyResolver;
+    use dialog_credentials::DidKeyResolver;
     use dialog_varsig::Principal;
 
     /// Create a test invocation chain with a valid delegation.
-    async fn create_test_invocation_chain() -> (InvocationChain<Ed25519Signature>, Did) {
+    async fn create_test_invocation_chain() -> (InvocationChain<AnySignature>, Did) {
         let subject_signer = generate_signer().await;
         let subject_did = subject_signer.did();
         let operator_signer = generate_signer().await;
@@ -320,7 +320,7 @@ mod tests {
         let cbor_bytes = serde_ipld_dagcbor::to_vec(&chain).expect("Failed to serialize");
 
         // Deserialize via serde from DAG-CBOR (this uses dialog_common::Bytes)
-        let restored: InvocationChain<Ed25519Signature> =
+        let restored: InvocationChain<AnySignature> =
             serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
 
         // Verify the chains match
@@ -334,11 +334,86 @@ mod tests {
         let (chain, _) = create_test_invocation_chain().await;
 
         // Should verify successfully
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed: {:?}",
             result
+        );
+    }
+
+    /// End-to-end acceptance test for algorithm-agnostic signing: an ed25519
+    /// principal delegates to a p256 principal, the p256 principal invokes with
+    /// that delegation as its proof, and the full chain verifies. The delegation
+    /// link is signed and verified under ed25519, the invocation link under
+    /// p256, each algorithm taken from its own varsig header.
+    #[dialog_common::test]
+    async fn it_verifies_mixed_algorithm_chain() {
+        use dialog_credentials::{Ed25519Signer, Es256Signer, Signer};
+
+        let issuer = Signer::from(Ed25519Signer::generate().await.unwrap());
+        let audience = Signer::from(Es256Signer::generate().await.unwrap());
+        let subject_did = issuer.did();
+        let audience_did = audience.did();
+
+        // ed25519 issuer delegates to the p256 audience.
+        let delegation = DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(&audience)
+            .subject(Subject::Specific(subject_did.clone()))
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build delegation");
+        let delegation_cid = delegation.to_cid();
+
+        // The p256 audience invokes, referencing the delegation as its proof.
+        let invocation = InvocationBuilder::new()
+            .issuer(audience.clone())
+            .audience(&audience_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![delegation_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+        let chain = InvocationChain::new(invocation, delegations);
+
+        // The full chain verifies: the delegation link under ed25519, the
+        // invocation link under p256, one validation pass over mixed algorithms.
+        let result = chain.verify(&DidKeyResolver).await;
+        assert!(
+            result.is_ok(),
+            "Expected mixed-algorithm chain to verify: {:?}",
+            result
+        );
+    }
+
+    /// Negative counterpart: a signature whose varsig header names one algorithm
+    /// but is checked against the other algorithm's key must be refused. A p256
+    /// signature verified by an ed25519 verifier is rejected on the tag
+    /// mismatch, so a forged or corrupted link cannot slip through.
+    #[dialog_common::test]
+    async fn it_refuses_mismatched_algorithm_signature() {
+        use dialog_credentials::{Ed25519Signer, Es256Signer, Signer};
+        use dialog_varsig::{Signer as VarsigSigner, Verifier as VarsigVerifier};
+
+        let es_signer = Signer::from(Es256Signer::generate().await.unwrap());
+        let ed_signer = Signer::from(Ed25519Signer::generate().await.unwrap());
+
+        let msg = b"mixed";
+        let sig = VarsigSigner::sign(&es_signer, msg).await.unwrap();
+
+        // The matching p256 verifier accepts it.
+        assert!(es_signer.verifier().verify(msg, &sig).await.is_ok());
+
+        // An ed25519 verifier refuses the p256-tagged signature.
+        assert!(
+            ed_signer.verifier().verify(msg, &sig).await.is_err(),
+            "Expected a p256 signature to be refused by an ed25519 verifier"
         );
     }
 
@@ -375,7 +450,7 @@ mod tests {
         let chain = InvocationChain::new(invocation, HashMap::new());
 
         // Should fail verification due to missing proof
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("proof not found"));
     }
@@ -416,7 +491,7 @@ mod tests {
         let chain = InvocationChain::new(invocation, delegations);
 
         // Should fail verification due to issuer mismatch
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(result.is_err());
     }
 
@@ -557,7 +632,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed with powerline in middle: {:?}",
@@ -597,7 +672,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_err(),
             "Expected verification to fail when invocation subject doesn't match powerline root issuer"
@@ -636,7 +711,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed when invocation subject matches powerline root issuer: {:?}",
@@ -689,7 +764,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_err(),
             "Expected verification to fail when redelegation after powerline root uses wrong subject"
@@ -741,7 +816,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed when redelegation after powerline root uses correct subject: {:?}",
@@ -826,7 +901,7 @@ mod tests {
 
         let cbor_bytes = serde_ipld_dagcbor::to_vec(&chain).expect("Failed to serialize");
 
-        let restored: InvocationChain<Ed25519Signature> =
+        let restored: InvocationChain<AnySignature> =
             serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
 
         assert_eq!(restored.command().to_string(), "/archive/put");
@@ -866,7 +941,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_ok(),
             "Expected /archive delegation to authorize /archive/put invocation: {:?}",
@@ -909,16 +984,16 @@ mod tests {
         let original_chain = InvocationChain::new(invocation, delegations);
 
         assert!(
-            original_chain.verify(&Ed25519KeyResolver).await.is_ok(),
+            original_chain.verify(&DidKeyResolver).await.is_ok(),
             "Original chain should verify"
         );
 
         let cbor_bytes = serde_ipld_dagcbor::to_vec(&original_chain).expect("Failed to serialize");
 
-        let restored_chain: InvocationChain<Ed25519Signature> =
+        let restored_chain: InvocationChain<AnySignature> =
             serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
 
-        let result = restored_chain.verify(&Ed25519KeyResolver).await;
+        let result = restored_chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_ok(),
             "Restored chain should still verify: {:?}",
@@ -950,7 +1025,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, HashMap::new());
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_ok(),
             "Self-invocation (issuer == subject, empty proofs) should verify: {:?}",
@@ -975,7 +1050,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, HashMap::new());
 
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_err(),
             "Invocation with issuer != subject and no proofs should fail verification"

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -546,7 +546,7 @@ mod tests {
 
         // Must be rejected: the delegation link's signature is not the
         // subject's, so the chain grants the attacker nothing.
-        let result = chain.verify(&Ed25519KeyResolver).await;
+        let result = chain.verify(&DidKeyResolver).await;
         assert!(
             result.is_err(),
             "forged delegation-link signature must be rejected, got: {result:?}"

--- a/rust/dialog-ucan-core/src/delegation.rs
+++ b/rust/dialog-ucan-core/src/delegation.rs
@@ -561,7 +561,8 @@ mod tests {
         subject::Subject,
     };
     use base64::prelude::*;
-    use dialog_credentials::ed25519::{Ed25519KeyResolver, Ed25519Signer};
+    use dialog_credentials::DidKeyResolver;
+    use dialog_credentials::ed25519::Ed25519Signer;
     use dialog_varsig::{did::Did, eddsa::Ed25519Signature, principal::Principal};
     use testresult::TestResult;
 
@@ -717,7 +718,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         delegation.verify_signature(&resolver).await?;
 
         Ok(())
@@ -834,7 +835,7 @@ mod tests {
 
         assert_eq!(delegation.subject(), &Subject::Any);
 
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         delegation.verify_signature(&resolver).await?;
 
         Ok(())
@@ -875,7 +876,7 @@ mod tests {
         assert_eq!(delegation1.nonce(), delegation2.nonce());
 
         // Both signatures should verify
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         delegation1.verify_signature(&resolver).await?;
         delegation2.verify_signature(&resolver).await?;
 
@@ -926,7 +927,7 @@ mod tests {
         );
 
         // But both should verify with their respective keys
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         delegation1.verify_signature(&resolver).await?;
         delegation2.verify_signature(&resolver).await?;
 

--- a/rust/dialog-ucan-core/src/envelope.rs
+++ b/rust/dialog-ucan-core/src/envelope.rs
@@ -74,12 +74,18 @@ where
                     return Err(de::Error::custom("expected signature to be bytes"));
                 };
 
-                let signature = S::try_from(sig_bytes.as_slice())
-                    .map_err(|_| de::Error::custom("invalid signature bytes"))?;
-
+                // The payload's varsig header is the single source of truth for
+                // the signature algorithm. Decode it first, then reconstruct the
+                // signature from the header's algorithm and the raw body. The
+                // body alone cannot distinguish algorithms of equal width, so we
+                // never guess from the bytes.
                 let payload: EnvelopePayload<S, T> = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                let signature =
+                    S::from_algorithm_bytes(payload.header.algorithm(), sig_bytes.as_slice())
+                        .map_err(|_| de::Error::custom("invalid signature bytes"))?;
 
                 Ok(Envelope(signature, payload))
             }

--- a/rust/dialog-ucan-core/src/helpers.rs
+++ b/rust/dialog-ucan-core/src/helpers.rs
@@ -7,28 +7,31 @@ use super::ContainerError;
 use crate::DelegationBuilder;
 use crate::delegation::Delegation;
 use crate::subject::Subject;
-use dialog_credentials::Ed25519Signer;
+use dialog_credentials::{Ed25519Signer, Signer};
+use dialog_varsig::AnySignature;
 use dialog_varsig::Principal;
-use dialog_varsig::eddsa::Ed25519Signature;
 
-/// Generate a new random Ed25519 signer.
+/// Generate a new random signer.
 ///
-/// This is useful for creating space signers in tests.
-pub async fn generate_signer() -> Ed25519Signer {
-    Ed25519Signer::generate()
-        .await
-        .expect("Failed to generate signer")
+/// Returns the algorithm-agnostic [`Signer`] (backed by a fresh ed25519 key),
+/// so delegations built with it carry the agnostic signature type.
+pub async fn generate_signer() -> Signer {
+    Signer::from(
+        Ed25519Signer::generate()
+            .await
+            .expect("Failed to generate signer"),
+    )
 }
 
 /// Create a delegation from issuer to audience for a subject with the given command.
 ///
 /// This is a convenience function for building simple delegations in tests.
 pub async fn create_delegation(
-    issuer: &Ed25519Signer,
+    issuer: &Signer,
     audience: &impl Principal,
     subject: &impl Principal,
     command: &[&str],
-) -> Result<Delegation<Ed25519Signature>, ContainerError> {
+) -> Result<Delegation<AnySignature>, ContainerError> {
     DelegationBuilder::new()
         .issuer(issuer.clone())
         .audience(audience)

--- a/rust/dialog-ucan-core/src/invocation.rs
+++ b/rust/dialog-ucan-core/src/invocation.rs
@@ -816,7 +816,8 @@ mod tests {
         time::{TimeRange, Timestamp},
     };
     use builder::InvocationBuilder;
-    use dialog_credentials::ed25519::{Ed25519KeyResolver, Ed25519Signer};
+    use dialog_credentials::DidKeyResolver;
+    use dialog_credentials::ed25519::Ed25519Signer;
     use dialog_varsig::{did::Did, eddsa::Ed25519Signature, principal::Principal};
     use std::{
         cell::RefCell,
@@ -920,7 +921,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         invocation.verify_signature(&resolver).await?;
 
         Ok(())
@@ -995,7 +996,7 @@ mod tests {
         assert_eq!(invocation1.nonce(), invocation2.nonce());
 
         // Both signatures should verify
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         invocation1.verify_signature(&resolver).await?;
         invocation2.verify_signature(&resolver).await?;
 
@@ -1049,7 +1050,7 @@ mod tests {
         );
 
         // But both should verify with their respective keys
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         invocation1.verify_signature(&resolver).await?;
         invocation2.verify_signature(&resolver).await?;
 
@@ -1082,7 +1083,7 @@ mod tests {
         assert_eq!(invocation.arguments(), &args);
 
         // Signature should still verify
-        let resolver = Ed25519KeyResolver;
+        let resolver = DidKeyResolver;
         invocation.verify_signature(&resolver).await?;
 
         Ok(())
@@ -1130,9 +1131,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -1168,9 +1167,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Chain check should fail when proof audience != invoker");
         let err_msg = err.to_string();
         assert!(
@@ -1218,9 +1215,7 @@ mod tests {
             .await?;
 
         // Should fail: proof.issuer (random) != subject
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Chain check should fail when proof issuer != subject");
         let err_msg = err.to_string();
         assert!(
@@ -1266,7 +1261,7 @@ mod tests {
         let tampered: Result<Invocation<Ed25519Signature>, _> =
             serde_ipld_dagcbor::from_slice(&bytes);
         if let Ok(tampered) = tampered {
-            let resolver = Ed25519KeyResolver;
+            let resolver = DidKeyResolver;
             let result = tampered.verify_signature(&resolver).await;
             assert!(
                 result.is_err(),
@@ -1305,9 +1300,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -1342,9 +1335,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: proof subject (b) != invocation subject (a)");
         let err_msg = err.to_string();
         assert!(
@@ -1393,9 +1384,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: root delegation issuer (b) != subject (a)");
         let err_msg = err.to_string();
         assert!(
@@ -1442,9 +1431,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -1478,9 +1465,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: powerline issuer (b) != invocation subject (a)");
         let err_msg = err.to_string();
         assert!(
@@ -1539,9 +1524,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -1588,9 +1571,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err =
             result.expect_err("Should fail: second proof subject (b) != established subject (a)");
         let err_msg = err.to_string();
@@ -1628,9 +1609,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: self-issued invocation with issuer != subject");
         let err_msg = err.to_string();
         assert!(
@@ -1665,9 +1644,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -1699,9 +1676,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: invocation command not covered by delegation");
         let err_msg = err.to_string();
         assert!(
@@ -1747,9 +1722,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -1795,9 +1768,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: arguments violate delegation policy");
         let err_msg = err.to_string();
         assert!(
@@ -1846,9 +1817,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -1904,9 +1873,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: chain linkage broken at second hop");
         let err_msg = err.to_string();
         assert!(
@@ -1973,9 +1940,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -2010,9 +1975,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -2036,9 +1999,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         Ok(())
     }
@@ -2058,9 +2019,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         assert_eq!(range, TimeRange::unbounded());
         Ok(())
@@ -2095,9 +2054,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         assert_eq!(range.not_before, Bound::Unbounded);
         assert_eq!(range.expiration, Bound::Included(exp));
@@ -2152,9 +2109,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         // nbf = max(now, unbounded) = now
         assert_eq!(range.not_before, Bound::Included(now));
@@ -2211,9 +2166,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await;
+        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
         let err = result.expect_err("Should fail: time windows don't overlap");
         let err_msg = err.to_string();
         assert!(
@@ -2256,9 +2209,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         // The invocation's tighter expiration should win
         assert_eq!(range.expiration, Bound::Included(exp_invocation));
@@ -2313,9 +2264,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation
-            .check(&delegation_store, &Ed25519KeyResolver)
-            .await?;
+        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
 
         // nbf = max(now, unbounded) = now (narrow wins)
         assert_eq!(range.not_before, Bound::Included(now));

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -8,13 +8,13 @@ use dialog_capability::access::{
     Authorization, AuthorizeError, Certificate, Delegation as AccessDelegation, Proof, Protocol,
     TimeRange,
 };
-use dialog_credentials::Ed25519Signer;
+use dialog_credentials::Signer;
 use dialog_ucan_core::delegation::builder::DelegationBuilder;
 use dialog_ucan_core::subject::Subject as UcanSubject;
 use dialog_ucan_core::time::Timestamp;
 use dialog_ucan_core::time::timestamp::{Duration, UNIX_EPOCH};
 use dialog_ucan_core::{Delegation, DelegationChain, InvocationBuilder, InvocationChain};
-use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::AnySignature;
 
 use super::scope::Scope;
 use super::{Ucan, UcanInvocation};
@@ -24,7 +24,7 @@ use super::{Ucan, UcanInvocation};
 /// Implements [`Certificate`] for generic chain verification.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
-pub struct UcanCertificate(pub Delegation<Ed25519Signature>);
+pub struct UcanCertificate(pub Delegation<AnySignature>);
 
 impl Certificate for UcanCertificate {
     type Access = Scope;
@@ -149,7 +149,7 @@ impl Proof<Ucan> for UcanProof {
         self.duration = duration;
     }
 
-    fn claim(self, signer: Ed25519Signer) -> Result<UcanAuthorization, AuthorizeError> {
+    fn claim(self, signer: Signer) -> Result<UcanAuthorization, AuthorizeError> {
         let mut iter = self.proofs.into_iter();
         let chain = match iter.next() {
             None => None,
@@ -181,7 +181,7 @@ pub struct UcanAuthorization {
     /// The delegation chain proving authority (None if self-authorized).
     pub chain: Option<DelegationChain>,
     /// The signer (operator key).
-    pub signer: Ed25519Signer,
+    pub signer: Signer,
     /// The scope of the capability being authorized.
     pub scope: Scope,
     /// The time range this authorization is valid for.
@@ -351,7 +351,7 @@ impl AccessDelegation for UcanDelegation {
 
 impl Protocol for Ucan {
     type Access = Scope;
-    type Signer = Ed25519Signer;
+    type Signer = Signer;
     type Certificate = UcanCertificate;
     type Delegation = UcanDelegation;
     type Invocation = UcanInvocation;
@@ -365,26 +365,27 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
+    use dialog_credentials::Ed25519Signer;
     use dialog_varsig::Principal;
 
-    async fn signer(seed: u8) -> Ed25519Signer {
-        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    async fn signer(seed: u8) -> Signer {
+        Signer::from(Ed25519Signer::import(&[seed; 32]).await.unwrap())
     }
 
     async fn build_delegation(
-        issuer: Ed25519Signer,
+        issuer: Signer,
         audience: &Did,
         subject: &Did,
-    ) -> Delegation<Ed25519Signature> {
+    ) -> Delegation<AnySignature> {
         build_delegation_for(issuer, audience, subject, vec![]).await
     }
 
     async fn build_delegation_for(
-        issuer: Ed25519Signer,
+        issuer: Signer,
         audience: &Did,
         subject: &Did,
         command: Vec<String>,
-    ) -> Delegation<Ed25519Signature> {
+    ) -> Delegation<AnySignature> {
         DelegationBuilder::new()
             .issuer(issuer)
             .audience(audience)

--- a/rust/dialog-ucan/src/certificate_store.rs
+++ b/rust/dialog-ucan/src/certificate_store.rs
@@ -4,7 +4,7 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use dialog_capability::access::{Certificate, CertificateStore};
-    use dialog_credentials::Ed25519Signer;
+    use dialog_credentials::{Ed25519Signer, Signer};
     use dialog_effects::storage::{Directory, Location};
     use dialog_storage::resource::Resource;
     use dialog_ucan_core::subject::Subject;
@@ -13,15 +13,11 @@ mod tests {
 
     use crate::{Ucan, UcanDelegation};
 
-    async fn generate_signer() -> Ed25519Signer {
-        Ed25519Signer::generate().await.unwrap()
+    async fn generate_signer() -> Signer {
+        Signer::from(Ed25519Signer::generate().await.unwrap())
     }
 
-    async fn delegate(
-        issuer: &Ed25519Signer,
-        audience: &Ed25519Signer,
-        subject: Subject,
-    ) -> UcanDelegation {
+    async fn delegate(issuer: &Signer, audience: &Signer, subject: Subject) -> UcanDelegation {
         let delegation = DelegationBuilder::new()
             .issuer(issuer.clone())
             .audience(audience)
@@ -261,7 +257,7 @@ mod tests {
         use dialog_ucan_core::command::Command;
         use dialog_ucan_core::subject::Subject as UcanSubject;
 
-        fn scope(subject: &Ed25519Signer, command: &[&str]) -> Scope {
+        fn scope(subject: &Signer, command: &[&str]) -> Scope {
             Scope {
                 subject: UcanSubject::Specific(subject.did()),
                 command: Command(command.iter().map(|s| s.to_string()).collect()),
@@ -359,8 +355,8 @@ mod tests {
         }
 
         async fn delegate_with_expiration(
-            issuer: &Ed25519Signer,
-            audience: &Ed25519Signer,
+            issuer: &Signer,
+            audience: &Signer,
             subject: Subject,
             expiration: dialog_ucan_core::time::timestamp::Timestamp,
         ) -> UcanDelegation {

--- a/rust/dialog-ucan/src/invocation.rs
+++ b/rust/dialog-ucan/src/invocation.rs
@@ -2,7 +2,7 @@
 
 use dialog_capability::Did;
 use dialog_ucan_core::InvocationChain;
-use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::AnySignature;
 
 /// A signed UCAN invocation ready to be redeemed at an access service.
 ///
@@ -13,7 +13,7 @@ use dialog_varsig::eddsa::Ed25519Signature;
 #[derive(Debug, Clone)]
 pub struct UcanInvocation {
     /// The signed invocation chain (invocation + delegation proofs).
-    pub chain: Box<InvocationChain<Ed25519Signature>>,
+    pub chain: Box<InvocationChain<AnySignature>>,
     /// The subject DID this invocation acts on.
     pub subject: Did,
     /// The ability path (e.g., "/storage/get").
@@ -32,7 +32,7 @@ impl UcanInvocation {
     }
 
     /// Get the invocation chain.
-    pub fn chain(&self) -> &InvocationChain<Ed25519Signature> {
+    pub fn chain(&self) -> &InvocationChain<AnySignature> {
         &self.chain
     }
 

--- a/rust/dialog-varsig/Cargo.toml
+++ b/rust/dialog-varsig/Cargo.toml
@@ -21,6 +21,7 @@ signature = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+serde_ipld_dagcbor = { workspace = true }
 testresult = { workspace = true }
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]

--- a/rust/dialog-varsig/src/algorithm/ecdsa.rs
+++ b/rust/dialog-varsig/src/algorithm/ecdsa.rs
@@ -9,6 +9,10 @@ use super::{
     curve::{Secp256k1, Secp256r1},
     hash::Multihasher,
 };
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+use crate::signature::Signature;
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+use signature::SignatureEncoding;
 use std::marker::PhantomData;
 
 /// The ECDSA signature algorithm.
@@ -51,6 +55,81 @@ impl SignatureAlgorithm for Es256 {
             None
         }
     }
+}
+
+/// ES256 (ECDSA over P-256) signature bytes (64 bytes: r followed by s).
+///
+/// This is a platform-agnostic fixed-width representation of a P-256 ECDSA
+/// signature. It converts to and from `p256::ecdsa::Signature`, whose
+/// canonical fixed-size encoding is exactly `r || s`, 32 bytes each.
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct Es256Signature(#[serde(with = "serde_bytes")] pub [u8; 64]);
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl Es256Signature {
+    /// Create a new signature from raw bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 64]) -> Self {
+        Self(bytes)
+    }
+
+    /// Get the raw signature bytes.
+    #[must_use]
+    pub const fn to_bytes(&self) -> [u8; 64] {
+        self.0
+    }
+}
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl From<[u8; 64]> for Es256Signature {
+    fn from(bytes: [u8; 64]) -> Self {
+        Self(bytes)
+    }
+}
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl From<Es256Signature> for [u8; 64] {
+    fn from(sig: Es256Signature) -> Self {
+        sig.0
+    }
+}
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl From<p256::ecdsa::Signature> for Es256Signature {
+    fn from(sig: p256::ecdsa::Signature) -> Self {
+        Self(sig.to_bytes().into())
+    }
+}
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl TryFrom<Es256Signature> for p256::ecdsa::Signature {
+    type Error = signature::Error;
+
+    fn try_from(sig: Es256Signature) -> Result<Self, Self::Error> {
+        p256::ecdsa::Signature::from_slice(&sig.0)
+    }
+}
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl SignatureEncoding for Es256Signature {
+    type Repr = [u8; 64];
+}
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl TryFrom<&[u8]> for Es256Signature {
+    type Error = signature::Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 64] = bytes.try_into().map_err(|_| signature::Error::new())?;
+        Ok(Self(bytes))
+    }
+}
+
+#[cfg(all(feature = "secp256r1", feature = "sha2_256"))]
+impl Signature for Es256Signature {
+    type Algorithm = Es256;
 }
 
 /// The ES384 signature algorithm.

--- a/rust/dialog-varsig/src/signature.rs
+++ b/rust/dialog-varsig/src/signature.rs
@@ -1,10 +1,12 @@
 //! Varsig header, signature trait, and signing/verification re-exports.
 
+pub mod any;
 pub mod signer;
 pub mod verifier;
 
 use super::{Codec, Format, SignatureAlgorithm};
 use ::signature::SignatureEncoding;
+pub use any::{AlgorithmTag, AnyAlgorithm, AnySignature};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use serde::{Deserialize, Serialize};
 pub use signer::Signer;

--- a/rust/dialog-varsig/src/signature.rs
+++ b/rust/dialog-varsig/src/signature.rs
@@ -15,6 +15,26 @@ pub use verifier::Verifier;
 pub trait Signature: SignatureEncoding + Debug + ConditionalSend + ConditionalSync {
     /// The signature algorithm that produces this signature type.
     type Algorithm: SignatureAlgorithm + ConditionalSend + ConditionalSync;
+
+    /// Reconstruct a signature from the algorithm named by a varsig header and
+    /// the raw signature body.
+    ///
+    /// For a concrete signature type the algorithm is implied by the type
+    /// itself, so the default implementation ignores it and decodes the bytes
+    /// exactly as [`TryFrom<&[u8]>`] would. An algorithm-agnostic signature that
+    /// stores an algorithm tag alongside its bytes overrides this to recover the
+    /// tag from the header, since the body alone cannot distinguish algorithms
+    /// whose signatures share a width.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bytes are not a valid signature body.
+    fn from_algorithm_bytes(
+        _algorithm: &Self::Algorithm,
+        bytes: &[u8],
+    ) -> Result<Self, ::signature::Error> {
+        Self::try_from(bytes).map_err(|_| ::signature::Error::new())
+    }
 }
 
 /// Variable signature configuration that ties signature algorithm

--- a/rust/dialog-varsig/src/signature/any.rs
+++ b/rust/dialog-varsig/src/signature/any.rs
@@ -1,0 +1,253 @@
+//! Algorithm-agnostic signature.
+//!
+//! The [`Signature`](super::Signature) and
+//! [`Verifier`](super::Verifier) traits are each generic over a single concrete
+//! signature type. To carry a signature without committing to an algorithm at
+//! the type level, [`AnySignature`] stores an algorithm tag alongside the raw
+//! signature body, and [`AnyAlgorithm`] is the matching
+//! [`SignatureAlgorithm`](crate::SignatureAlgorithm).
+//!
+//! The algorithm tag is authoritative: a varsig header already names the
+//! algorithm separately from the signature body, and
+//! [`AnySignature::from_algorithm_bytes`](super::Signature::from_algorithm_bytes)
+//! recovers the tag from that header rather than guessing from the bytes, which
+//! for two algorithms that share a signature width is impossible.
+//!
+//! The signer and verifier that pair a private or public key with these types
+//! live one layer up, in `dialog-credentials`; this module owns only the
+//! signature value and its algorithm descriptor.
+
+use super::Signature;
+use crate::SignatureAlgorithm;
+use crate::algorithm::eddsa::{Ed25519, Ed25519Signature};
+use ::signature::SignatureEncoding;
+
+#[cfg(feature = "es256")]
+use crate::algorithm::ecdsa::{Es256, Es256Signature};
+
+/// The algorithm tag carried by [`AnySignature`] and [`AnyAlgorithm`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AlgorithmTag {
+    /// Ed25519 (`EdDSA` over Edwards25519).
+    Ed25519,
+    /// ES256 (ECDSA over P-256).
+    #[cfg(feature = "es256")]
+    Es256,
+}
+
+/// Algorithm-agnostic [`SignatureAlgorithm`].
+///
+/// Wraps the concrete varsig algorithm descriptors. `Default` resolves to
+/// Ed25519 to satisfy the trait bound; the meaningful tag always travels with an
+/// [`AnySignature`] value, so the default is never used to interpret bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AnyAlgorithm(pub AlgorithmTag);
+
+impl Default for AnyAlgorithm {
+    fn default() -> Self {
+        AnyAlgorithm(AlgorithmTag::Ed25519)
+    }
+}
+
+impl SignatureAlgorithm for AnyAlgorithm {
+    fn prefix(&self) -> u64 {
+        match self.0 {
+            AlgorithmTag::Ed25519 => Ed25519::default().prefix(),
+            #[cfg(feature = "es256")]
+            AlgorithmTag::Es256 => Es256::default().prefix(),
+        }
+    }
+
+    fn config_tags(&self) -> Vec<u64> {
+        match self.0 {
+            AlgorithmTag::Ed25519 => Ed25519::default().config_tags(),
+            #[cfg(feature = "es256")]
+            AlgorithmTag::Es256 => Es256::default().config_tags(),
+        }
+    }
+
+    fn try_from_tags(bytes: &[u64]) -> Option<(Self, &[u64])> {
+        if let Some((_, rest)) = Ed25519::try_from_tags(bytes) {
+            return Some((AnyAlgorithm(AlgorithmTag::Ed25519), rest));
+        }
+        #[cfg(feature = "es256")]
+        if let Some((_, rest)) = Es256::try_from_tags(bytes) {
+            return Some((AnyAlgorithm(AlgorithmTag::Es256), rest));
+        }
+        None
+    }
+}
+
+/// Algorithm-agnostic signature: an algorithm tag plus the raw signature bytes.
+///
+/// Both supported algorithms use a 64-byte fixed-width signature, so the bytes
+/// are stored inline. The tag lets a verifier reject a signature produced by a
+/// different algorithm than it holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnySignature {
+    algorithm: AlgorithmTag,
+    bytes: [u8; 64],
+}
+
+impl AnySignature {
+    /// The algorithm that produced this signature.
+    #[must_use]
+    pub const fn algorithm(&self) -> AlgorithmTag {
+        self.algorithm
+    }
+
+    /// The raw 64-byte signature.
+    #[must_use]
+    pub const fn to_bytes(&self) -> [u8; 64] {
+        self.bytes
+    }
+
+    /// Reconstruct a signature from the algorithm named by a varsig header and
+    /// the raw signature body.
+    ///
+    /// The header is the single source of truth for the algorithm; the 64-byte
+    /// body alone cannot distinguish algorithms that share a signature width.
+    /// This refuses (rather than defaulting) when the body is not 64 bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is not exactly 64 bytes.
+    pub fn from_algorithm_and_bytes(
+        algorithm: &AnyAlgorithm,
+        bytes: &[u8],
+    ) -> Result<Self, ::signature::Error> {
+        let bytes: [u8; 64] = bytes.try_into().map_err(|_| ::signature::Error::new())?;
+        Ok(Self {
+            algorithm: algorithm.0,
+            bytes,
+        })
+    }
+}
+
+impl From<Ed25519Signature> for AnySignature {
+    fn from(sig: Ed25519Signature) -> Self {
+        Self {
+            algorithm: AlgorithmTag::Ed25519,
+            bytes: sig.to_bytes(),
+        }
+    }
+}
+
+#[cfg(feature = "es256")]
+impl From<Es256Signature> for AnySignature {
+    fn from(sig: Es256Signature) -> Self {
+        Self {
+            algorithm: AlgorithmTag::Es256,
+            bytes: sig.to_bytes(),
+        }
+    }
+}
+
+/// [`AnySignature`] encodes as its raw 64-byte body. The algorithm tag is
+/// carried out of band by the varsig header, which already names the algorithm
+/// separately from the signature body.
+impl SignatureEncoding for AnySignature {
+    type Repr = [u8; 64];
+}
+
+impl From<AnySignature> for [u8; 64] {
+    fn from(sig: AnySignature) -> Self {
+        sig.bytes
+    }
+}
+
+impl TryFrom<&[u8]> for AnySignature {
+    type Error = ::signature::Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 64] = bytes.try_into().map_err(|_| ::signature::Error::new())?;
+        // Bytes alone cannot name the algorithm. This byte-only path exists only
+        // to satisfy `SignatureEncoding`; decode goes through
+        // `from_algorithm_bytes`, which takes the tag from the varsig header.
+        Ok(Self {
+            algorithm: AlgorithmTag::Ed25519,
+            bytes,
+        })
+    }
+}
+
+/// Serializes as the raw 64-byte body, exactly like a concrete signature. The
+/// algorithm is not written here; a varsig envelope carries it in the header,
+/// and decode recovers it via [`AnySignature::from_algorithm_bytes`].
+impl serde::Serialize for AnySignature {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(&self.bytes)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AnySignature {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Only the body is on the wire. This exists to satisfy the `Signature +
+        // Deserialize` bound; a varsig envelope never decodes the signature this
+        // way, it goes through `from_algorithm_bytes` with the header algorithm.
+        let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?;
+        let bytes: [u8; 64] = bytes
+            .as_ref()
+            .try_into()
+            .map_err(|_| serde::de::Error::custom("expected a 64-byte signature"))?;
+        Ok(Self {
+            algorithm: AlgorithmTag::Ed25519,
+            bytes,
+        })
+    }
+}
+
+impl Signature for AnySignature {
+    type Algorithm = AnyAlgorithm;
+
+    fn from_algorithm_bytes(
+        algorithm: &Self::Algorithm,
+        bytes: &[u8],
+    ) -> Result<Self, ::signature::Error> {
+        Self::from_algorithm_and_bytes(algorithm, bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_algorithm_bytes_takes_tag_from_header_not_bytes() {
+        // The 64-byte body cannot name its algorithm. Reconstruction must take
+        // the tag from the (header-provided) algorithm, never guess from bytes.
+        let bytes = [7u8; 64];
+
+        let ed = <AnySignature as Signature>::from_algorithm_bytes(
+            &AnyAlgorithm(AlgorithmTag::Ed25519),
+            &bytes,
+        )
+        .unwrap();
+        assert_eq!(ed.algorithm(), AlgorithmTag::Ed25519);
+
+        #[cfg(feature = "es256")]
+        {
+            let es = <AnySignature as Signature>::from_algorithm_bytes(
+                &AnyAlgorithm(AlgorithmTag::Es256),
+                &bytes,
+            )
+            .unwrap();
+            assert_eq!(es.algorithm(), AlgorithmTag::Es256);
+            // Same bytes, different header algorithm, different tag: the header
+            // is authoritative.
+            assert_ne!(ed.algorithm(), es.algorithm());
+        }
+    }
+
+    #[test]
+    fn from_algorithm_bytes_refuses_wrong_length() {
+        let short = [0u8; 32];
+        assert!(
+            <AnySignature as Signature>::from_algorithm_bytes(
+                &AnyAlgorithm(AlgorithmTag::Ed25519),
+                &short,
+            )
+            .is_err()
+        );
+    }
+}

--- a/rust/dialog-varsig/src/signature/any.rs
+++ b/rust/dialog-varsig/src/signature/any.rs
@@ -35,6 +35,22 @@ pub enum AlgorithmTag {
     Es256,
 }
 
+impl AlgorithmTag {
+    /// Whether a signature body of `len` bytes is valid for this algorithm.
+    ///
+    /// Both algorithms defined today are fixed-width at 64 bytes. Variable
+    /// algorithms (future RSA / `WebAuthn`) would relax this to a range or a
+    /// permitted set; adding such an arm is a localized change here.
+    #[must_use]
+    fn accepts_len(self, len: usize) -> bool {
+        match self {
+            AlgorithmTag::Ed25519 => len == 64,
+            #[cfg(feature = "es256")]
+            AlgorithmTag::Es256 => len == 64,
+        }
+    }
+}
+
 /// Algorithm-agnostic [`SignatureAlgorithm`].
 ///
 /// Wraps the concrete varsig algorithm descriptors. `Default` resolves to
@@ -80,13 +96,16 @@ impl SignatureAlgorithm for AnyAlgorithm {
 
 /// Algorithm-agnostic signature: an algorithm tag plus the raw signature bytes.
 ///
-/// Both supported algorithms use a 64-byte fixed-width signature, so the bytes
-/// are stored inline. The tag lets a verifier reject a signature produced by a
-/// different algorithm than it holds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The body is stored variable-length (`Box<[u8]>`): the varsig header names the
+/// algorithm, and the algorithm determines the width. The two algorithms defined
+/// today are 64-byte fixed-width, but the type imposes no such limit, leaving
+/// room for algorithms with wider or variable signatures (RSA, `WebAuthn`). The
+/// tag lets a verifier reject a signature produced by a different algorithm than
+/// it holds.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnySignature {
     algorithm: AlgorithmTag,
-    bytes: [u8; 64],
+    bytes: Box<[u8]>,
 }
 
 impl AnySignature {
@@ -96,30 +115,34 @@ impl AnySignature {
         self.algorithm
     }
 
-    /// The raw 64-byte signature.
+    /// The raw signature body.
     #[must_use]
-    pub const fn to_bytes(&self) -> [u8; 64] {
-        self.bytes
+    pub fn to_bytes(&self) -> &[u8] {
+        &self.bytes
     }
 
     /// Reconstruct a signature from the algorithm named by a varsig header and
     /// the raw signature body.
     ///
-    /// The header is the single source of truth for the algorithm; the 64-byte
-    /// body alone cannot distinguish algorithms that share a signature width.
-    /// This refuses (rather than defaulting) when the body is not 64 bytes.
+    /// The header is the single source of truth for the algorithm; the body
+    /// alone cannot distinguish algorithms that share a signature width. The
+    /// body length is validated against the named algorithm and this refuses
+    /// (rather than defaulting) when the length does not match.
     ///
     /// # Errors
     ///
-    /// Returns an error if `bytes` is not exactly 64 bytes.
+    /// Returns an error if `bytes` is not a valid signature length for
+    /// `algorithm`.
     pub fn from_algorithm_and_bytes(
         algorithm: &AnyAlgorithm,
         bytes: &[u8],
     ) -> Result<Self, ::signature::Error> {
-        let bytes: [u8; 64] = bytes.try_into().map_err(|_| ::signature::Error::new())?;
+        if !algorithm.0.accepts_len(bytes.len()) {
+            return Err(::signature::Error::new());
+        }
         Ok(Self {
             algorithm: algorithm.0,
-            bytes,
+            bytes: Box::from(bytes),
         })
     }
 }
@@ -128,7 +151,7 @@ impl From<Ed25519Signature> for AnySignature {
     fn from(sig: Ed25519Signature) -> Self {
         Self {
             algorithm: AlgorithmTag::Ed25519,
-            bytes: sig.to_bytes(),
+            bytes: Box::from(sig.to_bytes().as_slice()),
         }
     }
 }
@@ -138,19 +161,19 @@ impl From<Es256Signature> for AnySignature {
     fn from(sig: Es256Signature) -> Self {
         Self {
             algorithm: AlgorithmTag::Es256,
-            bytes: sig.to_bytes(),
+            bytes: Box::from(sig.to_bytes().as_slice()),
         }
     }
 }
 
-/// [`AnySignature`] encodes as its raw 64-byte body. The algorithm tag is
+/// [`AnySignature`] encodes as its raw signature body. The algorithm tag is
 /// carried out of band by the varsig header, which already names the algorithm
 /// separately from the signature body.
 impl SignatureEncoding for AnySignature {
-    type Repr = [u8; 64];
+    type Repr = Box<[u8]>;
 }
 
-impl From<AnySignature> for [u8; 64] {
+impl From<AnySignature> for Box<[u8]> {
     fn from(sig: AnySignature) -> Self {
         sig.bytes
     }
@@ -160,13 +183,12 @@ impl TryFrom<&[u8]> for AnySignature {
     type Error = ::signature::Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let bytes: [u8; 64] = bytes.try_into().map_err(|_| ::signature::Error::new())?;
         // Bytes alone cannot name the algorithm. This byte-only path exists only
         // to satisfy `SignatureEncoding`; decode goes through
         // `from_algorithm_bytes`, which takes the tag from the varsig header.
         Ok(Self {
             algorithm: AlgorithmTag::Ed25519,
-            bytes,
+            bytes: Box::from(bytes),
         })
     }
 }
@@ -186,13 +208,9 @@ impl<'de> serde::Deserialize<'de> for AnySignature {
         // Deserialize` bound; a varsig envelope never decodes the signature this
         // way, it goes through `from_algorithm_bytes` with the header algorithm.
         let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?;
-        let bytes: [u8; 64] = bytes
-            .as_ref()
-            .try_into()
-            .map_err(|_| serde::de::Error::custom("expected a 64-byte signature"))?;
         Ok(Self {
             algorithm: AlgorithmTag::Ed25519,
-            bytes,
+            bytes: bytes.into_vec().into_boxed_slice(),
         })
     }
 }
@@ -241,6 +259,8 @@ mod tests {
 
     #[test]
     fn from_algorithm_bytes_refuses_wrong_length() {
+        // A 32-byte body is not a valid ed25519 signature length; per-algorithm
+        // validation refuses it rather than defaulting.
         let short = [0u8; 32];
         assert!(
             <AnySignature as Signature>::from_algorithm_bytes(
@@ -249,5 +269,55 @@ mod tests {
             )
             .is_err()
         );
+
+        #[cfg(feature = "es256")]
+        assert!(
+            <AnySignature as Signature>::from_algorithm_bytes(
+                &AnyAlgorithm(AlgorithmTag::Es256),
+                &short,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn ed25519_and_es256_roundtrip_as_64_byte_bodies() {
+        let bytes = [3u8; 64];
+
+        let ed = <AnySignature as Signature>::from_algorithm_bytes(
+            &AnyAlgorithm(AlgorithmTag::Ed25519),
+            &bytes,
+        )
+        .unwrap();
+        assert_eq!(ed.to_bytes(), &bytes[..]);
+        assert_eq!(ed.to_bytes().len(), 64);
+
+        #[cfg(feature = "es256")]
+        {
+            let es = <AnySignature as Signature>::from_algorithm_bytes(
+                &AnyAlgorithm(AlgorithmTag::Es256),
+                &bytes,
+            )
+            .unwrap();
+            assert_eq!(es.to_bytes(), &bytes[..]);
+            assert_eq!(es.to_bytes().len(), 64);
+        }
+    }
+
+    #[test]
+    fn agnostic_ed25519_wire_bytes_match_concrete() {
+        // The agnostic signature must serialize byte-identically to a concrete
+        // Ed25519Signature carrying the same body. This is the on-wire proof
+        // that widening the in-memory body to Box<[u8]> did not change the
+        // encoding for the fixed-width algorithms.
+        let body = [9u8; 64];
+
+        let concrete = Ed25519Signature::from_bytes(body);
+        let agnostic = AnySignature::from(concrete);
+
+        let concrete_wire = serde_ipld_dagcbor::to_vec(&concrete).unwrap();
+        let agnostic_wire = serde_ipld_dagcbor::to_vec(&agnostic).unwrap();
+
+        assert_eq!(concrete_wire, agnostic_wire);
     }
 }


### PR DESCRIPTION
Makes signing and authorization algorithm-agnostic. Identity and UCANs were hardcoded to ed25519; this removes that assumption end to end, so an ed25519 or P-256 principal signs and verifies the same way, with the algorithm carried by the varsig header. did:web / did:plc are a separate layer that builds on this.

## Why

`dialog-credentials` had no way to express "a principal of whatever algorithm" — everything named `Ed25519Signer` / `Ed25519Signature` concretely, and the UCAN chain was pinned to `Delegation<Ed25519Signature>`. The varsig `Signer` / `Verifier` / `Resolver` traits were already generic and async; only the concrete types leaked in. This threads an algorithm-agnostic type through the places that stored or named ed25519 directly.

## What changes

**Algorithm-agnostic types + P-256** (`99817f92`)
- `AnySignature` / `AnyAlgorithm` / `AnyVerifier` / `AnySigner`, implementing the varsig traits over a single tagged signature; a verifier rejects a signature whose algorithm tag does not match its arm.
- A real second algorithm: a P-256 (ES256) credentials module mirroring ed25519, with both a native (`p256` crate) backend and a browser WebCrypto (SubtleCrypto ECDSA P-256) backend for non-extractable keys — the curve WebAuthn / passkeys use. Native and browser produce identical `did:key`.

**The agnostic types become the default** (`6bc7bf1a`)
- They drop the `Any` prefix and are what `dialog-credentials` exports and uses (`Signature`, `Signer`, `Verifier`, `Algorithm`); the per-algorithm concrete types keep their names.
- `ed25519` is the default feature; every other algorithm (es256/p256, future curves) is opt-in behind its own feature. The enums are always enums, single-arm when only ed25519 is on.
- `SignerCredential`, `VerifierCredential`, and `Authority` hold the agnostic enums. The credential storage format was already multicodec-tagged, so import/export dispatch on the leading tag; existing ed25519 credentials load unchanged and their bytes are byte-identical (pinned by a backward-compat test).

**The varsig header is authoritative on decode** (`5e0a8402`)
- Envelope decode takes the signature algorithm from the varsig header rather than guessing from the signature bytes (which cannot tell a 64-byte ed25519 signature from a 64-byte P-256 one). Misalignment is refused: an unsupported or disabled algorithm, a wrong-length body, or a verifier whose key algorithm disagrees with the header. No silent fallback.

**UCANs sign and verify with any algorithm** (`f3fe2ed6`)
- The agnostic signature type moves down into `dialog-varsig` (it depends only on the per-algorithm descriptors); `DelegationChain` and the UCAN protocol types carry `Delegation<AnySignature>`. The operator passes its agnostic signer to `claim` directly.
- A `DidKeyResolver` resolves a `did:key` to the agnostic verifier by dispatching on the DID multicodec; the authorizer resolves through it.

## Cross-algorithm chains verify

`it_verifies_mixed_algorithm_chain`: an ed25519 principal delegates to a P-256 principal, the P-256 principal invokes referencing that delegation, and the invocation validates through the real verify path — the delegation link under ed25519, the invocation under P-256, each algorithm from its own varsig header, in one pass. `it_refuses_mismatched_algorithm_signature` pins the negative.

## Compatibility

ed25519 wire bytes and credential storage bytes are byte-identical; the existing UCAN round-trip and credential suites pass unchanged. The build defaults to ed25519 only; P-256 is opt-in.

## Not in this PR

did:web and did:plc. Those are resolvers layered on this foundation (an agnostic verifier resolved from a DID document over the network), and land as a separate PR. The operator's blake3 operator-key derivation stays ed25519 (a key-derivation concern, not signing).
