### PR TITLE
feat(rules): read back stored rules and persist their descriptions

### DIFF
--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -15,6 +15,7 @@
 //! [`AnalyzerError`](crate::AnalyzerError)) reference, so error
 //! reporting is uniform across both kinds.
 
+use crate::artifact::Entity;
 use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::{AnalysisError, TypeError};
 use crate::planner::Planner;
@@ -63,6 +64,33 @@ pub enum Rule {
 }
 
 impl Rule {
+    /// This rule's content-addressed identity, if it has a canonical
+    /// encoding — see [`DeductiveRule::try_this`] /
+    /// [`InductiveRule::try_this`].
+    pub fn try_this(&self) -> Option<Entity> {
+        match self {
+            Rule::Deductive(r) => r.try_this(),
+            Rule::Inductive(r) => r.try_this(),
+        }
+    }
+
+    /// Human-readable description, when the rule carries one.
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Rule::Deductive(r) => r.description(),
+            Rule::Inductive(r) => r.description(),
+        }
+    }
+
+    /// This rule with the given description. Descriptions live
+    /// outside the content address.
+    pub fn with_description(self, description: Option<String>) -> Self {
+        match self {
+            Rule::Deductive(r) => Rule::Deductive(r.with_description(description)),
+            Rule::Inductive(r) => Rule::Inductive(r.with_description(description)),
+        }
+    }
+
     /// The conclusion (head) of this rule.
     pub fn conclusion(&self) -> &ConceptDescriptor {
         match self {

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -35,17 +35,28 @@ pub struct DeductiveRule {
     /// The narrowed premises, inferred types, and dependency graph
     /// produced by analysis.
     analysis: AnalyzedRule,
+    /// Human-readable description, carried through compilation but
+    /// deliberately outside the content address (like the transient
+    /// marker on concepts): prose can change without moving the
+    /// rule's identity. Persisted as a sidecar
+    /// `dialog.rule/description` claim, never inside the canonical
+    /// body.
+    description: Option<String>,
 }
 impl Compile for DeductiveRule {
     const KIND: RuleKind = RuleKind::Deductive;
 
     fn from_analysis(analysis: AnalyzedRule) -> Self {
-        DeductiveRule { analysis }
+        DeductiveRule {
+            analysis,
+            description: None,
+        }
     }
 
     fn in_progress(conclusion: ConceptDescriptor, premises: Vec<Premise>) -> Self {
         DeductiveRule {
             analysis: AnalyzedRule::in_progress(conclusion, premises),
+            description: None,
         }
     }
 }
@@ -81,6 +92,18 @@ impl DeductiveRule {
             });
         }
         compile_rule::<Self>(conclusion, premises, reduce.into_iter().collect())
+    }
+
+    /// This rule with the given description. Descriptions live
+    /// outside the content address -- see the field docs.
+    pub fn with_description(mut self, description: Option<String>) -> Self {
+        self.description = description;
+        self
+    }
+
+    /// Human-readable description, when the rule carries one.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
     }
 
     /// The checked `reduce` clause entries, in head-field order.
@@ -162,7 +185,7 @@ impl DeductiveRule {
         }
 
         DeductiveRuleDescriptor {
-            description: None,
+            description: self.description.clone(),
             deduce: self.conclusion().clone(),
             when,
             unless,
@@ -192,7 +215,13 @@ impl DeductiveRule {
     /// needed. This is the same encoding dialog content-addresses with
     /// elsewhere.
     pub fn try_encode(&self) -> Option<Vec<u8>> {
-        serde_ipld_dagcbor::to_vec(&self.descriptor()).ok()
+        // The canonical form always carries `description: None`: the
+        // description is outside the content address, so a described
+        // rule and its description-less twin encode -- and are
+        // stored -- byte-identically.
+        let mut canonical = self.descriptor();
+        canonical.description = None;
+        serde_ipld_dagcbor::to_vec(&canonical).ok()
     }
 
     /// This rule's content-addressed identity, if it has a canonical

--- a/rust/dialog-query/src/rule/deductive/descriptor.rs
+++ b/rust/dialog-query/src/rule/deductive/descriptor.rs
@@ -111,7 +111,10 @@ impl DeductiveRuleDescriptor {
             premises.push(Premise::Unless(Negation::not(proposition)));
         }
 
-        DeductiveRule::with_reduce(self.deduce, premises, self.reduce)
+        Ok(
+            DeductiveRule::with_reduce(self.deduce, premises, self.reduce)?
+                .with_description(self.description),
+        )
     }
 }
 

--- a/rust/dialog-query/src/rule/inductive.rs
+++ b/rust/dialog-query/src/rule/inductive.rs
@@ -55,6 +55,13 @@ pub struct InductiveRule {
     analysis: AnalyzedRule,
     /// Whether a firing asserts or retracts the head's facts.
     polarity: Polarity,
+    /// Human-readable description, carried through compilation but
+    /// deliberately outside the content address (like the transient
+    /// marker on concepts): prose can change without moving the
+    /// rule's identity. Persisted as a sidecar
+    /// `dialog.rule/description` claim, never inside the canonical
+    /// body.
+    description: Option<String>,
 }
 
 impl Compile for InductiveRule {
@@ -64,6 +71,7 @@ impl Compile for InductiveRule {
         InductiveRule {
             analysis,
             polarity: Polarity::Assert,
+            description: None,
         }
     }
 
@@ -71,6 +79,7 @@ impl Compile for InductiveRule {
         InductiveRule {
             analysis: AnalyzedRule::in_progress(conclusion, premises),
             polarity: Polarity::Assert,
+            description: None,
         }
     }
 }
@@ -99,6 +108,18 @@ impl InductiveRule {
     pub fn with_polarity(mut self, polarity: Polarity) -> Self {
         self.polarity = polarity;
         self
+    }
+
+    /// This rule with the given description. Descriptions live
+    /// outside the content address — see the field docs.
+    pub fn with_description(mut self, description: Option<String>) -> Self {
+        self.description = description;
+        self
+    }
+
+    /// Human-readable description, when the rule carries one.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
     }
 
     /// Whether a firing asserts or retracts the head's facts.
@@ -144,8 +165,15 @@ impl InductiveRule {
     /// rules built directly from raw [`AttributeQuery`](crate::AttributeQuery)
     /// premises encode to nothing, because `Proposition`'s
     /// formal-notation `Serialize` rejects attribute propositions.
+    ///
+    /// The canonical form always carries `description: None`: the
+    /// description is outside the content address, so a described
+    /// rule and its description-less twin encode — and are stored —
+    /// byte-identically.
     pub fn try_encode(&self) -> Option<Vec<u8>> {
-        serde_ipld_dagcbor::to_vec(&self.descriptor()).ok()
+        let mut canonical = self.descriptor();
+        canonical.description = None;
+        serde_ipld_dagcbor::to_vec(&canonical).ok()
     }
 
     /// This rule's content-addressed identity, if it has a canonical
@@ -204,7 +232,7 @@ impl InductiveRule {
             Polarity::Retract => (None, Some(self.conclusion().clone())),
         };
         InductiveRuleDescriptor {
-            description: None,
+            description: self.description.clone(),
             assert,
             retract,
             when,

--- a/rust/dialog-query/src/rule/inductive/descriptor.rs
+++ b/rust/dialog-query/src/rule/inductive/descriptor.rs
@@ -64,12 +64,13 @@ impl InductiveRuleDescriptor {
             premises.push(Premise::Unless(Negation::not(proposition)));
         }
 
-        match (self.assert, self.retract) {
+        let rule = match (self.assert, self.retract) {
             (Some(conclusion), None) => InductiveRule::new(conclusion, premises),
             (None, Some(conclusion)) => InductiveRule::retracting(conclusion, premises),
             (Some(_), Some(_)) => Err(TypeError::ConflictingHead),
             (None, None) => Err(TypeError::MissingHead),
-        }
+        }?;
+        Ok(rule.with_description(self.description))
     }
 }
 
@@ -77,6 +78,39 @@ impl InductiveRuleDescriptor {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// A description survives compilation and serde, but never the
+    /// canonical encoding: the described rule and its
+    /// description-less twin share bytes and identity.
+    #[dialog_common::test]
+    fn it_keeps_the_description_outside_the_content_address() {
+        let body = json!({
+            "assert!": {
+                "with": { "count": { "the": "counter/count", "as": "UnsignedInteger" } }
+            },
+            "when": [{
+                "assert": {
+                    "with": { "count": { "the": "counter/count", "as": "UnsignedInteger" } }
+                },
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "count": { "?": { "name": "count" } }
+                }
+            }]
+        });
+        let mut described = body.clone();
+        described["description"] = json!("Carries the count forward");
+
+        let plain: InductiveRule = serde_json::from_value(body).unwrap();
+        let described: InductiveRule = serde_json::from_value(described).unwrap();
+
+        assert_eq!(described.description(), Some("Carries the count forward"));
+        assert_eq!(described.encode(), plain.encode());
+        assert_eq!(described.this(), plain.this());
+        // Serde round-trips the prose even though the encoding drops it.
+        let json = serde_json::to_value(&described).unwrap();
+        assert_eq!(json["description"], json!("Carries the count forward"));
+    }
 
     #[dialog_common::test]
     fn it_deserializes_increment_counter_rule() {

--- a/rust/dialog-query/src/rule/statement.rs
+++ b/rust/dialog-query/src/rule/statement.rs
@@ -37,6 +37,15 @@ pub fn conclusion_attr() -> Attribute {
     the!("dialog.rule/conclusion").into()
 }
 
+/// The `dialog.rule/description` sidecar attribute: a rule's
+/// human-readable prose, stored beside the canonical body rather than
+/// inside it so editing the prose never moves the rule's
+/// content-addressed identity (the same stance
+/// `dialog.concept/transient` takes for concepts).
+pub fn description_attr() -> Attribute {
+    the!("dialog.rule/description").into()
+}
+
 /// The `dialog.rule/induces` index attribute — the inductive sibling of
 /// `dialog.rule/conclusion`, kept separate so deductive resolution never
 /// hydrates (and discards) inductive rules concluding a queried
@@ -136,6 +145,13 @@ impl Statement for &DeductiveRule {
             rule_entity.clone(),
             Value::Bytes(self.encode()),
         );
+        if let Some(description) = self.description() {
+            update.associate(
+                description_attr(),
+                rule_entity.clone(),
+                Value::String(description.to_owned()),
+            );
+        }
         for reads in reads_entities(self) {
             update.associate(reads_attr(), rule_entity.clone(), Value::Entity(reads));
         }
@@ -153,6 +169,13 @@ impl Statement for &DeductiveRule {
             rule_entity.clone(),
             Value::Bytes(self.encode()),
         );
+        if let Some(description) = self.description() {
+            update.dissociate(
+                description_attr(),
+                rule_entity.clone(),
+                Value::String(description.to_owned()),
+            );
+        }
         for reads in reads_entities(self) {
             update.dissociate(reads_attr(), rule_entity.clone(), Value::Entity(reads));
         }
@@ -182,6 +205,13 @@ impl Statement for &InductiveRule {
             rule_entity.clone(),
             Value::Bytes(self.encode()),
         );
+        if let Some(description) = self.description() {
+            update.associate(
+                description_attr(),
+                rule_entity.clone(),
+                Value::String(description.to_owned()),
+            );
+        }
         update.associate(
             induces_attr(),
             rule_entity.clone(),
@@ -199,6 +229,13 @@ impl Statement for &InductiveRule {
             rule_entity.clone(),
             Value::Bytes(self.encode()),
         );
+        if let Some(description) = self.description() {
+            update.dissociate(
+                description_attr(),
+                rule_entity.clone(),
+                Value::String(description.to_owned()),
+            );
+        }
         update.dissociate(
             induces_attr(),
             rule_entity.clone(),

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use dialog_artifacts::inspect::Load;
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::{
     Artifact, ArtifactSelector, ArtifactStream, ArtifactViewStream as _, Changes,
-    DialogArtifactsError, Entity, Select, SortKey, Statement,
+    DialogArtifactsError, Entity, Select, SortKey, Statement, Value,
 };
 use dialog_capability::{Capability, Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
@@ -19,7 +19,7 @@ use dialog_query::error::EvaluationError;
 use dialog_query::query::{Application, Output};
 use dialog_query::session::ProgramAnalysis;
 use dialog_query::source::SelectRules;
-use dialog_query::{DeductiveRule, Negation, Premise, Proposition};
+use dialog_query::{DeductiveRule, InductiveRule, Negation, Premise, Proposition, Rule};
 use dialog_search_tree::Buffer;
 use dialog_storage::{Blake3Hash, StorageBackend};
 use futures_util::{StreamExt as _, TryStreamExt as _, stream};
@@ -27,8 +27,8 @@ use std::sync::Arc;
 
 use crate::layer::{filter_tombstones, merge_grouped, tombstones_from};
 use crate::rules::{
-    assemble, builtin, conclusion_selector, hydrate, overlay_rules, rule_entities, source_bytes,
-    source_selector,
+    assemble, builtin, conclusion_selector, description_attr, hydrate, overlay_rules,
+    rule_entities, source_attr, source_bytes, source_selector,
 };
 use crate::schema::{DidExt as _, Session, SessionBranch, session};
 use crate::{
@@ -745,6 +745,79 @@ impl Branch {
     pub fn with<S: Statement>(&self, statement: S) -> QueryLayer<'_> {
         self.query().with(statement)
     }
+
+    /// Every rule stored on this branch — deductive and inductive —
+    /// hydrated from its canonical `dialog.rule/source` body, in
+    /// entity order.
+    ///
+    /// An introspection surface, not a query-path one: evaluation
+    /// never enumerates rules (discovery is always "rules concluding
+    /// *this* concept", head-cached — see
+    /// [`rules`](crate::rules)), but tools that synthesize, migrate,
+    /// or audit a branch need the full set without depending on how
+    /// the facts are laid out. Each body is verified against the
+    /// entity it was stored under; an entry whose body does not hash
+    /// back to its entity is inert and skipped, the same stance the
+    /// query path takes. The sidecar `dialog.rule/description`
+    /// prose — deliberately outside the content address — is
+    /// re-attached to each hydrated rule.
+    pub async fn stored_rules<Env>(&self, env: &Env) -> Result<Vec<Rule>, DialogArtifactsError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let sources: Vec<Artifact> = select_from_branch(
+            self.clone(),
+            env,
+            ArtifactSelector::new().the(source_attr()),
+        )
+        .owned()
+        .try_collect()
+        .await?;
+        let prose: Vec<Artifact> = select_from_branch(
+            self.clone(),
+            env,
+            ArtifactSelector::new().the(description_attr()),
+        )
+        .owned()
+        .try_collect()
+        .await?;
+        let mut descriptions: HashMap<Entity, String> = prose
+            .into_iter()
+            .filter_map(|artifact| match artifact.is {
+                Value::String(text) => Some((artifact.of, text)),
+                _ => None,
+            })
+            .collect();
+
+        let mut rules: Vec<(Entity, Rule)> = Vec::with_capacity(sources.len());
+        for artifact in sources {
+            let Value::Bytes(bytes) = artifact.is else {
+                continue;
+            };
+            // The two kinds share the source attribute; the decoded
+            // descriptor's head field decides which one this is.
+            let rule = if let Ok(rule) = InductiveRule::decode(&bytes) {
+                Rule::Inductive(rule)
+            } else if let Ok(rule) = DeductiveRule::decode(&bytes) {
+                Rule::Deductive(rule)
+            } else {
+                continue;
+            };
+            if rule.try_this().as_ref() != Some(&artifact.of) {
+                continue;
+            }
+            let rule = rule.with_description(descriptions.remove(&artifact.of));
+            rules.push((artifact.of, rule));
+        }
+        rules.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(rules.into_iter().map(|(_, rule)| rule).collect())
+    }
 }
 
 /// Layered deductive-rule resolution — exhaustive coverage of the
@@ -850,6 +923,83 @@ mod rule_tests {
 
         let employees = query_employees(&branch, &operator).await?;
         assert!(employees.contains(&alice), "committed rule must resolve");
+        Ok(())
+    }
+
+    /// `stored_rules` reads back every committed rule — both kinds —
+    /// with the sidecar description re-attached and the content
+    /// address untouched by it.
+    #[dialog_common::test]
+    async fn it_reads_back_stored_rules_with_descriptions() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let deductive =
+            employee_from_person().with_description(Some("Employees from people".into()));
+        let inductive_json = serde_json::json!({
+            "assert!": { "with": { "name": { "the": "org/employee-name", "as": "Text" } } },
+            "when": [{
+                "assert": { "with": { "name": { "the": "org/person-name", "as": "Text" } } },
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "name": { "?": { "name": "name" } }
+                }
+            }]
+        });
+        let inductive: dialog_query::InductiveRule = serde_json::from_value(inductive_json)?;
+        let inductive = inductive.with_description(Some("Copies people into employees".into()));
+        // The description must not participate in the identity: the
+        // described rule stores under the same entity its
+        // description-less twin would.
+        assert_eq!(
+            deductive.this(),
+            employee_from_person().this(),
+            "description must stay outside the content address"
+        );
+
+        branch
+            .transaction()
+            .assert(&deductive)
+            .assert(&inductive)
+            .commit()
+            .perform(&operator)
+            .await?;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let stored = branch.stored_rules(&operator).await?;
+        assert_eq!(stored.len(), 2, "both kinds must enumerate");
+        let read_deductive = stored
+            .iter()
+            .find(|rule| matches!(rule, Rule::Deductive(_)))
+            .expect("deductive rule read back");
+        let read_inductive = stored
+            .iter()
+            .find(|rule| matches!(rule, Rule::Inductive(_)))
+            .expect("inductive rule read back");
+        assert_eq!(
+            read_deductive.description(),
+            Some("Employees from people"),
+            "sidecar prose re-attaches"
+        );
+        assert_eq!(
+            read_inductive.description(),
+            Some("Copies people into employees")
+        );
+        assert_eq!(read_deductive.try_this(), Some(deductive.this()));
+        assert_eq!(read_inductive.try_this(), Some(inductive.this()));
+
+        // Retracting the described rule erases the sidecar with the
+        // body: nothing remains to enumerate.
+        branch
+            .transaction()
+            .retract(&deductive)
+            .retract(&inductive)
+            .commit()
+            .perform(&operator)
+            .await?;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+        assert!(branch.stored_rules(&operator).await?.is_empty());
         Ok(())
     }
 

--- a/rust/dialog-repository/src/rules.rs
+++ b/rust/dialog-repository/src/rules.rs
@@ -60,7 +60,7 @@ use crate::{Revision, schema};
 // rule types themselves; this module re-uses them for its selectors,
 // caches, and dispatch probing.
 pub(crate) use dialog_query::rule::statement::{
-    conclusion_attr, on_attr, on_entity, reads_attr, source_attr,
+    conclusion_attr, description_attr, on_attr, on_entity, reads_attr, source_attr,
 };
 
 /// The `dialog.concept/transient` marker attribute. A concept carrying it


### PR DESCRIPTION
## Why

Downstream (tonk) needs to ask a branch *what its rules are* — to synthesize behavior documents, migrate repositories across format changes, and audit installs. Today the only way is to reach around the API and sweep `dialog.rule/*` claims directly, re-implementing hydration and content-address verification and coupling to the storage layout. Rules already have the right *write*-side contract (`changes.assert(&rule)` — dialog decides the fact lowering); this adds the symmetric read side, so the representation stays free to evolve without breaking consumers.

A second gap surfaced by the same work: rule descriptions are destroyed at compile time (`descriptor()` hardcodes `None`), so authored prose is unrecoverable from any source.

## How

- **`Branch::stored_rules(env)`** hydrates every committed `dialog.rule/source` body — deductive and inductive, dispatched on the decoded head field — verifying each body against the entity it was stored under (mismatches are inert and skipped, the same stance the query path takes). Documented as an introspection surface, not a query-path one: evaluation still never enumerates rules.
- **Descriptions survive compilation** (carried on the rule values, threaded through `descriptor().compile()`) and **persist as a sidecar `dialog.rule/description` claim** — deliberately outside the content address, the same stance `dialog.concept/transient` takes for concepts, so editing prose never moves a rule's identity and existing stored rules keep their addresses byte-for-byte. `try_encode()` canonicalizes with `description: None`; read-back re-attaches the sidecar.
- `Rule` (kind-erased) gains `try_this()` / `description()` / `with_description()`.

## Verification

- New round-trip test: a described rule and its description-less twin encode and store byte-identically; `stored_rules` returns both kinds with prose re-attached; retraction erases the sidecar with the body.
- Descriptor unit test pins description-outside-the-address across serde.
- `cargo test -p dialog-query -p dialog-repository --lib` (825 + 275 pass), workspace `cargo check`, fmt + clippy clean.
