### PR TITLE
feat(ucan): let a refusal say which question the chain failed

### DIFF
--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -60,7 +60,9 @@ use dialog_capability::{Capability, Constraint, Did, Policy};
 use dialog_did_web::{CachingResolver, PerformingResolver, Resolve, WebResolver};
 use dialog_effects::{archive, blob, memory};
 use dialog_remote_s3::{Address, Permit, S3Credential, S3Error};
+use dialog_ucan_core::invocation::CheckFailed;
 use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::time::TimeBoundError;
 use dialog_ucan_core::{Environment, InvocationChain, VerificationContext};
 use ipld_core::ipld::Ipld;
 use serde::de::DeserializeOwned;
@@ -246,6 +248,63 @@ macro_rules! dispatch {
     };
 }
 
+/// Name the access decision a chain check reached.
+///
+/// Every arm of [`CheckFailed`] has a counterpart in [`AuthorizeError`] —
+/// the variants were written to mirror each other — so this loses
+/// nothing. Only the two cases that are about a promise or an
+/// impossible window have no access-decision counterpart, and they stay
+/// descriptive.
+fn check_failed_to_authorize_error(reason: CheckFailed) -> AuthorizeError {
+    match reason {
+        CheckFailed::UnauthorizedSubject {
+            claimed,
+            authorized,
+        }
+        | CheckFailed::DelegationAudienceMismatch {
+            claimed,
+            authorized,
+        } => AuthorizeError::InvalidAudience {
+            claimed,
+            authorized,
+        },
+        CheckFailed::UnprovenSubject { subject, issuer } => AuthorizeError::UnprovenSubject {
+            claimed: issuer,
+            authorized: subject,
+        },
+        CheckFailed::CommandEscalation {
+            claimed,
+            authorized,
+        } => AuthorizeError::CommandEscalation {
+            claimed: claimed.to_string(),
+            authorized: authorized.to_string(),
+        },
+        CheckFailed::PolicyViolation(predicate) => AuthorizeError::PolicyViolation {
+            predicate: format!("{predicate:?}"),
+        },
+        CheckFailed::TimeBound(TimeBoundError::Expired { expiration, at }) => {
+            AuthorizeError::Expired {
+                expiration: expiration.to_unix(),
+                at: at.to_unix(),
+            }
+        }
+        CheckFailed::TimeBound(TimeBoundError::NotYetValid { not_before, at }) => {
+            AuthorizeError::NotValidBefore {
+                not_before: not_before.to_unix(),
+                at: at.to_unix(),
+            }
+        }
+        // A window no instant satisfies is a defect in the chain itself
+        // rather than a clock verdict, so it is not `Expired`: no fresh
+        // proof at any time would help.
+        other @ (CheckFailed::InvalidTimeWindow { .. }
+        | CheckFailed::PolicyIncompatibility(_)
+        | CheckFailed::WaitingOnPromise(_)) => AuthorizeError::Malformed {
+            detail: other.to_string(),
+        },
+    }
+}
+
 /// The resolution policy an authorizer uses unless told otherwise:
 /// `did:key` locally, `did:web` over the network, cached.
 ///
@@ -419,6 +478,12 @@ where
                 ContainerError::Revoked { .. } => AuthorizeError::Revoked {
                     subject: chain.subject().clone(),
                 },
+                // The chain was read and judged, so the refusal can say
+                // which question it failed. `Malformed` is reserved for
+                // input we could not read at all, and answering an
+                // expired proof with it would tell a caller to fix its
+                // encoding when it needs to fetch a fresh delegation.
+                ContainerError::Unauthorized(reason) => check_failed_to_authorize_error(reason),
                 ContainerError::Invocation(detail) => AuthorizeError::Malformed {
                     detail: format!("invocation chain did not verify: {detail}"),
                 },
@@ -986,6 +1051,232 @@ mod tests {
             ),
             "expected a revocation refusal, got: {error:?}"
         );
+    }
+
+    /// Asking beyond what a delegation grants is named as escalation.
+    ///
+    /// The grant covers `archive`, the invocation asks for `blob/put`.
+    /// That is a decision about authority, and it must be tellable from
+    /// unreadable input: the fix is a wider delegation, not a re-encoded
+    /// request.
+    #[dialog_common::test]
+    async fn it_names_a_command_escalation_as_escalation() {
+        let subject = test_signer().await;
+        let operator = Ed25519Signer::generate().await.expect("operator key");
+
+        let delegation = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&operator.did())
+            .subject(DelegatedSubject::Specific(subject.did()))
+            .command(vec!["archive".to_string()])
+            .try_build()
+            .await
+            .expect("delegation");
+        let cid = delegation.to_cid();
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert(
+            "digest".to_string(),
+            Promised::Bytes(Blake3Hash::hash(b"test").as_bytes().to_vec()),
+        );
+        let invocation = InvocationBuilder::new()
+            .issuer(operator.clone())
+            .audience(&subject.did())
+            .subject(&subject.did())
+            .command(vec!["blob".to_string(), "put".to_string()])
+            .arguments(args)
+            .proofs(vec![cid])
+            .try_build()
+            .await
+            .expect("invocation");
+
+        let mut delegations = std::collections::HashMap::new();
+        delegations.insert(cid, std::sync::Arc::new(delegation));
+        let container = InvocationChain::new(invocation, delegations)
+            .to_bytes()
+            .expect("container");
+
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let error = UcanAuthorizer::new(address, Some(S3Credential::new("key", "secret")))
+            .authorize(&container)
+            .await
+            .expect_err("asking beyond the grant must refuse the chain");
+
+        match error {
+            S3Error::Authorization(
+                dialog_capability::access::AuthorizeError::CommandEscalation {
+                    claimed,
+                    authorized,
+                },
+            ) => {
+                assert!(
+                    claimed.contains("blob"),
+                    "the refusal must name what was asked for, got: {claimed}"
+                );
+                assert!(
+                    authorized.contains("archive"),
+                    "and what was actually granted, got: {authorized}"
+                );
+            }
+            other => panic!("expected an escalation refusal, got: {other:?}"),
+        }
+    }
+
+    /// A proof issued to somebody else names both principals.
+    ///
+    /// The delegation is addressed to a third party, so the operator
+    /// presenting it was never its audience. Both DIDs survive the trip
+    /// to the boundary, which is the point: a caller can say whose proof
+    /// this was and who tried to use it, rather than reporting that
+    /// something unspecified did not line up.
+    #[dialog_common::test]
+    async fn it_names_both_principals_when_a_proof_was_issued_to_someone_else() {
+        let subject = test_signer().await;
+        let operator = Ed25519Signer::generate().await.expect("operator key");
+        let stranger = Ed25519Signer::generate().await.expect("stranger key");
+
+        let delegation = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&stranger.did())
+            .subject(DelegatedSubject::Specific(subject.did()))
+            .command(vec!["archive".to_string()])
+            .try_build()
+            .await
+            .expect("delegation");
+        let cid = delegation.to_cid();
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert(
+            "digest".to_string(),
+            Promised::Bytes(Blake3Hash::hash(b"test").as_bytes().to_vec()),
+        );
+        // The operator presents a proof addressed to the stranger.
+        let invocation = InvocationBuilder::new()
+            .issuer(operator.clone())
+            .audience(&subject.did())
+            .subject(&subject.did())
+            .command(vec!["archive".to_string(), "get".to_string()])
+            .arguments(args)
+            .proofs(vec![cid])
+            .try_build()
+            .await
+            .expect("invocation");
+
+        let mut delegations = std::collections::HashMap::new();
+        delegations.insert(cid, std::sync::Arc::new(delegation));
+        let container = InvocationChain::new(invocation, delegations)
+            .to_bytes()
+            .expect("container");
+
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let error = UcanAuthorizer::new(address, Some(S3Credential::new("key", "secret")))
+            .authorize(&container)
+            .await
+            .expect_err("a proof issued to someone else must refuse the chain");
+
+        match error {
+            S3Error::Authorization(
+                dialog_capability::access::AuthorizeError::InvalidAudience {
+                    claimed,
+                    authorized,
+                },
+            ) => {
+                assert_eq!(claimed, operator.did(), "the principal that presented it");
+                assert_eq!(authorized, stranger.did(), "the principal it was issued to");
+            }
+            other => panic!("expected an audience refusal, got: {other:?}"),
+        }
+    }
+
+    /// An expired proof is refused as expired, not as malformed input.
+    ///
+    /// The chain walk judges the window and knows exactly which bound
+    /// failed and when. That verdict used to reach the boundary as
+    /// rendered prose and land in `Malformed`, so a caller answering its
+    /// own clients could only say the request was unreadable — telling
+    /// the holder of a lapsed delegation to fix its encoding, when what
+    /// it needs is a fresh proof.
+    #[dialog_common::test]
+    async fn it_names_an_expired_proof_as_expired() {
+        use dialog_ucan_core::time::Timestamp;
+
+        let subject = test_signer().await;
+        let operator = Ed25519Signer::generate().await.expect("operator key");
+
+        let expired_at =
+            Timestamp::new(std::time::SystemTime::now() - std::time::Duration::from_secs(3_600))
+                .expect("a representable timestamp");
+        let delegation = DelegationBuilder::new()
+            .issuer(subject.clone())
+            .audience(&operator.did())
+            .subject(DelegatedSubject::Specific(subject.did()))
+            .command(vec!["archive".to_string()])
+            .expiration(expired_at)
+            .try_build()
+            .await
+            .expect("delegation");
+        let cid = delegation.to_cid();
+
+        let mut args = BTreeMap::new();
+        args.insert("catalog".to_string(), Promised::String("blobs".to_string()));
+        args.insert(
+            "digest".to_string(),
+            Promised::Bytes(Blake3Hash::hash(b"test").as_bytes().to_vec()),
+        );
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator.clone())
+            .audience(&subject.did())
+            .subject(&subject.did())
+            .command(vec!["archive".to_string(), "get".to_string()])
+            .arguments(args)
+            .proofs(vec![cid])
+            .try_build()
+            .await
+            .expect("invocation");
+
+        let mut delegations = std::collections::HashMap::new();
+        delegations.insert(cid, std::sync::Arc::new(delegation));
+        let container = InvocationChain::new(invocation, delegations)
+            .to_bytes()
+            .expect("container");
+
+        let address = Address::builder("https://s3.us-east-1.amazonaws.com")
+            .region("us-east-1")
+            .bucket("test-bucket")
+            .build()
+            .unwrap();
+        let authorizer =
+            UcanAuthorizer::new(address, Some(S3Credential::new("access-key-id", "secret")));
+
+        let error = authorizer
+            .authorize(&container)
+            .await
+            .expect_err("an expired proof must refuse the chain");
+        match error {
+            S3Error::Authorization(dialog_capability::access::AuthorizeError::Expired {
+                expiration,
+                at,
+            }) => {
+                assert_eq!(
+                    expiration,
+                    expired_at.to_unix(),
+                    "the refusal must name the bound that lapsed"
+                );
+                assert!(at >= expiration, "and the instant it was judged at");
+            }
+            other => panic!("expected an expiry refusal, got: {other:?}"),
+        }
     }
 
     /// locally without touching the (mocked) did:web fetcher. This proves the

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -1208,14 +1208,16 @@ mod tests {
     /// it needs is a fresh proof.
     #[dialog_common::test]
     async fn it_names_an_expired_proof_as_expired() {
-        use dialog_ucan_core::time::Timestamp;
+        // The crate's own re-exports, not `std::time`: on wasm a
+        // `Timestamp` wraps `web_time::SystemTime`, so std values do not
+        // convert.
+        use dialog_ucan_core::time::{Duration, SystemTime, Timestamp};
 
         let subject = test_signer().await;
         let operator = Ed25519Signer::generate().await.expect("operator key");
 
-        let expired_at =
-            Timestamp::new(std::time::SystemTime::now() - std::time::Duration::from_secs(3_600))
-                .expect("a representable timestamp");
+        let expired_at = Timestamp::new(SystemTime::now() - Duration::from_secs(3_600))
+            .expect("a representable timestamp");
         let delegation = DelegationBuilder::new()
             .issuer(subject.clone())
             .audience(&operator.did())

--- a/rust/dialog-ucan-core/src/container.rs
+++ b/rust/dialog-ucan-core/src/container.rs
@@ -60,6 +60,17 @@ pub enum ContainerError {
         revoker: Did,
     },
 
+    /// The chain does not authorize the invocation: a link's audience,
+    /// subject, command, policy, or validity window did not hold up.
+    ///
+    /// Carries the [`CheckFailed`] itself rather than its rendered text,
+    /// so a caller answering this to its own clients can distinguish an
+    /// expired proof from a forged chain and say which. Rendering it
+    /// early would leave every one of these looking like malformed
+    /// input.
+    #[error(transparent)]
+    Unauthorized(#[from] crate::invocation::CheckFailed),
+
     /// Invalid configuration.
     #[error("Configuration error: {0}")]
     Configuration(String),

--- a/rust/dialog-ucan-core/src/container/check_failed.rs
+++ b/rust/dialog-ucan-core/src/container/check_failed.rs
@@ -6,47 +6,11 @@ use super::ContainerError;
 use crate::invocation::CheckFailed;
 
 /// Convert a `CheckFailed` error to a `ContainerError`.
+///
+/// The decision travels whole. Each of these is a statement about the
+/// caller's material — which link, and how it failed — and a caller
+/// answering it to its own clients needs that to stay readable rather
+/// than arriving as prose it would have to parse.
 pub fn check_failed_to_container_error(err: CheckFailed) -> ContainerError {
-    match err {
-        CheckFailed::DelegationAudienceMismatch {
-            claimed,
-            authorized,
-        } => ContainerError::Invocation(format!(
-            "invalid proof issuer chain: claimed {} authorized {}",
-            claimed, authorized
-        )),
-        CheckFailed::UnauthorizedSubject {
-            claimed,
-            authorized,
-        } => ContainerError::Invocation(format!(
-            "subject not allowed by proof: claimed {} authorized {}",
-            claimed, authorized
-        )),
-        CheckFailed::UnprovenSubject { subject, issuer } => ContainerError::Invocation(format!(
-            "root proof issuer is not the subject: subject {} issuer {}",
-            subject, issuer
-        )),
-        CheckFailed::CommandEscalation {
-            claimed,
-            authorized,
-        } => ContainerError::Invocation(format!(
-            "command mismatch: expected {:?}, found {:?}",
-            authorized, claimed
-        )),
-        CheckFailed::PolicyViolation(predicate) => {
-            ContainerError::Invocation(format!("predicate failed: {:?}", predicate))
-        }
-        CheckFailed::PolicyIncompatibility(run_err) => {
-            ContainerError::Invocation(format!("predicate run error: {}", run_err))
-        }
-        CheckFailed::WaitingOnPromise(waiting) => {
-            ContainerError::Invocation(format!("waiting on promise: {:?}", waiting))
-        }
-        CheckFailed::InvalidTimeWindow { range } => {
-            ContainerError::Invocation(format!("invalid time window: {:?}", range))
-        }
-        CheckFailed::TimeBound(err) => {
-            ContainerError::Invocation(format!("time bound error: {:?}", err))
-        }
-    }
+    ContainerError::Unauthorized(err)
 }

--- a/rust/dialog-ucan-core/src/time/error.rs
+++ b/rust/dialog-ucan-core/src/time/error.rs
@@ -1,6 +1,6 @@
 //! Temporal errors.
 
-use super::timestamp::SystemTime;
+use super::timestamp::{SystemTime, Timestamp};
 use thiserror::Error;
 
 /// An error expressing when a time is larger than 2⁵³ seconds past the Unix epoch
@@ -24,15 +24,30 @@ pub enum NumberIsNotATimestamp {
 }
 
 /// An error expressing when a time is not within the bounds of a UCAN.
+///
+/// Each variant carries the bound it failed against and the instant it
+/// was judged at. A caller answering this to its own clients needs both:
+/// "expired" alone cannot say when, so it cannot be reported as anything
+/// more useful than a generic refusal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Error)]
 pub enum TimeBoundError {
     /// The UCAN has expired.
-    #[error("Expired")]
-    Expired,
+    #[error("Expired at {}, checked at {}", expiration.to_unix(), at.to_unix())]
+    Expired {
+        /// The bound that had already passed.
+        expiration: Timestamp,
+        /// The instant the check was made at.
+        at: Timestamp,
+    },
 
     /// The UCAN is not yet valid, but will be in the future.
-    #[error("Not yet valid")]
-    NotYetValid,
+    #[error("Not valid before {}, checked at {}", not_before.to_unix(), at.to_unix())]
+    NotYetValid {
+        /// The bound that has not been reached yet.
+        not_before: Timestamp,
+        /// The instant the check was made at.
+        at: Timestamp,
+    },
 }
 
 /// The UCAN has expired.

--- a/rust/dialog-ucan-core/src/time/range.rs
+++ b/rust/dialog-ucan-core/src/time/range.rs
@@ -63,14 +63,22 @@ impl TimeRange {
     /// * [`TimeBoundError::Expired`] — if `time` is past the expiration bound
     /// * [`TimeBoundError::NotYetValid`] — if `time` is before the not-before bound
     pub fn check(&self, time: &Timestamp) -> Result<(), TimeBoundError> {
+        let expired = |expiration| TimeBoundError::Expired {
+            expiration,
+            at: *time,
+        };
         match self.expiration {
-            Bound::Included(exp) if *time > exp => return Err(TimeBoundError::Expired),
-            Bound::Excluded(exp) if *time >= exp => return Err(TimeBoundError::Expired),
+            Bound::Included(exp) if *time > exp => return Err(expired(exp)),
+            Bound::Excluded(exp) if *time >= exp => return Err(expired(exp)),
             _ => {}
         }
+        let early = |not_before| TimeBoundError::NotYetValid {
+            not_before,
+            at: *time,
+        };
         match self.not_before {
-            Bound::Included(nbf) if *time < nbf => return Err(TimeBoundError::NotYetValid),
-            Bound::Excluded(nbf) if *time <= nbf => return Err(TimeBoundError::NotYetValid),
+            Bound::Included(nbf) if *time < nbf => return Err(early(nbf)),
+            Bound::Excluded(nbf) if *time <= nbf => return Err(early(nbf)),
             _ => {}
         }
         Ok(())


### PR DESCRIPTION
Stacked on #460 — both touch the `ContainerError` match in `authorize`, so they would conflict if opened side by side. Review #460 first; this one retargets to `main` once that lands.

`AuthorizeError` was written to mirror `CheckFailed` variant for variant — its doc comments say so, arm by arm ("Mirrors `CheckFailed::UnprovenSubject`", "Mirrors the `Expired` side of `CheckFailed::TimeBound`"). Nothing ever populated the mirror. `check_failed_to_container_error` rendered every typed reason into `ContainerError::Invocation(String)`, and the authorize boundary then mapped that whole class to `Malformed`.

The consequence is that a caller acting on these variants could not: an expired proof, a proof issued to somebody else, and a command escalation all arrived as "your bytes did not decode". A holder of a lapsed delegation was being told to fix its encoding when what it needed was a fresh proof. `notes/error-audit.md` flagged exactly this — that the client-side matching (`Expired` means refresh, `Revoked` means stop) "cannot fire for real verification failures" — and called the fix out as follow-up scope.

So the decision now travels whole. `ContainerError::Unauthorized` carries the `CheckFailed`, and the boundary names it. `TimeBoundError` grows the bound it failed against and the instant it was judged at, which `Expired { expiration, at }` and `NotValidBefore { not_before, at }` need and previously had no way to obtain — the old variants were unit-like and knew only *that* a bound failed.

Two cases stay descriptive on purpose: a window no instant satisfies is a defect in the chain rather than a clock verdict (no fresh proof at any time would help), and a pending promise is not an access decision.

Three tests pin the variants that were unreachable, each asserting the refusal names its particulars — the lapsed bound, the two principals by identity, both commands. All three fail if the mapping goes back to stringly `Malformed`.