### PR TITLE
feat(capability): a declined request is its own reason

### DIFF
--- a/rust/dialog-capability/src/access.rs
+++ b/rust/dialog-capability/src/access.rs
@@ -19,6 +19,7 @@
 use crate::{Ability, Attenuate, Capability, Constraint, Did, Effect};
 use dialog_common::{ConditionalSend, ConditionalSync};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::marker::PhantomData;
 use thiserror::Error;
 
@@ -622,6 +623,35 @@ pub trait CertificateStore<P: Protocol> {
     }
 }
 
+/// Whether a [`Declined`](AuthorizeError::Declined) refusal can change
+/// without the caller doing anything.
+///
+/// The only thing this crate can say about another party's policy, and
+/// the only thing a caller can act on generically: keep the request in
+/// hand and try again, or stop. What the policy actually is stays
+/// opaque -- it belongs to whoever set it, and this crate does not model
+/// other people's rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum Recourse {
+    /// The refusal stands until something changes elsewhere, and the
+    /// caller cannot make that happen by retrying. Stop.
+    None,
+    /// The condition is expected to clear on its own -- someone else
+    /// completes a step, a state settles -- so the same request may
+    /// succeed later. Retrying is the intended behavior, and a caller
+    /// waiting on it should hold what it has rather than start over.
+    Retry,
+}
+
+impl Display for Recourse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str(match self {
+            Self::None => "no recourse",
+            Self::Retry => "may succeed later",
+        })
+    }
+}
+
 /// Error during the authorize step.
 ///
 /// Most variants here are the caller's input failing to authorize what it
@@ -736,6 +766,31 @@ pub enum AuthorizeError {
         subject: Did,
     },
 
+    /// The chain authorizes the request and the responder declined it
+    /// anyway, on a policy of its own.
+    ///
+    /// Unlike every decision variant above, this says nothing about the
+    /// caller's proof: the authority is real and would be honored if the
+    /// responder were willing. What refused is a rule this crate does
+    /// not model and should not -- whose resources these are, what they
+    /// cost, what state an account is in are the responder's business.
+    ///
+    /// Mirrors no `CheckFailed` case, because no chain check produced it.
+    ///
+    /// So `reason` is opaque: it is whatever the responder said, kept
+    /// for logs and error surfaces, and matching on its text is the
+    /// mistake it looks like. The one thing a caller can act on
+    /// generically is [`Recourse`] -- whether the same request is worth
+    /// making again. A responder that wants to be understood more
+    /// precisely than that publishes its own vocabulary alongside.
+    #[error("The request was declined ({recourse}): {reason}")]
+    Declined {
+        /// Whether retrying the same request may succeed later.
+        recourse: Recourse,
+        /// The responder's own words, verbatim and unstructured.
+        reason: String,
+    },
+
     /// A proof's signature does not verify against its issuer's key.
     #[error("Proof does not carry a valid signature from '{issuer}'")]
     InvalidSignature {
@@ -811,7 +866,7 @@ mod tests {
     // Round-tripping every variant is what makes that safe -- a variant
     // that serializes but will not come back is a silent protocol break.
     mod wire {
-        use crate::access::AuthorizeError;
+        use crate::access::{AuthorizeError, Recourse};
         use crate::did;
 
         fn round_trip(error: AuthorizeError) {
@@ -836,6 +891,14 @@ mod tests {
                 },
                 AuthorizeError::PolicyViolation {
                     predicate: "size < 1024".into(),
+                },
+                AuthorizeError::Declined {
+                    recourse: Recourse::Retry,
+                    reason: "the subject's own registration awaits email activation".into(),
+                },
+                AuthorizeError::Declined {
+                    recourse: Recourse::None,
+                    reason: "the provider's registration is suspended".into(),
                 },
                 AuthorizeError::InvalidAudience {
                     claimed: audience.clone(),
@@ -871,8 +934,51 @@ mod tests {
     }
 
     mod reasons {
-        use crate::access::AuthorizeError;
+        use crate::access::{AuthorizeError, Recourse};
         use crate::did;
+
+        // Being declined is not failing to prove authority. The chain
+        // authorizes the request; what says no is a policy of the
+        // responder's, so a caller that reads this as "my credentials
+        // are wrong" would re-authenticate forever.
+        #[dialog_common::test]
+        async fn it_separates_a_declined_request_from_an_unproven_one() {
+            let declined = AuthorizeError::Declined {
+                recourse: Recourse::Retry,
+                reason: "awaiting something".into(),
+            };
+            assert!(matches!(declined, AuthorizeError::Declined { .. }));
+            assert!(!matches!(declined, AuthorizeError::UnprovenSubject { .. }));
+        }
+
+        // The one thing this crate says about someone else's policy.
+        // Everything about WHY stays in `reason`: the responder's own
+        // words, which are not ours to interpret.
+        #[dialog_common::test]
+        async fn it_says_only_whether_the_request_is_worth_repeating() {
+            let waiting = AuthorizeError::Declined {
+                recourse: Recourse::Retry,
+                reason: "settling".into(),
+            };
+            let final_answer = AuthorizeError::Declined {
+                recourse: Recourse::None,
+                reason: "withdrawn".into(),
+            };
+            assert!(matches!(
+                waiting,
+                AuthorizeError::Declined {
+                    recourse: Recourse::Retry,
+                    ..
+                }
+            ));
+            assert!(matches!(
+                final_answer,
+                AuthorizeError::Declined {
+                    recourse: Recourse::None,
+                    ..
+                }
+            ));
+        }
 
         // The distinction the split exists for. Both mean "this proof does not
         // authorize you right now", and a single `Denied(String)` could not


### PR DESCRIPTION
`AuthorizeError` says a lot about why a proof did not authorize a request, and nothing about the case where the proof is fine and the responder declines anyway. Tonk's access service has that case: it will not carry a subject nobody pays for, or one whose account has not finished registering. Today all of those arrive as `PolicyViolation` with the reason formatted into the predicate string, which reads fine in a log and gives a client nothing to act on.

`Declined` names the case. The distinction it draws is the one the enum already exists for: every other decision variant is about the caller's proof, so a client that reads this as bad credentials would re-authenticate forever, and one that reads a proof failure as a policy refusal would wait for something that is never coming.

**What it deliberately does not carry.** An earlier draft of this had the variant naming registration states directly — awaiting activation, suspended, unprovisioned. That is one service's vocabulary, and this crate has no business modelling whose resources these are or what state an account is in. So `reason` is opaque: the responder's own words, kept for logs and error surfaces, with the same warning `Rejection::Unclassified` already carries about matching on its text.

`Recourse` is the one thing that generalizes. Whether the same request is worth making again is answerable without knowing anything about the policy, and it is what a caller actually branches on: hold the request and retry, or stop. A responder wanting to be understood more precisely publishes its own vocabulary alongside.

Note the variant mirrors no `CheckFailed` case, unlike its neighbours: no chain check produced it. That is also why it does not belong under `PolicyViolation`, which is specifically a delegation's policy rejecting the arguments.

The existing round-trip test covers both recourse values, since as its comment says, a variant that serializes but will not come back is a silent protocol break.