### PR TITLE
feat(effects): storage commands live under /use, with HTTP verbs

### DIFF
--- a/rust/dialog-capability/src/ability.rs
+++ b/rust/dialog-capability/src/ability.rs
@@ -54,7 +54,14 @@ where
     fn ability(&self) -> String {
         let ability = self.capability.ability();
         if let Some(segment) = C::attenuation() {
-            let kebab = segment.to_case(Case::Kebab);
+            // A segment may be a path of its own (`use/query/memory/cell`);
+            // each component is kebab-cased on its own so the separators
+            // survive.
+            let kebab = segment
+                .split('/')
+                .map(|component| component.to_case(Case::Kebab))
+                .collect::<Vec<_>>()
+                .join("/");
             if ability == "/" {
                 format!("/{}", kebab)
             } else {

--- a/rust/dialog-capability/src/attenuation.rs
+++ b/rust/dialog-capability/src/attenuation.rs
@@ -2,6 +2,20 @@ use crate::settings::Caveat;
 use crate::{Constraint, Effect, Policy};
 use std::any::type_name;
 
+/// The last path component of a type name, without generics: what a type
+/// contributes to an ability path when it says nothing else.
+pub(crate) fn type_segment<T>() -> &'static str {
+    let full = type_name::<T>();
+    let without_generics = match full.find('<') {
+        Some(pos) => &full[..pos],
+        None => full,
+    };
+    without_generics
+        .rsplit("::")
+        .next()
+        .unwrap_or(without_generics)
+}
+
 /// Trait for constraints that narrow the ability path.
 ///
 /// Attenuation implies [`Policy`] via blanket impl. The `attenuation()` method
@@ -42,17 +56,7 @@ pub trait Attenuation: Sized + Caveat {
     /// By default, derives the segment from the struct name (lowercased).
     /// Override this method to use a custom segment.
     fn attenuation() -> &'static str {
-        let full = type_name::<Self>();
-        // Strip generic parameters first, then take the last path segment.
-        // e.g., "crate::credential::Retrieve<alloc::string::String>" → "Retrieve"
-        let without_generics = match full.find('<') {
-            Some(pos) => &full[..pos],
-            None => full,
-        };
-        without_generics
-            .rsplit("::")
-            .next()
-            .unwrap_or(without_generics)
+        type_segment::<Self>()
     }
 }
 
@@ -68,4 +72,8 @@ impl<T: Attenuation> Policy for T {
 // Effect implies Attenuation
 impl<T: Effect> Attenuation for T {
     type Of = <T as Effect>::Of;
+
+    fn attenuation() -> &'static str {
+        T::command()
+    }
 }

--- a/rust/dialog-capability/src/effect.rs
+++ b/rust/dialog-capability/src/effect.rs
@@ -1,3 +1,4 @@
+use crate::attenuation::type_segment;
 use crate::{Attenuate, Caveat, Constraint};
 use dialog_common::ConditionalSend;
 
@@ -15,4 +16,16 @@ pub trait Effect: Sized + Caveat + Attenuate {
     type Of: Constraint;
     /// The output type produced by the invocation of this effect when performed.
     type Output: ConditionalSend;
+
+    /// The command this effect invokes: the path it appends to the ability
+    /// of the capability it attaches to.
+    ///
+    /// Defaults to the effect's type name as one segment. An effect may
+    /// name a longer path instead, which is how a verb prefix such as
+    /// `use/get` sits above the resource it applies to: the command is
+    /// what a delegation attenuates, so an effect that only reads says so
+    /// in its path rather than in the type of its parent.
+    fn command() -> &'static str {
+        type_segment::<Self>()
+    }
 }

--- a/rust/dialog-effects/src/archive.rs
+++ b/rust/dialog-effects/src/archive.rs
@@ -13,6 +13,7 @@
 //!               └── Import { blocks } → Effect → Result<(), ArchiveError>
 //! ```
 
+use crate::Use;
 use std::error::Error;
 
 use crate::Rejection;
@@ -29,12 +30,14 @@ use thiserror::Error;
 
 /// Archive ability - restricts to archive operations.
 ///
-/// Attaches to Subject and provides the `/archive` ability path segment.
+/// Attaches to Subject. Contributes no ability segment of its own: the
+/// effects name the whole command (`/use/get/archive/block`), so the
+/// verb sits above the resource in the path.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Archive;
 
-impl Attenuation for Archive {
-    type Of = Subject;
+impl Policy for Archive {
+    type Of = Use;
 }
 
 /// Catalog policy that scopes operations to a named catalog.
@@ -81,6 +84,10 @@ impl Get {
 impl Effect for Get {
     type Of = Catalog;
     type Output = Result<Option<Vec<u8>>, ArchiveError>;
+
+    fn command() -> &'static str {
+        "get/archive/block"
+    }
 }
 
 /// Put operation - stores a single content-addressed block.
@@ -175,6 +182,10 @@ impl Put {
 impl Effect for Put {
     type Of = Catalog;
     type Output = Result<(), ArchiveError>;
+
+    fn command() -> &'static str {
+        "put/archive/block"
+    }
 }
 
 /// Import operation - stores a batch of content-addressed blocks.
@@ -226,6 +237,10 @@ impl Import {
 impl Effect for Import {
     type Of = Catalog;
     type Output = Result<(), ArchiveError>;
+
+    fn command() -> &'static str {
+        "put/archive/block"
+    }
 }
 
 pub mod prelude;
@@ -278,41 +293,46 @@ mod tests {
 
     #[test]
     fn it_builds_archive_claim_path() {
-        let claim = Subject::from(did!("key:zSpace")).attenuate(Archive);
+        let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
+            .attenuate(Archive);
 
         assert_eq!(claim.subject(), &did!("key:zSpace"));
-        assert_eq!(claim.ability(), "/archive");
+        assert_eq!(claim.ability(), "/use");
     }
 
     #[test]
     fn it_builds_catalog_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"));
 
         assert_eq!(claim.subject(), &did!("key:zSpace"));
         // Catalog is Policy, not Ability, so it doesn't add to path
-        assert_eq!(claim.ability(), "/archive");
+        assert_eq!(claim.ability(), "/use");
     }
 
     #[test]
     fn it_builds_get_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new([0u8; 32]));
 
-        assert_eq!(claim.ability(), "/archive/get");
+        assert_eq!(claim.ability(), "/use/get/archive/block");
     }
 
     #[test]
     fn it_builds_put_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(Vec::new())));
 
-        assert_eq!(claim.ability(), "/archive/put");
+        assert_eq!(claim.ability(), "/use/put/archive/block");
     }
 
     #[dialog_common::test]

--- a/rust/dialog-effects/src/archive/prelude.rs
+++ b/rust/dialog-effects/src/archive/prelude.rs
@@ -9,6 +9,7 @@ use dialog_capability::{Capability, Did, Policy, Subject};
 use dialog_common::{Blake3Hash, Buffer};
 
 use super::{Archive, Catalog, Get, Import, Put};
+use crate::Use;
 
 /// Extension trait to start an archive capability chain.
 pub trait ArchiveSubjectExt {
@@ -21,14 +22,14 @@ pub trait ArchiveSubjectExt {
 impl ArchiveSubjectExt for Subject {
     type Archive = Capability<Archive>;
     fn archive(self) -> Capability<Archive> {
-        self.attenuate(Archive)
+        self.attenuate(Use).attenuate(Archive)
     }
 }
 
 impl ArchiveSubjectExt for Did {
     type Archive = Capability<Archive>;
     fn archive(self) -> Capability<Archive> {
-        Subject::from(self).attenuate(Archive)
+        Subject::from(self).attenuate(Use).attenuate(Archive)
     }
 }
 

--- a/rust/dialog-effects/src/blob.rs
+++ b/rust/dialog-effects/src/blob.rs
@@ -33,11 +33,12 @@ pub use dialog_capability::{
     access::AuthorizeError,
 };
 
-/// Blob store domain under the archive. Adds the `/blob` ability segment.
+/// Blob store domain under the archive. Contributes no ability segment of
+/// its own: the effects name the whole command (`/use/get/archive/blob`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Blob;
 
-impl Attenuation for Blob {
+impl Policy for Blob {
     type Of = Archive;
 }
 
@@ -112,6 +113,10 @@ impl Read {
 impl Effect for Read {
     type Of = Blob;
     type Output = Result<BlobReader, BlobError>;
+
+    fn command() -> &'static str {
+        "get/archive/blob"
+    }
 }
 
 /// Ingest a blob whose hash is **discovered** during the write. Carries no
@@ -136,6 +141,10 @@ impl Default for Write {
 impl Effect for Write {
     type Of = Blob;
     type Output = Result<BlobWriter, BlobError>;
+
+    fn command() -> &'static str {
+        "put/archive/blob"
+    }
 }
 
 /// Import a blob whose hash is **already known**: a content-bound write used by
@@ -167,6 +176,10 @@ impl Import {
 impl Effect for Import {
     type Of = Blob;
     type Output = Result<BlobWriter, BlobError>;
+
+    fn command() -> &'static str {
+        "put/archive/blob"
+    }
 }
 
 pub mod prelude;
@@ -180,34 +193,38 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::prelude::*;
+    use crate::Use;
     use crate::archive::Archive;
     use dialog_capability::{Subject, did};
 
     #[dialog_common::test]
     fn it_builds_blob_read_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Archive)
             .blob()
             .read([0u8; 32]);
         assert_eq!(claim.subject(), &did!("key:zSpace"));
-        assert_eq!(claim.ability(), "/archive/blob/read");
+        assert_eq!(claim.ability(), "/use/get/archive/blob");
     }
 
     #[dialog_common::test]
     fn it_builds_blob_write_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Archive)
             .blob()
             .write();
-        assert_eq!(claim.ability(), "/archive/blob/write");
+        assert_eq!(claim.ability(), "/use/put/archive/blob");
     }
 
     #[dialog_common::test]
     fn it_builds_blob_import_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Archive)
             .blob()
             .import([0u8; 32], 4096);
-        assert_eq!(claim.ability(), "/archive/blob/import");
+        assert_eq!(claim.ability(), "/use/put/archive/blob");
     }
 }

--- a/rust/dialog-effects/src/lib.rs
+++ b/rust/dialog-effects/src/lib.rs
@@ -14,13 +14,14 @@
 //!
 //! ```
 //! use dialog_effects::archive::{Archive, Catalog, Get};
+//! use dialog_effects::Use;
 //! use dialog_capability::{did, Subject};
 //! use dialog_common::Blake3Hash;
 //!
 //! // Build a capability to get content from the "index" catalog
 //! let digest = Blake3Hash::hash(b"hello");
 //! let get_capability = Subject::from(did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"))
-//!     .attenuate(Archive)              // Domain: archive operations
+//!     .attenuate(Use).attenuate(Archive)              // Domain: archive operations
 //!     .attenuate(Catalog::new("index"))  // Policy: only the "index" catalog
 //!     .invoke(Get::new(digest));         // Effect: get this specific digest
 //! ```
@@ -61,3 +62,17 @@ pub mod prelude {
 // Re-export capability primitives for convenience
 pub use dialog_capability::{Attenuation, Capability, Effect, Policy, Subject};
 pub use rejection::Rejection;
+use serde::{Deserialize, Serialize};
+
+/// Everything a holder needs to use a subject's data: every read and
+/// every write (`/use/get/...`, `/use/put/...`, `/use/delete/...`). A delegation
+/// attenuated to `Use` lets its holder read and write the subject's data
+/// without holding `/ucan` (delegation and revocation), which is what a
+/// member of a shared space is given. `/void` is reserved beside it for
+/// operations that destroy rather than change; nothing lives there yet.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct Use;
+
+impl Attenuation for Use {
+    type Of = Subject;
+}

--- a/rust/dialog-effects/src/memory.rs
+++ b/rust/dialog-effects/src/memory.rs
@@ -14,6 +14,7 @@
 //!                     └── Retract { when } → Effect → Result<(), MemoryError>
 //! ```
 
+use crate::Use;
 use std::fmt;
 use std::str;
 
@@ -29,12 +30,14 @@ use thiserror::Error;
 
 /// Root attenuation for memory operations.
 ///
-/// Attaches to Subject and provides the `/memory` ability path segment.
+/// Attaches to Subject. Contributes no ability segment of its own: the
+/// effects name the whole command (`/use/get/memory/cell`), so the verb
+/// sits above the resource in the path.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Memory;
 
-impl Attenuation for Memory {
-    type Of = Subject;
+impl Policy for Memory {
+    type Of = Use;
 }
 
 /// Space policy that scopes operations to a memory space.
@@ -187,6 +190,10 @@ pub struct Resolve;
 impl Effect for Resolve {
     type Of = Cell;
     type Output = Result<Option<Edition<Vec<u8>>>, MemoryError>;
+
+    fn command() -> &'static str {
+        "get/memory/cell"
+    }
 }
 
 /// Publish operation - sets cell content with CAS semantics.
@@ -219,6 +226,10 @@ impl Publish {
 impl Effect for Publish {
     type Of = Cell;
     type Output = Result<Version, MemoryError>;
+
+    fn command() -> &'static str {
+        "put/memory/cell"
+    }
 }
 
 /// Retract operation - removes cell content with CAS semantics.
@@ -241,6 +252,10 @@ impl Retract {
 impl Effect for Retract {
     type Of = Cell;
     type Output = Result<(), MemoryError>;
+
+    fn command() -> &'static str {
+        "delete/memory/cell"
+    }
 }
 
 pub mod prelude;
@@ -284,65 +299,72 @@ mod tests {
 
     #[test]
     fn it_builds_memory_claim_path() {
-        let claim = Subject::from(did!("key:zSpace")).attenuate(Memory);
+        let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
+            .attenuate(Memory);
 
         assert_eq!(claim.subject(), &did!("key:zSpace"));
-        assert_eq!(claim.ability(), "/memory");
+        assert_eq!(claim.ability(), "/use");
     }
 
     #[test]
     fn it_builds_space_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"));
 
         assert_eq!(claim.subject(), &did!("key:zSpace"));
         // Space is Policy, not Ability, so it doesn't add to path
-        assert_eq!(claim.ability(), "/memory");
+        assert_eq!(claim.ability(), "/use");
     }
 
     #[test]
     fn it_builds_cell_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("main"));
 
         assert_eq!(claim.subject(), &did!("key:zSpace"));
         // Cell is Policy, not Ability, so it doesn't add to path
-        assert_eq!(claim.ability(), "/memory");
+        assert_eq!(claim.ability(), "/use");
     }
 
     #[test]
     fn it_builds_resolve_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("main"))
             .invoke(Resolve);
 
-        assert_eq!(claim.ability(), "/memory/resolve");
+        assert_eq!(claim.ability(), "/use/get/memory/cell");
     }
 
     #[test]
     fn it_builds_publish_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("main"))
             .invoke(Publish::new(b"test", None));
 
-        assert_eq!(claim.ability(), "/memory/publish");
+        assert_eq!(claim.ability(), "/use/put/memory/cell");
     }
 
     #[test]
     fn it_builds_retract_claim_path() {
         let claim = Subject::from(did!("key:zSpace"))
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("main"))
             .invoke(Retract::new(b"v1"));
 
-        assert_eq!(claim.ability(), "/memory/retract");
+        assert_eq!(claim.ability(), "/use/delete/memory/cell");
     }
 }

--- a/rust/dialog-effects/src/memory/prelude.rs
+++ b/rust/dialog-effects/src/memory/prelude.rs
@@ -8,6 +8,7 @@
 use dialog_capability::{Capability, Did, Policy, Subject};
 
 use super::{Cell, Memory, Publish, Resolve, Retract, Space, Version};
+use crate::Use;
 
 /// Extension trait to start a memory capability chain.
 pub trait MemorySubjectExt {
@@ -20,14 +21,14 @@ pub trait MemorySubjectExt {
 impl MemorySubjectExt for Subject {
     type Memory = Capability<Memory>;
     fn memory(self) -> Capability<Memory> {
-        self.attenuate(Memory)
+        self.attenuate(Use).attenuate(Memory)
     }
 }
 
 impl MemorySubjectExt for Did {
     type Memory = Capability<Memory>;
     fn memory(self) -> Capability<Memory> {
-        Subject::from(self).attenuate(Memory)
+        Subject::from(self).attenuate(Use).attenuate(Memory)
     }
 }
 

--- a/rust/dialog-remote-s3/src/lib.rs
+++ b/rust/dialog-remote-s3/src/lib.rs
@@ -15,6 +15,7 @@
 //! ```no_run
 //! use dialog_remote_s3::{Address, S3Credential, S3Request};
 //! use dialog_effects::archive::{Archive, Catalog, Get};
+//! use dialog_effects::Use;
 //! use dialog_capability::{Subject, did};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -31,7 +32,7 @@
 //! );
 //!
 //! let capability = Subject::from(subject)
-//!     .attenuate(Archive)
+//!     .attenuate(Use).attenuate(Archive)
 //!     .attenuate(Catalog::new("blobs"))
 //!     .invoke(Get::new([0u8; 32]));
 //!

--- a/rust/dialog-remote-s3/src/request.rs
+++ b/rust/dialog-remote-s3/src/request.rs
@@ -13,6 +13,7 @@
 //! ```
 //! use dialog_capability::{Subject, did};
 //! use dialog_effects::archive::{Archive, Catalog, Get, Put};
+//! use dialog_effects::Use;
 //! use dialog_common::Blake3Hash;
 //! use dialog_remote_s3::request::S3Request;
 //!
@@ -21,7 +22,7 @@
 //! // Build a capability to get content from the "index" catalog
 //! let digest = Blake3Hash::hash(b"hello");
 //! let get = Subject::from(subject.clone())
-//!     .attenuate(Archive)
+//!     .attenuate(Use).attenuate(Archive)
 //!     .attenuate(Catalog::new("index"))
 //!     .invoke(Get::new(digest));
 //!
@@ -147,6 +148,7 @@ mod tests {
     use super::{IntoRequest, RequestMethod};
     use dialog_capability::{Subject, did};
     use dialog_common::{Blake3Hash, Buffer};
+    use dialog_effects::Use;
     use dialog_effects::archive::{Archive, Catalog, Get, Put};
     use dialog_effects::blob::prelude::{ArchiveBlobExt, BlobExt};
     use dialog_effects::memory::Version;
@@ -174,6 +176,7 @@ mod tests {
         let digest = Blake3Hash::hash(b"content");
         let catalog = || {
             subject()
+                .attenuate(Use)
                 .attenuate(Archive)
                 .attenuate(Catalog::new("index"))
         };
@@ -184,8 +187,20 @@ mod tests {
     #[dialog_common::test]
     fn it_reports_the_method_the_blob_translations_produce() {
         let digest = Blake3Hash::hash(b"content");
-        method_matches(&subject().attenuate(Archive).blob().read(digest.clone()));
-        method_matches(&subject().attenuate(Archive).blob().import(digest, 3));
+        method_matches(
+            &subject()
+                .attenuate(Use)
+                .attenuate(Archive)
+                .blob()
+                .read(digest.clone()),
+        );
+        method_matches(
+            &subject()
+                .attenuate(Use)
+                .attenuate(Archive)
+                .blob()
+                .import(digest, 3),
+        );
     }
 
     #[dialog_common::test]

--- a/rust/dialog-remote-s3/src/s3/credential.rs
+++ b/rust/dialog-remote-s3/src/s3/credential.rs
@@ -250,6 +250,7 @@ mod tests {
     use crate::request::S3Request;
     use dialog_capability::{Subject, did};
     use dialog_common::Checksum;
+    use dialog_effects::Use;
     use dialog_effects::archive;
 
     fn test_subject() -> dialog_capability::Did {
@@ -276,6 +277,7 @@ mod tests {
     async fn it_signs_with_public_access() {
         let address = test_address();
         let get = Subject::from(test_subject())
+            .attenuate(Use)
             .attenuate(archive::Archive)
             .attenuate(archive::Catalog::new("blobs"))
             .invoke(archive::Get::new([0x42; 32]));
@@ -291,6 +293,7 @@ mod tests {
     async fn it_signs_with_private_credentials() {
         let address = test_address();
         let get = Subject::from(test_subject())
+            .attenuate(Use)
             .attenuate(archive::Archive)
             .attenuate(archive::Catalog::new("blobs"))
             .invoke(archive::Get::new([0x42; 32]));
@@ -307,6 +310,7 @@ mod tests {
         let address = test_address();
         let checksum = Checksum::Sha256([0u8; 32]);
         let put = Subject::from(test_subject())
+            .attenuate(Use)
             .attenuate(archive::Archive)
             .attenuate(archive::Catalog::new("index"))
             .attenuate(archive::PutAttenuation {
@@ -328,6 +332,7 @@ mod tests {
     async fn it_uses_path_style_for_localhost() {
         let address = localhost_address();
         let get = Subject::from(test_subject())
+            .attenuate(Use)
             .attenuate(archive::Archive)
             .attenuate(archive::Catalog::new("blobs"))
             .invoke(archive::Get::new([0x42; 32]));

--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -58,7 +58,7 @@ use std::collections::BTreeMap;
 
 use dialog_capability::{Capability, Constraint, Did, Policy};
 use dialog_did_web::{CachingResolver, PerformingResolver, Resolve, WebResolver};
-use dialog_effects::{archive, blob, memory};
+use dialog_effects::{Use, archive, blob, memory};
 use dialog_remote_s3::{Address, Permit, S3Credential, S3Error};
 use dialog_ucan_core::invocation::CheckFailed;
 use dialog_ucan_core::promise::Promised;
@@ -102,6 +102,7 @@ where
     let cell: memory::Cell = deserialize_from_args(args)?;
     let claim: C = deserialize_from_args(args)?;
     Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(Use)
         .attenuate(memory::Memory)
         .attenuate(space)
         .attenuate(cell)
@@ -117,6 +118,7 @@ where
     let catalog: archive::Catalog = deserialize_from_args(args)?;
     let claim: C = deserialize_from_args(args)?;
     Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(Use)
         .attenuate(archive::Archive)
         .attenuate(catalog)
         .attenuate(claim))
@@ -133,6 +135,7 @@ where
 {
     let claim: C = deserialize_from_args(args)?;
     Ok(dialog_capability::Subject::from(subject.clone())
+        .attenuate(Use)
         .attenuate(archive::Archive)
         .attenuate(blob::Blob)
         .attenuate(claim))
@@ -164,6 +167,7 @@ impl FromUcanArgs for memory::Resolve {
         let space: memory::Space = deserialize_from_args(args)?;
         let cell: memory::Cell = deserialize_from_args(args)?;
         Ok(dialog_capability::Subject::from(subject.clone())
+            .attenuate(Use)
             .attenuate(memory::Memory)
             .attenuate(space)
             .attenuate(cell)
@@ -503,6 +507,17 @@ where
         let command_segments: Vec<&str> = command.0.iter().map(|s| s.as_str()).collect();
 
         dispatch!(self, subject_did, args, command_segments.as_slice(), {
+            ["use", "get", "memory", "cell"]     => dialog_effects::memory::Resolve,
+            ["use", "put", "memory", "cell"]     => dialog_effects::memory::Publish,
+            ["use", "delete", "memory", "cell"]  => dialog_effects::memory::Retract,
+            ["use", "get", "archive", "block"]   => dialog_effects::archive::Get,
+            ["use", "put", "archive", "block"]   => dialog_effects::archive::Put,
+            ["use", "get", "archive", "blob"]    => dialog_effects::blob::Read,
+            ["use", "put", "archive", "blob"]    => dialog_effects::blob::Import,
+            // The spellings before the `use` prefix. Clients minted
+            // against an earlier release still invoke these; their chains
+            // are `/`, which covers both. Dropped once no such client is
+            // deployed.
             ["memory", "resolve"]  => dialog_effects::memory::Resolve,
             ["memory", "publish"]  => dialog_effects::memory::Publish,
             ["memory", "retract"]  => dialog_effects::memory::Retract,

--- a/rust/dialog-remote-ucan-s3/src/permit_cache.rs
+++ b/rust/dialog-remote-ucan-s3/src/permit_cache.rs
@@ -147,6 +147,7 @@ mod tests {
     use super::{MAX_ENTRIES, PERMIT_TTL, PermitCache, PermitKey};
     use dialog_capability::{Capability, Subject, did};
     use dialog_common::{Buffer, time};
+    use dialog_effects::Use;
     use dialog_effects::archive::{Archive, Catalog, Get, Put};
     use dialog_remote_s3::request::{IntoRequest, S3Request};
     use dialog_remote_s3::{Permit, Precondition};
@@ -174,6 +175,7 @@ mod tests {
 
     fn catalog() -> Capability<Catalog> {
         Subject::from(did!("key:zPermitCacheTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("blocks"))
     }

--- a/rust/dialog-remote-ucan-s3/src/provider.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider.rs
@@ -93,6 +93,7 @@ mod tests {
     use super::*;
     use dialog_capability::{Principal, Subject, did};
     use dialog_credentials::Ed25519Signer;
+    use dialog_effects::Use;
     use dialog_effects::archive::{Archive, ArchiveError, Catalog, Get};
     use dialog_remote_s3::Permit;
     use dialog_ucan::UcanInvocation;
@@ -146,6 +147,7 @@ mod tests {
     async fn it_retains_the_permit_after_a_transport_error() {
         let signer = Ed25519Signer::import(&[9u8; 32]).await.unwrap();
         let capability = Subject::from(did!("key:zPermitCacheTransportTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("blobs"))
             .invoke(Get::new([0u8; 32]));
@@ -181,6 +183,7 @@ mod tests {
     #[dialog_common::test]
     fn it_scopes_cached_permits_to_the_site() {
         let capability = Subject::from(did!("key:zPermitCacheScopeTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("blobs"))
             .invoke(Get::new([0u8; 32]));
@@ -225,6 +228,7 @@ mod tests {
             let signer = Ed25519Signer::import(&[7u8; 32]).await.unwrap();
             let digest = Blake3Hash::hash(b"not uploaded yet");
             let capability = Subject::from(did!("key:zPermitCacheProbeTest"))
+                .attenuate(Use)
                 .attenuate(Archive)
                 .blob()
                 .read(digest);
@@ -274,6 +278,7 @@ mod tests {
 
             let signer = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
             let capability = Subject::from(did!("key:zPermitCacheRejectTest"))
+                .attenuate(Use)
                 .attenuate(Archive)
                 .attenuate(Catalog::new("blocks"))
                 .invoke(Get::new([2u8; 32]));

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -645,6 +645,7 @@ mod tests {
             // Profile should be able to claim access to any memory space
             let capability = repo
                 .subject()
+                .attenuate(dialog_effects::Use)
                 .attenuate(fx_memory::Memory)
                 .attenuate(fx_memory::Space::new("data"));
 
@@ -670,6 +671,7 @@ mod tests {
             // Repo delegates only memory/space("data") to the profile
             let scoped_cap = repo
                 .subject()
+                .attenuate(dialog_effects::Use)
                 .attenuate(fx_memory::Memory)
                 .attenuate(fx_memory::Space::new("data"));
             let chain = repo
@@ -683,6 +685,7 @@ mod tests {
             // Claiming "data" space should succeed
             let data_cap = repo
                 .subject()
+                .attenuate(dialog_effects::Use)
                 .attenuate(fx_memory::Memory)
                 .attenuate(fx_memory::Space::new("data"));
             let result = profile.access().claim(data_cap).perform(&operator).await;
@@ -695,6 +698,7 @@ mod tests {
             // Claiming "secret" space should fail
             let secret_cap = repo
                 .subject()
+                .attenuate(dialog_effects::Use)
                 .attenuate(fx_memory::Memory)
                 .attenuate(fx_memory::Space::new("secret"));
             let result = profile.access().claim(secret_cap).perform(&operator).await;
@@ -718,6 +722,7 @@ mod tests {
             // Repo delegates memory/space("data") to the profile
             let scoped_cap = repo
                 .subject()
+                .attenuate(dialog_effects::Use)
                 .attenuate(fx_memory::Memory)
                 .attenuate(fx_memory::Space::new("data"));
             let chain = repo
@@ -731,6 +736,7 @@ mod tests {
             // Profile can re-delegate "data" space to operator
             let data_cap = repo
                 .subject()
+                .attenuate(dialog_effects::Use)
                 .attenuate(fx_memory::Memory)
                 .attenuate(fx_memory::Space::new("data"));
             let result = profile
@@ -748,6 +754,7 @@ mod tests {
             // Profile cannot delegate "secret" space (no chain)
             let secret_cap = repo
                 .subject()
+                .attenuate(dialog_effects::Use)
                 .attenuate(fx_memory::Memory)
                 .attenuate(fx_memory::Space::new("secret"));
             let result = profile

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -523,6 +523,7 @@ mod tests {
         use dialog_capability::{Did, Subject};
         use dialog_common::Blake3Hash;
         use dialog_credentials::{Ed25519Signer, SignerCredential};
+        use dialog_effects::Use;
         use dialog_effects::archive::{Archive, Catalog, Put};
         use dialog_effects::memory::{Cell, Memory, Publish, Space};
         use dialog_effects::prelude::*;
@@ -540,6 +541,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content)))
@@ -549,6 +551,7 @@ mod tests {
         // Memory creates "memory" store
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("head"))

--- a/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/archive.rs
@@ -119,6 +119,7 @@ mod tests {
     use super::*;
     use crate::helpers::{unique_name, unique_subject};
     use dialog_common::{Blake3Hash, Buffer};
+    use dialog_effects::Use;
     use dialog_effects::archive::{Archive, Catalog};
 
     #[dialog_common::test]
@@ -128,6 +129,7 @@ mod tests {
         let digest = Blake3Hash::hash(b"nonexistent");
 
         let effect = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
@@ -147,6 +149,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content.clone())))
@@ -154,6 +157,7 @@ mod tests {
             .await?;
 
         let result = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
@@ -175,6 +179,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Put::new(Buffer::from(content1.clone())))
@@ -183,6 +188,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Put::new(Buffer::from(content2.clone())))
@@ -191,6 +197,7 @@ mod tests {
 
         let result1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest1))
@@ -200,6 +207,7 @@ mod tests {
 
         let result2 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Get::new(digest2.clone()))
@@ -208,6 +216,7 @@ mod tests {
         assert_eq!(result2, Some(content2));
 
         let cross = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest2))
@@ -231,6 +240,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Import::new(blocks))
@@ -240,6 +250,7 @@ mod tests {
         for (i, digest) in digests.into_iter().enumerate() {
             let content = subject
                 .clone()
+                .attenuate(Use)
                 .attenuate(Archive)
                 .attenuate(Catalog::new("index"))
                 .invoke(Get::new(digest))
@@ -275,6 +286,7 @@ mod tests {
         for block in &blocks {
             subject
                 .clone()
+                .attenuate(Use)
                 .attenuate(Archive)
                 .attenuate(Catalog::new("puts"))
                 .invoke(Put::new(block.clone()))
@@ -286,6 +298,7 @@ mod tests {
         let start = js_sys::Date::now();
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("import"))
             .invoke(Import::new(blocks))

--- a/rust/dialog-storage/src/storage/provider/indexeddb/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/memory.rs
@@ -190,6 +190,7 @@ mod tests {
 
     use super::*;
     use crate::helpers::{unique_name, unique_subject};
+    use dialog_effects::Use;
     use dialog_effects::memory::{Cell, Memory, Space};
 
     #[dialog_common::test]
@@ -198,6 +199,7 @@ mod tests {
         let subject = unique_subject("memory-resolve-none");
 
         let effect = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("missing"))
@@ -218,6 +220,7 @@ mod tests {
         // Publish new content (when = None means expect empty)
         let edition = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -229,6 +232,7 @@ mod tests {
 
         // Resolve to verify
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -251,6 +255,7 @@ mod tests {
         // Create initial content
         let edition1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -261,6 +266,7 @@ mod tests {
         // Update with correct edition
         let edition2 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -272,6 +278,7 @@ mod tests {
 
         // Verify update
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -293,6 +300,7 @@ mod tests {
         // Create initial content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -303,6 +311,7 @@ mod tests {
         // Try to update with wrong edition
         let wrong_edition = Version::from(Blake3Hash::hash(b"wrong"));
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -323,6 +332,7 @@ mod tests {
         // Create initial content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -332,6 +342,7 @@ mod tests {
 
         // Try to create again (when = None means expect empty)
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -352,6 +363,7 @@ mod tests {
         // Create content
         let edition = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -362,6 +374,7 @@ mod tests {
         // Retract with correct edition
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -371,6 +384,7 @@ mod tests {
 
         // Verify deleted
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -391,6 +405,7 @@ mod tests {
         // Create content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -401,6 +416,7 @@ mod tests {
         // Try to retract with wrong edition
         let wrong_version = Blake3Hash::hash(b"wrong");
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -421,6 +437,7 @@ mod tests {
         // Publish to different spaces
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
@@ -430,6 +447,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
@@ -440,6 +458,7 @@ mod tests {
         // Resolve from space1
         let result1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
@@ -450,6 +469,7 @@ mod tests {
 
         // Resolve from space2
         let result2 = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
@@ -470,6 +490,7 @@ mod tests {
         // Create initial content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -480,6 +501,7 @@ mod tests {
         // Try to publish same content with wrong edition - should succeed
         let wrong_edition = Version::from(Blake3Hash::hash(b"wrong"));
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -502,6 +524,7 @@ mod tests {
         // Create value at cell1
         let edition1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell1"))
@@ -511,6 +534,7 @@ mod tests {
 
         // Create same value at cell2
         let edition2 = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell2"))
@@ -532,6 +556,7 @@ mod tests {
         // Try to retract non-existent cell - should succeed
         let wrong_edition = Blake3Hash::hash(b"wrong");
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("nonexistent"))

--- a/rust/dialog-storage/src/storage/provider/volatile.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile.rs
@@ -17,6 +17,7 @@
 //! use dialog_storage::provider::Volatile;
 //! use dialog_capability::{did, Did, Subject};
 //! use dialog_effects::archive::{Archive, Catalog, Get};
+//! use dialog_effects::Use;
 //! use dialog_common::Blake3Hash;
 //!
 //! # async fn example() -> anyhow::Result<()> {
@@ -24,7 +25,7 @@
 //! let digest = Blake3Hash::hash(b"hello");
 //!
 //! let effect = Subject::from(did!("key:z6Mk..."))
-//!     .attenuate(Archive)
+//!     .attenuate(Use).attenuate(Archive)
 //!     .attenuate(Catalog::new("index"))
 //!     .invoke(Get::new(digest));
 //!
@@ -226,6 +227,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_supports_concurrent_access() -> anyhow::Result<()> {
         use dialog_capability::Subject;
+        use dialog_effects::Use;
         use dialog_effects::archive::{Archive, Catalog, Get, Put};
         use std::sync::Arc;
 
@@ -242,6 +244,7 @@ mod tests {
 
                 subject
                     .clone()
+                    .attenuate(Use)
                     .attenuate(Archive)
                     .attenuate(Catalog::new("index"))
                     .invoke(Put::new(Buffer::from(content)))
@@ -250,6 +253,7 @@ mod tests {
                     .unwrap();
 
                 let result = subject
+                    .attenuate(Use)
                     .attenuate(Archive)
                     .attenuate(Catalog::new("index"))
                     .invoke(Get::new(digest))

--- a/rust/dialog-storage/src/storage/provider/volatile/archive.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/archive.rs
@@ -96,6 +96,7 @@ mod tests {
     use super::*;
     use crate::helpers::unique_subject;
     use dialog_common::{Blake3Hash, Buffer};
+    use dialog_effects::Use;
     use dialog_effects::archive::{Archive, Catalog};
 
     #[dialog_common::test]
@@ -105,6 +106,7 @@ mod tests {
         let digest = Blake3Hash::hash(b"nonexistent");
 
         let effect = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
@@ -125,6 +127,7 @@ mod tests {
         // Put content
         let put_effect = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content.clone())));
@@ -133,6 +136,7 @@ mod tests {
 
         // Get content
         let get_effect = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest));
@@ -155,6 +159,7 @@ mod tests {
         // Store in different catalogs
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Put::new(Buffer::from(content1.clone())))
@@ -163,6 +168,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Put::new(Buffer::from(content2.clone())))
@@ -172,6 +178,7 @@ mod tests {
         // Retrieve from catalog1
         let result1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest1))
@@ -182,6 +189,7 @@ mod tests {
         // Retrieve from catalog2
         let result2 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog2"))
             .invoke(Get::new(digest2.clone()))
@@ -191,6 +199,7 @@ mod tests {
 
         // Cross-catalog lookup should return None
         let cross = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("catalog1"))
             .invoke(Get::new(digest2))
@@ -211,6 +220,7 @@ mod tests {
         // Put twice - should succeed both times
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content.clone())))
@@ -219,6 +229,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content.clone())))
@@ -227,6 +238,7 @@ mod tests {
 
         // Should still be retrievable
         let result = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
@@ -246,6 +258,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content.clone())))
@@ -253,6 +266,7 @@ mod tests {
             .await?;
 
         let result = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
@@ -273,6 +287,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content.clone())))
@@ -280,6 +295,7 @@ mod tests {
             .await?;
 
         let result = subject
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))
@@ -303,6 +319,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Import::new(blocks))
@@ -312,6 +329,7 @@ mod tests {
         for (i, digest) in digests.into_iter().enumerate() {
             let content = subject
                 .clone()
+                .attenuate(Use)
                 .attenuate(Archive)
                 .attenuate(Catalog::new("index"))
                 .invoke(Get::new(digest))
@@ -330,6 +348,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Import::new(Vec::<Buffer>::new()))
@@ -341,6 +360,7 @@ mod tests {
         for _ in 0..2 {
             subject
                 .clone()
+                .attenuate(Use)
                 .attenuate(Archive)
                 .attenuate(Catalog::new("index"))
                 .invoke(Import::new([block.clone()]))
@@ -350,6 +370,7 @@ mod tests {
 
         let content = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest))

--- a/rust/dialog-storage/src/storage/provider/volatile/memory.rs
+++ b/rust/dialog-storage/src/storage/provider/volatile/memory.rs
@@ -146,6 +146,7 @@ impl Provider<Retract> for Volatile {
 mod tests {
     use super::*;
     use crate::helpers::unique_subject;
+    use dialog_effects::Use;
     use dialog_effects::memory::{Cell, Memory, Space, Version};
 
     #[dialog_common::test]
@@ -154,6 +155,7 @@ mod tests {
         let subject = unique_subject("memory-resolve-none");
 
         let effect = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("missing"))
@@ -174,6 +176,7 @@ mod tests {
         // Publish new content (when = None means expect empty)
         let edition = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -185,6 +188,7 @@ mod tests {
 
         // Resolve to verify
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -207,6 +211,7 @@ mod tests {
         // Create initial content
         let edition1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -217,6 +222,7 @@ mod tests {
         // Update with correct edition
         let edition2 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -228,6 +234,7 @@ mod tests {
 
         // Verify update
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -249,6 +256,7 @@ mod tests {
         // Create initial content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -259,6 +267,7 @@ mod tests {
         // Try to update with wrong edition
         let wrong_edition = Version::from(Blake3Hash::hash(b"wrong"));
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -279,6 +288,7 @@ mod tests {
         // Create initial content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -288,6 +298,7 @@ mod tests {
 
         // Try to create again (when = None means expect empty)
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -308,6 +319,7 @@ mod tests {
         // Create content
         let edition = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -318,6 +330,7 @@ mod tests {
         // Retract with correct edition
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -327,6 +340,7 @@ mod tests {
 
         // Verify deleted
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -347,6 +361,7 @@ mod tests {
         // Create content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -357,6 +372,7 @@ mod tests {
         // Try to retract with wrong edition
         let wrong_version = Version::from(Blake3Hash::hash(b"wrong"));
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -377,6 +393,7 @@ mod tests {
         // Publish to different spaces
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
@@ -386,6 +403,7 @@ mod tests {
 
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
@@ -396,6 +414,7 @@ mod tests {
         // Resolve from space1
         let result1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space1"))
             .attenuate(Cell::new("cell"))
@@ -406,6 +425,7 @@ mod tests {
 
         // Resolve from space2
         let result2 = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("space2"))
             .attenuate(Cell::new("cell"))
@@ -426,6 +446,7 @@ mod tests {
         // Create initial content
         subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -436,6 +457,7 @@ mod tests {
         // Try to publish same content with wrong edition - should succeed
         let wrong_version = Version::from(Blake3Hash::hash(b"wrong"));
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("test"))
@@ -458,6 +480,7 @@ mod tests {
         // Create value at cell1
         let edition1 = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell1"))
@@ -467,6 +490,7 @@ mod tests {
 
         // Create same value at cell2
         let edition2 = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("cell2"))
@@ -488,6 +512,7 @@ mod tests {
         // Try to retract non-existent cell - should succeed
         let wrong_version = Version::from(Blake3Hash::hash(b"wrong"));
         let result = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("nonexistent"))
@@ -509,6 +534,7 @@ mod tests {
         // Publish to nested space path
         let edition = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("parent/child/grandchild"))
             .attenuate(Cell::new("cell"))
@@ -520,6 +546,7 @@ mod tests {
 
         // Resolve to verify
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("parent/child/grandchild"))
             .attenuate(Cell::new("cell"))
@@ -541,6 +568,7 @@ mod tests {
 
         let edition = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("empty"))
@@ -551,6 +579,7 @@ mod tests {
         assert!(!edition.is_empty());
 
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("empty"))
@@ -573,6 +602,7 @@ mod tests {
 
         let edition = subject
             .clone()
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("large"))
@@ -583,6 +613,7 @@ mod tests {
         assert!(!edition.is_empty());
 
         let resolved = subject
+            .attenuate(Use)
             .attenuate(Memory)
             .attenuate(Space::new("local"))
             .attenuate(Cell::new("large"))

--- a/rust/dialog-ucan/src/parameters.rs
+++ b/rust/dialog-ucan/src/parameters.rs
@@ -83,6 +83,7 @@ mod tests {
     use super::*;
     use dialog_capability::{Subject, did};
     use dialog_common::{Blake3Hash, Buffer};
+    use dialog_effects::Use;
     use dialog_effects::archive::{Archive, Catalog, Get, Put};
 
     #[dialog_common::test]
@@ -95,6 +96,7 @@ mod tests {
     #[dialog_common::test]
     fn it_collects_parameters_from_archive_catalog_chain() {
         let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"));
         let params = parameters(&cap);
@@ -105,6 +107,7 @@ mod tests {
     fn it_collects_parameters_from_archive_get_invocation() {
         let digest = Blake3Hash::hash(b"my-content");
         let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("data"))
             .invoke(Get::new(digest));
@@ -125,6 +128,7 @@ mod tests {
     #[dialog_common::test]
     fn it_produces_equality_constraints_for_each_parameter() {
         let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("data"));
         let policy = parameters_to_policy(parameters(&cap));
@@ -143,6 +147,7 @@ mod tests {
     fn it_produces_multiple_constraints_for_chain_with_payload() {
         let content = b"hello world";
         let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Put::new(Buffer::from(content.to_vec())));

--- a/rust/dialog-ucan/src/scope.rs
+++ b/rust/dialog-ucan/src/scope.rs
@@ -233,6 +233,7 @@ mod tests {
     use super::*;
     use dialog_capability::{Subject, did};
     use dialog_common::Blake3Hash;
+    use dialog_effects::Use;
     use dialog_effects::archive::{Archive, Catalog, Get};
 
     #[dialog_common::test]
@@ -257,11 +258,15 @@ mod tests {
     #[dialog_common::test]
     fn it_builds_scope_from_archive_catalog() {
         let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"));
         let scope = Scope::from(&cap);
 
-        assert_eq!(scope.command, Command::parse("/archive").unwrap());
+        // A catalog is a policy, not a command of its own: the level a
+        // delegation attenuates at is `/use`, and the verb comes from the
+        // effect.
+        assert_eq!(scope.command, Command::parse("/use").unwrap());
 
         let policy = scope.policy();
         assert_eq!(policy.len(), 1);
@@ -281,12 +286,16 @@ mod tests {
     fn it_builds_scope_from_archive_get() {
         let digest = Blake3Hash::hash(b"hello");
         let cap = Subject::from(did!("key:z6MkTest"))
+            .attenuate(Use)
             .attenuate(Archive)
             .attenuate(Catalog::new("index"))
             .invoke(Get::new(digest.clone()));
         let scope = Scope::from(&cap);
 
-        assert_eq!(scope.command, Command::parse("/archive/get").unwrap());
+        assert_eq!(
+            scope.command,
+            Command::parse("/use/get/archive/block").unwrap()
+        );
 
         let policy = scope.policy();
         assert!(


### PR DESCRIPTION
Storage commands sat at the top of the command tree (`/memory/*`, `/archive/*`) next to `/ucan/*`, so the only delegation that covered a subject's data was `/`, and `/` also covers delegating and revoking. tonk hands members `/` on invite, and a delegated revocation is recorded under the subject it is proven for, so every member could remove anyone.

`Use` becomes a level of the capability hierarchy: `Subject → Use → Memory | Archive → …`. Effects name their own verb and resource, so the commands are:

| before | after |
|---|---|
| `/memory/resolve` | `/use/get/memory/cell` |
| `/memory/publish` | `/use/put/memory/cell` |
| `/memory/retract` | `/use/delete/memory/cell` |
| `/archive/get` | `/use/get/archive/block` |
| `/archive/put` | `/use/put/archive/block` |
| `/archive/blob/read` | `/use/get/archive/blob` |
| `/archive/blob/import` | `/use/put/archive/blob` |

`/use` is read+write; `/use/get` read, `/use/put` and `/use/delete` writes; `/ucan/*` stays outside; `/void` is reserved for destruction and empty. A member delegation is `Subject::attenuate(Use)`; a deposit scoped to a branch is `Subject::attenuate(Use).attenuate(Memory).attenuate(Space)` and spells `/use` with the policy, never `/`.

Mechanically: `Effect` gains `command()` (default: the type name, as before) and the blanket `Attenuation for Effect` uses it; ability composition kebab-cases per path component so an effect can name a multi-segment command; `Memory`/`Archive`/`Blob` are plain policies (no segment) hanging under `Use`; the `did.memory()` / `did.archive()` builders route through `Use`, so only direct `attenuate(Memory|Archive)` sites changed. The authorizer accepts both spellings during the transition.

Workspace tests, fmt green; clippy shows only the pre-existing unused imports in `dialog-operator` tests.
