### PR TITLE
fix(search-tree): a reader never waits on a read-ahead it cannot drive

### DIFF
--- a/rust/dialog-search-tree/src/accessor.rs
+++ b/rust/dialog-search-tree/src/accessor.rs
@@ -55,12 +55,7 @@ where
     pub(crate) async fn warm(&self, hash: Blake3Hash) {
         let _ = self
             .cache
-            .get_or_fetch(&hash, async |key| {
-                self.storage
-                    .retrieve(key)
-                    .await
-                    .map(|maybe_bytes| maybe_bytes.map(Buffer::from))
-            })
+            .warm(&hash, async |key| self.retrieve(key).await)
             .await;
     }
 
@@ -68,6 +63,15 @@ where
     ///
     /// Checks the cache first, then the storage backend. Returns an error if the
     /// node is in neither.
+    ///
+    /// Joins another demand read of the same node, but never a read-ahead:
+    /// a read-ahead queued by a range scan advances only while that scan is
+    /// polled, so a reader arriving from anywhere else — a point lookup, a
+    /// commit walking the tree, a consumer reading between two of the scan's
+    /// yields — would wait on an outcome only the task now waiting could
+    /// produce. Such a reader takes the node over and fetches for itself;
+    /// the scan's own reads, which do drive their read-aheads, join them
+    /// through [`get_node_joining`](Self::get_node_joining).
     pub async fn get_node<Key, Value>(
         &self,
         hash: &Blake3Hash,
@@ -79,14 +83,57 @@ where
             Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
         >,
     {
-        self.cache
-            .get_or_fetch(hash, async |key| {
-                self.storage
-                    .retrieve(key)
-                    .await
-                    .map(|maybe_bytes| maybe_bytes.map(Buffer::from))
-            })
-            .await?
+        let buffer = self
+            .cache
+            .get_or_fetch(hash, async |key| self.retrieve(key).await)
+            .await?;
+        Self::decode(hash, buffer)
+    }
+
+    /// [`get_node`](Self::get_node) for the range scan's own reads: joins a
+    /// read-ahead already in flight for the node instead of fetching again.
+    ///
+    /// Only sound where the caller keeps driving its warms while it waits —
+    /// the scan polls them alongside the read it awaits — because a joined
+    /// warm that nobody polls never publishes. Everyone else takes
+    /// [`get_node`](Self::get_node).
+    pub(crate) async fn get_node_joining<Key, Value>(
+        &self,
+        hash: &Blake3Hash,
+    ) -> Result<PersistentNode<Key, Value>, DialogSearchTreeError>
+    where
+        Key: self::Key,
+        Value: self::Value,
+        Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        >,
+    {
+        let buffer = self
+            .cache
+            .get_or_fetch_joining(hash, async |key| self.retrieve(key).await)
+            .await?;
+        Self::decode(hash, buffer)
+    }
+
+    async fn retrieve(&self, key: &Blake3Hash) -> Result<Option<Buffer>, DialogStorageError> {
+        self.storage
+            .retrieve(key)
+            .await
+            .map(|maybe_bytes| maybe_bytes.map(Buffer::from))
+    }
+
+    fn decode<Key, Value>(
+        hash: &Blake3Hash,
+        buffer: Option<Buffer>,
+    ) -> Result<PersistentNode<Key, Value>, DialogSearchTreeError>
+    where
+        Key: self::Key,
+        Value: self::Value,
+        Value::Archived: for<'a> CheckBytes<
+            Strategy<Validator<ArchiveValidator<'a>, SharedValidator>, rkyv::rancor::Error>,
+        >,
+    {
+        buffer
             .ok_or_else(|| {
                 DialogSearchTreeError::Node(format!("Blob not found in storage: {}", hash))
             })

--- a/rust/dialog-search-tree/src/cache.rs
+++ b/rust/dialog-search-tree/src/cache.rs
@@ -1,5 +1,5 @@
 mod fetches;
-use fetches::{Claim, Fetches};
+use fetches::{Claim, Fetch, Fetches, Kind};
 
 use dialog_common::{ConditionalSend, ConditionalSync};
 
@@ -98,11 +98,19 @@ where
     /// Retrieves a value from the cache, or fetches it using the provided
     /// function.
     ///
-    /// Only one fetch per key is ever in flight through a given cache: a
-    /// caller that misses while another caller is already fetching the same
-    /// key waits for that fetch instead of issuing its own. A fetch that fails
-    /// or is dropped before it publishes leaves nothing behind, so the callers
-    /// waiting on it start over and fetch for themselves.
+    /// A demand read: someone is awaiting it, so it is driven for as long as
+    /// it is in flight. Only one demand fetch per key is ever in flight
+    /// through a given cache — a caller that misses while another demand
+    /// read is already fetching the same key waits for that fetch instead
+    /// of issuing its own. A speculative read-ahead already on the key is
+    /// NOT waited on: it advances only while the walk that queued it is
+    /// polled, and this caller may be the only thing that would ever poll
+    /// it. The caller takes the key over and fetches for itself; the
+    /// read-ahead's bytes, if they ever land, are the same bytes.
+    ///
+    /// A fetch that fails or is dropped before it publishes leaves nothing
+    /// behind, so the callers waiting on it start over and fetch for
+    /// themselves.
     pub async fn get_or_fetch<F, E>(&self, key: &K, fetcher: F) -> Result<Option<V>, E>
     where
         F: AsyncFnOnce(&K) -> Result<Option<V>, E>,
@@ -112,9 +120,13 @@ where
                 return Ok(Some(value));
             }
 
-            match self.fetches.claim(key) {
+            match self.fetches.claim(key, Kind::Demand) {
                 Claim::Ours(fetch) => break fetch,
-                Claim::InFlight(mut outcome) => match outcome.recv().await {
+                Claim::InFlight {
+                    kind: Kind::Speculative,
+                    ..
+                } => break self.fetches.supersede(key),
+                Claim::InFlight { mut outcome, .. } => match outcome.recv().await {
                     Ok(value) => return Ok(value),
                     // The fetch we were waiting on failed or was dropped. Its
                     // claim is already withdrawn, so start over: either the
@@ -123,15 +135,71 @@ where
                 },
             }
         };
+        self.perform(fetch, key, fetcher).await
+    }
 
-        // A failure returns here, dropping the claim and releasing the key.
+    /// [`get_or_fetch`](Self::get_or_fetch) that also waits on a speculative
+    /// read-ahead already in flight for the key.
+    ///
+    /// Sound only for the walk that queued the read-ahead, because that walk
+    /// keeps polling its read-aheads alongside the read it awaits; anywhere
+    /// else, joining one is a wait on an outcome nobody may ever produce.
+    pub(crate) async fn get_or_fetch_joining<F, E>(
+        &self,
+        key: &K,
+        fetcher: F,
+    ) -> Result<Option<V>, E>
+    where
+        F: AsyncFnOnce(&K) -> Result<Option<V>, E>,
+    {
+        let fetch = loop {
+            if let Some(value) = self.get(key) {
+                return Ok(Some(value));
+            }
+
+            match self.fetches.claim(key, Kind::Demand) {
+                Claim::Ours(fetch) => break fetch,
+                Claim::InFlight { mut outcome, .. } => match outcome.recv().await {
+                    Ok(value) => return Ok(value),
+                    Err(_) => continue,
+                },
+            }
+        };
+        self.perform(fetch, key, fetcher).await
+    }
+
+    /// Loads `key` into the cache as a speculative read-ahead.
+    ///
+    /// Nobody awaits the outcome, so a key already being fetched by anyone
+    /// is simply left to them. The claim this takes out is marked
+    /// speculative: a demand read that finds it takes the key over rather
+    /// than waiting, since a read-ahead only advances while its walk is
+    /// polled.
+    pub(crate) async fn warm<F, E>(&self, key: &K, fetcher: F) -> Result<(), E>
+    where
+        F: AsyncFnOnce(&K) -> Result<Option<V>, E>,
+    {
+        if self.get(key).is_some() {
+            return Ok(());
+        }
+        match self.fetches.claim(key, Kind::Speculative) {
+            Claim::Ours(fetch) => self.perform(fetch, key, fetcher).await.map(|_| ()),
+            Claim::InFlight { .. } => Ok(()),
+        }
+    }
+
+    /// Run `fetcher` under `fetch`'s claim, landing the value in the cache
+    /// and handing it to whoever waited. A failure returns early, dropping
+    /// the claim and releasing the key.
+    async fn perform<F, E>(&self, fetch: Fetch<K, V>, key: &K, fetcher: F) -> Result<Option<V>, E>
+    where
+        F: AsyncFnOnce(&K) -> Result<Option<V>, E>,
+    {
         let value = fetcher(key).await?;
-
         if let Some(value) = &value {
             self.insert(key.clone(), value.clone());
         }
         fetch.publish(&value);
-
         Ok(value)
     }
 
@@ -172,6 +240,39 @@ mod tests {
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    /// A demand read that finds a speculative claim takes the key over
+    /// rather than waiting: the read-ahead behind that claim is polled only
+    /// by the walk that queued it, and here it is polled exactly once and
+    /// then never again — the shape of a walk parked between two yields.
+    // Native only: the bound is tokio's timer, which has no wasm runtime.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_never_makes_a_demand_read_wait_on_a_read_ahead() -> Result<()> {
+        use std::task::{Context, Poll};
+
+        let cache = Cache::<u32, u32>::new();
+
+        let mut warm = Box::pin(cache.warm(&7, async |_| {
+            std::future::pending::<Result<Option<u32>, ()>>().await
+        }));
+        let waker = std::task::Waker::noop();
+        let mut context = Context::from_waker(waker);
+        assert!(matches!(warm.as_mut().poll(&mut context), Poll::Pending));
+        assert_eq!(cache.fetches.len(), 1, "the read-ahead holds its claim");
+
+        let read = cache.get_or_fetch(&7, async |_| Ok::<_, ()>(Some(70)));
+        let value = tokio::time::timeout(std::time::Duration::from_secs(2), read)
+            .await
+            .expect("a demand read must not wait on a read-ahead nobody drives")
+            .unwrap();
+        assert_eq!(value, Some(70));
+
+        // The superseded read-ahead withdraws nothing that is not its own.
+        drop(warm);
+        assert_eq!(cache.get(&7), Some(70));
+        Ok(())
+    }
 
     #[dialog_common::test]
     async fn it_clears_the_inflight_entry_when_a_fetch_fails() -> Result<()> {

--- a/rust/dialog-search-tree/src/cache/fetches.rs
+++ b/rust/dialog-search-tree/src/cache/fetches.rs
@@ -3,31 +3,58 @@ use std::{collections::HashMap, hash::Hash, sync::Arc};
 use parking_lot::Mutex;
 use tokio::sync::broadcast;
 
-/// A claim's presence in the registry. A fetch starts [`Entry::Claimed`] —
-/// a bare marker, nothing allocated — and is upgraded to [`Entry::Awaited`]
-/// the moment a second caller arrives and needs a channel to wait on. A
-/// fetch nobody waits on never pays for one.
-enum Entry<V> {
-    /// A fetch is in flight; nobody is waiting on it yet.
+/// What kind of read took a claim out, which decides who may wait on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Kind {
+    /// A read someone is awaiting. Its owner polls it for as long as it
+    /// is in flight, so a waiter is guaranteed an outcome.
+    Demand,
+    /// A read-ahead nobody awaits. It advances only while the walk that
+    /// queued it is polled, so a waiter outside that walk could wait on an
+    /// outcome that only its own polling would ever produce.
+    Speculative,
+}
+
+/// A claim's outcome channel. A fetch starts [`Outcome::Claimed`] — a bare
+/// marker, nothing allocated — and is upgraded to [`Outcome::Awaited`] the
+/// moment a second caller arrives and needs a channel to wait on. A fetch
+/// nobody waits on never pays for one.
+enum Outcome<V> {
+    /// Nobody is waiting on it yet.
     Claimed,
-    /// A fetch is in flight and callers are subscribed to its outcome.
+    /// Callers are subscribed to its outcome.
     Awaited(broadcast::Sender<Option<V>>),
 }
 
-type Claims<K, V> = HashMap<K, Entry<V>>;
+/// A claim in the registry.
+///
+/// The `id` is what lets a claim be superseded: a demand read that finds a
+/// speculative claim replaces it with its own, and the superseded owner's
+/// later publish or withdrawal — carrying the old id — touches nothing.
+struct Entry<V> {
+    id: u64,
+    kind: Kind,
+    outcome: Outcome<V>,
+}
+
+struct Claims<K, V> {
+    next_id: u64,
+    entries: HashMap<K, Entry<V>>,
+}
 
 /// The fetches that are currently in flight for a [`Cache`](super::Cache),
 /// keyed exactly like the cache they front.
 ///
 /// A miss that finds no claim for its key takes one out and performs the
-/// fetch. A concurrent miss for the same key finds that claim and waits on its
-/// outcome instead of issuing a second fetch of its own. This matters most
-/// where a miss is expensive and shared: a cold tree read walks the same upper
-/// nodes for every query descending it at that moment.
+/// fetch. A concurrent miss for the same key finds that claim and, when its
+/// owner is guaranteed to drive it, waits on its outcome instead of issuing
+/// a second fetch of its own. This matters most where a miss is expensive
+/// and shared: a cold tree read walks the same upper nodes for every query
+/// descending it at that moment.
 ///
-/// The registry only ever holds claims that are still in flight. Publishing an
-/// outcome, failing, and dropping a claim all withdraw it, so a key is never
-/// left pointing at a fetch that no longer exists.
+/// The registry only ever holds claims that are still in flight. Publishing
+/// an outcome, failing, and dropping a claim all withdraw it, so a key is
+/// never left pointing at a fetch that no longer exists.
 pub(super) struct Fetches<K, V>
 where
     K: Eq + Hash,
@@ -54,47 +81,100 @@ where
     /// An empty registry.
     pub fn new() -> Self {
         Self {
-            claims: Arc::new(Mutex::new(HashMap::new())),
+            claims: Arc::new(Mutex::new(Claims {
+                next_id: 0,
+                entries: HashMap::new(),
+            })),
         }
     }
 
-    /// Take out the claim on `key`, or subscribe to the claim already in
+    /// Take out a claim of `kind` on `key`, or learn of the claim already in
     /// flight for it.
-    pub fn claim(&self, key: &K) -> Claim<K, V> {
+    pub fn claim(&self, key: &K, kind: Kind) -> Claim<K, V> {
         let mut claims = self.claims.lock();
 
-        match claims.get_mut(key) {
+        match claims.entries.get_mut(key) {
             None => {
-                claims.insert(key.clone(), Entry::Claimed);
+                let id = claims.next_id;
+                claims.next_id += 1;
+                claims.entries.insert(
+                    key.clone(),
+                    Entry {
+                        id,
+                        kind,
+                        outcome: Outcome::Claimed,
+                    },
+                );
                 Claim::Ours(Fetch {
                     key: key.clone(),
+                    id,
                     claims: self.claims.clone(),
                     withdrawn: false,
                 })
             }
-            Some(entry) => match entry {
-                // First waiter: give the claim its outcome channel.
-                Entry::Claimed => {
-                    let (outcome, receiver) = broadcast::channel(1);
-                    *entry = Entry::Awaited(outcome);
-                    Claim::InFlight(receiver)
+            Some(entry) => {
+                let outcome = match &mut entry.outcome {
+                    // First waiter: give the claim its outcome channel.
+                    Outcome::Claimed => {
+                        let (outcome, receiver) = broadcast::channel(1);
+                        entry.outcome = Outcome::Awaited(outcome);
+                        receiver
+                    }
+                    Outcome::Awaited(outcome) => outcome.subscribe(),
+                };
+                Claim::InFlight {
+                    outcome,
+                    kind: entry.kind,
                 }
-                Entry::Awaited(outcome) => Claim::InFlight(outcome.subscribe()),
+            }
+        }
+    }
+
+    /// Replace whatever claim is on `key` with a demand claim of our own.
+    ///
+    /// For a demand read that found a speculative claim: it must not wait on
+    /// a fetch that may never be driven, so it fetches for itself and takes
+    /// the key over. The superseded owner keeps fetching in the background —
+    /// nothing can stop it — but its outcome no longer lands on this key.
+    /// Whoever was waiting on it is sent back to the start by the dropped
+    /// sender, and joins the demand claim instead.
+    pub fn supersede(&self, key: &K) -> Fetch<K, V> {
+        let mut claims = self.claims.lock();
+        let id = claims.next_id;
+        claims.next_id += 1;
+        claims.entries.insert(
+            key.clone(),
+            Entry {
+                id,
+                kind: Kind::Demand,
+                outcome: Outcome::Claimed,
             },
+        );
+        Fetch {
+            key: key.clone(),
+            id,
+            claims: self.claims.clone(),
+            withdrawn: false,
         }
     }
 
     /// The number of fetches currently in flight.
     #[cfg(test)]
     pub fn len(&self) -> usize {
-        self.claims.lock().len()
+        self.claims.lock().entries.len()
     }
 
     /// Whether the in-flight fetch for `key` has waiters (and hence an
     /// allocated outcome channel).
     #[cfg(test)]
     pub fn awaited(&self, key: &K) -> bool {
-        matches!(self.claims.lock().get(key), Some(Entry::Awaited(_)))
+        matches!(
+            self.claims.lock().entries.get(key),
+            Some(Entry {
+                outcome: Outcome::Awaited(_),
+                ..
+            })
+        )
     }
 }
 
@@ -105,8 +185,12 @@ where
 {
     /// No fetch was in flight for the key, so this caller performs it.
     Ours(Fetch<K, V>),
-    /// A fetch was already in flight; this receiver carries its outcome.
-    InFlight(broadcast::Receiver<Option<V>>),
+    /// A fetch was already in flight; this receiver carries its outcome,
+    /// and its kind says whether waiting on it is sound.
+    InFlight {
+        outcome: broadcast::Receiver<Option<V>>,
+        kind: Kind,
+    },
 }
 
 /// A claim on the fetch for one key, held for as long as that fetch is in
@@ -121,6 +205,7 @@ where
     K: Eq + Hash,
 {
     key: K,
+    id: u64,
     claims: Arc<Mutex<Claims<K, V>>>,
     withdrawn: bool,
 }
@@ -129,12 +214,20 @@ impl<K, V> Fetch<K, V>
 where
     K: Eq + Hash,
 {
-    fn withdraw(&mut self) -> Option<Entry<V>> {
+    /// Withdraw this claim — unless the key has since been taken over by a
+    /// newer claim, which is then left exactly as it is.
+    fn withdraw(&mut self) -> Option<Outcome<V>> {
         if self.withdrawn {
             return None;
         }
         self.withdrawn = true;
-        self.claims.lock().remove(&self.key)
+        let mut claims = self.claims.lock();
+        match claims.entries.get(&self.key) {
+            Some(entry) if entry.id == self.id => {
+                claims.entries.remove(&self.key).map(|entry| entry.outcome)
+            }
+            _ => None,
+        }
     }
 }
 
@@ -150,7 +243,7 @@ where
     pub fn publish(mut self, value: &Option<V>) {
         // Withdraw first so a caller arriving after the send takes out a fresh
         // claim rather than subscribing to a channel that has already spoken.
-        if let Some(Entry::Awaited(outcome)) = self.withdraw() {
+        if let Some(Outcome::Awaited(outcome)) = self.withdraw() {
             let _ = outcome.send(value.clone());
         }
     }

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -488,8 +488,11 @@ where
                             warming.push(accessor.warm(index.hash_at(sibling)?.clone()));
                         }
 
+                        // The one read that may join an in-flight warm:
+                        // `while_warming` keeps polling the warms while
+                        // this read waits, so a joined warm always publishes.
                         let next_node = while_warming(
-                            accessor.get_node(index.hash_at(child_index)?),
+                            accessor.get_node_joining(index.hash_at(child_index)?),
                             &mut warming,
                         )
                         .await?;
@@ -1293,6 +1296,53 @@ mod prefetch_tests {
             .ok_or_else(|| anyhow::anyhow!("Node not stored"))?;
 
         Ok(PersistentNode::try_from(Buffer::from(bytes))?)
+    }
+
+    /// A reader that needs a node a read-ahead has claimed must not depend
+    /// on that read-ahead being driven. The read-ahead here is polled
+    /// exactly once — enough to claim the node and start its read — and
+    /// then never again, the shape of a walk parked between two yields. A
+    /// point read of a key under that node used to join the claim and wait
+    /// for an outcome only further polling of the read-ahead could produce.
+    // Native only: the bound is tokio's timer, which has no wasm runtime.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_serves_a_claimed_node_to_a_reader_the_read_ahead_cannot_reach() -> Result<()> {
+        use std::task::{Context, Poll};
+
+        let mut storage = ContentAddressedStorage::new(ObservingBackend::new());
+        let tree = built_tree(&mut storage).await?;
+        let accessor = crate::Accessor::new(tree.node_cache(), storage.clone());
+
+        // The root's second child, and a key from its leftmost leaf.
+        let root = load(&storage, tree.root()).await?;
+        let ArchivedNodeBody::Index(index) = root.body() else {
+            anyhow::bail!("the built tree has a single leaf; nothing to warm")
+        };
+        let sibling = index.hash_at(1)?.clone();
+        let mut hash = sibling.clone();
+        let key: [u8; 4] = loop {
+            let node = load(&storage, &hash).await?;
+            match node.body() {
+                ArchivedNodeBody::Index(index) => hash = index.hash_at(0)?.clone(),
+                ArchivedNodeBody::Segment(segment) => {
+                    break segment.first_key::<[u8; 4]>()?.as_slice().try_into()?;
+                }
+            }
+        };
+
+        let mut warm = Box::pin(accessor.warm(sibling));
+        let waker = std::task::Waker::noop();
+        let mut context = Context::from_waker(waker);
+        assert!(matches!(warm.as_mut().poll(&mut context), Poll::Pending));
+
+        let read = tree.get(&key, &storage);
+        let value = tokio::time::timeout(std::time::Duration::from_secs(2), read)
+            .await
+            .expect("a reader must not wait on a read-ahead nobody drives")?;
+        assert_eq!(value, Some(value_of(u32::from_be_bytes(key))));
+        drop(warm);
+        Ok(())
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
A range scan queues read-aheads for the siblings it is about to visit and drives them only while it is itself polled (`while_warming`). Each read-ahead held the single-flight claim on its node, so a reader that needed that node from anywhere else — a point lookup, a commit walking the tree, a consumer reading between two of the scan's yields — joined the claim and waited for an outcome only further polling of the scan could produce. The scan was suspended at a yield, waiting on that very consumer. Nothing was blocked on I/O; the process simply parked.

This is the hang tonk's e2e suite hit on every CI run of a device revocation (and about one run in five locally): the revoked CLI's account pull integrates new commits, the following adopt-and-materialize reads a node the pull's read-ahead had claimed, and a later local commit on the same tree hits it too. Traced with request-level logging (two requests complete in 6 ms, then 40 s with no I/O) and step breadcrumbs down to `access.pull().download()`, then to the claim.

**Fix.** Claims carry their kind. A demand read joins another demand read — that keeps the cold-start dedupe #435 introduced — but takes a speculative claim over and fetches for itself; only the scan's own read joins speculative claims, because it is the one polling them (`get_node_joining`, used solely inside `while_warming`). A superseded read-ahead keeps fetching and lands the same bytes; ids on claims make its later publish or withdrawal a no-op for the key.

**Tests.** One at the cache (a read-ahead polled exactly once, then a demand read of the same key must complete) and one on a real tree (claim the root's second child via the accessor, then `tree.get` a key beneath it without polling the claim again). Both time out on the old path and pass here; the existing dedupe and prefetch tests still pass, including "no node was read from the backend twice".

Fixes the root cause behind #465's symptom report.