### PR TITLE
fix(operator): a proof never waits on the fetch it is proving

### DIFF
--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -144,6 +144,11 @@ impl OperatorBuilder {
             .perform(&operator)
             .await
             .map_err(|e| OperatorError::Delegation(format!("{e}")))?;
+        // The reach-less operator below reads the access branch through
+        // caches of its own: its walk proves the fetches this handle makes,
+        // so sharing a cache would have that proof wait on the fetch it is
+        // proving whenever both need the same node.
+        let anchor_access = branch.with_own_caches();
         operator
             .delegations
             .set(branch)
@@ -157,6 +162,7 @@ impl OperatorBuilder {
         // recursion a fork-inside-a-proof would otherwise open.
         let anchor = Operator {
             reach: Arc::new(OnceLock::new()),
+            delegations: Arc::new(OnceLock::from(anchor_access)),
             ..operator.clone()
         };
         let reach = WalkReach {

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -13,7 +13,7 @@ use dialog_artifacts::history::Origin;
 use dialog_artifacts::history::{
     CausalityCache, ContextCache, RevisionRecord, TreeHistory, Version, log,
 };
-use dialog_artifacts::tree::SpillCache;
+use dialog_artifacts::tree::{SpillCache, spill_cache};
 use dialog_artifacts::{Exporter, Importer};
 use dialog_capability::Fork;
 use dialog_capability::{Capability, Did, Subject};
@@ -332,6 +332,26 @@ impl Branch {
     /// A shared handle to this branch's node cache, for seeding a read tree.
     pub(crate) fn node_cache(&self) -> Cache<Blake3Hash, Buffer> {
         self.node_cache.clone()
+    }
+
+    /// A handle on this branch that reads through caches of its own.
+    ///
+    /// Clones of a handle share its caches, and a node-cache miss is
+    /// single-flighted: a reader that finds a fetch of the same node in
+    /// flight waits for it. A handle from here never joins such a fetch,
+    /// which is what a reader needs when the fetch is waiting on IT. The
+    /// authorization walk is that reader: the proof for a fetch of the
+    /// access branch reads the access branch, and read through the
+    /// fetching handle's cache it would wait on the very fetch it is
+    /// proving. The head, upstream, and session overlay stay shared, so
+    /// the handle sees the same branch; only what it caches is its own.
+    pub fn with_own_caches(&self) -> Self {
+        Self {
+            node_cache: Cache::new(),
+            record_cache: Cache::new(),
+            spill_cache: spill_cache(),
+            ..self.clone()
+        }
     }
 
     /// The live-spine slot this branch's commits reuse.

--- a/rust/dialog-repository/src/repository/branch/integration_tests.rs
+++ b/rust/dialog-repository/src/repository/branch/integration_tests.rs
@@ -3632,3 +3632,160 @@ async fn it_downloads_spilled_values_a_pull_never_shipped(s3: S3Address) -> Resu
     }
     Ok(())
 }
+
+/// A proof walk that has to fetch a node of the access branch must never
+/// wait on that fetch's own proof.
+///
+/// The access branch is what authorization walks, and it is also a
+/// synced branch: a head adopted by root can reference nodes the local
+/// archive does not hold. The next proof then fetches such a node
+/// through the walk's reach, and that fetch is itself proven by a walk
+/// over the same branch that needs the same node. Read through one
+/// shared node cache, the inner walk joined the outer fetch's
+/// single-flight claim and waited on the proof it was itself producing:
+/// no I/O, nothing dropped, forever.
+///
+/// Bounded completion is the property; the outcome is not. An inner
+/// proof that resolves from what is local lets the fetch proceed, and
+/// one that cannot fails the operation it was proving.
+#[cfg(not(target_arch = "wasm32"))]
+#[dialog_common::test]
+async fn it_never_waits_on_its_own_fetch_when_the_access_head_ran_ahead_of_the_archive(
+    ucan: UcanS3Address,
+) -> Result<()> {
+    use dialog_capability::access::{Access as AccessAttenuation, Retain};
+    use dialog_credentials::{Credential as RawCredential, Ed25519Signer, SignerCredential};
+    use dialog_effects::storage::{LocationExt as _, Storage as StorageFx};
+    use dialog_operator::DeriveOperator as _;
+    use dialog_ucan::{Ucan, UcanDelegation};
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal as _;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let ucan_site = SiteAddress::Ucan(UcanAddress::new(&ucan.access_service_url));
+
+    // The account publishes its access branch, holding one grant, to the
+    // access service.
+    let account_storage = Storage::volatile();
+    let account_signer = Ed25519Signer::generate().await?;
+    let account_name = unique_name("account");
+    StorageFx::profile(account_name.clone())
+        .create(RawCredential::Signer(SignerCredential::from(
+            account_signer.clone(),
+        )))
+        .perform(&account_storage)
+        .await?;
+    let account_profile = Profile::load(account_name)
+        .perform(&account_storage)
+        .await?;
+    let account_operator = account_profile
+        .derive(b"account-device")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(account_storage)
+        .await?;
+    let space = Ed25519Signer::generate().await?;
+    let space_grant = DelegationBuilder::new()
+        .issuer(dialog_credentials::Signer::from(space.clone()))
+        .audience(&account_signer)
+        .subject(UcanSubject::Specific(space.did()))
+        .command(vec!["storage".to_string()])
+        .try_build()
+        .await?;
+    Subject::from(account_profile.did())
+        .attenuate(AccessAttenuation)
+        .invoke(Retain::<Ucan>::new(UcanDelegation::new(
+            DelegationChain::new(space_grant),
+        )))
+        .perform(&account_operator)
+        .await?;
+    let account_repo = crate::Repository::from(&account_profile);
+    let account_origin = account_repo
+        .remote("origin")
+        .create(ucan_site.clone())
+        .perform(&account_operator)
+        .await?;
+    let account_branch = account_repo
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&account_operator)
+        .await?;
+    let account_remote_branch = account_origin
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&account_operator)
+        .await?;
+    account_branch
+        .set_upstream(account_remote_branch)
+        .perform(&account_operator)
+        .await?;
+    account_branch.push().perform(&account_operator).await?;
+    let head = account_branch
+        .revision()
+        .context("the push established a head")?;
+
+    // A device of the account: its login grant retained locally, the
+    // account tracked as its access upstream.
+    let device_storage = Storage::volatile();
+    let device_profile = Profile::open(unique_name("device"))
+        .perform(&device_storage)
+        .await?;
+    let device_operator = device_profile
+        .derive(b"device")
+        .allow(Subject::any())
+        .network(Network::default())
+        .build(device_storage)
+        .await?;
+    let login_grant = DelegationBuilder::new()
+        .issuer(dialog_credentials::Signer::from(account_signer.clone()))
+        .audience(&device_profile.did())
+        .subject(UcanSubject::Any)
+        .command(vec![])
+        .try_build()
+        .await?;
+    Subject::from(device_profile.did())
+        .attenuate(AccessAttenuation)
+        .invoke(Retain::<Ucan>::new(UcanDelegation::new(
+            DelegationChain::new(login_grant),
+        )))
+        .perform(&device_operator)
+        .await?;
+    let device_repo = crate::Repository::from(&device_profile);
+    let device_origin = device_repo
+        .remote("account")
+        .create(ucan_site)
+        .subject(account_profile.did())
+        .perform(&device_operator)
+        .await?;
+    let device_branch = device_repo
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&device_operator)
+        .await?;
+    let device_remote_branch = device_origin
+        .branch(crate::ACCESS_BRANCH)
+        .open()
+        .perform(&device_operator)
+        .await?;
+    device_branch
+        .set_upstream(device_remote_branch)
+        .perform(&device_operator)
+        .await?;
+
+    // The head runs ahead of the archive: the account's revision, none
+    // of its nodes. Every proof from here has to fetch to read.
+    device_branch.reset(head).perform(&device_operator).await?;
+
+    let outcome = timeout(
+        Duration::from_secs(30),
+        device_branch.pull().perform(&device_operator),
+    )
+    .await;
+    assert!(
+        outcome.is_ok(),
+        "the proof over an access head that ran ahead of the archive waited on its own fetch"
+    );
+    Ok(())
+}


### PR DESCRIPTION
`tonk account devices` was parking for good after another device pushed to the account, with no I/O and nothing dropped. Traced with an in-process step recorder, the sequence is:

1. A bare pull adopts the other device's head by root, so the access branch head references nodes the local archive does not hold.
2. The next proof walks the access branch, hits such a node, and fetches it through the walk's reach.
3. That fetch is itself proven by the reach-less inner operator, whose walk over the same branch needs the same node, finds the outer fetch's single-flight claim in the shared node cache, and waits on it. The outer fetch is waiting on the inner proof.

The inner operator was meant to bound this recursion by resolving from what is already local, but "local" read through the shared cache includes waiting on someone else's in-flight remote fetch. It now reads through caches of its own (`Branch::with_own_caches`): the head, upstream, and overlay stay shared, only what it caches is its own. Its walk then resolves from local content or fails, and the fetch it proves proceeds or errors, within a bound either way.

The integration test resets a device's access head to the account's pushed head (the revision, none of its nodes) and requires the next pull to complete within 30s. It fails after 30s on `main` with exactly the recorded trail, and completes in milliseconds with the change.

Verified end to end on tonk's deterministic repro: three `devices` rounds went from 40.00s each to under 10ms.
