### PR TITLE
fix: choose delegation chains that are valid now

### DIFF
--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -38,6 +38,7 @@ use dialog_capability::access::{
     Retain, Scope as _, TimeRange,
 };
 use dialog_capability::{Capability, Command, Did, Fork, Policy as _, Provider, Subject};
+use dialog_common::time::{self, UNIX_EPOCH};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify};
@@ -50,6 +51,18 @@ use dialog_ucan_core::subject::Subject as UcanSubject;
 use std::collections::HashMap;
 
 use dialog_artifacts::history::Version;
+
+/// The current moment in unix seconds, the unit delegation bounds use.
+///
+/// A clock behind the epoch cannot happen on a machine that can verify a
+/// signature; falling back to zero keeps the caller total, and nothing is
+/// lapsed relative to zero.
+fn now_s() -> u64 {
+    time::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_secs())
+        .unwrap_or_default()
+}
 
 /// Resolved chains, valid for one branch head version.
 #[derive(Default)]
@@ -221,8 +234,8 @@ impl<S: Clone> Operator<S> {
 
     /// Serve a claim from the cache: the chain resolved for this key at
     /// the current epoch, re-verified against the claim's access and
-    /// duration. `None` on a miss or when the cached chain rejects this
-    /// particular claim.
+    /// duration, and still unlapsed. `None` on a miss or when the cached
+    /// chain rejects this particular claim.
     fn cached(&self, key: &(Did, Did, String), claim: &Prove<Ucan>) -> Option<UcanProof> {
         let branch = self.delegations.get()?;
         let epoch = branch.revision().map(|revision| revision.version());
@@ -238,6 +251,24 @@ impl<S: Clone> Operator<S> {
             effective = effective.intersect(&range);
         }
         if !effective.covers(&claim.duration) {
+            return None;
+        }
+        // The duration above is what the caller NEEDS, which for most
+        // read paths is nothing at all -- and an unbounded requirement is
+        // met by a window that closed hours ago. A memo, unlike a
+        // certificate, has no other reader to catch that: it is replayed
+        // for every claim on this key until the access branch head moves,
+        // so an entry that lapses mid-epoch would be served long past its
+        // end. Retiring it sends the claim back to the walk, which can
+        // still find a live route the memo has outlived.
+        //
+        // Only the lapsed end. An entry that has not STARTED yet may
+        // legitimately answer a claim for the window in which it does,
+        // and `covers` above already judged that.
+        if effective
+            .expiration
+            .is_some_and(|expiration| expiration < now_s())
+        {
             return None;
         }
 
@@ -690,6 +721,71 @@ mod tests {
             expiration: Some(now + 7200),
         };
         assert!(operator.resolve(widened).await.is_err());
+        Ok(())
+    }
+
+    /// A claim naming an instant resolves a route that is good then,
+    /// even when a lapsed one to the same subject is retained beside it.
+    ///
+    /// Both grants are admissible on everything but the clock, and
+    /// candidate order follows content hashes, so without the time bound
+    /// the walk picks between them arbitrarily -- and half the time
+    /// presents authority that stopped being valid an hour ago.
+    #[dialog_common::test]
+    async fn it_resolves_the_live_route_when_a_lapsed_one_sits_beside_it() -> Result<()> {
+        let (operator, _profile) = operator("lapsed-beside-live").await;
+        let space = Ed25519Signer::generate().await?;
+        let holder = Ed25519Signer::generate().await?;
+        let now = now_s();
+        let lapsed = Timestamp::try_from((now - 3600) as i128).unwrap();
+        let live = Timestamp::try_from((now + 3600) as i128).unwrap();
+        retain_grant(&operator, &space, &holder, Some(lapsed)).await;
+        retain_grant(&operator, &space, &holder, Some(live)).await;
+
+        let mut at_now = claim(&holder, &space);
+        at_now.duration = TimeRange {
+            not_before: Some(now),
+            expiration: Some(now),
+        };
+        let proof = operator.resolve(at_now).await?;
+
+        assert_eq!(
+            proof.duration().expiration,
+            Some(now + 3600),
+            "the walk presented the lapsed grant although a live one was retained",
+        );
+        Ok(())
+    }
+
+    /// A memo lapses with the chain it holds.
+    ///
+    /// The duration a claim carries is what the caller NEEDS, and the
+    /// read paths need nothing in particular -- an unbounded requirement
+    /// is met by a window that closed an hour ago. A certificate has the
+    /// walk to re-judge it; a memo has no other reader, and would be
+    /// replayed for every claim on its key until the branch head next
+    /// moved.
+    #[dialog_common::test]
+    async fn it_retires_a_memo_whose_chain_has_lapsed() -> Result<()> {
+        let (operator, _profile) = operator("cache-lapsed").await;
+        let space = Ed25519Signer::generate().await?;
+        let holder = Ed25519Signer::generate().await?;
+        let now = now_s();
+        let lapsed = Timestamp::try_from((now - 60) as i128).unwrap();
+        retain_grant(&operator, &space, &holder, Some(lapsed)).await;
+
+        // The walk itself has no clock, so an unbounded claim resolves
+        // the lapsed grant and records it: exactly the entry that must
+        // not then be served back.
+        operator.resolve(claim(&holder, &space)).await?;
+        assert_eq!(operator.cached_chains(), 1, "the walk's chain is recorded");
+
+        let key = Operator::<VolatileSpace>::cache_key(&claim(&holder, &space))
+            .expect("a specific subject and a distinct holder are cacheable");
+        assert!(
+            operator.cached(&key, &claim(&holder, &space)).is_none(),
+            "a memo holding a lapsed chain answered an unbounded claim",
+        );
         Ok(())
     }
 

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -4,12 +4,13 @@ use std::sync::Arc;
 
 use dialog_capability::access::{
     Access, Authorization as _, Authorize as AuthorizeEffect, AuthorizeError, FromCapability,
-    Protocol,
+    Protocol, TimeRange,
 };
 use dialog_capability::{
     Ability, Capability, Constraint, Effect, Fork, ForkInvocation, Provider, Site, SiteAddress,
     SiteFork, SiteId, Subject,
 };
+use dialog_common::time::{self, UNIX_EPOCH};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::Rejection;
 use dialog_effects::authority::{self, OperatorExt};
@@ -161,15 +162,49 @@ where
 
         let scope = <Ucan as Protocol>::Access::from_capability(self.0.capability());
 
+        // Ask for a chain that is good NOW, not merely for one that
+        // exists. The proof walk has no clock of its own: it filters
+        // candidates by whether their window covers the REQUESTED one,
+        // and an unbounded request is covered by every window, including
+        // one that closed yesterday. Leaving this unbounded is what let a
+        // lapsed certificate retained beside a live route be picked --
+        // arbitrarily, since candidate order follows content hashes --
+        // and then presented to a responder that does check the clock,
+        // which answers `Expired` for authority the holder still has.
+        //
+        // The requirement is the instant of presentation rather than a
+        // window reaching into the future: `covers` is inclusive, so this
+        // admits exactly what a responder checking `now` admits, and asks
+        // for no more lifetime than the request itself needs. It does not
+        // bound the resulting authorization -- the proof still reports
+        // the window its certificates agree on.
+        let at = now_s();
         let authorization = Subject::from(profile)
             .attenuate(Access)
-            .invoke(AuthorizeEffect::<Ucan>::new(operator, scope))
+            .invoke(
+                AuthorizeEffect::<Ucan>::new(operator, scope).during(TimeRange {
+                    not_before: Some(at),
+                    expiration: Some(at),
+                }),
+            )
             .perform(env)
             .await?;
 
         let invocation = authorization.invoke().await?;
         Ok(self.0.attest(UcanAuthorization::from(invocation)))
     }
+}
+
+/// The current moment in unix seconds, the unit delegation bounds use.
+///
+/// A clock this far behind the epoch cannot happen on a machine that can
+/// verify a signature; falling back to zero keeps the caller total, and a
+/// zero requirement is one every unexpired certificate meets.
+fn now_s() -> u64 {
+    time::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_secs())
+        .unwrap_or_default()
 }
 
 /// UCAN site configuration for delegated authorization.
@@ -204,6 +239,7 @@ mod tests {
 
     use super::*;
     use dialog_capability::did;
+    use dialog_effects::archive::prelude::*;
 
     #[cfg(not(target_arch = "wasm32"))]
     use std::collections::{BTreeMap, HashMap};
@@ -222,6 +258,87 @@ mod tests {
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
     #[cfg(not(target_arch = "wasm32"))]
     use tokio::net::TcpListener;
+
+    /// An env that answers `Identify` and records what window the fork
+    /// asked its authority to cover, refusing the claim afterwards --
+    /// the request is the whole subject here, not what comes back.
+    struct RecordingEnv {
+        profile: dialog_capability::Did,
+        operator: dialog_capability::Did,
+        asked: std::sync::Mutex<Option<TimeRange>>,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl Provider<authority::Identify> for RecordingEnv {
+        async fn execute(
+            &self,
+            _input: authority::Identify,
+        ) -> Result<Capability<authority::Operator>, dialog_effects::authority::AuthorityError>
+        {
+            Ok(Subject::from(self.profile.clone())
+                .attenuate(authority::Profile::local(self.profile.clone()))
+                .attenuate(authority::Operator::new(self.operator.clone())))
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl Provider<AuthorizeEffect<Ucan>> for RecordingEnv {
+        async fn execute(
+            &self,
+            input: Capability<AuthorizeEffect<Ucan>>,
+        ) -> Result<<Ucan as Protocol>::Authorization, AuthorizeError> {
+            *self.asked.lock().expect("uncontended") = Some(input.into_effect().duration);
+            Err(AuthorizeError::Unavailable {
+                detail: "recorded".to_string(),
+            })
+        }
+    }
+
+    /// The presign path asks for authority that is good NOW.
+    ///
+    /// The proof walk has no clock: it admits any certificate whose
+    /// window covers the REQUESTED one, and an unbounded request is
+    /// covered by a window that closed yesterday. Leaving this unbounded
+    /// is what let a lapsed certificate retained beside a live route be
+    /// picked and presented to a responder that does check the clock.
+    #[dialog_common::test]
+    async fn it_asks_for_authority_that_is_good_at_the_moment_it_presents() {
+        let profile = did!("key:z6MkrCD1csqtgdj8sRHYRPGLYcMFXAoDhkgvHNq2FML2xqCX");
+        let operator = did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+        let env = RecordingEnv {
+            profile: profile.clone(),
+            operator,
+            asked: std::sync::Mutex::new(None),
+        };
+
+        let before = now_s();
+        let fork = Subject::from(profile)
+            .archive()
+            .catalog("data")
+            .get(dialog_common::Blake3Hash::hash(b"block"))
+            .fork(&UcanAddress::new("https://access.test/ucan/"));
+        let _ = UcanFork::from(fork).authorize(&env).await;
+        let after = now_s();
+
+        let asked = env
+            .asked
+            .lock()
+            .expect("uncontended")
+            .expect("the fork claimed authority");
+        let (Some(not_before), Some(expiration)) = (asked.not_before, asked.expiration) else {
+            panic!("the fork asked for an unbounded window: {asked:?}");
+        };
+        assert_eq!(
+            not_before, expiration,
+            "the requirement is the instant of presentation, not a window",
+        );
+        assert!(
+            (before..=after).contains(&not_before),
+            "the fork asked about {not_before}, which is not now ({before}..={after})",
+        );
+    }
 
     // The reason travels as itself, so what this pins is the round
     // trip: whatever the responder built arrives as the same value.


### PR DESCRIPTION
The proof walk has no clock. It filters candidates by whether their
window covers the *requested* one, and the presign path requested
nothing — an unbounded requirement that every window satisfies,
including one that closed yesterday.

That is invisible while a subject has one route, and load-bearing the
moment it has two. Candidate order follows content hashes, so a lapsed
certificate retained beside a live route is picked about half the time,
signed, and presented to a responder that *does* check the clock. The
holder still has the authority; the request is refused anyway.

It then latches: the chain is memoized per `(principal, subject,
command)` against the branch epoch, and the hit-time re-verification
judges the entry against the same unbounded requirement — so one lapsed
pick is replayed for the rest of the epoch rather than flapping.

Two changes:

- **`dialog-remote-ucan-s3`** asks for authority good at the instant it
  presents (`during(now..now)`) rather than for any authority at all.
  `covers` is inclusive, so this admits exactly what a responder
  checking `now` admits, and asks for no more lifetime than the request
  needs. It does not bound the resulting authorization: the proof still
  reports the window its certificates agree on.
- **`dialog-operator`** retires a memoized chain once it has lapsed,
  sending the claim back to the walk, which can still find a live route
  the memo has outlived. Only the lapsed end is checked — an entry that
  has not started yet may legitimately answer a claim for the window in
  which it does, and the coverage test above already judges that.

Found from a tonk report: opening an invite link for a spot the
recipient had already joined installed a one-hour guest grant under the
same audience the durable route resolves to, and an hour later sync
began failing with `Authorization(Expired)` for a member whose
membership was intact.

## Tests

Three, each confirmed to fail without its change:

- `it_asks_for_authority_that_is_good_at_the_moment_it_presents` —
  without the site change: "the fork asked for an unbounded window".
- `it_retires_a_memo_whose_chain_has_lapsed` — without the operator
  change: "a memo holding a lapsed chain answered an unbounded claim".
- `it_resolves_the_live_route_when_a_lapsed_one_sits_beside_it` — pins
  the selection property the first change relies on.

`dialog-operator`, `dialog-remote-ucan-s3`, `dialog-ucan`,
`dialog-capability` and `dialog-repository` suites are green, and
`cargo clippy --all-targets --all-features -- -D warnings` and `cargo
fmt --check` both pass.

Branched from `tonk-2026-08-23` rather than `main`, so tonk can pin it
without taking everything else since the tag. (Rebased from
`tonk-2026-08-19` once tonk's staging moved to the newer tag; neither
file this touches changed between them.)

