### PR TITLE
refactor(ucan): verification context, revocation, and concurrent checks

### DIFF
--- a/rust/dialog-did-web/src/tests.rs
+++ b/rust/dialog-did-web/src/tests.rs
@@ -5,6 +5,7 @@
 //! agnostic verifier that resolution recovers is checked by actually verifying a
 //! signature the matching signer produced.
 
+use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_credentials::{Ed25519Signer, Es256Signer, Signer};
 use dialog_varsig::{Did, Principal, Signer as VarsigSigner, Verifier as VarsigVerifier};
 
@@ -16,6 +17,28 @@ use crate::url::did_web_url;
 use crate::{CachingResolver, ResolveError};
 
 /// The `did:key` multibase tail (`z...`) for a signer's public key.
+/// Verify `chain` against `resolver`, judged at the current time and
+/// performing no revocation lookups.
+async fn verify<R>(
+    chain: &dialog_ucan_core::InvocationChain<dialog_varsig::AnySignature>,
+    resolver: R,
+) -> Result<dialog_ucan_core::time::TimeRange, dialog_ucan_core::ContainerError>
+where
+    R: dialog_varsig::Resolver<
+            dialog_varsig::AnySignature,
+            Error: Clone + ConditionalSend + ConditionalSync + 'static,
+        >,
+{
+    let environment = dialog_ucan_core::Environment::new(
+        chain.proof_store(),
+        resolver,
+        dialog_ucan_core::UnverifiedRevocations,
+    );
+    chain
+        .verify(&dialog_ucan_core::VerificationContext::new(&environment))
+        .await
+}
+
 fn multibase_of(signer: &Signer) -> String {
     let did = signer.did();
     did.as_str()
@@ -755,8 +778,7 @@ async fn signs_and_verifies_under_did_web(key: Signer) {
     );
 
     let resolver = PerformingResolver::new(&env);
-    chain
-        .verify(&resolver)
+    verify(&chain, resolver)
         .await
         .expect("a did:web-issued invocation should verify");
 }
@@ -813,7 +835,7 @@ async fn it_refuses_did_web_with_wrong_key() {
 
     let resolver = PerformingResolver::new(&env);
     assert!(
-        chain.verify(&resolver).await.is_err(),
+        verify(&chain, resolver).await.is_err(),
         "a did:web document with the wrong key must not verify"
     );
 }

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -60,8 +60,8 @@ use dialog_capability::{Capability, Constraint, Did, Policy};
 use dialog_did_web::{CachingResolver, PerformingResolver, Resolve, WebResolver};
 use dialog_effects::{archive, blob, memory};
 use dialog_remote_s3::{Address, Permit, S3Credential, S3Error};
-use dialog_ucan_core::InvocationChain;
 use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::{Environment, InvocationChain, VerificationContext};
 use ipld_core::ipld::Ipld;
 use serde::de::DeserializeOwned;
 
@@ -353,7 +353,15 @@ where
         // fetches the DID document; a cache sits in front. The chain verify path
         // only sees a varsig resolver.
         let resolver = PerformingResolver::new(self.resolver.as_ref());
-        chain.verify(&resolver).await.map_err(|e| {
+        // No revocation store exists yet, so nothing is looked up. Named for
+        // what it does: it establishes nothing about revocation status.
+        let environment = Environment::new(
+            chain.proof_store(),
+            resolver,
+            dialog_ucan_core::UnverifiedRevocations,
+        );
+        let context = VerificationContext::new(&environment);
+        chain.verify(&context).await.map_err(|e| {
             // Two different failures arrive here: their material not
             // verifying, and our own setup being unable to check it (for
             // example, an unreachable did:web host). Only the first is a
@@ -365,6 +373,11 @@ where
                 ContainerError::InvalidDelegationSignature { issuer, .. } => {
                     AuthorizeError::InvalidSignature { issuer }
                 }
+                // The authority was withdrawn rather than never held or
+                // forged, so retrying with the same proof is pointless.
+                ContainerError::Revoked { .. } => AuthorizeError::Revoked {
+                    subject: chain.subject().clone(),
+                },
                 ContainerError::Invocation(detail) => AuthorizeError::Malformed {
                     detail: format!("invocation chain did not verify: {detail}"),
                 },

--- a/rust/dialog-ucan-core/src/container.rs
+++ b/rust/dialog-ucan-core/src/container.rs
@@ -22,6 +22,8 @@ pub mod invocation;
 mod check_failed;
 pub use check_failed::check_failed_to_container_error;
 
+use dialog_varsig::Did;
+use ipld_core::cid::Cid;
 use ipld_core::ipld::Ipld;
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -41,9 +43,20 @@ pub enum ContainerError {
     #[error("Delegation from '{issuer}' does not carry a valid signature: {detail}")]
     InvalidDelegationSignature {
         /// The principal the forged proof claims as its issuer.
-        issuer: dialog_varsig::Did,
+        issuer: Did,
         /// Human-readable description of the verification failure.
         detail: String,
+    },
+
+    /// A delegation in the chain has been revoked by a principal entitled
+    /// to revoke it. Kept distinct from a signature failure so the authorize
+    /// boundary can say the authority was withdrawn rather than forged.
+    #[error("Delegation '{cid}' was revoked by '{revoker}'")]
+    Revoked {
+        /// The revoked delegation.
+        cid: Cid,
+        /// The principal that revoked it.
+        revoker: Did,
     },
 
     /// Invalid configuration.

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -19,7 +19,12 @@ use super::check_failed_to_container_error;
 use super::{Container, ContainerError};
 use crate::{
     Delegation, Invocation,
-    invocation::{InvocationCheckError, SignatureVerificationError, StoredCheckError},
+    command::Command,
+    invocation::{Invalid, Unavailable, VerifyError},
+    promise::Promised,
+    revocation::RevocationChecker,
+    time::TimeRange,
+    verification::{Verifiable, VerificationContext},
 };
 use dialog_varsig::AnySignature;
 use dialog_varsig::Did;
@@ -67,66 +72,94 @@ impl<S: Signature> InvocationChain<S> {
         }
     }
 
-    /// Verify the invocation chain using rs-ucan's verification.
+    /// Verify this invocation chain.
     ///
-    /// This performs complete verification:
-    /// 1. Signature verification (issuer signed the invocation)
-    /// 2. Proof chain validation (issuer->subject chain via proofs)
-    /// 3. Command attenuation checks
-    /// 4. Policy predicate evaluation
+    /// Checks, in order: the proof chain's structure (principal alignment,
+    /// subject consistency, command attenuation, policy predicates, and time
+    /// bounds against `ctx`'s sampled instant), then every signature — the
+    /// invocation's and each delegation link's — and every link's revocation
+    /// status.
     ///
-    /// The invocation's `proofs` field contains CIDs that reference
-    /// delegations in the container. This method builds a store from
-    /// those delegations and uses rs-ucan's `Invocation::check` to verify.
-    pub async fn verify<R: Resolver<S>>(&self, resolver: &R) -> Result<(), ContainerError>
+    /// Structure is checked first and costs no I/O, so a chain that does not
+    /// hold up spends no DID resolutions and no crypto. Resolution then runs
+    /// once per *distinct* issuer, and signatures and revocation lookups run
+    /// concurrently, stopping at the first decisive refusal.
+    ///
+    /// Returns the chain's effective time window.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ContainerError`] if the chain does not hold up, a
+    /// signature does not verify, an issuer cannot be resolved, or a link
+    /// has been revoked.
+    pub async fn verify<C>(
+        &self,
+        ctx: &VerificationContext<'_, C>,
+    ) -> Result<TimeRange, ContainerError>
     where
-        R::Error: std::error::Error,
+        C: Verifiable<
+                Runtime,
+                S,
+                Proof = Arc<Delegation<S>>,
+                Delegations = ProofStore<S>,
+                Revocations: RevocationChecker,
+            >,
+        <C::Resolver as Resolver<S>>::Error: std::error::Error + Clone + 'static,
     {
-        // Build delegation store from our map
-        let store: ProofStore<S> = Arc::new(Mutex::new(self.delegations.clone()));
-
-        // Use rs-ucan's full verification
         self.invocation
-            .check::<Runtime, _, _, _>(&store, resolver)
+            .check::<Runtime, _, _, _>(ctx)
             .await
-            .map(|_| ())
             .map_err(|err| match err {
-                // A resolution failure (an unreachable did:web host, a resolver
-                // that cannot look the issuer up) is our setup being unable to
-                // check their material, not a statement that their material is
-                // bad. It reads as Configuration, not Invocation.
-                InvocationCheckError::SignatureVerification(
-                    SignatureVerificationError::ResolutionError(resolve_err),
-                ) => ContainerError::Configuration(format!(
-                    "could not resolve the invocation issuer: {resolve_err}"
-                )),
-                InvocationCheckError::SignatureVerification(sig_err) => {
-                    ContainerError::Invocation(format!("invalid signature: {}", sig_err))
-                }
-                InvocationCheckError::StoredCheck(stored_err) => match stored_err {
-                    StoredCheckError::GetError(get_err) => {
-                        ContainerError::Invocation(format!("proof not found: {}", get_err))
+                // Their material did not hold up: the decision crosses the
+                // boundary as itself.
+                VerifyError::Invalid(invalid) => match invalid {
+                    Invalid::InvocationSignature(sig_err) => {
+                        ContainerError::Invocation(format!("invalid signature: {sig_err}"))
                     }
-                    StoredCheckError::SignatureVerification { issuer, source } => {
+                    Invalid::DelegationSignature { issuer, source } => {
                         ContainerError::InvalidDelegationSignature {
                             issuer,
                             detail: source.to_string(),
                         }
                     }
-                    StoredCheckError::CheckFailed(check_err) => {
-                        check_failed_to_container_error(check_err)
+                    Invalid::MissingProof(get_err) => {
+                        ContainerError::Invocation(format!("proof not found: {get_err}"))
                     }
+                    Invalid::Chain(check_err) => check_failed_to_container_error(check_err),
+                    Invalid::Revoked { cid, found } => ContainerError::Revoked {
+                        cid,
+                        revoker: found.principal,
+                    },
+                },
+                // Our own setup being unable to check says nothing about
+                // their request, so it must not read as a denial.
+                VerifyError::Unavailable(unavailable) => match unavailable {
+                    Unavailable::DidResolution { did, detail } => ContainerError::Configuration(
+                        format!("could not resolve '{did}': {detail}"),
+                    ),
+                    Unavailable::RevocationLookup { cid, source } => ContainerError::Configuration(
+                        format!("could not determine revocation status of '{cid}': {source}"),
+                    ),
                 },
             })
     }
 
+    /// The proof store this chain's delegations live in.
+    ///
+    /// Exposed so an environment implementing [`Verifiable`] can hand the
+    /// chain's own proofs to the verifier.
+    #[must_use]
+    pub fn proof_store(&self) -> ProofStore<S> {
+        Arc::new(Mutex::new(self.delegations.clone()))
+    }
+
     /// Get the command from the invocation.
-    pub fn command(&self) -> &crate::command::Command {
+    pub fn command(&self) -> &Command {
         self.invocation.command()
     }
 
     /// Get the arguments from the invocation.
-    pub fn arguments(&self) -> &BTreeMap<String, crate::promise::Promised> {
+    pub fn arguments(&self) -> &BTreeMap<String, Promised> {
         self.invocation.arguments()
     }
 
@@ -255,11 +288,33 @@ impl<'de> Deserialize<'de> for InvocationChain<AnySignature> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command::Command;
     use crate::helpers::{create_delegation, generate_signer};
+    use crate::revocation::UnverifiedRevocations;
+    use crate::revocation::{RevocationMatch, RevocationSelector};
     use crate::subject::Subject;
+    use crate::verification::Environment;
     use crate::{DelegationBuilder, InvocationBuilder};
     use dialog_credentials::DidKeyResolver;
     use dialog_varsig::Principal;
+
+    /// The environment these tests verify against: the chain's own proofs,
+    /// `did:key` resolution, and no revocation lookups.
+    type TestEnv = Environment<
+        ProofStore<AnySignature>,
+        DidKeyResolver,
+        UnverifiedRevocations,
+        Arc<Delegation<AnySignature>>,
+    >;
+
+    fn test_environment(chain: &InvocationChain<AnySignature>) -> TestEnv {
+        Environment::new(chain.proof_store(), DidKeyResolver, UnverifiedRevocations)
+    }
+
+    /// A context over `env`, judged against the system clock.
+    fn test_context(env: &TestEnv) -> VerificationContext<'_, TestEnv> {
+        VerificationContext::new(env)
+    }
 
     /// Create a test invocation chain with a valid delegation.
     async fn create_test_invocation_chain() -> (InvocationChain<AnySignature>, Did) {
@@ -343,7 +398,7 @@ mod tests {
         let (chain, _) = create_test_invocation_chain().await;
 
         // Should verify successfully
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed: {:?}",
@@ -393,7 +448,7 @@ mod tests {
 
         // The full chain verifies: the delegation link under ed25519, the
         // invocation link under p256, one validation pass over mixed algorithms.
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_ok(),
             "Expected mixed-algorithm chain to verify: {:?}",
@@ -459,7 +514,7 @@ mod tests {
         let chain = InvocationChain::new(invocation, HashMap::new());
 
         // Should fail verification due to missing proof
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("proof not found"));
     }
@@ -500,8 +555,213 @@ mod tests {
         let chain = InvocationChain::new(invocation, delegations);
 
         // Should fail verification due to issuer mismatch
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(result.is_err());
+    }
+
+    /// Reports every query as unanswerable.
+    #[derive(Debug, thiserror::Error)]
+    #[error("revocation service unreachable")]
+    struct Unreachable;
+
+    #[derive(Debug, Clone, Copy)]
+    struct OfflineRevocations;
+
+    impl RevocationChecker for OfflineRevocations {
+        type Error = Unreachable;
+
+        async fn query(
+            &self,
+            _selector: RevocationSelector<'_>,
+        ) -> Result<Option<RevocationMatch>, Self::Error> {
+            Err(Unreachable)
+        }
+    }
+
+    /// Reports one specific delegation as revoked, by a named principal.
+    #[derive(Debug, Clone)]
+    struct RevokedLink {
+        cid: Cid,
+        principal: Did,
+    }
+
+    impl RevocationChecker for RevokedLink {
+        type Error = Unreachable;
+
+        async fn query(
+            &self,
+            selector: RevocationSelector<'_>,
+        ) -> Result<Option<RevocationMatch>, Self::Error> {
+            if selector.delegation == self.cid && selector.by.contains(&self.principal) {
+                return Ok(Some(RevocationMatch {
+                    revocation: selector.delegation,
+                    principal: self.principal.clone(),
+                }));
+            }
+            Ok(None)
+        }
+    }
+
+    // The validity invariant, at its sharpest. A caller may legitimately
+    // choose to fail open when the revocation service is unreachable, so
+    // "revocation unavailable" must never be what a caller sees for a chain
+    // that does not verify — otherwise that choice would also accept forged
+    // chains. Tolerance relaxes revocation and nothing else.
+    #[dialog_common::test]
+    async fn it_reports_a_forged_signature_even_when_revocation_is_unreachable() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let attacker_signer = generate_signer().await;
+
+        // Claims the subject as issuer so principal alignment passes and
+        // only the signature is wrong. Structured any other way, the chain
+        // would fail alignment first and this would pass with signature
+        // checking disabled entirely.
+        let forged = Delegation::forge(
+            subject_did.clone(),
+            attacker_signer.did(),
+            Subject::Specific(subject_did.clone()),
+            Command::new(vec!["storage".to_string(), "get".to_string()]),
+            &attacker_signer,
+        )
+        .await
+        .expect("forged delegation");
+        let forged_cid = forged.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(attacker_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![forged_cid])
+            .try_build()
+            .await
+            .expect("invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(forged_cid, Arc::new(forged));
+        let chain = InvocationChain::new(invocation, delegations);
+
+        // The most permissive revocation policy available.
+        let environment = Environment::new(
+            chain.proof_store(),
+            DidKeyResolver,
+            OfflineRevocations.tolerate_unavailable(),
+        );
+        let ctx = VerificationContext::new(&environment);
+        let error = chain
+            .verify(&ctx)
+            .await
+            .expect_err("a forged signature must refuse the chain");
+
+        assert!(
+            matches!(error, ContainerError::InvalidDelegationSignature { .. }),
+            "expected the signature refusal rather than an unavailable \
+             revocation service, got: {error:?}"
+        );
+    }
+
+    // A refusal names which link was revoked and who withdrew it, so an
+    // operator can tell which authority failed rather than only that
+    // something did.
+    #[dialog_common::test]
+    async fn it_names_the_revoked_link_and_its_revoker() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["storage", "get"],
+        )
+        .await
+        .expect("delegation");
+        let cid = delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![cid])
+            .try_build()
+            .await
+            .expect("invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(cid, Arc::new(delegation));
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let environment = Environment::new(
+            chain.proof_store(),
+            DidKeyResolver,
+            RevokedLink {
+                cid,
+                principal: subject_did.clone(),
+            },
+        );
+        let ctx = VerificationContext::new(&environment);
+        let error = chain
+            .verify(&ctx)
+            .await
+            .expect_err("a revoked link must refuse the chain");
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains(&cid.to_string()),
+            "the refusal must name the revoked link: {rendered}"
+        );
+    }
+
+    // Tolerance is about not knowing, never knowing-and-ignoring: a
+    // revocation the checker did find still refuses the chain.
+    #[dialog_common::test]
+    async fn it_refuses_a_confirmed_revocation_even_when_tolerating() {
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = create_delegation(
+            &subject_signer,
+            &operator_signer,
+            &subject_signer,
+            &["storage", "get"],
+        )
+        .await
+        .expect("delegation");
+        let cid = delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer.clone())
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![cid])
+            .try_build()
+            .await
+            .expect("invocation");
+
+        let mut delegations = HashMap::new();
+        delegations.insert(cid, Arc::new(delegation));
+        let chain = InvocationChain::new(invocation, delegations);
+
+        let environment = Environment::new(
+            chain.proof_store(),
+            DidKeyResolver,
+            RevokedLink {
+                cid,
+                principal: subject_did,
+            }
+            .tolerate_unavailable(),
+        );
+        let ctx = VerificationContext::new(&environment);
+        assert!(
+            chain.verify(&ctx).await.is_err(),
+            "tolerating an unavailable service must not tolerate a \
+             confirmed revocation"
+        );
     }
 
     // Pins the delegation-link signature forgery. A structurally-valid
@@ -555,7 +815,7 @@ mod tests {
 
         // Must be rejected: the delegation link's signature is not the
         // subject's, so the chain grants the attacker nothing.
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_err(),
             "forged delegation-link signature must be rejected, got: {result:?}"
@@ -641,7 +901,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed with powerline in middle: {:?}",
@@ -681,7 +941,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_err(),
             "Expected verification to fail when invocation subject doesn't match powerline root issuer"
@@ -720,7 +980,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed when invocation subject matches powerline root issuer: {:?}",
@@ -773,7 +1033,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_err(),
             "Expected verification to fail when redelegation after powerline root uses wrong subject"
@@ -825,7 +1085,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_ok(),
             "Expected verification to succeed when redelegation after powerline root uses correct subject: {:?}",
@@ -950,7 +1210,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_ok(),
             "Expected /archive delegation to authorize /archive/put invocation: {:?}",
@@ -993,7 +1253,10 @@ mod tests {
         let original_chain = InvocationChain::new(invocation, delegations);
 
         assert!(
-            original_chain.verify(&DidKeyResolver).await.is_ok(),
+            original_chain
+                .verify(&test_context(&test_environment(&original_chain)))
+                .await
+                .is_ok(),
             "Original chain should verify"
         );
 
@@ -1002,7 +1265,9 @@ mod tests {
         let restored_chain: InvocationChain<AnySignature> =
             serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
 
-        let result = restored_chain.verify(&DidKeyResolver).await;
+        let result = restored_chain
+            .verify(&test_context(&test_environment(&restored_chain)))
+            .await;
         assert!(
             result.is_ok(),
             "Restored chain should still verify: {:?}",
@@ -1034,7 +1299,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, HashMap::new());
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_ok(),
             "Self-invocation (issuer == subject, empty proofs) should verify: {:?}",
@@ -1059,7 +1324,7 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, HashMap::new());
 
-        let result = chain.verify(&DidKeyResolver).await;
+        let result = chain.verify(&test_context(&test_environment(&chain))).await;
         assert!(
             result.is_err(),
             "Invocation with issuer != subject and no proofs should fail verification"

--- a/rust/dialog-ucan-core/src/delegation.rs
+++ b/rust/dialog-ucan-core/src/delegation.rs
@@ -168,15 +168,32 @@ impl<S: Signature> Delegation<S> {
     where
         R: dialog_varsig::resolver::Resolver<S>,
     {
-        let payload = self
-            .envelope()
-            .encode()
-            .map_err(SignatureVerificationError::EncodingError)?;
         let verifier = resolver
             .resolve(self.issuer())
             .await
             .map_err(SignatureVerificationError::ResolutionError)?;
-        Verifier::verify(&verifier, &payload, self.signature())
+        self.verify_with::<R::Error>(&verifier).await
+    }
+
+    /// Verify this delegation's signature against an already-resolved verifier.
+    ///
+    /// Split out from [`verify_signature`](Self::verify_signature) so a chain
+    /// can resolve each distinct issuer DID once and reuse the verifier across
+    /// every link that names it, rather than resolving per link.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SignatureVerificationError`] if the payload cannot be
+    /// encoded or the signature does not verify.
+    pub async fn verify_with<E: std::error::Error>(
+        &self,
+        verifier: &impl Verifier<S>,
+    ) -> Result<(), SignatureVerificationError<E>> {
+        let payload = self
+            .envelope()
+            .encode()
+            .map_err(SignatureVerificationError::EncodingError)?;
+        Verifier::verify(verifier, &payload, self.signature())
             .await
             .map_err(SignatureVerificationError::VerificationError)
     }

--- a/rust/dialog-ucan-core/src/invocation.rs
+++ b/rust/dialog-ucan-core/src/invocation.rs
@@ -20,8 +20,14 @@ use crate::{
     subject::Subject,
     time::{TimeBoundError, range::TimeRange, timestamp::Timestamp},
 };
+use crate::{
+    delegation::SignatureVerificationError as DelegationSignatureError,
+    revocation::{RevocationChecker, RevocationMatch, RevocationSelector},
+    verification::{Verifiable, VerificationContext},
+};
 use builder::InvocationBuilder;
 use dialog_varsig::{Did, Resolver, Signature, Verifier};
+use futures::{StreamExt, stream::FuturesUnordered};
 use ipld_core::{cid::Cid, ipld::Ipld};
 use serde::{
     Deserialize, Deserializer, Serialize,
@@ -29,7 +35,7 @@ use serde::{
 };
 use std::{
     borrow::{Borrow, Cow},
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet, HashMap},
     fmt::Debug,
 };
 use thiserror::Error;
@@ -116,42 +122,195 @@ impl<S: Signature> Invocation<S> {
         to_dagcbor_cid(&self)
     }
 
-    /// Check if this invocation is valid.
+    /// Verify this invocation and its whole proof chain.
     ///
-    /// This method performs two checks:
-    /// 1. Verifies that the invocation's signature is valid
-    /// 2. Validates the proof chain using the provided delegation store
+    /// Runs in three phases, ordered so that cheap refusals cost nothing and
+    /// expensive work is shared and overlapped:
+    ///
+    /// 1. **Structural, no I/O.** Proof lookup and
+    ///    [`syntactic_checks`](InvocationPayload::syntactic_checks): alignment,
+    ///    attenuation, policy, and time bounds against the context's sampled
+    ///    instant. A chain that fails here spends no network calls and no
+    ///    crypto.
+    /// 2. **Resolution, concurrent and deduplicated.** Every distinct issuer
+    ///    DID is resolved exactly once, all in flight together. Deduplication
+    ///    is load-bearing rather than an optimization: the caching resolver
+    ///    has no in-flight dedup, so resolving per link concurrently would
+    ///    turn one fetch into N for a DID that appears more than once — and
+    ///    repeated issuers are the normal case.
+    /// 3. **Signatures and revocations, concurrent.** Every link's signature
+    ///    (against its already-resolved verifier) and every link's revocation
+    ///    query are driven together. The first decisive refusal returns at
+    ///    once, dropping the rest, which cancels the in-flight work.
+    ///
+    /// Verification is strict: a revocation query that cannot be performed
+    /// fails the chain rather than proceeding as though the delegation stood.
+    /// A caller willing to proceed without that evidence says so by wrapping
+    /// the checker (see
+    /// [`tolerate_unavailable`](crate::RevocationChecker::tolerate_unavailable)),
+    /// which is a choice made where the environment is built.
     ///
     /// # Errors
     ///
-    /// Returns an [`InvocationCheckError`] if signature verification fails
-    /// or if the proof chain validation fails.
-    pub async fn check<
+    /// Returns a [`VerifyError`] if the chain does not check out,
+    /// a signature does not verify, an issuer cannot be resolved, or a link
+    /// has been revoked.
+    pub async fn check<K, T, St, C>(
+        &self,
+        ctx: &VerificationContext<'_, C>,
+    ) -> Result<
+        TimeRange,
+        VerifyError<
+            K,
+            S,
+            T,
+            St,
+            <C::Resolver as Resolver<S>>::Error,
+            <C::Revocations as RevocationChecker>::Error,
+        >,
+    >
+    where
         K: FutureKind,
         T: Borrow<Delegation<S>>,
         St: DelegationStore<K, S, T>,
-        R: Resolver<S>,
-    >(
-        &self,
-        proof_store: &St,
-        resolver: &R,
-    ) -> Result<TimeRange, InvocationCheckError<K, S, T, St, R>> {
-        // 1. Verify signature
-        self.verify_signature(resolver)
-            .await
-            .map_err(InvocationCheckError::SignatureVerification)?;
-
-        // 2. Check proof chain and compute valid time range. This also
-        //    verifies each delegation link's own signature against its
-        //    resolved issuer key, so a forged proof cannot pass just
-        //    because the invocation itself is validly signed.
-        let time_range = self
+        C: Verifiable<K, S, Proof = T, Delegations = St>,
+        // Cloned when a resolution failure is reported: several links may
+        // name the same unresolvable issuer.
+        <C::Resolver as Resolver<S>>::Error: Clone,
+    {
+        // Phase 1: structure. Nothing below runs if this fails.
+        let (proofs, range) = self
             .payload()
-            .check(proof_store, resolver)
+            .check::<K, S, T, St, C, _>(ctx)
             .await
-            .map_err(InvocationCheckError::StoredCheck)?;
+            .map_err(VerifyError::Invalid)?;
 
-        Ok(time_range)
+        let delegations: Vec<&Delegation<S>> = proofs.iter().map(Borrow::borrow).collect();
+
+        // Phase 2 and the revocation half of phase 3 are independent, so they
+        // run together rather than in sequence: revocation queries do not
+        // need any resolved key.
+        // Who may revoke each link.
+        //
+        // The revocation spec's pseudocode computes one `delegators` set for
+        // the whole chain:
+        //
+        //     const delegators = invocation.prf.map(proof => proof.iss)
+        //
+        // Applied uniformly that is too permissive: for a chain a -> b -> c -> d
+        // it lets d's issuer revoke c, so a principal who merely *received*
+        // authority could revoke the grant it depends on. Authority to revoke
+        // flows downward, so the candidate set is scoped per link: the issuers
+        // at or above it, plus that link's own audience (its immediate
+        // recipient, who may always disclaim what it was given).
+        //
+        //     check a  => [a.iss, a.aud]
+        //     check c  => [a.iss, b.iss, c.iss, c.aud]
+        //
+        // d.iss never appears when checking c.
+        let mut prefix: Vec<Did> = Vec::with_capacity(delegations.len() + 1);
+        let revokers_per_link: Vec<Vec<Did>> = delegations
+            .iter()
+            .map(|delegation| {
+                prefix.push(delegation.issuer().clone());
+                let mut candidates = prefix.clone();
+                candidates.push(delegation.audience().clone());
+                candidates
+            })
+            .collect();
+
+        let mut revocations = FuturesUnordered::new();
+        for (delegation, revokers) in delegations.iter().zip(&revokers_per_link) {
+            let cid = delegation.to_cid();
+            let revokers = revokers.as_slice();
+            revocations.push(async move {
+                match ctx
+                    .environment()
+                    .revocations()
+                    .query(RevocationSelector::new(cid, revokers))
+                    .await
+                {
+                    Ok(None) => Ok(()),
+                    Ok(Some(found)) => Err(VerifyError::<K, S, T, St, _, _>::Invalid(
+                        Invalid::Revoked { cid, found },
+                    )),
+                    // The question went unanswered. A caller willing to
+                    // proceed without the answer says so by wrapping the
+                    // checker, not by us guessing here.
+                    Err(source) => Err(VerifyError::Unavailable(Unavailable::RevocationLookup {
+                        cid,
+                        source,
+                    })),
+                }
+            });
+        }
+
+        // Resolve each distinct issuer exactly once, while the revocation
+        // lookups above are already in flight.
+        let mut wanted: BTreeSet<&Did> = delegations.iter().map(|d| d.issuer()).collect();
+        wanted.insert(self.issuer());
+        let verifiers = resolve_each_once(ctx.environment().resolver(), wanted).await;
+
+        let verifier_for = |did: &Did| {
+            verifiers
+                .get(did)
+                .expect("every issuer was collected before resolving")
+                .as_ref()
+        };
+
+        // Two homogeneous queues rather than one boxed queue: the two kinds
+        // of check have different future types, and boxing them into a single
+        // stream would make the whole verification `!Send`. They are still
+        // driven together below.
+        let mut signatures = FuturesUnordered::new();
+
+        for delegation in delegations.iter().map(Some).chain(std::iter::once(None)) {
+            // `None` stands for the invocation's own signature, checked
+            // alongside the links rather than before them.
+            let issuer = delegation.map_or_else(|| self.issuer(), |d| d.issuer());
+            signatures.push(async move {
+                let verifier = match verifier_for(issuer) {
+                    Ok(verifier) => verifier,
+                    // Without the key the signature cannot be checked, so the
+                    // chain is unproven — not merely un-revocation-checked.
+                    // No tolerance setting can accept that.
+                    Err(detail) => {
+                        return Err(VerifyError::Unavailable(Unavailable::DidResolution {
+                            did: issuer.clone(),
+                            detail: detail.clone(),
+                        }));
+                    }
+                };
+
+                match delegation {
+                    Some(delegation) => delegation
+                        .verify_with::<<C::Resolver as Resolver<S>>::Error>(verifier)
+                        .await
+                        .map_err(|source| {
+                            VerifyError::Invalid(Invalid::DelegationSignature {
+                                issuer: issuer.clone(),
+                                source,
+                            })
+                        }),
+                    None => self
+                        .verify_with::<<C::Resolver as Resolver<S>>::Error>(verifier)
+                        .await
+                        .map_err(|err| VerifyError::Invalid(Invalid::InvocationSignature(err))),
+                }
+            });
+        }
+
+        // Drive both queues together, aborting on the first refusal.
+        // Dropping them cancels whatever is still in flight.
+        loop {
+            futures::select_biased! {
+                result = signatures.select_next_some() => result?,
+                result = revocations.select_next_some() => result?,
+                complete => break,
+            }
+        }
+
+        Ok(range)
     }
 
     #[must_use]
@@ -184,15 +343,32 @@ impl<S: Signature> Invocation<S> {
     where
         R: Resolver<S>,
     {
-        let encoded = self
-            .envelope()
-            .encode()
-            .map_err(SignatureVerificationError::EncodingError)?;
         let verifier = resolver
             .resolve(self.issuer())
             .await
             .map_err(SignatureVerificationError::ResolutionError)?;
-        Verifier::verify(&verifier, &encoded, self.signature())
+        self.verify_with::<R::Error>(&verifier).await
+    }
+
+    /// Verify this invocation's signature against an already-resolved verifier.
+    ///
+    /// Split out from [`verify_signature`](Self::verify_signature) so a chain
+    /// can resolve each distinct issuer DID once and share the verifier with
+    /// every delegation link that names the same issuer.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SignatureVerificationError`] if the payload cannot be
+    /// encoded or the signature does not verify.
+    pub async fn verify_with<E: std::error::Error>(
+        &self,
+        verifier: &impl Verifier<S>,
+    ) -> Result<(), SignatureVerificationError<E>> {
+        let encoded = self
+            .envelope()
+            .encode()
+            .map_err(SignatureVerificationError::EncodingError)?;
+        Verifier::verify(verifier, &encoded, self.signature())
             .await
             .map_err(SignatureVerificationError::VerificationError)
     }
@@ -327,47 +503,47 @@ impl InvocationPayload {
         to_dagcbor_cid(&self)
     }
 
-    /// Check if an [`InvocationPayload`] with proofs stored in a delegation store is valid.
+    /// Check that this payload's proof chain authorizes it.
     ///
-    /// In addition to the structural [`syntactic_checks`](Self::syntactic_checks),
-    /// this verifies each delegation link's own signature against the key its
-    /// `iss` resolves to. A proof that is not actually signed by its claimed
-    /// issuer is rejected, even when the invocation itself is validly signed.
+    /// This is the structural pass only: principal alignment, subject
+    /// consistency, command attenuation, policy predicates, and time bounds
+    /// judged against the context's sampled instant. It performs no key
+    /// resolution, no signature verification, and no revocation lookup — the
+    /// caller does those, after this has passed.
+    ///
+    /// Running structure first is deliberate: a chain that fails alignment
+    /// costs nothing, rather than paying a DID resolution per link before
+    /// finding out.
     ///
     /// # Errors
     ///
-    /// Returns a [`StoredCheckError`] if the check fails.
-    pub async fn check<
+    /// Returns an [`Invalid`] if a proof is missing from the store or
+    /// the chain does not check out.
+    pub async fn check<K, S, T, St, C, RE>(
+        &self,
+        ctx: &VerificationContext<'_, C>,
+    ) -> Result<(Vec<T>, TimeRange), Invalid<K, S, T, St, RE>>
+    where
         K: FutureKind,
         S: Signature,
         T: Borrow<Delegation<S>>,
         St: DelegationStore<K, S, T>,
-        R: Resolver<S>,
-    >(
-        &self,
-        proof_store: &St,
-        resolver: &R,
-    ) -> Result<TimeRange, StoredCheckError<K, S, T, St, R>> {
-        let realized_proofs: Vec<T> = proof_store
+        C: Verifiable<K, S, Proof = T, Delegations = St>,
+        RE: std::error::Error,
+    {
+        let proofs: Vec<T> = ctx
+            .environment()
+            .delegations()
             .get_all(&self.proofs)
             .await
-            .map_err(StoredCheckError::GetError)?;
-        let dlgs: Vec<&Delegation<S>> = realized_proofs.iter().map(Borrow::borrow).collect();
+            .map_err(Invalid::MissingProof)?;
 
-        // Every link must carry a signature that verifies against its own
-        // resolved issuer key. Without this a forged delegation (valid
-        // structure, garbage signature) would authorize an attacker.
-        for delegation in &dlgs {
-            delegation
-                .verify_signature(resolver)
-                .await
-                .map_err(|source| StoredCheckError::SignatureVerification {
-                    issuer: delegation.issuer().clone(),
-                    source,
-                })?;
-        }
+        let range = {
+            let borrowed: Vec<&Delegation<S>> = proofs.iter().map(Borrow::borrow).collect();
+            self.syntactic_checks(borrowed, ctx.time())?
+        };
 
-        Ok(self.syntactic_checks(dlgs)?)
+        Ok((proofs, range))
     }
 
     /// Check if an [`InvocationPayload`] is valid.
@@ -382,6 +558,7 @@ impl InvocationPayload {
     pub fn syntactic_checks<'a, S: Signature + 'a, I: IntoIterator<Item = &'a Delegation<S>>>(
         &'a self,
         proofs: I,
+        now: Option<Timestamp>,
     ) -> Result<TimeRange, CheckFailed> {
         let args: Ipld = self
             .arguments()
@@ -483,6 +660,14 @@ impl InvocationPayload {
         // Verify the accumulated time window is non-empty.
         if !time_range.is_valid() {
             return Err(CheckFailed::InvalidTimeWindow { range: time_range });
+        }
+
+        // A non-empty window only says the chain *could* be valid at some
+        // instant. Judge it against the one this verification was given:
+        // without this an expired delegation still authorizes. `None` is a
+        // deliberate opt-out (historical replay, no trusted clock).
+        if let Some(now) = now {
+            time_range.check(&now)?;
         }
 
         Ok(time_range)
@@ -664,6 +849,35 @@ impl PayloadTag for InvocationPayload {
     }
 }
 
+/// Resolve each distinct DID exactly once, all concurrently.
+///
+/// Deduplicating before resolving is the point: the caching resolver has no
+/// in-flight dedup, so N concurrent lookups of the same DID would all miss the
+/// cache together and all fetch. Collapsing to distinct DIDs first keeps that
+/// at one request per DID no matter how many links name it.
+///
+/// The resolver's verifier type is opaque (RPITIT), so this returns the map by
+/// way of a generic rather than naming it.
+async fn resolve_each_once<'a, 'r, S, R>(
+    resolver: &'r R,
+    dids: BTreeSet<&'a Did>,
+) -> HashMap<&'a Did, Result<impl Verifier<S> + use<'a, 'r, S, R>, R::Error>>
+where
+    S: Signature,
+    R: Resolver<S>,
+{
+    let mut pending = FuturesUnordered::new();
+    for did in dids {
+        pending.push(async move { (did, resolver.resolve(did).await) });
+    }
+
+    let mut resolved = HashMap::new();
+    while let Some((did, result)) = pending.next().await {
+        resolved.insert(did, result);
+    }
+    resolved
+}
+
 /// Errors that can occur when checking an invocation
 #[derive(Debug, Clone, Error)]
 pub enum CheckFailed {
@@ -736,35 +950,6 @@ pub enum CheckFailed {
     TimeBound(#[from] TimeBoundError),
 }
 
-/// Errors that can occur when checking an invocation with proofs stored in a delegation store
-#[derive(Debug, Error)]
-pub enum StoredCheckError<
-    K: FutureKind,
-    S: Signature,
-    T: Borrow<Delegation<S>>,
-    St: DelegationStore<K, S, T>,
-    R: Resolver<S>,
-> {
-    /// Error getting proofs from the store
-    #[error(transparent)]
-    GetError(St::GetError),
-
-    /// A delegation link's own signature did not verify against its
-    /// resolved issuer key. The `issuer` is the principal the proof claims
-    /// to be signed by.
-    #[error("delegation from '{issuer}' does not carry a valid signature: {source}")]
-    SignatureVerification {
-        /// The principal the forged proof claims as its issuer.
-        issuer: Did,
-        /// The underlying verification failure.
-        source: crate::delegation::SignatureVerificationError<R::Error>,
-    },
-
-    /// Proof check failed
-    #[error(transparent)]
-    CheckFailed(#[from] CheckFailed),
-}
-
 /// Error type for invocation signature verification.
 #[derive(Debug, thiserror::Error)]
 pub enum SignatureVerificationError<E: std::error::Error = signature::Error> {
@@ -783,20 +968,118 @@ pub enum SignatureVerificationError<E: std::error::Error = signature::Error> {
 
 /// Errors that can occur when checking an invocation (signature + proofs)
 #[derive(Debug, Error)]
-pub enum InvocationCheckError<
+pub enum VerifyError<
     K: FutureKind,
     S: Signature,
     T: Borrow<Delegation<S>>,
     St: DelegationStore<K, S, T>,
-    R: Resolver<S>,
+    RE: std::error::Error,
+    XE: std::error::Error,
 > {
-    /// Signature verification failed
+    /// The chain does not hold up: it is invalid, and no retry or better
+    /// connectivity changes that.
+    ///
+    /// Every variant of [`Invalid`] is a statement about the caller's
+    /// material.
     #[error(transparent)]
-    SignatureVerification(SignatureVerificationError<R::Error>),
+    Invalid(#[from] Invalid<K, S, T, St, RE>),
 
-    /// Proof chain check failed
+    /// We could not establish whether the chain holds up.
+    ///
+    /// This says nothing about the chain — only that something we depend on
+    /// was unreachable. It must never be reported as a denial.
     #[error(transparent)]
-    StoredCheck(StoredCheckError<K, S, T, St, R>),
+    Unavailable(#[from] Unavailable<RE, XE>),
+}
+
+/// The error [`Invocation::check`] produces for a given environment.
+///
+/// Spells out the six parameters once so callers can name the type without
+/// repeating them.
+pub type CheckError<K, S, C> = VerifyError<
+    K,
+    S,
+    <C as Verifiable<K, S>>::Proof,
+    <C as Verifiable<K, S>>::Delegations,
+    <<C as Verifiable<K, S>>::Resolver as Resolver<S>>::Error,
+    <<C as Verifiable<K, S>>::Revocations as RevocationChecker>::Error,
+>;
+
+/// The chain is invalid. A statement about the caller's material.
+#[derive(Debug, Error)]
+pub enum Invalid<
+    K: FutureKind,
+    S: Signature,
+    T: Borrow<Delegation<S>>,
+    St: DelegationStore<K, S, T>,
+    RE: std::error::Error,
+> {
+    /// The invocation's own signature did not verify.
+    #[error("invocation does not carry a valid signature: {0}")]
+    InvocationSignature(SignatureVerificationError<RE>),
+
+    /// A delegation link's signature did not verify against its claimed
+    /// issuer's key.
+    #[error("delegation from '{issuer}' does not carry a valid signature: {source}")]
+    DelegationSignature {
+        /// The principal the proof claims as its issuer.
+        issuer: Did,
+        /// The underlying verification failure.
+        source: DelegationSignatureError<RE>,
+    },
+
+    /// A proof the chain refers to was not supplied.
+    #[error(transparent)]
+    MissingProof(St::GetError),
+
+    /// The chain's structure does not authorize the invocation: principal
+    /// alignment, attenuation, policy, or time bounds.
+    #[error(transparent)]
+    Chain(#[from] CheckFailed),
+
+    /// A delegation in the chain has been revoked.
+    #[error("delegation '{cid}' was revoked by '{}'", found.principal)]
+    Revoked {
+        /// The revoked delegation.
+        cid: Cid,
+        /// The revocation that matched: its document and its issuer.
+        found: RevocationMatch,
+    },
+}
+
+/// We could not establish whether the chain holds up.
+///
+/// Distinct from [`Invalid`] because the two mean opposite things at a trust
+/// boundary: one is grounds to refuse, the other is grounds to say "ask again".
+#[derive(Debug, Error)]
+pub enum Unavailable<RE: std::error::Error, XE: std::error::Error> {
+    /// An issuer DID could not be resolved to a verifier.
+    ///
+    /// Without the key the signature cannot be checked, so the chain is
+    /// unproven — not invalid. Distinct from a revocation gap: this leaves a
+    /// signature unverified, so no tolerance setting can accept it.
+    #[error("could not resolve issuer '{did}': {detail}")]
+    DidResolution {
+        /// The issuer that could not be resolved.
+        did: Did,
+        /// Why resolution failed.
+        detail: RE,
+    },
+
+    /// A revocation lookup failed and the checker did not tolerate it.
+    ///
+    /// Says nothing about whether the delegation was revoked, only that the
+    /// question went unanswered. A caller willing to proceed without that
+    /// answer uses
+    /// [`tolerate_unavailable`](crate::RevocationChecker::tolerate_unavailable),
+    /// which turns this into an unknown recorded in the verdict instead.
+    #[error("could not determine revocation status of '{cid}': {source}")]
+    RevocationLookup {
+        /// The delegation whose status is unknown.
+        cid: Cid,
+        /// Why the lookup failed.
+        source: XE,
+    },
 }
 
 #[cfg(test)]
@@ -811,9 +1094,12 @@ mod tests {
             policy::{predicate::Predicate, selector::select::Select},
             store,
         },
+        future::Local,
         promise::Promised,
+        revocation::{RevocationMatch, UnverifiedRevocations},
         subject::Subject,
         time::{TimeRange, Timestamp},
+        verification::Environment,
     };
     use builder::InvocationBuilder;
     use dialog_credentials::DidKeyResolver;
@@ -1104,6 +1390,41 @@ mod tests {
         store::insert(store, Rc::new(delegation)).await.unwrap()
     }
 
+    /// A verification environment over `store`, judged against the system
+    /// clock and performing no revocation lookups.
+    type TestEnv = Environment<
+        DelegationStore,
+        DidKeyResolver,
+        UnverifiedRevocations,
+        Rc<Delegation<Ed25519Signature>>,
+    >;
+
+    fn env(store: &DelegationStore) -> TestEnv {
+        Environment::new(store.clone(), DidKeyResolver, UnverifiedRevocations)
+    }
+
+    /// Verify against the system clock.
+    async fn check(
+        invocation: &Invocation<Ed25519Signature>,
+        store: &DelegationStore,
+    ) -> Result<TimeRange, String> {
+        check_at(invocation, store, Some(Timestamp::now())).await
+    }
+
+    /// Verify against a specific instant (`None` skips time bounds).
+    async fn check_at(
+        invocation: &Invocation<Ed25519Signature>,
+        store: &DelegationStore,
+        time: Option<Timestamp>,
+    ) -> Result<TimeRange, String> {
+        let environment = env(store);
+        let ctx = VerificationContext::at(&environment, time);
+        invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .map_err(|err| err.to_string())
+    }
+
     #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), tokio::test)]
     #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     async fn chain_check_valid_single_delegation() -> TestResult {
@@ -1131,7 +1452,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1167,7 +1488,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Chain check should fail when proof audience != invoker");
         let err_msg = err.to_string();
         assert!(
@@ -1215,7 +1536,7 @@ mod tests {
             .await?;
 
         // Should fail: proof.issuer (random) != subject
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Chain check should fail when proof issuer != subject");
         let err_msg = err.to_string();
         assert!(
@@ -1300,7 +1621,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1335,7 +1656,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: proof subject (b) != invocation subject (a)");
         let err_msg = err.to_string();
         assert!(
@@ -1384,7 +1705,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: root delegation issuer (b) != subject (a)");
         let err_msg = err.to_string();
         assert!(
@@ -1431,7 +1752,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1465,7 +1786,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: powerline issuer (b) != invocation subject (a)");
         let err_msg = err.to_string();
         assert!(
@@ -1524,7 +1845,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1571,7 +1892,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err =
             result.expect_err("Should fail: second proof subject (b) != established subject (a)");
         let err_msg = err.to_string();
@@ -1609,7 +1930,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: self-issued invocation with issuer != subject");
         let err_msg = err.to_string();
         assert!(
@@ -1644,7 +1965,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1676,7 +1997,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: invocation command not covered by delegation");
         let err_msg = err.to_string();
         assert!(
@@ -1722,7 +2043,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1768,7 +2089,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: arguments violate delegation policy");
         let err_msg = err.to_string();
         assert!(
@@ -1817,7 +2138,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1873,7 +2194,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: chain linkage broken at second hop");
         let err_msg = err.to_string();
         assert!(
@@ -1940,7 +2261,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1975,7 +2296,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -1999,7 +2320,7 @@ mod tests {
             .try_build()
             .await?;
 
-        invocation.check(&delegation_store, &DidKeyResolver).await?;
+        check(&invocation, &delegation_store).await?;
 
         Ok(())
     }
@@ -2019,7 +2340,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
+        let range = check(&invocation, &delegation_store).await?;
 
         assert_eq!(range, TimeRange::unbounded());
         Ok(())
@@ -2054,7 +2375,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
+        let range = check(&invocation, &delegation_store).await?;
 
         assert_eq!(range.not_before, Bound::Unbounded);
         assert_eq!(range.expiration, Bound::Included(exp));
@@ -2109,7 +2430,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
+        let range = check(&invocation, &delegation_store).await?;
 
         // nbf = max(now, unbounded) = now
         assert_eq!(range.not_before, Bound::Included(now));
@@ -2166,7 +2487,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let result = invocation.check(&delegation_store, &DidKeyResolver).await;
+        let result = check(&invocation, &delegation_store).await;
         let err = result.expect_err("Should fail: time windows don't overlap");
         let err_msg = err.to_string();
         assert!(
@@ -2209,7 +2530,7 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
+        let range = check(&invocation, &delegation_store).await?;
 
         // The invocation's tighter expiration should win
         assert_eq!(range.expiration, Bound::Included(exp_invocation));
@@ -2264,12 +2585,529 @@ mod tests {
             .try_build()
             .await?;
 
-        let range = invocation.check(&delegation_store, &DidKeyResolver).await?;
+        let range = check(&invocation, &delegation_store).await?;
 
         // nbf = max(now, unbounded) = now (narrow wins)
         assert_eq!(range.not_before, Bound::Included(now));
         // exp = min(exp_narrow, exp_wide) = exp_narrow (narrow wins)
         assert_eq!(range.expiration, Bound::Included(exp_narrow));
+        Ok(())
+    }
+
+    use crate::time::timestamp::{Duration, UNIX_EPOCH};
+
+    /// A checker that fails every lookup, standing in for an unreachable
+    /// revocation service.
+    #[derive(Debug, thiserror::Error)]
+    #[error("revocation service unreachable")]
+    struct Unreachable;
+
+    #[derive(Debug, Clone, Copy)]
+    struct OfflineRevocations;
+
+    impl RevocationChecker for OfflineRevocations {
+        type Error = Unreachable;
+
+        async fn query(
+            &self,
+            _selector: RevocationSelector<'_>,
+        ) -> Result<Option<RevocationMatch>, Self::Error> {
+            Err(Unreachable)
+        }
+    }
+
+    /// Records the candidate revoker sets it was queried with.
+    #[derive(Debug, Clone, Default)]
+    struct RecordingRevocations(Rc<RefCell<Vec<Vec<Did>>>>);
+
+    impl RevocationChecker for RecordingRevocations {
+        type Error = Unreachable;
+
+        async fn query(
+            &self,
+            selector: RevocationSelector<'_>,
+        ) -> Result<Option<RevocationMatch>, Self::Error> {
+            RefCell::borrow_mut(&self.0).push(selector.by.to_vec());
+            Ok(None)
+        }
+    }
+
+    /// A checker that reports every delegation as revoked.
+    #[derive(Debug, Clone)]
+    struct AllRevoked(Did);
+
+    impl RevocationChecker for AllRevoked {
+        type Error = Unreachable;
+
+        async fn query(
+            &self,
+            selector: RevocationSelector<'_>,
+        ) -> Result<Option<RevocationMatch>, Self::Error> {
+            Ok(Some(RevocationMatch {
+                revocation: selector.delegation,
+                principal: self.0.clone(),
+            }))
+        }
+    }
+
+    /// A resolver that counts how many times each DID was resolved.
+    #[derive(Debug, Default, Clone)]
+    struct CountingResolver(Rc<RefCell<usize>>);
+
+    impl dialog_varsig::Resolver<Ed25519Signature> for CountingResolver {
+        type Error = dialog_credentials::DidKeyResolveError;
+
+        async fn resolve(
+            &self,
+            did: &Did,
+        ) -> Result<impl dialog_varsig::Verifier<Ed25519Signature>, Self::Error> {
+            *RefCell::borrow_mut(&self.0) += 1;
+            dialog_varsig::Resolver::<Ed25519Signature>::resolve(&DidKeyResolver, did).await
+        }
+    }
+
+    /// Build a one-link chain: `subject -> invoker`, invoked by `invoker`.
+    async fn one_link_chain(
+        expiration: Option<Timestamp>,
+    ) -> TestResult<(Invocation<Ed25519Signature>, DelegationStore)> {
+        let subject = test_signer(90).await;
+        let invoker = test_signer(91).await;
+
+        let mut builder = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&invoker)
+            .subject(Subject::Specific(subject.did()))
+            .command(vec!["test".to_string()]);
+        if let Some(exp) = expiration {
+            builder = builder.expiration(exp);
+        }
+        let delegation = builder.try_build().await?;
+
+        let store = new_store();
+        let cid = store_delegation(&store, delegation).await;
+
+        let invocation = InvocationBuilder::new()
+            .issuer(invoker.clone())
+            .audience(&subject)
+            .subject(&subject)
+            .command(vec!["test".to_string()])
+            .proofs(vec![cid])
+            .try_build()
+            .await?;
+
+        Ok((invocation, store))
+    }
+
+    /// Build an `n`-hop chain rooted at `subject`, invoked by the final
+    /// audience. Returns the invocation, the store, and the signers in chain
+    /// order (`[subject, hop1, hop2, ..., invoker]`).
+    async fn multi_hop_chain(
+        hops: usize,
+    ) -> TestResult<(
+        Invocation<Ed25519Signature>,
+        DelegationStore,
+        Vec<Ed25519Signer>,
+    )> {
+        assert!(hops >= 1, "a chain needs at least one delegation");
+
+        let mut signers = Vec::with_capacity(hops + 1);
+        for seed in 0..=hops {
+            signers.push(test_signer(120 + u8::try_from(seed).expect("small seed")).await);
+        }
+        let subject = signers[0].clone();
+
+        let store = new_store();
+        let mut cids = Vec::with_capacity(hops);
+        for hop in 0..hops {
+            let delegation = DelegationBuilder::new()
+                .issuer(signers[hop].clone())
+                .audience(&signers[hop + 1])
+                .subject(Subject::Specific(subject.did()))
+                .command(vec!["test".to_string()])
+                .try_build()
+                .await?;
+            cids.push(store_delegation(&store, delegation).await);
+        }
+
+        let invoker = signers[hops].clone();
+        let invocation = InvocationBuilder::new()
+            .issuer(invoker)
+            .audience(&subject)
+            .subject(&subject)
+            .command(vec!["test".to_string()])
+            .proofs(cids)
+            .try_build()
+            .await?;
+
+        Ok((invocation, store, signers))
+    }
+
+    /// Run a verification whose revocation checker records what it was asked,
+    /// returning the candidate revoker set per link, in chain order.
+    async fn recorded_revokers(
+        invocation: &Invocation<Ed25519Signature>,
+        store: &DelegationStore,
+    ) -> TestResult<Vec<Vec<Did>>> {
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let environment: Environment<
+            DelegationStore,
+            DidKeyResolver,
+            RecordingRevocations,
+            Rc<Delegation<Ed25519Signature>>,
+        > = Environment::new(
+            store.clone(),
+            DidKeyResolver,
+            RecordingRevocations(seen.clone()),
+        );
+        let ctx = VerificationContext::new(&environment);
+        invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let mut recorded = RefCell::borrow(&seen).clone();
+        // Queries complete concurrently, so order by chain position: each
+        // link's prefix is strictly longer than the one before it.
+        recorded.sort_by_key(Vec::len);
+        Ok(recorded)
+    }
+
+    #[dialog_common::test]
+    async fn an_expired_delegation_is_refused() -> TestResult {
+        // Expired in 2001. Before this check existed, it authorized.
+        let expired = Timestamp::try_from(UNIX_EPOCH + Duration::from_secs(1_000_000_000))?;
+        let (invocation, store) = one_link_chain(Some(expired)).await?;
+
+        let result = check(&invocation, &store).await;
+        assert!(result.is_err(), "an expired delegation must not authorize");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_expired_delegation_passes_when_time_is_not_judged() -> TestResult {
+        // `None` is the explicit opt-out: replaying history, or no trusted
+        // clock. It must skip the bound rather than default to the epoch.
+        let expired = Timestamp::try_from(UNIX_EPOCH + Duration::from_secs(1_000_000_000))?;
+        let (invocation, store) = one_link_chain(Some(expired)).await?;
+
+        check_at(&invocation, &store, None).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_delegation_is_refused_before_it_is_valid() -> TestResult {
+        let subject = test_signer(92).await;
+        let invoker = test_signer(93).await;
+
+        let delegation = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&invoker)
+            .subject(Subject::Specific(subject.did()))
+            .command(vec!["test".to_string()])
+            .not_before(Timestamp::five_years_from_now())
+            .try_build()
+            .await?;
+
+        let store = new_store();
+        let cid = store_delegation(&store, delegation).await;
+
+        let invocation = InvocationBuilder::new()
+            .issuer(invoker.clone())
+            .audience(&subject)
+            .subject(&subject)
+            .command(vec!["test".to_string()])
+            .proofs(vec![cid])
+            .try_build()
+            .await?;
+
+        assert!(
+            check(&invocation, &store).await.is_err(),
+            "a not-yet-valid delegation must not authorize"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn each_distinct_issuer_is_resolved_exactly_once() -> TestResult {
+        // Regression guard for the concurrency-vs-cache hazard: the caching
+        // resolver has no in-flight dedup, so resolving per link would turn
+        // one fetch into N for a repeated DID.
+        let (invocation, store) = one_link_chain(None).await?;
+
+        let counter = Rc::new(RefCell::new(0usize));
+        let environment = Environment::new(
+            store.clone(),
+            CountingResolver(counter.clone()),
+            UnverifiedRevocations,
+        );
+        let ctx = VerificationContext::new(&environment);
+        invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Two distinct issuers here (subject and invoker), each resolved once.
+        assert_eq!(
+            *RefCell::borrow(&*counter),
+            2,
+            "each distinct issuer resolves once"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_structural_failure_costs_no_resolutions() -> TestResult {
+        // Pins the phase ordering: structure is judged before any I/O.
+        let subject = test_signer(94).await;
+        let invoker = test_signer(95).await;
+        let stranger = test_signer(96).await;
+
+        // Delegation to someone other than the invoker: misaligned chain.
+        let delegation = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&stranger)
+            .subject(Subject::Specific(subject.did()))
+            .command(vec!["test".to_string()])
+            .try_build()
+            .await?;
+
+        let store = new_store();
+        let cid = store_delegation(&store, delegation).await;
+
+        let invocation = InvocationBuilder::new()
+            .issuer(invoker.clone())
+            .audience(&subject)
+            .subject(&subject)
+            .command(vec!["test".to_string()])
+            .proofs(vec![cid])
+            .try_build()
+            .await?;
+
+        let counter = Rc::new(RefCell::new(0usize));
+        let environment = Environment::new(
+            store.clone(),
+            CountingResolver(counter.clone()),
+            UnverifiedRevocations,
+        );
+        let ctx = VerificationContext::new(&environment);
+        let result = invocation.check::<Local, _, _, _>(&ctx).await;
+
+        assert!(result.is_err(), "a misaligned chain must be refused");
+        assert_eq!(
+            *RefCell::borrow(&*counter),
+            0,
+            "a structural failure must not pay for any DID resolution"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_unreachable_revocation_service_is_not_a_denial() -> TestResult {
+        let (invocation, store) = one_link_chain(None).await?;
+
+        let environment = Environment::new(store.clone(), DidKeyResolver, OfflineRevocations);
+        let ctx = VerificationContext::new(&environment);
+        let err = invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .expect_err("a strict checker must not accept an unknown status");
+
+        // It must read as "could not check", never as "invalid".
+        assert!(
+            matches!(
+                err,
+                VerifyError::Unavailable(Unavailable::RevocationLookup { .. })
+            ),
+            "expected an unavailability, got: {err:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn tolerating_an_unreachable_service_lets_a_valid_chain_pass() -> TestResult {
+        // Wrapping the checker is the whole opt-in: verification stays strict
+        // otherwise, and the caller made this choice where the environment
+        // was built.
+        let (invocation, store) = one_link_chain(None).await?;
+
+        let environment = Environment::new(
+            store.clone(),
+            DidKeyResolver,
+            OfflineRevocations.tolerate_unavailable(),
+        );
+        let ctx = VerificationContext::new(&environment);
+        invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn tolerating_still_refuses_a_confirmed_revocation() -> TestResult {
+        // Tolerance is about not knowing, never knowing-and-ignoring.
+        let (invocation, store) = one_link_chain(None).await?;
+        let revoker = test_did(90).await;
+
+        let environment = Environment::new(
+            store.clone(),
+            DidKeyResolver,
+            AllRevoked(revoker).tolerate_unavailable(),
+        );
+        let ctx = VerificationContext::new(&environment);
+        let err = invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .expect_err("a confirmed revocation must be refused");
+
+        assert!(
+            matches!(err, VerifyError::Invalid(Invalid::Revoked { .. })),
+            "expected a revocation refusal, got: {err:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_invalid_chain_beats_an_unreachable_revocation_service() -> TestResult {
+        // The central invariant: if the chain is bad, the caller must learn
+        // *that*, never "revocation service unreachable". Otherwise a caller
+        // willing to fail open on unavailability would accept a bad chain.
+        let expired = Timestamp::try_from(UNIX_EPOCH + Duration::from_secs(1_000_000_000))?;
+        let (invocation, store) = one_link_chain(Some(expired)).await?;
+
+        let environment = Environment::new(store.clone(), DidKeyResolver, OfflineRevocations);
+        let ctx = VerificationContext::new(&environment);
+        let err = invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .expect_err("an expired chain must be refused");
+
+        assert!(
+            matches!(err, VerifyError::Invalid(_)),
+            "an invalid chain must report its invalidity, got: {err:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_single_link_is_revocable_by_its_issuer_and_its_audience() -> TestResult {
+        // The root grant: its issuer made it, its audience received it, and
+        // either may withdraw it.
+        let (invocation, store, signers) = multi_hop_chain(1).await?;
+        let recorded = recorded_revokers(&invocation, &store).await?;
+
+        assert_eq!(recorded.len(), 1, "one query per link");
+        assert_eq!(recorded[0], vec![signers[0].did(), signers[1].did()]);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn each_link_is_revocable_by_its_prefix_and_its_own_audience() -> TestResult {
+        // a -> b -> c -> d
+        //   check a  => [a.iss, a.aud]
+        //   check b  => [a.iss, b.iss, b.aud]
+        //   check c  => [a.iss, b.iss, c.iss, c.aud]
+        let (invocation, store, signers) = multi_hop_chain(3).await?;
+        let recorded = recorded_revokers(&invocation, &store).await?;
+
+        assert_eq!(recorded.len(), 3, "one query per link");
+        assert_eq!(recorded[0], vec![signers[0].did(), signers[1].did()]);
+        assert_eq!(
+            recorded[1],
+            vec![signers[0].did(), signers[1].did(), signers[2].did()]
+        );
+        assert_eq!(
+            recorded[2],
+            vec![
+                signers[0].did(),
+                signers[1].did(),
+                signers[2].did(),
+                signers[3].did()
+            ]
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_downstream_principal_may_not_revoke_an_upstream_link() -> TestResult {
+        // The central rule: in a -> b -> c -> d, d's issuer must not appear
+        // when checking c. Authority to revoke flows downward, so a principal
+        // that merely received authority cannot revoke the grant it rests on.
+        let (invocation, store, signers) = multi_hop_chain(3).await?;
+        let recorded = recorded_revokers(&invocation, &store).await?;
+
+        // Link index i is delegation signers[i] -> signers[i+1]. Everyone
+        // strictly below it must be absent.
+        for (link, candidates) in recorded.iter().enumerate() {
+            for (position, signer) in signers.iter().enumerate().skip(link + 2) {
+                assert!(
+                    !candidates.contains(&signer.did()),
+                    "link {link}: principal at position {position} is downstream \
+                     and must not be able to revoke it"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn the_invocation_issuer_may_revoke_only_the_link_it_received() -> TestResult {
+        // The invoker is the final delegation's audience, so it may revoke
+        // that link — but no earlier one.
+        let (invocation, store, signers) = multi_hop_chain(3).await?;
+        let recorded = recorded_revokers(&invocation, &store).await?;
+        let invoker = signers.last().expect("chain has signers").did();
+
+        assert!(
+            recorded[2].contains(&invoker),
+            "the invoker received the last link and may disclaim it"
+        );
+        assert!(
+            !recorded[0].contains(&invoker) && !recorded[1].contains(&invoker),
+            "the invoker must not be able to revoke links it did not receive"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_self_issued_invocation_queries_no_revocations() -> TestResult {
+        // No proofs means no links, so there is nothing to look up.
+        let signer = test_signer(140).await;
+        let invocation = InvocationBuilder::new()
+            .issuer(signer.clone())
+            .audience(&signer)
+            .subject(&signer)
+            .command(vec!["test".to_string()])
+            .proofs(vec![])
+            .try_build()
+            .await?;
+
+        let recorded = recorded_revokers(&invocation, &new_store()).await?;
+        assert!(recorded.is_empty(), "no proofs, no revocation queries");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_revocation_by_an_authorized_principal_refuses_the_chain() -> TestResult {
+        let (invocation, store, signers) = multi_hop_chain(2).await?;
+        let root = signers[0].did();
+
+        let environment: Environment<
+            DelegationStore,
+            DidKeyResolver,
+            AllRevoked,
+            Rc<Delegation<Ed25519Signature>>,
+        > = Environment::new(store.clone(), DidKeyResolver, AllRevoked(root));
+        let ctx = VerificationContext::new(&environment);
+        let err = invocation
+            .check::<Local, _, _, _>(&ctx)
+            .await
+            .expect_err("a revoked link must refuse the chain");
+
+        assert!(
+            matches!(err, VerifyError::Invalid(Invalid::Revoked { .. })),
+            "expected a revocation refusal, got: {err:?}"
+        );
         Ok(())
     }
 }

--- a/rust/dialog-ucan-core/src/lib.rs
+++ b/rust/dialog-ucan-core/src/lib.rs
@@ -17,11 +17,14 @@ pub mod issuer;
 pub mod number;
 pub mod principal;
 pub mod promise;
+pub mod revocation;
 // pub mod receipt; TODO Reenable after first release
 pub mod subject;
+pub mod sync;
 pub mod task;
 pub mod time;
 pub mod unset;
+pub mod verification;
 
 #[cfg(any(test, feature = "helpers"))]
 pub mod helpers;
@@ -38,6 +41,11 @@ pub use delegation::{
     builder::{BuildError as DelegationBuildError, DelegationBuilder},
 };
 pub use invocation::{
-    CheckFailed, Invocation, InvocationPayload,
+    CheckError, CheckFailed, Invalid, Invocation, InvocationPayload, Unavailable, VerifyError,
     builder::{BuildError as InvocationBuildError, InvocationBuilder},
 };
+pub use revocation::{
+    RevocationChecker, RevocationMatch, RevocationSelector, TolerateUnavailability,
+    UnverifiedRevocations,
+};
+pub use verification::{Environment, Verifiable, VerificationContext};

--- a/rust/dialog-ucan-core/src/revocation.rs
+++ b/rust/dialog-ucan-core/src/revocation.rs
@@ -1,0 +1,230 @@
+//! Revocation lookup.
+//!
+//! Per the [UCAN revocation spec](https://github.com/ucan-wg/revocation), an
+//! issuer of a delegation in a proof chain may revoke that delegation, and a
+//! revocation counts only if its issuer appears in the chain. So the question
+//! a verifier asks is never "is this CID revoked?" in the abstract — it is
+//! "did any of *these* principals revoke it?" Only the verifier knows the
+//! chain, so it supplies the candidate set.
+
+use crate::sync::{ConditionalSend, ConditionalSync};
+use dialog_varsig::Did;
+use ipld_core::cid::Cid;
+use std::error::Error;
+use std::future::Future;
+
+/// Which revocations to match: those of a given delegation, issued by any of
+/// a set of principals.
+#[derive(Debug, Clone, Copy)]
+pub struct RevocationSelector<'a> {
+    /// The delegation being checked.
+    pub delegation: Cid,
+
+    /// The principals whose revocation would count for this link — the
+    /// issuers in the proof chain. A revocation by anyone else is not
+    /// authorized and must not be reported.
+    pub by: &'a [Did],
+}
+
+impl<'a> RevocationSelector<'a> {
+    /// Match revocations of `delegation` issued by any of `by`.
+    #[must_use]
+    pub const fn new(delegation: Cid, by: &'a [Did]) -> Self {
+        Self { delegation, by }
+    }
+}
+
+/// A revocation that matched a [`RevocationSelector`].
+///
+/// Carries the revocation's own address rather than just a verdict, so a
+/// refusal can be audited back to the document that caused it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RevocationMatch {
+    /// The revocation document.
+    pub revocation: Cid,
+
+    /// The principal that issued it. Always one of the `by` set in the
+    /// [`RevocationSelector`] that produced this match.
+    pub principal: Did,
+}
+
+/// Queries whether a delegation has been revoked by anyone who could.
+pub trait RevocationChecker {
+    /// Error type for query failures.
+    ///
+    /// A failure means the question went unanswered — never that the answer
+    /// was "not revoked".
+    type Error: Error + ConditionalSend + ConditionalSync + 'static;
+
+    /// Find a revocation of `selector.delegation` issued by any of `selector.by`.
+    ///
+    /// `Ok(None)` means no such revocation exists: a positive finding, not an
+    /// absence of information. When the query cannot be performed, that is
+    /// `Err`, and verification fails rather than proceeding as though the
+    /// delegation stood.
+    ///
+    /// Async because the answer generally lives across a network boundary.
+    fn query(
+        &self,
+        selector: RevocationSelector<'_>,
+    ) -> impl Future<Output = Result<Option<RevocationMatch>, Self::Error>>;
+
+    /// Treat an unavailable service as "no revocation found".
+    ///
+    /// Verification is otherwise strict: a query that cannot be performed
+    /// fails the chain. Wrapping a checker in this is how a caller opts into
+    /// proceeding without that evidence — an explicit choice, made where the
+    /// environment is built.
+    ///
+    /// This tolerates *not knowing*, never knowing-and-ignoring: a revocation
+    /// the inner checker did find is still returned and still fails the chain.
+    /// To tolerate only some links, wrap with a checker that applies that
+    /// policy per selector.
+    fn tolerate_unavailable(self) -> TolerateUnavailability<Self>
+    where
+        Self: Sized,
+    {
+        TolerateUnavailability(self)
+    }
+}
+
+/// A checker that queries nothing: every delegation comes back unrevoked.
+///
+/// Named for what it does rather than for its effect. It does not establish
+/// that nothing was revoked — it never looks. It exists so the verification
+/// pipeline is complete and every call site is revocation-aware before a real
+/// revocation store lands.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UnverifiedRevocations;
+
+/// Error type for checkers that cannot fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("unreachable: this checker cannot fail")]
+pub struct Never;
+
+impl RevocationChecker for UnverifiedRevocations {
+    type Error = Never;
+
+    async fn query(
+        &self,
+        _selector: RevocationSelector<'_>,
+    ) -> Result<Option<RevocationMatch>, Self::Error> {
+        Ok(None)
+    }
+}
+
+/// Turns query failures into "no revocation matched".
+///
+/// Built via [`RevocationChecker::tolerate_unavailable`].
+#[derive(Debug, Clone, Copy)]
+pub struct TolerateUnavailability<T>(pub T);
+
+impl<T: RevocationChecker> RevocationChecker for TolerateUnavailability<T> {
+    type Error = Never;
+
+    async fn query(
+        &self,
+        selector: RevocationSelector<'_>,
+    ) -> Result<Option<RevocationMatch>, Self::Error> {
+        // A failed query becomes "nothing matched" rather than a failed
+        // verification. A revocation the inner checker did match passes
+        // through untouched.
+        Ok(self.0.query(selector).await.unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cid::to_dagcbor_cid;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("service unavailable")]
+    struct Unavailable;
+
+    struct AlwaysFails;
+
+    impl RevocationChecker for AlwaysFails {
+        type Error = Unavailable;
+
+        async fn query(
+            &self,
+            _selector: RevocationSelector<'_>,
+        ) -> Result<Option<RevocationMatch>, Self::Error> {
+            Err(Unavailable)
+        }
+    }
+
+    struct AlwaysRevoked;
+
+    impl RevocationChecker for AlwaysRevoked {
+        type Error = Unavailable;
+
+        async fn query(
+            &self,
+            selector: RevocationSelector<'_>,
+        ) -> Result<Option<RevocationMatch>, Self::Error> {
+            Ok(Some(RevocationMatch {
+                revocation: cid(),
+                principal: selector.by.first().cloned().unwrap_or_else(did),
+            }))
+        }
+    }
+
+    fn cid() -> Cid {
+        to_dagcbor_cid(&"test")
+    }
+
+    fn did() -> Did {
+        "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z"
+            .parse()
+            .expect("valid did")
+    }
+
+    #[dialog_common::test]
+    async fn unverified_matches_nothing() {
+        let found = UnverifiedRevocations
+            .query(RevocationSelector::new(cid(), &[]))
+            .await
+            .expect("cannot fail");
+        assert!(found.is_none());
+    }
+
+    #[dialog_common::test]
+    async fn an_unavailable_query_is_an_error_by_default() {
+        // Strict by default: the question went unanswered, so the caller must
+        // deal with it rather than proceed as though nothing was revoked.
+        assert!(
+            AlwaysFails
+                .query(RevocationSelector::new(cid(), &[]))
+                .await
+                .is_err()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn tolerating_turns_a_failure_into_nothing_matched() {
+        let found = AlwaysFails
+            .tolerate_unavailable()
+            .query(RevocationSelector::new(cid(), &[]))
+            .await
+            .expect("tolerated");
+        assert!(found.is_none());
+    }
+
+    #[dialog_common::test]
+    async fn tolerating_does_not_swallow_a_revocation() {
+        // Tolerance is about not knowing, never about knowing and ignoring.
+        let revoker = did();
+        let found = AlwaysRevoked
+            .tolerate_unavailable()
+            .query(RevocationSelector::new(
+                cid(),
+                std::slice::from_ref(&revoker),
+            ))
+            .await
+            .expect("tolerated")
+            .expect("the revocation must survive");
+        assert_eq!(found.principal, revoker);
+    }
+}

--- a/rust/dialog-ucan-core/src/sync.rs
+++ b/rust/dialog-ucan-core/src/sync.rs
@@ -1,0 +1,43 @@
+//! Cross-target bound compatibility traits.
+//!
+//! These support writing code that targets both `wasm32-unknown-unknown` and
+//! native targets, where a native implementer may be shared across threads but
+//! a wasm one (holding, say, a `JsValue` WebCrypto handle) cannot be.
+//!
+//! On `wasm32-unknown-unknown` these are no additional bound; elsewhere
+//! [`ConditionalSend`] is `Send` and [`ConditionalSync`] is `Sync`. Each means
+//! exactly what its name says, so code needing both writes both.
+//!
+//! `dialog_common` defines a similar pair, but this crate deliberately does
+//! not depend on it: this code is meant to be upstreamable to the UCAN repos
+//! it was forked from, so it must not reach into dialog internals. (That pair
+//! also defines `ConditionalSync` as `Send + Sync`, which these do not.)
+
+// bare-send-ok: this is the definition site, so it must name the auto traits
+// it abstracts over; every other use in the crate goes through these.
+#[allow(missing_docs)]
+#[cfg(not(target_arch = "wasm32"))]
+pub trait ConditionalSend: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> ConditionalSend for S where S: Send {}
+
+// bare-send-ok: definition site, as above.
+#[allow(missing_docs)]
+#[cfg(not(target_arch = "wasm32"))]
+pub trait ConditionalSync: Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> ConditionalSync for S where S: Sync {}
+
+#[allow(missing_docs)]
+#[cfg(target_arch = "wasm32")]
+pub trait ConditionalSend {}
+
+#[cfg(target_arch = "wasm32")]
+impl<S> ConditionalSend for S {}
+
+#[allow(missing_docs)]
+#[cfg(target_arch = "wasm32")]
+pub trait ConditionalSync {}
+
+#[cfg(target_arch = "wasm32")]
+impl<S> ConditionalSync for S {}

--- a/rust/dialog-ucan-core/src/verification.rs
+++ b/rust/dialog-ucan-core/src/verification.rs
@@ -1,0 +1,160 @@
+//! Verification context and verdict.
+//!
+//! Verifying an invocation chain needs four things from its environment: the
+//! delegations the chain refers to, a resolver for issuer keys, a revocation
+//! checker, and the instant to judge time bounds against. [`Verifiable`] names
+//! the first three; [`VerificationContext`] pairs an environment with a
+//! sampled instant.
+
+use crate::sync::{ConditionalSend, ConditionalSync};
+use crate::{
+    Delegation, delegation::store::DelegationStore, future::FutureKind,
+    revocation::RevocationChecker, time::timestamp::Timestamp,
+};
+use dialog_varsig::{Resolver, Signature};
+use std::borrow::Borrow;
+use std::marker::PhantomData;
+
+/// What an environment must supply to verify an invocation chain.
+pub trait Verifiable<K: FutureKind, S: Signature> {
+    /// The proof type the delegation store yields.
+    type Proof: Borrow<Delegation<S>>;
+
+    /// Where the chain's delegations are read from.
+    type Delegations: DelegationStore<K, S, Self::Proof>;
+
+    /// Resolves issuer DIDs to verifiers.
+    ///
+    /// The error is `'static` so a failed resolution can be type-erased and
+    /// carried through the concurrent pass alongside failures from other
+    /// resolvers.
+    type Resolver: Resolver<S, Error: ConditionalSend + ConditionalSync + 'static>;
+
+    /// Looks up revocation status.
+    type Revocations: RevocationChecker;
+
+    /// The delegation store.
+    fn delegations(&self) -> &Self::Delegations;
+
+    /// The DID resolver.
+    fn resolver(&self) -> &Self::Resolver;
+
+    /// The revocation checker.
+    fn revocations(&self) -> &Self::Revocations;
+}
+
+/// An environment plus the instant this verification judges against.
+///
+/// `time` is sampled once, when the context is built, and is a field rather
+/// than a method — so no phase can re-read the clock and judge two parts of
+/// one chain against two different instants. Re-sampling is not something a
+/// phase neglects to avoid; it is not expressible, because no phase holds a
+/// clock.
+pub struct VerificationContext<'a, T> {
+    ctx: &'a T,
+    time: Option<Timestamp>,
+}
+
+impl<'a, T> VerificationContext<'a, T> {
+    /// Judge against the system clock, sampled now.
+    #[must_use]
+    pub fn new(ctx: &'a T) -> Self {
+        Self {
+            ctx,
+            time: Some(Timestamp::now()),
+        }
+    }
+
+    /// Judge against a caller-supplied instant.
+    ///
+    /// `None` means "do not judge time at all" — for replaying a historical
+    /// chain, or checking a token on a device with no trusted clock. It is a
+    /// deliberate opt-out, never a default.
+    #[must_use]
+    pub const fn at(ctx: &'a T, time: Option<Timestamp>) -> Self {
+        Self { ctx, time }
+    }
+
+    /// The environment.
+    #[must_use]
+    pub const fn environment(&self) -> &'a T {
+        self.ctx
+    }
+
+    /// The instant this verification judges against, sampled once.
+    #[must_use]
+    pub const fn time(&self) -> Option<Timestamp> {
+        self.time
+    }
+}
+
+/// A ready-made environment: a proof store, a resolver, and a revocation
+/// checker bundled into something [`Verifiable`].
+///
+/// Most callers want this rather than implementing [`Verifiable`] themselves.
+/// Pair it with [`VerificationContext::new`] to judge against the system
+/// clock:
+///
+/// ```no_run
+/// # use dialog_ucan_core::{
+/// #     Delegation, InvocationChain, UnverifiedRevocations, VerificationContext,
+/// #     verification::Environment,
+/// # };
+/// # use dialog_credentials::DidKeyResolver;
+/// # use dialog_varsig::AnySignature;
+/// # use std::sync::Arc;
+/// # async fn example(chain: &InvocationChain<AnySignature>) {
+/// // `Environment` is generic over the proof type, which the store fixes.
+/// let env: Environment<_, _, _, Arc<Delegation<AnySignature>>> =
+///     Environment::new(chain.proof_store(), DidKeyResolver, UnverifiedRevocations);
+///
+/// let range = chain.verify(&VerificationContext::new(&env)).await;
+/// # let _ = range;
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct Environment<St, R, Rev, T> {
+    delegations: St,
+    resolver: R,
+    revocations: Rev,
+    proof: PhantomData<fn() -> T>,
+}
+
+impl<St, R, Rev, T> Environment<St, R, Rev, T> {
+    /// Bundle a store, a resolver, and a revocation checker.
+    pub const fn new(delegations: St, resolver: R, revocations: Rev) -> Self {
+        Self {
+            delegations,
+            resolver,
+            revocations,
+            proof: PhantomData,
+        }
+    }
+}
+
+impl<K, S, T, St, R, Rev> Verifiable<K, S> for Environment<St, R, Rev, T>
+where
+    K: FutureKind,
+    S: Signature,
+    T: Borrow<Delegation<S>>,
+    St: DelegationStore<K, S, T>,
+    R: Resolver<S, Error: ConditionalSend + ConditionalSync + 'static>,
+    Rev: RevocationChecker,
+{
+    type Proof = T;
+    type Delegations = St;
+    type Resolver = R;
+    type Revocations = Rev;
+
+    fn delegations(&self) -> &Self::Delegations {
+        &self.delegations
+    }
+
+    fn resolver(&self) -> &Self::Resolver {
+        &self.resolver
+    }
+
+    fn revocations(&self) -> &Self::Revocations {
+        &self.revocations
+    }
+}

--- a/rust/dialog-ucan-core/tests/invocation_conformance.rs
+++ b/rust/dialog-ucan-core/tests/invocation_conformance.rs
@@ -2,7 +2,10 @@
 mod invocation_conformance {
     use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::OnceLock};
 
-    use dialog_ucan_core::{Delegation, Invocation, delegation::store};
+    use dialog_ucan_core::{
+        CheckError, Delegation, Invocation, VerificationContext, delegation::store, future::Local,
+        revocation::UnverifiedRevocations, time::TimeRange, verification::Environment,
+    };
     use dialog_varsig::eddsa::Ed25519Signature;
     use ipld_core::{cid::Cid, ipld::Ipld};
     use testresult::TestResult;
@@ -28,6 +31,35 @@ mod invocation_conformance {
     }
 
     type DelegationStore = Rc<RefCell<HashMap<Cid, Rc<Delegation<Ed25519Signature>>>>>;
+
+    use dialog_credentials::ed25519::Ed25519KeyResolver;
+
+    /// Verify `invocation` against `store`, judging time bounds at `time`.
+    ///
+    /// The fixtures carry the instant each case is meant to be evaluated at,
+    /// so the check runs against that rather than the wall clock.
+    async fn check_at(
+        invocation: &Invocation<Ed25519Signature>,
+        store: &DelegationStore,
+        time: Option<dialog_ucan_core::time::Timestamp>,
+    ) -> Result<TimeRange, CheckError<Local, Ed25519Signature, TestEnv>> {
+        let environment = test_environment(store);
+        let ctx = VerificationContext::at(&environment, time);
+        invocation.check::<Local, _, _, _>(&ctx).await
+    }
+
+    /// The environment these tests verify against: the fixture's own store,
+    /// `did:key` resolution, and no revocation lookups.
+    type TestEnv = Environment<
+        DelegationStore,
+        Ed25519KeyResolver,
+        UnverifiedRevocations,
+        Rc<Delegation<Ed25519Signature>>,
+    >;
+
+    fn test_environment(store: &DelegationStore) -> TestEnv {
+        Environment::new(store.clone(), Ed25519KeyResolver, UnverifiedRevocations)
+    }
 
     fn new_store() -> DelegationStore {
         Rc::new(RefCell::new(HashMap::new()))
@@ -171,7 +203,6 @@ mod invocation_conformance {
 
     mod valid {
         use super::*;
-        use dialog_credentials::ed25519::Ed25519KeyResolver;
 
         #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         use wasm_bindgen_test::wasm_bindgen_test;
@@ -190,20 +221,15 @@ mod invocation_conformance {
                 let proofs = parse_proofs(entry);
                 let delegation_store = build_store(proofs).await;
 
-                let result = invocation
-                    .check(&delegation_store, &Ed25519KeyResolver)
-                    .await;
-
-                let range = result.unwrap_or_else(|e| {
-                    panic!("valid[{idx}] '{name}' should pass check but got: {e:?}")
-                });
-
-                range.check(&time).unwrap_or_else(|e| {
-                    panic!(
-                        "valid[{idx}] '{name}': fixture time not in range: {e}, \
-                         range={range:?}, time={time:?}"
-                    )
-                });
+                // The fixture's instant is judged inside the check now, so a
+                // valid case must pass at that instant rather than merely
+                // yield a range the caller could test.
+                let verdict: TimeRange = check_at(&invocation, &delegation_store, Some(time))
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!("valid[{idx}] '{name}' should pass check but got: {e:?}")
+                    });
+                let range = &verdict;
 
                 eprintln!("valid[{idx}] '{name}': check passed, time_range = {range:?}");
             }
@@ -214,8 +240,7 @@ mod invocation_conformance {
 
     mod invalid {
         use super::*;
-        use dialog_credentials::ed25519::Ed25519KeyResolver;
-        use dialog_ucan_core::invocation::{CheckFailed, InvocationCheckError, StoredCheckError};
+        use dialog_ucan_core::{CheckFailed, Invalid, VerifyError};
 
         #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         use wasm_bindgen_test::wasm_bindgen_test;
@@ -315,16 +340,14 @@ mod invocation_conformance {
 
                 let delegation_store = build_store(valid_proofs).await;
 
-                let result = invocation
-                    .check(&delegation_store, &Ed25519KeyResolver)
-                    .await;
+                let result = check_at(&invocation, &delegation_store, Some(time)).await;
 
                 match error_name {
                     "InvalidClaim" => {
                         let err = result
                             .expect_err(&format!("invalid[{idx}] '{name}' should fail check"));
                         match &err {
-                            InvocationCheckError::StoredCheck(StoredCheckError::CheckFailed(
+                            VerifyError::Invalid(Invalid::Chain(
                                 CheckFailed::UnauthorizedSubject { .. }
                                 | CheckFailed::UnprovenSubject { .. },
                             )) => {}
@@ -338,32 +361,25 @@ mod invocation_conformance {
                         let err = result
                             .expect_err(&format!("invalid[{idx}] '{name}' should fail check"));
                         match &err {
-                            InvocationCheckError::StoredCheck(StoredCheckError::GetError(_)) => {}
+                            VerifyError::Invalid(Invalid::MissingProof(_)) => {}
                             other => panic!(
                                 "invalid[{idx}] '{name}': expected GetError(Missing), got: {other:?}"
                             ),
                         }
                     }
                     "Expired" | "TooEarly" => {
-                        match &result {
-                            Ok(range) => {
-                                assert!(
-                                    range.check(&time).is_err(),
-                                    "invalid[{idx}] '{name}' ({error_name}): \
-                                     expected fixture time to be outside range, \
-                                     but range={range:?}, time={time:?}"
-                                );
-                            }
-                            Err(_) => {
-                                // Any error is an acceptable rejection.
-                            }
-                        }
+                        // Time is judged inside the check, so these must be
+                        // rejected outright rather than merely yielding a
+                        // range that excludes the fixture instant.
+                        result.expect_err(&format!(
+                            "invalid[{idx}] '{name}' ({error_name}) should fail check at {time:?}"
+                        ));
                     }
                     "InvalidAudience" => {
                         let err = result
                             .expect_err(&format!("invalid[{idx}] '{name}' should fail check"));
                         match &err {
-                            InvocationCheckError::StoredCheck(StoredCheckError::CheckFailed(
+                            VerifyError::Invalid(Invalid::Chain(
                                 CheckFailed::DelegationAudienceMismatch { .. },
                             )) => {}
                             other => panic!(
@@ -376,7 +392,7 @@ mod invocation_conformance {
                         let err = result
                             .expect_err(&format!("invalid[{idx}] '{name}' should fail check"));
                         match &err {
-                            InvocationCheckError::StoredCheck(StoredCheckError::CheckFailed(
+                            VerifyError::Invalid(Invalid::Chain(
                                 CheckFailed::UnauthorizedSubject { .. }
                                 | CheckFailed::UnprovenSubject { .. },
                             )) => {}
@@ -390,8 +406,11 @@ mod invocation_conformance {
                         let err = result
                             .expect_err(&format!("invalid[{idx}] '{name}' should fail check"));
                         match &err {
-                            InvocationCheckError::SignatureVerification(_) => {}
-                            InvocationCheckError::StoredCheck(StoredCheckError::GetError(_)) => {}
+                            VerifyError::Invalid(
+                                Invalid::InvocationSignature(_)
+                                | Invalid::DelegationSignature { .. }
+                                | Invalid::MissingProof(_),
+                            ) => {}
                             other => panic!(
                                 "invalid[{idx}] '{name}': expected SignatureVerification \
                                  or GetError(Missing), got: {other:?}"
@@ -402,7 +421,7 @@ mod invocation_conformance {
                         let err = result
                             .expect_err(&format!("invalid[{idx}] '{name}' should fail check"));
                         match &err {
-                            InvocationCheckError::StoredCheck(StoredCheckError::CheckFailed(
+                            VerifyError::Invalid(Invalid::Chain(
                                 CheckFailed::PolicyViolation(_)
                                 | CheckFailed::PolicyIncompatibility(_),
                             )) => {}


### PR DESCRIPTION
## What

`InvocationChain::verify` took a delegation store and a resolver as separate parameters, and checked neither expiry nor revocation. This threads a verification context through instead, closes both gaps, and reorders the pipeline so cheap refusals cost nothing.

## Two live gaps closed

**Expiry was never compared to a clock.** `syntactic_checks` intersected all `nbf`/`exp` into a `TimeRange` and asserted only that the interval was non-empty. `TimeRange::check(&now)` existed but was called only from conformance tests, and `verify` discarded the range entirely. **A delegation that expired years ago authorized.**

**Revocation did not exist.** No store, no lookup, no way to pass one. `AuthorizeError::Revoked` was a variant nothing constructed.

## Shape

```rust
pub trait Verifiable<K: FutureKind, S: Signature> {
    type Proof; type Delegations; type Resolver; type Revocations;
    fn delegations(&self) -> &Self::Delegations;
    fn resolver(&self) -> &Self::Resolver;
    fn revocations(&self) -> &Self::Revocations;
}

pub struct VerificationContext<'a, T> { ctx: &'a T, time: Option<Timestamp> }
```

`time` is sampled once in the constructor and is a **field, not a method**, so no phase can re-read the clock and judge two parts of one chain against two instants. Re-sampling is not something a phase neglects to avoid; it is not expressible. `None` opts out deliberately (historical replay, no trusted clock).

`Environment` is a ready-made `Verifiable`, so callers don't implement the trait.

## Revocation

```rust
pub struct RevocationSelector<'a> { pub delegation: Cid, pub by: &'a [Did] }
pub struct RevocationMatch { pub revocation: Cid, pub principal: Did }

fn query(&self, selector: RevocationSelector<'_>)
    -> impl Future<Output = Result<Option<RevocationMatch>, Self::Error>>;
```

A query either matches or does not. A service that cannot answer is `Err`, never a third success state — folding unavailability into the success type would let "we could not check" read as "nothing was revoked". `RevocationMatch` carries the revocation's own CID so a refusal can be audited back to the document that caused it.

### Who may revoke which link — a deliberate departure from the spec

The revocation spec's pseudocode computes one set for the whole chain:

```js
const delegators = invocation.prf.map(proof => proof.iss)
```

Applied uniformly that is too permissive. For `a -> b -> c -> d` it lets `d`'s issuer revoke `c` — a principal that merely *received* authority revoking the grant its own authority rests on. Authority to revoke flows downward, so the candidate set is scoped **per link**: the issuers at or above it, plus that link's own audience, who may always disclaim what it was given.

```
check a  => [a.iss, a.aud]
check b  => [a.iss, b.iss, b.aud]
check c  => [a.iss, b.iss, c.iss, c.aud]
```

`d.iss` never appears when checking `c`. The invocation's own issuer is the last link's audience, so it may disclaim that link and no earlier one.

### Strict, with loosening as a wrapper

Verification either passes or fails. `tolerate_unavailable()` is how a caller opts into proceeding without revocation evidence — an explicit choice made where the environment is built:

```rust
VerificationContext::new(&env)                          // strict
VerificationContext::new(&env.tolerate_unavailable())   // tolerant
```

It tolerates *not knowing*, never knowing-and-ignoring: a revocation the inner checker did match still fails the chain. Partial policies are wrappers too (e.g. requiring positive evidence for the root grant), so nothing about per-link tolerance leaks into the result type.

`UnverifiedRevocations` ships as the concrete checker until a real store exists, named for the fact that it looks nothing up rather than for its effect.

## Pipeline

1. **Structural, no I/O** — proofs, alignment, attenuation, policy, time bounds, and the wall-clock check. Previously the signature loop ran *before* this, so a chain failing principal alignment paid a DID resolution per link before finding out.
2. **Resolution, concurrent and deduplicated.** Load-bearing rather than an optimization: `CachingResolver` has **no in-flight dedup**, so concurrent per-link resolution would have had N lookups of the same DID all miss the cache and all fetch. Repeated issuers are the normal case.
3. **Signatures and revocations, concurrent.** Two homogeneous `FuturesUnordered` queues driven with `select_biased!` — one boxed queue would have made the whole verification `!Send`. Revocation queries are enqueued before resolution so they overlap it. First refusal returns immediately; dropping the queues cancels in-flight work.

## Errors

```rust
pub enum VerifyError<..> {
    Invalid(..),      // the chain does not hold up
    Unavailable(..),  // we could not establish whether it does
}
```

This upholds the invariant that motivated the split: **if the chain is invalid, the caller sees that**, never "revocation service unreachable". Otherwise a caller willing to fail open on unavailability could accept an invalid chain. An unresolvable *issuer* is `Unavailable` but not tolerable — without the key a signature goes unverified, so the chain is unproven rather than merely un-revocation-checked.

`CheckError<K, S, C>` aliases the six parameters so callers never spell them out.

## Notes

- `sync.rs` duplicates `dialog_common`'s conditional markers rather than depending on it, keeping this crate upstreamable to the UCAN repos it was forked from. Unlike that pair, `ConditionalSync` here means `Sync` alone.
- No `dyn` anywhere: resolver and checker errors are real associated types. Cost is a `Clone` bound on resolver errors.
- The conformance suite now passes each fixture's own instant into the check, so `Expired`/`TooEarly` cases must fail outright rather than merely yield a range the caller could test separately. Worth a look during review.
