### PR TITLE
fix(wbg-pool): stop the daemon from lingering at 100% CPU

### DIFF
--- a/rust/wbg-pool/src/daemon.rs
+++ b/rust/wbg-pool/src/daemon.rs
@@ -168,6 +168,15 @@ async fn run(state_dir: PathBuf, idle_timeout: u64) -> Result<()> {
 }
 
 pub async fn shutdown(daemon: &Daemon) -> ! {
+    // A daemon that starts shutting down and never finishes is the worst
+    // outcome available here: it is detached, so nothing reaps it, and it
+    // keeps whatever it was holding. Guarantee the exit from a plain
+    // thread, which still runs if the async runtime stops making progress.
+    std::thread::spawn(|| {
+        std::thread::sleep(Duration::from_secs(10));
+        browser::kill_browser_group();
+        std::process::exit(0);
+    });
     daemon.browser.kill().await;
     remove_state_file_if_ours(&daemon.state_dir);
     let _ = std::fs::remove_dir_all(&daemon.work_dir);
@@ -189,10 +198,22 @@ fn sweep_stale_work_dirs(state_dir: &Path) {
         else {
             continue;
         };
-        if pid != std::process::id() && !std::path::Path::new(&format!("/proc/{pid}")).exists() {
+        if pid != std::process::id() && !process_alive(pid) {
             let _ = std::fs::remove_dir_all(entry.path());
         }
     }
+}
+
+/// Whether a process is still running. `/proc` is not portable across the
+/// unices this runs on (macOS has no `/proc`, where every pid would look
+/// dead and a live daemon's work directory would be swept out from under
+/// it), so ask the kernel directly. `EPERM` means the pid exists but is
+/// someone else's, which still counts as alive.
+fn process_alive(pid: u32) -> bool {
+    if unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 fn write_state_file(state_dir: &Path, port: u16) -> Result<()> {

--- a/rust/wbg-pool/src/daemon/browser.rs
+++ b/rust/wbg-pool/src/daemon/browser.rs
@@ -7,11 +7,25 @@ use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::{mpsc, oneshot, Mutex};
+
+/// Process group of the running browser, if any. The daemon's shutdown
+/// watchdog runs on a plain thread with no access to async state, so it
+/// needs a way to take the browser down without going through [`Browser`].
+static BROWSER_GROUP: AtomicI32 = AtomicI32::new(0);
+
+/// Kills the browser and everything it spawned, from anywhere, without the
+/// async runtime. Safe to call when no browser is running.
+pub fn kill_browser_group() {
+    let group = BROWSER_GROUP.swap(0, Ordering::SeqCst);
+    if group > 0 {
+        unsafe { libc::killpg(group, libc::SIGKILL) };
+    }
+}
 
 pub struct BrowserPool {
     profile_dir: PathBuf,
@@ -176,11 +190,18 @@ impl Browser {
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
+            // Chrome's renderers, GPU process and zygote are its children,
+            // and a renderer wedged in a runaway test loop never services
+            // the IPC teardown that is supposed to stop it. Putting the
+            // browser in its own process group lets `kill` reach the whole
+            // tree instead of leaving orphans behind burning cores.
+            .process_group(0)
             .kill_on_drop(true);
 
         let mut child = command
             .spawn()
             .with_context(|| format!("failed to launch browser {}", binary.display()))?;
+        let group = child.id().unwrap_or_default() as i32;
 
         let stderr = child.stderr.take().context("browser stderr not piped")?;
         let mut lines = tokio::io::BufReader::new(stderr).lines();
@@ -213,11 +234,20 @@ impl Browser {
         tokio::spawn(async move { while lines.next_line().await.ok().flatten().is_some() {} });
 
         let cdp = CdpClient::connect(&ws_url).await?;
+        // Only published once the browser is fully up: every earlier return
+        // drops `child`, which kills it (`kill_on_drop`), and a stale group
+        // recorded here could later name an unrelated recycled pid.
+        BROWSER_GROUP.store(group, Ordering::SeqCst);
         Ok(Browser { child, cdp })
     }
 
     async fn kill(&mut self) {
-        let _ = self.child.kill().await;
+        kill_browser_group();
+        let _ = self.child.start_kill();
+        // Reaping goes through the runtime's signal driver; if that is not
+        // making progress the daemon must still be able to exit, so this
+        // wait is bounded. The browser is already dead either way.
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.child.wait()).await;
     }
 }
 
@@ -310,13 +340,11 @@ impl CdpClient {
                                 Ok(text) => text,
                                 Err(_) => continue,
                             },
-                            _ => {
-                                task_alive.store(false, Ordering::SeqCst);
-                                for (_, reply) in pending.drain() {
-                                    let _ = reply.send(Err(anyhow!("browser connection lost")));
-                                }
-                                continue;
-                            }
+                            // The browser went away. A closed WebSocketStream
+                            // is fused: it answers every subsequent poll
+                            // immediately, so the reader has to stop here
+                            // rather than loop and burn a core forever.
+                            _ => break,
                         };
                         let Ok(value) = serde_json::from_str::<Value>(text.as_str()) else { continue };
                         let Some(id) = value.get("id").and_then(Value::as_u64) else { continue };
@@ -330,6 +358,10 @@ impl CdpClient {
                         }
                     }
                 }
+            }
+            task_alive.store(false, Ordering::SeqCst);
+            for (_, reply) in pending.drain() {
+                let _ = reply.send(Err(anyhow!("browser connection lost")));
             }
         });
 
@@ -361,5 +393,56 @@ impl CdpClient {
             .await
             .context("timed out waiting for the browser to answer a CDP call")?
             .map_err(|_| anyhow!("browser connection lost"))?
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// CPU time this process has burned, in milliseconds.
+    fn cpu_millis() -> u128 {
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+        let millis = |time: libc::timeval| time.tv_sec as u128 * 1000 + time.tv_usec as u128 / 1000;
+        millis(usage.ru_utime) + millis(usage.ru_stime)
+    }
+
+    /// Serves one WebSocket handshake and then drops the connection, the way
+    /// the browser's DevTools endpoint goes away when Chrome exits.
+    async fn closing_devtools_endpoint() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            drop(tokio_tungstenite::accept_async(stream).await.unwrap());
+        });
+        format!("ws://{addr}")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_reader_stops_when_the_browser_goes_away() {
+        let client = CdpClient::connect(&closing_devtools_endpoint().await)
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // A closed WebSocketStream answers every poll immediately, so a
+        // reader that keeps polling it pegs a core for as long as the daemon
+        // lives -- which is until its idle timeout, or forever when the
+        // spinning starves the shutdown path that killing the browser began.
+        let before = cpu_millis();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let burned = cpu_millis() - before;
+        assert!(
+            burned < 100,
+            "the CDP reader burned {burned}ms of CPU while idle after the browser exited"
+        );
+
+        assert!(!client.is_alive());
+        assert!(client
+            .call("Target.createTarget", json!({}), None)
+            .await
+            .is_err());
     }
 }

--- a/rust/wbg-pool/src/daemon/server.rs
+++ b/rust/wbg-pool/src/daemon/server.rs
@@ -86,6 +86,46 @@ async fn coverage() -> StatusCode {
     StatusCode::NO_CONTENT
 }
 
+/// Releases a run's browser tab and page slot, including when the request
+/// future is dropped instead of finishing. nextest kills runner processes
+/// routinely (a slow-test timeout, `--fail-fast`, Ctrl-C), which cancels the
+/// handler mid-run; a tab left behind keeps executing its test, and a test
+/// that never returns then pegs a core for as long as the daemon lives.
+struct RunGuard {
+    daemon: Arc<Daemon>,
+    run_id: u64,
+    target: Option<String>,
+}
+
+impl RunGuard {
+    fn new(daemon: &Arc<Daemon>, run_id: u64) -> RunGuard {
+        RunGuard {
+            daemon: daemon.clone(),
+            run_id,
+            target: None,
+        }
+    }
+
+    /// Hands the guard the tab to close once the run is over.
+    fn owns_tab(&mut self, target: String) {
+        self.target = Some(target);
+    }
+}
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        self.daemon.runs.lock().unwrap().remove(&self.run_id);
+        let Some(target) = self.target.take() else {
+            return;
+        };
+        let daemon = self.daemon.clone();
+        tokio::spawn(async move {
+            daemon.browser.close_tab(&target).await;
+            daemon.touch();
+        });
+    }
+}
+
 struct ActiveGuard(Arc<Daemon>);
 
 impl ActiveGuard {
@@ -163,6 +203,7 @@ async fn execute_run(daemon: &Arc<Daemon>, request: RunRequest) -> Result<RunRep
     );
 
     let (report_tx, report_rx) = oneshot::channel();
+    let mut guard = RunGuard::new(daemon, run_id);
     daemon.runs.lock().unwrap().insert(
         run_id,
         RunSlot {
@@ -177,13 +218,12 @@ async fn execute_run(daemon: &Arc<Daemon>, request: RunRequest) -> Result<RunRep
     // and with it fresh IndexedDB, OPFS, localStorage, caches and cookies.
     let url = format!("http://t-{run_id}.localhost:{}/r/{run_id}/", daemon.port);
 
-    let target = match daemon.browser.create_tab(&url).await {
-        Ok(target) => target,
-        Err(error) => {
-            daemon.runs.lock().unwrap().remove(&run_id);
-            return Err(error).context("failed to open a browser tab");
-        }
-    };
+    let target = daemon
+        .browser
+        .create_tab(&url)
+        .await
+        .context("failed to open a browser tab")?;
+    guard.owns_tab(target.clone());
 
     let timeout = Duration::from_secs(request.timeout_secs.max(1));
     let report = match tokio::time::timeout(timeout, report_rx).await {
@@ -217,10 +257,6 @@ async fn execute_run(daemon: &Arc<Daemon>, request: RunRequest) -> Result<RunRep
             }
         }
     };
-
-    daemon.browser.close_tab(&target).await;
-    daemon.runs.lock().unwrap().remove(&run_id);
-    daemon.touch();
 
     Ok(report)
 }


### PR DESCRIPTION
The daemon could outlive its own shutdown and peg a core indefinitely.
Three defects, in descending order of impact:

The CDP reader spun on a dead socket. When the browser exits, the
DevTools WebSocketStream ends, and a closed stream is fused: it answers
every subsequent poll immediately. The reader treated that as a
recoverable event and looped, so from the moment the browser went away
the daemon burned a full core. Killing the browser is the first thing
shutdown does, which made this self-inflicted: the spinning reader then
starved the runtime's signal driver, the wait that reaps the browser
never completed, and the daemon hung before its `exit`. Observed on
every idle-timeout shutdown in testing, and intermittently on SIGTERM,
leaving a detached process at 100% CPU holding an unreaped Chrome, and
nothing to stop it. The reader now stops when the stream ends and fails
its pending calls on the way out.

Cancelled runs leaked their tab. `close_tab` ran after the awaits in
`execute_run`, so it was skipped whenever the handler future was dropped
mid-run -- which is routine, since nextest kills runner processes on
slow-test timeouts, `--fail-fast` and Ctrl-C. The tab stayed open and
kept executing its test until the daemon exited. A `RunGuard` now
releases the tab and the page slot on drop.

Shutdown had no floor. Cleanup is now bounded: the browser reap waits at
most five seconds, and a plain watchdog thread (immune to a wedged
runtime) kills the browser group and exits the process if shutdown has
not finished in ten. The browser also runs in its own process group so
that kill reaches renderers, which do not always service the IPC
teardown when they are stuck in a runaway test.

Also fixes the stale-work-dir sweep, which asked `/proc` whether a pid
was alive. On macOS, where `/proc` does not exist, every other daemon
looked dead and a live one's browser profile and generated assets could
be deleted out from under it.

