### PR TITLE
feat(repository): snapshots read and transact like branches

### DIFF
--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -43,6 +43,8 @@ pub use remote::*;
 mod snapshot;
 pub use snapshot::*;
 
+pub(crate) mod source;
+
 // `Revision` and `TreeReference` moved to `dialog-capability` (the
 // light crate that owns `Did`) so engine-free clients can name them
 // without linking `dialog-query` or the storage/transport stack.

--- a/rust/dialog-repository/src/repository/branch.rs
+++ b/rust/dialog-repository/src/repository/branch.rs
@@ -6,12 +6,13 @@ use dialog_common::ConditionalSync;
 use dialog_effects::memory;
 use dialog_query::concept::query::PlanCache;
 
-use crate::{NetworkedIndex, RemoteSite, RepositoryArchiveExt as _};
+use crate::repository::source::{Caches, SourceRef};
+use crate::{NetworkedIndex, RemoteSite};
 use dialog_artifacts::DialogArtifactsError;
 use dialog_artifacts::Entity;
 use dialog_artifacts::history::Origin;
 use dialog_artifacts::history::{
-    CausalityCache, ContextCache, RevisionRecord, TreeHistory, Version, log,
+    CausalityCache, ContextCache, RevisionRecord, TreeHistory, Version,
 };
 use dialog_artifacts::tree::SpillCache;
 use dialog_artifacts::{Exporter, Importer};
@@ -279,13 +280,7 @@ impl Branch {
             + ConditionalSync
             + 'static,
     {
-        let store = NetworkedIndex::new(env, self.archive().index(), None);
-        let root = self
-            .revision()
-            .map(|revision| *revision.tree.hash())
-            .unwrap_or(crate::EMPTY_TREE_HASH);
-        TreeHistory::from_root_with_cache(&root, store, self.node_cache())
-            .with_record_cache(self.records())
+        SourceRef::from(self).history(env)
     }
 
     /// The branch's committed history, newest first — at most `limit`
@@ -306,10 +301,7 @@ impl Branch {
             + ConditionalSync
             + 'static,
     {
-        let Some(head) = self.revision() else {
-            return Ok(Vec::new());
-        };
-        log(&head.version(), &self.history(env), limit).await
+        SourceRef::from(self).log(env, limit).await
     }
 
     /// Export all artifacts from this branch to the given exporter.
@@ -332,6 +324,23 @@ impl Branch {
     /// A shared handle to this branch's node cache, for seeding a read tree.
     pub(crate) fn node_cache(&self) -> Cache<Blake3Hash, Buffer> {
         self.node_cache.clone()
+    }
+
+    /// Shared handles to every cache this branch carries, for a
+    /// [`Snapshot`](crate::Snapshot) minted from it to read and commit
+    /// through. All content- or version-addressed, so sharing them
+    /// never serves a stale entry.
+    pub(crate) fn caches(&self) -> Caches {
+        Caches {
+            nodes: self.node_cache.clone(),
+            spills: self.spill_cache.clone(),
+            rules: self.rule_cache.clone(),
+            plans: self.plan_cache.clone(),
+            causality: self.causality_cache.clone(),
+            contexts: self.context_cache.clone(),
+            records: self.record_cache.clone(),
+            spine: self.spine.clone(),
+        }
     }
 
     /// The live-spine slot this branch's commits reuse.

--- a/rust/dialog-repository/src/repository/branch/blob.rs
+++ b/rust/dialog-repository/src/repository/branch/blob.rs
@@ -63,9 +63,11 @@
 //! # }
 //! ```
 
+use crate::repository::source::SourceRef;
 use crate::{
     Branch, CommitError, EMPTY_TREE_HASH, Index, NetworkedIndex, RemoteFallback, RemoteSite,
-    RepositoryArchiveExt as _, RepositoryMemoryExt as _, Revision, TreeReference, Upstream,
+    RepositoryArchiveExt as _, RepositoryMemoryExt as _, Revision, Snapshot, TreeReference,
+    Upstream,
 };
 use dialog_artifacts::history::{Context, TreeHistory, context_of, extend_skips};
 use dialog_artifacts::tree::ArtifactTreeExt as _;
@@ -84,26 +86,53 @@ use dialog_effects::memory::{Publish, Resolve};
 use dialog_search_tree::Delta;
 use futures_util::{Stream, StreamExt};
 
-/// A branch's blob store: the target that blob reads and writes bind to.
+/// A line's blob store: the target that blob reads and writes bind to.
 ///
-/// Holds a reference to the [`Branch`], so it carries the subject (for the
-/// capability chain), the blob index (for size lookups), and the upstream (for
-/// remote hydration). Obtain one with [`Branch::blobs`] or `branch.into()`.
+/// Holds a reference to the [`Branch`] or [`Snapshot`], so it carries the
+/// subject (for the capability chain), the blob index (for size lookups),
+/// and — for a branch — the upstream (for remote hydration). Obtain one
+/// with [`Branch::blobs`], [`Snapshot::blobs`], or `branch.into()`.
+///
+/// Reads bind to either kind. Writes and retractions advance the line,
+/// which a reference to a snapshot cannot do (its revision is held by
+/// value): they fail with [`CommitError::Detached`], and the snapshot is
+/// advanced by consuming it instead.
 #[derive(Clone, Copy)]
 pub struct BlobArchive<'a> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
 }
 
 impl<'a> From<&'a Branch> for BlobArchive<'a> {
     fn from(branch: &'a Branch) -> Self {
-        Self { branch }
+        Self {
+            source: SourceRef::from(branch),
+        }
+    }
+}
+
+impl<'a> From<&'a Snapshot> for BlobArchive<'a> {
+    fn from(snapshot: &'a Snapshot) -> Self {
+        Self {
+            source: SourceRef::from(snapshot),
+        }
+    }
+}
+
+impl<'a> BlobArchive<'a> {
+    /// The branch behind this archive, for the operations that advance
+    /// it; a snapshot's archive refuses them.
+    fn branch(&self) -> Result<&'a Branch, CommitError> {
+        match self.source {
+            SourceRef::Branch(branch) => Ok(branch),
+            SourceRef::Snapshot(_) => Err(CommitError::Detached),
+        }
     }
 }
 
 impl Branch {
     /// This branch's blob store, the target for [`Blob`] reads and writes.
     pub fn blobs(&self) -> BlobArchive<'_> {
-        BlobArchive { branch: self }
+        BlobArchive::from(self)
     }
 }
 
@@ -197,14 +226,18 @@ fn blob_hash(entity: &Entity) -> Result<Blake3Hash, BlobError> {
 /// its blob index — after a fast-forward pull only the revision pointer is
 /// local, and the index nodes hydrate lazily. Fall back to the remote archive
 /// on a local miss (caching what lands), as `commit` does. With no remote
-/// upstream this degrades to a plain local index.
-pub(crate) async fn index_store<'e, Env>(branch: &Branch, env: &'e Env) -> NetworkedIndex<'e, Env>
+/// upstream (a snapshot never has one) this degrades to a plain local index.
+pub(crate) async fn index_store<'s, 'e, Env>(
+    source: impl Into<SourceRef<'s>>,
+    env: &'e Env,
+) -> NetworkedIndex<'e, Env>
 where
     Env: Provider<Resolve> + ConditionalSync + 'static,
 {
-    let remote = match branch.upstream() {
+    let source = source.into();
+    let remote = match source.upstream() {
         Some(Upstream::Remote { remote: name, .. }) => {
-            let loaded = branch
+            let loaded = source
                 .subject()
                 .remote(name.clone())
                 .load()
@@ -214,13 +247,13 @@ where
         }
         _ => RemoteFallback::None,
     };
-    NetworkedIndex::new(env, branch.archive().index(), remote)
+    NetworkedIndex::new(env, source.archive().index(), remote)
 }
 
-/// The size recorded for `hash` in the branch's blob index, or `None` if the
+/// The size recorded for `hash` in the line's blob index, or `None` if the
 /// current tree does not reference it.
 async fn index_size<Env>(
-    branch: &Branch,
+    source: SourceRef<'_>,
     hash: &Blake3Hash,
     env: &Env,
 ) -> Result<Option<u64>, CommitError>
@@ -232,10 +265,10 @@ where
         + ConditionalSync
         + 'static,
 {
-    let Some(revision) = branch.revision() else {
+    let Some(revision) = source.revision() else {
         return Ok(None);
     };
-    let store = index_store(branch, env).await;
+    let store = index_store(source, env).await;
     let tree = Index::from_hash(NodeHash::from(*revision.tree.hash()));
     Ok(tree
         .get_blob(&store, hash.as_bytes())
@@ -261,7 +294,7 @@ impl BlobSize<'_> {
             + 'static,
     {
         let hash = blob_hash(&self.entity)?;
-        index_size(self.archive.branch, &hash, env).await
+        index_size(self.archive.source, &hash, env).await
     }
 }
 
@@ -293,11 +326,11 @@ impl ReadBlob<'_> {
             + ConditionalSync
             + 'static,
     {
-        let branch = self.archive.branch;
+        let line = self.archive.source;
         let hash = blob_hash(&self.entity)?;
         let range = self.range;
 
-        let local = branch
+        let local = line
             .archive()
             .blob()
             .invoke(BlobRead {
@@ -313,18 +346,19 @@ impl ReadBlob<'_> {
             Err(other) => return Err(other.into()),
         };
 
-        // Local miss. Hydrate from the remote upstream, if any.
-        let Some(Upstream::Remote { remote: name, .. }) = branch.upstream() else {
+        // Local miss. Hydrate from the remote upstream, if any (a
+        // snapshot has none: its reads are local).
+        let Some(Upstream::Remote { remote: name, .. }) = line.upstream() else {
             return Err(BlobError::NotFound(miss_key).into());
         };
 
         // The index must already reference the blob for us to import it; without
         // a size we have no import to issue and the miss is genuine.
-        let Some(size) = index_size(branch, &hash, env).await? else {
+        let Some(size) = index_size(line, &hash, env).await? else {
             return Err(BlobError::NotFound(miss_key).into());
         };
 
-        let remote = branch
+        let remote = line
             .subject()
             .remote(name)
             .load()
@@ -345,7 +379,7 @@ impl ReadBlob<'_> {
             .await?;
 
         // Write the bytes through a local digest-verified import sink.
-        let mut sink = branch
+        let mut sink = line
             .archive()
             .blob()
             .import(hash.clone(), size)
@@ -357,8 +391,7 @@ impl ReadBlob<'_> {
         sink.finish().await?;
 
         // Serve the requested read from the now-local copy.
-        branch
-            .archive()
+        line.archive()
             .blob()
             .invoke(BlobRead {
                 digest: hash,
@@ -404,7 +437,7 @@ where
             + ConditionalSync
             + 'static,
     {
-        let branch = self.archive.branch;
+        let branch = self.archive.branch()?;
 
         // 1. Stream the bytes into the local blob store. The hash is discovered
         //    as the bytes are written; the size is counted alongside. The bytes
@@ -628,9 +661,12 @@ impl RetractBlob<'_> {
             + ConditionalSync
             + 'static,
     {
-        let branch = self.archive.branch;
+        let branch = self.archive.branch()?;
         let hash = blob_hash(&self.entity)?;
-        if index_size(branch, &hash, env).await?.is_none() {
+        if index_size(SourceRef::from(branch), &hash, env)
+            .await?
+            .is_none()
+        {
             return Ok(());
         }
         advance_blob_index(

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -1,11 +1,14 @@
+use crate::repository::source::SourceRef;
 use crate::{
-    Branch, CommitError, EMPTY_TREE_HASH, Index, NetworkedIndex, PublishError, RemoteFallback,
-    RemoteSite, RepositoryArchiveExt as _, RepositoryMemoryExt, Revision, TreeReference,
+    Branch, CommitError, EMPTY_TREE_HASH, Index, NetworkedIndex, PublishError, RemoteSite,
+    RepositoryArchiveExt as _, Revision, Snapshot, TreeReference, origin_of,
 };
-use dialog_artifacts::history::{Context, Edition, TreeHistory, Version, context_of, extend_skips};
+use dialog_artifacts::history::{
+    Context, Edition, Origin, RevisionRecord, TreeHistory, Version, context_of, extend_skips,
+};
 use dialog_artifacts::tree::WriteScope;
-use dialog_artifacts::{Datum, DialogArtifactsError, Instruction, Key, State};
-use dialog_capability::{Fork, Provider};
+use dialog_artifacts::{Datum, DialogArtifactsError, Entity, Instruction, Key, State};
+use dialog_capability::{Did, Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
 use dialog_common::{ConditionalSend, ConditionalSync};
 use dialog_effects::archive::prelude::CatalogExt as _;
@@ -15,11 +18,13 @@ use dialog_effects::memory::{Publish, Resolve};
 use dialog_search_tree::Delta;
 use futures_util::Stream;
 
-/// Command that commits a stream of changes (assert/retract) to a branch.
+/// Command that commits a stream of changes (assert/retract) to a branch
+/// or a snapshot.
 ///
-/// Created by [`Branch::commit`]. Execute with `.perform(&env)`.
+/// Created by [`Branch::commit`] or [`Snapshot::commit`]. Execute with
+/// `.perform(&env)`.
 pub struct Commit<'a, Changes> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
     changes: Changes,
     allow_empty: bool,
     canonicalize: bool,
@@ -28,9 +33,9 @@ pub struct Commit<'a, Changes> {
 }
 
 impl<'a, Changes> Commit<'a, Changes> {
-    fn new(branch: &'a Branch, changes: Changes) -> Self {
+    pub(crate) fn new(source: impl Into<SourceRef<'a>>, changes: Changes) -> Self {
         Self {
-            branch,
+            source: source.into(),
             changes,
             allow_empty: false,
             canonicalize: false,
@@ -116,16 +121,26 @@ impl Branch {
     }
 }
 
+impl Snapshot {
+    /// Commit a stream of changes to this snapshot: the same [`Commit`]
+    /// a branch runs. The minted revision is persisted and the snapshot
+    /// advances to it; no branch head moves. Mirrors [`Branch::commit`].
+    pub fn commit<Changes>(&self, changes: Changes) -> Commit<'_, Changes> {
+        Commit::new(self, changes)
+    }
+}
+
 impl<Changes> Commit<'_, Changes>
 where
     Changes: Stream<Item = Instruction> + ConditionalSend,
 {
     /// Execute the commit, returning the newly-published [`Revision`].
     ///
-    /// Load the branch's current search tree, apply every change in the
+    /// Load the line's current search tree, apply every change in the
     /// stream to the three (entity / attribute / value) indexes, then
-    /// publish a new [`Revision`] to the branch's revision cell with the
-    /// updated logical clock.
+    /// adopt the new [`Revision`] with the updated logical clock: a
+    /// branch publishes it to its revision cell, a snapshot advances its
+    /// own head.
     #[tracing::instrument(skip_all, name = "commit")]
     pub async fn perform<Env>(self, env: &Env) -> Result<Revision, CommitError>
     where
@@ -141,8 +156,32 @@ where
             + ConditionalSync
             + 'static,
     {
-        let branch = self.branch;
-        let changes = self.changes;
+        match self.source {
+            SourceRef::Branch(branch) => self.perform_on_branch(branch, env).await,
+            SourceRef::Snapshot(snapshot) => self.perform_on_snapshot(snapshot, env).await,
+        }
+    }
+
+    /// The branch path: build on the checkpointed head, publish CAS'd
+    /// against it.
+    async fn perform_on_branch<Env>(
+        self,
+        branch: &Branch,
+        env: &Env,
+    ) -> Result<Revision, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
         // Checkpoint the head: capture the version we build this commit on top
         // of, so the publish below CAS's against it. A concurrent commit or
         // pull that advances the head while we apply changes then makes this
@@ -152,7 +191,211 @@ where
         let base_revision = branch.revision();
         let base_version = branch.revision.edition().map(|edition| edition.version);
 
-        // If the branch tracks a remote upstream, commits must be able
+        let minted = Mint {
+            source: SourceRef::from(branch),
+            base: base_revision,
+            changes: self.changes,
+            entries: self.entries,
+            scope: self.scope,
+            allow_empty: self.allow_empty,
+            canonicalize: self.canonicalize,
+        }
+        .perform(env, |profile, issuer| {
+            branch.commit_identity(profile, issuer)
+        })
+        .await?;
+
+        let Minted {
+            revision,
+            record,
+            context,
+        } = match minted {
+            // A no-op verdict is only true of the head it was judged
+            // against, and this early return never reaches the publish CAS
+            // below — so re-read the head before reporting "nothing to do".
+            // If another writer advanced it, the same instructions may not be
+            // no-ops against the current head (a re-assertion of a value the
+            // head has since retracted, for example): fail with the same
+            // `VersionMismatch` any other stale write gets, so the caller
+            // refreshes and retries against the fresh snapshot.
+            Outcome::Unchanged(base) => {
+                branch.revision.resolve().perform(env).await?;
+                let actual = branch.revision.edition().map(|edition| edition.version);
+                if actual != base_version {
+                    return Err(PublishError::VersionMismatch {
+                        expected: base_version,
+                        actual,
+                    }
+                    .into());
+                }
+                return Ok(base);
+            }
+            Outcome::Minted(minted) => *minted,
+        };
+
+        head.publish(revision.clone(), env).await?;
+
+        // Seed the memos with what was just published: the next commit's
+        // skip-table walk starts at this very record, and later pulls
+        // through this handle answer the context from memory. Seeded only
+        // once the head has actually advanced — a publish that lost its
+        // CAS is re-minted under the same version with a different
+        // parent, and a memo entry from the losing attempt would be wrong.
+        let version = revision.version();
+        branch.records().insert(version, record);
+        branch.contexts().insert(version, context);
+
+        Ok(revision)
+    }
+
+    /// The snapshot path: build on the head the snapshot holds, mint on
+    /// the snapshot's own lineage, and advance the head in place.
+    async fn perform_on_snapshot<Env>(
+        self,
+        snapshot: &Snapshot,
+        env: &Env,
+    ) -> Result<Revision, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        // The head this commit builds on and the line it mints on, read
+        // together. The lineage is inherited from the snapshot's earlier
+        // commits, or allocated now for its first: random rather than
+        // derived, because two clones of one base must not share it.
+        let (base, lineage) = snapshot.head();
+        let lineage = match lineage {
+            Some(lineage) => lineage,
+            None => Entity::new()?,
+        };
+
+        let minted = Mint {
+            source: SourceRef::from(snapshot),
+            base: Some(base.clone()),
+            changes: self.changes,
+            entries: self.entries,
+            scope: self.scope,
+            allow_empty: self.allow_empty,
+            canonicalize: self.canonicalize,
+        }
+        .perform(env, |_, issuer| {
+            (lineage.clone(), origin_of(&lineage, issuer))
+        })
+        .await?;
+
+        let Minted {
+            revision,
+            record,
+            context,
+        } = match minted {
+            Outcome::Unchanged(base) => return Ok(base),
+            Outcome::Minted(minted) => *minted,
+        };
+
+        // Adopt the revision: the in-memory CAS against the head this
+        // commit built on, refused if a commit through this same handle
+        // advanced it in the meantime.
+        snapshot.advance(&base, revision.clone(), lineage)?;
+
+        // Seed the memos once the head has moved, as the branch path
+        // does: the next commit's skip-table walk starts at this record,
+        // and the context memo answers the successor's context without
+        // an ancestry walk.
+        let version = revision.version();
+        snapshot.caches().records.insert(version, record);
+        snapshot.caches().contexts.insert(version, context);
+
+        Ok(revision)
+    }
+}
+
+/// A revision minted by [`Mint`] and persisted, but not yet adopted:
+/// the branch adopts it through its head cell, a snapshot by value.
+pub(crate) struct Minted {
+    /// The signed head, naming the persisted tree root.
+    pub(crate) revision: Revision,
+    /// Its signed in-tree record, for the verified-record memo.
+    pub(crate) record: RevisionRecord,
+    /// Its causal context, for the context memo.
+    pub(crate) context: Context,
+}
+
+/// How a [`Mint`] came out.
+pub(crate) enum Outcome {
+    /// The batch left the indexes untouched and `allow_empty` was not
+    /// asked for: nothing was minted or persisted, and the line keeps
+    /// the revision it had. Only possible when there was a base
+    /// revision to keep.
+    Unchanged(Revision),
+    /// A revision was minted and its blocks persisted.
+    Minted(Box<Minted>),
+}
+
+/// The commit procedure shared by every line: apply a change batch to
+/// the tree at `base`, mint the successor revision under the line's
+/// identity, sign it, and persist its blocks. What it deliberately does
+/// not do is adopt the result — a branch publishes it CAS'd against
+/// its head cell, a snapshot takes it by value — so the caller owns the
+/// step that makes the revision visible.
+pub(crate) struct Mint<'a, Changes> {
+    /// The line the commit builds on: where its store, caches, and
+    /// remote fallback come from.
+    pub(crate) source: SourceRef<'a>,
+    /// The revision the batch applies on top of, captured by the caller
+    /// (a branch checkpoints it for its CAS).
+    pub(crate) base: Option<Revision>,
+    /// The instruction stream to apply.
+    pub(crate) changes: Changes,
+    /// Pre-built machinery entries riding the same batch. See
+    /// [`Commit::with_entries`].
+    pub(crate) entries: Vec<(Key, State<Datum>)>,
+    /// Which attributes the stream may write. See [`Commit::machinery`].
+    pub(crate) scope: WriteScope,
+    /// Mint even when the batch changes nothing. See
+    /// [`Commit::allow_empty`].
+    pub(crate) allow_empty: bool,
+    /// Flush buffers to the leaves first. See [`Commit::canonicalize`].
+    pub(crate) canonicalize: bool,
+}
+
+impl<Changes> Mint<'_, Changes>
+where
+    Changes: Stream<Item = Instruction> + ConditionalSend,
+{
+    /// Run the commit procedure. `line` names the entity and origin the
+    /// revision is minted under, given the profile and issuer the
+    /// environment identifies as — a branch's content-derived branch
+    /// entity, a snapshot's own lineage.
+    pub(crate) async fn perform<Env>(
+        self,
+        env: &Env,
+        line: impl FnOnce(&Did, &Did) -> (Entity, Origin),
+    ) -> Result<Outcome, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let source = self.source;
+        let base_revision = self.base;
+        let changes = self.changes;
+
+        // If the line tracks a remote upstream, commits must be able
         // to read remote-only blocks on demand (pull only merges the
         // tree metadata, not every block). `NetworkedIndex` falls back
         // to the remote when a block is missing locally. A remote that
@@ -161,26 +404,14 @@ where
         // from, so the failure is carried into the fallback and surfaces
         // — with its cause — on the first read that needed it, while a
         // commit every block of which is local proceeds untouched.
-        let upstreams = branch.upstreams();
-        let remote = match upstreams.remote_name() {
-            Some(name) => {
-                let loaded = branch
-                    .subject()
-                    .remote(name.to_string())
-                    .load()
-                    .perform(env)
-                    .await;
-                RemoteFallback::from_load(name, loaded)
-            }
-            None => RemoteFallback::None,
-        };
-        let mut store = NetworkedIndex::new(env, branch.archive().index(), remote);
+        let remote = source.fallback(env).await;
+        let mut store = NetworkedIndex::new(env, source.archive().index(), remote);
 
         // Discover who we are up front: the revision is attributed to the
         // profile / operator, and the commit's `Version` — the identifier
         // every datum and history record it writes is tagged with — derives
-        // from the issuer and the subject. The subject comes from the
-        // branch itself, not the identity chain.
+        // from the issuer and the line. The line comes from the caller,
+        // not the identity chain.
         let authority = Identify.perform(env).await?;
         let issuer = authority.did();
         let profile = authority.profile().clone();
@@ -189,23 +420,23 @@ where
             .as_ref()
             .map(|base| base.edition.successor())
             .unwrap_or(Edition::GENESIS);
-        let (branch_entity, origin) = branch.commit_identity(&profile, &issuer);
+        let (line_entity, origin) = line(&profile, &issuer);
         let version = Version::new(origin, edition);
 
-        // Walk forward from the current revision's tree root, or from
-        // the empty tree if the branch has no commits yet.
+        // Walk forward from the base revision's tree root, or from the
+        // empty tree if the line has no commits yet.
         let base_tree_hash = base_revision
             .as_ref()
             .map(|rev| *rev.tree.hash())
             .unwrap_or(EMPTY_TREE_HASH);
 
-        // Read through the branch's shared node cache: the commit's
+        // Read through the line's shared node cache: the commit's
         // supersession scans and history reads then hit blocks earlier
         // commits and queries already fetched (and blocks the persist below
         // seeds), instead of re-fetching everything into a cache that dies
         // with this commit.
         let mut tree =
-            Index::from_hash_with_cache(NodeHash::from(base_tree_hash), branch.node_cache());
+            Index::from_hash_with_cache(NodeHash::from(base_tree_hash), source.node_cache());
 
         // Drain the change stream into the tree. EAV/AEV/VAE writes,
         // cardinality-one supersession, retraction — and, because the
@@ -232,7 +463,7 @@ where
         // `Commit::canonicalize`).
         let mut delta = Delta::zero();
         let batch = dialog_artifacts::BufferedBatch::apply_reusing(
-            branch.spine(),
+            source.spine(),
             &tree,
             &mut store,
             Some(version),
@@ -248,53 +479,34 @@ where
         // re-asserting metadata that is already in place) is a no-op:
         // keep the current revision rather than minting one that differs
         // only by edition (unless `allow_empty` asks for one). Only a
-        // branch with no revision at all still publishes, to establish
+        // line with no revision at all still publishes, to establish
         // its genesis.
-        //
-        // A no-op verdict is only true of the snapshot it was judged
-        // against, and this early return never reaches the publish CAS
-        // below — so re-read the head before reporting "nothing to do".
-        // If another writer advanced it, the same instructions may not be
-        // no-ops against the current head (a re-assertion of a value the
-        // head has since retracted, for example): fail with the same
-        // `VersionMismatch` any other stale write gets, so the caller
-        // refreshes and retries against the fresh snapshot.
         if !changed
             && !self.allow_empty
             && let Some(base) = base_revision
         {
-            branch.revision.resolve().perform(env).await?;
-            let actual = branch.revision.edition().map(|edition| edition.version);
-            if actual != base_version {
-                return Err(PublishError::VersionMismatch {
-                    expected: base_version,
-                    actual,
-                }
-                .into());
-            }
-            return Ok(base);
+            return Ok(Outcome::Unchanged(base));
         }
 
         // Mint the revision (the placeholder tree root is replaced below,
         // after its own records are in the tree) and record its DAG edge on
-        // the branch lineage entity, its skip links, plus its attribute
-        // claims on the revision entity, in the same batch delta. None of
-        // those records depend on the final root — a root cannot appear
-        // inside itself.
+        // the line entity, its skip links, plus its attribute claims on the
+        // revision entity, in the same batch delta. None of those records
+        // depend on the final root — a root cannot appear inside itself.
         //
         // The skip table (logarithmic leaps through the revision DAG for
         // `common_ancestor` — see `dialog_artifacts::history::extend_skips`)
         // is lifted from the parent's recorded table, read out of the base
-        // tree through the branch's shared node cache.
+        // tree through the line's shared node cache.
         let parent = base_revision.as_ref().map(Revision::version);
         let skips = match &parent {
             Some(parent) => {
                 let history = TreeHistory::from_root_with_cache(
                     &base_tree_hash,
                     store.clone(),
-                    branch.node_cache(),
+                    source.node_cache(),
                 )
-                .with_record_cache(branch.records());
+                .with_record_cache(source.records());
                 extend_skips(&history, parent).await?
             }
             None => Vec::new(),
@@ -302,10 +514,10 @@ where
 
         // The new head's causal context: the parent's plus this commit's
         // own version. Sourced from the parent head's published context,
-        // the branch memo, or (once, for lineages minted before heads
+        // the line's memo, or (once, for lineages minted before heads
         // carried contexts) the ancestry walk — so every head published
         // from here on carries its watermark for peers to read.
-        let contexts = branch.contexts();
+        let contexts = source.contexts();
         let base_context = base_revision.as_ref().and_then(|base| base.context.clone());
         let context = {
             let mut context = match (&parent, base_context) {
@@ -317,9 +529,9 @@ where
                         let history = TreeHistory::from_root_with_cache(
                             &base_tree_hash,
                             store.clone(),
-                            branch.node_cache(),
+                            source.node_cache(),
                         )
-                        .with_record_cache(branch.records());
+                        .with_record_cache(source.records());
                         context_of(parent, &history).await?
                     }
                 },
@@ -329,8 +541,8 @@ where
         };
 
         let mut revision = match base_revision {
-            Some(base) => base.advance(TreeReference::default(), branch_entity.clone(), issuer),
-            None => Revision::new(TreeReference::default(), branch_entity.clone(), issuer),
+            Some(base) => base.advance(TreeReference::default(), line_entity.clone(), issuer),
+            None => Revision::new(TreeReference::default(), line_entity.clone(), issuer),
         };
         debug_assert_eq!(revision.version(), version);
         // Sign the record before it enters the tree: the issuer's signature
@@ -352,11 +564,6 @@ where
         // and entries together.
         let batch = batch.record(&store, self.entries).await?;
         let batch = batch.record(&store, entries).await?;
-        // Seed the verified-record memo with what we just minted. The next
-        // commit's skip-table walk starts at this very record, so without this
-        // it is read back out of the tree and its signature re-verified on the
-        // immediately following commit.
-        branch.records().insert(version, record.clone());
 
         // ONE seal covers the data writes and the record entries, into the
         // batch delta (flushing buffers to the leaves first when the caller
@@ -369,7 +576,7 @@ where
         // reference-counted, so nothing is copied on the way in, and
         // providers with native batching persist it in a single round trip
         // (one IndexedDB transaction).
-        branch
+        source
             .archive()
             .index()
             .import(delta.flush().map(|(_, buffer)| buffer))
@@ -386,13 +593,11 @@ where
         // see `Pull`.
         revision.signature = Attest::new(revision.payload()).perform(env).await?;
 
-        head.publish(revision.clone(), env).await?;
-
-        // Advance the branch memo so later pulls through this handle
-        // answer the context from memory.
-        contexts.insert(revision.version(), context);
-
-        Ok(revision)
+        Ok(Outcome::Minted(Box::new(Minted {
+            revision,
+            record,
+            context,
+        })))
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/download.rs
+++ b/rust/dialog-repository/src/repository/branch/download.rs
@@ -96,7 +96,7 @@ impl Download<'_> {
         // The items themselves carry nothing the local store does not
         // already hold by the time they are yielded, so draining the
         // stream is the whole job.
-        let items = Snapshot::of(branch.subject(), revision)
+        let items = Snapshot::new(branch.subject(), revision)
             .export()
             .download(remote)
             .perform(env);

--- a/rust/dialog-repository/src/repository/branch/select.rs
+++ b/rust/dialog-repository/src/repository/branch/select.rs
@@ -12,34 +12,39 @@ use dialog_search_tree::{Buffer, DialogSearchTreeError};
 use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
 use futures_util::Stream;
 
+use crate::repository::source::SourceRef;
 use crate::{
-    Branch, EMPTY_TREE_HASH, Index, NetworkedIndex, RemoteFallback, RemoteSite,
-    RepositoryArchiveExt as _, RepositoryMemoryExt,
+    Branch, EMPTY_TREE_HASH, Index, NetworkedIndex, RemoteSite, RepositoryArchiveExt as _,
 };
 
-/// Command struct for selecting artifacts from a branch.
+/// Command struct for selecting artifacts from a branch or a snapshot.
 pub struct Select<'a> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
     selector: ArtifactSelector<Constrained>,
 }
 
 impl<'a> Select<'a> {
     /// Create a select command for the given branch and artifact selector.
     pub fn new(branch: &'a Branch, selector: ArtifactSelector<Constrained>) -> Self {
-        Self { branch, selector }
+        Self::from_source(SourceRef::from(branch), selector)
+    }
+
+    /// Create a select command for the given line (branch or snapshot)
+    /// and artifact selector.
+    pub(crate) fn from_source(
+        source: SourceRef<'a>,
+        selector: ArtifactSelector<Constrained>,
+    ) -> Self {
+        Self { source, selector }
     }
 
     fn tree_hash(&self) -> Blake3Hash {
-        self.branch
-            .revision()
-            .as_ref()
-            .map(|rev| *rev.tree.hash())
-            .unwrap_or(EMPTY_TREE_HASH)
+        self.source.root()
     }
 
-    /// The catalog (archive index) scoped to this branch's subject.
+    /// The catalog (archive index) scoped to this line's subject.
     pub fn catalog(&self) -> Capability<Catalog> {
-        self.branch.subject().archive().index()
+        self.source.subject().archive().index()
     }
 }
 
@@ -60,8 +65,8 @@ impl<'a> Select<'a> {
 }
 
 impl Select<'_> {
-    /// Execute the select, using fallback to remote if the branch has
-    /// a remote upstream.
+    /// Execute the select, using fallback to remote if the line is a
+    /// branch with a remote upstream.
     ///
     /// Rows stream as borrowed-access [`ArtifactView`]s; chain
     /// [`to_owned`](Self::to_owned) before this call for owned
@@ -82,27 +87,13 @@ impl Select<'_> {
             + ConditionalSync
             + 'static,
     {
-        // Load a remote if the branch tracks one so the networked
-        // index can fall back to it for blocks missing locally. A
-        // failed load (e.g. no credentials) is carried into the
-        // fallback rather than swallowed: the local archive alone may
-        // still satisfy the query, but a read that misses fails with
-        // the load failure as its cause instead of a bare not-found.
-        let upstreams = self.branch.upstreams();
-        let remote = match upstreams.remote_name() {
-            Some(name) => {
-                let loaded = self
-                    .branch
-                    .subject()
-                    .remote(name.to_string())
-                    .load()
-                    .perform(env)
-                    .await;
-                RemoteFallback::from_load(name, loaded)
-            }
-            None => RemoteFallback::None,
-        };
-
+        // Load a remote if the line tracks one so the networked index
+        // can fall back to it for blocks missing locally. A failed load
+        // (e.g. no credentials) is carried into the fallback rather
+        // than swallowed: the local archive alone may still satisfy the
+        // query, but a read that misses fails with the load failure as
+        // its cause instead of a bare not-found.
+        let remote = self.source.fallback(env).await;
         let store = NetworkedIndex::new(env, self.catalog(), remote);
         self.execute(store).await
     }
@@ -140,7 +131,7 @@ impl Select<'_> {
         // still fetching (and, through `NetworkedIndex`, replicating) on a
         // genuine miss and failing fast when the root is truly absent.
         let tree_hash = self.tree_hash();
-        let node_cache = self.branch.node_cache();
+        let node_cache = self.source.node_cache();
         if tree_hash != EMPTY_TREE_HASH {
             node_cache
                 .get_or_fetch(&NodeHash::from(tree_hash), async |hash| {
@@ -164,7 +155,7 @@ impl Select<'_> {
         // `ArtifactTreeExt::scan` so branch scans and Changes-overlay
         // scans agree on key order — that adjacency invariant is what
         // the cardinality-one sliding window relies on.
-        Ok(tree.scan(store, self.branch.spill_cache(), self.selector))
+        Ok(tree.scan(store, self.source.spill_cache(), self.selector))
     }
 
     /// [`execute`](Self::execute) materializing every row from the scan's
@@ -186,7 +177,7 @@ impl Select<'_> {
     {
         // The same eager root probe as `execute`; see the comment there.
         let tree_hash = self.tree_hash();
-        let node_cache = self.branch.node_cache();
+        let node_cache = self.source.node_cache();
         if tree_hash != EMPTY_TREE_HASH {
             node_cache
                 .get_or_fetch(&NodeHash::from(tree_hash), async |hash| {
@@ -205,7 +196,7 @@ impl Select<'_> {
         }
 
         let tree = Index::from_hash_with_cache(NodeHash::from(tree_hash), node_cache);
-        Ok(tree.scan_owned(store, self.branch.spill_cache(), self.selector))
+        Ok(tree.scan_owned(store, self.source.spill_cache(), self.selector))
     }
 }
 
@@ -221,7 +212,7 @@ impl Select<'_> {
 pub struct SelectOwned<'a>(Select<'a>);
 
 impl SelectOwned<'_> {
-    /// The catalog (archive index) scoped to this branch's subject.
+    /// The catalog (archive index) scoped to this line's subject.
     pub fn catalog(&self) -> Capability<Catalog> {
         self.0.catalog()
     }
@@ -243,22 +234,7 @@ impl SelectOwned<'_> {
     {
         // The same remote fallback as `Select::perform`; see the comment
         // there.
-        let upstreams = self.0.branch.upstreams();
-        let remote = match upstreams.remote_name() {
-            Some(name) => {
-                let loaded = self
-                    .0
-                    .branch
-                    .subject()
-                    .remote(name.to_string())
-                    .load()
-                    .perform(env)
-                    .await;
-                RemoteFallback::from_load(name, loaded)
-            }
-            None => RemoteFallback::None,
-        };
-
+        let remote = self.0.source.fallback(env).await;
         let store = NetworkedIndex::new(env, self.catalog(), remote);
         self.execute(store).await
     }

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -26,53 +26,57 @@ use futures_util::{StreamExt as _, TryStreamExt as _, stream};
 use std::sync::Arc;
 
 use crate::layer::{filter_tombstones, merge_grouped, tombstones_from};
+use crate::repository::source::{Source, SourceRef};
 use crate::rules::{
     assemble, builtin, conclusion_selector, hydrate, overlay_rules, rule_entities, source_bytes,
     source_selector,
 };
 use crate::schema::{DidExt as _, Session, SessionBranch, session};
-use crate::{
-    Branch, NetworkedIndex, RemoteFallback, RemoteSite, RepositoryArchiveExt as _,
-    RepositoryMemoryExt, Upstream,
-};
+use crate::{Branch, NetworkedIndex, RemoteSite, RepositoryArchiveExt as _, Snapshot};
 
-/// A composable query over one or more branches plus an in-memory
-/// overlay.
+/// A composable query over one or more lines (branches, snapshots)
+/// plus an in-memory overlay.
 ///
-/// `branch.query()` returns a `QueryLayer` rooted at that branch.
-/// From there:
+/// `branch.query()` (or `snapshot.query()`) returns a `QueryLayer`
+/// rooted at that line. From there:
 ///
 /// - [`with`](Self::with) folds any [`Statement`] (a concept
 ///   instance, an attribute expression, a [`Changes`] batch) into the
-///   overlay — its asserts/replaces surface alongside branch facts,
-///   its retracts tombstone matching branch facts.
-/// - [`join`](Self::join) merges in another branch or `QueryLayer`.
+///   overlay — its asserts/replaces surface alongside stored facts,
+///   its retracts tombstone matching stored facts.
+/// - [`join`](Self::join) merges in another branch, snapshot, or
+///   `QueryLayer`.
 /// - [`select`](Self::select) stages a query; `.perform(&env)` runs it.
 ///
-/// All branches in the layer are peers — there is no distinguished
-/// "primary". A query reads the union of every branch's facts plus
-/// the overlay.
+/// All lines in the layer are peers — there is no distinguished
+/// "primary". A query reads the union of every line's facts plus the
+/// overlay.
 ///
 /// # Auto-injected schema metadata
 ///
 /// At `.perform(env)` the layer resolves the operator's identity via
 /// [`Identify`] and folds in [`metadata`](Self::metadata): one
-/// [`Origin`](crate::schema::Replica) + [`Branch`](crate::schema::Branch)
+/// [`Replica`](crate::schema::Replica) + [`Branch`](crate::schema::Branch)
 /// (+ [`BranchRevision`](crate::schema::BranchRevision) when committed)
-/// per branch, plus a single [`Session`]. Callers don't pass the
-/// profile or operator DID, and nothing is written to any branch's
-/// tree.
+/// per branch, a [`Replica`](crate::schema::Replica) per snapshot,
+/// plus a single [`Session`]. Callers don't pass the profile or
+/// operator DID, and nothing is written to any line's tree.
 ///
-/// ```ignore
-/// branch.query()
-///     .join(&other_branch)            // another branch source
-///     .with(custom_concept_instance)  // user-asserted overlay facts
-///     .select(query)
-///     .perform(&env);                 // metadata auto-injected
+/// ```no_run
+/// # use dialog_repository::{Branch, Snapshot};
+/// # use dialog_query::query::Application;
+/// # fn example<Q: Application>(branch: &Branch, snapshot: &Snapshot, query: Q, facts: dialog_artifacts::Changes) {
+/// let layer = branch
+///     .query()
+///     .join(snapshot)                 // another line
+///     .with(facts);                   // user-asserted overlay facts
+/// let staged = layer.select(query);   // `.perform(&env)` injects metadata
+/// # let _ = staged;
+/// # }
 /// ```
 #[derive(Default, Clone)]
 pub struct QueryLayer<'a> {
-    branches: Vec<&'a Branch>,
+    sources: Vec<SourceRef<'a>>,
     changes: Changes,
 }
 
@@ -96,19 +100,37 @@ impl<'a> QueryLayer<'a> {
         self
     }
 
-    /// Merge another layer in: union the branches, fold the other
+    /// Merge another layer in: union the lines, fold the other
     /// layer's changes via its `Statement` impl. Accepts anything
-    /// convertible into a `QueryLayer` — a `&Branch` or a `Changes`.
+    /// convertible into a `QueryLayer` — a `&Branch`, a `&Snapshot`, or
+    /// a `Changes`.
     pub fn join(mut self, other: impl Into<QueryLayer<'a>>) -> Self {
         let other = other.into();
-        self.branches.extend(other.branches);
+        self.sources.extend(other.sources);
         other.changes.assert(&mut self.changes);
         self
     }
 
-    /// The branches this layer reads from.
-    pub fn branches(&self) -> &[&'a Branch] {
-        &self.branches
+    /// The branches this layer reads from, in join order.
+    pub fn branches(&self) -> Vec<&'a Branch> {
+        self.sources
+            .iter()
+            .filter_map(|source| match source {
+                SourceRef::Branch(branch) => Some(*branch),
+                SourceRef::Snapshot(_) => None,
+            })
+            .collect()
+    }
+
+    /// The snapshots this layer reads from, in join order.
+    pub fn snapshots(&self) -> Vec<&'a Snapshot> {
+        self.sources
+            .iter()
+            .filter_map(|source| match source {
+                SourceRef::Snapshot(snapshot) => Some(*snapshot),
+                SourceRef::Branch(_) => None,
+            })
+            .collect()
     }
 
     /// The caller-supplied overlay changes (no auto-injected metadata).
@@ -117,20 +139,21 @@ impl<'a> QueryLayer<'a> {
     }
 
     /// The schema-metadata [`Changes`] for this layer: every branch's
-    /// [`BranchMetadata`](super::metadata::BranchMetadata) plus a
-    /// single [`Session`] (with one cardinality-many
-    /// `dialog.session/branch` per branch in scope).
+    /// [`BranchMetadata`](super::metadata::BranchMetadata), every
+    /// snapshot's [`Replica`](crate::schema::Replica), plus a single
+    /// [`Session`] (with one cardinality-many `dialog.session/branch`
+    /// per branch in scope — a snapshot is not a branch and gets none).
     ///
     /// `operator` (from [`Identify`]) supplies the profile + operator
     /// DIDs the schema entities are derived from.
     pub fn metadata(&self, operator: &Capability<Operator>) -> Changes {
         let mut changes = Changes::new();
 
-        let mut branch_entities = Vec::with_capacity(self.branches.len());
-        for branch in &self.branches {
-            let metadata = branch.metadata(operator);
-            branch_entities.push(metadata.branch.this.clone());
-            metadata.assert(&mut changes);
+        let mut branch_entities = Vec::with_capacity(self.sources.len());
+        for source in &self.sources {
+            if let Some(entity) = source.metadata(operator, &mut changes) {
+                branch_entities.push(entity);
+            }
         }
 
         let session_entity = Session::entity();
@@ -172,24 +195,36 @@ impl<'a> QueryLayer<'a> {
     }
 }
 
-// Folds the branch's transient session overlay
-// ([`Branch::overlay`]): every read path — `branch.select`,
-// `branch.query`, transaction queries, subscription evaluations —
-// constructs through here, so session facts participate in all of
-// them with no per-path wiring.
+// Folds the line's transient session overlay ([`Branch::overlay`],
+// [`Snapshot::overlay`]): every read path — `select`, `query`,
+// transaction queries, subscription evaluations — constructs through
+// here, so session facts participate in all of them with no per-path
+// wiring.
+impl<'a> From<SourceRef<'a>> for QueryLayer<'a> {
+    fn from(source: SourceRef<'a>) -> Self {
+        Self {
+            sources: vec![source],
+            changes: source.overlay().changes(),
+        }
+    }
+}
+
 impl<'a> From<&'a Branch> for QueryLayer<'a> {
     fn from(branch: &'a Branch) -> Self {
-        Self {
-            branches: vec![branch],
-            changes: branch.overlay().changes(),
-        }
+        Self::from(SourceRef::from(branch))
+    }
+}
+
+impl<'a> From<&'a Snapshot> for QueryLayer<'a> {
+    fn from(snapshot: &'a Snapshot) -> Self {
+        Self::from(SourceRef::from(snapshot))
     }
 }
 
 impl From<Changes> for QueryLayer<'_> {
     fn from(changes: Changes) -> Self {
         Self {
-            branches: Vec::new(),
+            sources: Vec::new(),
             changes,
         }
     }
@@ -202,9 +237,9 @@ pub struct SelectQuery<'a, Q> {
 }
 
 impl<'a, Q> SelectQuery<'a, Q> {
-    pub(crate) fn new(branch: &'a Branch, query: Q) -> Self {
+    pub(crate) fn new(source: impl Into<SourceRef<'a>>, query: Q) -> Self {
         Self {
-            layer: QueryLayer::from(branch),
+            layer: QueryLayer::from(source.into()),
             query,
         }
     }
@@ -216,7 +251,7 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
     /// Resolves the operator's identity via [`Identify`], builds the
     /// query overlay (caller changes + auto-injected schema metadata)
     /// via [`QueryLayer::overlay`], lifts any retracts in it into
-    /// tombstones, and unions every branch stream (tombstone-filtered)
+    /// tombstones, and unions every line's stream (tombstone-filtered)
     /// with the overlay.
     pub fn perform<Env>(self, env: &'a Env) -> impl Output<Q::Conclusion> + 'a
     where
@@ -239,8 +274,8 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
             let overlay = layer.overlay(&operator);
             let tombstones = Arc::new(tombstones_from(&overlay));
 
-            let branches = layer.branches.iter().map(|&branch| branch.clone()).collect();
-            let query_env = QueryEnv::new(branches, overlay, tombstones, env);
+            let sources = layer.sources.iter().map(|source| source.to_source()).collect();
+            let query_env = QueryEnv::new(sources, overlay, tombstones, env);
             let results = Box::pin(query.perform(&query_env));
             for await result in results {
                 yield result?;
@@ -249,7 +284,7 @@ impl<'a, Q: Application> SelectQuery<'a, Q> {
     }
 }
 
-/// The runtime environment that bridges the layer's branches and
+/// The runtime environment that bridges the layer's lines and
 /// per-query overlay changes into the query engine's Provider bounds.
 ///
 /// Built fresh on each `.perform(env)`; the environment reference
@@ -262,7 +297,7 @@ pub(crate) struct QueryEnv<'a, Env> {
     /// enclosing future `Send`-general on native (two independent
     /// erased lifetimes in `QueryEnv<'0>: Provider<Select<'1>>` hit
     /// rustc's #100013 limitation; a named lifetime does not).
-    branches: Vec<Branch>,
+    sources: Vec<Source>,
     /// All overlay facts — caller-asserted + auto-injected metadata —
     /// merged into one batch. Queried via `Provider<Select> for Changes`.
     changes: Changes,
@@ -284,23 +319,24 @@ pub(crate) struct QueryEnv<'a, Env> {
 }
 
 impl<'a, Env> QueryEnv<'a, Env> {
-    /// Build a runtime env from already-resolved parts: the branches to
+    /// Build a runtime env from already-resolved parts: the lines to
     /// read, the per-query overlay (caller changes + injected metadata),
     /// the tombstones lifted from it, and the underlying capability env.
     ///
-    /// Both `Branch::query` and the transaction-query path construct
-    /// through here so there is exactly one query env — a transaction
-    /// query is just a single-branch `QueryEnv`. Deductive-rule
-    /// resolution is built in (a durable layer per branch + the overlay
-    /// as a transient layer), so the two paths can never diverge on it.
+    /// `Branch::query`, `Snapshot::query`, and the transaction-query
+    /// paths all construct through here so there is exactly one query
+    /// env — a transaction query is just a single-line `QueryEnv`.
+    /// Deductive-rule resolution is built in (a durable layer per line +
+    /// the overlay as a transient layer), so the paths can never
+    /// diverge on it.
     pub(crate) fn new(
-        branches: Vec<Branch>,
+        sources: Vec<Source>,
         changes: Changes,
         tombstones: Arc<HashSet<SortKey>>,
         env: &'a Env,
     ) -> Self {
         Self {
-            branches,
+            sources,
             changes,
             tombstones,
             demand: None,
@@ -336,7 +372,7 @@ impl<'a, Env> QueryEnv<'a, Env> {
 impl<Env> Clone for QueryEnv<'_, Env> {
     fn clone(&self) -> Self {
         Self {
-            branches: self.branches.clone(),
+            sources: self.sources.clone(),
             changes: self.changes.clone(),
             tombstones: self.tombstones.clone(),
             demand: self.demand.clone(),
@@ -346,16 +382,16 @@ impl<Env> Clone for QueryEnv<'_, Env> {
     }
 }
 
-/// Execute a select against a single branch, transparently routing through
-/// the branch's remote upstream when configured. Extracted as a freestanding
-/// helper so every branch in a [`QueryEnv`] shares the exact same branch-read
-/// path (a transaction query is itself a single-branch `QueryEnv`).
+/// Execute a select against a single line, transparently routing through
+/// a branch's remote upstream when configured. Extracted as a freestanding
+/// helper so every line in a [`QueryEnv`] shares the exact same read path
+/// (a transaction query is itself a single-line `QueryEnv`).
 ///
-/// Takes the branch by value (a cheap clone: shared caches) and moves
-/// it into the returned stream, so the stream borrows only the env —
+/// Takes the line by value (a cheap clone: shared caches) and moves it
+/// into the returned stream, so the stream borrows only the env —
 /// errors surface as the stream's first item.
-pub(crate) fn select_from_branch<'a, Env>(
-    branch: Branch,
+pub(crate) fn select_from_source<'a, Env>(
+    source: Source,
     env: &'a Env,
     input: ArtifactSelector<Constrained>,
 ) -> ArtifactStream<'a>
@@ -369,21 +405,8 @@ where
         + 'static,
 {
     Box::pin(async_stream::try_stream! {
-        let select = branch.claims().select(input);
-
-        let remote = match branch.upstream() {
-            Some(Upstream::Remote { remote: name, .. }) => {
-                let loaded = branch
-                    .subject()
-                    .remote(name.clone())
-                    .load()
-                    .perform(env)
-                    .await;
-                RemoteFallback::from_load(name, loaded)
-            }
-            _ => RemoteFallback::None,
-        };
-
+        let select = crate::Select::from_source(source.as_ref(), input);
+        let remote = source.as_ref().fallback(env).await;
         let store = NetworkedIndex::new(env, select.catalog(), remote);
         let stream = select.execute(store).await?;
         for await artifact in stream {
@@ -422,14 +445,14 @@ where
         input: ArtifactSelector<Constrained>,
     ) -> Result<ArtifactStream<'a>, DialogArtifactsError> {
         self.record_demand(&input);
-        let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.branches.len() + 1);
+        let mut streams: Vec<ArtifactStream<'a>> = Vec::with_capacity(self.sources.len() + 1);
 
-        // Branch streams — each filtered by tombstones from the
+        // Line streams — each filtered by tombstones from the
         // overlay's retracts so a `tx.retract(x)` (or any user-asserted
         // retract in `with(..)`) suppresses matching source facts. Each
-        // owns its branch clone and borrows only `self.env`.
-        for branch in &self.branches {
-            let raw = select_from_branch(branch.clone(), self.env, input.clone());
+        // owns its line clone and borrows only `self.env`.
+        for source in &self.sources {
+            let raw = select_from_source(source.clone(), self.env, input.clone());
             streams.push(filter_tombstones(raw, self.tombstones.clone()));
         }
 
@@ -457,11 +480,11 @@ where
 // co). No demand is recorded: the block behind a hash is
 // content-addressed and can never change, so no tree diff could ever
 // invalidate a row derived from it — the soundness argument lives in
-// `dialog_artifacts::inspect`. Reads go through each branch's archive
+// `dialog_artifacts::inspect`. Reads go through each line's archive
 // catalog capability with the same remote fallback a fact scan uses;
-// the first branch that has the block wins (content addressing makes
+// the first line that has the block wins (content addressing makes
 // them interchangeable), and a block absent everywhere contributes
-// nothing. Reads go through the branch's shared node cache (the same
+// nothing. Reads go through the line's shared node cache (the same
 // one the eager root probe in `select.rs` and `Subscription::touched`
 // use): a resolver join re-resolves the same reference once per outer
 // row, and a raw backend get would re-fetch that identical immutable
@@ -479,21 +502,11 @@ where
         + 'static,
 {
     async fn execute(&self, input: Blake3Hash) -> Result<Option<Vec<u8>>, DialogArtifactsError> {
-        for branch in &self.branches {
-            let remote = match branch.upstream() {
-                Some(Upstream::Remote { remote: name, .. }) => {
-                    let loaded = branch
-                        .subject()
-                        .remote(name.clone())
-                        .load()
-                        .perform(self.env)
-                        .await;
-                    RemoteFallback::from_load(name, loaded)
-                }
-                _ => RemoteFallback::None,
-            };
-            let store = NetworkedIndex::new(self.env, branch.archive().index(), remote);
-            let cached = branch
+        for source in &self.sources {
+            let source = source.as_ref();
+            let remote = source.fallback(self.env).await;
+            let store = NetworkedIndex::new(self.env, source.archive().index(), remote);
+            let cached = source
                 .node_cache()
                 .get_or_fetch(&NodeHash::from(input), async |hash| {
                     StorageBackend::get(&store, hash.as_bytes())
@@ -519,14 +532,14 @@ where
         + ConditionalSync
         + 'static,
 {
-    /// Read a `dialog.rule/*` selector against a single branch's committed
+    /// Read a `dialog.rule/*` selector against a single line's committed
     /// tree only (NOT the overlay) and collect the matching artifacts.
     /// The durable layer's reads must be tree-only so the head-keyed
     /// discovery cache stays correct — overlay rules are handled
     /// separately, fresh, by the transient layer.
     async fn select_tree(
         &self,
-        branch: &Branch,
+        source: &Source,
         selector: ArtifactSelector<Constrained>,
     ) -> Result<Vec<Artifact>, DialogArtifactsError> {
         // Rule-discovery reads are demand too: a rule committed
@@ -539,23 +552,23 @@ where
         }
         // Rule bodies are hydrated from the full artifact, so this read
         // genuinely needs owned rows; it is head-cached, not per-query hot.
-        select_from_branch(branch.clone(), self.env, selector)
+        select_from_source(source.clone(), self.env, selector)
             .owned()
             .try_collect()
             .await
     }
 
-    /// The durable rules concluding `concept` on `branch`: the committed
-    /// `dialog.rule/*` rules, read from the tree and cached by branch head
+    /// The durable rules concluding `concept` on `source`: the committed
+    /// `dialog.rule/*` rules, read from the tree and cached by head
     /// (re-scanned only when the head moves), with hydrated bodies
     /// cached by content-addressed rule entity.
     async fn durable_rules(
         &self,
-        branch: &Branch,
+        source: &Source,
         concept: &Entity,
     ) -> Result<Vec<DeductiveRule>, EvaluationError> {
-        let cache = branch.rule_cache();
-        let head = branch.revision();
+        let cache = source.as_ref().rule_cache();
+        let head = source.as_ref().revision();
 
         // Discovery: which rule entities conclude this concept (committed).
         // Cached per (concept, head); a head move (commit/pull) re-scans.
@@ -563,7 +576,7 @@ where
             Some(entities) => entities,
             None => {
                 let claims = self
-                    .select_tree(branch, conclusion_selector(concept))
+                    .select_tree(source, conclusion_selector(concept))
                     .await
                     .map_err(|e| {
                         EvaluationError::Store(format!("rule conclusion lookup: {e:?}"))
@@ -585,7 +598,7 @@ where
                 continue;
             }
             let source_claims = self
-                .select_tree(branch, source_selector(&rule_entity))
+                .select_tree(source, source_selector(&rule_entity))
                 .await
                 .map_err(|e| EvaluationError::Store(format!("rule source lookup: {e:?}")))?;
             let Some(source) = source_bytes(source_claims) else {
@@ -612,7 +625,7 @@ where
         + 'static,
 {
     /// Resolve a concept's deductive rules by unioning across layers:
-    /// each branch is a durable layer (committed `dialog.rule/*`, head-cached),
+    /// each line is a durable layer (committed `dialog.rule/*`, head-cached),
     /// the overlay is a transient layer (uncommitted `dialog.rule/*`, fresh).
     /// The implicit per-descriptor rule is assembled once on top.
     ///
@@ -636,20 +649,20 @@ where
         // `dialog.revision/*`.
         rules.extend(builtin(&concept));
 
-        // Durable layers — one per branch.
-        for branch in &self.branches {
-            rules.extend(self.durable_rules(branch, &concept).await?);
+        // Durable layers — one per line.
+        for source in &self.sources {
+            rules.extend(self.durable_rules(source, &concept).await?);
         }
         // Transient layer — the per-query overlay, read fresh.
         rules.extend(overlay_rules(&self.changes, &concept));
 
-        // Plan cache rides a branch (peers share content-addressed plans;
-        // any branch's cache is correct). The overlay-only query has no
-        // branch, so it falls back to a private cache.
+        // Plan cache rides a line (peers share content-addressed plans;
+        // any line's cache is correct). The overlay-only query has no
+        // line, so it falls back to a private cache.
         let plan_cache = self
-            .branches
+            .sources
             .first()
-            .map(|branch| branch.plan_cache())
+            .map(|source| source.as_ref().plan_cache())
             .unwrap_or_default();
 
         let bundle = assemble(&input, rules, plan_cache);
@@ -721,8 +734,8 @@ where
                 continue;
             }
             let mut rules: Vec<DeductiveRule> = builtin(&entity);
-            for branch in &self.branches {
-                rules.extend(self.durable_rules(branch, &entity).await?);
+            for source in &self.sources {
+                rules.extend(self.durable_rules(source, &entity).await?);
             }
             rules.extend(overlay_rules(&self.changes, &entity));
             let bundle = assemble(&descriptor, rules, PlanCache::default());

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -89,6 +89,7 @@ use futures_util::TryStreamExt as _;
 
 use super::session::{QueryEnv, QueryLayer};
 use crate::layer::tombstones_from;
+use crate::repository::source::Source;
 use crate::{
     Branch, EMPTY_TREE_HASH, Index, NetworkedIndex, RemoteFallback, RemoteSite,
     RepositoryArchiveExt as _, RepositoryMemoryExt as _, Revision, Upstream,
@@ -734,7 +735,7 @@ where
                 // future stays Send-general on native — see the note
                 // on `QueryEnv::branches`.
                 let query_env: QueryEnv<'a, Env> = QueryEnv::new(
-                    vec![self.branch.clone()],
+                    vec![Source::Branch(self.branch.clone())],
                     overlay,
                     Arc::new(tombstones),
                     env,
@@ -848,7 +849,7 @@ where
             // Named env lifetime: keeps the poll future Send-general
             // on native — see the note on `QueryEnv::branches`.
             let mut query_env: QueryEnv<'a, Env> = QueryEnv::new(
-                vec![self.branch.clone()],
+                vec![Source::Branch(self.branch.clone())],
                 overlay,
                 Arc::new(tombstones),
                 env,
@@ -902,7 +903,7 @@ where
             // Named env lifetime: keeps the poll future Send-general
             // on native — see the note on `QueryEnv::branches`.
             let query_env: QueryEnv<'a, Env> = QueryEnv::new(
-                vec![self.branch.clone()],
+                vec![Source::Branch(self.branch.clone())],
                 overlay,
                 Arc::new(tombstones),
                 env,

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -2,8 +2,10 @@ mod induce;
 mod query;
 pub use query::{TransactionQuery, TransactionSelectQuery};
 
-use crate::rules::{TriggerFootprint, on_attr, reads_attr};
-use crate::{Branch, CommitError, RemoteSite, Revision};
+use crate::Commit;
+use crate::repository::source::SourceRef;
+use crate::rules::{SharedRuleCache, TriggerFootprint, on_attr, reads_attr};
+use crate::{Branch, CommitError, RemoteSite, Revision, Snapshot};
 use dialog_artifacts::{Changes, Instruction, Statement, Update};
 use dialog_capability::{Fork, Provider};
 use dialog_common::ConditionalSync;
@@ -11,18 +13,19 @@ use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify};
 use dialog_effects::memory::{Publish, Resolve};
 
-/// A transaction on a branch.
+/// A transaction on a branch or a snapshot.
 ///
-/// Created by [`Branch::transaction`]. Accumulates durable changes via
-/// `.assert()` / `.retract()` and *transient* facts (commands) via
-/// `.dispatch()`, then commits atomically via `.commit().perform(&env)`.
+/// Created by [`Branch::transaction`] or [`Snapshot::transaction`].
+/// Accumulates durable changes via `.assert()` / `.retract()` and
+/// *transient* facts (commands) via `.dispatch()`, then commits
+/// atomically via `.commit().perform(&env)`.
 ///
 /// Transients are visible to every read through [`query`](Self::query)
 /// and to inductive-rule bodies during commit-time induction, but they
 /// never enter the durable batch: they live for exactly one induction
 /// round and leave no trace in the committed tree.
 pub struct Transaction<'a> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
     changes: Changes,
     transients: Changes,
 }
@@ -77,18 +80,17 @@ impl<'a> Transaction<'a> {
     }
 
     /// Run queries against this transaction's "as-if committed" view of
-    /// the branch.
+    /// the line it runs on.
     ///
     /// Pending asserts and retracts are surfaced through a
     /// [`TransactionQuery`] handle — assertions show up alongside the
-    /// branch's stored facts; retractions tombstone matching facts in
-    /// the branch's stream before the merge. Dispatched transients are
-    /// part of the view too. The transaction itself stays open and
-    /// committable.
+    /// stored facts; retractions tombstone matching facts in the stored
+    /// stream before the merge. Dispatched transients are part of the
+    /// view too. The transaction itself stays open and committable.
     pub fn query(&self) -> TransactionQuery<'_> {
         let mut view = self.changes.clone();
         self.transients.clone().assert(&mut view);
-        TransactionQuery::new(self.branch, &view)
+        TransactionQuery::new(self.source, &view)
     }
 
     /// Finalize the transaction into a commit command.
@@ -102,7 +104,7 @@ impl<'a> Transaction<'a> {
     /// dropped, never written.
     pub fn commit(self) -> TransactionCommit<'a> {
         TransactionCommit {
-            branch: self.branch,
+            source: self.source,
             changes: self.changes,
             transients: self.transients,
             allow_empty: false,
@@ -118,7 +120,24 @@ impl Branch {
     /// then `.commit().perform(&env)` to apply them.
     pub fn transaction(&self) -> Transaction<'_> {
         Transaction {
-            branch: self,
+            source: SourceRef::from(self),
+            changes: Changes::new(),
+            transients: Changes::new(),
+        }
+    }
+}
+
+impl Snapshot {
+    /// Start a transaction on this snapshot: the same [`Transaction`]
+    /// a branch runs, committing through [`Snapshot::commit`].
+    ///
+    /// Use `.assert()` and `.retract()` to accumulate changes, then
+    /// `.commit().perform(&env)` to apply them; the snapshot advances to
+    /// the revision `perform` returns. Clone first to keep the view you
+    /// have.
+    pub fn transaction(&self) -> Transaction<'_> {
+        Transaction {
+            source: SourceRef::from(self),
             changes: Changes::new(),
             transients: Changes::new(),
         }
@@ -127,7 +146,7 @@ impl Branch {
 
 /// Command committing a [`Transaction`]: runs commit-time induction
 /// over the transaction's delta, then delegates the settled durable
-/// batch to [`Branch::commit`].
+/// batch to [`Branch::commit`] / [`Snapshot::commit`].
 ///
 /// Mirrors [`Commit`](crate::Commit)'s builder surface
 /// ([`allow_empty`](Self::allow_empty) /
@@ -135,7 +154,7 @@ impl Branch {
 /// induction step in front and that transients never reach the
 /// durable batch.
 pub struct TransactionCommit<'a> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
     changes: Changes,
     transients: Changes,
     allow_empty: bool,
@@ -175,25 +194,12 @@ impl<'a> TransactionCommit<'a> {
             + 'static,
     {
         let mut changes = self.changes;
-        induce::induce(self.branch, &mut changes, self.transients, env).await?;
+        induce::induce(self.source, &mut changes, self.transients, env).await?;
 
-        // The trigger footprint is a pure function of the committed
-        // `dialog.rule/on` and `dialog.rule/reads` facts, so a commit
-        // touching neither (checked after induction, which may fold
-        // rule installs into the batch) carries the cached footprint
-        // forward to the head it publishes. Without this every commit
-        // advances the head past the cache's key and the steady-state
-        // no-rules commit re-pays both footprint range scans.
-        let previous = self.branch.revision();
-        let touches_rules = {
-            let on = on_attr();
-            let reads = reads_attr();
-            changes
-                .iter()
-                .any(|(_, attribute, _)| *attribute == on || *attribute == reads)
-        };
+        let previous = self.source.revision();
+        let touches_rules = touches_rules(&changes);
 
-        let mut commit = self.branch.commit(changes.into_stream());
+        let mut commit = Commit::new(self.source, changes.into_stream());
         if self.allow_empty {
             commit = commit.allow_empty();
         }
@@ -207,26 +213,55 @@ impl<'a> TransactionCommit<'a> {
         // plus any lag, and the settled batch is what `revision`
         // holds). A raced publish here at worst regresses the
         // watermark, which re-induces a covered span — idempotent
-        // under the novelty check.
-        let cell = self.branch.induction_cell();
-        if cell.content().as_ref() != Some(&revision) {
-            cell.publish(revision.clone()).perform(env).await?;
+        // under the novelty check. A snapshot keeps no watermark: its
+        // head moves only through commits like this one, every one of
+        // which induces, so it is always at the head.
+        if let SourceRef::Branch(branch) = self.source {
+            let cell = branch.induction_cell();
+            if cell.content().as_ref() != Some(&revision) {
+                cell.publish(revision.clone()).perform(env).await?;
+            }
         }
 
         if !touches_rules {
-            let footprint = match previous {
-                // A genesis commit sees an empty branch: no committed
-                // rules exist, so the empty footprint is exact.
-                None => Some(TriggerFootprint::default()),
-                Some(previous) => self.branch.rule_cache().footprint(&previous),
-            };
-            if let Some(footprint) = footprint {
-                self.branch
-                    .rule_cache()
-                    .record_footprint(revision.clone(), footprint);
-            }
+            carry_footprint(&self.source.rule_cache(), previous.as_ref(), &revision);
         }
         Ok(revision)
+    }
+}
+
+/// Whether a settled change batch touches the trigger structures, i.e.
+/// asserts or retracts `dialog.rule/on` or `dialog.rule/reads` facts.
+pub(crate) fn touches_rules(changes: &Changes) -> bool {
+    let on = on_attr();
+    let reads = reads_attr();
+    changes
+        .iter()
+        .any(|(_, attribute, _)| *attribute == on || *attribute == reads)
+}
+
+/// Carry the trigger footprint cached at `previous` forward to
+/// `revision`.
+///
+/// The footprint is a pure function of the committed `dialog.rule/on`
+/// and `dialog.rule/reads` facts, so a commit touching neither (checked
+/// after induction, which may fold rule installs into the batch) keys
+/// the same footprint under the head it minted. Without this every
+/// commit advances the head past the cache's key and the steady-state
+/// no-rules commit re-pays both footprint range scans.
+pub(crate) fn carry_footprint(
+    cache: &SharedRuleCache,
+    previous: Option<&Revision>,
+    revision: &Revision,
+) {
+    let footprint = match previous {
+        // A genesis commit sees an empty line: no committed rules
+        // exist, so the empty footprint is exact.
+        None => Some(TriggerFootprint::default()),
+        Some(previous) => cache.footprint(previous),
+    };
+    if let Some(footprint) = footprint {
+        cache.record_footprint(revision.clone(), footprint);
     }
 }
 

--- a/rust/dialog-repository/src/repository/branch/transaction/induce.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/induce.rs
@@ -47,15 +47,15 @@ use dialog_query::{Any, Binding, Cardinality, Environment, InductiveRule, Match,
 use futures_util::{StreamExt as _, TryStreamExt};
 use std::sync::Arc;
 
-use crate::RemoteFallback;
 use crate::layer::tombstones_from;
 use crate::repository::branch::QueryLayer;
 use crate::repository::branch::session::QueryEnv;
+use crate::repository::source::SourceRef;
 use crate::rules::{
     TriggerFootprint, hydrate, hydrate_inductive, on_attr, on_entity, reads_attr, source_attr,
     transient_attr,
 };
-use crate::{Branch, CommitError, RemoteSite, Revision};
+use crate::{CommitError, RemoteSite, Revision};
 
 /// Round bound for the induction loop: a cascade still emitting
 /// transients or novelty after this many rounds fails the commit
@@ -67,7 +67,7 @@ pub(crate) const MAX_ROUNDS: u32 = 16;
 /// durable novelty into `changes`. Transients never enter `changes`;
 /// they are visible to rule bodies for exactly one round.
 pub(crate) async fn induce<Env>(
-    branch: &Branch,
+    source: SourceRef<'_>,
     changes: &mut Changes,
     transients: Changes,
     env: &Env,
@@ -89,7 +89,7 @@ where
     // missed one is caught up.
     let mut stimulus: Vec<Instruction> = changes.clone().into_instructions();
     stimulus.extend(transients.clone().into_instructions());
-    stimulus.extend(lag_delta(branch, env).await?);
+    stimulus.extend(lag_delta(source, env).await?);
     if stimulus.is_empty() {
         return Ok(());
     }
@@ -100,7 +100,7 @@ where
     // cache lookup below. The overlay slice is never head-cached; it
     // is re-scanned each round (cheap, in-memory) so rules installed
     // by this very commit — or by a rule during induction — fire.
-    let dispatch = Dispatch::resolve(branch, env).await?;
+    let dispatch = Dispatch::resolve(source, env).await?;
 
     // The identity is resolved once: it only feeds the schema-metadata
     // overlay of the round view, which does not change across rounds.
@@ -195,11 +195,11 @@ where
         // mid-transaction query would.
         let mut view_changes = changes.clone();
         transient_overlay.clone().assert(&mut view_changes);
-        let layered = QueryLayer::from(branch)
+        let layered = QueryLayer::from(source)
             .with(view_changes)
             .overlay(&operator);
         let tombstones = Arc::new(tombstones_from(&layered));
-        let view = QueryEnv::new(vec![branch.clone()], layered, tombstones, env);
+        let view = QueryEnv::new(vec![source.to_source()], layered, tombstones, env);
 
         // Close the touched set over derivation: a base-fact write
         // reaches inductive rules premised on the derived concepts it
@@ -285,13 +285,13 @@ where
 }
 
 /// The committed side of trigger dispatch for one induction run: the
-/// branch, the head every cache entry is keyed by, and the trigger
-/// footprint (the O(1) gate). All committed lookups flow through the
-/// branch's shared [`RuleCache`](crate::RuleCache) under the
-/// established disciplines — discovery head-keyed, hydrated bodies
+/// line (branch or snapshot), the head every cache entry is keyed by,
+/// and the trigger footprint (the O(1) gate). All committed lookups
+/// flow through the line's shared [`RuleCache`](crate::RuleCache) under
+/// the established disciplines — discovery head-keyed, hydrated bodies
 /// content-addressed, the overlay never head-cached.
 struct Dispatch<'a> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
     head: Option<Revision>,
     footprint: TriggerFootprint,
 }
@@ -375,7 +375,7 @@ impl<'a> Dispatch<'a> {
     /// Resolve the committed dispatch state: the branch head and the
     /// trigger footprint at it (cached per head; one range scan over
     /// each of `dialog.rule/on` and `dialog.rule/reads` on a miss).
-    async fn resolve<Env>(branch: &'a Branch, env: &Env) -> Result<Dispatch<'a>, CommitError>
+    async fn resolve<Env>(source: SourceRef<'a>, env: &Env) -> Result<Dispatch<'a>, CommitError>
     where
         Env: Provider<Get>
             + Provider<Put>
@@ -385,28 +385,28 @@ impl<'a> Dispatch<'a> {
             + ConditionalSync
             + 'static,
     {
-        let head = branch.revision();
+        let head = source.revision();
         let Some(head) = head else {
             // A branch with no commits has no committed rules.
             return Ok(Dispatch {
-                branch,
+                source,
                 head: None,
                 footprint: TriggerFootprint::default(),
             });
         };
 
-        let cache = branch.rule_cache();
+        let cache = source.rule_cache();
         let footprint = match cache.footprint(&head) {
             Some(footprint) => footprint,
             None => {
                 let mut footprint = TriggerFootprint::default();
-                for claim in committed(branch, ArtifactSelector::new().the(on_attr()), env).await? {
+                for claim in committed(source, ArtifactSelector::new().the(on_attr()), env).await? {
                     if let Value::Entity(key) = claim.is {
                         footprint.on.insert(key);
                     }
                 }
                 for claim in
-                    committed(branch, ArtifactSelector::new().the(reads_attr()), env).await?
+                    committed(source, ArtifactSelector::new().the(reads_attr()), env).await?
                 {
                     if let Value::Entity(key) = claim.is {
                         footprint.reads.insert(key);
@@ -417,7 +417,7 @@ impl<'a> Dispatch<'a> {
             }
         };
         Ok(Dispatch {
-            branch,
+            source,
             head: Some(head),
             footprint,
         })
@@ -445,14 +445,14 @@ impl<'a> Dispatch<'a> {
         if let Some(head) = &self.head
             && self.footprint.on.contains(on)
         {
-            let cache = self.branch.rule_cache();
+            let cache = self.source.rule_cache();
             let committed_entities = match cache.triggers(on, head) {
                 Some(entities) => entities,
                 None => {
                     let selector = ArtifactSelector::new()
                         .the(on_attr())
                         .is(Value::Entity(on.clone()));
-                    let entities: Vec<Entity> = committed(self.branch, selector, env)
+                    let entities: Vec<Entity> = committed(self.source, selector, env)
                         .await?
                         .into_iter()
                         .map(|claim| claim.of)
@@ -493,7 +493,7 @@ impl<'a> Dispatch<'a> {
             + ConditionalSync
             + 'static,
     {
-        let cache = self.branch.rule_cache();
+        let cache = self.source.rule_cache();
         let mut frontier: Vec<Attribute> = touched.iter().cloned().collect();
         while let Some(attribute) = frontier.pop() {
             let Some(on) = on_entity(&attribute) else {
@@ -510,7 +510,7 @@ impl<'a> Dispatch<'a> {
                         let selector = ArtifactSelector::new()
                             .the(reads_attr())
                             .is(Value::Entity(on.clone()));
-                        let entities: Vec<Entity> = committed(self.branch, selector, env)
+                        let entities: Vec<Entity> = committed(self.source, selector, env)
                             .await?
                             .into_iter()
                             .map(|claim| claim.of)
@@ -560,7 +560,7 @@ impl<'a> Dispatch<'a> {
             + ConditionalSync
             + 'static,
     {
-        let cache = self.branch.rule_cache();
+        let cache = self.source.rule_cache();
         if let Some(body) = cache.body(entity) {
             return Ok(Some(body));
         }
@@ -597,7 +597,7 @@ impl<'a> Dispatch<'a> {
             + ConditionalSync
             + 'static,
     {
-        let cache = self.branch.rule_cache();
+        let cache = self.source.rule_cache();
         if let Some(rule) = cache.inductive(entity) {
             return Ok(Some(rule));
         }
@@ -651,14 +651,14 @@ impl<'a> Dispatch<'a> {
         let Some(head) = &self.head else {
             return Ok(false);
         };
-        let cache = self.branch.rule_cache();
+        let cache = self.source.rule_cache();
         if let Some(verdict) = cache.transient(concept, head) {
             return Ok(verdict);
         }
         let selector = ArtifactSelector::new()
             .the(transient_attr())
             .of(concept.clone());
-        let verdict = !committed(self.branch, selector, env).await?.is_empty();
+        let verdict = !committed(self.source, selector, env).await?.is_empty();
         cache.record_transient(concept.clone(), head.clone(), verdict);
         Ok(verdict)
     }
@@ -684,7 +684,7 @@ impl<'a> Dispatch<'a> {
         let selector = ArtifactSelector::new()
             .the(source_attr())
             .of(entity.clone());
-        Ok(committed(self.branch, selector, env)
+        Ok(committed(self.source, selector, env)
             .await?
             .into_iter()
             .find_map(|claim| match claim.is {
@@ -698,7 +698,9 @@ impl<'a> Dispatch<'a> {
 /// left the branch between the induction watermark and the current
 /// head — arrivals as `Assert`, departures as `Retract`. Empty when
 /// the watermark is at the head (the steady state: the previous
-/// inducing instant advanced it).
+/// inducing instant advanced it), and always empty for a snapshot: a
+/// snapshot's head moves only through its own transactions, every one
+/// of which induces, so nothing can slip past.
 ///
 /// A `None` watermark (this replica has never induced) adopts the
 /// current head *without* catch-up: induction is fire-forward — a
@@ -708,7 +710,7 @@ impl<'a> Dispatch<'a> {
 /// records, which every commit writes) are excluded from the lag, so
 /// catching up over N commits stimulates rules with the *data* those
 /// commits changed, not their bookkeeping.
-async fn lag_delta<Env>(branch: &Branch, env: &Env) -> Result<Vec<Instruction>, CommitError>
+async fn lag_delta<Env>(source: SourceRef<'_>, env: &Env) -> Result<Vec<Instruction>, CommitError>
 where
     Env: Provider<Get>
         + Provider<Put>
@@ -718,12 +720,15 @@ where
         + ConditionalSync
         + 'static,
 {
-    use crate::{RepositoryArchiveExt as _, RepositoryMemoryExt as _};
+    use crate::RepositoryArchiveExt as _;
     use dialog_artifacts::tree::{TreeStorageBridge, fetch_spilled};
     use dialog_artifacts::{EntityKey, Key, KeyViewConstruct, State};
     use dialog_common::Blake3Hash as NodeHash;
     use dialog_search_tree::{Change as TreeChange, ContentAddressedStorage};
 
+    let SourceRef::Branch(branch) = source else {
+        return Ok(Vec::new());
+    };
     let Some(head) = branch.revision() else {
         return Ok(Vec::new());
     };
@@ -741,19 +746,7 @@ where
     // surfaces once. Reads go through the networked store exactly as a
     // select does: a pulled head's changed paths may reference
     // remote-only blocks.
-    let upstreams = branch.upstreams();
-    let remote = match upstreams.remote_name() {
-        Some(name) => {
-            let loaded = branch
-                .subject()
-                .remote(name.to_string())
-                .load()
-                .perform(env)
-                .await;
-            RemoteFallback::from_load(name, loaded)
-        }
-        None => RemoteFallback::None,
-    };
+    let remote = source.fallback(env).await;
     let store = crate::NetworkedIndex::new(env, branch.archive().index(), remote);
     let raw_store = store.clone();
     let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
@@ -818,10 +811,10 @@ where
     Ok(lag)
 }
 
-/// Collect the artifacts a selector matches on the branch's committed
+/// Collect the artifacts a selector matches on the line's committed
 /// tree (no overlay — the cacheable slice).
 async fn committed<Env>(
-    branch: &Branch,
+    source: SourceRef<'_>,
     selector: ArtifactSelector<Constrained>,
     env: &Env,
 ) -> Result<Vec<Artifact>, CommitError>
@@ -834,9 +827,7 @@ where
         + ConditionalSync
         + 'static,
 {
-    let stream = branch
-        .claims()
-        .select(selector)
+    let stream = crate::Select::from_source(source, selector)
         .perform(env)
         .await
         .map_err(|error| CommitError::Induction(format!("committed probe: {error}")))?;

--- a/rust/dialog-repository/src/repository/branch/transaction/query.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/query.rs
@@ -58,28 +58,30 @@ use dialog_effects::memory::Resolve;
 use dialog_query::query::{Application, Output};
 use std::sync::Arc;
 
+use crate::RemoteSite;
 use crate::layer::tombstones_from;
 use crate::repository::branch::QueryLayer;
 use crate::repository::branch::session::QueryEnv;
-use crate::{Branch, RemoteSite};
+use crate::repository::source::SourceRef;
 
 /// A non-composable query handle returned by
-/// [`Transaction::query`](crate::repository::branch::Transaction::query).
+/// [`Transaction::query`](crate::repository::branch::Transaction::query)
+/// and [`SnapshotTransaction::query`](crate::SnapshotTransaction::query).
 ///
 /// Holds an immutable snapshot of the transaction's pending changes
-/// plus a reference to the branch. The transaction itself remains
-/// open and committable.
+/// plus a reference to the line (branch or snapshot) it runs on. The
+/// transaction itself remains open and committable.
 ///
 /// See module docs for tombstone semantics.
 pub struct TransactionQuery<'a> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
     changes: Changes,
 }
 
 impl<'a> TransactionQuery<'a> {
-    pub(crate) fn new(branch: &'a Branch, changes: &Changes) -> Self {
+    pub(crate) fn new(source: impl Into<SourceRef<'a>>, changes: &Changes) -> Self {
         Self {
-            branch,
+            source: source.into(),
             changes: changes.clone(),
         }
     }
@@ -88,7 +90,7 @@ impl<'a> TransactionQuery<'a> {
     /// [`perform`](TransactionSelectQuery::perform) to execute.
     pub fn select<Q: Application>(self, query: Q) -> TransactionSelectQuery<'a, Q> {
         TransactionSelectQuery {
-            branch: self.branch,
+            source: self.source,
             changes: self.changes,
             query,
         }
@@ -97,7 +99,7 @@ impl<'a> TransactionQuery<'a> {
 
 /// A staged query on a [`TransactionQuery`].
 pub struct TransactionSelectQuery<'a, Q> {
-    branch: &'a Branch,
+    source: SourceRef<'a>,
     changes: Changes,
     query: Q,
 }
@@ -126,7 +128,7 @@ impl<'a, Q: Application> TransactionSelectQuery<'a, Q> {
             + 'static,
     {
         let TransactionSelectQuery {
-            branch,
+            source,
             changes,
             query,
         } = self;
@@ -143,17 +145,17 @@ impl<'a, Q: Application> TransactionSelectQuery<'a, Q> {
             // `with(changes)` preserves Assert/Replace/Retract
             // polarity via `Statement for Changes`, so the user's
             // retracts stay retracts and lift into tombstones below.
-            let overlay = QueryLayer::from(branch)
+            let overlay = QueryLayer::from(source)
                 .with(changes)
                 .overlay(&operator);
             let tombstones = tombstones_from(&overlay);
 
-            // A transaction query is just a single-branch `QueryEnv`.
+            // A transaction query is just a single-line `QueryEnv`.
             // Constructing the *same* env type the branch-session path
             // uses is what guarantees identical behavior — fact reads,
             // tombstones, schema metadata, and deductive-rule
             // resolution all share one implementation.
-            let query_env = QueryEnv::new(vec![branch.clone()], overlay, Arc::new(tombstones), env);
+            let query_env = QueryEnv::new(vec![source.to_source()], overlay, Arc::new(tombstones), env);
             let results = Box::pin(query.perform(&query_env));
             for await result in results {
                 yield result?;

--- a/rust/dialog-repository/src/repository/error.rs
+++ b/rust/dialog-repository/src/repository/error.rs
@@ -231,6 +231,17 @@ pub enum CommitError {
     /// Evaluating or loading an inductive rule during commit failed.
     #[error("Commit-time induction failed: {0}")]
     Induction(String),
+
+    /// A write was attempted through a reference to a snapshot.
+    ///
+    /// A snapshot holds its revision by value, so nothing reached
+    /// through `&Snapshot` can advance it. Blob writes and retractions
+    /// through [`Snapshot::blobs`](crate::Snapshot::blobs) land here;
+    /// advance the snapshot by consuming it instead, through
+    /// [`Snapshot::transaction`](crate::Snapshot::transaction) or
+    /// [`Snapshot::commit`](crate::Snapshot::commit).
+    #[error("A snapshot cannot be advanced through a reference; transact it instead")]
+    Detached,
 }
 
 /// Errors specific to a pull operation.

--- a/rust/dialog-repository/src/repository/snapshot.rs
+++ b/rust/dialog-repository/src/repository/snapshot.rs
@@ -1,11 +1,21 @@
-//! Immutable views of a repository at one revision, and the content
-//! transfer built on them.
+//! Views of a repository at one revision: readable, transactable, and
+//! the content transfer built on them.
 //!
-//! A [`Snapshot`] holds its revision by value, so what it names cannot
-//! change while you hold it -- unlike a [`Branch`](crate::Branch), whose
-//! head advances as it commits. Nothing here publishes or moves a head:
+//! A [`Snapshot`] holds its own head, so what it names moves only when
+//! it commits -- unlike a [`Branch`](crate::Branch), whose head lives in
+//! a memory cell every handle to the branch shares. It reads exactly
+//! like a branch ([`claims`](Snapshot::claims), [`select`](Snapshot::select),
+//! [`query`](Snapshot::query), [`history`](Snapshot::history), blob
+//! reads) and it transacts exactly like one
+//! ([`transaction`](Snapshot::transaction), [`commit`](Snapshot::commit)
+//! return the branch's own command types). Clone to keep the view you
+//! have before advancing.
+//!
+//! Nothing here publishes or moves a branch head. A snapshot's commits
+//! are minted on a line of their own (see [`Snapshot`]); making one
+//! visible under a name stays a separate act, as does content transfer:
 //! [`Snapshot::export`] reads content out, [`Repository::import`] writes
-//! content in, and making a revision visible stays a separate act.
+//! content in.
 //!
 //! # Two channels, not one
 //!
@@ -38,30 +48,46 @@
 //! upstream as the walk proceeds, which is what makes the result complete.
 
 use std::collections::HashSet;
-use std::marker::PhantomData;
 
 use async_stream::try_stream;
+use dialog_artifacts::history::{
+    CausalityCache, ContextCache, RevisionRecord, TreeHistory, Version,
+};
+use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::tree::TreeStorageBridge;
-use dialog_artifacts::{BlobIndexExt as _, Datum, Key, ShipmentRef, State, shipment_ref};
-use dialog_capability::{Capability, Fork, Provider, Subject};
+use dialog_artifacts::{
+    ArtifactSelector, BlobIndexExt as _, Datum, DialogArtifactsError, Entity, Key, ShipmentRef,
+    State, Statement, shipment_ref,
+};
+use dialog_capability::{Capability, Did, Fork, Provider, Subject};
 use dialog_common::{Blake3Hash as NodeHash, Buffer, ConditionalSync};
 use dialog_effects::archive::prelude::{ArchiveSubjectExt as _, CatalogExt as _};
-use dialog_effects::archive::{Catalog, Get, Put};
+use dialog_effects::archive::{Archive, Catalog, Get, Put};
 use dialog_effects::blob::prelude::{ArchiveBlobExt as _, BlobExt as _};
 use dialog_effects::blob::{BlobError, BlobReader, Import as BlobImport, Read as BlobRead};
+use dialog_effects::memory;
+use dialog_query::query::Application;
 use dialog_search_tree::{
     ArchivedNodeBody, ContentAddressedStorage as TreeStorage, NoveltyOp, Traversable as _, Visit,
     into_owned,
 };
 use futures_util::{Stream, StreamExt as _, stream};
+use parking_lot::RwLock;
 
-use dialog_credentials::Credential;
 use dialog_varsig::Principal;
 
+use crate::repository::source::{Caches, SourceRef};
 use crate::{
-    Index, NetworkedIndex, RemoteRepository, RemoteSite, Repository, RepositoryArchiveExt as _,
-    Revision, SnapshotError,
+    BlobArchive, Branch, Index, NetworkedIndex, Overlay, PublishError, RemoteRepository,
+    RemoteSite, Repository, RepositoryArchiveExt as _, Revision, Select, SelectQuery,
+    SnapshotError,
 };
+
+#[cfg(test)]
+mod read_tests;
+
+#[cfg(test)]
+mod transaction_tests;
 
 /// How many spill or blob fetches an export keeps in flight at once.
 ///
@@ -99,57 +125,311 @@ impl Block {
     }
 }
 
-/// An immutable view of a repository at one revision.
+/// A view of a repository at one revision.
 ///
 /// Holds the repository's subject rather than the repository itself:
-/// everything an export touches — the archive catalog, the blob channel —
-/// derives from the subject, which lets a [`Branch`](crate::Branch) mint
-/// a snapshot of its own repository too (see
-/// [`Branch::download`](crate::Branch::download)).
-pub struct Snapshot<'a, C: Principal = Credential> {
+/// everything a read touches — the archive catalog, the blob channel —
+/// derives from the subject, which lets a [`Branch`] mint a snapshot of
+/// its own repository too (see [`Branch::snapshot`]).
+///
+/// # Pinned, and advanced only through itself
+///
+/// The head is held by the snapshot, not by a memory cell shared with
+/// other handles: nothing but a commit through *this* handle can move
+/// it. It reads and transacts with the same API a branch has —
+/// [`transaction`](Self::transaction) and [`commit`](Self::commit)
+/// return the branch's [`Transaction`](crate::Transaction) and
+/// [`Commit`](crate::Commit), and `perform` returns the minted
+/// [`Revision`] and advances the snapshot to it. A [`Clone`] copies the
+/// head, so it is how you keep the view you have:
+///
+/// ```no_run
+/// # use dialog_repository::Snapshot;
+/// # async fn example<Env>(snapshot: Snapshot, env: &Env, facts: dialog_artifacts::Changes)
+/// # -> anyhow::Result<()>
+/// # where Env: dialog_capability::Provider<dialog_effects::memory::Resolve> {
+/// # let _ = (env, facts);
+/// let before = snapshot.clone();
+/// // snapshot.transaction().integrate(facts).commit().perform(env).await?;
+/// // `before` still reads the base revision; `snapshot` reads the new one.
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Its own line
+///
+/// A revision's [`Version`] is `(origin, edition)`, and an origin must be
+/// a single sequential actor: two revisions minted under one origin at
+/// the same edition would be an equivocation. A snapshot is not the
+/// branch it was taken from — the branch may advance from the same base
+/// concurrently — so its commits are minted on a *lineage* of their own.
+/// The lineage is allocated on the snapshot's first commit and kept for
+/// the ones after, which is what makes a chain of transactions one
+/// origin with increasing editions. A clone starts a line of its own for
+/// the same reason: two clones transacting from the same base must not
+/// collide.
+///
+/// The base branch is still reachable: the minted record's parent is
+/// the base revision, so ancestry, causality, and
+/// [`log`](Self::log) walk straight through.
+///
+/// # Reads are local
+///
+/// A snapshot tracks no upstream. A read that misses a block the local
+/// store does not hold fails rather than fetching; materialize first
+/// with [`SnapshotExport::download`] (or
+/// [`Branch::download`](crate::Branch::download)) when the revision was
+/// pulled by reference.
+#[derive(Debug)]
+pub struct Snapshot {
     subject: Subject,
+    head: RwLock<Head>,
+    caches: Caches,
+    overlay: Overlay,
+}
+
+/// What a snapshot's commits move: the revision, and the line they are
+/// minted on once one has been allocated.
+#[derive(Debug, Clone)]
+struct Head {
     revision: Revision,
-    repository: PhantomData<&'a C>,
+    /// `None` until the first commit through this handle.
+    lineage: Option<Entity>,
 }
 
 impl<C: Principal> Repository<C> {
-    /// An immutable view at `revision`.
+    /// A view at `revision`.
     ///
     /// The revision is taken by value: whatever advances afterwards, this
     /// view keeps naming the same state. How the revision was obtained is
     /// the caller's business -- a snapshot does not require the branch it
-    /// was minted on to be present, which is why it also cannot hydrate
-    /// from an upstream (see [`SnapshotExport::download`]).
-    pub fn snapshot(&self, revision: Revision) -> Snapshot<'_, C> {
-        Snapshot {
-            subject: self.subject(),
-            revision,
-            repository: PhantomData,
-        }
+    /// was minted on to be present. Starts with cold caches; prefer
+    /// [`Branch::snapshot`] when a branch handle at the revision is at
+    /// hand, so its warm caches carry over.
+    pub fn snapshot(&self, revision: Revision) -> Snapshot {
+        Snapshot::new(self.subject(), revision)
     }
 }
 
-impl Snapshot<'static> {
-    /// An immutable view of `subject`'s repository at `revision`, for
-    /// callers that hold a branch rather than a repository.
-    pub(crate) fn of(subject: Subject, revision: Revision) -> Self {
+impl Branch {
+    /// A snapshot of this branch's current revision, or `None` before
+    /// its first commit.
+    ///
+    /// The snapshot shares this branch's caches: every one of them is
+    /// content- or version-addressed, so blocks, rules, and records the
+    /// branch has already read are warm for the snapshot, and what the
+    /// snapshot reads or mints warms the branch in turn. The head is
+    /// copied, not shared — the branch advancing afterwards leaves the
+    /// snapshot where it was, and the snapshot's commits never touch
+    /// the branch.
+    pub fn snapshot(&self) -> Option<Snapshot> {
+        let revision = self.revision()?;
+        Some(Snapshot {
+            subject: self.subject(),
+            head: RwLock::new(Head {
+                revision,
+                lineage: None,
+            }),
+            caches: self.caches(),
+            overlay: Overlay::default(),
+        })
+    }
+}
+
+impl Snapshot {
+    /// A view of `subject`'s repository at `revision`, with cold caches.
+    pub fn new(subject: Subject, revision: Revision) -> Self {
         Snapshot {
             subject,
-            revision,
-            repository: PhantomData,
+            head: RwLock::new(Head {
+                revision,
+                lineage: None,
+            }),
+            caches: Caches::new(),
+            overlay: Overlay::default(),
         }
     }
-}
 
-impl<C: Principal> Snapshot<'_, C> {
     /// The revision this snapshot names.
-    pub fn revision(&self) -> &Revision {
-        &self.revision
+    pub fn revision(&self) -> Revision {
+        self.head.read().revision.clone()
+    }
+
+    /// The subject (repository) this snapshot is a view of.
+    pub fn subject(&self) -> Subject {
+        self.subject.clone()
+    }
+
+    /// The DID of the repository this snapshot is a view of.
+    pub fn of(&self) -> &Did {
+        self.subject.did()
+    }
+
+    /// Archive capability for this snapshot's subject.
+    pub fn archive(&self) -> Capability<Archive> {
+        self.subject().archive()
     }
 
     /// The archive catalog this snapshot's blocks live in.
     pub(crate) fn index(&self) -> Capability<Catalog> {
         self.subject.clone().archive().index()
+    }
+
+    /// The revision a commit builds on and the line it mints on, read
+    /// together so they name the same head.
+    pub(crate) fn head(&self) -> (Revision, Option<Entity>) {
+        let head = self.head.read();
+        (head.revision.clone(), head.lineage.clone())
+    }
+
+    /// Move the head from `base` to `next`, recording the line `next`
+    /// was minted on.
+    ///
+    /// The in-memory counterpart of a branch's CAS publish: a commit
+    /// builds on the head it read, and if another commit through this
+    /// same handle advanced it in the meantime, adopting `next` would
+    /// silently drop that one — so the advance is refused with the same
+    /// [`VersionMismatch`](PublishError::VersionMismatch) a stale branch
+    /// write gets, carrying the tree roots as the versions.
+    pub(crate) fn advance(
+        &self,
+        base: &Revision,
+        next: Revision,
+        lineage: Entity,
+    ) -> Result<(), PublishError> {
+        let mut head = self.head.write();
+        if head.revision != *base {
+            return Err(PublishError::VersionMismatch {
+                expected: Some(memory::Version::from(base.tree.hash())),
+                actual: Some(memory::Version::from(head.revision.tree.hash())),
+            });
+        }
+        head.revision = next;
+        head.lineage = Some(lineage);
+        Ok(())
+    }
+
+    /// The shared caches this snapshot reads and commits through.
+    pub(crate) fn caches(&self) -> &Caches {
+        &self.caches
+    }
+
+    /// The snapshot's artifact index.
+    ///
+    /// Use `.select(selector).perform(&env)` to query artifacts.
+    pub fn claims(&self) -> SnapshotClaims<'_> {
+        SnapshotClaims { snapshot: self }
+    }
+
+    /// Query with an application. Shortcut for
+    /// `snapshot.query().select(query)`.
+    pub fn select<Q: Application>(&self, query: Q) -> SelectQuery<'_, Q> {
+        SelectQuery::new(self, query)
+    }
+
+    /// Open a query over this snapshot: a
+    /// [`QueryLayer`](crate::QueryLayer) rooted at it, to
+    /// [`with`](crate::QueryLayer::with) statements into,
+    /// [`join`](crate::QueryLayer::join) branches or other snapshots
+    /// onto, and [`select`](crate::QueryLayer::select) from. Schema
+    /// metadata is auto-injected at perform time, as for a branch.
+    pub fn query(&self) -> crate::QueryLayer<'_> {
+        crate::QueryLayer::from(self)
+    }
+
+    /// Open a query over this snapshot with `statement` folded into the
+    /// overlay in one step. Shorthand for `self.query().with(stmt)`.
+    pub fn with<S: Statement>(&self, statement: S) -> crate::QueryLayer<'_> {
+        self.query().with(statement)
+    }
+
+    /// The snapshot's transient session overlay: assert or retract
+    /// ephemeral facts that every read of this snapshot observes but no
+    /// commit persists. A [`Clone`] shares it, like branch clones do.
+    /// See [`Overlay`].
+    pub fn overlay(&self) -> &Overlay {
+        &self.overlay
+    }
+
+    /// This snapshot's blob store, the target for [`Blob`](crate::Blob)
+    /// reads. Blob writes advance the line through the branch's memory
+    /// cell, which a snapshot does not have — see [`BlobArchive`].
+    pub fn blobs(&self) -> BlobArchive<'_> {
+        BlobArchive::from(self)
+    }
+
+    /// The recorded claim lineage at this snapshot's revision. See
+    /// [`Branch::history`].
+    pub fn history<'a, Env>(&self, env: &'a Env) -> TreeHistory<NetworkedIndex<'a, Env>>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Fork<RemoteSite, Get>>
+            + ConditionalSync
+            + 'static,
+    {
+        SourceRef::from(self).history(env)
+    }
+
+    /// The snapshot's committed history, newest first — at most `limit`
+    /// entries of `(version, record)`. See [`Branch::log`].
+    pub async fn log<Env>(
+        &self,
+        env: &Env,
+        limit: usize,
+    ) -> Result<Vec<(Version, RevisionRecord)>, DialogArtifactsError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Fork<RemoteSite, Get>>
+            + ConditionalSync
+            + 'static,
+    {
+        SourceRef::from(self).log(env, limit).await
+    }
+
+    /// A shared handle to this snapshot's causal-verdict memo. See
+    /// [`Branch::causality`].
+    pub fn causality(&self) -> CausalityCache {
+        self.caches.causality.clone()
+    }
+
+    /// A shared handle to this snapshot's causal-context memo. See
+    /// [`Branch::contexts`].
+    pub fn contexts(&self) -> ContextCache {
+        self.caches.contexts.clone()
+    }
+}
+
+// A clone is the same view on its own line: it copies the head (so the
+// original advancing leaves it where it is, and vice versa), shares the
+// caches and the session overlay (both safe to share, like a branch
+// clone's), and starts without a lineage — see the type docs for why
+// two handles that may both transact from one base must mint under
+// different origins.
+impl Clone for Snapshot {
+    fn clone(&self) -> Self {
+        Snapshot {
+            subject: self.subject.clone(),
+            head: RwLock::new(Head {
+                revision: self.revision(),
+                lineage: None,
+            }),
+            caches: self.caches.clone(),
+            overlay: self.overlay.clone(),
+        }
+    }
+}
+
+/// The snapshot's artifact index. Created by [`Snapshot::claims`].
+pub struct SnapshotClaims<'a> {
+    snapshot: &'a Snapshot,
+}
+
+impl<'a> SnapshotClaims<'a> {
+    /// Select artifacts matching the selector.
+    pub fn select(self, selector: ArtifactSelector<Constrained>) -> Select<'a> {
+        Select::from_source(SourceRef::from(self.snapshot), selector)
     }
 }
 
@@ -223,14 +503,14 @@ pub enum Reach {
 /// than pushing into a consumer, so what happens to the content is the
 /// caller's decision: hand it to [`Repository::import`], write it to a
 /// file, count it, filter it.
-pub struct SnapshotExport<'a, C: Principal = Credential> {
-    snapshot: Snapshot<'a, C>,
+pub struct SnapshotExport {
+    snapshot: Snapshot,
     reach: Reach,
 }
 
-impl<'a, C: Principal> Snapshot<'a, C> {
+impl Snapshot {
     /// Prepare to read this snapshot's content.
-    pub fn export(self) -> SnapshotExport<'a, C> {
+    pub fn export(self) -> SnapshotExport {
         SnapshotExport {
             snapshot: self,
             reach: Reach::Complete,
@@ -238,7 +518,7 @@ impl<'a, C: Principal> Snapshot<'a, C> {
     }
 }
 
-impl<C: Principal> SnapshotExport<'_, C> {
+impl SnapshotExport {
     /// Export whatever is reachable locally instead of requiring
     /// everything.
     ///
@@ -294,7 +574,7 @@ impl<C: Principal> SnapshotExport<'_, C> {
         // travel their own channel, so the blob loop needs its own.
         let hydrate = upstream.clone();
         let sparse = matches!(self.reach, Reach::Sparse);
-        let root = NodeHash::from(*self.snapshot.revision.tree.hash());
+        let root = NodeHash::from(*self.snapshot.revision().tree.hash());
 
         try_stream! {
             // With an upstream a read-miss falls through to the remote and

--- a/rust/dialog-repository/src/repository/snapshot/read_tests.rs
+++ b/rust/dialog-repository/src/repository/snapshot/read_tests.rs
@@ -1,0 +1,673 @@
+//! A snapshot reads exactly like the branch it was taken from, and keeps
+//! reading the same thing after the branch moves on.
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+use anyhow::Result;
+use dialog_artifacts::history::History as _;
+use dialog_artifacts::{Artifact, ArtifactSelector, Entity, Value};
+use dialog_effects::blob::BlobError;
+use dialog_operator::helpers::test_operator_with_profile;
+use dialog_query::query::Output;
+use dialog_query::{Concept, Query, Term, the};
+use futures_util::{StreamExt as _, stream};
+
+use crate::helpers::test_repo;
+use crate::repository::source::SourceRef;
+use crate::schema::DidExt as _;
+use dialog_capability::{Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::authority::Identify;
+use dialog_effects::memory::Resolve;
+
+use crate::{Blob, CommitError, QueryLayer, RemoteSite, Select, TreeReference, schema};
+
+mod people {
+    /// `test/name` attribute used by the Person concept below.
+    #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("test")]
+    pub struct Name(
+        /// The person's name string.
+        pub String,
+    );
+}
+
+/// A simple concept to query through.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Person {
+    /// The person entity.
+    pub this: Entity,
+    /// Their `test/name` attribute.
+    pub name: people::Name,
+}
+
+fn person(id: &str, name: &str) -> Person {
+    Person {
+        this: id.parse().expect("entity parses"),
+        name: people::Name(name.into()),
+    }
+}
+
+/// Every `test/name` value on a line, sorted, read through the raw
+/// artifact index (the lowest read path there is).
+async fn names<'a, Env>(source: impl Into<SourceRef<'a>>, env: &Env) -> Result<Vec<String>>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let rows: Vec<Artifact> = Select::from_source(
+        source.into(),
+        ArtifactSelector::new().the("test/name".parse()?),
+    )
+    .to_owned()
+    .perform(env)
+    .await?
+    .collect::<Vec<_>>()
+    .await
+    .into_iter()
+    .collect::<Result<_, _>>()?;
+    let mut names: Vec<String> = rows
+        .into_iter()
+        .filter_map(|row| match row.is {
+            Value::String(name) => Some(name),
+            _ => None,
+        })
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+/// The `SessionBranch` rows a query layer yields.
+async fn session_branches<Env>(
+    layer: QueryLayer<'_>,
+    env: &Env,
+) -> Result<Vec<schema::SessionBranch>>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Identify>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    Ok(layer
+        .select(Query::<schema::SessionBranch> {
+            this: schema::Session::entity().into(),
+            branch: Term::var("branch"),
+        })
+        .perform(env)
+        .try_vec()
+        .await?)
+}
+
+/// Every `Person` a query layer yields, by name, sorted.
+async fn people<Env>(layer: QueryLayer<'_>, env: &Env) -> Result<Vec<String>>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Identify>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let mut names: Vec<String> = layer
+        .select(Query::<Person> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+        })
+        .perform(env)
+        .try_vec()
+        .await?
+        .into_iter()
+        .map(|row| row.name.0)
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+#[dialog_common::test]
+async fn it_reads_what_the_branch_reads() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    branch
+        .transaction()
+        .assert(person("id:alice", "Alice"))
+        .assert(person("id:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    let snapshot = branch.snapshot().expect("a committed branch snapshots");
+    assert_eq!(snapshot.revision(), branch.revision().expect("head"));
+    assert_eq!(snapshot.of(), branch.of());
+
+    // The raw index, the typed shortcut, and the composable layer all
+    // read the same two facts the branch does.
+    let expected = vec!["Alice".to_string(), "Bob".to_string()];
+    assert_eq!(names(&snapshot, &operator).await?, expected);
+    assert_eq!(names(&branch, &operator).await?, expected);
+    assert_eq!(people(snapshot.query(), &operator).await?, expected);
+    let typed: Vec<Person> = snapshot
+        .select(Query::<Person> {
+            this: "id:alice".parse::<Entity>()?.into(),
+            name: Term::var("name"),
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?;
+    assert_eq!(typed, vec![person("id:alice", "Alice")]);
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_stays_pinned_while_the_branch_advances() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    branch
+        .transaction()
+        .assert(person("id:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let snapshot = branch.snapshot().expect("snapshot");
+    let pinned = snapshot.revision().clone();
+
+    branch
+        .transaction()
+        .assert(person("id:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string()],
+        "the snapshot keeps naming the revision it was taken at"
+    );
+    assert_eq!(snapshot.revision(), pinned);
+    assert_eq!(
+        names(&branch, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()]
+    );
+    // A fresh snapshot follows the branch.
+    let later = branch.snapshot().expect("snapshot");
+    assert_eq!(
+        names(&later, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()]
+    );
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_has_no_snapshot_before_the_first_commit() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    assert!(branch.snapshot().is_none());
+    Ok(())
+}
+
+/// A snapshot minted cold from the repository (no branch handle, no
+/// warm caches) reads the same revision the same way.
+#[dialog_common::test]
+async fn it_reads_through_a_cold_handle() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    let revision = branch
+        .transaction()
+        .assert(person("id:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    let cold = repo.snapshot(revision);
+    assert_eq!(names(&cold, &operator).await?, vec!["Alice".to_string()]);
+    assert_eq!(
+        people(cold.query(), &operator).await?,
+        vec!["Alice".to_string()]
+    );
+    Ok(())
+}
+
+/// A revision whose root the store does not hold fails at the read,
+/// naming the missing block, exactly as an unreachable branch does.
+#[dialog_common::test]
+async fn it_fails_when_the_root_is_absent() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    let mut revision = branch
+        .transaction()
+        .assert(person("id:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    revision.tree = TreeReference::from([7u8; 32]);
+
+    let snapshot = repo.snapshot(revision);
+    let result = snapshot
+        .claims()
+        .select(ArtifactSelector::new().the("test/name".parse()?))
+        .perform(&operator)
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(dialog_search_tree::DialogSearchTreeError::Node(_))
+        ),
+        "an absent root must fail the read up front"
+    );
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_joins_a_snapshot_into_a_branch_query() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let main = repo.branch("main").open().perform(&operator).await?;
+    main.transaction()
+        .assert(person("id:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let snapshot = main.snapshot().expect("snapshot");
+
+    let feature = repo.branch("feature").open().perform(&operator).await?;
+    feature
+        .transaction()
+        .assert(person("id:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(
+        people(feature.query().join(&snapshot), &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()],
+        "a joined snapshot is a peer source"
+    );
+    assert_eq!(
+        people(snapshot.query().join(&feature), &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()],
+        "in either order"
+    );
+    let layer = feature.query().join(&snapshot);
+    assert_eq!(layer.branches().len(), 1);
+    assert_eq!(layer.snapshots().len(), 1);
+    Ok(())
+}
+
+/// A snapshot query carries the session and replica metadata a branch
+/// query does; it is not a branch, so it mints no `SessionBranch` row —
+/// and joining a branch in adds exactly that branch's row.
+#[dialog_common::test]
+async fn it_injects_session_metadata() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    branch
+        .transaction()
+        .assert(person("id:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let snapshot = branch.snapshot().expect("snapshot");
+
+    let sessions: Vec<schema::Session> = snapshot
+        .query()
+        .select(Query::<schema::Session> {
+            this: schema::Session::entity().into(),
+            profile: Term::var("profile"),
+            operator: Term::var("operator"),
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?;
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].profile.0, profile.did().this());
+
+    let replica = schema::Replica::new(profile.did(), branch.of().clone());
+    let replicas: Vec<schema::Replica> = snapshot
+        .query()
+        .select(Query::<schema::Replica> {
+            this: replica.this.clone().into(),
+            subject: Term::var("subject"),
+            profile: Term::var("profile"),
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?;
+    assert_eq!(replicas, vec![replica.clone()]);
+
+    assert!(
+        session_branches(snapshot.query(), &operator)
+            .await?
+            .is_empty(),
+        "a snapshot is not a branch in scope"
+    );
+    let joined = session_branches(snapshot.query().join(&branch), &operator).await?;
+    assert_eq!(joined.len(), 1);
+    assert_eq!(
+        joined[0].branch.0,
+        schema::Branch::new(&replica, "main").this
+    );
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_folds_the_overlay_into_reads() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    branch
+        .transaction()
+        .assert(person("id:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let snapshot = branch.snapshot().expect("snapshot");
+
+    snapshot.overlay().assert(person("id:bob", "Bob"));
+    assert_eq!(
+        people(snapshot.query(), &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()],
+        "an overlay assert surfaces in reads"
+    );
+    snapshot.overlay().retract(
+        the!("test/name")
+            .of("id:alice".parse::<Entity>()?)
+            .is("Alice".to_string()),
+    );
+    assert_eq!(
+        people(snapshot.query(), &operator).await?,
+        vec!["Bob".to_string()],
+        "an overlay retract tombstones the stored fact"
+    );
+    // The branch's own overlay is separate.
+    assert_eq!(
+        people(branch.query(), &operator).await?,
+        vec!["Alice".to_string()]
+    );
+    // A clone shares the overlay, like branch clones do.
+    let clone = snapshot.clone();
+    assert_eq!(
+        people(clone.query(), &operator).await?,
+        vec!["Bob".to_string()]
+    );
+    snapshot.overlay().clear();
+    assert_eq!(
+        people(clone.query(), &operator).await?,
+        vec!["Alice".to_string()]
+    );
+    Ok(())
+}
+
+/// A deductive rule committed on the branch derives on the snapshot,
+/// resolved through the same layered rule resolution.
+#[dialog_common::test]
+async fn it_resolves_committed_rules() -> Result<()> {
+    use dialog_query::rule::DeductiveRuleDescriptor;
+    use dialog_query::{ConceptQuery, Parameters};
+
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+
+    // employee(this, name) :- person-name(this, name)
+    let rule = {
+        let json = serde_json::json!({
+            "deduce": { "with": { "name": { "the": "org/employee-name", "as": "Text" } } },
+            "when": [{
+                "assert": { "with": { "name": { "the": "org/person-name", "as": "Text" } } },
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "name": { "?": { "name": "name" } }
+                }
+            }]
+        });
+        let descriptor: DeductiveRuleDescriptor =
+            serde_json::from_value(json).expect("descriptor parses");
+        descriptor.compile().expect("rule compiles")
+    };
+    let employee = rule.conclusion().clone();
+    let alice: Entity = "id:alice".parse()?;
+    branch
+        .transaction()
+        .assert(&rule)
+        .assert(
+            the!("org/person-name")
+                .of(alice.clone())
+                .is("Alice".to_string()),
+        )
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    let snapshot = branch.snapshot().expect("snapshot");
+    let mut terms = Parameters::new();
+    terms.insert("this".into(), Term::var("this"));
+    terms.insert("name".into(), Term::var("name"));
+    let rows = snapshot
+        .query()
+        .select(ConceptQuery {
+            predicate: employee,
+            terms,
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?;
+    assert_eq!(rows.len(), 1, "the committed rule derives on the snapshot");
+    assert_eq!(*rows[0].entity(), alice);
+    Ok(())
+}
+
+/// The built-in derived version-control concepts — the DAG edge and
+/// its recursive closure — resolve on a snapshot, concluded from the
+/// signed records in its tree.
+#[dialog_common::test]
+async fn it_resolves_derived_revision_concepts() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+
+    let mut revisions = Vec::new();
+    for name in ["Alice", "Bob", "Carol"] {
+        revisions.push(
+            branch
+                .transaction()
+                .assert(the!("user/name").of(Entity::new()?).is(name.to_string()))
+                .commit()
+                .perform(&operator)
+                .await?,
+        );
+    }
+    let [first, second, third] = &revisions[..] else {
+        unreachable!("three commits were made");
+    };
+    let snapshot = branch.snapshot().expect("snapshot");
+
+    let edges: Vec<schema::RevisionParent> = snapshot
+        .query()
+        .select(Query::<schema::RevisionParent> {
+            this: third.entity().into(),
+            parent: Term::var("parent"),
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?;
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].parent.0, second.entity());
+
+    let mut reachable: Vec<Entity> = snapshot
+        .query()
+        .select(Query::<schema::RevisionAncestor> {
+            this: third.entity().into(),
+            ancestor: Term::var("ancestor"),
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?
+        .into_iter()
+        .map(|row| row.ancestor.0)
+        .collect();
+    reachable.sort();
+    let mut expected = vec![first.entity(), second.entity()];
+    expected.sort();
+    assert_eq!(reachable, expected);
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_logs_history() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    let mut revisions = Vec::new();
+    for name in ["Alice", "Bob"] {
+        revisions.push(
+            branch
+                .transaction()
+                .assert(the!("user/name").of(Entity::new()?).is(name.to_string()))
+                .commit()
+                .perform(&operator)
+                .await?,
+        );
+    }
+    let snapshot = branch.snapshot().expect("snapshot");
+
+    let log = snapshot.log(&operator, 10).await?;
+    let versions: Vec<_> = log.iter().map(|(version, _)| *version).collect();
+    assert_eq!(
+        versions,
+        vec![revisions[1].version(), revisions[0].version()],
+        "newest first, through the whole ancestry"
+    );
+    assert_eq!(
+        versions,
+        branch
+            .log(&operator, 10)
+            .await?
+            .iter()
+            .map(|(version, _)| *version)
+            .collect::<Vec<_>>()
+    );
+    let record = snapshot
+        .history(&operator)
+        .revision_record(&revisions[1].version())
+        .await?
+        .expect("the head's record is retrievable");
+    assert_eq!(record.parents, vec![revisions[0].version()]);
+    Ok(())
+}
+
+/// Blob reads bind to a snapshot; writes and retractions, which would
+/// have to advance it through a reference, are refused and leave both
+/// the snapshot and the branch as they were.
+#[dialog_common::test]
+async fn it_reads_blobs_and_refuses_to_write_them() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+
+    let bytes = b"snapshot blob".repeat(64);
+    let entity = Blob::import(stream::iter(vec![Ok(bytes.clone())]))
+        .write(branch.blobs())
+        .perform(&operator)
+        .await?;
+    let snapshot = branch.snapshot().expect("snapshot");
+
+    let size = Blob::from(entity.clone())
+        .size(snapshot.blobs())
+        .perform(&operator)
+        .await?;
+    assert_eq!(size, Some(bytes.len() as u64));
+
+    let mut reader = Blob::from(entity.clone())
+        .read(snapshot.blobs())
+        .perform(&operator)
+        .await?;
+    let mut read = Vec::new();
+    while let Some(chunk) = reader.next().await? {
+        read.extend_from_slice(&chunk);
+    }
+    assert_eq!(read, bytes);
+
+    let refused = Blob::import(stream::iter(vec![Ok::<_, BlobError>(b"more".to_vec())]))
+        .write(snapshot.blobs())
+        .perform(&operator)
+        .await
+        .err();
+    assert!(
+        matches!(refused, Some(CommitError::Detached)),
+        "a blob write through a snapshot reference is refused: {refused:?}"
+    );
+    let refused = Blob::from(entity.clone())
+        .retract(snapshot.blobs())
+        .perform(&operator)
+        .await;
+    assert!(
+        matches!(refused, Err(CommitError::Detached)),
+        "a blob retraction through a snapshot reference is refused: {refused:?}"
+    );
+
+    // Nothing moved.
+    assert_eq!(snapshot.revision(), branch.revision().expect("head"));
+    let fresh = repo.branch("main").load().perform(&operator).await?;
+    assert_eq!(fresh.revision(), branch.revision());
+    assert_eq!(
+        Blob::from(entity)
+            .size(fresh.blobs())
+            .perform(&operator)
+            .await?,
+        Some(bytes.len() as u64)
+    );
+    Ok(())
+}
+
+/// A blob the snapshot's revision does not reference is a miss, not an
+/// error path into some upstream — a snapshot has none.
+#[dialog_common::test]
+async fn it_reports_an_unreferenced_blob_as_absent() -> Result<()> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    branch
+        .transaction()
+        .assert(person("id:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let snapshot = branch.snapshot().expect("snapshot");
+
+    let never = Entity::from_blob(&[3u8; 32])?;
+    assert_eq!(
+        Blob::from(never.clone())
+            .size(snapshot.blobs())
+            .perform(&operator)
+            .await?,
+        None
+    );
+    let missing = Blob::from(never)
+        .read(snapshot.blobs())
+        .perform(&operator)
+        .await
+        .err();
+    assert!(
+        matches!(missing, Some(CommitError::Blob(BlobError::NotFound(_)))),
+        "an unreferenced blob is not found: {missing:?}"
+    );
+    Ok(())
+}

--- a/rust/dialog-repository/src/repository/snapshot/transaction_tests.rs
+++ b/rust/dialog-repository/src/repository/snapshot/transaction_tests.rs
@@ -1,0 +1,850 @@
+//! A snapshot transacts with the branch's own command types, advances in
+//! place, and never touches the branch it was taken from.
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+use anyhow::Result;
+use dialog_artifacts::history::{History as _, Version};
+use dialog_artifacts::{Artifact, ArtifactSelector, Changes, Entity, Instruction, Value};
+use dialog_capability::{Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::authority::Identify;
+use dialog_effects::memory::Resolve;
+use dialog_operator::helpers::test_operator_with_profile;
+use dialog_query::attribute::The;
+use dialog_query::query::Output;
+use dialog_query::{Query, Term, the};
+use dialog_storage::provider::storage::VolatileSpace;
+use futures_util::{StreamExt as _, stream};
+
+use crate::helpers::test_repo;
+use crate::repository::source::SourceRef;
+use crate::{
+    Branch, CommitError, Item, PublishError, RemoteSite, Repository, Select, Snapshot,
+    TreeReference, schema,
+};
+
+/// Every `user/name` value on a line, sorted.
+async fn names<'a, Env>(source: impl Into<SourceRef<'a>>, env: &Env) -> Result<Vec<String>>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let mut names: Vec<String> = values(source, env, "user/name", None)
+        .await?
+        .into_iter()
+        .filter_map(|value| match value {
+            Value::String(name) => Some(name),
+            _ => None,
+        })
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+/// The values under `the` on a line, narrowed to `of` when given.
+async fn values<'a, Env>(
+    source: impl Into<SourceRef<'a>>,
+    env: &Env,
+    the: &str,
+    of: Option<&Entity>,
+) -> Result<Vec<Value>>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let mut selector = ArtifactSelector::new().the(the.parse()?);
+    if let Some(of) = of {
+        selector = selector.of(of.clone());
+    }
+    let rows: Vec<Artifact> = Select::from_source(source.into(), selector)
+        .to_owned()
+        .perform(env)
+        .await?
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<_, _>>()?;
+    Ok(rows.into_iter().map(|row| row.is).collect())
+}
+
+/// Every `user/name` value a query layer yields, sorted: the overlay
+/// and metadata path, as opposed to the raw index `names` reads.
+async fn queried_names<Env>(layer: crate::QueryLayer<'_>, env: &Env) -> Result<Vec<String>>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Identify>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let mut rows: Vec<String> = layer
+        .select(dialog_query::AttributeQuery::from(
+            Term::<The>::from(the!("user/name"))
+                .of(Term::<Entity>::var("e"))
+                .is(Term::<String>::var("v")),
+        ))
+        .perform(env)
+        .try_vec()
+        .await?
+        .into_iter()
+        .filter_map(|claim| match claim.is {
+            Value::String(name) => Some(name),
+            _ => None,
+        })
+        .collect();
+    rows.sort();
+    Ok(rows)
+}
+
+/// A `user/name` statement, for transactions.
+fn name(of: &str, is: &str) -> impl dialog_artifacts::Statement {
+    the!("user/name")
+        .of(of.parse::<Entity>().expect("entity parses"))
+        .is(is.to_string())
+}
+
+/// A `user/name` artifact, for raw commits.
+fn fact(of: &str, is: &str) -> Artifact {
+    Artifact {
+        the: "user/name".parse().expect("attribute parses"),
+        of: of.parse().expect("entity parses"),
+        is: Value::String(is.to_string()),
+        cause: None,
+    }
+}
+
+/// A branch with one committed fact and a snapshot of it.
+async fn staged() -> Result<(
+    dialog_operator::Operator<VolatileSpace>,
+    dialog_identity::Profile,
+    Repository,
+    Branch,
+    Snapshot,
+)> {
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+    branch
+        .transaction()
+        .assert(name("user:alice", "Alice"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let snapshot = branch.snapshot().expect("a committed branch snapshots");
+    Ok((operator, profile, repo, branch, snapshot))
+}
+
+#[dialog_common::test]
+async fn it_advances_the_snapshot_and_not_the_branch() -> Result<()> {
+    let (operator, _, repo, branch, snapshot) = staged().await?;
+    let base = snapshot.revision();
+
+    let minted = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(
+        snapshot.revision(),
+        minted,
+        "the snapshot advanced to the revision the commit returned"
+    );
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()],
+        "and reads the new fact on top of the base"
+    );
+    assert_eq!(minted.edition, base.edition.successor());
+    assert_ne!(minted.tree, base.tree);
+
+    // The branch head did not move: neither the handle nor storage.
+    assert_eq!(branch.revision(), Some(base.clone()));
+    let fresh = repo.branch("main").load().perform(&operator).await?;
+    assert_eq!(fresh.revision(), Some(base.clone()));
+    assert_eq!(names(&fresh, &operator).await?, vec!["Alice".to_string()]);
+
+    // The minted record's parent is the base revision.
+    let record = snapshot
+        .history(&operator)
+        .revision_record(&minted.version())
+        .await?
+        .expect("the minted record is in the tree");
+    assert_eq!(record.parents, vec![base.version()]);
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_keeps_the_view_you_cloned() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let kept = snapshot.clone();
+    let base = kept.revision();
+
+    snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(kept.revision(), base, "the clone still names the base");
+    assert_eq!(names(&kept, &operator).await?, vec!["Alice".to_string()]);
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()]
+    );
+
+    // And the other way round: advancing the clone leaves the original.
+    let head = snapshot.revision();
+    kept.transaction()
+        .assert(name("user:carol", "Carol"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    assert_eq!(snapshot.revision(), head);
+    assert_eq!(
+        names(&kept, &operator).await?,
+        vec!["Alice".to_string(), "Carol".to_string()]
+    );
+    Ok(())
+}
+
+/// The snapshot and the branch both advance from the same base under
+/// the same operator: they must mint distinct versions, or one origin
+/// would name two revisions at one edition.
+#[dialog_common::test]
+async fn it_mints_on_its_own_line() -> Result<()> {
+    let (operator, _, _, branch, snapshot) = staged().await?;
+    let base = snapshot.revision();
+
+    let detached = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let on_branch = branch
+        .transaction()
+        .assert(name("user:carol", "Carol"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(detached.edition, on_branch.edition);
+    assert_ne!(
+        detached.version(),
+        on_branch.version(),
+        "two lines advancing from one base mint distinct versions"
+    );
+    assert_ne!(detached.origin(), base.origin());
+    assert_eq!(on_branch.origin(), base.origin());
+    assert_ne!(
+        detached.branch, base.branch,
+        "a snapshot's revision names its own lineage, not the branch"
+    );
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()]
+    );
+    assert_eq!(
+        names(&branch, &operator).await?,
+        vec!["Alice".to_string(), "Carol".to_string()]
+    );
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_keeps_one_origin_across_consecutive_transactions() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let base = snapshot.revision();
+
+    let first = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let second = snapshot
+        .transaction()
+        .assert(name("user:carol", "Carol"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(
+        second.origin(),
+        first.origin(),
+        "a chain of transactions is one sequential actor"
+    );
+    assert_eq!(second.edition, base.edition.successor().successor());
+    assert_eq!(snapshot.revision(), second);
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string(), "Carol".to_string()]
+    );
+
+    // The log walks the chain back into the branch's history.
+    let versions: Vec<Version> = snapshot
+        .log(&operator, 10)
+        .await?
+        .into_iter()
+        .map(|(version, _)| version)
+        .collect();
+    assert_eq!(
+        versions,
+        vec![second.version(), first.version(), base.version()]
+    );
+    // And the head's context carries both origins' watermarks.
+    let context = second
+        .context
+        .clone()
+        .expect("a minted head carries its context");
+    assert!(context.observes(&base.version()));
+    assert!(context.observes(&second.version()));
+    Ok(())
+}
+
+/// A clone of an advanced snapshot is a new line: it and the original
+/// can both go on from the same revision without minting the same
+/// version.
+#[dialog_common::test]
+async fn it_gives_a_clone_its_own_line() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let first = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let fork = snapshot.clone();
+
+    let left = snapshot
+        .transaction()
+        .assert(name("user:carol", "Carol"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let right = fork
+        .transaction()
+        .assert(name("user:dave", "Dave"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(left.edition, right.edition);
+    assert_ne!(left.version(), right.version());
+    assert_ne!(left.origin(), right.origin());
+    assert_eq!(
+        left.origin(),
+        first.origin(),
+        "the original keeps the line it started"
+    );
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string(), "Carol".to_string()]
+    );
+    assert_eq!(
+        names(&fork, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string(), "Dave".to_string()]
+    );
+    // Both records point back at the fork point.
+    for (side, minted) in [(&snapshot, &left), (&fork, &right)] {
+        let record = side
+            .history(&operator)
+            .revision_record(&minted.version())
+            .await?
+            .expect("record");
+        assert_eq!(record.parents, vec![first.version()]);
+    }
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_keeps_the_revision_for_a_noop() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let base = snapshot.revision();
+
+    let unchanged = snapshot.transaction().commit().perform(&operator).await?;
+    assert_eq!(unchanged, base, "an empty batch mints nothing");
+    assert_eq!(snapshot.revision(), base);
+
+    let unchanged = snapshot
+        .transaction()
+        .retract(name("user:nobody", "Never"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    assert_eq!(unchanged, base, "retracting an absent fact mints nothing");
+
+    let unchanged = snapshot
+        .commit(stream::iter(Vec::<Instruction>::new()))
+        .perform(&operator)
+        .await?;
+    assert_eq!(unchanged, base);
+
+    // `allow_empty` mints anyway: the lineage advances, and the
+    // revision's own records still land in the tree.
+    let empty = snapshot
+        .transaction()
+        .commit()
+        .allow_empty()
+        .perform(&operator)
+        .await?;
+    assert_eq!(empty.edition, base.edition.successor());
+    assert_ne!(empty.tree, base.tree);
+    assert_eq!(snapshot.revision(), empty);
+    let record = snapshot
+        .history(&operator)
+        .revision_record(&empty.version())
+        .await?
+        .expect("record");
+    assert_eq!(record.parents, vec![base.version()]);
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string()]
+    );
+    Ok(())
+}
+
+/// What a snapshot commit mints is persisted, not merely cached on the
+/// handle: a cold handle at the new revision reads it, and a complete
+/// export of it succeeds.
+#[dialog_common::test]
+async fn it_persists_what_it_mints() -> Result<()> {
+    let (operator, _, repo, _, snapshot) = staged().await?;
+    let minted = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    let cold = repo.snapshot(minted);
+    assert_eq!(
+        names(&cold, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()]
+    );
+
+    let items = cold.export().perform(&operator);
+    futures_util::pin_mut!(items);
+    let mut blocks = 0;
+    while let Some(item) = items.next().await {
+        match item? {
+            Item::Block(block) => {
+                assert!(block.is_intact());
+                blocks += 1;
+            }
+            Item::Blob { .. } => {}
+        }
+    }
+    assert!(blocks > 0, "the complete export walks the persisted tree");
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_surfaces_pending_changes_in_the_transaction_query() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let transaction = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .retract(name("user:alice", "Alice"));
+
+    let pending: Vec<String> = {
+        let mut rows: Vec<String> = transaction
+            .query()
+            .select(dialog_query::AttributeQuery::from(
+                Term::<The>::from(the!("user/name"))
+                    .of(Term::<Entity>::var("e"))
+                    .is(Term::<String>::var("v")),
+            ))
+            .perform(&operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .filter_map(|claim| match claim.is {
+                Value::String(name) => Some(name),
+                _ => None,
+            })
+            .collect();
+        rows.sort();
+        rows
+    };
+    assert_eq!(
+        pending,
+        vec!["Bob".to_string()],
+        "the view shows the pending assert and tombstones the pending retract"
+    );
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string()],
+        "the snapshot itself is untouched until commit"
+    );
+
+    transaction.commit().perform(&operator).await?;
+    assert_eq!(names(&snapshot, &operator).await?, vec!["Bob".to_string()]);
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_signs_the_minted_revision() -> Result<()> {
+    let (operator, profile, _, _, snapshot) = staged().await?;
+    let base = snapshot.revision();
+    let revision = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(revision.issuer, operator.did());
+    revision.verify()?;
+    let mut tampered = revision.clone();
+    tampered.tree = TreeReference::from([9u8; 32]);
+    assert!(tampered.verify().is_err());
+
+    let record = snapshot
+        .history(&operator)
+        .revision_record(&revision.version())
+        .await?
+        .expect("record");
+    assert_eq!(record.issuer, operator.did().to_string());
+    assert_eq!(record.authority, profile.did().to_string());
+    assert_eq!(record.branch, revision.branch);
+    assert_ne!(record.branch, base.branch);
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_rejects_writes_to_the_reserved_namespace() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let base = snapshot.revision();
+    let forged = Artifact {
+        the: "dialog.db/revision".parse()?,
+        of: "forged:revision".parse()?,
+        is: Value::String("lies".to_string()),
+        cause: None,
+    };
+    let result = snapshot
+        .commit(stream::iter(vec![Instruction::Assert(forged)]))
+        .perform(&operator)
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(CommitError::Artifact(
+                dialog_artifacts::DialogArtifactsError::ReservedAttribute(_)
+            ))
+        ),
+        "writes to the reserved namespace must be refused: {result:?}"
+    );
+    assert_eq!(snapshot.revision(), base, "a refused commit moves nothing");
+    Ok(())
+}
+
+/// Two commits through one handle that both built on the same head:
+/// the second is refused rather than silently dropping the first, the
+/// same way a stale branch write is.
+#[dialog_common::test]
+async fn it_refuses_a_commit_built_on_a_stale_head() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let base = snapshot.revision();
+
+    // A commit built on `base` that has not adopted its result yet is
+    // exactly what a concurrent transaction on the same handle sees.
+    // Reproduce it by advancing the head out from under a prepared
+    // adoption.
+    let first = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let stale = snapshot.advance(&base, first.clone(), Entity::new()?);
+    assert!(
+        matches!(stale, Err(PublishError::VersionMismatch { .. })),
+        "an advance built on a superseded head is refused: {stale:?}"
+    );
+    assert_eq!(snapshot.revision(), first, "the winning commit stands");
+    Ok(())
+}
+
+/// Commit-time induction runs on a snapshot transaction exactly as on
+/// a branch: a dispatched command fires the committed rule, the rule's
+/// durable head folds into the snapshot's commit, and the command
+/// itself is never written. The branch is untouched.
+#[dialog_common::test]
+async fn it_induces_on_commit() -> Result<()> {
+    use dialog_query::InductiveRule;
+
+    let (operator, profile) = test_operator_with_profile().await;
+    let repo = test_repo(&operator, &profile).await;
+    let branch = repo.branch("main").open().perform(&operator).await?;
+
+    let increment: InductiveRule = serde_json::from_value(serde_json::json!({
+        "description": "Increment a counter on an increment command",
+        "assert!": {
+            "with": { "count": { "the": "counter/count", "as": "UnsignedInteger" } }
+        },
+        "when": [
+            {
+                "assert": {
+                    "with": { "counter": { "the": "cmd.increment/counter", "as": "Entity" } }
+                },
+                "where": { "counter": { "?": { "name": "this" } } }
+            },
+            {
+                "assert": {
+                    "with": { "count": { "the": "counter/count", "as": "UnsignedInteger" } }
+                },
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "count": { "?": { "name": "prev" } }
+                }
+            },
+            {
+                "assert": "math/sum",
+                "where": {
+                    "of": { "?": { "name": "prev" } },
+                    "with": 1,
+                    "is": { "?": { "name": "count" } }
+                }
+            }
+        ]
+    }))
+    .expect("increment rule compiles");
+
+    let counter: Entity = "ctr:1".parse()?;
+    branch
+        .transaction()
+        .assert(increment)
+        .assert(the!("counter/count").of(counter.clone()).is(1u64))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let snapshot = branch.snapshot().expect("snapshot");
+
+    let command: Entity = "cmd:1".parse()?;
+    snapshot
+        .transaction()
+        .dispatch(
+            the!("cmd.increment/counter")
+                .of(command.clone())
+                .is(counter.clone()),
+        )
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    assert_eq!(
+        values(&snapshot, &operator, "counter/count", Some(&counter)).await?,
+        vec![Value::UnsignedInt(2)],
+        "the rule's durable head folded into the snapshot's commit"
+    );
+    assert!(
+        values(
+            &snapshot,
+            &operator,
+            "cmd.increment/counter",
+            Some(&command)
+        )
+        .await?
+        .is_empty(),
+        "the dispatched command never reaches the tree"
+    );
+    assert_eq!(
+        values(&branch, &operator, "counter/count", Some(&counter)).await?,
+        vec![Value::UnsignedInt(1)],
+        "the branch is untouched"
+    );
+
+    // The next transaction on the snapshot induces against the head it
+    // just minted: the counter goes on from 2, not from the branch's 1.
+    snapshot
+        .transaction()
+        .dispatch(
+            the!("cmd.increment/counter")
+                .of(command)
+                .is(counter.clone()),
+        )
+        .commit()
+        .perform(&operator)
+        .await?;
+    assert_eq!(
+        values(&snapshot, &operator, "counter/count", Some(&counter)).await?,
+        vec![Value::UnsignedInt(3)]
+    );
+    Ok(())
+}
+
+/// A deductive rule staged in the transaction resolves in its query,
+/// uncommitted, as on a branch.
+#[dialog_common::test]
+async fn it_resolves_rules_pending_in_the_transaction() -> Result<()> {
+    use dialog_query::rule::DeductiveRuleDescriptor;
+    use dialog_query::{ConceptQuery, Parameters};
+
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let rule = {
+        let json = serde_json::json!({
+            "deduce": { "with": { "name": { "the": "org/employee-name", "as": "Text" } } },
+            "when": [{
+                "assert": { "with": { "name": { "the": "org/person-name", "as": "Text" } } },
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "name": { "?": { "name": "name" } }
+                }
+            }]
+        });
+        let descriptor: DeductiveRuleDescriptor =
+            serde_json::from_value(json).expect("descriptor parses");
+        descriptor.compile().expect("rule compiles")
+    };
+    let employee = rule.conclusion().clone();
+    let alice: Entity = "id:alice".parse()?;
+    let transaction = snapshot.transaction().assert(&rule).assert(
+        the!("org/person-name")
+            .of(alice.clone())
+            .is("Alice".to_string()),
+    );
+
+    let mut terms = Parameters::new();
+    terms.insert("this".into(), Term::var("this"));
+    terms.insert("name".into(), Term::var("name"));
+    let rows = transaction
+        .query()
+        .select(ConceptQuery {
+            predicate: employee,
+            terms,
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(*rows[0].entity(), alice);
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_integrates_external_changes() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    let mut external = Changes::new();
+    external.assert(name("user:bob", "Bob"));
+    external.retract(name("user:alice", "Alice"));
+
+    snapshot
+        .transaction()
+        .integrate(external)
+        .commit()
+        .perform(&operator)
+        .await?;
+    assert_eq!(names(&snapshot, &operator).await?, vec!["Bob".to_string()]);
+    Ok(())
+}
+
+/// The session overlay stays with the snapshot across commits and is
+/// never written.
+#[dialog_common::test]
+async fn it_keeps_the_overlay_across_commits() -> Result<()> {
+    let (operator, _, _, _, snapshot) = staged().await?;
+    snapshot.overlay().assert(name("user:ghost", "Ghost"));
+    snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    assert_eq!(
+        queried_names(snapshot.query(), &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string(), "Ghost".to_string()]
+    );
+    assert_eq!(
+        names(&snapshot, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()],
+        "the overlay fact was never committed"
+    );
+    Ok(())
+}
+
+/// The derived ancestry closure of a snapshot-minted revision runs
+/// through the base into the branch's history.
+#[dialog_common::test]
+async fn it_derives_ancestry_through_the_base() -> Result<()> {
+    let (operator, _, _, branch, snapshot) = staged().await?;
+    let base = snapshot.revision();
+    assert_eq!(Some(base.clone()), branch.revision());
+
+    let first = snapshot
+        .transaction()
+        .assert(name("user:bob", "Bob"))
+        .commit()
+        .perform(&operator)
+        .await?;
+    let second = snapshot
+        .transaction()
+        .assert(name("user:carol", "Carol"))
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    let mut ancestors: Vec<Entity> = snapshot
+        .query()
+        .select(Query::<schema::RevisionAncestor> {
+            this: second.entity().into(),
+            ancestor: Term::var("ancestor"),
+        })
+        .perform(&operator)
+        .try_vec()
+        .await?
+        .into_iter()
+        .map(|row| row.ancestor.0)
+        .collect();
+    ancestors.sort();
+    let mut expected = vec![base.entity(), first.entity()];
+    expected.sort();
+    assert_eq!(ancestors, expected);
+    Ok(())
+}
+
+/// A commit through a snapshot minted cold from the repository (never a
+/// branch handle) works the same: the base's blocks are read from
+/// storage, the new ones written to it.
+#[dialog_common::test]
+async fn it_commits_through_a_cold_handle() -> Result<()> {
+    let (operator, _, repo, _, snapshot) = staged().await?;
+    let cold = repo.snapshot(snapshot.revision());
+    let minted = cold
+        .commit(stream::iter(vec![Instruction::Assert(fact(
+            "user:bob", "Bob",
+        ))]))
+        .canonicalize()
+        .perform(&operator)
+        .await?;
+    assert_eq!(cold.revision(), minted);
+    assert_eq!(
+        names(&cold, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()]
+    );
+    let again = repo.snapshot(minted);
+    assert_eq!(
+        names(&again, &operator).await?,
+        vec!["Alice".to_string(), "Bob".to_string()]
+    );
+    Ok(())
+}

--- a/rust/dialog-repository/src/repository/source.rs
+++ b/rust/dialog-repository/src/repository/source.rs
@@ -1,0 +1,352 @@
+//! What a read or a commit needs from the line it works on, whether
+//! that line is a [`Branch`] or a [`Snapshot`].
+//!
+//! The two differ in one thing only: where the head lives. A branch keeps
+//! it in a memory cell that advances under CAS and that every handle to
+//! the branch shares; a snapshot keeps its own, which moves only through
+//! commits on that very handle. Everything a query or a commit does
+//! downstream of "which root, which store, which caches" is identical,
+//! so it is written once against [`SourceRef`] and both kinds plug in.
+
+use dialog_artifacts::history::{
+    CausalityCache, ContextCache, RevisionRecord, TreeHistory, Version, log,
+};
+use dialog_artifacts::tree::{SpillCache, spill_cache};
+use dialog_artifacts::{Changes, DialogArtifactsError, Entity, SpineSlot, Statement as _};
+use dialog_capability::{Capability, Fork, Provider, Subject};
+use dialog_common::{Blake3Hash as NodeHash, ConditionalSync};
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+use dialog_effects::archive::{Archive, Get as ArchiveGet, Put as ArchivePut};
+use dialog_effects::authority::{Operator, OperatorExt as _};
+use dialog_effects::memory::Resolve;
+use dialog_query::concept::query::PlanCache;
+use dialog_search_tree::{Buffer, Cache};
+use dialog_storage::Blake3Hash;
+use std::sync::Arc;
+
+use crate::rules::{RuleCache, SharedRuleCache};
+use crate::schema::Replica;
+use crate::{
+    Branch, EMPTY_TREE_HASH, NetworkedIndex, Overlay, RemoteFallback, RemoteSite,
+    RepositoryArchiveExt as _, RepositoryMemoryExt as _, Revision, Snapshot, Upstream,
+};
+
+/// An owned line to read from: a branch or a snapshot, cheaply cloned
+/// (both share their caches by handle). Query environments hold these
+/// so the only lifetime they carry is the capability environment's.
+#[derive(Debug, Clone)]
+pub(crate) enum Source {
+    /// A named line whose head lives in a memory cell.
+    Branch(Branch),
+    /// A detached line whose head is held by value.
+    Snapshot(Snapshot),
+}
+
+impl Source {
+    /// Borrow this line.
+    pub(crate) fn as_ref(&self) -> SourceRef<'_> {
+        match self {
+            Source::Branch(branch) => SourceRef::Branch(branch),
+            Source::Snapshot(snapshot) => SourceRef::Snapshot(snapshot),
+        }
+    }
+}
+
+impl From<Branch> for Source {
+    fn from(branch: Branch) -> Self {
+        Source::Branch(branch)
+    }
+}
+
+impl From<Snapshot> for Source {
+    fn from(snapshot: Snapshot) -> Self {
+        Source::Snapshot(snapshot)
+    }
+}
+
+/// A borrowed line to read from. `Copy`, so builders that hold one stay
+/// as cheap to pass around as the `&Branch` they used to hold.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SourceRef<'a> {
+    /// A named line whose head lives in a memory cell.
+    Branch(&'a Branch),
+    /// A detached line whose head is held by value.
+    Snapshot(&'a Snapshot),
+}
+
+impl<'a> From<&'a Branch> for SourceRef<'a> {
+    fn from(branch: &'a Branch) -> Self {
+        SourceRef::Branch(branch)
+    }
+}
+
+impl<'a> From<&'a Snapshot> for SourceRef<'a> {
+    fn from(snapshot: &'a Snapshot) -> Self {
+        SourceRef::Snapshot(snapshot)
+    }
+}
+
+impl<'a> From<&'a Source> for SourceRef<'a> {
+    fn from(source: &'a Source) -> Self {
+        source.as_ref()
+    }
+}
+
+impl<'a> SourceRef<'a> {
+    /// An owned handle to the same line.
+    pub(crate) fn to_source(self) -> Source {
+        match self {
+            SourceRef::Branch(branch) => Source::Branch(branch.clone()),
+            SourceRef::Snapshot(snapshot) => Source::Snapshot(snapshot.clone()),
+        }
+    }
+
+    /// The repository this line lives in.
+    pub(crate) fn subject(self) -> Subject {
+        match self {
+            SourceRef::Branch(branch) => branch.subject(),
+            SourceRef::Snapshot(snapshot) => snapshot.subject(),
+        }
+    }
+
+    /// The archive capability for this line's repository.
+    pub(crate) fn archive(self) -> Capability<Archive> {
+        self.subject().archive()
+    }
+
+    /// The revision this line currently names, or `None` for a branch
+    /// with no commits yet. A snapshot always has one.
+    pub(crate) fn revision(self) -> Option<Revision> {
+        match self {
+            SourceRef::Branch(branch) => branch.revision(),
+            SourceRef::Snapshot(snapshot) => Some(snapshot.revision()),
+        }
+    }
+
+    /// The tree root to read: the revision's, or the empty tree's.
+    pub(crate) fn root(self) -> Blake3Hash {
+        match self {
+            SourceRef::Branch(branch) => branch
+                .revision()
+                .map(|revision| *revision.tree.hash())
+                .unwrap_or(EMPTY_TREE_HASH),
+            SourceRef::Snapshot(snapshot) => *snapshot.revision().tree.hash(),
+        }
+    }
+
+    /// The default upstream: a branch's tracked one. A snapshot tracks
+    /// nothing, so blob reads through it are local (see
+    /// [`SnapshotExport::download`](crate::SnapshotExport::download)
+    /// for hydrating one ahead of time).
+    pub(crate) fn upstream(self) -> Option<Upstream> {
+        match self {
+            SourceRef::Branch(branch) => branch.upstream(),
+            SourceRef::Snapshot(_) => None,
+        }
+    }
+
+    /// The remote block reads fall back to on a local miss: the first
+    /// remote among a branch's tracked upstreams (a branch whose default
+    /// upstream is local but which tracks a remote must still hydrate
+    /// blocks it holds by reference); none for a snapshot.
+    ///
+    /// A remote that fails to load is carried as
+    /// [`RemoteFallback::Unavailable`] rather than dropped: reads the
+    /// local archive serves still succeed, and a local miss surfaces the
+    /// load failure as its cause instead of a bare not-found.
+    pub(crate) async fn fallback<Env>(self, env: &Env) -> RemoteFallback
+    where
+        Env: Provider<Resolve> + ConditionalSync + 'static,
+    {
+        let SourceRef::Branch(branch) = self else {
+            return RemoteFallback::None;
+        };
+        let upstreams = branch.upstreams();
+        match upstreams.remote_name() {
+            Some(name) => {
+                let loaded = branch
+                    .subject()
+                    .remote(name.to_string())
+                    .load()
+                    .perform(env)
+                    .await;
+                RemoteFallback::from_load(name, loaded)
+            }
+            None => RemoteFallback::None,
+        }
+    }
+
+    /// The shared node cache tree reads go through.
+    pub(crate) fn node_cache(self) -> Cache<NodeHash, Buffer> {
+        match self {
+            SourceRef::Branch(branch) => branch.node_cache(),
+            SourceRef::Snapshot(snapshot) => snapshot.caches().nodes.clone(),
+        }
+    }
+
+    /// The shared spilled-value block cache.
+    pub(crate) fn spill_cache(self) -> SpillCache {
+        match self {
+            SourceRef::Branch(branch) => branch.spill_cache(),
+            SourceRef::Snapshot(snapshot) => snapshot.caches().spills.clone(),
+        }
+    }
+
+    /// The shared deductive-rule cache.
+    pub(crate) fn rule_cache(self) -> SharedRuleCache {
+        match self {
+            SourceRef::Branch(branch) => branch.rule_cache(),
+            SourceRef::Snapshot(snapshot) => snapshot.caches().rules.clone(),
+        }
+    }
+
+    /// The shared query-plan cache.
+    pub(crate) fn plan_cache(self) -> PlanCache {
+        match self {
+            SourceRef::Branch(branch) => branch.plan_cache(),
+            SourceRef::Snapshot(snapshot) => snapshot.caches().plans.clone(),
+        }
+    }
+
+    /// The shared verified-record memo.
+    pub(crate) fn records(self) -> Cache<Version, RevisionRecord> {
+        match self {
+            SourceRef::Branch(branch) => branch.records(),
+            SourceRef::Snapshot(snapshot) => snapshot.caches().records.clone(),
+        }
+    }
+
+    /// The shared causal-context memo.
+    pub(crate) fn contexts(self) -> ContextCache {
+        match self {
+            SourceRef::Branch(branch) => branch.contexts(),
+            SourceRef::Snapshot(snapshot) => snapshot.caches().contexts.clone(),
+        }
+    }
+
+    /// The live-spine slot commits on this line reuse.
+    pub(crate) fn spine(self) -> &'a SpineSlot {
+        match self {
+            SourceRef::Branch(branch) => branch.spine(),
+            SourceRef::Snapshot(snapshot) => &snapshot.caches().spine,
+        }
+    }
+
+    /// The transient session overlay every read of this line folds in.
+    pub(crate) fn overlay(self) -> &'a Overlay {
+        match self {
+            SourceRef::Branch(branch) => branch.overlay(),
+            SourceRef::Snapshot(snapshot) => snapshot.overlay(),
+        }
+    }
+
+    /// Fold this line's schema metadata into `changes`, returning the
+    /// branch entity when the line is a branch (a
+    /// [`SessionBranch`](crate::schema::SessionBranch) row is minted
+    /// per branch in scope; a snapshot is not a branch and gets none).
+    ///
+    /// A branch contributes its full
+    /// [`BranchMetadata`](crate::BranchMetadata); a snapshot contributes
+    /// the [`Replica`] it is a view of. Its revision is already
+    /// queryable through the derived
+    /// [`Revision`](crate::schema::Revision) concepts, concluded from
+    /// the signed record in the tree.
+    pub(crate) fn metadata(
+        self,
+        operator: &Capability<Operator>,
+        changes: &mut Changes,
+    ) -> Option<Entity> {
+        match self {
+            SourceRef::Branch(branch) => {
+                let metadata = branch.metadata(operator);
+                let entity = metadata.branch.this.clone();
+                metadata.assert(changes);
+                Some(entity)
+            }
+            SourceRef::Snapshot(snapshot) => {
+                Replica::new(operator.profile().clone(), snapshot.of().clone()).assert(changes);
+                None
+            }
+        }
+    }
+
+    /// The recorded claim lineage at this line's revision. History
+    /// records live in the same tree as the data, so this reads the
+    /// history region of the revision's tree. Reads that miss locally
+    /// are not fetched from a remote — traversal over unreplicated
+    /// history surfaces as `IncompleteHistory`.
+    pub(crate) fn history<'e, Env>(self, env: &'e Env) -> TreeHistory<NetworkedIndex<'e, Env>>
+    where
+        Env: Provider<ArchiveGet>
+            + Provider<ArchivePut>
+            + Provider<Fork<RemoteSite, ArchiveGet>>
+            + ConditionalSync
+            + 'static,
+    {
+        let store = NetworkedIndex::new(env, self.archive().index(), None);
+        TreeHistory::from_root_with_cache(&self.root(), store, self.node_cache())
+            .with_record_cache(self.records())
+    }
+
+    /// This line's committed history, newest first — at most `limit`
+    /// entries of `(version, record)`. See [`Branch::log`].
+    pub(crate) async fn log<Env>(
+        self,
+        env: &Env,
+        limit: usize,
+    ) -> Result<Vec<(Version, RevisionRecord)>, DialogArtifactsError>
+    where
+        Env: Provider<ArchiveGet>
+            + Provider<ArchivePut>
+            + Provider<Fork<RemoteSite, ArchiveGet>>
+            + ConditionalSync
+            + 'static,
+    {
+        let Some(head) = self.revision() else {
+            return Ok(Vec::new());
+        };
+        log(&head.version(), &self.history(env), limit).await
+    }
+}
+
+/// The caches a line carries between its reads and commits. Every one
+/// is content- or version-addressed, so a set may be shared between a
+/// branch and the snapshots minted from it, and between a snapshot and
+/// the snapshots its transactions produce, without ever serving a
+/// stale entry.
+#[derive(Debug, Clone)]
+pub(crate) struct Caches {
+    /// Tree nodes by hash, so blocks one read fetched stay warm for the next.
+    pub(crate) nodes: Cache<NodeHash, Buffer>,
+    /// Spilled value blocks by content reference.
+    pub(crate) spills: SpillCache,
+    /// Deductive-rule discovery (by head) and hydrated bodies (by entity).
+    pub(crate) rules: SharedRuleCache,
+    /// Query plans by content-addressed `(rule, adornment)`.
+    pub(crate) plans: PlanCache,
+    /// Causal verdicts between fixed claims or revisions.
+    pub(crate) causality: CausalityCache,
+    /// Causal contexts by head version.
+    pub(crate) contexts: ContextCache,
+    /// Verified revision records by version.
+    pub(crate) records: Cache<Version, RevisionRecord>,
+    /// The live buffered spine between commits, keyed by the root it was
+    /// persisted as.
+    pub(crate) spine: SpineSlot,
+}
+
+impl Caches {
+    /// A cold set.
+    pub(crate) fn new() -> Self {
+        Self {
+            nodes: Cache::new(),
+            spills: spill_cache(),
+            rules: Arc::new(RuleCache::new()),
+            plans: PlanCache::default(),
+            causality: CausalityCache::new(),
+            contexts: ContextCache::new(),
+            records: Cache::new(),
+            spine: SpineSlot::new(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`Snapshot` becomes a full read and transact peer of `Branch`, with the same API: `claims()`, `select()`, `query()`/`with()` (joinable with branches and other snapshots), `overlay()`, `blobs()`, `history()`, `log()`, and `transaction()` / `commit()` returning the branch's own `Transaction` / `Commit` types. `perform` returns the minted `Revision` and advances the snapshot in place; a `Clone` copies the head, so it is how you keep the view you have. Nothing a snapshot does moves a branch head.

## How

- A crate-private `Source` / `SourceRef<'a>` enum (`repository/source.rs`) over `Branch | Snapshot` now backs `Select`, `QueryLayer` / `QueryEnv`, `TransactionQuery`, commit-time induction, `BlobArchive`, `history` / `log`. Public signatures are unchanged except `QueryLayer::branches()` now returns `Vec<&Branch>` (and gains `snapshots()`), and `QueryLayer::join` / `From` accept a `&Snapshot`.
- The commit procedure is extracted into a shared `Mint` core in `commit.rs` (`Outcome::Unchanged | Minted`). `Commit::perform` dispatches to the branch path (checkpoint + CAS publish, as before) or the snapshot path (mint, then an in-memory CAS advance of the snapshot's head, refused with `PublishError::VersionMismatch` if a commit through the same handle got there first).
- The record and context memos are now seeded only after the head has actually advanced. Previously `commit` seeded the verified-record memo before the publish CAS, so a lost CAS left a record in the memo under a version that gets re-minted with a different parent.
- `Branch::snapshot()` shares the branch's caches with the snapshot (all content- or version-addressed); `Repository::snapshot(revision)` starts cold. `Snapshot` drops its `<'a, C>` generics.

## Identity

A revision's `Version` is `(origin, edition)` and an origin must be one sequential actor. A snapshot and its branch (or two clones) can advance from one base under the same operator, so snapshot commits mint on a random lineage entity allocated on the snapshot's first commit and kept for the ones after: a chain of transactions on one snapshot is one origin with increasing editions, and a clone starts a line of its own. The minted record's parent is the base revision, so ancestry, causality, and `log` walk through into the branch's history.

## Boundaries

- Snapshot metadata contributes `Replica`; there is no `SessionBranch` row for a snapshot.
- Snapshot reads are local: no upstream fallback (materialize with `SnapshotExport::download` first).
- Blob reads bind to a snapshot; blob writes and retractions through `&Snapshot` fail with the new `CommitError::Detached`.
- Not in scope: subscriptions on snapshots, blob writes via a snapshot transaction, merging a snapshot's line back into a branch.

## Tests

`snapshot/read_tests.rs` and `snapshot/transaction_tests.rs`: read parity with the branch, pinning while the branch advances, cold handles, absent root, join, session metadata, overlay, committed and pending rules, derived revision concepts, log/history, blob read + refused write; in-place advance without moving the branch, clone independence both ways, distinct origins (snapshot vs branch, clone vs original), one origin across chained transactions, no-op / `allow_empty`, persistence via a cold handle + complete export, transaction-query view, stale-head refusal, signatures and record attribution, reserved namespace, induction on commit (including the second round inducing against the snapshot's own head), `integrate`, overlay across commits, ancestry through the base.
