### PR TITLE
fix(ucan): verify every delegation-link signature, not just the invocation

### DIFF
--- a/rust/dialog-remote-ucan-s3/Cargo.toml
+++ b/rust/dialog-remote-ucan-s3/Cargo.toml
@@ -66,6 +66,7 @@ anyhow = { workspace = true }
 async-signature = { workspace = true }
 dialog-common = { workspace = true, features = ["helpers"] }
 dialog-storage = { workspace = true }
+dialog-ucan-core = { workspace = true, features = ["helpers"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 wasm-bindgen-test = { workspace = true }

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -301,6 +301,12 @@ impl UcanAuthorizer {
             // Only the first is a statement about their request, so only
             // the first may read as one.
             S3Error::Authorization(match e {
+                // A proof whose signature is not its claimed issuer's is a
+                // forged chain, not merely malformed input: name the issuer
+                // so the caller learns exactly which link did not hold.
+                ContainerError::InvalidDelegationSignature { issuer, .. } => {
+                    AuthorizeError::InvalidSignature { issuer }
+                }
                 ContainerError::Invocation(detail) => AuthorizeError::Malformed {
                     detail: format!("invocation chain did not verify: {detail}"),
                 },
@@ -391,6 +397,81 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
         chain.to_bytes().expect("Failed to serialize container")
+    }
+
+    // A forged proof (iss claims the subject, but signed by the attacker)
+    // must not authorize the attacker. The authorize path has to reject it
+    // and name the forged issuer via `AuthorizeError::InvalidSignature`,
+    // rather than passing because only the invocation's own signature was
+    // ever checked.
+    #[dialog_common::test]
+    async fn it_rejects_a_forged_delegation_signature() {
+        let subject_signer = test_signer().await;
+        let subject_did = subject_signer.did();
+        let attacker_signer = Ed25519Signer::import(&[7u8; 32]).await.unwrap();
+        let attacker_did = attacker_signer.did();
+
+        let command = vec!["memory".to_string(), "resolve".to_string()];
+
+        // Forge: iss = subject, aud = attacker, sub = subject, signed by
+        // the attacker (who cannot sign as the subject).
+        let forged = dialog_ucan_core::Delegation::forge(
+            subject_did.clone(),
+            attacker_did.clone(),
+            DelegatedSubject::Specific(subject_did.clone()),
+            dialog_ucan_core::command::Command::new(command.clone()),
+            &attacker_signer,
+        )
+        .await
+        .expect("Failed to forge delegation");
+
+        let forged_cid = forged.to_cid();
+
+        let mut args = BTreeMap::new();
+        args.insert(
+            "space".to_string(),
+            Promised::String("test-space".to_string()),
+        );
+        args.insert(
+            "cell".to_string(),
+            Promised::String("test-cell".to_string()),
+        );
+
+        // Attacker validly signs the invocation referencing the forged proof.
+        let invocation = InvocationBuilder::new()
+            .issuer(attacker_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(command)
+            .arguments(args)
+            .proofs(vec![forged_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = std::collections::HashMap::new();
+        delegations.insert(forged_cid, std::sync::Arc::new(forged));
+        let chain = InvocationChain::new(invocation, delegations);
+        let container = chain.to_bytes().expect("Failed to serialize container");
+
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let credentials = S3Credential::new("access-key-id", "secret-access-key");
+        let authorizer = UcanAuthorizer::new(address, Some(credentials));
+
+        let result = authorizer.authorize(&container).await;
+        match result {
+            Err(S3Error::Authorization(AuthorizeError::InvalidSignature { issuer })) => {
+                assert_eq!(
+                    issuer, subject_did,
+                    "the forged issuer named in the rejection must be the subject"
+                );
+            }
+            other => panic!("expected InvalidSignature, got {other:?}"),
+        }
     }
 
     #[dialog_common::test]

--- a/rust/dialog-repository/Cargo.toml
+++ b/rust/dialog-repository/Cargo.toml
@@ -50,6 +50,7 @@ url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 dialog-operator = { workspace = true, features = ["helpers"] }
+dialog-ucan-core = { workspace = true, features = ["helpers"] }
 dialog-remote-s3 = { workspace = true, features = ["helpers"] }
 dialog-remote-ucan-s3 = { workspace = true, features = ["helpers"] }
 dialog-storage = { workspace = true, features = ["helpers"] }

--- a/rust/dialog-repository/src/repository/branch/delegation/prove.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation/prove.rs
@@ -387,6 +387,27 @@ impl ProveDelegation<'_> {
             return Ok(None);
         }
 
+        // The envelope's structure agrees with the facts, but structure is
+        // not authority: any peer with push access can plant a forged
+        // envelope whose `iss` claims a principal it cannot sign for. Verify
+        // the signature against the claimed issuer's key before admitting the
+        // link, so a forgery is skipped like any other broken candidate. The
+        // resolver is a local did:key parse (no network, no I/O), so this is
+        // a cheap check at admission.
+        if let Err(error) = certificate
+            .0
+            .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+            .await
+        {
+            tracing::warn!(
+                entity = %candidate.entity,
+                issuer = %certificate.issuer(),
+                %error,
+                "delegation envelope signature does not verify; skipping candidate"
+            );
+            return Ok(None);
+        }
+
         let Ok(range) = certificate.verify(&self.access) else {
             return Ok(None);
         };
@@ -1032,6 +1053,130 @@ mod tests {
             matches!(verdict, Err(AuthorizeError::UnprovenSubject { .. })),
             "spoofed facts must not assemble a proof from a mismatched envelope: {:?}",
             verdict.err()
+        );
+        Ok(())
+    }
+
+    /// Plant a forged delegation whose `iss` claims `claimed_issuer` but is
+    /// signed by `actual_signer` (who cannot sign as `claimed_issuer`), with
+    /// facts that AGREE with the envelope so the fact/envelope consistency
+    /// guard passes. This is exactly what a peer with push access can write:
+    /// a self-consistent envelope + facts whose only defect is the signature.
+    async fn plant_forged(
+        harness: &Harness,
+        claimed_issuer: &Ed25519Signer,
+        audience: &Ed25519Signer,
+        subject: &Ed25519Signer,
+        actual_signer: &Ed25519Signer,
+    ) -> Result<()> {
+        let forged = dialog_ucan_core::Delegation::forge(
+            claimed_issuer.did(),
+            audience.did(),
+            UcanSubject::Specific(subject.did()),
+            Command(vec!["storage".to_string()]),
+            actual_signer,
+        )
+        .await
+        .expect("forge a delegation");
+        let certificate = UcanCertificate(forged);
+
+        use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
+        let bytes: Vec<u8> = certificate
+            .encode()
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        let mut sink = harness
+            .branch
+            .archive()
+            .blob()
+            .write()
+            .perform(&harness.operator)
+            .await?;
+        sink.write_all(&bytes).await?;
+        let hash = sink.finish().await?;
+        let index_hash: dialog_storage::Blake3Hash = *hash.as_bytes();
+        let entity = Entity::from_blob(&index_hash)?;
+
+        // Facts that AGREE with the forged envelope, so it passes the
+        // fact/envelope consistency guard and only the signature is wrong.
+        plant_facts(
+            harness,
+            &entity,
+            &claimed_issuer.did(),
+            &audience.did(),
+            &subject.did(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// TEST A -- forged-only fails: the only delegation covering the request
+    /// carries a forged signature (iss claims the subject but is signed by an
+    /// attacker), with facts that AGREE with the envelope (passing the
+    /// consistency guard) and a command cover that satisfies `verify`. The
+    /// prover must skip the forged candidate and, finding no other authority,
+    /// return unproven. This is the primary hole: any peer with push access
+    /// can plant such an envelope + facts, and the signature check is the
+    /// only thing standing between it and a spliced proof.
+    #[dialog_common::test]
+    async fn it_rejects_a_forged_delegation_signature() -> Result<()> {
+        let harness = Harness::new("prove-forged-signature").await?;
+        let space = signer().await;
+        let holder = signer().await;
+        let attacker = signer().await;
+
+        // Forged direct grant: iss = space (the subject), signed by attacker.
+        plant_forged(&harness, &space, &holder, &space, &attacker).await?;
+
+        let verdict = harness
+            .branch
+            .delegations()
+            .prove(holder.did(), scope(&space, &["storage"]))
+            .perform(&harness.operator)
+            .await;
+        assert!(
+            matches!(verdict, Err(AuthorizeError::UnprovenSubject { .. })),
+            "a forged envelope signature must not assemble a proof: {:?}",
+            verdict.err()
+        );
+        Ok(())
+    }
+
+    /// TEST B -- a valid delegation heals it: the same forged delegation is
+    /// present, but a SECOND, properly-signed delegation also authorizes the
+    /// request. The prover must skip the forged candidate and prove via the
+    /// valid one. This pins the crucial semantic: a bad-signature candidate
+    /// is SKIPPED, not a hard error, so a malicious peer injecting a forged
+    /// fact cannot deny service to an otherwise-provable request.
+    #[dialog_common::test]
+    async fn it_proves_via_a_valid_delegation_despite_a_forged_one() -> Result<()> {
+        let harness = Harness::new("prove-forged-plus-valid").await?;
+        let space = signer().await;
+        let holder = signer().await;
+        let attacker = signer().await;
+
+        // The forged direct grant from `space` to `holder`, still present.
+        plant_forged(&harness, &space, &holder, &space, &attacker).await?;
+
+        // A genuine direct grant from `space` to `holder`, properly signed.
+        harness
+            .retain(delegate(&space, &holder, UcanSubject::Specific(space.did())).await)
+            .await?;
+
+        let verdict = harness
+            .branch
+            .delegations()
+            .prove(holder.did(), scope(&space, &["storage"]))
+            .perform(&harness.operator)
+            .await;
+        assert!(
+            verdict.is_ok(),
+            "a forged candidate must be skipped, not poison an otherwise-provable request: {:?}",
+            verdict.err()
+        );
+        assert_eq!(
+            verdict.expect("valid delegation proves").proofs().len(),
+            1,
+            "the proof is assembled from the valid delegation alone"
         );
         Ok(())
     }

--- a/rust/dialog-ucan-core/src/container.rs
+++ b/rust/dialog-ucan-core/src/container.rs
@@ -34,6 +34,18 @@ pub enum ContainerError {
     #[error("Invocation error: {0}")]
     Invocation(String),
 
+    /// A delegation link in the chain does not carry a valid signature
+    /// from the principal its `iss` field claims. Kept distinct from
+    /// [`Invocation`](Self::Invocation) so the authorize boundary can
+    /// name the forged issuer.
+    #[error("Delegation from '{issuer}' does not carry a valid signature: {detail}")]
+    InvalidDelegationSignature {
+        /// The principal the forged proof claims as its issuer.
+        issuer: dialog_varsig::Did,
+        /// Human-readable description of the verification failure.
+        detail: String,
+    },
+
     /// Invalid configuration.
     #[error("Configuration error: {0}")]
     Configuration(String),

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -98,6 +98,12 @@ impl<S: Signature> InvocationChain<S> {
                     StoredCheckError::GetError(get_err) => {
                         ContainerError::Invocation(format!("proof not found: {}", get_err))
                     }
+                    StoredCheckError::SignatureVerification { issuer, source } => {
+                        ContainerError::InvalidDelegationSignature {
+                            issuer,
+                            detail: source.to_string(),
+                        }
+                    }
                     StoredCheckError::CheckFailed(check_err) => {
                         check_failed_to_container_error(check_err)
                     }
@@ -412,6 +418,69 @@ mod tests {
         // Should fail verification due to issuer mismatch
         let result = chain.verify(&Ed25519KeyResolver).await;
         assert!(result.is_err());
+    }
+
+    // Pins the delegation-link signature forgery. A structurally-valid
+    // delegation whose `iss` claims the subject but whose signature is not
+    // the subject's must be rejected: the attacker cannot sign as the
+    // subject, so the chain must not authorize them. Before delegation
+    // signatures were verified this passed verification, since only the
+    // invocation's own signature was checked.
+    #[dialog_common::test]
+    async fn it_fails_verification_when_delegation_signature_is_forged() {
+        use crate::command::Command;
+        use crate::subject::Subject;
+
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let attacker_signer = generate_signer().await;
+        let attacker_did = attacker_signer.did();
+
+        // Forge a delegation: iss claims the subject, aud is the attacker,
+        // sub is the subject's resource, but it is signed by the attacker,
+        // not the subject. The structure is valid (root issuer == subject),
+        // only the signature does not verify against the subject's key.
+        let forged = Delegation::forge(
+            subject_did.clone(),
+            attacker_did.clone(),
+            Subject::Specific(subject_did.clone()),
+            Command::new(vec!["storage".to_string(), "get".to_string()]),
+            &attacker_signer,
+        )
+        .await
+        .expect("Failed to forge delegation");
+
+        let forged_cid = forged.to_cid();
+
+        // Attacker builds a valid invocation, correctly signed by themselves,
+        // referencing the forged delegation as its proof.
+        let invocation = InvocationBuilder::new()
+            .issuer(attacker_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![forged_cid])
+            .try_build()
+            .await
+            .expect("Failed to build invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(forged_cid, Arc::new(forged));
+
+        let chain = InvocationChain::new(invocation, delegations);
+
+        // Must be rejected: the delegation link's signature is not the
+        // subject's, so the chain grants the attacker nothing.
+        let result = chain.verify(&Ed25519KeyResolver).await;
+        assert!(
+            result.is_err(),
+            "forged delegation-link signature must be rejected, got: {result:?}"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("signature"),
+            "rejection should name a signature failure, got: {err}"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/dialog-ucan-core/src/delegation.rs
+++ b/rust/dialog-ucan-core/src/delegation.rs
@@ -182,6 +182,54 @@ impl<S: Signature> Delegation<S> {
     }
 }
 
+#[cfg(any(test, feature = "helpers"))]
+impl<S: Signature> Delegation<S> {
+    /// Build a delegation whose `iss` field claims one principal while the
+    /// envelope is actually signed by another.
+    ///
+    /// This exists solely to forge structurally-valid delegations with
+    /// signatures that do not verify against the claimed issuer, so tests
+    /// can prove that chain verification rejects them. It must never be
+    /// reachable in production, hence the feature gate.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`builder::BuildError`] if encoding or signing fails.
+    pub async fn forge<I: crate::issuer::Issuer<S>>(
+        claimed_issuer: Did,
+        audience: Did,
+        subject: Subject,
+        command: Command,
+        actual_signer: &I,
+    ) -> Result<Self, builder::BuildError> {
+        let payload = DelegationPayload {
+            issuer: claimed_issuer,
+            audience,
+            subject,
+            command,
+            policy: Vec::new(),
+            expiration: None,
+            not_before: None,
+            meta: None,
+            #[allow(clippy::expect_used)]
+            nonce: Nonce::generate_16().expect("failed to generate nonce"),
+        };
+
+        let envelope = EnvelopePayload::from(payload);
+        let encoded = envelope
+            .encode()
+            .map_err(|e| builder::BuildError::EncodingError(e.to_string()))?;
+
+        // Signed by `actual_signer`, not by `claimed_issuer`, so the
+        // signature will not verify against the resolved issuer key.
+        let signature = dialog_varsig::signature::Signer::sign(actual_signer, &encoded)
+            .await
+            .map_err(builder::BuildError::SigningError)?;
+
+        Ok(Self::new(Envelope(signature, envelope)))
+    }
+}
+
 impl<S: Signature> Debug for Delegation<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Delegation").field(&self.envelope).finish()

--- a/rust/dialog-ucan-core/src/invocation.rs
+++ b/rust/dialog-ucan-core/src/invocation.rs
@@ -141,10 +141,13 @@ impl<S: Signature> Invocation<S> {
             .await
             .map_err(InvocationCheckError::SignatureVerification)?;
 
-        // 2. Check proof chain and compute valid time range
+        // 2. Check proof chain and compute valid time range. This also
+        //    verifies each delegation link's own signature against its
+        //    resolved issuer key, so a forged proof cannot pass just
+        //    because the invocation itself is validly signed.
         let time_range = self
             .payload()
-            .check(proof_store)
+            .check(proof_store, resolver)
             .await
             .map_err(InvocationCheckError::StoredCheck)?;
 
@@ -326,6 +329,11 @@ impl InvocationPayload {
 
     /// Check if an [`InvocationPayload`] with proofs stored in a delegation store is valid.
     ///
+    /// In addition to the structural [`syntactic_checks`](Self::syntactic_checks),
+    /// this verifies each delegation link's own signature against the key its
+    /// `iss` resolves to. A proof that is not actually signed by its claimed
+    /// issuer is rejected, even when the invocation itself is validly signed.
+    ///
     /// # Errors
     ///
     /// Returns a [`StoredCheckError`] if the check fails.
@@ -334,15 +342,31 @@ impl InvocationPayload {
         S: Signature,
         T: Borrow<Delegation<S>>,
         St: DelegationStore<K, S, T>,
+        R: Resolver<S>,
     >(
         &self,
         proof_store: &St,
-    ) -> Result<TimeRange, StoredCheckError<K, S, T, St>> {
+        resolver: &R,
+    ) -> Result<TimeRange, StoredCheckError<K, S, T, St, R>> {
         let realized_proofs: Vec<T> = proof_store
             .get_all(&self.proofs)
             .await
             .map_err(StoredCheckError::GetError)?;
         let dlgs: Vec<&Delegation<S>> = realized_proofs.iter().map(Borrow::borrow).collect();
+
+        // Every link must carry a signature that verifies against its own
+        // resolved issuer key. Without this a forged delegation (valid
+        // structure, garbage signature) would authorize an attacker.
+        for delegation in &dlgs {
+            delegation
+                .verify_signature(resolver)
+                .await
+                .map_err(|source| StoredCheckError::SignatureVerification {
+                    issuer: delegation.issuer().clone(),
+                    source,
+                })?;
+        }
+
         Ok(self.syntactic_checks(dlgs)?)
     }
 
@@ -713,16 +737,28 @@ pub enum CheckFailed {
 }
 
 /// Errors that can occur when checking an invocation with proofs stored in a delegation store
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Error)]
 pub enum StoredCheckError<
     K: FutureKind,
     S: Signature,
     T: Borrow<Delegation<S>>,
     St: DelegationStore<K, S, T>,
+    R: Resolver<S>,
 > {
     /// Error getting proofs from the store
     #[error(transparent)]
     GetError(St::GetError),
+
+    /// A delegation link's own signature did not verify against its
+    /// resolved issuer key. The `issuer` is the principal the proof claims
+    /// to be signed by.
+    #[error("delegation from '{issuer}' does not carry a valid signature: {source}")]
+    SignatureVerification {
+        /// The principal the forged proof claims as its issuer.
+        issuer: Did,
+        /// The underlying verification failure.
+        source: crate::delegation::SignatureVerificationError<R::Error>,
+    },
 
     /// Proof check failed
     #[error(transparent)]
@@ -760,7 +796,7 @@ pub enum InvocationCheckError<
 
     /// Proof chain check failed
     #[error(transparent)]
-    StoredCheck(StoredCheckError<K, S, T, St>),
+    StoredCheck(StoredCheckError<K, S, T, St, R>),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Security fix: delegation signatures were not verified

Authorization checked a delegation chain for structure and coverage (subject, audience, command prefix, policy, time) but **never verified the delegations were actually signed by their claimed issuers**. `Delegation::verify_signature` existed with no production caller, and `AuthorizeError::InvalidSignature { issuer }` existed but was never produced. The check was modeled and dropped.

### Impact

An attacker could forge authority. Mint a delegation naming any issuer:

```
Delegation { issuer: Alice, audience: Attacker, subject: Alice's-resource }
```

with a signature that is not Alice's (they cannot sign as Alice and do not need to). Because delegations are content-addressed and, in the repository, arrive as **synced facts**, a peer with push access could land a self-consistent forged envelope and have it spliced into a proof chain. Verification passed: structure aligned, coverage matched, and the delegation's signature was never checked. Alice's authority was forged.

Pre-existing on `main`, independent of the recent algorithm-agnostic / did:web work; surfaced while building a did:web signing test.

### Fix — both verification paths

**Presented invocation chains** (`dialog-remote-ucan-s3` authorizer). `InvocationPayload::check` now takes the resolver and, before the structural checks, resolves each proof's issuer DID and verifies that link's own signature. A bad link becomes `StoredCheckError::SignatureVerification` -> `ContainerError::InvalidDelegationSignature` -> `AuthorizeError::InvalidSignature { issuer }` at the authorizer (a presented invocation with a forged proof is a hard error).

**The prover** (`dialog-repository`, the primary path — delegations as synced facts). At the candidate admission point, after the fact/envelope consistency guard and before the coverage check, the envelope signature is verified against the issuer's `did:key` via the local `Ed25519KeyResolver` (no network for did:key). A candidate whose signature does not verify is **skipped** like any other non-matching candidate: a forged fact is simply not proof. So it cannot authorize on its own, and it cannot deny-service a request that a valid delegation still authorizes. The operator's authorize path routes its only untrusted admission through this prover; cached chains and self-minted session grants are trusted by construction.

Signature verification is parameterized over the resolver, so did:web and other DID methods thread through the same seam later without reshaping these call sites.

### Tests (test-first, red -> green)

- **Authorizer:** a forged invocation chain is rejected with `InvalidSignature { issuer }`.
- **Prover, forged-only:** a chain whose only covering delegation has a forged signature is **unproven**.
- **Prover, healed:** the same chain plus a validly-signed delegation for the same request **proves** (the forged candidate is skipped, not fatal) — pinning that a forged fact cannot deny-service an otherwise-provable request.

Each forged test fails against the pre-fix code (confirmed by neutering the new checks: the forged chain is wrongly accepted). Every pre-existing valid-chain test passes unchanged; none was masking the bug via unsigned delegations.