### PR TITLE
feat(did-web): resolve did:plc identities via plc.directory

### DIFF
--- a/rust/dialog-did-web/src/lib.rs
+++ b/rust/dialog-did-web/src/lib.rs
@@ -4,8 +4,9 @@
 //! [`Verifier`](dialog_credentials::Verifier). Resolution is expressed as an
 //! ambient [`Resolve`] capability performed against a
 //! [`Provider`](dialog_capability::Provider): `did:key` is parsed locally,
-//! `did:web` fetches the DID document over HTTPS, a [`MethodResolver`] routes by
-//! DID method, and a [`CachingResolver`] layers a TTL cache on top. The caller
+//! `did:web` fetches the DID document over HTTPS, `did:plc` fetches it from the
+//! PLC directory, a [`MethodResolver`] routes by DID method, and a
+//! [`CachingResolver`] layers a TTL cache on top. The caller
 //! only writes `Resolve::new(did).perform(&env)`; where the answer comes from is
 //! entirely a provider concern.
 //!
@@ -41,10 +42,10 @@ pub use cache::{CachingResolver, DEFAULT_NEGATIVE_TTL, DEFAULT_TTL, MAX_ENTRIES}
 pub use document::{DidDocument, Jwk, VerificationMethod};
 pub use error::ResolveError;
 pub use fetch::{Fetch, MAX_DOCUMENT_BYTES, ReqwestFetch};
-pub use provider::{DidKeyProvider, DidWebProvider, MethodResolver, WebResolver};
+pub use provider::{DidKeyProvider, DidPlcProvider, DidWebProvider, MethodResolver, WebResolver};
 pub use resolve::Resolve;
 pub use resolver::PerformingResolver;
-pub use url::did_web_url;
+pub use url::{did_plc_url, did_web_url};
 pub use verifier::MultiVerifier;
 
 #[cfg(feature = "test-fetch")]

--- a/rust/dialog-did-web/src/provider.rs
+++ b/rust/dialog-did-web/src/provider.rs
@@ -13,7 +13,7 @@ use crate::document::DidDocument;
 use crate::error::ResolveError;
 use crate::fetch::{Fetch, ReqwestFetch};
 use crate::resolve::Resolve;
-use crate::url::did_web_url;
+use crate::url::{did_plc_url, did_web_url};
 use crate::verifier::MultiVerifier;
 
 /// Resolves `did:key` DIDs locally, with no network access.
@@ -87,51 +87,125 @@ impl<F: Fetch> Provider<Resolve> for DidWebProvider<F> {
     }
 }
 
-/// Routes a resolution to a sub-provider by the DID's method.
+/// Resolves `did:plc` DIDs by fetching the DID document from the PLC directory.
 ///
-/// The varsig `CompositeResolver` composes by signature type, not DID method,
-/// so it cannot express "`did:key` here, `did:web` there". This does.
+/// A `did:plc` is resolved with a single GET to
+/// `https://plc.directory/did:plc:<identifier>`, which returns a W3C DID
+/// document of the same shape as a `did:web` document (a `verificationMethod`
+/// array of `Multikey` entries carrying `publicKeyMultibase`). So this provider
+/// is deliberately `did:web` with a different URL derivation and method guard:
+/// it reuses [`DidDocument`] and [`MultiVerifier`] unchanged.
+///
+/// # Trust model
+///
+/// This provider TRUSTS the PLC directory. `did:plc` is defined by an
+/// append-only operation log with an auditable signature chain, but this
+/// resolver does NOT fetch, replay, or validate that log. It takes the document
+/// `plc.directory` returns as authoritative for the DID. This is a deliberate
+/// design choice (the directory is the trust anchor), not an oversight: a future
+/// reader must not "fix" it by adding unrequested audit-chain validation without
+/// revisiting this decision.
+///
+/// Generic over a [`Fetch`] so the network dependency is swappable (and
+/// mockable in tests). [`DidPlcProvider::new`] uses [`ReqwestFetch`].
 #[derive(Debug, Clone, Default)]
-pub struct MethodResolver<K = DidKeyProvider, W = DidWebProvider> {
-    key: K,
-    web: W,
+pub struct DidPlcProvider<F = ReqwestFetch> {
+    fetch: F,
 }
 
-impl MethodResolver<DidKeyProvider, DidWebProvider> {
-    /// A resolver that handles `did:key` locally and `did:web` over the network
-    /// with the default fetcher.
+impl DidPlcProvider<ReqwestFetch> {
+    /// A provider backed by the default `reqwest` fetcher.
     #[must_use]
     pub fn new() -> Self {
         Self {
-            key: DidKeyProvider,
-            web: DidWebProvider::new(),
+            fetch: ReqwestFetch::new(),
         }
     }
 }
 
-impl<K, W> MethodResolver<K, W> {
-    /// A resolver from explicit `did:key` and `did:web` providers.
-    pub fn with_providers(key: K, web: W) -> Self {
-        Self { key, web }
+impl<F: Fetch> DidPlcProvider<F> {
+    /// A provider backed by a custom [`Fetch`].
+    pub fn with_fetch(fetch: F) -> Self {
+        Self { fetch }
     }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<K, W> Provider<Resolve> for MethodResolver<K, W>
+impl<F: Fetch> Provider<Resolve> for DidPlcProvider<F> {
+    async fn execute(&self, input: Resolve) -> Result<MultiVerifier, ResolveError> {
+        if input.did.method() != "plc" {
+            return Err(ResolveError::UnsupportedMethod(input.did.method().into()));
+        }
+
+        let fragment = input.did.as_str().rsplit_once('#').map(|(_, f)| f);
+        let did_for_url = fragment.map_or(input.did.as_str(), |frag| {
+            &input.did.as_str()[..input.did.as_str().len() - frag.len() - 1]
+        });
+
+        // The verifier's identity is the did:plc DID (without any #fragment),
+        // not any single member key's did:key.
+        let subject: dialog_varsig::Did = did_for_url
+            .parse()
+            .map_err(|_| ResolveError::MalformedDid(did_for_url.into()))?;
+
+        let url = did_plc_url(did_for_url)?;
+        let body = self.fetch.get(&url).await?;
+        let document: DidDocument = serde_json::from_slice(&body)
+            .map_err(|e| ResolveError::MalformedDocument(e.to_string()))?;
+        document.verifier(&subject, fragment)
+    }
+}
+
+/// Routes a resolution to a sub-provider by the DID's method.
+///
+/// The varsig `CompositeResolver` composes by signature type, not DID method,
+/// so it cannot express "`did:key` here, `did:web` there". This does.
+#[derive(Debug, Clone, Default)]
+pub struct MethodResolver<K = DidKeyProvider, W = DidWebProvider, P = DidPlcProvider> {
+    key: K,
+    web: W,
+    plc: P,
+}
+
+impl MethodResolver<DidKeyProvider, DidWebProvider, DidPlcProvider> {
+    /// A resolver that handles `did:key` locally and `did:web`/`did:plc` over
+    /// the network with the default fetcher.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            key: DidKeyProvider,
+            web: DidWebProvider::new(),
+            plc: DidPlcProvider::new(),
+        }
+    }
+}
+
+impl<K, W, P> MethodResolver<K, W, P> {
+    /// A resolver from explicit `did:key`, `did:web`, and `did:plc` providers.
+    pub fn with_providers(key: K, web: W, plc: P) -> Self {
+        Self { key, web, plc }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<K, W, P> Provider<Resolve> for MethodResolver<K, W, P>
 where
     K: Provider<Resolve> + dialog_common::ConditionalSync,
     W: Provider<Resolve> + dialog_common::ConditionalSync,
+    P: Provider<Resolve> + dialog_common::ConditionalSync,
 {
     async fn execute(&self, input: Resolve) -> Result<MultiVerifier, ResolveError> {
         match input.did.method() {
             "key" => self.key.execute(input).await,
             "web" => self.web.execute(input).await,
+            "plc" => self.plc.execute(input).await,
             other => Err(ResolveError::UnsupportedMethod(other.into())),
         }
     }
 }
 
 /// Convenience alias for the default network-capable resolver: `did:key`
-/// locally, `did:web` over `reqwest`.
-pub type WebResolver = MethodResolver<DidKeyProvider, DidWebProvider>;
+/// locally, `did:web` and `did:plc` over `reqwest`.
+pub type WebResolver = MethodResolver<DidKeyProvider, DidWebProvider, DidPlcProvider>;

--- a/rust/dialog-did-web/src/resolver.rs
+++ b/rust/dialog-did-web/src/resolver.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use crate::document::DidDocument;
     use crate::fetch::MapFetch;
-    use crate::provider::{DidWebProvider, MethodResolver};
+    use crate::provider::{DidPlcProvider, DidWebProvider, MethodResolver};
     use dialog_credentials::{Ed25519Signer, Signer};
     use dialog_varsig::{
         AnySignature, Principal, Signer as VarsigSigner, Verifier as VarsigVerifier,
@@ -101,6 +101,7 @@ mod tests {
         let env = MethodResolver::with_providers(
             crate::provider::DidKeyProvider,
             DidWebProvider::with_fetch(fetch),
+            DidPlcProvider::with_fetch(MapFetch::new()),
         );
         let resolver = PerformingResolver::new(&env);
 
@@ -128,6 +129,7 @@ mod tests {
         let env = MethodResolver::with_providers(
             crate::provider::DidKeyProvider,
             DidWebProvider::with_fetch(MapFetch::new()),
+            DidPlcProvider::with_fetch(MapFetch::new()),
         );
         let resolver = PerformingResolver::new(&env);
 

--- a/rust/dialog-did-web/src/tests.rs
+++ b/rust/dialog-did-web/src/tests.rs
@@ -214,6 +214,36 @@ async fn it_verifies_a_signature_by_any_did_plc_key() {
     verifier.verify(msg, &sig1).await.unwrap();
 }
 
+/// A `#fragment` on a `did:plc` selects exactly that verification method, the
+/// same kid-hint path `did:web` has. The provider strips the fragment before
+/// URL derivation (a `#` is not base32, so an unstripped fragment would refuse
+/// the whole DID) and restricts the verifier to the selected method: a
+/// signature by the other key must not verify.
+#[dialog_common::test]
+async fn it_selects_a_single_plc_key_by_fragment() {
+    let key1 = Signer::from(Ed25519Signer::generate().await.unwrap());
+    let key2 = Signer::from(Ed25519Signer::generate().await.unwrap());
+    let doc = did_document_two_keys(PLC_DID, &key1, &key2);
+    let fetch = MapFetch::new().with(plc_url(PLC_DID), doc.into_bytes());
+    let provider = DidPlcProvider::with_fetch(fetch);
+
+    let did: Did = format!("{PLC_DID}#key-2").parse().unwrap();
+    let verifier = Resolve::new(did).perform(&provider).await.unwrap();
+
+    // The verifier's identity is the base did:plc DID (fragment stripped).
+    assert_eq!(verifier.did().as_str(), PLC_DID);
+
+    let msg = b"selected by plc fragment";
+    let sig2 = VarsigSigner::sign(&key2, msg).await.unwrap();
+    verifier.verify(msg, &sig2).await.unwrap();
+
+    let sig1 = VarsigSigner::sign(&key1, msg).await.unwrap();
+    assert!(
+        verifier.verify(msg, &sig1).await.is_err(),
+        "a fragment-selected plc verifier must refuse a signature by another key"
+    );
+}
+
 /// A `did:plc` document may list an unsupported key type (plc DIDs may carry a
 /// secp256k1 key we do not support yet). That method is SKIPPED, and resolution
 /// still succeeds as long as one supported key remains.

--- a/rust/dialog-did-web/src/tests.rs
+++ b/rust/dialog-did-web/src/tests.rs
@@ -10,7 +10,7 @@ use dialog_varsig::{Did, Principal, Signer as VarsigSigner, Verifier as VarsigVe
 
 use crate::document::DidDocument;
 use crate::fetch::MapFetch;
-use crate::provider::{DidKeyProvider, DidWebProvider, MethodResolver};
+use crate::provider::{DidKeyProvider, DidPlcProvider, DidWebProvider, MethodResolver};
 use crate::resolve::Resolve;
 use crate::url::did_web_url;
 use crate::{CachingResolver, ResolveError};
@@ -155,6 +155,179 @@ async fn it_selects_a_single_key_by_fragment() {
         verifier.verify(msg, &sig1).await.is_err(),
         "a fragment-selected verifier must refuse a signature by another key"
     );
+}
+
+/// A plausible `did:plc` identifier (24 chars of base32 [a-z2-7]).
+const PLC_DID: &str = "did:plc:ewvi7nxzyoun6zhxrhs64oiz";
+
+/// The `plc.directory` URL a `did:plc` resolves against.
+fn plc_url(did: &str) -> String {
+    format!("https://plc.directory/{did}")
+}
+
+/// A `did:plc` document is the same shape as a `did:web` one: a Multikey
+/// verification method carrying `publicKeyMultibase`. Resolving it recovers a
+/// verifier that checks a signature the matching signer produced.
+async fn resolves_plc_algorithm(signer: Signer) {
+    let doc = did_document_multibase(PLC_DID, &signer);
+    let fetch = MapFetch::new().with(plc_url(PLC_DID), doc.into_bytes());
+    let provider = DidPlcProvider::with_fetch(fetch);
+
+    let did: Did = PLC_DID.parse().unwrap();
+    let verifier = Resolve::new(did).perform(&provider).await.unwrap();
+    assert_eq!(verifier.did().as_str(), PLC_DID);
+
+    let msg = b"resolve me through the plc directory";
+    let sig = VarsigSigner::sign(&signer, msg).await.unwrap();
+    verifier.verify(msg, &sig).await.unwrap();
+}
+
+#[dialog_common::test]
+async fn it_resolves_ed25519_did_plc() {
+    let signer = Signer::from(Ed25519Signer::generate().await.unwrap());
+    resolves_plc_algorithm(signer).await;
+}
+
+#[dialog_common::test]
+async fn it_resolves_es256_did_plc() {
+    let signer = Signer::from(Es256Signer::generate().await.unwrap());
+    resolves_plc_algorithm(signer).await;
+}
+
+/// A `did:plc` document with two keys must verify a signature by EITHER key.
+#[dialog_common::test]
+async fn it_verifies_a_signature_by_any_did_plc_key() {
+    let key1 = Signer::from(Ed25519Signer::generate().await.unwrap());
+    let key2 = Signer::from(Es256Signer::generate().await.unwrap());
+    let doc = did_document_two_keys(PLC_DID, &key1, &key2);
+    let fetch = MapFetch::new().with(plc_url(PLC_DID), doc.into_bytes());
+    let provider = DidPlcProvider::with_fetch(fetch);
+
+    let did: Did = PLC_DID.parse().unwrap();
+    let verifier = Resolve::new(did).perform(&provider).await.unwrap();
+    assert_eq!(verifier.did().as_str(), PLC_DID);
+
+    let msg = b"either plc key may have signed";
+    let sig2 = VarsigSigner::sign(&key2, msg).await.unwrap();
+    verifier.verify(msg, &sig2).await.unwrap();
+    let sig1 = VarsigSigner::sign(&key1, msg).await.unwrap();
+    verifier.verify(msg, &sig1).await.unwrap();
+}
+
+/// A `did:plc` document may list an unsupported key type (plc DIDs may carry a
+/// secp256k1 key we do not support yet). That method is SKIPPED, and resolution
+/// still succeeds as long as one supported key remains.
+#[dialog_common::test]
+async fn it_skips_unsupported_key_but_keeps_supported() {
+    let supported = Signer::from(Ed25519Signer::generate().await.unwrap());
+    // A fake secp256k1 Multikey: a `z`-multibase whose bytes are not a key type
+    // this build can parse. It must be skipped, not fatal.
+    let doc = format!(
+        r#"{{
+            "id": "{PLC_DID}",
+            "verificationMethod": [
+                {{
+                    "id": "{PLC_DID}#atproto",
+                    "type": "Multikey",
+                    "controller": "{PLC_DID}",
+                    "publicKeyMultibase": "zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBmed"
+                }},
+                {{
+                    "id": "{PLC_DID}#key-2",
+                    "type": "Multikey",
+                    "controller": "{PLC_DID}",
+                    "publicKeyMultibase": "{multibase}"
+                }}
+            ]
+        }}"#,
+        multibase = multibase_of(&supported),
+    );
+    let fetch = MapFetch::new().with(plc_url(PLC_DID), doc.into_bytes());
+    let provider = DidPlcProvider::with_fetch(fetch);
+
+    let did: Did = PLC_DID.parse().unwrap();
+    let verifier = Resolve::new(did).perform(&provider).await.unwrap();
+
+    let msg = b"only the supported key can sign";
+    let sig = VarsigSigner::sign(&supported, msg).await.unwrap();
+    verifier.verify(msg, &sig).await.unwrap();
+}
+
+#[dialog_common::test]
+async fn it_refuses_missing_plc_document() {
+    let provider = DidPlcProvider::with_fetch(MapFetch::new());
+    let did: Did = PLC_DID.parse().unwrap();
+    let err = Resolve::new(did).perform(&provider).await.unwrap_err();
+    assert!(matches!(err, ResolveError::Fetch(_)), "got {err:?}");
+}
+
+#[dialog_common::test]
+async fn it_refuses_malformed_plc_document() {
+    let fetch = MapFetch::new().with(plc_url(PLC_DID), b"not json".to_vec());
+    let provider = DidPlcProvider::with_fetch(fetch);
+    let did: Did = PLC_DID.parse().unwrap();
+    let err = Resolve::new(did).perform(&provider).await.unwrap_err();
+    assert!(
+        matches!(err, ResolveError::MalformedDocument(_)),
+        "got {err:?}"
+    );
+}
+
+#[dialog_common::test]
+async fn it_refuses_plc_no_verification_method() {
+    let doc = format!(r#"{{ "id": "{PLC_DID}", "verificationMethod": [] }}"#);
+    let fetch = MapFetch::new().with(plc_url(PLC_DID), doc.into_bytes());
+    let provider = DidPlcProvider::with_fetch(fetch);
+    let did: Did = PLC_DID.parse().unwrap();
+    let err = Resolve::new(did).perform(&provider).await.unwrap_err();
+    assert!(
+        matches!(err, ResolveError::NoSupportedVerificationMethod),
+        "got {err:?}"
+    );
+}
+
+/// The plc provider refuses a non-plc method.
+#[dialog_common::test]
+async fn it_refuses_non_plc_method() {
+    let provider = DidPlcProvider::with_fetch(MapFetch::new());
+    let did: Did = "did:web:example.com".parse().unwrap();
+    let err = Resolve::new(did).perform(&provider).await.unwrap_err();
+    assert!(
+        matches!(err, ResolveError::UnsupportedMethod(_)),
+        "got {err:?}"
+    );
+}
+
+/// `did:plc` routes to the plc provider (which fetches the plc.directory URL),
+/// while `did:key` stays local and `did:web` routes to the web provider. Asserts
+/// routing by the URL each arm's mock fetcher is asked for.
+#[dialog_common::test]
+async fn method_dispatch_routes_did_plc_to_plc_fetcher() {
+    let signer = Signer::from(Ed25519Signer::generate().await.unwrap());
+    let doc = did_document_multibase(PLC_DID, &signer);
+    let plc_fetch = MapFetch::new().with(plc_url(PLC_DID), doc.into_bytes());
+    let web_fetch = MapFetch::new();
+    let resolver = MethodResolver::with_providers(
+        DidKeyProvider,
+        DidWebProvider::with_fetch(web_fetch.clone()),
+        DidPlcProvider::with_fetch(plc_fetch.clone()),
+    );
+
+    let did: Did = PLC_DID.parse().unwrap();
+    let verifier = Resolve::new(did).perform(&resolver).await.unwrap();
+    assert_eq!(verifier.did().as_str(), PLC_DID);
+
+    assert_eq!(plc_fetch.calls(), 1, "did:plc must hit the plc fetcher");
+    assert_eq!(web_fetch.calls(), 0, "did:plc must not hit the web fetcher");
+
+    // did:key through the same resolver stays local: no fetch on either arm.
+    let key_signer = Signer::from(Ed25519Signer::generate().await.unwrap());
+    Resolve::new(key_signer.did())
+        .perform(&resolver)
+        .await
+        .unwrap();
+    assert_eq!(plc_fetch.calls(), 1, "did:key must not hit the plc fetcher");
+    assert_eq!(web_fetch.calls(), 0, "did:key must not hit the web fetcher");
 }
 
 async fn resolves_algorithm(signer: Signer) {
@@ -372,8 +545,11 @@ async fn it_excludes_a_method_controlled_by_another_did() {
 async fn method_dispatch_resolves_did_key_without_fetching() {
     let signer = Signer::from(Ed25519Signer::generate().await.unwrap());
     let fetch = MapFetch::new();
-    let resolver =
-        MethodResolver::with_providers(DidKeyProvider, DidWebProvider::with_fetch(fetch.clone()));
+    let resolver = MethodResolver::with_providers(
+        DidKeyProvider,
+        DidWebProvider::with_fetch(fetch.clone()),
+        DidPlcProvider::with_fetch(fetch.clone()),
+    );
 
     let did = signer.did();
     let verifier = Resolve::new(did).perform(&resolver).await.unwrap();
@@ -393,8 +569,11 @@ async fn method_dispatch_routes_did_web_to_fetcher() {
         "https://route.example/.well-known/did.json",
         doc.into_bytes(),
     );
-    let resolver =
-        MethodResolver::with_providers(DidKeyProvider, DidWebProvider::with_fetch(fetch.clone()));
+    let resolver = MethodResolver::with_providers(
+        DidKeyProvider,
+        DidWebProvider::with_fetch(fetch.clone()),
+        DidPlcProvider::with_fetch(MapFetch::new()),
+    );
 
     let did: Did = did_web.parse().unwrap();
     Resolve::new(did).perform(&resolver).await.unwrap();
@@ -505,7 +684,11 @@ async fn signs_and_verifies_under_did_web(key: Signer) {
         "https://issuer.example/.well-known/did.json",
         doc.into_bytes(),
     );
-    let env = MethodResolver::with_providers(DidKeyProvider, DidWebProvider::with_fetch(fetch));
+    let env = MethodResolver::with_providers(
+        DidKeyProvider,
+        DidWebProvider::with_fetch(fetch),
+        DidPlcProvider::with_fetch(MapFetch::new()),
+    );
 
     let resolver = PerformingResolver::new(&env);
     chain
@@ -558,7 +741,11 @@ async fn it_refuses_did_web_with_wrong_key() {
         "https://issuer.example/.well-known/did.json",
         doc.into_bytes(),
     );
-    let env = MethodResolver::with_providers(DidKeyProvider, DidWebProvider::with_fetch(fetch));
+    let env = MethodResolver::with_providers(
+        DidKeyProvider,
+        DidWebProvider::with_fetch(fetch),
+        DidPlcProvider::with_fetch(MapFetch::new()),
+    );
 
     let resolver = PerformingResolver::new(&env);
     assert!(

--- a/rust/dialog-did-web/src/tests.rs
+++ b/rust/dialog-did-web/src/tests.rs
@@ -261,6 +261,40 @@ async fn it_refuses_missing_plc_document() {
     assert!(matches!(err, ResolveError::Fetch(_)), "got {err:?}");
 }
 
+/// A `did:plc` document served for one identifier must not be accepted for a
+/// different one. `plc.directory` is trusted, but the trust is "the directory
+/// answers honestly for the DID we asked about"; a document whose `id` names a
+/// *different* did:plc (returned by a redirect, a cache mixup, or a directory
+/// compromise) must be refused. Without the `id` check the wrong identity's
+/// keys are bound to the requested DID, so the wrong key verifies as this DID.
+#[dialog_common::test]
+async fn it_refuses_plc_document_whose_id_is_a_different_did() {
+    let attacker = Signer::from(Ed25519Signer::generate().await.unwrap());
+    // The document is fetched at PLC_DID's URL but claims to be another did:plc.
+    let other_plc = "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa";
+    let doc = did_document_multibase(other_plc, &attacker);
+    let fetch = MapFetch::new().with(plc_url(PLC_DID), doc.into_bytes());
+    let provider = DidPlcProvider::with_fetch(fetch);
+
+    let did: Did = PLC_DID.parse().unwrap();
+    let outcome = Resolve::new(did).perform(&provider).await;
+
+    let Err(err) = &outcome else {
+        let verifier = outcome.unwrap();
+        let msg = b"attacker speaks as another plc identity";
+        let sig = VarsigSigner::sign(&attacker, msg).await.unwrap();
+        let forged = verifier.verify(msg, &sig).await.is_ok();
+        panic!(
+            "resolving {PLC_DID} accepted a document with id={other_plc}; \
+             attacker key verifies as {PLC_DID} = {forged}"
+        );
+    };
+    assert!(
+        matches!(err, ResolveError::MalformedDocument(_)),
+        "expected an id-mismatch refusal, got {err:?}"
+    );
+}
+
 #[dialog_common::test]
 async fn it_refuses_malformed_plc_document() {
     let fetch = MapFetch::new().with(plc_url(PLC_DID), b"not json".to_vec());

--- a/rust/dialog-did-web/src/tests.rs
+++ b/rust/dialog-did-web/src/tests.rs
@@ -917,7 +917,11 @@ async fn caching_is_bounded_against_attacker_chosen_dids() {
 
     let fetch = MapFetch::new();
     let cached = CachingResolver::with_ttls_and_capacity(
-        MethodResolver::with_providers(DidKeyProvider, DidWebProvider::with_fetch(fetch.clone())),
+        MethodResolver::with_providers(
+            DidKeyProvider,
+            DidWebProvider::with_fetch(fetch.clone()),
+            DidPlcProvider::with_fetch(fetch.clone()),
+        ),
         std::time::Duration::from_secs(300),
         std::time::Duration::from_secs(30),
         CAPACITY,

--- a/rust/dialog-did-web/src/url.rs
+++ b/rust/dialog-did-web/src/url.rs
@@ -153,9 +153,6 @@ pub fn did_web_url(did: &str) -> Result<String, ResolveError> {
 /// The `plc.directory` origin every `did:plc` resolves against.
 const PLC_DIRECTORY: &str = "https://plc.directory";
 
-/// The fixed length of a `did:plc` identifier: 24 base32 characters.
-const PLC_IDENTIFIER_LEN: usize = 24;
-
 /// Derive the resolution URL for a `did:plc` DID string.
 ///
 /// The whole DID (`did:plc:<identifier>`) is the last path segment:
@@ -164,16 +161,10 @@ const PLC_IDENTIFIER_LEN: usize = 24;
 /// DID has exactly three colon-separated segments and needs no percent-encoding
 /// (a literal `:` is valid in a URL path segment).
 ///
-/// Both the charset and the length are checked before the identifier reaches
-/// the URL. The charset is what keeps a crafted DID from escaping the
-/// `plc.directory` path (no `/`, `?`, `#`, `.` or `%` can appear), and the
-/// length is what keeps a well-formed-looking but bogus identifier from
-/// becoming a directory request at all.
-///
 /// # Errors
 ///
 /// Returns [`ResolveError::MalformedDid`] if the string is not a `did:plc` DID
-/// whose identifier is 24 base32 characters.
+/// with a plausible identifier.
 pub fn did_plc_url(did: &str) -> Result<String, ResolveError> {
     let identifier = did
         .strip_prefix("did:plc:")
@@ -194,13 +185,6 @@ pub fn did_plc_url(did: &str) -> Result<String, ResolveError> {
     {
         return Err(ResolveError::MalformedDid(format!(
             "did:plc identifier is not base32 [a-z2-7]: {did}"
-        )));
-    }
-
-    if identifier.len() != PLC_IDENTIFIER_LEN {
-        return Err(ResolveError::MalformedDid(format!(
-            "did:plc identifier must be {PLC_IDENTIFIER_LEN} characters, got {}: {did}",
-            identifier.len()
         )));
     }
 
@@ -417,5 +401,27 @@ mod tests {
             did_plc_url("did:plc:UPPERCASE"),
             Err(ResolveError::MalformedDid(_))
         ));
+    }
+
+    /// A did:plc identifier is exactly 24 base32 characters (per the PLC spec,
+    /// a truncated 32-byte SHA-256 in base32). The doc comment already asserts
+    /// this length; the code must enforce it, not just the charset, so a
+    /// malformed short or long identifier is refused before it becomes a
+    /// directory request URL.
+    #[test]
+    fn plc_rejects_wrong_length_identifier() {
+        // One char: passes the charset test but is not a plc identifier.
+        assert!(
+            matches!(did_plc_url("did:plc:a"), Err(ResolveError::MalformedDid(_))),
+            "a 1-char identifier must be refused"
+        );
+        // 25 base32 chars: one over the fixed length.
+        assert!(
+            matches!(
+                did_plc_url("did:plc:aaaaaaaaaaaaaaaaaaaaaaaaa"),
+                Err(ResolveError::MalformedDid(_))
+            ),
+            "an over-length identifier must be refused"
+        );
     }
 }

--- a/rust/dialog-did-web/src/url.rs
+++ b/rust/dialog-did-web/src/url.rs
@@ -383,7 +383,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[dialog_common::test]
     fn plc_identifier_in_path() {
         assert_eq!(
             did_plc_url("did:plc:ewvi7nxzyoun6zhxrhs64oiz").unwrap(),
@@ -391,7 +391,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[dialog_common::test]
     fn plc_rejects_non_plc() {
         assert!(matches!(
             did_plc_url("did:web:example.com"),
@@ -399,7 +399,7 @@ mod tests {
         ));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn plc_rejects_empty_identifier() {
         assert!(matches!(
             did_plc_url("did:plc:"),
@@ -407,7 +407,7 @@ mod tests {
         ));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn plc_rejects_non_base32_identifier() {
         assert!(matches!(
             did_plc_url("did:plc:has/slash"),
@@ -424,7 +424,7 @@ mod tests {
     /// this length; the code must enforce it, not just the charset, so a
     /// malformed short or long identifier is refused before it becomes a
     /// directory request URL.
-    #[test]
+    #[dialog_common::test]
     fn plc_rejects_wrong_length_identifier() {
         // One char: passes the charset test but is not a plc identifier.
         assert!(

--- a/rust/dialog-did-web/src/url.rs
+++ b/rust/dialog-did-web/src/url.rs
@@ -153,6 +153,9 @@ pub fn did_web_url(did: &str) -> Result<String, ResolveError> {
 /// The `plc.directory` origin every `did:plc` resolves against.
 const PLC_DIRECTORY: &str = "https://plc.directory";
 
+/// The fixed length of a `did:plc` identifier: 24 base32 characters.
+const PLC_IDENTIFIER_LEN: usize = 24;
+
 /// Derive the resolution URL for a `did:plc` DID string.
 ///
 /// The whole DID (`did:plc:<identifier>`) is the last path segment:
@@ -161,10 +164,16 @@ const PLC_DIRECTORY: &str = "https://plc.directory";
 /// DID has exactly three colon-separated segments and needs no percent-encoding
 /// (a literal `:` is valid in a URL path segment).
 ///
+/// Both the charset and the length are checked before the identifier reaches
+/// the URL. The charset is what keeps a crafted DID from escaping the
+/// `plc.directory` path (no `/`, `?`, `#`, `.` or `%` can appear), and the
+/// length is what keeps a well-formed-looking but bogus identifier from
+/// becoming a directory request at all.
+///
 /// # Errors
 ///
 /// Returns [`ResolveError::MalformedDid`] if the string is not a `did:plc` DID
-/// with a plausible identifier.
+/// whose identifier is 24 base32 characters.
 pub fn did_plc_url(did: &str) -> Result<String, ResolveError> {
     let identifier = did
         .strip_prefix("did:plc:")
@@ -185,6 +194,13 @@ pub fn did_plc_url(did: &str) -> Result<String, ResolveError> {
     {
         return Err(ResolveError::MalformedDid(format!(
             "did:plc identifier is not base32 [a-z2-7]: {did}"
+        )));
+    }
+
+    if identifier.len() != PLC_IDENTIFIER_LEN {
+        return Err(ResolveError::MalformedDid(format!(
+            "did:plc identifier must be {PLC_IDENTIFIER_LEN} characters, got {}: {did}",
+            identifier.len()
         )));
     }
 

--- a/rust/dialog-did-web/src/url.rs
+++ b/rust/dialog-did-web/src/url.rs
@@ -1,9 +1,13 @@
-//! `did:web` to HTTPS URL derivation, per the did:web method spec.
+//! DID to HTTPS URL derivation.
 //!
+//! `did:web`, per the did:web method spec:
 //! - `did:web:example.com` becomes `https://example.com/.well-known/did.json`.
 //! - `did:web:example.com:path:to` becomes `https://example.com/path/to/did.json`.
 //! - a percent-encoded colon in the host segment (`did:web:host%3A3000`) decodes
 //!   to a port (`host:3000`).
+//!
+//! `did:plc`, resolved against the PLC directory:
+//! - `did:plc:xxxx` becomes `https://plc.directory/did:plc:xxxx`.
 //!
 //! # Validating the decoded output
 //!
@@ -20,6 +24,9 @@
 //! an identity-substitution vector. So each *decoded* segment is checked against
 //! an allowlist: a host may hold only letters, digits, `-`, `.`, and a single
 //! `:port` suffix, and a path segment only unreserved characters.
+//!
+//! `did:plc` needs no decoding at all: the identifier is base32 (`a-z2-7`) of a
+//! fixed length, which [`did_plc_url`] checks before it reaches the URL.
 
 use percent_encoding::percent_decode_str;
 
@@ -141,6 +148,63 @@ pub fn did_web_url(did: &str) -> Result<String, ResolveError> {
     };
 
     Ok(url)
+}
+
+/// The `plc.directory` origin every `did:plc` resolves against.
+const PLC_DIRECTORY: &str = "https://plc.directory";
+
+/// The fixed length of a `did:plc` identifier: 24 base32 characters.
+const PLC_IDENTIFIER_LEN: usize = 24;
+
+/// Derive the resolution URL for a `did:plc` DID string.
+///
+/// The whole DID (`did:plc:<identifier>`) is the last path segment:
+/// `did:plc:xxxx` becomes `https://plc.directory/did:plc:xxxx`. A `did:plc`
+/// identifier is 24 characters of base32 (`a-z2-7`) and contains no `:`, so the
+/// DID has exactly three colon-separated segments and needs no percent-encoding
+/// (a literal `:` is valid in a URL path segment).
+///
+/// Both the charset and the length are checked before the identifier reaches
+/// the URL. The charset is what keeps a crafted DID from escaping the
+/// `plc.directory` path (no `/`, `?`, `#`, `.` or `%` can appear), and the
+/// length is what keeps a well-formed-looking but bogus identifier from
+/// becoming a directory request at all.
+///
+/// # Errors
+///
+/// Returns [`ResolveError::MalformedDid`] if the string is not a `did:plc` DID
+/// whose identifier is 24 base32 characters.
+pub fn did_plc_url(did: &str) -> Result<String, ResolveError> {
+    let identifier = did
+        .strip_prefix("did:plc:")
+        .ok_or_else(|| ResolveError::MalformedDid(format!("not a did:plc DID: {did}")))?;
+
+    if identifier.is_empty() {
+        return Err(ResolveError::MalformedDid(format!(
+            "did:plc has no identifier: {did}"
+        )));
+    }
+
+    // A did:plc identifier is base32 [a-z2-7]. Anything else (an embedded ':',
+    // a '/', uppercase, a fragment) is not a plc identifier and must not be
+    // spliced into the URL path.
+    if !identifier
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || (b'2'..=b'7').contains(&b))
+    {
+        return Err(ResolveError::MalformedDid(format!(
+            "did:plc identifier is not base32 [a-z2-7]: {did}"
+        )));
+    }
+
+    if identifier.len() != PLC_IDENTIFIER_LEN {
+        return Err(ResolveError::MalformedDid(format!(
+            "did:plc identifier must be {PLC_IDENTIFIER_LEN} characters, got {}: {did}",
+            identifier.len()
+        )));
+    }
+
+    Ok(format!("{PLC_DIRECTORY}/did:plc:{identifier}"))
 }
 
 #[cfg(test)]
@@ -317,5 +381,41 @@ mod tests {
             matches!(url, Err(ResolveError::MalformedDid(_))),
             "a path segment decoding to control bytes must be refused, got {url:?}"
         );
+    }
+
+    #[test]
+    fn plc_identifier_in_path() {
+        assert_eq!(
+            did_plc_url("did:plc:ewvi7nxzyoun6zhxrhs64oiz").unwrap(),
+            "https://plc.directory/did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+        );
+    }
+
+    #[test]
+    fn plc_rejects_non_plc() {
+        assert!(matches!(
+            did_plc_url("did:web:example.com"),
+            Err(ResolveError::MalformedDid(_))
+        ));
+    }
+
+    #[test]
+    fn plc_rejects_empty_identifier() {
+        assert!(matches!(
+            did_plc_url("did:plc:"),
+            Err(ResolveError::MalformedDid(_))
+        ));
+    }
+
+    #[test]
+    fn plc_rejects_non_base32_identifier() {
+        assert!(matches!(
+            did_plc_url("did:plc:has/slash"),
+            Err(ResolveError::MalformedDid(_))
+        ));
+        assert!(matches!(
+            did_plc_url("did:plc:UPPERCASE"),
+            Err(ResolveError::MalformedDid(_))
+        ));
     }
 }

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -835,7 +835,9 @@ mod tests {
     /// configurable-resolver wiring carries through to `authorize`.
     #[dialog_common::test]
     async fn it_authorizes_through_an_injected_resolver() {
-        use dialog_did_web::{DidKeyProvider, DidWebProvider, MapFetch, MethodResolver};
+        use dialog_did_web::{
+            DidKeyProvider, DidPlcProvider, DidWebProvider, MapFetch, MethodResolver,
+        };
 
         let signer = test_signer().await;
 
@@ -851,6 +853,7 @@ mod tests {
         let resolver = MethodResolver::with_providers(
             DidKeyProvider,
             DidWebProvider::with_fetch(MapFetch::new()),
+            DidPlcProvider::with_fetch(MapFetch::new()),
         );
         let authorizer = UcanAuthorizer::with_resolver(address, Some(credentials), resolver);
 


### PR DESCRIPTION
Stacked on the did:web PR. Adds did:plc resolution.

## Approach

A did:plc DID resolves to a standard W3C DID document (served by `plc.directory`), the same shape did:web already parses. So did:plc reuses the whole machinery: `DidPlcProvider` fetches `https://plc.directory/<did>`, parses the same `DidDocument`, and returns the same `MultiVerifier` over the document's key set. Multi-key any-match, `#fragment` selection, and skipping unsupported key types all come for free. `MethodResolver` routes `did:plc` alongside `did:key` and `did:web`, so the authorizer's default resolver stack now resolves all three.

## Trust model (deliberate)

The plc operation log is an append-only, auditable signature chain. **This resolver does not fetch or validate it** — the document `plc.directory` returns is taken as authoritative for the DID. This is a chosen trust boundary, documented on `DidPlcProvider` so it is not mistaken for an oversight. Validating the operation log (rotation-key chains, recovery windows, genesis-hash-matches-DID) is a larger, separate piece of work that can layer on later if the trust boundary needs tightening.

## Tests

Mock-fetched (no network): ed25519 and p256 did:plc resolve-and-verify; a two-key document verifies a signature by either key; an unsupported key type is skipped as long as a supported one remains; malformed / missing documents and non-plc methods are refused; method dispatch routes did:plc to the network while did:key stays local. Plus URL-derivation unit tests (base32 identifier validation).


## Security review fixes

The security review confirmed that the document-`id` binding gap from the did:web layer applies here too, and pinned a length gap specific to did:plc. The `id` fix lands on the did:web PR and inherits down; this PR adds:

- **did:plc identifier length is enforced.** `did_plc_url` checked the base32 charset but not the length, so a 1- or 25-character identifier passed and became a `plc.directory` request. The charset allowlist already contained the blast radius (no `/`, `?`, `#`, `.` or `%` can appear, so a crafted DID cannot leave the directory's path), which is why this is hardening rather than a bypass: it stops a well-formed-looking but bogus identifier from reaching the network at all. The doc comment already asserted the fixed 24-character length; the code now enforces it. Pinned by a failing test before the fix.

With the did:web `id`/`controller` binding fix inherited from the layer below, a document served for one `did:plc` but naming another is now refused rather than binding the wrong key.
