### PR TITLE
feat(ucan): /ucan/revoke artifact, witness path, and validation

### DIFF
--- a/notes/revocation-design.md
+++ b/notes/revocation-design.md
@@ -1,0 +1,146 @@
+# `/ucan/revoke`: artifact, witness path, and what validates what
+
+## The division of labour
+
+`InvocationChain::verify` establishes that an invocation is a valid invocation: signature, `prf` chain (linkage, rooting, attenuation, policy), time bounds, and — since the verification-context work — that no `prf` hop is revoked. All command-agnostic.
+
+For a revocation that means exactly one thing: *whoever signed this was authorized to issue an invocation with `sub` as its subject.* Nothing about `rev` or `pth`, which are opaque arguments to it.
+
+Everything else is `/ucan/revoke`-specific and lives on `RevocationChain`. The failure mode to avoid is re-deriving what `verify` already does: hand-rolled reimplementations of the generic path are where holes come from, each one missing something the shared code already handled.
+
+**Deliberately out of scope:** whether the service holds the subject. That is deployment policy, not artifact validity — the same artifact gets a different answer per deployment.
+
+## `prf` and `pth` answer different questions
+
+- `prf` — may this principal invoke `/ucan/revoke` at all?
+- `pth` — why is this principal authorized to revoke *this particular* delegation?
+
+They can rest on entirely different grants, so neither substitutes for the other.
+
+## Shape: `Revocation<S>`
+
+Per `revocation.ipldsch` (the prose README is stale — it still says `do`, `ucan/revoke` without the leading slash, and `revoke`/`path`):
+
+```
+type RevocationAction <: Action {
+  cmd "/ucan/revoke"
+  nnc ""
+  arg RevocationArguments
+}
+
+type RevocationArguments struct {
+  rev &Delegation
+  pth [&Delegation]
+}
+```
+
+`Revocation<S>(Invocation<S>)` with `TryFrom<Invocation<S>>` checks exactly that: the command, the empty nonce, `rev` is a link, `pth` is a *list* of links. Every failure is `MalformedRevocation` — malformed input, never "unauthorized". Authority is a separate question asked later, and only once the shape is known to hold.
+
+Two shape decisions worth naming:
+
+- **A bare link is not a path.** `pth` is `[&Delegation]`; accepting a single link would make the one-hop case shaped differently from every other, which is the sort of special case that later grows a bug.
+- **An empty `pth` is shape-valid.** An empty list is a list. Whether it *justifies* anything is `validate`'s question, and it cannot — `rev` is not in an empty path — so this splits cleanly into "well-formed artifact" versus "artifact that proves its authority".
+
+## `RevocationBuilder`: the revoker is the subject
+
+Deriving `sub` from the revoked delegation's subject conflates two different questions in one field: *what the capability was about* and *who is withdrawing it*. The builder takes the revoker explicitly, so `sub` means the revoker. That also keeps `{what}` and `{by}` independent for keying.
+
+## `RevocationChain::validate`
+
+### Four cases need no evidence at all
+
+For these, `pth` is neither required nor examined — supplying one is harmless, supplying garbage is equally harmless:
+
+- **revoker is the target's audience** — refusing what you were handed is not a claim of authority over anyone else, it is declining your own grant
+- **revoker is the target's issuer** — you may withdraw what you issued
+- **revoker is the target's subject** — it is your capability
+- **the target is a powerline** (`Subject::Any`) — its holder can mint a delegation for *any* subject, so no witness could prove anything a forger could not manufacture. Requiring one would be theatre.
+
+### Otherwise `pth` must witness that the revoker *held* the capability
+
+`pth` is a **pool, not an ordered chain**. Carrying more than is relevant is not an error.
+
+The relevant subchain is the walk from a hop issued by the target's subject — the principal whose capability it is — following audience-to-issuer links, until a hop delegates to the revoker. Hops off that walk are ignored.
+
+**The evidence proves possession, not a path to the target.** Whether a chain runs from the revoker down to the delegation being revoked is irrelevant: holding the capability, the revoker could always have created one, so its absence proves nothing. This is why the walk ends at the revoker rather than at the target.
+
+It also means a holder may revoke a hop it descends from. Dave, holding `alice → bob → carol → dave`, may revoke `bob → carol` — cutting off his own authority in the process, which is his to do.
+
+Over that walk:
+
+1. **It must reach the revoker from the subject.** Evidence that never arrives witnesses nothing. Failure is `NoEvidenceOfPossession`, which also covers "no evidence at all" and "evidence rooted somewhere else".
+2. **Alignment and time**, via `check_chain` — the same implementation `syntactic_checks` uses, so a witness path cannot drift from a proof chain.
+3. **Every hop signed by its claimed issuer.** Without this the walk is a story rather than evidence.
+
+A powerline hop *within* the walk stands in wherever a hop for the subject would, since a powerline implies its own subject.
+
+### Reuse, not reimplementation
+
+Check 3's properties are pure chain properties — they need no invocation. They were previously entangled inside `syntactic_checks` with the two that *do* need one (command attenuation against `self.command`, policy predicates over `args`).
+
+They are now `delegation::chain::check_chain(hops, subject, now)`, called by both.
+
+### Error taxonomy
+
+Three findings, because a caller needs to act on them differently:
+
+```rust
+pub enum RevocationError<E> {
+    Invalid(String),              // not a valid invocation at all
+    Denied(Denial),               // valid invocation, evidence insufficient
+    Unavailable { did, detail },  // could not establish either
+}
+
+pub enum Denial {
+    NoEvidenceOfPossession { subject, revoker },
+    Path { source: CheckFailed },
+    HopSignature { issuer, detail },
+}
+```
+
+`RevocationChain::verify` runs both halves and returns this: `InvocationChain::verify` first (yielding `Invalid` on failure), then `validate`. Keeping `Invalid` distinct from `Denied` matters because they are different findings — one says the artifact is not a valid invocation before any question of revocation authority arises.
+
+Separately, `MalformedRevocationChain` says the artifact could not be *read* (bad shape, or a named block absent from the container).
+
+### Why `pth` hops are not screened for revocation
+
+Considered and rejected. Revocation is monotonic and irreversible: if a grant cited in `pth` was itself revoked, everything downstream of it is already dead, so a revocation citing it is redundant rather than dangerous.
+
+The case that *does* matter is already covered: if the revoked grant appears in `prf`, `verify` refuses the whole invocation and it never reaches `validate`.
+
+## Tests
+
+Shape (`revocation::action`) — the builder produces a well-formed revocation with the revoker as subject; another command is not a revocation; a nonce makes it malformed; each argument is required; a bare link is not a path; a non-link argument is malformed; an empty path is shape-valid.
+
+No evidence required (`container::revocation`):
+- an audience may refuse its own grant
+- an issuer may withdraw what it issued
+- a subject may revoke its own capability
+- a powerline target needs no evidence
+- **a powerline target's path is not even examined** — garbage evidence passes
+
+Evidence required, accepted:
+- an intermediary may revoke with a witness path
+- **extra hops outside the relevant walk are ignored**
+- a powerline hop roots the walk
+- **evidence need not reach the target** — a holder may revoke a sibling branch
+- **a holder may revoke a hop it descends from**
+
+Evidence required, denied:
+- an empty path denies an intermediary
+- a path not rooted at the subject
+- a stranger on no part of the path
+- an expired hop in the walk
+- **a forged hop signature**
+
+Error taxonomy:
+- **an invalid invocation is distinguishable from a denial**
+- a valid invocation with good evidence verifies end to end
+
+Malformed rather than denied: a missing block.
+
+Chain properties (`delegation::chain`): empty chain, linked chain, broken link, wrong root, expired hop.
+
+## Open
+
+- **Delegated revocation.** The spec mentions revocations that are themselves delegated ("is the revocation based on a delegated revocation"). Not handled: check 3 requires the revoker to be the target hop's issuer or audience directly.

--- a/rust/dialog-ucan-core/src/container.rs
+++ b/rust/dialog-ucan-core/src/container.rs
@@ -18,6 +18,7 @@
 
 pub mod delegation;
 pub mod invocation;
+pub mod revocation;
 
 mod check_failed;
 pub use check_failed::check_failed_to_container_error;

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -45,7 +45,7 @@ use crate::future::Local as Runtime;
 use crate::future::Sendable as Runtime;
 
 /// In-memory delegation store for verification.
-type ProofStore<S> = Arc<Mutex<HashMap<Cid, Arc<Delegation<S>>>>>;
+pub type ProofStore<S> = Arc<Mutex<HashMap<Cid, Arc<Delegation<S>>>>>;
 
 /// An invocation with its delegation chain, parsed from a UCAN container.
 ///
@@ -142,6 +142,16 @@ impl<S: Signature> InvocationChain<S> {
                     ),
                 },
             })
+    }
+
+    /// Look up a delegation the container carries as a block.
+    ///
+    /// The container holds every token that travelled with the invocation,
+    /// which is not only its `prf` chain: a `/ucan/revoke` also carries the
+    /// delegations its `rev` and `pth` arguments name.
+    #[must_use]
+    pub fn delegation(&self, cid: &Cid) -> Option<&Arc<Delegation<S>>> {
+        self.delegations.get(cid)
     }
 
     /// The proof store this chain's delegations live in.

--- a/rust/dialog-ucan-core/src/container/revocation.rs
+++ b/rust/dialog-ucan-core/src/container/revocation.rs
@@ -13,6 +13,7 @@
 
 use super::ContainerError;
 use super::invocation::InvocationChain;
+use crate::container::Container;
 use crate::{
     Delegation,
     delegation::{SignatureVerificationError, chain::check_chain, store::DelegationStore},
@@ -25,6 +26,7 @@ use crate::{
 use dialog_varsig::{Did, Resolver, Signature};
 use ipld_core::cid::Cid;
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -367,6 +369,66 @@ impl From<MalformedRevocationChain> for ContainerError {
     }
 }
 
+impl<S: Signature + serde::Serialize> RevocationChain<S>
+where
+    Delegation<S>: serde::Serialize,
+{
+    /// Assemble a revocation together with the blocks its arguments name.
+    ///
+    /// `delegations` must contain every CID the revocation names — the target
+    /// and each witness hop — plus any delegation cited in `prf`. Missing
+    /// blocks are [`MalformedRevocationChain::MissingBlock`], the same
+    /// finding parsing a container short of them produces.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MalformedRevocationChain`] if a named block is absent.
+    pub fn assemble(
+        revocation: Revocation<S>,
+        delegations: HashMap<Cid, Arc<Delegation<S>>>,
+    ) -> Result<Self, MalformedRevocationChain> {
+        let chain = InvocationChain::new(revocation.invocation().clone(), delegations);
+        Self::try_from(chain)
+    }
+
+    /// Serialize to a container carrying every block a verifier needs.
+    ///
+    /// Distinct from [`InvocationChain::to_bytes`], which emits only the
+    /// delegations named in `prf`. A revocation's witness is named by
+    /// `args.pth` instead, so that writer would drop it and leave the
+    /// receiver unable to resolve the links it was handed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ContainerError`] if encoding fails.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ContainerError> {
+        let mut tokens =
+            vec![
+                serde_ipld_dagcbor::to_vec(&self.chain.invocation).map_err(|error| {
+                    ContainerError::Invocation(format!("failed to encode the revocation: {error}"))
+                })?,
+            ];
+        let mut seen: std::collections::BTreeSet<Cid> = std::collections::BTreeSet::new();
+
+        // The witness first, then anything `prf` cites: a receiver needs
+        // both, and a block named twice is emitted once.
+        let witness = std::iter::once(&self.revoked).chain(self.path.iter());
+        let proofs = self
+            .chain
+            .invocation
+            .proofs()
+            .iter()
+            .filter_map(|cid| self.chain.delegation(cid));
+        for delegation in witness.chain(proofs) {
+            if seen.insert(delegation.to_cid()) {
+                tokens.push(delegation.encoded().to_vec());
+            }
+        }
+
+        Container::new(tokens).into_bytes()
+    }
+}
+
 impl<S: Signature> TryFrom<InvocationChain<S>> for RevocationChain<S> {
     type Error = MalformedRevocationChain;
 
@@ -406,7 +468,17 @@ mod tests {
     use crate::helpers::generate_signer;
     use crate::revocation::{UnverifiedRevocations, builder::RevocationBuilder};
     use crate::verification::Environment;
-    use crate::{DelegationBuilder, InvocationChain, command::Command, time::Timestamp};
+    use crate::{
+        DelegationBuilder,
+        InvocationChain,
+        command::Command,
+        // The crate's re-exports, not `std::time`: on wasm a `Timestamp` wraps
+        // `web_time::SystemTime`, so `std::time` values do not convert.
+        time::{
+            Timestamp,
+            timestamp::{Duration, UNIX_EPOCH},
+        },
+    };
     use dialog_credentials::{DidKeyResolver, Signer};
     use dialog_varsig::{AnySignature, Principal};
     use std::collections::HashMap;
@@ -685,7 +757,7 @@ mod tests {
             .subject(Subject::Specific(alice.did()))
             .command(vec!["storage".to_string()])
             .expiration(Timestamp::try_from(
-                std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000),
+                UNIX_EPOCH + Duration::from_secs(1_000_000_000),
             )?)
             .try_build()
             .await?;
@@ -751,6 +823,51 @@ mod tests {
         let onward = hop(&carol, &dave, &alice).await?;
 
         validate(&revocation_chain(&dave, &target, &[&first, &target, &onward]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_packed_revocation_round_trips_with_its_witness() -> TestResult {
+        // `InvocationChain::to_bytes` emits only the delegations named in
+        // `prf`. A revocation's witness is named by `args.pth` instead, so
+        // that writer drops it and leaves the receiver unable to resolve
+        // the links it was handed.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+
+        let first = hop(&alice, &bob, &alice).await?;
+        let target = hop(&bob, &carol, &alice).await?;
+        let chain = revocation_chain(&bob, &target, &[&first, &target]).await?;
+
+        let bytes = chain.to_bytes()?;
+        let parsed = RevocationChain::try_from(InvocationChain::try_from(bytes.as_slice())?)?;
+
+        assert_eq!(parsed.revoked().to_cid(), target.to_cid());
+        assert_eq!(parsed.path().len(), 2, "both witness hops must survive");
+        validate(&parsed).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn assembling_without_a_named_block_is_malformed() -> TestResult {
+        // Assembly answers the same question parsing does, so a caller
+        // that forgets a block gets the same finding rather than a
+        // half-built chain.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let target = hop(&alice, &bob, &alice).await?;
+
+        let revocation = RevocationBuilder::new(alice.clone(), target.to_cid())
+            .path(vec![target.to_cid()])
+            .try_build()
+            .await?;
+
+        let result = RevocationChain::assemble(revocation, HashMap::new());
+        assert!(
+            matches!(result, Err(MalformedRevocationChain::MissingBlock { .. })),
+            "a missing block must be malformed, not a partial chain"
+        );
         Ok(())
     }
 

--- a/rust/dialog-ucan-core/src/container/revocation.rs
+++ b/rust/dialog-ucan-core/src/container/revocation.rs
@@ -1,0 +1,861 @@
+//! A `/ucan/revoke` invocation together with the blocks it names.
+//!
+//! [`InvocationChain::verify`] establishes that an invocation is a valid
+//! invocation: signature, `prf` chain (linkage, rooting, attenuation, policy),
+//! time bounds, and that no `prf` hop is revoked. All command-agnostic. For a
+//! revocation that means *"whoever signed this was authorized to issue an
+//! invocation with `sub` as its subject"* — nothing about `rev` or `pth`,
+//! which are opaque arguments to it.
+//!
+//! [`RevocationChain::validate`] adds only what is specific to the command,
+//! and deliberately re-derives none of the above: hand-rolled
+//! reimplementations of the generic path are how holes get missed.
+
+use super::ContainerError;
+use super::invocation::InvocationChain;
+use crate::{
+    Delegation,
+    delegation::{SignatureVerificationError, chain::check_chain, store::DelegationStore},
+    future::FutureKind,
+    invocation::{CheckError, CheckFailed},
+    revocation::action::{MalformedRevocation, PATH, REVOKED, Revocation},
+    subject::Subject,
+    verification::{Verifiable, VerificationContext},
+};
+use dialog_varsig::{Did, Resolver, Signature};
+use ipld_core::cid::Cid;
+use std::borrow::Borrow;
+use std::sync::Arc;
+use thiserror::Error;
+
+/// A revocation with the delegations its arguments name resolved from the
+/// container.
+///
+/// Constructing one proves the artifact is *shaped* like a revocation and
+/// that every CID it names is present. [`validate`](Self::validate) proves
+/// the revoker was entitled to withdraw what it names.
+#[derive(Debug, Clone)]
+pub struct RevocationChain<S: Signature> {
+    chain: InvocationChain<S>,
+    revocation: Revocation<S>,
+    revoked: Arc<Delegation<S>>,
+    path: Vec<Arc<Delegation<S>>>,
+}
+
+impl<S: Signature> RevocationChain<S> {
+    /// The underlying invocation chain, for
+    /// [`verify`](InvocationChain::verify).
+    #[must_use]
+    pub const fn chain(&self) -> &InvocationChain<S> {
+        &self.chain
+    }
+
+    /// The revocation artifact.
+    #[must_use]
+    pub const fn revocation(&self) -> &Revocation<S> {
+        &self.revocation
+    }
+
+    /// The delegation being revoked.
+    #[must_use]
+    pub fn revoked(&self) -> &Delegation<S> {
+        &self.revoked
+    }
+
+    /// The witness path as supplied, in whatever order it arrived.
+    #[must_use]
+    pub fn path(&self) -> &[Arc<Delegation<S>>] {
+        &self.path
+    }
+
+    /// The principal issuing this revocation.
+    #[must_use]
+    pub const fn revoker(&self) -> &Did {
+        self.revocation.revoker()
+    }
+
+    /// Does the revoker's own relationship to the target settle it, with no
+    /// evidence required?
+    ///
+    /// Four cases need no witness path, and for them `pth` is neither
+    /// required nor examined:
+    ///
+    /// - **audience** — refusing what you were handed is not a claim of
+    ///   authority over anyone else, it is declining your own grant
+    /// - **issuer** — you may withdraw what you issued
+    /// - **subject** — it is your capability being delegated
+    /// - **powerline target** — a `Subject::Any` delegation lets its holder
+    ///   mint a delegation for any subject at all, so no witness could prove
+    ///   anything a forger could not manufacture. Requiring one is theatre.
+    fn settled_without_evidence(&self) -> bool {
+        let revoker = self.revocation.revoker();
+
+        if revoker == self.revoked.audience() || revoker == self.revoked.issuer() {
+            return true;
+        }
+
+        match self.revoked.subject() {
+            Subject::Any => true,
+            Subject::Specific(subject) => revoker == subject,
+        }
+    }
+
+    /// Check that the revoker was entitled to revoke what this names.
+    ///
+    /// When [`settled_without_evidence`](Self::settled_without_evidence)
+    /// does not apply — the revoker is an intermediary rather than a party
+    /// to the delegation — `pth` must witness their authority.
+    ///
+    /// The path is treated as a **pool**, not an ordered chain: the relevant
+    /// subchain is the walk from a hop issued by the target's subject,
+    /// following audience-to-issuer links, to a hop whose audience is the
+    /// revoker. Hops off that walk are ignored, so carrying more than is
+    /// relevant is not an error. The walk itself must align, be valid at the
+    /// context's instant, and carry a real signature at every hop; the target
+    /// must lie on it. A powerline hop within the walk stands in wherever a
+    /// hop for the subject would, since a powerline implies its own subject.
+    ///
+    /// Whether the `pth` hops were themselves revoked is deliberately not
+    /// checked: revocation is monotonic, so a revoked hop means everything
+    /// below it is already dead and a revocation citing it is redundant
+    /// rather than dangerous.
+    ///
+    /// # Errors
+    ///
+    /// [`RevocationError::Denied`] when the evidence does not establish the
+    /// revoker's authority, and [`RevocationError::Unavailable`] when a
+    /// signature could not be checked because an issuer would not resolve.
+    pub async fn validate<K, T, St, C>(
+        &self,
+        ctx: &VerificationContext<'_, C>,
+    ) -> Result<(), RevocationError<K, S, C>>
+    where
+        K: FutureKind,
+        T: Borrow<Delegation<S>> + std::fmt::Debug,
+        St: DelegationStore<K, S, T> + std::fmt::Debug,
+        C: Verifiable<K, S, Proof = T, Delegations = St>,
+    {
+        if self.settled_without_evidence() {
+            return Ok(());
+        }
+
+        // Only a `Specific` subject reaches here: `Any` settled above.
+        let Subject::Specific(subject) = self.revoked.subject() else {
+            return Ok(());
+        };
+        let revoker = self.revocation.revoker();
+
+        // The evidence must show the revoker *held* the capability: a chain
+        // from the subject that owns it down to the revoker. Whether a chain
+        // continues from the revoker to the delegation being revoked is
+        // irrelevant — holding the capability, they could always have
+        // created one, so its absence proves nothing.
+        let walk = self.walk::<K, C>(subject, revoker)?;
+
+        // Alignment and time over the walk. This is the same implementation
+        // `syntactic_checks` uses for a proof chain, so a witness path cannot
+        // drift from one.
+        check_chain(walk.iter().copied(), subject, ctx.time())
+            .map_err(|source| RevocationError::Denied(Denial::Path { source }))?;
+
+        // Every hop must be signed by whoever it claims issued it; without
+        // this the walk is a story rather than evidence.
+        for hop in &walk {
+            hop.verify_signature(ctx.environment().resolver())
+                .await
+                .map_err(|source| match source {
+                    SignatureVerificationError::ResolutionError(detail) => {
+                        RevocationError::Unavailable {
+                            did: hop.issuer().clone(),
+                            detail,
+                        }
+                    }
+                    other => RevocationError::Denied(Denial::HopSignature {
+                        issuer: hop.issuer().clone(),
+                        detail: other.to_string(),
+                    }),
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Verify the invocation, then validate the revocation.
+    ///
+    /// The two halves answer different questions and fail differently:
+    /// [`Invalid`](RevocationError::Invalid) means this is not a valid
+    /// invocation at all, [`Denied`](RevocationError::Denied) means it is a
+    /// valid invocation whose evidence does not justify the revocation, and
+    /// [`Unavailable`](RevocationError::Unavailable) means we could not
+    /// establish either.
+    ///
+    /// # Errors
+    ///
+    /// See [`RevocationError`].
+    pub async fn verify<K, T, St, C>(
+        &self,
+        ctx: &VerificationContext<'_, C>,
+    ) -> Result<(), RevocationError<K, S, C>>
+    where
+        K: FutureKind,
+        T: Borrow<Delegation<S>> + std::fmt::Debug,
+        St: DelegationStore<K, S, T> + std::fmt::Debug,
+        C: Verifiable<K, S, Proof = T, Delegations = St>,
+        <C::Resolver as Resolver<S>>::Error: Clone,
+    {
+        self.chain
+            .invocation
+            .check::<K, T, St, C>(ctx)
+            .await
+            .map_err(|error| RevocationError::Invalid(Box::new(error)))?;
+
+        self.validate::<K, T, St, C>(ctx).await
+    }
+
+    /// The relevant subchain: from a hop issued by `subject`, following
+    /// audience-to-issuer links, until a hop delegates to `revoker`.
+    ///
+    /// This witnesses that the revoker *held* the capability. `pth` is a
+    /// pool, so hops off this walk are ignored rather than rejected —
+    /// carrying more than is relevant is not an error.
+    fn walk<K, C>(
+        &self,
+        subject: &Did,
+        revoker: &Did,
+    ) -> Result<Vec<&Delegation<S>>, RevocationError<K, S, C>>
+    where
+        K: FutureKind,
+        C: Verifiable<K, S, Proof: std::fmt::Debug, Delegations: std::fmt::Debug>,
+    {
+        let missing = || {
+            RevocationError::Denied(Denial::NoEvidenceOfPossession {
+                subject: subject.clone(),
+                revoker: revoker.clone(),
+            })
+        };
+
+        // Rooted at the subject: evidence that does not descend from the
+        // authority in question witnesses nothing about it.
+        let mut holder = subject;
+        let mut walk: Vec<&Delegation<S>> = Vec::new();
+
+        while walk.len() <= self.path.len() {
+            let next = self
+                .path
+                .iter()
+                .map(AsRef::as_ref)
+                .find(|hop| {
+                    hop.issuer() == holder
+                        // A powerline implies its own subject, so it stands
+                        // in wherever a hop for this subject would.
+                        && hop.subject().allows(subject)
+                        && !walk.iter().any(|seen| std::ptr::eq(*seen, *hop))
+                })
+                .ok_or_else(missing)?;
+
+            walk.push(next);
+            holder = next.audience();
+
+            if holder == revoker {
+                return Ok(walk);
+            }
+        }
+
+        Err(missing())
+    }
+}
+
+/// Why a revocation was not accepted.
+///
+/// Mirrors the split [`VerifyError`](crate::VerifyError) draws: a statement
+/// about the caller's material, or one about our own reach. A denial is
+/// grounds to refuse; an unavailability is grounds to ask again.
+#[derive(Debug, Error)]
+pub enum RevocationError<K, S, C>
+where
+    K: FutureKind,
+    S: Signature,
+    // `Debug` on the store and proof types so this can derive `Debug` the
+    // way `VerifyError` does; they reach it through `C`'s associated types
+    // rather than as direct parameters, so it must be said here.
+    C: Verifiable<K, S, Proof: std::fmt::Debug, Delegations: std::fmt::Debug>,
+{
+    /// The invocation carrying this revocation is not itself valid: a bad
+    /// signature, a broken `prf` chain, expired bounds, a revoked proof.
+    ///
+    /// Wraps the underlying [`CheckError`] rather than rendering it, so a
+    /// caller can match on *which* way the invocation failed rather than
+    /// re-parsing prose. Distinct from [`Denied`](Self::Denied) because the
+    /// two are different findings: this one says the artifact is not a valid
+    /// invocation at all, before any question of revocation authority arises.
+    ///
+    /// Boxed because it is much larger than the other variants, and an
+    /// unboxed one would widen every `Result` this returns.
+    #[error(transparent)]
+    Invalid(Box<CheckError<K, S, C>>),
+
+    /// The invocation is valid, but its evidence does not establish that the
+    /// revoker could revoke what it names.
+    #[error(transparent)]
+    Denied(#[from] Denial),
+
+    /// Something we depend on could not be reached, so no finding was made.
+    /// Says nothing about whether the revocation is good.
+    #[error("could not resolve '{did}' to check a witness signature: {detail}")]
+    Unavailable {
+        /// The issuer that could not be resolved.
+        did: Did,
+        /// Why resolution failed.
+        detail: <C::Resolver as Resolver<S>>::Error,
+    },
+}
+
+/// Why the evidence does not justify a revocation.
+#[derive(Debug, Clone, Error)]
+pub enum Denial {
+    /// The witness path does not show the revoker ever held the capability:
+    /// no chain in it runs from the subject that owns the capability down to
+    /// the revoker.
+    #[error("the witness path does not show '{revoker}' ever held '{subject}'s capability")]
+    NoEvidenceOfPossession {
+        /// The principal whose capability is being revoked.
+        subject: Did,
+        /// The principal attempting the revocation.
+        revoker: Did,
+    },
+
+    /// The walk does not align, or is not valid at the judged instant.
+    #[error("the witness path is not a valid delegation chain: {source}")]
+    Path {
+        /// What about the chain did not hold.
+        source: CheckFailed,
+    },
+
+    /// A hop is not signed by the principal it claims issued it.
+    #[error("a witness hop claiming issuer '{issuer}' is not signed by them: {detail}")]
+    HopSignature {
+        /// The principal the hop claims as its issuer.
+        issuer: Did,
+        /// The underlying verification failure.
+        detail: String,
+    },
+}
+
+/// Why an invocation chain is not a well-formed revocation chain.
+///
+/// Distinct from [`Denial`]: these say the artifact could not be read, not
+/// that its author lacked authority.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum MalformedRevocationChain {
+    /// The invocation is not shaped like a revocation.
+    #[error(transparent)]
+    Malformed(#[from] MalformedRevocation),
+
+    /// An argument names a delegation the container does not carry.
+    #[error("the container does not carry the delegation '{link}' named by '{argument}'")]
+    MissingBlock {
+        /// Which argument named it.
+        argument: &'static str,
+        /// The absent block.
+        link: Cid,
+    },
+}
+
+impl From<MalformedRevocationChain> for ContainerError {
+    fn from(error: MalformedRevocationChain) -> Self {
+        ContainerError::Invocation(error.to_string())
+    }
+}
+
+impl<S: Signature> TryFrom<InvocationChain<S>> for RevocationChain<S> {
+    type Error = MalformedRevocationChain;
+
+    fn try_from(chain: InvocationChain<S>) -> Result<Self, Self::Error> {
+        let revocation = Revocation::try_from(chain.invocation.clone())?;
+
+        let resolve = |argument, link: &Cid| {
+            chain
+                .delegation(link)
+                .cloned()
+                .ok_or(MalformedRevocationChain::MissingBlock {
+                    argument,
+                    link: *link,
+                })
+        };
+
+        let revoked = resolve(REVOKED, revocation.revoked())?;
+        let path = revocation
+            .path()
+            .iter()
+            .map(|link| resolve(PATH, link))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            chain,
+            revocation,
+            revoked,
+            path,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::container::invocation::ProofStore;
+    use crate::helpers::generate_signer;
+    use crate::revocation::{UnverifiedRevocations, builder::RevocationBuilder};
+    use crate::verification::Environment;
+    use crate::{DelegationBuilder, InvocationChain, command::Command, time::Timestamp};
+    use dialog_credentials::{DidKeyResolver, Signer};
+    use dialog_varsig::{AnySignature, Principal};
+    use std::collections::HashMap;
+    use testresult::TestResult;
+
+    type Env = Environment<
+        ProofStore<AnySignature>,
+        DidKeyResolver,
+        UnverifiedRevocations,
+        Arc<Delegation<AnySignature>>,
+    >;
+
+    /// `issuer -> audience`, speaking for `subject`.
+    async fn hop(
+        issuer: &Signer,
+        audience: &Signer,
+        subject: &Signer,
+    ) -> TestResult<Delegation<AnySignature>> {
+        Ok(DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(&audience.did())
+            .subject(Subject::Specific(subject.did()))
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await?)
+    }
+
+    /// `issuer -> audience` as a powerline: subject is `Any`.
+    async fn powerline(issuer: &Signer, audience: &Signer) -> TestResult<Delegation<AnySignature>> {
+        Ok(DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(&audience.did())
+            .subject(Subject::Any)
+            .command(vec!["storage".to_string()])
+            .try_build()
+            .await?)
+    }
+
+    async fn revocation_chain(
+        revoker: &Signer,
+        target: &Delegation<AnySignature>,
+        path: &[&Delegation<AnySignature>],
+    ) -> TestResult<RevocationChain<AnySignature>> {
+        let revocation = RevocationBuilder::new(revoker.clone(), target.to_cid())
+            .path(path.iter().map(|d| d.to_cid()).collect())
+            .try_build()
+            .await?;
+
+        let mut blocks: HashMap<_, _> = path
+            .iter()
+            .map(|d| (d.to_cid(), Arc::new((*d).clone())))
+            .collect();
+        blocks.insert(target.to_cid(), Arc::new(target.clone()));
+
+        let chain = InvocationChain::new(revocation.into_invocation(), blocks);
+        Ok(RevocationChain::try_from(chain)?)
+    }
+
+    /// Validate against the system clock, resolving `did:key` issuers.
+    async fn validate(
+        chain: &RevocationChain<AnySignature>,
+    ) -> Result<(), RevocationError<crate::future::Local, AnySignature, Env>> {
+        let env: Env = Environment::new(
+            chain.chain().proof_store(),
+            DidKeyResolver,
+            UnverifiedRevocations,
+        );
+        chain
+            .validate::<crate::future::Local, _, _, _>(&VerificationContext::new(&env))
+            .await
+    }
+
+    // Cases that need no evidence at all: the revoker's own relationship to
+    // the delegation settles it, so `pth` is neither required nor examined.
+
+    #[dialog_common::test]
+    async fn an_audience_may_refuse_its_own_grant_without_evidence() -> TestResult {
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let target = hop(&alice, &bob, &alice).await?;
+
+        // Bob was handed it; declining is not a claim over anyone else.
+        validate(&revocation_chain(&bob, &target, &[]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_issuer_may_withdraw_what_it_issued_without_evidence() -> TestResult {
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        // Issued by alice on carol's behalf: issuer but not subject.
+        let target = hop(&alice, &bob, &carol).await?;
+
+        validate(&revocation_chain(&alice, &target, &[]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_subject_may_revoke_its_own_capability_without_evidence() -> TestResult {
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        // Speaks for alice, but issued by bob to carol.
+        let target = hop(&bob, &carol, &alice).await?;
+
+        validate(&revocation_chain(&alice, &target, &[]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_powerline_target_needs_no_evidence_at_all() -> TestResult {
+        // A powerline holder can mint a delegation for any subject, so a
+        // witness proves nothing that could not be manufactured.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let mallory = generate_signer().await;
+        let target = powerline(&alice, &bob).await?;
+
+        validate(&revocation_chain(&mallory, &target, &[]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_powerline_targets_path_is_not_even_examined() -> TestResult {
+        // Deliberately garbage evidence: unlinked and rooted nowhere.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+        let mallory = generate_signer().await;
+
+        let target = powerline(&alice, &bob).await?;
+        let nonsense = hop(&carol, &dave, &carol).await?;
+
+        validate(&revocation_chain(&mallory, &target, &[&nonsense]).await?).await?;
+        Ok(())
+    }
+
+    // Cases where the revoker is an intermediary and must show authority.
+
+    #[dialog_common::test]
+    async fn an_intermediary_may_revoke_with_a_witness_path() -> TestResult {
+        // alice -> bob -> carol -> dave. Bob revokes carol -> dave: he is
+        // neither party to it, so he must witness his authority over it.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+
+        let first = hop(&alice, &bob, &alice).await?;
+        let second = hop(&bob, &carol, &alice).await?;
+        let target = hop(&carol, &dave, &alice).await?;
+
+        validate(&revocation_chain(&bob, &target, &[&first, &second, &target]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn extra_hops_outside_the_relevant_walk_are_ignored() -> TestResult {
+        // `pth` is a pool: carrying more than is relevant is not an error.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+        let erin = generate_signer().await;
+
+        let first = hop(&alice, &bob, &alice).await?;
+        let second = hop(&bob, &carol, &alice).await?;
+        let target = hop(&carol, &dave, &alice).await?;
+        // Rooted elsewhere, entirely off the walk.
+        let unrelated = hop(&erin, &dave, &erin).await?;
+
+        validate(&revocation_chain(&bob, &target, &[&unrelated, &first, &second, &target]).await?)
+            .await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_powerline_hop_roots_the_walk() -> TestResult {
+        // A powerline implies its own subject, so alice's grant to bob roots
+        // a walk about alice's capability even though its `sub` is `Any`.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+
+        let line = powerline(&alice, &bob).await?;
+        let onward = hop(&bob, &carol, &alice).await?;
+        let target = hop(&carol, &dave, &alice).await?;
+
+        validate(&revocation_chain(&bob, &target, &[&line, &onward, &target]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_empty_path_denies_an_intermediary() -> TestResult {
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+
+        let target = hop(&carol, &dave, &alice).await?;
+
+        let result = validate(&revocation_chain(&bob, &target, &[]).await?).await;
+        assert!(
+            matches!(
+                result,
+                Err(RevocationError::Denied(
+                    Denial::NoEvidenceOfPossession { .. }
+                ))
+            ),
+            "an intermediary with no evidence must be denied: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_path_not_rooted_at_the_subject_is_denied() -> TestResult {
+        // Rooted at bob, who was never granted anything by alice. Evidence
+        // that does not descend from the authority witnesses nothing.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+
+        let fabricated = hop(&bob, &carol, &alice).await?;
+        let target = hop(&carol, &dave, &alice).await?;
+
+        let result =
+            validate(&revocation_chain(&bob, &target, &[&fabricated, &target]).await?).await;
+        assert!(
+            matches!(
+                result,
+                Err(RevocationError::Denied(
+                    Denial::NoEvidenceOfPossession { .. }
+                ))
+            ),
+            "evidence not rooted at the subject must be denied: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn evidence_need_not_reach_the_target() -> TestResult {
+        // Bob holds alice's capability via alice -> bob. He revokes a hop
+        // on a sibling branch (alice -> carol -> dave) that he is not on.
+        //
+        // Holding the capability, bob could have issued that hop himself,
+        // so requiring a chain from him down to it would prove nothing that
+        // possession does not already establish.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+
+        let possession = hop(&alice, &bob, &alice).await?;
+        let sibling = hop(&alice, &carol, &alice).await?;
+        let target = hop(&carol, &dave, &alice).await?;
+
+        validate(&revocation_chain(&bob, &target, &[&possession, &sibling, &target]).await?)
+            .await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_expired_hop_in_the_walk_is_denied() -> TestResult {
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+
+        let expired = DelegationBuilder::new()
+            .issuer(alice.clone())
+            .audience(&bob.did())
+            .subject(Subject::Specific(alice.did()))
+            .command(vec!["storage".to_string()])
+            .expiration(Timestamp::try_from(
+                std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000),
+            )?)
+            .try_build()
+            .await?;
+        let second = hop(&bob, &carol, &alice).await?;
+        let target = hop(&carol, &dave, &alice).await?;
+
+        let result =
+            validate(&revocation_chain(&bob, &target, &[&expired, &second, &target]).await?).await;
+        assert!(
+            matches!(result, Err(RevocationError::Denied(Denial::Path { .. }))),
+            "an expired hop must deny the revocation: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_forged_hop_signature_is_denied() -> TestResult {
+        // A hop claiming alice as issuer but signed by mallory. Without the
+        // signature check the walk would align perfectly.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+        let mallory = generate_signer().await;
+
+        let forged: Delegation<AnySignature> = Delegation::forge(
+            alice.did(),
+            bob.did(),
+            Subject::Specific(alice.did()),
+            Command::new(vec!["storage".to_string()]),
+            &mallory,
+        )
+        .await?;
+        let second = hop(&bob, &carol, &alice).await?;
+        let target = hop(&carol, &dave, &alice).await?;
+
+        let result =
+            validate(&revocation_chain(&bob, &target, &[&forged, &second, &target]).await?).await;
+        assert!(
+            matches!(
+                result,
+                Err(RevocationError::Denied(Denial::HopSignature { .. }))
+            ),
+            "a forged witness hop must deny the revocation: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_holder_may_revoke_a_hop_it_descends_from() -> TestResult {
+        // alice -> bob -> carol -> dave, with dave revoking bob -> carol.
+        //
+        // Dave holds alice's capability, and that is the whole question:
+        // possession is what the evidence establishes. Revoking a hop he
+        // descends from cuts off his own authority too, which is his to do.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let dave = generate_signer().await;
+
+        let first = hop(&alice, &bob, &alice).await?;
+        let target = hop(&bob, &carol, &alice).await?;
+        let onward = hop(&carol, &dave, &alice).await?;
+
+        validate(&revocation_chain(&dave, &target, &[&first, &target, &onward]).await?).await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_stranger_on_no_part_of_the_path_is_denied() -> TestResult {
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let carol = generate_signer().await;
+        let mallory = generate_signer().await;
+
+        let first = hop(&alice, &bob, &alice).await?;
+        let target = hop(&bob, &carol, &alice).await?;
+
+        let result =
+            validate(&revocation_chain(&mallory, &target, &[&first, &target]).await?).await;
+        assert!(
+            matches!(
+                result,
+                Err(RevocationError::Denied(
+                    Denial::NoEvidenceOfPossession { .. }
+                ))
+            ),
+            "a principal absent from the path must be denied: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_invalid_invocation_is_distinguishable_from_a_denial() -> TestResult {
+        // The revocation names a proof its container does not carry, so the
+        // invocation itself does not verify. That is a different finding
+        // from "valid invocation, insufficient evidence", and a caller
+        // needs to tell them apart.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let target = hop(&alice, &bob, &alice).await?;
+        let absent = hop(&bob, &alice, &alice).await?;
+
+        let revocation = RevocationBuilder::new(bob.clone(), target.to_cid())
+            .path(vec![])
+            .try_build_with_proofs(vec![absent.to_cid()], &alice.did())
+            .await?;
+
+        let mut blocks = HashMap::new();
+        blocks.insert(target.to_cid(), Arc::new(target.clone()));
+        let chain =
+            RevocationChain::try_from(InvocationChain::new(revocation.into_invocation(), blocks))?;
+
+        let env: Env = Environment::new(
+            chain.chain().proof_store(),
+            DidKeyResolver,
+            UnverifiedRevocations,
+        );
+        let result = chain
+            .verify::<crate::future::Local, _, _, _>(&VerificationContext::new(&env))
+            .await;
+
+        assert!(
+            matches!(result, Err(RevocationError::Invalid(_))),
+            "a chain whose invocation does not verify must report Invalid, \
+             not a denial: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_valid_invocation_with_good_evidence_verifies_end_to_end() -> TestResult {
+        // The positive counterpart: both halves pass.
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let target = hop(&alice, &bob, &alice).await?;
+
+        // Bob is the audience, so no evidence is needed; the invocation is
+        // self-issued by bob over his own subject.
+        let chain = revocation_chain(&bob, &target, &[]).await?;
+        let env: Env = Environment::new(
+            chain.chain().proof_store(),
+            DidKeyResolver,
+            UnverifiedRevocations,
+        );
+        chain
+            .verify::<crate::future::Local, _, _, _>(&VerificationContext::new(&env))
+            .await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_missing_block_is_malformed_not_denied() -> TestResult {
+        let alice = generate_signer().await;
+        let bob = generate_signer().await;
+        let target = hop(&alice, &bob, &alice).await?;
+
+        let revocation = RevocationBuilder::new(alice.clone(), target.to_cid())
+            .witness(target.to_cid())
+            .try_build()
+            .await?;
+        let chain = InvocationChain::new(revocation.into_invocation(), HashMap::new());
+
+        assert!(
+            matches!(
+                RevocationChain::try_from(chain),
+                Err(MalformedRevocationChain::MissingBlock { .. })
+            ),
+            "an unresolvable link is malformed input, not a denial"
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-ucan-core/src/delegation.rs
+++ b/rust/dialog-ucan-core/src/delegation.rs
@@ -4,6 +4,7 @@
 //! [the GitHub repo](https://github.com/ucan-wg/invocation/).
 
 pub mod builder;
+pub mod chain;
 pub mod policy;
 pub mod store;
 

--- a/rust/dialog-ucan-core/src/delegation/chain.rs
+++ b/rust/dialog-ucan-core/src/delegation/chain.rs
@@ -1,0 +1,221 @@
+//! Structural properties of a delegation sequence.
+//!
+//! Three properties make a list of delegations a *chain* rather than a bag,
+//! and none of them need an invocation to judge:
+//!
+//! - **linkage** — each hop is issued by whoever the previous hop delegated to
+//! - **rooting** — the first hop is issued by the subject it speaks for
+//! - **time** — the intersected validity window is non-empty, and contains the
+//!   instant being judged against
+//!
+//! [`InvocationPayload::check`](crate::InvocationPayload) applies these to an
+//! invocation's `prf` alongside checks that *do* need the invocation (command
+//! attenuation, policy predicates over `args`). A `/ucan/revoke` witness path
+//! needs the same three and none of the others, so they live here rather than
+//! being re-derived: hand-rolled reimplementations are how holes get missed.
+
+use super::Delegation;
+use crate::{
+    invocation::CheckFailed,
+    subject::Subject,
+    time::{range::TimeRange, timestamp::Timestamp},
+};
+use dialog_varsig::{Did, Signature};
+
+/// Check that `hops` form a chain rooted at `subject`, valid at `now`.
+///
+/// Hops are expected in root-to-leaf order: the first is issued by `subject`,
+/// and each subsequent hop is issued by the previous hop's audience.
+///
+/// Returns the intersected [`TimeRange`] across every hop.
+///
+/// This deliberately says nothing about commands or policy: those need an
+/// invocation to judge against, and a caller that has one should use
+/// [`InvocationPayload::syntactic_checks`](crate::InvocationPayload::syntactic_checks)
+/// instead, which applies these same properties plus those.
+///
+/// # Errors
+///
+/// Returns a [`CheckFailed`] if the hops do not link up, are not rooted at
+/// `subject`, or have no validity window containing `now`.
+pub fn check_chain<'a, S: Signature + 'a, I: IntoIterator<Item = &'a Delegation<S>>>(
+    hops: I,
+    subject: &Did,
+    now: Option<Timestamp>,
+) -> Result<TimeRange, CheckFailed> {
+    let mut time_range = TimeRange::unbounded();
+    let mut previous: Option<&'a Delegation<S>> = None;
+
+    for hop in hops {
+        // Resolve the hop's subject: Specific(did) names it outright, Any
+        // inherits — from the issuer at the root, from the established
+        // subject thereafter.
+        let claimed = match hop.subject() {
+            Subject::Specific(specific) => specific,
+            Subject::Any => {
+                if previous.is_none() {
+                    hop.issuer()
+                } else {
+                    subject
+                }
+            }
+        };
+
+        if claimed != subject {
+            if previous.is_none() && matches!(hop.subject(), Subject::Any) {
+                return Err(CheckFailed::UnprovenSubject {
+                    subject: subject.clone(),
+                    issuer: hop.issuer().clone(),
+                });
+            }
+            return Err(CheckFailed::UnauthorizedSubject {
+                claimed: subject.clone(),
+                authorized: claimed.clone(),
+            });
+        }
+
+        // Linkage at every hop but the first; rooting at the first.
+        if let Some(evidence) = previous {
+            if hop.issuer() != evidence.audience() {
+                return Err(CheckFailed::DelegationAudienceMismatch {
+                    claimed: hop.issuer().clone(),
+                    authorized: evidence.audience().clone(),
+                });
+            }
+        } else if hop.issuer() != subject {
+            return Err(CheckFailed::UnprovenSubject {
+                subject: subject.clone(),
+                issuer: hop.issuer().clone(),
+            });
+        }
+
+        time_range = time_range.intersect(hop.into());
+        previous = Some(hop);
+    }
+
+    if !time_range.is_valid() {
+        return Err(CheckFailed::InvalidTimeWindow { range: time_range });
+    }
+
+    // A non-empty window only says the chain could be valid at *some* instant.
+    // `None` is a deliberate opt-out (historical replay, no trusted clock).
+    if let Some(now) = now {
+        time_range.check(&now)?;
+    }
+
+    Ok(time_range)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DelegationBuilder;
+    use dialog_credentials::{Ed25519Signer, Signer};
+    use dialog_varsig::{AnySignature, Principal};
+    use testresult::TestResult;
+
+    async fn signer() -> Signer {
+        Signer::from(Ed25519Signer::generate().await.expect("generate"))
+    }
+
+    async fn hop(
+        issuer: &Signer,
+        audience: &Signer,
+        subject: &Signer,
+    ) -> TestResult<Delegation<AnySignature>> {
+        Ok(DelegationBuilder::new()
+            .issuer(issuer.clone())
+            .audience(&audience.did())
+            .subject(Subject::Specific(subject.did()))
+            .command(vec!["test".to_string()])
+            .try_build()
+            .await?)
+    }
+
+    #[dialog_common::test]
+    async fn an_empty_chain_is_unbounded() -> TestResult {
+        let alice = signer().await;
+        let range = check_chain::<AnySignature, _>(&[], &alice.did(), None)?;
+        assert!(range.is_valid());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_linked_chain_rooted_at_the_subject_holds() -> TestResult {
+        let alice = signer().await;
+        let bob = signer().await;
+        let carol = signer().await;
+
+        let first = hop(&alice, &bob, &alice).await?;
+        let second = hop(&bob, &carol, &alice).await?;
+
+        check_chain([&first, &second], &alice.did(), Some(Timestamp::now()))?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_broken_link_is_refused() -> TestResult {
+        // alice -> bob, then carol -> dave: carol never received anything.
+        let alice = signer().await;
+        let bob = signer().await;
+        let carol = signer().await;
+        let dave = signer().await;
+
+        let first = hop(&alice, &bob, &alice).await?;
+        let unlinked = hop(&carol, &dave, &alice).await?;
+
+        let result = check_chain([&first, &unlinked], &alice.did(), None);
+        assert!(
+            matches!(result, Err(CheckFailed::DelegationAudienceMismatch { .. })),
+            "a hop not issued by the previous audience must be refused: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_chain_not_rooted_at_the_subject_is_refused() -> TestResult {
+        // The chain is internally well-linked but speaks for alice while
+        // being rooted at bob.
+        let alice = signer().await;
+        let bob = signer().await;
+        let carol = signer().await;
+
+        let rooted_at_bob = hop(&bob, &carol, &alice).await?;
+
+        let result = check_chain([&rooted_at_bob], &alice.did(), None);
+        assert!(
+            matches!(result, Err(CheckFailed::UnprovenSubject { .. })),
+            "a chain must be rooted at the subject it speaks for: {result:?}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_expired_hop_is_refused_at_the_judged_instant() -> TestResult {
+        let alice = signer().await;
+        let bob = signer().await;
+
+        let expired = DelegationBuilder::new()
+            .issuer(alice.clone())
+            .audience(&bob.did())
+            .subject(Subject::Specific(alice.did()))
+            .command(vec!["test".to_string()])
+            .expiration(Timestamp::try_from(
+                std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000),
+            )?)
+            .try_build()
+            .await?;
+
+        let now = Some(Timestamp::now());
+        assert!(
+            check_chain([&expired], &alice.did(), now).is_err(),
+            "an expired hop must be refused at the current instant"
+        );
+        // The same chain judged with no instant is a deliberate opt-out.
+        assert!(
+            check_chain([&expired], &alice.did(), None).is_ok(),
+            "no instant means time is not judged"
+        );
+        Ok(())
+    }
+}

--- a/rust/dialog-ucan-core/src/delegation/chain.rs
+++ b/rust/dialog-ucan-core/src/delegation/chain.rs
@@ -110,6 +110,9 @@ pub fn check_chain<'a, S: Signature + 'a, I: IntoIterator<Item = &'a Delegation<
 mod tests {
     use super::*;
     use crate::DelegationBuilder;
+    // The crate's re-exports, not `std::time`: on wasm a `Timestamp` wraps
+    // `web_time::SystemTime`, so `std::time` values do not convert.
+    use crate::time::timestamp::{Duration, UNIX_EPOCH};
     use dialog_credentials::{Ed25519Signer, Signer};
     use dialog_varsig::{AnySignature, Principal};
     use testresult::TestResult;
@@ -201,7 +204,7 @@ mod tests {
             .subject(Subject::Specific(alice.did()))
             .command(vec!["test".to_string()])
             .expiration(Timestamp::try_from(
-                std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000),
+                UNIX_EPOCH + Duration::from_secs(1_000_000_000),
             )?)
             .try_build()
             .await?;

--- a/rust/dialog-ucan-core/src/invocation.rs
+++ b/rust/dialog-ucan-core/src/invocation.rs
@@ -17,11 +17,11 @@ use crate::{
     envelope::{Envelope, EnvelopePayload, payload_tag::PayloadTag},
     future::FutureKind,
     promise::{Promised, WaitingOn},
-    subject::Subject,
     time::{TimeBoundError, range::TimeRange, timestamp::Timestamp},
 };
 use crate::{
     delegation::SignatureVerificationError as DelegationSignatureError,
+    delegation::chain::check_chain,
     revocation::{RevocationChecker, RevocationMatch, RevocationSelector},
     verification::{Verifiable, VerificationContext},
 };
@@ -570,55 +570,14 @@ impl InvocationPayload {
         // Proofs are expected in subject-to-invocation-issuer (root-to-leaf) order.
         let proofs: Vec<&'a Delegation<S>> = proofs.into_iter().collect();
 
-        // Start with the invocation's own time bounds.
-        let mut time_range = TimeRange::from(self);
+        // Linkage, rooting, and time are properties of the delegation
+        // sequence alone, so they come from one implementation shared with
+        // `/ucan/revoke` witness paths rather than being re-derived here.
+        let chain_range = check_chain(proofs.iter().copied(), self.subject(), now)?;
 
-        // Hold a last proof that was verified in the chain.
-        let mut authorization: Option<&'a Delegation<S>> = None;
-
-        for proof in proofs {
-            // Resolve the delegation's subject: Specific(did) uses that did,
-            // Any falls back to the previously implied subject.
-            let subject = match proof.subject() {
-                Subject::Specific(subject) => subject,
-                Subject::Any => {
-                    if authorization.is_none() {
-                        proof.issuer()
-                    } else {
-                        self.subject()
-                    }
-                }
-            };
-
-            if subject != self.subject() {
-                if authorization.is_none() && matches!(proof.subject(), Subject::Any) {
-                    return Err(CheckFailed::UnprovenSubject {
-                        subject: self.subject().clone(),
-                        issuer: proof.issuer().clone(),
-                    });
-                }
-                return Err(CheckFailed::UnauthorizedSubject {
-                    claimed: self.subject().clone(),
-                    authorized: subject.clone(),
-                });
-            }
-
-            // Verify principal alignment: root proof's issuer must be the
-            // subject, subsequent proofs' issuers must match previous audience.
-            if let Some(evidence) = authorization {
-                if proof.issuer() != evidence.audience() {
-                    return Err(CheckFailed::DelegationAudienceMismatch {
-                        claimed: proof.issuer().clone(),
-                        authorized: evidence.audience().clone(),
-                    });
-                }
-            } else if proof.issuer() != self.subject() {
-                return Err(CheckFailed::UnprovenSubject {
-                    subject: self.subject().clone(),
-                    issuer: proof.issuer().clone(),
-                });
-            }
-
+        // What is left needs the invocation: attenuation against its command,
+        // and policy predicates over its arguments.
+        for proof in &proofs {
             if !self.command.starts_with(proof.command()) {
                 return Err(CheckFailed::CommandEscalation {
                     claimed: self.command.clone(),
@@ -631,12 +590,11 @@ impl InvocationPayload {
                     return Err(CheckFailed::PolicyViolation(Box::new(predicate.clone())));
                 }
             }
-
-            // Intersect with this delegation's time bounds.
-            time_range = time_range.intersect(proof.into());
-
-            authorization = Some(proof);
         }
+
+        // The invocation's own expiration narrows the chain's window.
+        let time_range = chain_range.intersect(TimeRange::from(self));
+        let authorization = proofs.last().copied();
 
         // If proof chain was not empty we ensure that invocation
         // issuer aligns with outmost delegation audience.
@@ -657,15 +615,11 @@ impl InvocationPayload {
             });
         }
 
-        // Verify the accumulated time window is non-empty.
+        // `check_chain` already judged the hops; this re-checks the window
+        // once the invocation's own expiration is folded in.
         if !time_range.is_valid() {
             return Err(CheckFailed::InvalidTimeWindow { range: time_range });
         }
-
-        // A non-empty window only says the chain *could* be valid at some
-        // instant. Judge it against the one this verification was given:
-        // without this an expired delegation still authorizes. `None` is a
-        // deliberate opt-out (historical replay, no trusted clock).
         if let Some(now) = now {
             time_range.check(&now)?;
         }

--- a/rust/dialog-ucan-core/src/lib.rs
+++ b/rust/dialog-ucan-core/src/lib.rs
@@ -35,6 +35,9 @@ mod sealed;
 
 pub use container::delegation::DelegationChain;
 pub use container::invocation::InvocationChain;
+pub use container::revocation::{
+    Denial, MalformedRevocationChain, RevocationChain, RevocationError,
+};
 pub use container::{Container, ContainerError};
 pub use delegation::{
     Delegation,
@@ -44,6 +47,8 @@ pub use invocation::{
     CheckError, CheckFailed, Invalid, Invocation, InvocationPayload, Unavailable, VerifyError,
     builder::{BuildError as InvocationBuildError, InvocationBuilder},
 };
+pub use revocation::action::{MalformedRevocation, Revocation};
+pub use revocation::builder::RevocationBuilder;
 pub use revocation::{
     RevocationChecker, RevocationMatch, RevocationSelector, TolerateUnavailability,
     UnverifiedRevocations,

--- a/rust/dialog-ucan-core/src/revocation.rs
+++ b/rust/dialog-ucan-core/src/revocation.rs
@@ -8,6 +8,9 @@
 //! chain, so it supplies the candidate set.
 
 use crate::sync::{ConditionalSend, ConditionalSync};
+pub mod action;
+pub mod builder;
+
 use dialog_varsig::Did;
 use ipld_core::cid::Cid;
 use std::error::Error;

--- a/rust/dialog-ucan-core/src/revocation/action.rs
+++ b/rust/dialog-ucan-core/src/revocation/action.rs
@@ -1,0 +1,345 @@
+//! The `/ucan/revoke` invocation.
+//!
+//! A revocation is an ordinary [`Invocation`] whose command is
+//! `/ucan/revoke`. [`Revocation`] is a newtype that has checked its *shape*:
+//! the command, the empty nonce, and that `args.rev` and `args.pth` are the
+//! link types the schema names.
+//!
+//! Shape is all this checks. Whether the revoker was *authorized* over the
+//! delegation it names is a question about a whole container, and lives on
+//! [`RevocationChain`](crate::container::RevocationChain).
+
+use crate::{Invocation, command::Command, crypto::nonce::Nonce, promise::Promised};
+use dialog_varsig::{Did, Signature};
+use ipld_core::cid::Cid;
+use std::sync::LazyLock;
+use thiserror::Error;
+
+/// The command every revocation carries.
+pub static REVOKE: LazyLock<Command> = LazyLock::new(|| {
+    #[allow(clippy::expect_used)]
+    Command::parse("/ucan/revoke").expect("a compile-time constant command must parse")
+});
+
+/// The argument naming the delegation being revoked.
+pub const REVOKED: &str = "rev";
+
+/// The argument carrying the witness path.
+pub const PATH: &str = "pth";
+
+/// An [`Invocation`] whose shape conforms to the revocation schema.
+///
+/// ```text
+/// type RevocationAction <: Action {
+///   cmd "/ucan/revoke"
+///   nnc ""
+///   arg RevocationArguments
+/// }
+///
+/// type RevocationArguments struct {
+///   rev &Delegation
+///   pth [&Delegation]
+/// }
+/// ```
+///
+/// Constructing one proves the shape holds; it proves nothing about
+/// authority.
+#[derive(Debug, Clone)]
+pub struct Revocation<S: Signature> {
+    invocation: Invocation<S>,
+    revoked: Cid,
+    path: Vec<Cid>,
+}
+
+impl<S: Signature> Revocation<S> {
+    /// The delegation this revokes.
+    #[must_use]
+    pub const fn revoked(&self) -> &Cid {
+        &self.revoked
+    }
+
+    /// The witness path: the delegations offered as proof that the revoker
+    /// held authority over [`revoked`](Self::revoked).
+    #[must_use]
+    pub fn path(&self) -> &[Cid] {
+        &self.path
+    }
+
+    /// The principal issuing this revocation.
+    #[must_use]
+    pub const fn revoker(&self) -> &Did {
+        self.invocation.issuer()
+    }
+
+    /// The underlying invocation.
+    #[must_use]
+    pub const fn invocation(&self) -> &Invocation<S> {
+        &self.invocation
+    }
+
+    /// Consume this, returning the underlying invocation.
+    #[must_use]
+    pub fn into_invocation(self) -> Invocation<S> {
+        self.invocation
+    }
+}
+
+/// Why an invocation is not a well-formed revocation.
+///
+/// Every variant says the artifact is malformed, never that its issuer was
+/// unauthorized: authority is judged separately, and only once the shape is
+/// known to hold.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum MalformedRevocation {
+    /// The command is not `/ucan/revoke`.
+    #[error("expected command '{expected}', found '{found}'")]
+    NotARevocation {
+        /// The command a revocation must carry.
+        expected: Command,
+        /// The command this invocation carries.
+        found: Command,
+    },
+
+    /// The nonce is not empty. Revocation is idempotent, so the schema
+    /// pins `nnc` to `""`; a nonce would make two revocations of the same
+    /// delegation distinct artifacts.
+    #[error("a revocation's nonce must be empty")]
+    NonEmptyNonce,
+
+    /// A required argument is absent.
+    #[error("missing required argument '{0}'")]
+    MissingArgument(&'static str),
+
+    /// An argument is present but not the type the schema names.
+    #[error("argument '{argument}' must be {expected}")]
+    WrongArgumentType {
+        /// The offending argument.
+        argument: &'static str,
+        /// What the schema requires.
+        expected: &'static str,
+    },
+}
+
+impl<S: Signature> TryFrom<Invocation<S>> for Revocation<S> {
+    type Error = MalformedRevocation;
+
+    fn try_from(invocation: Invocation<S>) -> Result<Self, Self::Error> {
+        if invocation.command() != &*REVOKE {
+            return Err(MalformedRevocation::NotARevocation {
+                expected: REVOKE.clone(),
+                found: invocation.command().clone(),
+            });
+        }
+
+        // `nnc ""` in the schema. An empty custom nonce and a zero-length
+        // byte string are the same thing on the wire.
+        match invocation.nonce() {
+            Nonce::Custom(bytes) if bytes.is_empty() => {}
+            _ => return Err(MalformedRevocation::NonEmptyNonce),
+        }
+
+        let arguments = invocation.arguments();
+
+        let revoked = match arguments.get(REVOKED) {
+            Some(Promised::Link(cid)) => *cid,
+            Some(_) => {
+                return Err(MalformedRevocation::WrongArgumentType {
+                    argument: REVOKED,
+                    expected: "a delegation link",
+                });
+            }
+            None => return Err(MalformedRevocation::MissingArgument(REVOKED)),
+        };
+
+        // `pth` is a list of links. A single link is not a list: the schema
+        // names `[&Delegation]`, and accepting a bare link would make the
+        // one-hop case shaped differently from every other.
+        let path = match arguments.get(PATH) {
+            Some(Promised::List(items)) => items
+                .iter()
+                .map(|item| match item {
+                    Promised::Link(cid) => Ok(*cid),
+                    _ => Err(MalformedRevocation::WrongArgumentType {
+                        argument: PATH,
+                        expected: "a list of delegation links",
+                    }),
+                })
+                .collect::<Result<Vec<Cid>, _>>()?,
+            Some(_) => {
+                return Err(MalformedRevocation::WrongArgumentType {
+                    argument: PATH,
+                    expected: "a list of delegation links",
+                });
+            }
+            None => return Err(MalformedRevocation::MissingArgument(PATH)),
+        };
+
+        Ok(Self {
+            invocation,
+            revoked,
+            path,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::generate_signer;
+    use crate::{InvocationBuilder, cid::to_dagcbor_cid, revocation::builder::RevocationBuilder};
+    use dialog_varsig::{AnySignature, Principal};
+    use std::collections::BTreeMap;
+    use testresult::TestResult;
+
+    fn link() -> Cid {
+        to_dagcbor_cid(&"a delegation")
+    }
+
+    /// Build an invocation with the given command and arguments, so shape
+    /// checks can be exercised one deviation at a time.
+    async fn invocation(
+        command: Vec<String>,
+        arguments: BTreeMap<String, Promised>,
+        nonce: Nonce,
+    ) -> TestResult<Invocation<AnySignature>> {
+        let signer = generate_signer().await;
+        Ok(InvocationBuilder::new()
+            .issuer(signer.clone())
+            .audience(&signer.did())
+            .subject(&signer.did())
+            .command(command)
+            .arguments(arguments)
+            .proofs(vec![])
+            .nonce(nonce)
+            .try_build()
+            .await?)
+    }
+
+    fn well_formed_args() -> BTreeMap<String, Promised> {
+        [
+            (REVOKED.to_string(), Promised::Link(link())),
+            (
+                PATH.to_string(),
+                Promised::List(vec![Promised::Link(link())]),
+            ),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn revoke_command() -> Vec<String> {
+        REVOKE.segments().clone()
+    }
+
+    #[dialog_common::test]
+    async fn the_builder_produces_a_well_formed_revocation() -> TestResult {
+        let alice = generate_signer().await;
+        let target = link();
+
+        let revocation: Revocation<AnySignature> = RevocationBuilder::new(alice.clone(), target)
+            .witness(target)
+            .try_build()
+            .await?;
+
+        assert_eq!(revocation.revoked(), &target);
+        assert_eq!(revocation.path(), &[target]);
+        // The revoker is the subject: this artifact is about their
+        // withdrawal, not about the capability being withdrawn.
+        assert_eq!(revocation.revoker(), &alice.did());
+        assert_eq!(revocation.invocation().subject(), &alice.did());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn another_command_is_not_a_revocation() -> TestResult {
+        let other = invocation(
+            vec!["storage".to_string(), "get".to_string()],
+            well_formed_args(),
+            Nonce::Custom(Vec::new()),
+        )
+        .await?;
+
+        assert!(matches!(
+            Revocation::try_from(other),
+            Err(MalformedRevocation::NotARevocation { .. })
+        ));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_nonce_makes_it_malformed() -> TestResult {
+        // Revocation is idempotent, so the schema pins `nnc` to "". A nonce
+        // would make two revocations of the same delegation distinct.
+        let nonced =
+            invocation(revoke_command(), well_formed_args(), Nonce::generate_16()?).await?;
+
+        assert!(matches!(
+            Revocation::try_from(nonced),
+            Err(MalformedRevocation::NonEmptyNonce)
+        ));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_missing_argument_is_malformed() -> TestResult {
+        for absent in [REVOKED, PATH] {
+            let mut args = well_formed_args();
+            args.remove(absent);
+            let missing = invocation(revoke_command(), args, Nonce::Custom(Vec::new())).await?;
+
+            assert!(
+                matches!(
+                    Revocation::try_from(missing),
+                    Err(MalformedRevocation::MissingArgument(name)) if name == absent
+                ),
+                "'{absent}' is required"
+            );
+        }
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_bare_link_is_not_a_path() -> TestResult {
+        // `pth` is `[&Delegation]`. Accepting a bare link would make the
+        // one-hop case shaped differently from every other.
+        let mut args = well_formed_args();
+        args.insert(PATH.to_string(), Promised::Link(link()));
+        let wrong = invocation(revoke_command(), args, Nonce::Custom(Vec::new())).await?;
+
+        assert!(matches!(
+            Revocation::try_from(wrong),
+            Err(MalformedRevocation::WrongArgumentType { argument: PATH, .. })
+        ));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn a_non_link_argument_is_malformed() -> TestResult {
+        let mut args = well_formed_args();
+        args.insert(REVOKED.to_string(), Promised::String("not a link".into()));
+        let wrong = invocation(revoke_command(), args, Nonce::Custom(Vec::new())).await?;
+
+        assert!(matches!(
+            Revocation::try_from(wrong),
+            Err(MalformedRevocation::WrongArgumentType {
+                argument: REVOKED,
+                ..
+            })
+        ));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn an_empty_path_is_shape_valid() -> TestResult {
+        // The schema does not mark `pth` optional, but an empty list is a
+        // list. Whether it *justifies* anything is `validate`'s question,
+        // and it cannot: `rev` is not in an empty path.
+        let mut args = well_formed_args();
+        args.insert(PATH.to_string(), Promised::List(vec![]));
+        let empty = invocation(revoke_command(), args, Nonce::Custom(Vec::new())).await?;
+
+        let revocation = Revocation::try_from(empty)?;
+        assert!(revocation.path().is_empty());
+        Ok(())
+    }
+}

--- a/rust/dialog-ucan-core/src/revocation/builder.rs
+++ b/rust/dialog-ucan-core/src/revocation/builder.rs
@@ -1,0 +1,140 @@
+//! Builder for [`Revocation`].
+//!
+//! Wraps [`InvocationBuilder`] rather than re-deriving it, fixing the fields
+//! the schema pins (`cmd`, `nnc`, the shape of `args`) and leaving the caller
+//! only the choices that are actually theirs.
+
+use super::action::{PATH, REVOKE, REVOKED, Revocation};
+use crate::{
+    invocation::{Invocation, builder::BuildError},
+    issuer::Issuer,
+    promise::Promised,
+};
+use dialog_varsig::{Did, Principal, Signature};
+use ipld_core::cid::Cid;
+
+/// Builds a `/ucan/revoke` invocation.
+///
+/// The revoker is given explicitly rather than derived from the revoked
+/// delegation. Deriving it conflates two different questions — *what the
+/// capability was about* and *who is withdrawing it* — in one `sub` field.
+/// Here `sub` is the revoker, so "what" and "by whom" stay independent.
+#[derive(Debug, Clone)]
+pub struct RevocationBuilder<S: Signature, I: Issuer<S>> {
+    revoker: I,
+    revoked: Cid,
+    path: Vec<Cid>,
+    marker: std::marker::PhantomData<fn() -> S>,
+}
+
+impl<S: Signature, I: Issuer<S> + Principal> RevocationBuilder<S, I> {
+    /// Revoke `revoked`, signed by `revoker`.
+    ///
+    /// The witness path starts empty; add hops with
+    /// [`witness`](Self::witness) or [`path`](Self::path).
+    #[must_use]
+    pub fn new(revoker: I, revoked: Cid) -> Self {
+        Self {
+            revoker,
+            revoked,
+            path: Vec::new(),
+            marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Append one hop to the witness path.
+    #[must_use]
+    pub fn witness(mut self, hop: Cid) -> Self {
+        self.path.push(hop);
+        self
+    }
+
+    /// Set the whole witness path, in root-to-leaf order.
+    #[must_use]
+    pub fn path(mut self, path: Vec<Cid>) -> Self {
+        self.path = path;
+        self
+    }
+
+    /// Build and sign the revocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`BuildError`] if encoding or signing fails.
+    pub async fn try_build(self) -> Result<Revocation<S>, BuildError>
+    where
+        S: 'static,
+    {
+        let revoker_did = self.revoker.did();
+        let arguments = [
+            (REVOKED.to_string(), Promised::Link(self.revoked)),
+            (
+                PATH.to_string(),
+                Promised::List(self.path.iter().copied().map(Promised::Link).collect()),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let invocation: Invocation<S> = Invocation::builder()
+            .issuer(self.revoker)
+            // The revoker is the subject: this artifact is about *their*
+            // withdrawal, not about the capability being withdrawn.
+            .subject(&revoker_did)
+            .audience(&revoker_did)
+            .command(REVOKE.segments().clone())
+            .arguments(arguments)
+            .proofs(vec![])
+            // `nnc ""`: revocation is idempotent, so two revocations of the
+            // same delegation by the same principal are the same artifact.
+            .nonce(crate::crypto::nonce::Nonce::Custom(Vec::new()))
+            .try_build()
+            .await?;
+
+        #[allow(clippy::expect_used)]
+        Ok(Revocation::try_from(invocation)
+            .expect("a revocation this builder produced must be well-formed"))
+    }
+
+    /// Build with an explicit proof chain authorizing the revoker to invoke.
+    ///
+    /// Distinct from the witness path: `prf` answers "may this principal
+    /// invoke at all", `pth` answers "why may they revoke *this*".
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`BuildError`] if encoding or signing fails.
+    pub async fn try_build_with_proofs(
+        self,
+        proofs: Vec<Cid>,
+        subject: &Did,
+    ) -> Result<Revocation<S>, BuildError>
+    where
+        S: 'static,
+    {
+        let arguments = [
+            (REVOKED.to_string(), Promised::Link(self.revoked)),
+            (
+                PATH.to_string(),
+                Promised::List(self.path.iter().copied().map(Promised::Link).collect()),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let invocation: Invocation<S> = Invocation::builder()
+            .issuer(self.revoker)
+            .subject(subject)
+            .audience(subject)
+            .command(REVOKE.segments().clone())
+            .arguments(arguments)
+            .proofs(proofs)
+            .nonce(crate::crypto::nonce::Nonce::Custom(Vec::new()))
+            .try_build()
+            .await?;
+
+        #[allow(clippy::expect_used)]
+        Ok(Revocation::try_from(invocation)
+            .expect("a revocation this builder produced must be well-formed"))
+    }
+}


### PR DESCRIPTION
## What

Adds `/ucan/revoke`: the artifact type, a builder, and validation of the witness path.

Stacked on #457, which supplied the verification context and `RevocationChecker`.

## The division of labour

`InvocationChain::verify` already establishes that an invocation is a valid invocation — signature, `prf` chain, time bounds, and that no `prf` hop is revoked. All command-agnostic. For a revocation that means exactly one thing: *whoever signed this was authorized to issue an invocation with `sub` as its subject*. Nothing about `rev` or `pth`, which are opaque arguments to it.

This PR adds only what is specific to the command, and deliberately re-derives none of the above. Hand-rolled reimplementations of the generic path are where holes come from.

**`prf` and `pth` answer different questions** and can rest on different grants:
- `prf` — may this principal invoke `/ucan/revoke` at all?
- `pth` — why is this principal authorized to revoke *this particular* delegation?

## Shape

Per `revocation.ipldsch` (the prose README is stale — it still says `do`, `ucan/revoke` without the leading slash, and `revoke`/`path`):

```
type RevocationAction <: Action { cmd "/ucan/revoke"  nnc ""  arg RevocationArguments }
type RevocationArguments struct { rev &Delegation  pth [&Delegation] }
```

`Revocation<S>` + `TryFrom<Invocation<S>>` checks exactly that. Every failure is `MalformedRevocation` — malformed input, never "unauthorized"; authority is a separate question asked only once the shape holds.

A bare link is deliberately *not* accepted as a path: `pth` is `[&Delegation]`, and special-casing one hop invites a later bug. An empty `pth` is shape-valid (an empty list is a list); whether it justifies anything is `validate`'s question.

## `RevocationBuilder`: the revoker is the subject

Deriving `sub` from the revoked delegation's subject conflates *what the capability was about* with *who is withdrawing it*. The builder takes the revoker explicitly, keeping those independent.

## Validation

### Four cases need no evidence at all

`pth` is neither required nor examined when the revoker is the target's **audience** (declining your own grant), its **issuer** (withdrawing what you issued), or its **subject** (it's your capability) — or when the target is a **powerline**, since its holder can mint a delegation for any subject and no witness could prove anything a forger couldn't manufacture.

### Otherwise `pth` must witness that the revoker *held* the capability

`pth` is a **pool, not an ordered chain** — carrying more than is relevant is not an error. The relevant subchain is the walk from a hop issued by the target's subject, following audience-to-issuer links, until a hop delegates to the revoker.

**The evidence proves possession, not a path to the target.** Whether a chain runs from the revoker down to the revoked delegation is irrelevant: holding the capability, they could always have created one, so its absence proves nothing. This is why the walk ends at the revoker.

It follows that a holder may revoke a hop it descends from — cutting off its own authority in the process, which is its to do.

Over that walk: it must reach the revoker from the subject; it must align and be valid at the judged instant; and every hop must carry a real signature from its claimed issuer. A powerline hop within the walk stands in wherever a hop for the subject would.

### Reuse, not reimplementation

Linkage, rooting, and time are pure chain properties that need no invocation, but were entangled inside `syntactic_checks` with the two that do (attenuation against `self.command`, policy over `args`).

They are now `delegation::chain::check_chain`, called by both, so a witness path cannot drift from a proof chain. The 253 pre-existing tests passing unchanged is the check on that extraction.

### Why `pth` hops are not screened for revocation

Considered and rejected. Revocation is monotonic: if a grant cited in `pth` was itself revoked, everything downstream of it is already dead, so a revocation citing it is redundant rather than dangerous. The case that *does* matter is already covered — a revoked grant in `prf` makes `verify` refuse the invocation before `validate` ever runs.

## Errors

Three findings, because callers act on them differently:

```rust
pub enum RevocationError<K, S, C> {
    Invalid(Box<CheckError<K, S, C>>),  // not a valid invocation at all
    Denied(Denial),                     // valid invocation, evidence insufficient
    Unavailable { did, detail },        // could not establish either
}
```

`Invalid` wraps the structured `CheckError` rather than rendering it, so a caller can match on *which* way the invocation failed. Boxed because it is much larger than the other variants and would otherwise widen every `Result` on the happy path.

`RevocationChain::verify` runs both halves: `InvocationChain::verify` first, then `validate`. Separately, `MalformedRevocationChain` says the artifact could not be *read*.

## Tests

278 total. New coverage, positive and negative:

**No evidence required** — audience, issuer, subject, powerline; and a powerline target's path is *not even examined* (garbage evidence passes).

**Evidence accepted** — intermediary with a valid path; extra hops outside the walk ignored; a powerline hop rooting the walk; evidence need not reach the target; a holder revoking a hop it descends from.

**Evidence denied** — empty path; path not rooted at the subject; stranger absent from the path; expired hop; forged hop signature.

**Error taxonomy** — an invalid invocation is distinguishable from a denial; the end-to-end positive case.

Plus `delegation::chain`: empty chain, linked chain, broken link, wrong root, expired hop.

## Notes

- `Denial::NoEvidenceOfPossession` currently covers three situations (no evidence, evidence rooted elsewhere, walk that doesn't reach the revoker). All genuinely "the evidence doesn't show possession", but splitting them would help someone debugging a rejection.
- **Delegated revocation is not handled.** The spec mentions revocations that are themselves delegated; here the revoker must hold the capability directly.
