### PR TITLE
feat: keyed collection fields, queried and induced

### DIFF
--- a/notes/notation.md
+++ b/notes/notation.md
@@ -398,6 +398,17 @@ Internally the concept's rule scans the domain with the attribute slot refined
 by `domain` and `name.case`, and projects the key with `dialog/attribute-parts`
 (`of` → `domain`, `name`).
 
+**Deriving.** A rule head may be a collection field. A deductive head yields
+`(key, value)` rows like the concept itself; an inductive head writes the
+entry under `<domain>/<key>`, so the body must bind the key operand, and a
+key of the wrong shape for the collection (an uppercase name for a
+dictionary, a lowercase one for a sequence) fails the commit rather than
+landing in the other half of the domain. The trigger index files a
+collection premise under the half's cover key (`on:<domain>/_position` or
+`on:<domain>/_symbol`), which every write in that half probes alongside its
+own attribute's key, so a rule reading a collection wakes for any member
+write.
+
 ### Deductive Rules
 
 An advanced form of composition that goes beyond stitching attributes together. Rules can impose additional constraints, compute derived values using formulas, and follow transitive paths across relations. A rule's body is a set of premises; its conclusion is a concept instance. Rules are resolved at query time by the semantic layer.

--- a/notes/notation.md
+++ b/notes/notation.md
@@ -46,7 +46,15 @@ org.example.hr
 
 ### Name
 
-The name component of an attribute uses lowercase kebab-case.
+The name component of an attribute takes one of two forms, distinguished by
+the case of its first byte. The two are disjoint and exhaustive, which is what
+lets a single scan of one domain serve both and lets a query narrow to either
+half as a contiguous key range.
+
+#### Symbol names
+
+A named predicate, in lowercase kebab-case. This is the ordinary case: the
+named fields of an entity.
 
 **Rules:**
 
@@ -66,6 +74,34 @@ recipe-step
 ```
 ^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$
 ```
+
+#### Position names
+
+A fractional position, beginning with an uppercase letter. A position name
+marks its fact as a member of an ordered relation rather than a named field,
+and positions sort lexicographically — so members of one collection come back
+from a single range scan already in order, with no per-element join and no
+order state held outside the facts themselves.
+
+```
+N
+N5
+Zk3
+```
+
+Because the two forms differ in the case of the first byte, one domain can
+carry both at once — an entity's named fields and its ordered members
+together:
+
+```
+todo.list/title     a symbol name: the list's title
+todo.list/owner     a symbol name
+todo.list/N         a position name: a member
+todo.list/N5        a position name: a later member
+```
+
+A query selects one half with `name.case` (see [Variables](#variables)), or
+omits the constraint to take both and split them downstream.
 
 ### References
 
@@ -122,6 +158,15 @@ as: Text
         "description": "Cardinality of the attribute. Defaults to 'one' when omitted.",
         "default": "one"
       },
+      "optional": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether the field is set-widened: a missing claim yields a row with the field bound to absent rather than dropping the row."
+      },
+      "conforms": {
+        "type": "string",
+        "description": "A concept the field's target entity must satisfy, as its 'concept:{hash}' URI. Entity-valued attributes only; mutually exclusive with 'optional'."
+      },
       "as": {
         "description": "Value type of the attribute. If omitted, any type is allowed.",
         "type": "string",
@@ -147,33 +192,19 @@ The `as` field declares what kind of value the attribute admits. Scalar types fr
 | `UnsignedInteger` | Unsigned integer            |
 | `SignedInteger`   | Signed integer              |
 | `Float`           | IEEE 754 floating point     |
+| `Record`          | Structured data, opaque to the query layer |
 | `Symbol`          | Symbolic identifier         |
+
+A concept can additionally require an entity-valued field's target to satisfy
+a concept — see [Concept-typed fields](#concept-typed-fields). That constraint
+lives on the field inside a concept's `with`, not on the attribute itself: an
+attribute is reusable across concepts, and conformance is a demand one concept
+makes of its own field.
 
 #### Future Attribute Extensions
 
-An attribute will also be able to reference a concept as its value type, or constrain values to a fixed set of symbols (neither is yet supported):
-
-```json
-{
-  "description": "Ingredient used in the recipe",
-  "the": "diy.cook/ingredient",
-  "as": {
-    "description": "An ingredient",
-    "with": {
-      "name": {
-        "description": "Ingredient name",
-        "the": "diy.cook/ingredient-name",
-        "as": "Text"
-      },
-      "quantity": {
-        "description": "Amount needed",
-        "the": "diy.cook/quantity",
-        "as": "UnsignedInteger"
-      }
-    }
-  }
-}
-```
+**Not yet supported.** An attribute will be able to constrain values to a
+fixed set of symbols:
 
 ```json
 {
@@ -255,9 +286,6 @@ with:
         },
         "minProperties": 1
       },
-      "maybe": {
-        "description": "[Future extension, not yet supported] Optional fields. The entity may or may not have these attributes."
-      }
     },
     "required": ["with"]
   }
@@ -269,9 +297,12 @@ Fields under `with` are required; an entity must have claims satisfying all thos
 
 #### Optional attributes
 
-> ⚠️ Optional attributes are not currently supported. For now `maybe` field can be used as metadata which is ignored by the query engine.
+An attribute marked `"optional": true` may or may not have a claim. The entity
+still matches the concept as long as every *required* attribute is satisfied,
+and the optional value is included in the conclusion when present.
 
-Fields under `maybe` define attributes that the entity may or may not have related claims for. The entity will still match the concept as long as all required attributes (defined in `with`) are satisfied. Optional attribute values will be included in the conclusion when present.
+Optionality is carried **per attribute, inside `with`** — there is no separate
+block. A concept must still declare at least one required attribute.
 
 ```json
 {
@@ -281,24 +312,36 @@ Fields under `maybe` define attributes that the entity may or may not have relat
       "description": "What to do in this step",
       "the": "diy.cook.recipe-step/instruction",
       "as": "Text"
-    }
-  },
-  "maybe": {
+    },
     "after": {
       "description": "Step that must be completed before this one",
       "the": "diy.cook.recipe-step/after",
-      "as": "Entity"
+      "as": "Entity",
+      "optional": true
     },
     "duration": {
       "description": "Time in minutes this step takes",
       "the": "diy.cook.recipe-step/duration",
-      "as": "UnsignedInteger"
+      "as": "UnsignedInteger",
+      "optional": true
     }
   }
 }
 ```
 
-An entity matches this concept if it has a claim for `diy.cook.recipe-step/instruction`. Claims for `diy.cook.recipe-step/after` and `diy.cook.recipe-step/duration` are included in the conclusion when present but are not required for the entity to match.
+An entity matches this concept if it has a claim for
+`diy.cook.recipe-step/instruction`. Claims for `diy.cook.recipe-step/after` and
+`diy.cook.recipe-step/duration` are included when present but are not required
+for the entity to match.
+
+An optional attribute is **set-widened** rather than filtered: a missing claim
+yields a row with the field bound to *absent*, instead of dropping the row. So
+the field's type admits absence — the `option` member of a variable's type set
+(see [Constraining a variable](#constraining-a-variable)) — and a consuming
+rule sees that an absent binding can arrive through this boundary.
+
+Marking an attribute optional changes the concept's identity: a required
+attribute hashes as an empty map, an optional one as `{"optional": true}`.
 
 ### Deductive Rules
 
@@ -402,6 +445,91 @@ In the formal notation, a named variable is `{ "?": { "name": "x" } }` and a bla
 ```
 
 In the abbreviated notation, `?person` is shorthand for `{ "?": { "name": "person" } }` and `_` is shorthand for `{ "?": {} }`.
+
+##### Constraining a variable
+
+A variable may carry a `where` record narrowing what it admits. Every slot is
+optional and all present slots are conjoined; a variable with no `where` is
+unconstrained.
+
+```json
+{ "?": { "name": "count", "where": { "type": { "uint": {} }, ">=": 1 } } }
+```
+
+Two container conventions run through the format, and they are not
+interchangeable:
+
+- An **object is a union** where its entries are alternatives of one kind. The
+  `type` set is the case: a value matching any present key is admitted, and
+  intersecting two sets keeps the keys they share.
+- An **array is an intersection** where its entries are independent
+  obligations. Conformance (`as`) is the case: every listed concept must be
+  satisfied.
+- A **record of fixed named slots** is neither. `where` itself is one: each
+  slot appears at most once, and two constraints on one slot merge rather than
+  accumulate.
+
+**`type`** — the set of admissible types. Ten members, each mapping to a value
+type except `option`, which is the row-level absence atom: present alongside
+others it marks the variable optional.
+
+```json
+{ "type": { "text": {} } }
+{ "type": { "text": {}, "symbol": {} } }
+{ "type": { "text": {}, "option": {} } }
+```
+
+| key | admits |
+| --- | --- |
+| `bytes` | a byte buffer |
+| `entity` | an entity reference |
+| `boolean` | a boolean |
+| `text` | a UTF-8 string |
+| `uint` | an unsigned integer |
+| `int` | a signed integer |
+| `float` | a floating-point number |
+| `record` | structured data, opaque to the query layer |
+| `symbol` | a symbol — the type attributes carry |
+| `option` | absence (an optional value) |
+
+Each value is a per-variant parameter record, empty today; it is where a
+future parameter such as an integer width would go.
+
+**`domain`** and **`name`** — constrain the two halves of an attribute
+structurally. Symbol-typed values only.
+
+```json
+{ "domain": { "is": "todo.list" }, "name": { "case": "position" } }
+```
+
+The domain is written **without** a trailing slash; the separator is an
+encoding detail supplied on the way in. `name.case` is `position` or `symbol`
+(see [Name](#name)); omitting it admits either half.
+
+**`starts-with`** — a lexical prefix. Applies to types with a lexical form
+(text, symbol, entity). For attributes prefer `domain`/`name`, which say the
+same thing structurally and cannot be written in a way that silently degrades
+the scan.
+
+**`as`** — concepts the value's entity must conform to. An array, and so an
+intersection: all listed concepts must be satisfied. Entity-typed values only.
+Enforced structurally — the target concept's premises are conjoined into the
+query — rather than as a per-row test.
+
+```json
+{ "as": [{ "concept:bafy...": {} }] }
+```
+
+**`>=`, `>`, `<=`, `<`** — order bounds. Comparable types only.
+
+```json
+{ "type": { "uint": {} }, ">=": 1, "<": 100 }
+```
+
+Every slot other than `type` narrows the admissible type set as a side effect:
+a prefix implies a textual type, conformance implies `entity`, an order bound
+implies a comparable type. A constraint whose narrowing would empty the set is
+rejected rather than silently yielding a variable that matches nothing.
 
 The variable `this` (`?this` in abbreviated notation) is implicit in every rule and refers to the entity of the asserted concept. It must not be declared in the concept's `with` (because it is not an attribute); it must be used in the `when` premises to bind the entity of the conclusion.
 
@@ -603,6 +731,80 @@ Because disjunction is expressed by separate rules, a new rule deriving an exist
 ```
 
 If the `unless` pattern can be satisfied, the result is excluded. This reflects the closed-world assumption: if something cannot be derived from what is known, it is treated as absent.
+
+#### Aggregation
+
+A deductive rule may carry a `reduce` clause beside `when` and `unless`. Each
+entry names a head field and the fold that defines it; the head stays an
+ordinary concept, so a reducing rule's conclusion composes like any other.
+
+```json
+{
+  "deduce": {
+    "with": {
+      "dept":  { "the": "org.employee/dept",  "as": "Entity" },
+      "total": { "the": "org.employee/total", "as": "UnsignedInteger" }
+    }
+  },
+  "when": [
+    {
+      "assert": {
+        "with": {
+          "dept":   { "the": "org.employee/dept",   "as": "Entity" },
+          "salary": { "the": "org.employee/salary", "as": "UnsignedInteger" }
+        }
+      },
+      "where": {
+        "dept":   { "?": { "name": "dept" } },
+        "salary": { "?": { "name": "salary" } }
+      }
+    }
+  ],
+  "reduce": {
+    "total": { "apply": "sum", "of": { "?": { "name": "salary" } } }
+  }
+}
+```
+
+Evaluation is a pipeline: evaluate `when`/`unless` as usual, group the
+resulting rows by the head fields that are **not** reduced, fold each group,
+and emit one row per group.
+
+The grouping set is **derived**, never declared — it is exactly the head fields
+absent from `reduce`. That is what makes the classic aggregation hazard
+unwriteable: a field cannot be both grouped and reduced, because a key is
+either present in `reduce` or it isn't. In this example `dept` groups because
+`reduce` does not mention it, and `total` is folded because it does.
+
+**Aggregators**
+
+| `apply` | folds to |
+| --- | --- |
+| `count` | number of present bindings |
+| `count-distinct` | number of distinct present values |
+| `sum` | sum of the group's values; identity `0` |
+| `min` | least present value |
+| `max` | greatest present value |
+| `avg` | mean of the present numeric values |
+
+**Absent inputs are skipped**, SQL-NULL style: a fold consumes only present
+bindings, and `count` counts present bindings. Coalesce first if you want
+other behaviour.
+
+Whether a reduced field may be required depends on its fold having an
+identity. `count` and `sum` always produce a value, so their head field can be
+required. `min`, `max`, and `avg` have no identity, so over an input that
+admits absence they may produce nothing — and their head field must then be
+declared optional.
+
+`min` and `max` require comparable values; `sum` and `avg` require numeric
+ones. Mixing the integer band with floats inside one group is an error rather
+than a silent promotion.
+
+**Stratification.** A fold reads a complete relation, so every concept premise
+of a reducing rule contributes an aggregating edge to the dependency graph,
+treated like negation: aggregation through recursion is rejected, exactly as
+negation through recursion is.
 
 #### Constraints
 
@@ -1350,21 +1552,39 @@ as: UnsignedInteger
 
 The name `quantity` comes from the label, but the domain is overridden to `io.gozala.person`.
 
-#### Future attribute extensions
+#### Concept-typed fields
 
-**Not yet supported.** Concept references use dot-prefix notation, and symbol enumerations use array syntax:
+An entity-valued field can require its target to satisfy a concept, written
+with dot-prefix notation:
 
 ```yaml
 diy.cook:
   ingredient:
     description: An ingredient in a recipe
     as: .Ingredient
+```
+
+`.Ingredient` resolves to `diy.cook/Ingredient` within the current domain. The
+constraint is enforced structurally: the target concept's premises are
+conjoined onto the field, so only entities that actually satisfy it match.
+
+Only entity-valued attributes can conform, and a conforming field cannot also
+be optional — the left join over "edge exists AND target conforms" is absence
+over a derived predicate, which stratification has to own first.
+
+#### Future attribute extensions
+
+**Not yet supported.** Symbol enumerations use array syntax:
+
+```yaml
+diy.cook:
   unit:
     description: The unit of measurement
     as: [:tsp, :mls]
 ```
 
-`.Ingredient` resolves to `diy.cook/Ingredient` within the current domain. `[:tsp, :mls]` means the value must be one of the symbols `diy.cook/tsp` or `diy.cook/mls`.
+`[:tsp, :mls]` means the value must be one of the symbols `diy.cook/tsp` or
+`diy.cook/mls`.
 
 ### Concept
 
@@ -1477,9 +1697,10 @@ Expands to:
 
 `name` defined inline inside `io.gozala/Person` lives at `io.gozala.person/name` and can be referenced from anywhere by that path.
 
-#### Future concept extensions
+#### Optional fields
 
-**Not yet supported.** Optional fields use the `maybe` key:
+An optional field carries `optional: true` alongside its other keys, inside
+`with`:
 
 ```yaml
 diy.cook:
@@ -1487,10 +1708,10 @@ diy.cook:
     description: A cooking step
     with:
       instruction: .
-    maybe:
       after:
         description: Step to perform this after
         as: .RecipeStep
+        optional: true
 ```
 
 ### Deductive Rules

--- a/notes/notation.md
+++ b/notes/notation.md
@@ -343,6 +343,61 @@ rule sees that an absent binding can arrive through this boundary.
 Marking an attribute optional changes the concept's identity: a required
 attribute hashes as an empty map, an optional one as `{"optional": true}`.
 
+#### Keyed collections
+
+A field may select *every entry of a domain* rather than one attribute. Its
+`the` names a domain and which half of it (see [Name](#name)): the
+symbol-named half is a **dictionary**, the position-named half a
+**sequence**. `as` is the type of each entry's value.
+
+```json
+{
+  "with": {
+    "title": { "the": "todo.list/title", "as": "Text" },
+    "member": {
+      "description": "The list's members, in order",
+      "the": { "domain": "todo.list", "keyed": "sequence" },
+      "cardinality": "many",
+      "as": "Text"
+    }
+  }
+}
+```
+
+The facts behind such a field are ordinary claims whose attribute's name half
+is the entry's key: `todo.list/N` and `todo.list/N5` are two members. A
+collection field is therefore *many facts* by construction; `cardinality` is
+per entry (whether one key may hold two values), not about the collection.
+
+A collection field cannot be optional: it is zero-or-more already, and an
+entity with no entries simply yields no rows.
+
+Because a dictionary takes every symbol-named fact in its domain, a dictionary
+field's domain must be its own — a scalar attribute declared in the same
+domain would read as one more entry. A sequence shares a domain with scalars
+safely, since positions and symbols are disjoint by first byte.
+
+**Querying.** Each matched entry is one row binding the field to the entry's
+value and the field's **key** to the entry's key, the name half as text (`N5`,
+`title`). In a `where`, a collection field is bound as an **entry**, a mini
+fact in the slots an attribute query uses: `the` for the key, `is` for the
+value.
+
+```json
+{ "member": { "the": { "?": { "name": "key" } }, "is": { "?": { "name": "member" } } } }
+```
+
+A constant `the` selects one entry (`{"the": "N5", "is": …}`); a bare term
+under the field (`"member": {"?": {"name": "m"}}`) binds every entry with the
+key unconstrained. The key joins, filters, and feeds formulas like any other
+term; for a sequence it is what `dialog/position` reads to derive a neighbour's
+position. In a conclusion the pair is the field's operand and its key operand,
+`<field>/key`, which the entry form spells on the wire.
+
+Internally the concept's rule scans the domain with the attribute slot refined
+by `domain` and `name.case`, and projects the key with `dialog/attribute-parts`
+(`of` → `domain`, `name`).
+
 ### Deductive Rules
 
 An advanced form of composition that goes beyond stitching attributes together. Rules can impose additional constraints, compute derived values using formulas, and follow transitive paths across relations. A rule's body is a set of premises; its conclusion is a concept instance. Rules are resolved at query time by the semantic layer.

--- a/notes/notation/schema.json
+++ b/notes/notation/schema.json
@@ -3,7 +3,6 @@
   "$id": "https://gozala.io/schema/dialog/notation/schema.json",
   "title": "Dialog Schema",
   "description": "Schema for Dialog domain modeling: attributes, concepts, rules, formulas, and relations.",
-
   "$defs": {
     "Attribute": {
       "type": "object",
@@ -26,27 +25,44 @@
         "as": {
           "$ref": "#/$defs/Assert",
           "description": "Value type of the attribute. If omitted, any type is allowed."
+        },
+        "optional": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this field is set-widened: a missing claim yields a row with the field bound to absent rather than dropping the row. Required fields (the default) omit this. Marking a field optional changes the concept's identity."
+        },
+        "conforms": {
+          "type": "string",
+          "description": "A concept the field's target entity must satisfy \u2014 a concept-typed field, written as the target's `concept:{hash}` URI. Entity-valued attributes only, and mutually exclusive with `optional`: the join over \"edge exists AND target conforms\" is absence over a derived predicate, which stratification has to own first. Enforced structurally, by conjoining the target's premises onto the field."
         }
       },
-      "required": ["the"]
+      "required": [
+        "the"
+      ]
     },
-
     "Cardinality": {
       "type": "string",
-      "enum": ["one", "many"],
+      "enum": [
+        "one",
+        "many"
+      ],
       "description": "'one' means asserting a new value retracts the prior claim. 'many' means new claims accumulate alongside existing ones.",
       "default": "one"
     },
-
     "Assert": {
       "description": "The asserted value type for an attribute. Currently only scalar types are supported. Concept references and symbol enumerations are planned future extensions.",
       "oneOf": [
-        { "$ref": "#/$defs/ScalarType" },
-        { "$ref": "#/$defs/ConceptRef" },
-        { "$ref": "#/$defs/SymbolEnum" }
+        {
+          "$ref": "#/$defs/ScalarType"
+        },
+        {
+          "$ref": "#/$defs/ConceptRef"
+        },
+        {
+          "$ref": "#/$defs/SymbolEnum"
+        }
       ]
     },
-
     "ScalarType": {
       "type": "string",
       "enum": [
@@ -57,17 +73,16 @@
         "UnsignedInteger",
         "SignedInteger",
         "Float",
+        "Record",
         "Symbol"
       ],
       "description": "Built-in scalar types from the dialog domain. 'Text' is shorthand for 'dialog/Text', etc."
     },
-
     "ConceptRef": {
       "type": "string",
       "pattern": "^[a-zA-Z]",
       "description": "Reference to a concept. Can be dot-prefixed (.Ingredient) for current domain, or fully qualified (diy.cook/Ingredient)."
     },
-
     "SymbolEnum": {
       "type": "array",
       "items": {
@@ -76,7 +91,6 @@
       "minItems": 1,
       "description": "[Future extension, not yet supported] A fixed set of fully qualified symbol values (e.g. [\"diy.cook/tsp\", \"diy.cook/mls\"])."
     },
-
     "Concept": {
       "type": "object",
       "description": "A composition of attributes sharing an entity. An entity matches a concept if and only if it has claims satisfying all required attributes.",
@@ -87,33 +101,32 @@
         },
         "with": {
           "$ref": "#/$defs/NamedRelations",
-          "description": "Required fields. An entity must have claims satisfying all these attributes to match.",
+          "description": "The concept's attributes, required and optional alike. An entity must have claims satisfying every REQUIRED attribute to match; optional ones are marked per-attribute with \"optional\": true. At least one required attribute must be declared.",
           "minProperties": 1
-        },
-        "maybe": {
-          "$ref": "#/$defs/NamedRelations",
-          "description": "[Future extension , not yet supported] Optional fields. The entity may or may not have claims for these attributes."
         }
       },
-      "required": ["with"]
+      "required": [
+        "with"
+      ]
     },
-
     "NamedRelations": {
       "type": "object",
       "description": "Map of field names to attribute descriptors (inline) or attribute references (string paths).",
       "additionalProperties": {
         "oneOf": [
-          { "$ref": "#/$defs/Attribute" },
-          { "$ref": "#/$defs/AttributeRef" }
+          {
+            "$ref": "#/$defs/Attribute"
+          },
+          {
+            "$ref": "#/$defs/AttributeRef"
+          }
         ]
       }
     },
-
     "AttributeRef": {
       "type": "string",
       "description": "Reference to a pre-defined attribute. '.' means same-named attribute under the current domain. '.name' resolves within current domain. 'domain/name' is fully qualified."
     },
-
     "Rule": {
       "type": "object",
       "description": "A deductive rule that derives conclusions from existing information through pattern matching, computation, and logical composition.",
@@ -128,19 +141,32 @@
         },
         "when": {
           "type": "array",
-          "items": { "$ref": "#/$defs/Premise" },
+          "items": {
+            "$ref": "#/$defs/Premise"
+          },
           "minItems": 1,
           "description": "Conjunction of premises. All must be satisfied by the same variable bindings."
         },
         "unless": {
           "type": "array",
-          "items": { "$ref": "#/$defs/Premise" },
+          "items": {
+            "$ref": "#/$defs/Premise"
+          },
           "description": "Exclusion patterns. If any can be satisfied, the result is filtered out (negation as failure)."
+        },
+        "reduce": {
+          "type": "object",
+          "description": "Aggregation. Each entry names a head field and the fold defining it. The grouping set is DERIVED \u2014 the head fields absent from `reduce` \u2014 so a field cannot be both grouped and reduced. Omitted for a plain rule.",
+          "additionalProperties": {
+            "$ref": "#/$defs/ReduceSpec"
+          }
         }
       },
-      "required": ["deduce", "when"]
+      "required": [
+        "deduce",
+        "when"
+      ]
     },
-
     "FormulaRef": {
       "type": "string",
       "enum": [
@@ -160,13 +186,13 @@
       ],
       "description": "Reference to a built-in formula by name."
     },
-
     "ConstraintRef": {
       "type": "string",
-      "enum": ["=="],
+      "enum": [
+        "=="
+      ],
       "description": "Reference to a built-in constraint by name."
     },
-
     "Premise": {
       "type": "object",
       "description": "A single premise in a rule body. Combines an assertion (what to match) with named term bindings (how to bind variables).",
@@ -174,20 +200,30 @@
         "assert": {
           "description": "What to match: a concept (inline definition), a formula reference, or a constraint reference.",
           "oneOf": [
-            { "$ref": "#/$defs/Concept" },
-            { "$ref": "#/$defs/FormulaRef" },
-            { "$ref": "#/$defs/ConstraintRef" }
+            {
+              "$ref": "#/$defs/Concept"
+            },
+            {
+              "$ref": "#/$defs/FormulaRef"
+            },
+            {
+              "$ref": "#/$defs/ConstraintRef"
+            }
           ]
         },
         "where": {
           "type": "object",
           "description": "Named terms mapping field names to variables or constants. For concepts, names correspond to the concept's attribute names. For formulas and constraints, names correspond to their parameter names.",
-          "additionalProperties": { "$ref": "#/$defs/Term" }
+          "additionalProperties": {
+            "$ref": "#/$defs/Term"
+          }
         }
       },
-      "required": ["assert", "where"]
+      "required": [
+        "assert",
+        "where"
+      ]
     },
-
     "MathFormula": {
       "type": "object",
       "description": "Arithmetic formulas over integer values.",
@@ -196,7 +232,10 @@
           "type": "object",
           "description": "Adds two integers: is = of + with.",
           "properties": {
-            "of": { "$ref": "#/$defs/Term", "description": "First operand." },
+            "of": {
+              "$ref": "#/$defs/Term",
+              "description": "First operand."
+            },
             "with": {
               "$ref": "#/$defs/Term",
               "description": "Second operand."
@@ -206,13 +245,20 @@
               "description": "Derived: sum of the two operands."
             }
           },
-          "required": ["of", "with", "is"]
+          "required": [
+            "of",
+            "with",
+            "is"
+          ]
         },
         "math/difference": {
           "type": "object",
           "description": "Subtracts second from first (saturating at 0): is = of - subtract.",
           "properties": {
-            "of": { "$ref": "#/$defs/Term", "description": "Minuend." },
+            "of": {
+              "$ref": "#/$defs/Term",
+              "description": "Minuend."
+            },
             "subtract": {
               "$ref": "#/$defs/Term",
               "description": "Subtrahend."
@@ -222,47 +268,83 @@
               "description": "Derived: difference (saturating)."
             }
           },
-          "required": ["of", "subtract", "is"]
+          "required": [
+            "of",
+            "subtract",
+            "is"
+          ]
         },
         "math/product": {
           "type": "object",
           "description": "Multiplies two integers: is = of * times.",
           "properties": {
-            "of": { "$ref": "#/$defs/Term", "description": "Multiplicand." },
-            "times": { "$ref": "#/$defs/Term", "description": "Multiplier." },
-            "is": { "$ref": "#/$defs/Term", "description": "Derived: product." }
+            "of": {
+              "$ref": "#/$defs/Term",
+              "description": "Multiplicand."
+            },
+            "times": {
+              "$ref": "#/$defs/Term",
+              "description": "Multiplier."
+            },
+            "is": {
+              "$ref": "#/$defs/Term",
+              "description": "Derived: product."
+            }
           },
-          "required": ["of", "times", "is"]
+          "required": [
+            "of",
+            "times",
+            "is"
+          ]
         },
         "math/quotient": {
           "type": "object",
           "description": "Divides first by second: is = of / by. Produces no result when divisor is zero.",
           "properties": {
-            "of": { "$ref": "#/$defs/Term", "description": "Dividend." },
-            "by": { "$ref": "#/$defs/Term", "description": "Divisor." },
+            "of": {
+              "$ref": "#/$defs/Term",
+              "description": "Dividend."
+            },
+            "by": {
+              "$ref": "#/$defs/Term",
+              "description": "Divisor."
+            },
             "is": {
               "$ref": "#/$defs/Term",
               "description": "Derived: quotient (empty if by = 0)."
             }
           },
-          "required": ["of", "by", "is"]
+          "required": [
+            "of",
+            "by",
+            "is"
+          ]
         },
         "math/modulo": {
           "type": "object",
           "description": "Remainder of division: is = of % by. Produces no result when divisor is zero.",
           "properties": {
-            "of": { "$ref": "#/$defs/Term", "description": "Dividend." },
-            "by": { "$ref": "#/$defs/Term", "description": "Divisor." },
+            "of": {
+              "$ref": "#/$defs/Term",
+              "description": "Dividend."
+            },
+            "by": {
+              "$ref": "#/$defs/Term",
+              "description": "Divisor."
+            },
             "is": {
               "$ref": "#/$defs/Term",
               "description": "Derived: remainder (empty if by = 0)."
             }
           },
-          "required": ["of", "by", "is"]
+          "required": [
+            "of",
+            "by",
+            "is"
+          ]
         }
       }
     },
-
     "TextFormula": {
       "type": "object",
       "description": "String operation formulas.",
@@ -271,7 +353,10 @@
           "type": "object",
           "description": "Joins two strings: is = first ++ second.",
           "properties": {
-            "first": { "$ref": "#/$defs/Term", "description": "First string." },
+            "first": {
+              "$ref": "#/$defs/Term",
+              "description": "First string."
+            },
             "second": {
               "$ref": "#/$defs/Term",
               "description": "Second string."
@@ -281,7 +366,11 @@
               "description": "Derived: concatenation."
             }
           },
-          "required": ["first", "second", "is"]
+          "required": [
+            "first",
+            "second",
+            "is"
+          ]
         },
         "text/length": {
           "type": "object",
@@ -296,7 +385,10 @@
               "description": "Derived: byte length as integer."
             }
           },
-          "required": ["of", "is"]
+          "required": [
+            "of",
+            "is"
+          ]
         },
         "text/upper-case": {
           "type": "object",
@@ -311,7 +403,10 @@
               "description": "Derived: uppercased string."
             }
           },
-          "required": ["of", "is"]
+          "required": [
+            "of",
+            "is"
+          ]
         },
         "text/lower-case": {
           "type": "object",
@@ -326,13 +421,19 @@
               "description": "Derived: lowercased string."
             }
           },
-          "required": ["of", "is"]
+          "required": [
+            "of",
+            "is"
+          ]
         },
         "text/like": {
           "type": "object",
           "description": "Glob pattern match. Produces a result only when the pattern matches. '*' matches any sequence, '?' matches a single character.",
           "properties": {
-            "text": { "$ref": "#/$defs/Term", "description": "Text to match." },
+            "text": {
+              "$ref": "#/$defs/Term",
+              "description": "Text to match."
+            },
             "pattern": {
               "$ref": "#/$defs/Term",
               "description": "Glob pattern."
@@ -342,11 +443,14 @@
               "description": "Derived: the matched text (empty if no match)."
             }
           },
-          "required": ["text", "pattern", "is"]
+          "required": [
+            "text",
+            "pattern",
+            "is"
+          ]
         }
       }
     },
-
     "LogicFormula": {
       "type": "object",
       "description": "Boolean logic formulas.",
@@ -355,7 +459,10 @@
           "type": "object",
           "description": "Logical AND of two booleans.",
           "properties": {
-            "left": { "$ref": "#/$defs/Term", "description": "First boolean." },
+            "left": {
+              "$ref": "#/$defs/Term",
+              "description": "First boolean."
+            },
             "right": {
               "$ref": "#/$defs/Term",
               "description": "Second boolean."
@@ -365,13 +472,20 @@
               "description": "Derived: left AND right."
             }
           },
-          "required": ["left", "right", "is"]
+          "required": [
+            "left",
+            "right",
+            "is"
+          ]
         },
         "boolean/or": {
           "type": "object",
           "description": "Logical OR of two booleans.",
           "properties": {
-            "left": { "$ref": "#/$defs/Term", "description": "First boolean." },
+            "left": {
+              "$ref": "#/$defs/Term",
+              "description": "First boolean."
+            },
             "right": {
               "$ref": "#/$defs/Term",
               "description": "Second boolean."
@@ -381,7 +495,11 @@
               "description": "Derived: left OR right."
             }
           },
-          "required": ["left", "right", "is"]
+          "required": [
+            "left",
+            "right",
+            "is"
+          ]
         },
         "boolean/not": {
           "type": "object",
@@ -396,26 +514,42 @@
               "description": "Derived: NOT value."
             }
           },
-          "required": ["value", "is"]
+          "required": [
+            "value",
+            "is"
+          ]
         }
       }
     },
-
     "EqualityConstraint": {
       "type": "object",
       "description": "Equality constraint, referenced as '==' in a premise's assert field. Asserts two terms must hold equal values. Can filter (both bound), infer (one bound, one free), or fail (neither bound). Used via { \"assert\": \"==\", \"where\": { \"this\": ..., \"is\": ... } }.",
       "properties": {
-        "this": { "$ref": "#/$defs/Term", "description": "Left-hand term." },
-        "is": { "$ref": "#/$defs/Term", "description": "Right-hand term." }
+        "this": {
+          "$ref": "#/$defs/Term",
+          "description": "Left-hand term."
+        },
+        "is": {
+          "$ref": "#/$defs/Term",
+          "description": "Right-hand term."
+        }
       },
-      "required": ["this", "is"]
+      "required": [
+        "this",
+        "is"
+      ]
     },
-
     "Term": {
       "description": "A term is either a variable or a constant value.",
-      "oneOf": [{ "$ref": "#/$defs/Variable" }, { "$ref": "#/$defs/Constant" }]
+      "oneOf": [
+        {
+          "$ref": "#/$defs/Variable"
+        },
+        {
+          "$ref": "#/$defs/Constant"
+        }
+      ]
     },
-
     "Variable": {
       "type": "object",
       "description": "A query variable. Variables are bound by the query engine. The same variable appearing in multiple positions requires unification. A blank variable { \"?\": {} } matches any value without binding.",
@@ -426,23 +560,36 @@
             "name": {
               "type": "string",
               "description": "Variable name. When omitted, acts as a blank (wildcard) that matches any value without binding."
+            },
+            "where": {
+              "$ref": "#/$defs/TypeConstraint",
+              "description": "Constraints narrowing what this variable admits. Absent means unconstrained."
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
-      "required": ["?"]
+      "required": [
+        "?"
+      ]
     },
-
     "Constant": {
       "description": "A concrete value: string, number, or boolean.",
       "oneOf": [
-        { "type": "string" },
-        { "type": "number" },
-        { "type": "integer" },
-        { "type": "boolean" }
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
       ]
     },
-
     "Claim": {
       "type": "object",
       "description": "A claim in the associative layer. An assertion that has been incorporated by the transactor. Composed of a relation (the), an entity (of), a value (is), and provenance (cause).",
@@ -458,10 +605,18 @@
         "is": {
           "description": "The value being linked to the entity through this relation.",
           "oneOf": [
-            { "type": "string" },
-            { "type": "number" },
-            { "type": "integer" },
-            { "type": "boolean" }
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            }
           ]
         },
         "cause": {
@@ -469,9 +624,13 @@
           "description": "Provenance describing who produced this claim and when."
         }
       },
-      "required": ["the", "of", "is", "cause"]
+      "required": [
+        "the",
+        "of",
+        "is",
+        "cause"
+      ]
     },
-
     "Provenance": {
       "type": "object",
       "description": "Provenance of a claim, capturing when and where it was produced. Establishes partial order across a distributed system.",
@@ -491,7 +650,183 @@
           "description": "Uncoordinated local time component: moment within a period."
         }
       },
-      "required": ["by", "period", "moment"]
+      "required": [
+        "by",
+        "period",
+        "moment"
+      ]
+    },
+    "TypeConstraint": {
+      "type": "object",
+      "description": "Constraints on a variable, all conjoined. A record of fixed slots: each appears at most once, and two constraints on one slot merge rather than accumulate. Every slot but `type` narrows the admissible type set as a side effect (a prefix implies a textual type, conformance implies entity, an order bound implies a comparable type); a constraint whose narrowing empties the set is rejected.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/TypeSet"
+        },
+        "domain": {
+          "type": "object",
+          "description": "Constrains the domain half of an attribute (the part before `/`). Symbol-typed values only.",
+          "properties": {
+            "is": {
+              "type": "string",
+              "description": "The domain, written WITHOUT a trailing slash. The separator is an encoding detail supplied on the way in."
+            }
+          },
+          "required": [
+            "is"
+          ],
+          "additionalProperties": false
+        },
+        "name": {
+          "type": "object",
+          "description": "Constrains the name half of an attribute (the part after `/`). Symbol-typed values only.",
+          "properties": {
+            "case": {
+              "type": "string",
+              "enum": [
+                "position",
+                "symbol"
+              ],
+              "description": "Which of the two name forms. A name beginning with an uppercase byte is a fractional position (an ordered relation's member); a lowercase byte is a symbol (a named predicate). The classes are disjoint and exhaustive, so one domain scan serves both and this narrows to a contiguous key range. Absent admits either."
+            }
+          },
+          "required": [
+            "case"
+          ],
+          "additionalProperties": false
+        },
+        "starts-with": {
+          "type": "string",
+          "description": "Lexical prefix every admitted value must begin with. Narrows the type set to those with a lexical form (text, symbol, entity). For attributes prefer `domain`/`name`, which say the same thing structurally."
+        },
+        "as": {
+          "type": "array",
+          "description": "Concepts the value's entity must conform to. An ARRAY here is an INTERSECTION: every listed concept must be satisfied. Entity-typed values only. Enforced structurally (the target's premises are conjoined into the query), not as a per-row test.",
+          "items": {
+            "$ref": "#/$defs/ConformanceRef"
+          }
+        },
+        ">=": {
+          "description": "Inclusive lower bound. Comparable types only."
+        },
+        ">": {
+          "description": "Strict lower bound. Comparable types only."
+        },
+        "<=": {
+          "description": "Inclusive upper bound. Comparable types only."
+        },
+        "<": {
+          "description": "Strict upper bound. Comparable types only."
+        }
+      },
+      "additionalProperties": false
+    },
+    "TypeSet": {
+      "type": "object",
+      "description": "The set of types a variable admits. An OBJECT here is a UNION: a value matching any present key is admitted, and intersecting two sets keeps the keys they share. Values are per-variant parameter records, empty today and the place future parameters (an integer width, say) would go. An empty object is the uninhabited set. Omitting `type` leaves the variable untyped.",
+      "properties": {
+        "bytes": {
+          "type": "object",
+          "description": "A byte buffer.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "entity": {
+          "type": "object",
+          "description": "An entity reference.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "boolean": {
+          "type": "object",
+          "description": "A boolean.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "text": {
+          "type": "object",
+          "description": "A UTF-8 string.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "uint": {
+          "type": "object",
+          "description": "An unsigned integer.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "int": {
+          "type": "object",
+          "description": "A signed integer.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "float": {
+          "type": "object",
+          "description": "A floating-point number.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "record": {
+          "type": "object",
+          "description": "Structured data, opaque to the query layer.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "symbol": {
+          "type": "object",
+          "description": "A symbol \u2014 the type attributes carry, distinguishing them from ordinary strings.",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "option": {
+          "type": "object",
+          "description": "The absence atom: a row-level absent value. Present alongside other members, it marks the variable optional.",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConformanceRef": {
+      "type": "object",
+      "description": "One conformance obligation, keyed by the target concept's URI (`concept:{hash}`). The value is a parameter record, empty today.",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    "ReduceSpec": {
+      "type": "object",
+      "description": "One fold: the aggregator to apply and the term supplying its input, one lookup per body row.",
+      "properties": {
+        "apply": {
+          "$ref": "#/$defs/Aggregator"
+        },
+        "of": {
+          "$ref": "#/$defs/Term",
+          "description": "The term supplying the fold's input."
+        }
+      },
+      "required": [
+        "apply",
+        "of"
+      ],
+      "additionalProperties": false
+    },
+    "Aggregator": {
+      "type": "string",
+      "enum": [
+        "count",
+        "count-distinct",
+        "sum",
+        "min",
+        "max",
+        "avg"
+      ],
+      "description": "The fold applied to a group. Absent inputs are skipped. `count` and `sum` have identities, so their head field may be required; `min`, `max`, and `avg` do not, so over an input admitting absence their head field must be optional. `min`/`max` need comparable values, `sum`/`avg` numeric ones."
     }
   }
 }

--- a/notes/notation/schema.json
+++ b/notes/notation/schema.json
@@ -4,6 +4,33 @@
   "title": "Dialog Schema",
   "description": "Schema for Dialog domain modeling: attributes, concepts, rules, formulas, and relations.",
   "$defs": {
+    "Collection": {
+      "type": "object",
+      "description": "Every entry of one domain, keyed by the name half of each attribute: the symbol-named half is a dictionary, the position-named half a sequence.",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "The domain the entries share, without a trailing separator.",
+          "pattern": "^[a-z][a-z0-9.-]*[a-z0-9]?$"
+        },
+        "keyed": {
+          "type": "string",
+          "enum": ["dictionary", "sequence"],
+          "description": "Which half of the domain: symbol-named entries (dictionary) or position-named members in list order (sequence)."
+        }
+      },
+      "required": ["domain", "keyed"],
+      "additionalProperties": false
+    },
+    "Entry": {
+      "type": "object",
+      "description": "A binding for a keyed-collection field: the entry's key in `the` (the attribute's name half, as text) and its value in `is`. A constant `the` selects one entry; a variable binds every entry's key. Either slot may be omitted, which leaves it blank.",
+      "properties": {
+        "the": { "$ref": "#/$defs/Term" },
+        "is": { "$ref": "#/$defs/Term" }
+      },
+      "additionalProperties": false
+    },
     "Attribute": {
       "type": "object",
       "description": "A relation elevated with domain-specific invariants. An attribute's identity is structural: (the, type, cardinality).",
@@ -13,10 +40,16 @@
           "description": "Human-readable description of the attribute."
         },
         "the": {
-          "type": "string",
-          "description": "The relation in domain/name format (e.g. 'diy.cook/quantity'). Max 64 bytes total. Domain: lowercase letters, digits, hyphens, dots; must start with a letter. Name: lowercase kebab-case (no dots); must start with a letter.",
-          "maxLength": 64,
-          "pattern": "^[a-z][a-z0-9.-]*[a-z0-9]?/[a-z][a-z0-9-]*[a-z0-9]?$"
+          "description": "What the attribute selects: one relation in domain/name format, or every entry of a keyed collection.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "The relation in domain/name format (e.g. 'diy.cook/quantity'). Max 64 bytes total. Domain: lowercase letters, digits, hyphens, dots; must start with a letter. Name: lowercase kebab-case (no dots); must start with a letter.",
+              "maxLength": 64,
+              "pattern": "^[a-z][a-z0-9.-]*[a-z0-9]?/[a-z][a-z0-9-]*[a-z0-9]?$"
+            },
+            { "$ref": "#/$defs/Collection" }
+          ]
         },
         "cardinality": {
           "$ref": "#/$defs/Cardinality",
@@ -213,9 +246,12 @@
         },
         "where": {
           "type": "object",
-          "description": "Named terms mapping field names to variables or constants. For concepts, names correspond to the concept's attribute names. For formulas and constraints, names correspond to their parameter names.",
+          "description": "Named terms mapping field names to variables or constants. For concepts, names correspond to the concept's attribute names, and a keyed-collection field is bound as an entry. For formulas and constraints, names correspond to their parameter names.",
           "additionalProperties": {
-            "$ref": "#/$defs/Term"
+            "oneOf": [
+              { "$ref": "#/$defs/Term" },
+              { "$ref": "#/$defs/Entry" }
+            ]
           }
         }
       },

--- a/rust/dialog-macros/src/query/attribute.rs
+++ b/rust/dialog-macros/src/query/attribute.rs
@@ -267,9 +267,14 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 <Self as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor()
             }
 
-            /// Returns the attribute identifier.
+            /// Returns the attribute identifier. A derived attribute
+            /// always names one attribute — the keyed-collection
+            /// relation has no derive path.
             pub fn the() -> dialog_query::The {
-                Self::descriptor().the().clone()
+                match Self::descriptor().the() {
+                    dialog_query::Relation::Attribute(the) => the.clone(),
+                    _ => unreachable!("a derived attribute names one relation"),
+                }
             }
 
             /// Returns the cardinality of this attribute.
@@ -288,8 +293,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let desc = Self::descriptor();
                 f.debug_struct(stringify!(#struct_name))
-                    .field("domain", &desc.domain())
-                    .field("name", &desc.name())
+                    .field("the", &desc.the().to_string())
                     .field("value", &self.0)
                     .finish()
             }
@@ -299,11 +303,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         impl std::fmt::Display for #struct_name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let desc = Self::descriptor();
-                write!(f, "{}/{}: {:?}",
-                    desc.domain(),
-                    desc.name(),
-                    self.0
-                )
+                write!(f, "{}: {:?}", desc.the(), self.0)
             }
         }
 

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -683,7 +683,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                         let value_param = <#field_types as dialog_query::ConceptField>::term(raw_param);
                         let descriptor = <<#field_types as dialog_query::ConceptField>::Attribute
                             as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor();
-                        let the_term = descriptor.the().term();
+                        let the_term = descriptor.the().term(stringify!(#field_names));
                         let cardinality = Some(descriptor.cardinality());
                         let query = dialog_query::AttributeQuery::new(
                             the_term,

--- a/rust/dialog-macros/src/query/concept.rs
+++ b/rust/dialog-macros/src/query/concept.rs
@@ -683,9 +683,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                         let value_param = <#field_types as dialog_query::ConceptField>::term(raw_param);
                         let descriptor = <<#field_types as dialog_query::ConceptField>::Attribute
                             as dialog_query::Descriptor<dialog_query::AttributeDescriptor>>::descriptor();
-                        let the_term = dialog_query::Term::Constant(
-                            dialog_query::Value::from(descriptor.the().clone())
-                        );
+                        let the_term = descriptor.the().term();
                         let cardinality = Some(descriptor.cardinality());
                         let query = dialog_query::AttributeQuery::new(
                             the_term,

--- a/rust/dialog-query/src/attribute.rs
+++ b/rust/dialog-query/src/attribute.rs
@@ -109,7 +109,7 @@ mod tests {
         use crate::descriptor::Descriptor;
         let _name = person::Name("hello".into());
         assert_eq!(person::Name::descriptor().domain(), "person");
-        assert_eq!(person::Name::descriptor().name(), "name");
+        assert_eq!(person::Name::descriptor().name(), Some("name"));
     }
 
     mod employee_derive {
@@ -149,7 +149,7 @@ mod tests {
             employee_derive::Name::descriptor().domain(),
             "employee-derive"
         );
-        assert_eq!(employee_derive::Name::descriptor().name(), "name");
+        assert_eq!(employee_derive::Name::descriptor().name(), Some("name"));
         assert_eq!(
             employee_derive::Name::descriptor().description(),
             "Name of the employee"
@@ -170,7 +170,7 @@ mod tests {
             employee_derive::Job::descriptor().domain(),
             "employee-derive"
         );
-        assert_eq!(employee_derive::Job::descriptor().name(), "job");
+        assert_eq!(employee_derive::Job::descriptor().name(), Some("job"));
         assert_eq!(
             employee_derive::Job::descriptor().description(),
             "Job title of the employee"
@@ -191,7 +191,7 @@ mod tests {
             employee_derive::Salary::descriptor().domain(),
             "employee-derive"
         );
-        assert_eq!(employee_derive::Salary::descriptor().name(), "salary");
+        assert_eq!(employee_derive::Salary::descriptor().name(), Some("salary"));
         assert_eq!(
             employee_derive::Salary::descriptor().description(),
             "Salary of the employee"
@@ -209,7 +209,7 @@ mod tests {
         let name = person_derive::Name("Bob".to_string());
 
         assert_eq!(person_derive::Name::descriptor().domain(), "person-derive");
-        assert_eq!(person_derive::Name::descriptor().name(), "name");
+        assert_eq!(person_derive::Name::descriptor().name(), Some("name"));
         assert_eq!(
             person_derive::Name::descriptor().the().to_string(),
             "person-derive/name"
@@ -244,7 +244,7 @@ mod tests {
         let field = custom_ns_derive::Field("value".to_string());
 
         assert_eq!(custom_ns_derive::Field::descriptor().domain(), "custom");
-        assert_eq!(custom_ns_derive::Field::descriptor().name(), "field");
+        assert_eq!(custom_ns_derive::Field::descriptor().name(), Some("field"));
         assert_eq!(
             custom_ns_derive::Field::descriptor().the().to_string(),
             "custom/field"
@@ -295,7 +295,7 @@ mod tests {
     #[dialog_common::test]
     fn it_converts_underscores_to_hyphens() {
         assert_eq!(account_name::Name::descriptor().domain(), "account-name");
-        assert_eq!(account_name::Name::descriptor().name(), "name");
+        assert_eq!(account_name::Name::descriptor().name(), Some("name"));
         assert_eq!(
             account_name::Name::descriptor().the().to_string(),
             "account-name/name"
@@ -305,7 +305,7 @@ mod tests {
     #[dialog_common::test]
     fn it_derives_nested_module_domain() {
         assert_eq!(ns_my::config::Key::descriptor().domain(), "config");
-        assert_eq!(ns_my::config::Key::descriptor().name(), "key");
+        assert_eq!(ns_my::config::Key::descriptor().name(), Some("key"));
         assert_eq!(
             ns_my::config::Key::descriptor().the().to_string(),
             "config/key"
@@ -315,7 +315,7 @@ mod tests {
     #[dialog_common::test]
     fn it_overrides_domain_explicitly() {
         assert_eq!(NsValue::descriptor().domain(), "my.custom.namespace");
-        assert_eq!(NsValue::descriptor().name(), "ns-value");
+        assert_eq!(NsValue::descriptor().name(), Some("ns-value"));
         assert_eq!(
             NsValue::descriptor().the().to_string(),
             "my.custom.namespace/ns-value"
@@ -325,7 +325,7 @@ mod tests {
     #[dialog_common::test]
     fn it_accepts_domain_identifier_syntax() {
         assert_eq!(NsCustomValue::descriptor().domain(), "custom");
-        assert_eq!(NsCustomValue::descriptor().name(), "ns-custom-value");
+        assert_eq!(NsCustomValue::descriptor().name(), Some("ns-custom-value"));
         assert_eq!(
             NsCustomValue::descriptor().the().to_string(),
             "custom/ns-custom-value"
@@ -335,7 +335,7 @@ mod tests {
     #[dialog_common::test]
     fn it_accepts_domain_string_literal() {
         assert_eq!(NsDottedValue::descriptor().domain(), "io.gozala");
-        assert_eq!(NsDottedValue::descriptor().name(), "ns-dotted-value");
+        assert_eq!(NsDottedValue::descriptor().name(), Some("ns-dotted-value"));
         assert_eq!(
             NsDottedValue::descriptor().the().to_string(),
             "io.gozala/ns-dotted-value"
@@ -348,7 +348,10 @@ mod tests {
             ns_my_app::user_profile::Email::descriptor().domain(),
             "user-profile"
         );
-        assert_eq!(ns_my_app::user_profile::Email::descriptor().name(), "email");
+        assert_eq!(
+            ns_my_app::user_profile::Email::descriptor().name(),
+            Some("email")
+        );
         assert_eq!(
             ns_my_app::user_profile::Email::descriptor()
                 .the()
@@ -362,7 +365,7 @@ mod tests {
         let name = account_name::Name("John Doe".to_string());
 
         assert_eq!(account_name::Name::descriptor().domain(), "account-name");
-        assert_eq!(account_name::Name::descriptor().name(), "name");
+        assert_eq!(account_name::Name::descriptor().name(), Some("name"));
         assert_eq!(
             account_name::Name::descriptor().description(),
             "Account holder's name"
@@ -386,16 +389,19 @@ mod tests {
 
     #[dialog_common::test]
     fn it_converts_pascal_to_kebab() {
-        assert_eq!(test_pascal::UserName::descriptor().name(), "user-name");
+        assert_eq!(
+            test_pascal::UserName::descriptor().name(),
+            Some("user-name")
+        );
     }
 
     #[dialog_common::test]
     fn it_converts_consecutive_capitals() {
         assert_eq!(
             test_pascal::HTTPRequest::descriptor().name(),
-            "http-request"
+            Some("http-request")
         );
-        assert_eq!(test_pascal::APIKey::descriptor().name(), "api-key");
+        assert_eq!(test_pascal::APIKey::descriptor().name(), Some("api-key"));
     }
 
     #[dialog_common::test]
@@ -403,14 +409,14 @@ mod tests {
         let descriptor = test_pascal::UserName::descriptor();
 
         assert!(!descriptor.domain().is_empty());
-        assert_eq!(descriptor.name(), "user-name");
+        assert_eq!(descriptor.name(), Some("user-name"));
         let _ = descriptor.description();
     }
 
     #[dialog_common::test]
     fn it_exposes_static_schema() {
         let schema = &test_pascal::UserName::descriptor();
-        assert_eq!(schema.name(), "user-name");
+        assert_eq!(schema.name(), Some("user-name"));
         assert_eq!(schema.cardinality(), Cardinality::One);
     }
 

--- a/rust/dialog-query/src/attribute/descriptor.rs
+++ b/rust/dialog-query/src/attribute/descriptor.rs
@@ -98,22 +98,56 @@ impl Relation {
         }
     }
 
-    /// How this relation is selected: a constant for one attribute, a
-    /// variable refined by the domain and key kind for a collection.
-    /// The refined form is what narrows a domain scan to the demanded
-    /// half — see `dialog_artifacts::NameShape`.
-    pub fn term(&self) -> Term<The> {
+    /// How this relation is selected when lowered for the field
+    /// `field`: a constant for one attribute, a variable refined by
+    /// the domain and key kind for a collection. The refined form is
+    /// what narrows a domain scan to the demanded half — see
+    /// `dialog_artifacts::NameShape`.
+    ///
+    /// The variable is named after the field (`<field>/the`) so two
+    /// collection fields on one concept scan independently rather
+    /// than unifying on a shared name.
+    pub fn term(&self, field: &str) -> Term<The> {
         match self {
             Relation::Attribute(the) => Term::Constant(Value::from(the.clone())),
-            Relation::Collection { domain, keyed } => {
-                let kind = Kind::from(Type::Symbol)
+            Relation::Collection { .. } => Term::<The>::var(Self::attribute_variable(field))
+                .with_kind(
+                    self.kind()
+                        .expect("a collection is refined by construction"),
+                ),
+        }
+    }
+
+    /// The kind a collection's attribute slot is refined to: a symbol
+    /// under the domain prefix, narrowed to the key kind's name shape.
+    /// `None` for a plain attribute, which is selected by constant.
+    pub fn kind(&self) -> Option<Kind> {
+        match self {
+            Relation::Attribute(_) => None,
+            Relation::Collection { domain, keyed } => Some(
+                Kind::from(Type::Symbol)
                     .with_prefix(format!("{}/", domain.as_str()))
                     .expect("symbol is textual")
                     .with_name_shape(NameShape::from(*keyed))
-                    .expect("a name shape composes with a domain prefix");
-                Term::<The>::var("the").with_kind(kind)
-            }
+                    .expect("a name shape composes with a domain prefix"),
+            ),
         }
+    }
+
+    /// The body variable a collection field's scan binds the matched
+    /// attribute to. Internal to the concept's own rule: the key an
+    /// author sees is the attribute's name half, bound to the
+    /// [`key_operand`](Self::key_operand) by `dialog/attribute-parts`.
+    pub fn attribute_variable(field: &str) -> String {
+        format!("{field}/the")
+    }
+
+    /// The operand carrying a collection field's key: the name half
+    /// of each matched attribute. `{?key: ?value}` under the field in
+    /// notation is this operand and the field's own, and the two
+    /// serialize back into that form.
+    pub fn key_operand(field: &str) -> String {
+        format!("{field}/key")
     }
 }
 
@@ -326,7 +360,7 @@ impl AttributeDescriptor {
         };
 
         Ok(AttributeQuery::new(
-            self.the().term(),
+            self.the().term("the"),
             of,
             is,
             cause,
@@ -690,7 +724,7 @@ mod collection_tests {
             Some(Type::String),
         );
         assert!(
-            matches!(descriptor.the().term(), Term::Constant(_)),
+            matches!(descriptor.the().term("title"), Term::Constant(_)),
             "an attribute pins `the`"
         );
         assert_eq!(descriptor.domain(), "todo.list");
@@ -707,7 +741,7 @@ mod collection_tests {
             (Keyed::Dictionary, NameShape::Symbol),
         ] {
             let descriptor = collection(keyed);
-            let term = descriptor.the().term();
+            let term = descriptor.the().term("member");
             assert!(
                 matches!(term, Term::Variable { .. }),
                 "a collection leaves `the` open"

--- a/rust/dialog-query/src/attribute/descriptor.rs
+++ b/rust/dialog-query/src/attribute/descriptor.rs
@@ -5,11 +5,14 @@ use crate::attribute::query::AttributeQuery;
 use crate::error::{FieldTypeError, TypeError};
 use crate::schema::Cardinality;
 use crate::term::Term;
+use crate::type_system::Type as Kind;
 use crate::types::Any;
 use crate::types::Type;
+use dialog_artifacts::{NameShape, Symbol};
 
 use base58::ToBase58;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// A validated attribute–value pair with its cardinality, produced by
 /// [`AttributeDescriptor::resolve`]. Used inside [`ConceptStatement`](crate::concept::descriptor::ConceptStatement)
@@ -24,6 +27,114 @@ pub struct Attribution {
     pub cardinality: Cardinality,
 }
 
+/// What an attribute descriptor selects: one attribute, or every
+/// entry of a keyed collection.
+///
+/// Dialog stores a collection as facts sharing a domain whose *name*
+/// half is the entry's key — `todo.list/title` for a dictionary
+/// entry, `todo.list/N5` for a sequence member. The two key kinds are
+/// disjoint by their first byte (symbols lowercase, positions
+/// uppercase), so one domain can carry both and a scan can take
+/// either half as a contiguous key range.
+///
+/// The key kind is the variant rather than a field, so a collection
+/// cannot be described with a key kind that disagrees with it: there
+/// is no state to validate.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Relation {
+    /// One attribute, named in full: `todo.list/title`.
+    Attribute(The),
+    /// Every entry of one domain, keyed by name.
+    Collection {
+        /// The domain the entries share, without a trailing separator.
+        domain: Symbol,
+        /// Which half of the domain: symbol-named entries
+        /// (a dictionary) or position-named members (a sequence).
+        keyed: Keyed,
+    },
+}
+
+/// Which half of a domain a [`Relation::Collection`] selects.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Keyed {
+    /// Symbol-named entries: a dictionary.
+    Dictionary,
+    /// Position-named members, in list order: a sequence.
+    Sequence,
+}
+
+impl From<Keyed> for NameShape {
+    fn from(keyed: Keyed) -> Self {
+        match keyed {
+            Keyed::Dictionary => NameShape::Symbol,
+            Keyed::Sequence => NameShape::Position,
+        }
+    }
+}
+
+impl Relation {
+    /// A collection of `domain`, keyed as `keyed`.
+    pub fn collection(domain: Symbol, keyed: Keyed) -> Self {
+        Relation::Collection { domain, keyed }
+    }
+
+    /// The domain these facts live under.
+    pub fn domain(&self) -> &str {
+        match self {
+            Relation::Attribute(the) => the.domain(),
+            Relation::Collection { domain, .. } => domain.as_str(),
+        }
+    }
+
+    /// The attribute's name half, or `None` for a collection — whose
+    /// name half is a key that varies per entry rather than a fixed
+    /// part of the selector.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Relation::Attribute(the) => Some(the.name()),
+            Relation::Collection { .. } => None,
+        }
+    }
+
+    /// How this relation is selected: a constant for one attribute, a
+    /// variable refined by the domain and key kind for a collection.
+    /// The refined form is what narrows a domain scan to the demanded
+    /// half — see `dialog_artifacts::NameShape`.
+    pub fn term(&self) -> Term<The> {
+        match self {
+            Relation::Attribute(the) => Term::Constant(Value::from(the.clone())),
+            Relation::Collection { domain, keyed } => {
+                let kind = Kind::from(Type::Symbol)
+                    .with_prefix(format!("{}/", domain.as_str()))
+                    .expect("symbol is textual")
+                    .with_name_shape(NameShape::from(*keyed))
+                    .expect("a name shape composes with a domain prefix");
+                Term::<The>::var("the").with_kind(kind)
+            }
+        }
+    }
+}
+
+impl Relation {
+    /// The concrete attribute to write a fact under, when there is
+    /// one. A collection has none: its facts are keyed per entry, so
+    /// the key has to come from the writer rather than the schema.
+    pub fn attribute(&self) -> Option<ArtifactsAttribute> {
+        match self {
+            Relation::Attribute(the) => Some(ArtifactsAttribute::from(the)),
+            Relation::Collection { .. } => None,
+        }
+    }
+}
+
+impl From<The> for Relation {
+    fn from(the: The) -> Self {
+        Relation::Attribute(the)
+    }
+}
+
 /// Static metadata for a single attribute: its storage-level selector
 /// ([`The`]), human-readable description, value type, and cardinality.
 ///
@@ -35,7 +146,7 @@ pub struct Attribution {
 ///    an [`Attribution`].
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttributeDescriptor {
-    the: The,
+    the: Relation,
     #[serde(default)]
     description: String,
     #[serde(default)]
@@ -52,6 +163,22 @@ impl AttributeDescriptor {
         cardinality: Cardinality,
         content_type: Option<Type>,
     ) -> Self {
+        Self::over(
+            Relation::Attribute(the),
+            description,
+            cardinality,
+            content_type,
+        )
+    }
+
+    /// Creates a descriptor over any [`Relation`] — one attribute, or
+    /// every entry of a keyed collection.
+    pub fn over(
+        the: Relation,
+        description: impl Into<String>,
+        cardinality: Cardinality,
+        content_type: Option<Type>,
+    ) -> Self {
         Self {
             the,
             description: description.into(),
@@ -61,7 +188,7 @@ impl AttributeDescriptor {
     }
 
     /// Returns a relation identifier comprised of the attribute's domain and name.
-    pub fn the(&self) -> &The {
+    pub fn the(&self) -> &Relation {
         &self.the
     }
 
@@ -70,8 +197,9 @@ impl AttributeDescriptor {
         self.the.domain()
     }
 
-    /// Returns the attribute name.
-    pub fn name(&self) -> &str {
+    /// Returns the attribute name, or `None` for a collection — whose
+    /// name half is a per-entry key rather than part of the selector.
+    pub fn name(&self) -> Option<&str> {
         self.the.name()
     }
 
@@ -118,8 +246,17 @@ impl AttributeDescriptor {
         };
 
         if type_matches {
+            // A collection field describes many facts, one per key,
+            // so there is no single attribute to write this value
+            // under: the key belongs to the entry, not the schema.
+            let the = self
+                .the
+                .attribute()
+                .ok_or_else(|| FieldTypeError::UnkeyedCollection {
+                    domain: self.the.domain().to_owned(),
+                })?;
             Ok(Attribution {
-                the: ArtifactsAttribute::from(&self.the),
+                the,
                 is: value.clone(),
                 cardinality: self.cardinality(),
             })
@@ -189,7 +326,7 @@ impl AttributeDescriptor {
         };
 
         Ok(AttributeQuery::new(
-            Term::Constant(Value::from(self.the().clone())),
+            self.the().term(),
             of,
             is,
             cause,
@@ -209,6 +346,12 @@ impl AttributeDescriptor {
     pub fn to_cbor_bytes(&self) -> Vec<u8> {
         use serde::Serialize;
 
+        // `name` carries the attribute's name half for a plain
+        // attribute and the key kind for a collection — the two are
+        // the same slot because they are the same thing: what the
+        // name half of these facts holds. A plain attribute therefore
+        // encodes exactly as it did before collections existed, so
+        // every existing identity is preserved.
         #[derive(Serialize)]
         struct CborAttributeDescriptor<'a> {
             domain: &'a str,
@@ -218,9 +361,16 @@ impl AttributeDescriptor {
             content_type: Option<Type>,
         }
 
+        let name = match &self.the {
+            Relation::Attribute(the) => the.name(),
+            Relation::Collection { keyed, .. } => match keyed {
+                Keyed::Dictionary => "<dictionary>",
+                Keyed::Sequence => "<sequence>",
+            },
+        };
         let schema = CborAttributeDescriptor {
             domain: self.domain(),
-            name: self.name(),
+            name,
             cardinality: self.cardinality(),
             content_type: self.content_type(),
         };
@@ -266,15 +416,34 @@ impl From<AttributeDescriptor> for Entity {
     }
 }
 
+/// A descriptor's concrete attribute. Panics for a keyed collection,
+/// which has no single attribute — use
+/// [`Relation::attribute`](Relation::attribute) where that is
+/// possible.
 impl From<&AttributeDescriptor> for ArtifactsAttribute {
     fn from(descriptor: &AttributeDescriptor) -> Self {
-        ArtifactsAttribute::from(&descriptor.the)
+        descriptor
+            .the
+            .attribute()
+            .expect("a keyed collection has no single attribute")
     }
 }
 
 impl From<AttributeDescriptor> for ArtifactsAttribute {
     fn from(descriptor: AttributeDescriptor) -> Self {
-        ArtifactsAttribute::from(descriptor.the)
+        ArtifactsAttribute::from(&descriptor)
+    }
+}
+
+impl Display for Relation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Relation::Attribute(the) => write!(f, "{the}"),
+            Relation::Collection { domain, keyed } => match keyed {
+                Keyed::Dictionary => write!(f, "{}/<symbol>", domain.as_str()),
+                Keyed::Sequence => write!(f, "{}/<position>", domain.as_str()),
+            },
+        }
     }
 }
 
@@ -356,7 +525,7 @@ mod tests {
         }"#;
         let attr: AttributeDescriptor = serde_json::from_str(json).unwrap();
         assert_eq!(attr.domain(), "io.gozala.person");
-        assert_eq!(attr.name(), "name");
+        assert_eq!(attr.name(), Some("name"));
         assert_eq!(attr.description(), "Name of the person");
         assert_eq!(attr.cardinality(), Cardinality::One);
         assert_eq!(attr.content_type(), Some(Type::String));
@@ -367,7 +536,7 @@ mod tests {
         let json = r#"{ "the": "person/name" }"#;
         let attr: AttributeDescriptor = serde_json::from_str(json).unwrap();
         assert_eq!(attr.domain(), "person");
-        assert_eq!(attr.name(), "name");
+        assert_eq!(attr.name(), Some("name"));
         assert_eq!(attr.description(), "");
         assert_eq!(attr.cardinality(), Cardinality::One);
         assert_eq!(attr.content_type(), None);
@@ -484,5 +653,155 @@ mod tests {
             result.is_err(),
             "should reject non-string cardinality value"
         );
+    }
+}
+
+#[cfg(test)]
+mod collection_tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::the;
+    use dialog_artifacts::NameShape;
+    use std::str::FromStr;
+
+    fn domain() -> Symbol {
+        Symbol::from_str("todo.list").expect("a valid domain")
+    }
+
+    fn collection(keyed: Keyed) -> AttributeDescriptor {
+        AttributeDescriptor::over(
+            Relation::collection(domain(), keyed),
+            "the list's members",
+            Cardinality::Many,
+            Some(Type::Entity),
+        )
+    }
+
+    /// A plain attribute selects itself: the query pins `the` to a
+    /// constant, exactly as before collections existed.
+    #[dialog_common::test]
+    fn it_selects_one_attribute_by_constant() {
+        let descriptor = AttributeDescriptor::new(
+            the!("todo.list/title"),
+            "the list's title",
+            Cardinality::One,
+            Some(Type::String),
+        );
+        assert!(
+            matches!(descriptor.the().term(), Term::Constant(_)),
+            "an attribute pins `the`"
+        );
+        assert_eq!(descriptor.domain(), "todo.list");
+        assert_eq!(descriptor.name(), Some("title"));
+    }
+
+    /// A collection selects a whole domain: the query leaves `the` a
+    /// variable, refined by the domain and the key kind, so the scan
+    /// covers exactly the demanded half.
+    #[dialog_common::test]
+    fn it_selects_a_collection_by_refined_variable() {
+        for (keyed, shape) in [
+            (Keyed::Sequence, NameShape::Position),
+            (Keyed::Dictionary, NameShape::Symbol),
+        ] {
+            let descriptor = collection(keyed);
+            let term = descriptor.the().term();
+            assert!(
+                matches!(term, Term::Variable { .. }),
+                "a collection leaves `the` open"
+            );
+            let refinement = term
+                .kind()
+                .as_ref()
+                .and_then(Kind::refinement)
+                .cloned()
+                .expect("the term carries a refinement");
+
+            assert_eq!(
+                refinement.prefix.as_deref(),
+                Some("todo.list/"),
+                "the domain becomes the scan's prefix, separator included"
+            );
+            assert_eq!(
+                refinement.name_shape,
+                Some(shape),
+                "the key kind becomes the name shape"
+            );
+        }
+    }
+
+    /// A collection has no single name: its name half is a per-entry
+    /// key, not part of the selector.
+    #[dialog_common::test]
+    fn it_has_no_name_for_a_collection() {
+        let descriptor = collection(Keyed::Sequence);
+        assert_eq!(descriptor.domain(), "todo.list");
+        assert_eq!(descriptor.name(), None);
+        assert_eq!(descriptor.the().attribute(), None);
+    }
+
+    /// Writing one value to a collection is refused rather than
+    /// guessed at: every entry needs its own key, which the schema
+    /// does not carry.
+    #[dialog_common::test]
+    fn it_refuses_to_write_a_collection_without_a_key() {
+        let descriptor = collection(Keyed::Sequence);
+        let entity = Entity::new().expect("an entity");
+        assert_eq!(
+            descriptor.resolve(Value::Entity(entity)),
+            Err(FieldTypeError::UnkeyedCollection {
+                domain: "todo.list".to_owned()
+            })
+        );
+    }
+
+    /// Adding the collection variant must not move any existing
+    /// attribute's identity: a plain attribute hashes exactly what it
+    /// hashed before, and the two key kinds are distinct from it and
+    /// from each other.
+    #[dialog_common::test]
+    fn it_keeps_identities_distinct_and_stable() {
+        let attribute = AttributeDescriptor::new(
+            the!("todo.list/title"),
+            "",
+            Cardinality::Many,
+            Some(Type::Entity),
+        );
+        let sequence = collection(Keyed::Sequence);
+        let dictionary = collection(Keyed::Dictionary);
+
+        assert_ne!(sequence.hash(), dictionary.hash(), "key kinds differ");
+        assert_ne!(
+            sequence.hash(),
+            attribute.hash(),
+            "a collection is not an attribute"
+        );
+
+        // The encoding a plain attribute produces is the one it
+        // produced before collections existed: domain, name,
+        // cardinality, type — nothing added, nothing reordered.
+        let cbor = attribute.to_cbor_bytes();
+        let decoded: serde_json::Value =
+            serde_ipld_dagcbor::from_slice(&cbor).expect("valid dag-cbor");
+        assert_eq!(decoded["domain"], "todo.list");
+        assert_eq!(decoded["name"], "title");
+    }
+
+    /// The wire form round-trips, and a stored attribute still reads
+    /// as one: `"the": "todo.list/title"` is untagged, so documents
+    /// written before this variant existed load unchanged.
+    #[dialog_common::test]
+    fn it_round_trips_through_serde() {
+        let stored = r#"{"the":"todo.list/title","as":"Entity","cardinality":"one"}"#;
+        let attribute: AttributeDescriptor =
+            serde_json::from_str(stored).expect("a stored attribute still loads");
+        assert_eq!(attribute.name(), Some("title"));
+
+        let sequence = collection(Keyed::Sequence);
+        let json = serde_json::to_string(&sequence).expect("serializes");
+        let back: AttributeDescriptor = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, sequence, "a collection survives the round trip");
     }
 }

--- a/rust/dialog-query/src/attribute/descriptor.rs
+++ b/rust/dialog-query/src/attribute/descriptor.rs
@@ -13,6 +13,7 @@ use dialog_artifacts::{NameShape, Symbol};
 use base58::ToBase58;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
 
 /// A validated attribute–value pair with its cardinality, produced by
 /// [`AttributeDescriptor::resolve`]. Used inside [`ConceptStatement`](crate::concept::descriptor::ConceptStatement)
@@ -161,11 +162,85 @@ impl Relation {
             Relation::Collection { .. } => None,
         }
     }
+
+    /// The attribute one entry of a collection is written under:
+    /// `domain/key`, where the key must have the collection's name
+    /// shape — a position for a sequence, a symbol for a dictionary.
+    /// A plain attribute ignores the key and is its own entry.
+    pub fn entry(&self, key: &str) -> Result<ArtifactsAttribute, FieldTypeError> {
+        match self {
+            Relation::Attribute(the) => Ok(ArtifactsAttribute::from(the)),
+            Relation::Collection { domain, keyed } => {
+                let mismatch = || FieldTypeError::KeyShape {
+                    domain: domain.as_str().to_owned(),
+                    key: key.to_owned(),
+                    keyed: *keyed,
+                };
+                let attribute = ArtifactsAttribute::try_from(format!("{}/{key}", domain.as_str()))
+                    .map_err(|_| mismatch())?;
+                let (_, name) = attribute.split().map_err(|_| mismatch())?;
+                if name.shape() != NameShape::from(*keyed) {
+                    return Err(mismatch());
+                }
+                Ok(attribute)
+            }
+        }
+    }
 }
 
 impl From<The> for Relation {
     fn from(the: The) -> Self {
         Relation::Attribute(the)
+    }
+}
+
+/// A relation spells as an attribute does, `domain/name`, with a
+/// collection's name half naming the key kind in brackets:
+/// `todo.list/[position]` for a sequence, `todo.list/[symbol]` for a
+/// dictionary — the same bracket the declaration form uses. A
+/// bracketed name can never be a stored attribute's name, so the two
+/// forms are disjoint and the spelling round-trips.
+impl Display for Relation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Relation::Attribute(the) => write!(f, "{the}"),
+            Relation::Collection { domain, keyed } => {
+                write!(f, "{}/{}", domain.as_str(), keyed.bracketed())
+            }
+        }
+    }
+}
+
+impl Keyed {
+    /// The bracketed key kind a collection's name slot spells:
+    /// `[position]` or `[symbol]`.
+    pub fn bracketed(self) -> &'static str {
+        match self {
+            Keyed::Sequence => "[position]",
+            Keyed::Dictionary => "[symbol]",
+        }
+    }
+
+    fn from_bracketed(name: &str) -> Option<Keyed> {
+        match name {
+            "[position]" => Some(Keyed::Sequence),
+            "[symbol]" => Some(Keyed::Dictionary),
+            _ => None,
+        }
+    }
+}
+
+impl FromStr for Relation {
+    type Err = <The as FromStr>::Err;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        if let Some((domain, name)) = text.split_once('/')
+            && let Some(keyed) = Keyed::from_bracketed(name)
+            && let Ok(domain) = Symbol::from_str(domain)
+        {
+            return Ok(Relation::Collection { domain, keyed });
+        }
+        text.parse::<The>().map(Relation::Attribute)
     }
 }
 
@@ -469,18 +544,6 @@ impl From<AttributeDescriptor> for ArtifactsAttribute {
     }
 }
 
-impl Display for Relation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Relation::Attribute(the) => write!(f, "{the}"),
-            Relation::Collection { domain, keyed } => match keyed {
-                Keyed::Dictionary => write!(f, "{}/<symbol>", domain.as_str()),
-                Keyed::Sequence => write!(f, "{}/<position>", domain.as_str()),
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -711,6 +774,31 @@ mod collection_tests {
             Cardinality::Many,
             Some(Type::Entity),
         )
+    }
+
+    /// A relation spells as `domain/name`, a collection with its key
+    /// kind bracketed, and either form parses back.
+    #[dialog_common::test]
+    fn it_spells_and_parses_a_relation() {
+        let sequence = Relation::collection(
+            Symbol::from_str("todo.list").expect("a valid domain"),
+            Keyed::Sequence,
+        );
+        assert_eq!(sequence.to_string(), "todo.list/[position]");
+        let parse = |text: &str| text.parse::<Relation>().expect("a relation parses");
+        assert_eq!(parse("todo.list/[position]"), sequence);
+        assert_eq!(
+            parse("todo.list/[symbol]"),
+            Relation::collection(
+                Symbol::from_str("todo.list").expect("a valid domain"),
+                Keyed::Dictionary
+            )
+        );
+        assert_eq!(
+            parse("todo.list/title"),
+            Relation::Attribute(the!("todo.list/title"))
+        );
+        assert!("todo.list/[list]".parse::<Relation>().is_err());
     }
 
     /// A plain attribute selects itself: the query pins `the` to a

--- a/rust/dialog-query/src/attribute/expression/typed.rs
+++ b/rust/dialog-query/src/attribute/expression/typed.rs
@@ -223,7 +223,7 @@ where
         let value: Term<A::Type> = is.into();
         let descriptor = <A as Descriptor<AttributeDescriptor>>::descriptor();
         let query = DynamicAttributeQuery::new(
-            descriptor.the().term(),
+            descriptor.the().term("the"),
             of.into(),
             value.into(),
             cause.as_cause_term(),

--- a/rust/dialog-query/src/attribute/expression/typed.rs
+++ b/rust/dialog-query/src/attribute/expression/typed.rs
@@ -12,7 +12,10 @@ use std::iter;
 use std::marker::PhantomData;
 use std::ops::Not;
 
-use crate::artifact::Value;
+/// A `#[derive(Attribute)]` type always names one concrete
+/// attribute; the keyed-collection variant has no derive path.
+const STATIC_ATTRIBUTE: &str = "a derived attribute names one relation";
+
 use crate::attribute::query::dynamic::DynamicAttributeQuery;
 
 use super::ExpressionCause;
@@ -159,13 +162,15 @@ where
     fn assert(self, update: &mut impl Update) {
         let (of, is, _) = self.into_parts();
         let desc = <A as Descriptor<AttributeDescriptor>>::descriptor();
-        let the = desc.the().clone();
+        // A `#[derive(Attribute)]` type names one concrete attribute:
+        // there is no derive path that produces a keyed collection.
+        let the = desc.the().attribute().expect(STATIC_ATTRIBUTE);
         let attr: A = is.into();
         let value = attr.value().clone().into();
         if desc.cardinality() == Cardinality::One {
-            update.associate_unique(the.into(), of, value);
+            update.associate_unique(the, of, value);
         } else {
-            update.associate(the.into(), of, value);
+            update.associate(the, of, value);
         }
     }
 
@@ -173,7 +178,11 @@ where
         let (of, is, _) = self.into_parts();
         let desc = <A as Descriptor<AttributeDescriptor>>::descriptor();
         let attr: A = is.into();
-        update.dissociate(desc.the().clone().into(), of, attr.value().clone().into());
+        update.dissociate(
+            desc.the().attribute().expect(STATIC_ATTRIBUTE),
+            of,
+            attr.value().clone().into(),
+        );
     }
 }
 
@@ -191,7 +200,7 @@ where
         let desc = <A as Descriptor<AttributeDescriptor>>::descriptor();
         let attr: A = is.into();
         iter::once(DynamicAttributeExpression {
-            the: desc.the().clone(),
+            the: desc.the().attribute().expect(STATIC_ATTRIBUTE).into(),
             of,
             is: attr.value().clone().into(),
             cause,
@@ -214,7 +223,7 @@ where
         let value: Term<A::Type> = is.into();
         let descriptor = <A as Descriptor<AttributeDescriptor>>::descriptor();
         let query = DynamicAttributeQuery::new(
-            Term::Constant(Value::from(descriptor.the().clone())),
+            descriptor.the().term(),
             of.into(),
             value.into(),
             cause.as_cause_term(),
@@ -255,7 +264,7 @@ where
         let desc = <A as Descriptor<AttributeDescriptor>>::descriptor();
         let attr: A = is.into();
         DynamicAttributeExpression {
-            the: desc.the().clone(),
+            the: desc.the().attribute().expect(STATIC_ATTRIBUTE).into(),
             of,
             is: attr.value().clone().into(),
             cause,

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -220,14 +220,27 @@ impl AttributeQueryAll {
     /// Returns the schema describing this application's parameters.
     pub fn schema(&self) -> Schema {
         let requirement = Requirement::new_group();
+        // A ranged attribute slot (a variable refined by a domain
+        // prefix) constrains the scan by itself: the AEV range over
+        // the prefix is the lookup, and every slot is derived from
+        // what it yields. Otherwise one of the slots has to be
+        // supplied for the scan to be more than a full sweep.
+        let slot = if self.the.is_ranged() {
+            Requirement::Optional
+        } else {
+            requirement.required()
+        };
         let mut schema = Schema::new();
 
+        // The slot carries the term's own kind, so a domain-refined
+        // attribute variable keeps its refinement through inference
+        // and the planner's re-stamping — the same way `is` does.
         schema.insert(
             "the".to_string(),
             Field {
                 description: "The relation identifier".to_string(),
-                content_type: Some(Kind::from(Type::Symbol)),
-                requirement: requirement.required(),
+                content_type: Some(self.the.kind().unwrap_or_else(|| Kind::from(Type::Symbol))),
+                requirement: slot.clone(),
                 cardinality: Cardinality::One,
             },
         );
@@ -237,7 +250,7 @@ impl AttributeQueryAll {
             Field {
                 description: "Entity of the relation".to_string(),
                 content_type: Some(Kind::from(Type::Entity)),
-                requirement: requirement.required(),
+                requirement: slot.clone(),
                 cardinality: Cardinality::One,
             },
         );
@@ -249,7 +262,7 @@ impl AttributeQueryAll {
             Field {
                 description: "Value of the relation".to_string(),
                 content_type: self.is.kind(),
-                requirement: requirement.required(),
+                requirement: slot.clone(),
                 cardinality: Cardinality::One,
             },
         );
@@ -259,7 +272,7 @@ impl AttributeQueryAll {
             Field {
                 description: "Causal stamp of the relation".to_string(),
                 content_type: Some(Kind::from(Type::Bytes)),
-                requirement: requirement.required(),
+                requirement: slot,
                 cardinality: Cardinality::One,
             },
         );
@@ -269,7 +282,10 @@ impl AttributeQueryAll {
 
     /// Estimate cost for Cardinality::Many semantics.
     pub fn estimate(&self, env: &Environment) -> Option<usize> {
-        let the = self.the.is_bound(env);
+        // A ranged attribute costs as a bound one: the prefix range
+        // is an AEV lookup, wider than one attribute's but the same
+        // access path.
+        let the = self.the.is_bound(env) || self.the.is_ranged();
         let of = self.of.is_bound(env);
         let is = self.is.is_bound(env);
 

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -1072,6 +1072,82 @@ mod tests {
         Ok(())
     }
 
+    /// A name-shape refinement survives a JSON round trip and still
+    /// drives the scan. This is the `/query` endpoint's path: a
+    /// request body carries `Term`s, and a term serializes its full
+    /// `type_system::Type` — so a keyed-collection query (a domain
+    /// prefix plus a name shape) is expressible over the wire
+    /// without the stored `AttributeDescriptor` declaring it.
+    #[dialog_common::test]
+    async fn it_preserves_a_name_shape_scan_across_a_json_round_trip() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        // One domain, both name shapes: a dictionary entry plus two
+        // ordered members. Position names are uppercase, outside the
+        // `the!` notation, so they are composed at runtime.
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        let second = The::from(ArtifactsAttribute::try_from("todo.list/N5".to_string())?);
+        branch
+            .transaction()
+            .assert(
+                the!("todo.list/title")
+                    .of(list.clone())
+                    .is("Groceries".to_string()),
+            )
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .assert(second.of(list.clone()).is("Bread".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let scan = |shape: NameShape| -> anyhow::Result<AttributeQueryAll> {
+            let kind = Kind::from(Type::Symbol)
+                .with_prefix("todo.list/")
+                .expect("symbol is textual")
+                .with_name_shape(shape)
+                .expect("shapes compose with prefixes");
+            let term: Term<The> = Term::<The>::var("a").with_kind(kind);
+            let restored: Term<The> = serde_json::from_str(&serde_json::to_string(&term)?)?;
+            assert_eq!(restored, term, "the refined term survives the round trip");
+            Ok(AttributeQueryAll::new(
+                restored,
+                Term::<Entity>::var("e"),
+                Term::var("v"),
+                Term::var("cause"),
+            ))
+        };
+
+        let members = scan(NameShape::Position)?
+            .perform(&source)
+            .try_vec()
+            .await?;
+        // `Value` has no `Ord`, so compare the rendered forms.
+        let mut ordered: Vec<String> = members
+            .iter()
+            .map(|row| format!("{:?}", row.is()))
+            .collect();
+        ordered.sort();
+        assert_eq!(
+            ordered,
+            vec![
+                format!("{:?}", Value::String("Bread".to_string())),
+                format!("{:?}", Value::String("Milk".to_string())),
+            ],
+            "the ordered half, after the wire hop"
+        );
+
+        let entries = scan(NameShape::Symbol)?.perform(&source).try_vec().await?;
+        assert_eq!(entries.len(), 1, "only the symbol-named entry matches");
+        assert_eq!(entries[0].is(), &Value::String("Groceries".to_string()));
+
+        Ok(())
+    }
+
     #[dialog_common::test]
     async fn it_keeps_symbol_matches_under_prefix_pushdown() -> anyhow::Result<()> {
         let (operator, profile) = test_operator_with_profile().await;

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -169,7 +169,7 @@ impl AttributeQueryOnly {
     /// VERIFY overhead for VAE-based lookups, so no additional adjustment
     /// is needed here.
     pub fn estimate(&self, env: &Environment) -> Option<usize> {
-        let the = self.the().is_bound(env);
+        let the = self.the().is_bound(env) || self.the().is_ranged();
         let of = self.of().is_bound(env);
         let is = self.is().is_bound(env);
 

--- a/rust/dialog-query/src/attribute/query/typed.rs
+++ b/rust/dialog-query/src/attribute/query/typed.rs
@@ -63,7 +63,7 @@ where
     fn from(query: StaticAttributeQuery<A>) -> Self {
         let descriptor = <A as Descriptor<AttributeDescriptor>>::descriptor();
         DynamicAttributeQuery::new(
-            descriptor.the().term(),
+            descriptor.the().term("the"),
             query.of,
             query.is.into(),
             Term::blank(),

--- a/rust/dialog-query/src/attribute/query/typed.rs
+++ b/rust/dialog-query/src/attribute/query/typed.rs
@@ -63,7 +63,7 @@ where
     fn from(query: StaticAttributeQuery<A>) -> Self {
         let descriptor = <A as Descriptor<AttributeDescriptor>>::descriptor();
         DynamicAttributeQuery::new(
-            Term::Constant(Value::from(descriptor.the().clone())),
+            descriptor.the().term(),
             query.of,
             query.is.into(),
             Term::blank(),

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -163,7 +163,11 @@ where
     fn push_statements(&self, this: Entity, buf: &mut Vec<AttributeStatement>) {
         let descriptor = <Self as Descriptor<AttributeDescriptor>>::descriptor();
         let expr = AttributeStatement {
-            the: descriptor.the().clone(),
+            the: descriptor
+                .the()
+                .attribute()
+                .expect("a derived attribute names one relation")
+                .into(),
             of: this,
             is: <<N as Attribute>::Type as Into<Value>>::into(
                 <Self as Attribute>::value(self).clone(),
@@ -236,7 +240,11 @@ where
         if let Some(inner) = self.as_ref() {
             let descriptor = <N as Descriptor<AttributeDescriptor>>::descriptor();
             let expr = AttributeStatement {
-                the: descriptor.the().clone(),
+                the: descriptor
+                    .the()
+                    .attribute()
+                    .expect("a derived attribute names one relation")
+                    .into(),
                 of: this,
                 is: <<N as Attribute>::Type as Into<Value>>::into(
                     <N as Attribute>::value(inner).clone(),
@@ -1744,7 +1752,7 @@ mod tests {
     #[dialog_common::test]
     fn it_derives_attribute_name_as_kebab_case() {
         // Kind struct should derive name from struct name via kebab-case
-        assert_eq!(item::Kind::descriptor().name(), "kind");
+        assert_eq!(item::Kind::descriptor().name(), Some("kind"));
     }
 
     #[dialog_common::test]
@@ -1765,7 +1773,7 @@ mod tests {
     #[dialog_common::test]
     fn it_leaves_unrenamed_attribute_unchanged() {
         // Name without rename should behave normally
-        assert_eq!(item::Name::descriptor().name(), "name");
+        assert_eq!(item::Name::descriptor().name(), Some("name"));
         assert_eq!(item::Name::descriptor().domain(), "item");
     }
 
@@ -1801,7 +1809,7 @@ mod tests {
         );
 
         // The 'type' key should point to the item/kind attribute (attribute name is "kind")
-        assert_eq!(type_attr.unwrap().1.name(), "kind");
+        assert_eq!(type_attr.unwrap().1.name(), Some("kind"));
         assert_eq!(type_attr.unwrap().1.domain(), "item");
     }
 
@@ -1897,7 +1905,7 @@ mod tests {
     #[dialog_common::test]
     fn it_combines_concept_rename_with_attribute() {
         // Attribute name is derived from struct name (no rename on attributes)
-        assert_eq!(task::Reference::descriptor().name(), "reference");
+        assert_eq!(task::Reference::descriptor().name(), Some("reference"));
         assert_eq!(task::Reference::the().to_string(), "task/reference");
 
         // Concept descriptor should have "ref" key (concept field rename)
@@ -1906,6 +1914,6 @@ mod tests {
         let ref_attr = attrs.iter().find(|(k, _)| *k == "ref");
         assert!(ref_attr.is_some(), "Should have 'ref' key in descriptor");
         // The attribute descriptor's name is still "reference" (no attribute rename)
-        assert_eq!(ref_attr.unwrap().1.name(), "reference");
+        assert_eq!(ref_attr.unwrap().1.name(), Some("reference"));
     }
 }

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -4,8 +4,9 @@ pub use named_attributes::{ConceptFieldDescriptor, NamedAttributes};
 
 use std::iter;
 
+use crate::Binding;
 use crate::Predicate;
-use crate::attribute::{AttributeDescriptor, Attribution};
+use crate::attribute::{AttributeDescriptor, Attribution, Relation};
 use crate::concept::query::ConceptQuery;
 use crate::concept::{Concept, Conclusion};
 use crate::error::TypeError;
@@ -14,6 +15,7 @@ use crate::selection::{Match, Selection};
 use crate::statement::Retraction;
 use crate::term::Term;
 use crate::type_system::{ConceptRef, Primitive, Type as Kind};
+use crate::types::Any;
 use crate::types::Scalar;
 use crate::{
     Cardinality, Entity, EvaluationError, Field, Parameters, Proposition, Requirement, Schema,
@@ -111,13 +113,44 @@ impl ConceptDescriptor {
     /// `Absent`, so they are not subject to the required-head
     /// grounding check. Use [`Self::with`] to enumerate every
     /// attribute including optional ones.
-    pub fn required_operands(&self) -> impl Iterator<Item = &str> {
-        iter::once("this").chain(
+    pub fn required_operands(&self) -> impl Iterator<Item = String> + '_ {
+        iter::once("this".to_string()).chain(
             self.with()
                 .iter()
                 .filter(|(_, attribute)| !attribute.is_optional())
-                .map(|(name, _)| name),
+                .flat_map(|(name, field)| Self::field_operands(name, field)),
         )
+    }
+
+    /// Every operand of this concept: `this`, each field, and the
+    /// key operand of each keyed-collection field.
+    pub fn operands(&self) -> impl Iterator<Item = String> + '_ {
+        iter::once("this".to_string()).chain(
+            self.with()
+                .iter()
+                .flat_map(|(name, field)| Self::field_operands(name, field)),
+        )
+    }
+
+    /// The operands one field contributes: its own name, plus the
+    /// key operand when it is a keyed collection. A collection
+    /// entry is a `(key, value)` pair, and both halves are bound by
+    /// the concept's own rule, so both are operands a query may
+    /// bind and a conclusion carries.
+    fn field_operands(name: &str, field: &ConceptFieldDescriptor) -> Vec<String> {
+        match field.the() {
+            Relation::Attribute(_) => vec![name.to_string()],
+            Relation::Collection { .. } => {
+                vec![name.to_string(), Relation::key_operand(name)]
+            }
+        }
+    }
+
+    /// The keyed-collection fields of this concept.
+    pub fn collections(&self) -> impl Iterator<Item = (&str, &ConceptFieldDescriptor)> {
+        self.with()
+            .iter()
+            .filter(|(_, field)| field.the().attribute().is_none())
     }
 
     /// Derives a `Schema` from this descriptor's attributes.
@@ -356,6 +389,23 @@ impl From<&ConceptDescriptor> for Schema {
             );
         }
 
+        // A collection field's key rides as its own operand: the
+        // name half of the matched attribute, bound by the concept's
+        // rule through `dialog/attribute-parts`. Text, because a
+        // position and a symbol are both spelled as text once split
+        // from the domain.
+        for (name, field) in predicate.collections() {
+            schema.insert(
+                Relation::key_operand(name),
+                Field {
+                    description: format!("The key of an entry of {name}"),
+                    content_type: Some(Kind::from(Type::String)),
+                    requirement: Requirement::Optional,
+                    cardinality: field.cardinality(),
+                },
+            );
+        }
+
         if !schema.contains("this") {
             schema.insert(
                 "this".into(),
@@ -469,11 +519,46 @@ impl<'a> Builder<'a> {
 /// Field values are accessed by the term bindings from the query.
 /// The `terms` map provides the mapping from field names to variable terms
 /// used in the match.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ConceptConclusion {
     this: Entity,
     terms: Parameters,
     source: Match,
+}
+
+/// A conclusion is a row: its identity is the entity plus the value
+/// each operand resolved to. Whether an operand was supplied as a
+/// constant or bound through a variable is how the row was *asked
+/// for*, not what it *is* — a subscription re-deriving one entity
+/// pins `this` to a constant, and the rows it yields must still
+/// compare equal to the ones retained from the open query, or every
+/// maintenance emits a retract-and-reassert of unchanged rows.
+impl PartialEq for ConceptConclusion {
+    fn eq(&self, other: &Self) -> bool {
+        self.this == other.this && self.values() == other.values()
+    }
+}
+
+impl ConceptConclusion {
+    /// Each operand's resolved value, `None` when absent or unbound.
+    fn values(&self) -> BTreeMap<&str, Option<Value>> {
+        self.terms
+            .iter()
+            .map(|(operand, term)| {
+                let value = match term {
+                    Term::Constant(value) => Some(value.clone()),
+                    Term::Variable {
+                        name: Some(name), ..
+                    } => match self.source.lookup(&Term::<Any>::var(name.clone())) {
+                        Ok(Binding::Present(value)) => Some(value),
+                        _ => None,
+                    },
+                    Term::Variable { name: None, .. } => None,
+                };
+                (operand.as_str(), value)
+            })
+            .collect()
+    }
 }
 
 impl ConceptConclusion {

--- a/rust/dialog-query/src/concept/descriptor.rs
+++ b/rust/dialog-query/src/concept/descriptor.rs
@@ -728,7 +728,7 @@ mod tests {
             .map(|(_, v)| v)
             .expect("Should have email attribute");
         assert_eq!(email_attr.domain(), "person");
-        assert_eq!(email_attr.name(), "email");
+        assert_eq!(email_attr.name(), Some("email"));
         assert_eq!(email_attr.description(), "Person's email address");
         assert_eq!(email_attr.content_type(), Some(Type::String));
 
@@ -739,7 +739,7 @@ mod tests {
             .map(|(_, v)| v)
             .expect("Should have active attribute");
         assert_eq!(active_attr.domain(), "person");
-        assert_eq!(active_attr.name(), "active");
+        assert_eq!(active_attr.name(), Some("active"));
         assert_eq!(active_attr.description(), "Whether person is active");
         assert_eq!(active_attr.content_type(), Some(Type::Boolean));
     }
@@ -1196,7 +1196,7 @@ mod tests {
         let (name, attr) = concept.with().iter().next().unwrap();
         assert_eq!(name, "status");
         assert_eq!(attr.domain(), "task");
-        assert_eq!(attr.name(), "status");
+        assert_eq!(attr.name(), Some("status"));
     }
 
     #[dialog_common::test]

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -1,6 +1,7 @@
 use crate::Cardinality;
 use crate::artifact::Type;
-use crate::attribute::{AttributeDescriptor, The};
+use crate::attribute::AttributeDescriptor;
+use crate::attribute::Relation;
 use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::TypeError;
 use serde::de::Error as _;
@@ -117,8 +118,9 @@ impl ConceptFieldDescriptor {
         self.conforms.as_deref()
     }
 
-    /// Convenience: the attribute's relation identifier.
-    pub fn the(&self) -> &The {
+    /// Convenience: what this field selects — one attribute, or every
+    /// entry of a keyed collection.
+    pub fn the(&self) -> &Relation {
         self.descriptor.the()
     }
 
@@ -127,8 +129,9 @@ impl ConceptFieldDescriptor {
         self.descriptor.domain()
     }
 
-    /// Convenience: the attribute's name.
-    pub fn name(&self) -> &str {
+    /// Convenience: the attribute's name, or `None` for a keyed
+    /// collection, whose name half varies per entry.
+    pub fn name(&self) -> Option<&str> {
         self.descriptor.name()
     }
 

--- a/rust/dialog-query/src/concept/descriptor/named_attributes.rs
+++ b/rust/dialog-query/src/concept/descriptor/named_attributes.rs
@@ -210,6 +210,11 @@ impl NamedAttributes {
             return Err(TypeError::EmptyConcept);
         }
         for field in map.values() {
+            if field.is_optional() && field.the().attribute().is_none() {
+                return Err(TypeError::OptionalCollection {
+                    domain: field.domain().to_string(),
+                });
+            }
             if let Some(target) = field.conforms() {
                 if field.content_type() != Some(Type::Entity) {
                     return Err(TypeError::NonEntityConformance {

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -14,17 +14,20 @@ pub use rules::ConceptRules;
 
 use std::fmt;
 
+use crate::attribute::Relation;
 use crate::concept::descriptor::{ConceptDescriptor, ConceptFieldDescriptor};
 use crate::planner::Disjunction;
 use crate::rule::deductive::DeductiveRule;
 use crate::schema::CONCEPT_OVERHEAD;
 use crate::selection::Selection;
 use crate::source::SelectRules;
+use crate::types::Any;
 use crate::{
     Binding, Cardinality, Environment, EvaluationError, Match, Parameters, Schema, Term, try_stream,
 };
 use dialog_capability::Provider;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt::Display;
 
 /// Extract a Match with parameter names from a Match with user
@@ -106,14 +109,119 @@ fn merge_parameters(
 ///
 /// Serializes as the formal notation:
 /// `{ "assert": <ConceptDescriptor>, "where": <Parameters> }`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// A keyed-collection field is bound as an **entry**: under the field,
+/// `{"the": <key term>, "is": <value term>}` — a mini fact, in the
+/// slots an attribute query already uses. Internally the pair is two
+/// operands, the field and its key operand
+/// ([`Relation::key_operand`]), and the two forms convert on the
+/// wire: the entry is what a document holds, the operands are what
+/// the rule binds.
+#[derive(Debug, Clone, PartialEq)]
 pub struct ConceptQuery {
     /// The concept predicate being applied.
-    #[serde(rename = "assert")]
     pub predicate: ConceptDescriptor,
     /// The term bindings for this concept application.
-    #[serde(rename = "where")]
     pub terms: Parameters,
+}
+
+/// One binding of a `where` map on the wire: a term, or a
+/// collection entry.
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum Bound {
+    Entry {
+        #[serde(default = "Term::blank", skip_serializing_if = "Term::is_blank")]
+        the: Term<Any>,
+        #[serde(default = "Term::blank", skip_serializing_if = "Term::is_blank")]
+        is: Term<Any>,
+    },
+    Term(Term<Any>),
+}
+
+#[derive(Serialize)]
+struct ConceptQueryOut<'a> {
+    assert: &'a ConceptDescriptor,
+    #[serde(rename = "where")]
+    terms: BTreeMap<&'a str, Bound>,
+}
+
+#[derive(Deserialize)]
+struct ConceptQueryIn {
+    assert: ConceptDescriptor,
+    #[serde(rename = "where")]
+    terms: BTreeMap<String, serde_json::Value>,
+}
+
+impl Serialize for ConceptQuery {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut terms: BTreeMap<&str, Bound> = BTreeMap::new();
+        let mut keys: BTreeMap<String, &str> = BTreeMap::new();
+        for (name, _) in self.predicate.collections() {
+            keys.insert(Relation::key_operand(name), name);
+        }
+        for (name, term) in self.terms.iter() {
+            if let Some(field) = keys.get(name) {
+                // The key half of an entry: folded under its field.
+                let is = self.terms.get(field).cloned().unwrap_or_else(Term::blank);
+                terms.insert(
+                    field,
+                    Bound::Entry {
+                        the: term.clone(),
+                        is,
+                    },
+                );
+            } else if self.predicate.collections().any(|(field, _)| field == name) {
+                terms.entry(name).or_insert_with(|| Bound::Entry {
+                    the: Term::blank(),
+                    is: term.clone(),
+                });
+            } else {
+                terms.insert(name, Bound::Term(term.clone()));
+            }
+        }
+        ConceptQueryOut {
+            assert: &self.predicate,
+            terms,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConceptQuery {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+        let raw = ConceptQueryIn::deserialize(deserializer)?;
+        let mut terms = Parameters::new();
+        for (name, value) in raw.terms {
+            let collection = raw.assert.collections().any(|(field, _)| field == name);
+            // An entry object carries `the`/`is` and no `?`; anything
+            // else under a collection field is a bare value term,
+            // which binds every entry (`{_: ?value}`).
+            let entry = collection
+                && value.as_object().is_some_and(|map| {
+                    !map.contains_key("?") && (map.contains_key("the") || map.contains_key("is"))
+                });
+            let bound: Bound = if entry {
+                serde_json::from_value(value).map_err(D::Error::custom)?
+            } else {
+                Bound::Term(serde_json::from_value(value).map_err(D::Error::custom)?)
+            };
+            match bound {
+                Bound::Entry { the, is } => {
+                    terms.insert(Relation::key_operand(&name), the);
+                    terms.insert(name, is);
+                }
+                Bound::Term(term) => {
+                    terms.insert(name, term);
+                }
+            }
+        }
+        Ok(ConceptQuery {
+            predicate: raw.assert,
+            terms,
+        })
+    }
 }
 
 impl ConceptQuery {
@@ -385,6 +493,97 @@ impl Display for ConceptQuery {
 
 #[cfg(test)]
 mod tests {
+    mod entry_form {
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+        use crate::attribute::{AttributeDescriptor, Keyed, Relation};
+        use crate::concept::descriptor::ConceptFieldDescriptor;
+        use crate::{Cardinality, ConceptDescriptor, ConceptQuery, Term, Type};
+        use dialog_artifacts::Symbol;
+        use std::str::FromStr;
+
+        fn ordered() -> ConceptDescriptor {
+            ConceptDescriptor::try_from(vec![(
+                "member".to_owned(),
+                ConceptFieldDescriptor::required(AttributeDescriptor::over(
+                    Relation::collection(
+                        Symbol::from_str("todo.list").expect("a valid domain"),
+                        Keyed::Sequence,
+                    ),
+                    "members",
+                    Cardinality::Many,
+                    Some(Type::String),
+                )),
+            )])
+            .expect("a collection field builds a concept")
+        }
+
+        /// `member: {the: ?key, is: ?member}` on the wire is the two
+        /// operands `member/key` and `member` in the query, and
+        /// writes back as the entry.
+        #[dialog_common::test]
+        fn it_reads_and_writes_a_collection_entry() {
+            let wire = serde_json::json!({
+                "assert": ordered(),
+                "where": {
+                    "this": {"?": {"name": "list"}},
+                    "member": {"the": {"?": {"name": "key"}}, "is": {"?": {"name": "member"}}}
+                }
+            });
+            let query: ConceptQuery = serde_json::from_value(wire.clone()).expect("parses");
+            assert_eq!(query.terms.get("member/key"), Some(&Term::var("key")));
+            assert_eq!(query.terms.get("member"), Some(&Term::var("member")));
+            assert_eq!(query.terms.get("this"), Some(&Term::var("list")));
+
+            let written = serde_json::to_value(&query).expect("serializes");
+            assert_eq!(
+                written["where"], wire["where"],
+                "the entry form round-trips"
+            );
+        }
+
+        /// A literal key is a constant `the`; a bare term under a
+        /// collection field binds every entry with the key blank, and
+        /// the operand form is accepted on the way in.
+        #[dialog_common::test]
+        fn it_accepts_literal_bare_and_operand_forms() {
+            let literal: ConceptQuery = serde_json::from_value(serde_json::json!({
+                "assert": ordered(),
+                "where": {"member": {"the": "N5", "is": {"?": {"name": "m"}}}}
+            }))
+            .expect("parses");
+            assert_eq!(
+                literal.terms.get("member/key"),
+                Some(&Term::constant("N5".to_string()))
+            );
+
+            let bare: ConceptQuery = serde_json::from_value(serde_json::json!({
+                "assert": ordered(),
+                "where": {"member": {"?": {"name": "m"}}}
+            }))
+            .expect("parses");
+            assert_eq!(bare.terms.get("member"), Some(&Term::var("m")));
+            assert!(bare.terms.get("member/key").is_none());
+            let written = serde_json::to_value(&bare).expect("serializes");
+            assert_eq!(
+                written["where"]["member"],
+                serde_json::json!({"is": {"?": {"name": "m"}}}),
+                "a bare value writes as an entry with no key"
+            );
+
+            let operands: ConceptQuery = serde_json::from_value(serde_json::json!({
+                "assert": ordered(),
+                "where": {
+                    "member": {"?": {"name": "m"}},
+                    "member/key": {"?": {"name": "k"}}
+                }
+            }))
+            .expect("parses");
+            assert_eq!(operands.terms.get("member/key"), Some(&Term::var("k")));
+        }
+    }
+
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
@@ -1012,7 +1211,7 @@ mod tests {
         .unwrap();
         let rule = DeductiveRule::from(&predicate);
 
-        let params: HashSet<&str> = rule.parameters().collect();
+        let params: HashSet<String> = rule.parameters().collect();
         assert!(params.contains("this"));
         assert!(params.contains("name"));
         assert!(params.contains("age"));

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -265,10 +265,9 @@ fn bind_occurrence(matched: &mut Match, occurrence: &ConceptQuery, row: &Row) ->
 /// resolved to `Absent` (or never bound) are omitted.
 pub(crate) fn project(descriptor: &ConceptDescriptor, matched: &Match) -> Row {
     let mut row = Row::new();
-    let operands = iter::once("this").chain(descriptor.with().keys());
-    for operand in operands {
-        if let Ok(Binding::Present(value)) = matched.lookup(&Term::<Any>::var(operand)) {
-            row.insert(operand.to_string(), value);
+    for operand in descriptor.operands() {
+        if let Ok(Binding::Present(value)) = matched.lookup(&Term::<Any>::var(&operand)) {
+            row.insert(operand, value);
         }
     }
     row

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -6,6 +6,7 @@ use std::error;
 use std::fmt;
 
 use crate::artifact::{ArtifactTypeError, DialogArtifactsError, Type, Value};
+use crate::attribute::Keyed;
 pub use crate::environment::Environment;
 pub use crate::proposition::Proposition;
 use crate::reduce::Aggregator;
@@ -62,6 +63,23 @@ pub enum TypeError {
         binding: String,
         /// The collection's domain.
         domain: String,
+    },
+
+    /// A collection entry's key has the wrong name shape for its
+    /// collection.
+    #[error(
+        "Binding \"{binding}\" key {key:?} is not a valid {keyed:?} key for \
+         collection {domain}"
+    )]
+    KeyShape {
+        /// The binding's name.
+        binding: String,
+        /// The collection's domain.
+        domain: String,
+        /// The offending key.
+        key: String,
+        /// The collection's key kind.
+        keyed: Keyed,
     },
 
     /// A required binding was not provided.
@@ -193,20 +211,6 @@ pub enum TypeError {
     NegatedOptional {
         /// The offending rule.
         rule: Box<Rule>,
-    },
-
-    /// A rule concludes into a keyed collection field, which
-    /// induction cannot track. See
-    /// [`AnalysisError::CollectionHead`].
-    #[error(
-        "conclusion field {field} is a keyed collection ({domain}): a rule \
-         cannot derive one"
-    )]
-    CollectionHead {
-        /// The offending head field.
-        field: String,
-        /// The collection's domain.
-        domain: String,
     },
 
     /// A rule negates its own conclusion concept: a negative
@@ -461,6 +465,19 @@ pub enum FieldTypeError {
         /// The collection's domain.
         domain: String,
     },
+    /// A collection entry's key does not have the collection's name
+    /// shape: a sequence is keyed by positions, a dictionary by
+    /// symbols, and a key of the other shape would land in the other
+    /// half of the domain.
+    #[error("key {key:?} is not a valid {keyed:?} key for collection {domain}")]
+    KeyShape {
+        /// The collection's domain.
+        domain: String,
+        /// The offending key.
+        key: String,
+        /// The collection's key kind.
+        keyed: Keyed,
+    },
     /// A required term is missing.
     #[error("Required term is missing")]
     OmittedRequirement,
@@ -486,6 +503,12 @@ impl FieldTypeError {
             FieldTypeError::UnkeyedCollection { domain } => {
                 TypeError::UnkeyedCollection { binding, domain }
             }
+            FieldTypeError::KeyShape { domain, key, keyed } => TypeError::KeyShape {
+                binding,
+                domain,
+                key,
+                keyed,
+            },
             FieldTypeError::OmittedRequirement => TypeError::OmittedRequirement { binding },
             FieldTypeError::BlankRequirement => TypeError::BlankRequirement { binding },
         }
@@ -864,21 +887,6 @@ pub enum AnalysisError {
     Inference {
         /// Description of the conflict.
         reason: String,
-    },
-    /// A rule concludes into a keyed collection field. Induction
-    /// tracks which attributes a rule touches, per attribute; a
-    /// collection spans a domain and has no single attribute to
-    /// track, so a rule deriving one could not be re-evaluated when
-    /// its inputs changed.
-    #[error(
-        "conclusion field {field} is a keyed collection ({domain}): a rule \
-         cannot derive one"
-    )]
-    CollectionHead {
-        /// The offending head field.
-        field: String,
-        /// The collection's domain.
-        domain: String,
     },
     /// A conclusion variable's inferred type admits `Nothing`:
     /// the rule could produce `Absent` in a required slot.

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -52,6 +52,18 @@ pub enum TypeError {
         actual: Box<Term<Any>>,
     },
 
+    /// A keyed collection field was asked to produce one fact.
+    #[error(
+        "Binding \"{binding}\" is the keyed collection {domain}: every \
+         entry needs its own key, so it cannot take a single value"
+    )]
+    UnkeyedCollection {
+        /// The binding's name.
+        binding: String,
+        /// The collection's domain.
+        domain: String,
+    },
+
     /// A required binding was not provided.
     #[error("Required binding \"{binding}\" was omitted")]
     OmittedRequirement {
@@ -168,6 +180,20 @@ pub enum TypeError {
     NegatedOptional {
         /// The offending rule.
         rule: Box<Rule>,
+    },
+
+    /// A rule concludes into a keyed collection field, which
+    /// induction cannot track. See
+    /// [`AnalysisError::CollectionHead`].
+    #[error(
+        "conclusion field {field} is a keyed collection ({domain}): a rule \
+         cannot derive one"
+    )]
+    CollectionHead {
+        /// The offending head field.
+        field: String,
+        /// The collection's domain.
+        domain: String,
     },
 
     /// A rule negates its own conclusion concept: a negative
@@ -411,6 +437,17 @@ pub enum FieldTypeError {
         /// Actual term provided.
         actual: Box<Term<Any>>,
     },
+    /// A collection field was asked to produce one fact. Its facts
+    /// are keyed per entry, so the key comes from the writer rather
+    /// than from the schema.
+    #[error(
+        "Cannot write a single fact for the keyed collection {domain}: \
+         every entry needs its own key"
+    )]
+    UnkeyedCollection {
+        /// The collection's domain.
+        domain: String,
+    },
     /// A required term is missing.
     #[error("Required term is missing")]
     OmittedRequirement,
@@ -433,6 +470,9 @@ impl FieldTypeError {
                 expected,
                 actual,
             },
+            FieldTypeError::UnkeyedCollection { domain } => {
+                TypeError::UnkeyedCollection { binding, domain }
+            }
             FieldTypeError::OmittedRequirement => TypeError::OmittedRequirement { binding },
             FieldTypeError::BlankRequirement => TypeError::BlankRequirement { binding },
         }
@@ -811,6 +851,21 @@ pub enum AnalysisError {
     Inference {
         /// Description of the conflict.
         reason: String,
+    },
+    /// A rule concludes into a keyed collection field. Induction
+    /// tracks which attributes a rule touches, per attribute; a
+    /// collection spans a domain and has no single attribute to
+    /// track, so a rule deriving one could not be re-evaluated when
+    /// its inputs changed.
+    #[error(
+        "conclusion field {field} is a keyed collection ({domain}): a rule \
+         cannot derive one"
+    )]
+    CollectionHead {
+        /// The offending head field.
+        field: String,
+        /// The collection's domain.
+        domain: String,
     },
     /// A conclusion variable's inferred type admits `Nothing`:
     /// the rule could produce `Absent` in a required slot.

--- a/rust/dialog-query/src/error.rs
+++ b/rust/dialog-query/src/error.rs
@@ -121,6 +121,19 @@ pub enum TypeError {
         /// The offending attribute selector.
         the: String,
     },
+    /// A keyed collection field is marked optional. A collection's
+    /// key is projected by a formula over the matched attribute, and
+    /// a formula filters an `Absent` input, so an optional collection
+    /// could never yield the widened row it promises. A collection
+    /// is already zero-or-more; leave it required.
+    #[error(
+        "collection field over {domain} is optional; a keyed collection is \
+         zero-or-more already and cannot be widened"
+    )]
+    OptionalCollection {
+        /// The collection's domain.
+        domain: String,
+    },
 
     /// A rule declares a parameter that none of its premises use.
     #[error("Rule {rule} does not use parameter \"{parameter}\"")]

--- a/rust/dialog-query/src/formula.rs
+++ b/rust/dialog-query/src/formula.rs
@@ -32,6 +32,8 @@ pub mod math;
 /// String manipulation formulas (concatenate, length, uppercase, lowercase, like)
 pub mod string;
 
+/// Attribute decomposition (attribute-parts)
+pub mod attribute;
 /// Index-key decomposition formulas (key-part, separator-part)
 pub mod key;
 /// Fractional-position formulas for ordered relations
@@ -39,6 +41,7 @@ pub mod position;
 /// Version-control revision record projections (revision, revision-parent)
 pub mod revision;
 
+pub use attribute::AttributeParts as AttributePartsFormula;
 pub use conversions::{ParseFloat, ParseSignedInteger, ParseUnsignedInteger, ToString};
 pub use key::{KeyPart as KeyPartFormula, SeparatorPart as SeparatorPartFormula};
 pub use logic::{And, Not, Or};

--- a/rust/dialog-query/src/formula/attribute.rs
+++ b/rust/dialog-query/src/formula/attribute.rs
@@ -1,0 +1,85 @@
+//! Attribute decomposition: `dialog/attribute-parts` splits an
+//! attribute into its domain and name halves.
+//!
+//! This is how a keyed collection's key reaches an author. The
+//! collection's scan binds the whole attribute (`todo.list/N5`) to an
+//! internal variable; this formula projects the name half (`N5`) onto
+//! the field's key operand, so `{?key: ?value}` binds the key as a
+//! plain text term that joins, filters, and feeds `dialog/position`
+//! like any other. Unlike [`PositionParts`](super::position::PositionParts)
+//! it admits both name shapes, because a dictionary's keys are
+//! symbols and a sequence's are positions.
+
+use dialog_artifacts::{Attribute, Name};
+
+use crate::Formula;
+use crate::formula::Input;
+
+/// Split an attribute into `domain` and `name`. Registered as
+/// `dialog/attribute-parts`.
+#[derive(Debug, Clone, Formula)]
+pub struct AttributeParts {
+    /// The attribute, as bound by a scan's `the` slot.
+    pub of: Attribute,
+    /// The domain half.
+    #[output]
+    pub domain: String,
+    /// The name half: a symbol for a named predicate, a position for
+    /// an ordered member.
+    #[output]
+    pub name: String,
+}
+
+impl AttributeParts {
+    /// One row per attribute; an attribute that does not split (which
+    /// a stored one never is) projects nothing.
+    pub fn compute(input: Input<Self>) -> Vec<Self> {
+        match input.of.split() {
+            Ok((domain, name)) => {
+                let name = match name {
+                    Name::Symbol(symbol) => symbol.as_str().to_string(),
+                    Name::Position(position) => position.as_str().to_string(),
+                };
+                vec![AttributeParts {
+                    of: input.of.clone(),
+                    domain: domain.to_string(),
+                    name,
+                }]
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+
+    fn parts(attribute: &str) -> Vec<AttributeParts> {
+        AttributeParts::compute(AttributePartsInput {
+            of: attribute.parse().expect("attribute parses"),
+        })
+    }
+
+    /// A named predicate splits into its domain and symbol name.
+    #[dialog_common::test]
+    fn it_splits_a_symbol_name() {
+        let rows = parts("todo.list/title");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].domain, "todo.list");
+        assert_eq!(rows[0].name, "title");
+    }
+
+    /// An ordered member splits into its domain and position, the
+    /// same slot a symbol name lands in.
+    #[dialog_common::test]
+    fn it_splits_a_position_name() {
+        let rows = parts("todo.list/N5");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].domain, "todo.list");
+        assert_eq!(rows[0].name, "N5");
+    }
+}

--- a/rust/dialog-query/src/formula/query.rs
+++ b/rust/dialog-query/src/formula/query.rs
@@ -118,6 +118,7 @@ define_formulas! {
     "dialog/separator-part"   => SeparatorPart(super::key::SeparatorPart, super::key::SeparatorPartQuery),
     "dialog/position"         => Position(super::position::Position, super::position::PositionQuery),
     "dialog/position-parts"   => PositionParts(super::position::PositionParts, super::position::PositionPartsQuery),
+    "dialog/attribute-parts"  => AttributeParts(super::attribute::AttributeParts, super::attribute::AttributePartsQuery),
 }
 
 impl FormulaQuery {

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -197,9 +197,6 @@ pub(crate) fn compile_rule<T: Compile>(
                     rule: Box::new(rule.into()),
                     reason,
                 },
-                AnalysisError::CollectionHead { field, domain } => {
-                    TypeError::CollectionHead { field, domain }
-                }
                 AnalysisError::NegatedOptional => TypeError::NegatedOptional {
                     rule: Box::new(rule.into()),
                 },

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -235,7 +235,6 @@ pub(crate) fn compile_rule<T: Compile>(
         .required_operands()
         .filter(|name| !reduced(name))
         .find(|name| !join.binds.contains(name))
-        .map(String::from)
         .or_else(|| {
             // A reducing rule's optional non-reduced fields join the
             // derived grouping set, and the fold looks every grouping

--- a/rust/dialog-query/src/rule.rs
+++ b/rust/dialog-query/src/rule.rs
@@ -197,6 +197,9 @@ pub(crate) fn compile_rule<T: Compile>(
                     rule: Box::new(rule.into()),
                     reason,
                 },
+                AnalysisError::CollectionHead { field, domain } => {
+                    TypeError::CollectionHead { field, domain }
+                }
                 AnalysisError::NegatedOptional => TypeError::NegatedOptional {
                     rule: Box::new(rule.into()),
                 },
@@ -436,7 +439,7 @@ mod tests {
             .map(|(_, f)| f)
             .expect("name field present");
         assert_eq!(name.domain(), "macro-person");
-        assert_eq!(name.name(), "name");
+        assert_eq!(name.name(), Some("name"));
         assert_eq!(name.description(), "Name of the person");
         assert_eq!(name.content_type(), Some(Type::String));
 
@@ -446,7 +449,7 @@ mod tests {
             .map(|(_, f)| f)
             .expect("birthday field present");
         assert_eq!(birthday.domain(), "macro-person");
-        assert_eq!(birthday.name(), "birthday");
+        assert_eq!(birthday.name(), Some("birthday"));
         assert_eq!(birthday.description(), "Birthday of the person");
         assert_eq!(birthday.content_type(), Some(Type::UnsignedInt));
 
@@ -467,9 +470,9 @@ mod tests {
         let name_desc = macro_person::Name::descriptor();
         let birthday_desc = macro_person::Birthday::descriptor();
         assert_eq!(name_desc.domain(), "macro-person");
-        assert_eq!(name_desc.name(), "name");
+        assert_eq!(name_desc.name(), Some("name"));
         assert_eq!(birthday_desc.domain(), "macro-person");
-        assert_eq!(birthday_desc.name(), "birthday");
+        assert_eq!(birthday_desc.name(), Some("birthday"));
     }
 
     mod macro_employee {

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -324,25 +324,6 @@ pub fn analyze_with(
     kind: RuleKind,
     reduce: Vec<(String, ReduceSpec)>,
 ) -> Result<AnalyzedRule, AnalysisError> {
-    // A deductive head over a collection derives `(key, value)`
-    // rows, which is exactly what the concept's own self-rule does.
-    // An inductive head has to WRITE a fact, and induction tracks a
-    // rule's reach per attribute (the `touched` sets in
-    // `transaction::induce`); a collection spans a domain, so its
-    // facts would land where nothing recorded the rule had reached.
-    // Refuse that case until induction's reach is a cover.
-    if kind == RuleKind::Inductive {
-        for (field, descriptor) in conclusion.with().iter() {
-            let relation = descriptor.descriptor().the();
-            if relation.attribute().is_none() {
-                return Err(AnalysisError::CollectionHead {
-                    field: field.to_string(),
-                    domain: relation.domain().to_owned(),
-                });
-            }
-        }
-    }
-
     let mut types = TypeEnv::infer(&premises).map_err(|err| AnalysisError::Inference {
         reason: err.to_string(),
     })?;
@@ -496,44 +477,6 @@ mod tests {
             ),
         )])
         .unwrap()
-    }
-
-    /// A rule cannot derive into a keyed collection. Induction tracks
-    /// a rule's reach per attribute, and a collection spans a domain —
-    /// so such a rule's consumers would never learn it had written
-    /// anything. The refusal is what lets `transaction::induce` treat
-    /// every head field as naming one attribute.
-    #[dialog_common::test]
-    fn it_refuses_a_rule_that_derives_into_a_collection() {
-        use crate::attribute::{Keyed, Relation};
-        use dialog_artifacts::Symbol;
-        use std::str::FromStr;
-
-        let conclusion = ConceptDescriptor::try_from(vec![(
-            "member",
-            AttributeDescriptor::over(
-                Relation::collection(
-                    Symbol::from_str("todo.list").expect("a valid domain"),
-                    Keyed::Sequence,
-                ),
-                "",
-                Cardinality::Many,
-                Some(ValueType::Entity),
-            ),
-        )])
-        .expect("the concept itself is fine — only inducing one is not");
-
-        let error = analyze(conclusion, Vec::new(), RuleKind::Inductive)
-            .expect_err("a collection head is refused");
-
-        assert!(
-            matches!(
-                error,
-                AnalysisError::CollectionHead { ref field, ref domain }
-                    if field == "member" && domain == "todo.list"
-            ),
-            "expected a CollectionHead rejection naming the field, got {error:?}"
-        );
     }
 
     /// Analysis output carries the inferred type environment.

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -324,18 +324,22 @@ pub fn analyze_with(
     kind: RuleKind,
     reduce: Vec<(String, ReduceSpec)>,
 ) -> Result<AnalyzedRule, AnalysisError> {
-    // Induction tracks a rule's reach per attribute (the `touched`
-    // sets in `transaction::induce`). A keyed collection spans a
-    // domain instead, so a rule concluding into one would derive
-    // facts nothing could see it had touched — its consumers would
-    // never re-evaluate. Refuse it here rather than let the induction
-    // machinery silently drop it.
-    for (field, descriptor) in conclusion.with().iter() {
-        if descriptor.descriptor().the().attribute().is_none() {
-            return Err(AnalysisError::CollectionHead {
-                field: field.to_string(),
-                domain: descriptor.descriptor().the().domain().to_owned(),
-            });
+    // A deductive head over a collection derives `(key, value)`
+    // rows, which is exactly what the concept's own self-rule does.
+    // An inductive head has to WRITE a fact, and induction tracks a
+    // rule's reach per attribute (the `touched` sets in
+    // `transaction::induce`); a collection spans a domain, so its
+    // facts would land where nothing recorded the rule had reached.
+    // Refuse that case until induction's reach is a cover.
+    if kind == RuleKind::Inductive {
+        for (field, descriptor) in conclusion.with().iter() {
+            let relation = descriptor.descriptor().the();
+            if relation.attribute().is_none() {
+                return Err(AnalysisError::CollectionHead {
+                    field: field.to_string(),
+                    domain: relation.domain().to_owned(),
+                });
+            }
         }
     }
 
@@ -517,9 +521,9 @@ mod tests {
                 Some(ValueType::Entity),
             ),
         )])
-        .expect("the concept itself is fine — only deriving one is not");
+        .expect("the concept itself is fine — only inducing one is not");
 
-        let error = analyze(conclusion, Vec::new(), RuleKind::Deductive)
+        let error = analyze(conclusion, Vec::new(), RuleKind::Inductive)
             .expect_err("a collection head is refused");
 
         assert!(

--- a/rust/dialog-query/src/rule/analyzer.rs
+++ b/rust/dialog-query/src/rule/analyzer.rs
@@ -324,6 +324,21 @@ pub fn analyze_with(
     kind: RuleKind,
     reduce: Vec<(String, ReduceSpec)>,
 ) -> Result<AnalyzedRule, AnalysisError> {
+    // Induction tracks a rule's reach per attribute (the `touched`
+    // sets in `transaction::induce`). A keyed collection spans a
+    // domain instead, so a rule concluding into one would derive
+    // facts nothing could see it had touched — its consumers would
+    // never re-evaluate. Refuse it here rather than let the induction
+    // machinery silently drop it.
+    for (field, descriptor) in conclusion.with().iter() {
+        if descriptor.descriptor().the().attribute().is_none() {
+            return Err(AnalysisError::CollectionHead {
+                field: field.to_string(),
+                domain: descriptor.descriptor().the().domain().to_owned(),
+            });
+        }
+    }
+
     let mut types = TypeEnv::infer(&premises).map_err(|err| AnalysisError::Inference {
         reason: err.to_string(),
     })?;
@@ -477,6 +492,44 @@ mod tests {
             ),
         )])
         .unwrap()
+    }
+
+    /// A rule cannot derive into a keyed collection. Induction tracks
+    /// a rule's reach per attribute, and a collection spans a domain —
+    /// so such a rule's consumers would never learn it had written
+    /// anything. The refusal is what lets `transaction::induce` treat
+    /// every head field as naming one attribute.
+    #[dialog_common::test]
+    fn it_refuses_a_rule_that_derives_into_a_collection() {
+        use crate::attribute::{Keyed, Relation};
+        use dialog_artifacts::Symbol;
+        use std::str::FromStr;
+
+        let conclusion = ConceptDescriptor::try_from(vec![(
+            "member",
+            AttributeDescriptor::over(
+                Relation::collection(
+                    Symbol::from_str("todo.list").expect("a valid domain"),
+                    Keyed::Sequence,
+                ),
+                "",
+                Cardinality::Many,
+                Some(ValueType::Entity),
+            ),
+        )])
+        .expect("the concept itself is fine — only deriving one is not");
+
+        let error = analyze(conclusion, Vec::new(), RuleKind::Deductive)
+            .expect_err("a collection head is refused");
+
+        assert!(
+            matches!(
+                error,
+                AnalysisError::CollectionHead { ref field, ref domain }
+                    if field == "member" && domain == "todo.list"
+            ),
+            "expected a CollectionHead rejection naming the field, got {error:?}"
+        );
     }
 
     /// Analysis output carries the inferred type environment.

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -1,10 +1,13 @@
 /// Serializable rule descriptor matching the formal notation.
 pub mod descriptor;
 
+use crate::Formula;
 use crate::artifact::Entity;
+use crate::attribute::Relation;
 use crate::attribute::query::AttributeQuery;
 pub use crate::concept::descriptor::ConceptDescriptor;
 use crate::error::TypeError;
+use crate::formula::attribute::AttributeParts;
 use crate::negation::Negation;
 use crate::optional::OptionalAttributeQuery;
 pub use crate::planner::Plan;
@@ -132,11 +135,11 @@ impl DeductiveRule {
 
     /// Returns an iterator over the required operand names of this
     /// rule's conclusion.
-    pub fn required_operands(&self) -> impl Iterator<Item = &str> {
+    pub fn required_operands(&self) -> impl Iterator<Item = String> + '_ {
         self.conclusion().required_operands()
     }
     /// Returns the names of the parameters for this rule.
-    pub fn parameters(&self) -> impl Iterator<Item = &str> {
+    pub fn parameters(&self) -> impl Iterator<Item = String> + '_ {
         self.conclusion().required_operands()
     }
 
@@ -338,7 +341,7 @@ fn concept_premises(concept: &ConceptDescriptor) -> Vec<Premise> {
 
         let premise: Premise = if field.is_optional() {
             OptionalAttributeQuery::new(
-                field.the().term(),
+                field.the().term(name),
                 this.clone(),
                 value.clone(),
                 Term::blank(),
@@ -347,7 +350,7 @@ fn concept_premises(concept: &ConceptDescriptor) -> Vec<Premise> {
             .into()
         } else {
             AttributeQuery::new(
-                field.the().term(),
+                field.the().term(name),
                 this.clone(),
                 value.clone(),
                 Term::blank(),
@@ -356,6 +359,25 @@ fn concept_premises(concept: &ConceptDescriptor) -> Vec<Premise> {
             .into()
         };
         premises.push(premise);
+
+        // A keyed collection's scan binds the whole attribute
+        // (`domain/key`) to an internal variable; the author-facing
+        // key is its name half, projected onto the field's key
+        // operand. One entry, one row, `(key, value)` bound flat.
+        if let Relation::Collection { .. } = field.the() {
+            let mut parts = Parameters::new();
+            parts.insert(
+                "of".to_string(),
+                Term::var(Relation::attribute_variable(name)),
+            );
+            parts.insert("domain".to_string(), Term::blank());
+            parts.insert("name".to_string(), Term::var(Relation::key_operand(name)));
+            premises.push(
+                AttributeParts::apply(parts)
+                    .expect("attribute-parts operands are well-formed by construction")
+                    .into(),
+            );
+        }
 
         // Conformance is "facts exist", not a property of the
         // scalar, so it desugars to the target concept applied

--- a/rust/dialog-query/src/rule/deductive.rs
+++ b/rust/dialog-query/src/rule/deductive.rs
@@ -338,7 +338,7 @@ fn concept_premises(concept: &ConceptDescriptor) -> Vec<Premise> {
 
         let premise: Premise = if field.is_optional() {
             OptionalAttributeQuery::new(
-                Term::Constant(Value::from(field.the().clone())),
+                field.the().term(),
                 this.clone(),
                 value.clone(),
                 Term::blank(),
@@ -347,7 +347,7 @@ fn concept_premises(concept: &ConceptDescriptor) -> Vec<Premise> {
             .into()
         } else {
             AttributeQuery::new(
-                Term::Constant(Value::from(field.the().clone())),
+                field.the().term(),
                 this.clone(),
                 value.clone(),
                 Term::blank(),

--- a/rust/dialog-query/src/rule/inductive.rs
+++ b/rust/dialog-query/src/rule/inductive.rs
@@ -128,7 +128,7 @@ impl InductiveRule {
     }
 
     /// Required operand names of the head.
-    pub fn required_operands(&self) -> impl Iterator<Item = &str> {
+    pub fn required_operands(&self) -> impl Iterator<Item = String> + '_ {
         self.conclusion().required_operands()
     }
 

--- a/rust/dialog-query/src/rule/statement.rs
+++ b/rust/dialog-query/src/rule/statement.rs
@@ -81,7 +81,12 @@ fn premise_trigger_entities<'p>(
     for proposition in propositions {
         if let Proposition::Concept(query) = proposition {
             for (_, field) in query.predicate.with().iter() {
-                let attribute: Attribute = field.descriptor().the().clone().into();
+                // A keyed collection names a domain rather than one
+                // attribute, so there is no single attribute to read
+                // an entity off.
+                let Some(attribute) = field.descriptor().the().attribute() else {
+                    continue;
+                };
                 if let Some(entity) = on_entity(&attribute) {
                     entities.insert(entity);
                 }

--- a/rust/dialog-query/src/rule/statement.rs
+++ b/rust/dialog-query/src/rule/statement.rs
@@ -21,9 +21,10 @@
 use std::collections::BTreeSet;
 
 use crate::artifact::{Entity, Value};
+use crate::attribute::Relation;
 use crate::rule::{DeductiveRule, InductiveRule, Rule};
 use crate::{Proposition, Statement, Update, the};
-use dialog_artifacts::Attribute;
+use dialog_artifacts::{Attribute, NameShape, Symbol};
 
 /// The `dialog.rule/source` body attribute, validated at compile time.
 /// Shared by both rule kinds — hydration dispatches on the decoded
@@ -70,6 +71,98 @@ pub fn on_entity(attribute: &Attribute) -> Option<Entity> {
     format!("on:{attribute}").parse().ok()
 }
 
+/// What a rule reaches through one concept field: a single attribute,
+/// or one keyed half of a domain. Induction tracks a rule's reach in
+/// these units — the attributes a stimulus touches, the attributes a
+/// premise reads, the attributes a head writes — and a fact is inside
+/// a reach when the reach [`covers`](Reach::covers) its attribute.
+///
+/// The trigger index stores one `on:` entity per reach: an attribute's
+/// own `on:<domain>/<name>`, and for a domain half a cover key,
+/// `on:<domain>/_position` or `on:<domain>/_symbol`, spelled with a
+/// leading underscore so it can never collide with a stored name
+/// (symbols begin with a letter, positions with an uppercase one). A
+/// touched attribute probes both its own key and its half's cover
+/// key, so a rule reading a collection wakes for any member write.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Reach {
+    /// One attribute.
+    Attribute(Attribute),
+    /// Every attribute of `domain` whose name has `shape`.
+    Domain {
+        /// The domain the attributes share.
+        domain: Symbol,
+        /// Which half of the domain.
+        shape: NameShape,
+    },
+}
+
+impl Reach {
+    /// The reach of a concept field.
+    pub fn of(relation: &Relation) -> Reach {
+        match relation {
+            Relation::Attribute(the) => Reach::Attribute(the.into()),
+            Relation::Collection { domain, keyed } => Reach::Domain {
+                domain: domain.clone(),
+                shape: NameShape::from(*keyed),
+            },
+        }
+    }
+
+    /// The cover key for one half of a domain.
+    fn cover_entity(domain: &str, shape: NameShape) -> Option<Entity> {
+        let half = match shape {
+            NameShape::Position => "_position",
+            NameShape::Symbol => "_symbol",
+        };
+        format!("on:{domain}/{half}").parse().ok()
+    }
+
+    /// Whether `attribute` is inside this reach.
+    pub fn covers(&self, attribute: &Attribute) -> bool {
+        match self {
+            Reach::Attribute(the) => the == attribute,
+            Reach::Domain { domain, shape } => attribute
+                .split()
+                .is_ok_and(|(of, name)| &of == domain && name.shape() == *shape),
+        }
+    }
+
+    /// Whether the two reaches share an attribute.
+    pub fn overlaps(&self, other: &Reach) -> bool {
+        match (self, other) {
+            (Reach::Attribute(the), other) | (other, Reach::Attribute(the)) => other.covers(the),
+            (Reach::Domain { .. }, Reach::Domain { .. }) => self == other,
+        }
+    }
+
+    /// The trigger-index entity a rule is filed under for this reach.
+    pub fn on_entity(&self) -> Option<Entity> {
+        match self {
+            Reach::Attribute(the) => on_entity(the),
+            Reach::Domain { domain, shape } => Self::cover_entity(domain.as_str(), *shape),
+        }
+    }
+
+    /// The trigger-index entities a touched reach probes: an attribute
+    /// probes its own key and its half's cover key, so both a rule
+    /// reading that attribute and a rule reading the collection it
+    /// belongs to are found; a domain half probes its cover key.
+    pub fn probes(&self) -> Vec<Entity> {
+        match self {
+            Reach::Attribute(the) => {
+                let mut probes = Vec::new();
+                probes.extend(on_entity(the));
+                if let Ok((domain, name)) = the.split() {
+                    probes.extend(Self::cover_entity(domain.as_str(), name.shape()));
+                }
+                probes
+            }
+            Reach::Domain { .. } => self.on_entity().into_iter().collect(),
+        }
+    }
+}
+
 /// The `on:` entities for the attributes a set of propositions' concept
 /// premises name. Formula and constraint premises contribute nothing;
 /// attribute-query premises can't occur in stored rules (they have no
@@ -81,13 +174,7 @@ fn premise_trigger_entities<'p>(
     for proposition in propositions {
         if let Proposition::Concept(query) = proposition {
             for (_, field) in query.predicate.with().iter() {
-                // A keyed collection names a domain rather than one
-                // attribute, so there is no single attribute to read
-                // an entity off.
-                let Some(attribute) = field.descriptor().the().attribute() else {
-                    continue;
-                };
-                if let Some(entity) = on_entity(&attribute) {
+                if let Some(entity) = Reach::of(field.descriptor().the()).on_entity() {
                     entities.insert(entity);
                 }
             }

--- a/rust/dialog-query/src/term.rs
+++ b/rust/dialog-query/src/term.rs
@@ -247,6 +247,20 @@ impl<T: Typed> Term<T> {
         }
     }
 
+    /// Returns `true` if this term is a variable whose kind carries a
+    /// lexical prefix: not bound, but *ranged*. A ranged attribute
+    /// slot constrains a scan on its own (an AEV range over the
+    /// prefix), which is what lets a keyed collection's domain scan
+    /// plan without any of its slots bound.
+    pub fn is_ranged(&self) -> bool {
+        matches!(self, Term::Variable { .. })
+            && self
+                .kind()
+                .as_ref()
+                .and_then(type_system::Type::refinement)
+                .is_some_and(|refinement| refinement.prefix.is_some())
+    }
+
     /// Adds this term's variable name to the environment.
     ///
     /// Only named variables are added; constants and blanks are ignored.

--- a/rust/dialog-query/src/type_system.rs
+++ b/rust/dialog-query/src/type_system.rs
@@ -21,6 +21,7 @@
 //! have.
 
 pub mod unifier;
+pub mod wire;
 
 use crate::artifact::Type as ValueType;
 use crate::artifact::Value;

--- a/rust/dialog-query/src/type_system/wire.rs
+++ b/rust/dialog-query/src/type_system/wire.rs
@@ -1,0 +1,564 @@
+//! The wire form of a [`Type`]: what a `/query` request body carries.
+//!
+//! [`Type`] is a bitset (`Primitive`) optionally narrowed by a
+//! [`Refinement`], and its derived serde form published both — a
+//! `{"bits": 128}` field whose meaning depends on enum discriminant
+//! order, and a positional `[set, refinement]` tuple. This module is
+//! the stable form instead: named variants, named constraints, and
+//! nothing whose spelling changes when a `ValueType` is added.
+//!
+//! ```json
+//! {"type": {"symbol": {}},
+//!  "domain": {"is": "todo.list"},
+//!  "name": {"case": "position"}}
+//! ```
+//!
+//! Two container conventions run through it, and they are not
+//! interchangeable:
+//!
+//! - An **object is a union** where entries are alternatives of one
+//!   kind. `type` is the case: a value matching any present key is
+//!   admitted, and intersecting two sets keeps the shared keys —
+//!   which is what `Primitive::intersect` does to the bits.
+//! - An **array is an intersection** where entries are independent
+//!   obligations. `as` (conformance) is the case: every listed
+//!   concept must hold.
+//! - A **record of fixed slots** is neither. The constraint object
+//!   itself is one: each slot appears at most once, and two
+//!   constraints on one slot merge rather than accumulate.
+//!
+//! Reading is deliberately looser than writing: the legacy
+//! `{"primitive": …}` / `{"refined": …}` forms still parse, so a rule
+//! stored before this module loads unchanged. Only the form above is
+//! ever written.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as Json};
+
+use crate::artifact::{Type as ValueType, Value, decode_value};
+
+use super::{ConceptRef, NameShape, Primitive, Refinement, Type};
+
+/// The wire name for each admissible type, and the `Primitive` bit it
+/// denotes. `option` has no `ValueType`: it is the synthetic absence
+/// atom, and a set containing it alongside others marks the variable
+/// optional.
+const VARIANTS: [(&str, Option<ValueType>); 10] = [
+    ("bytes", Some(ValueType::Bytes)),
+    ("entity", Some(ValueType::Entity)),
+    ("boolean", Some(ValueType::Boolean)),
+    ("text", Some(ValueType::String)),
+    ("uint", Some(ValueType::UnsignedInt)),
+    ("int", Some(ValueType::SignedInt)),
+    ("float", Some(ValueType::Float)),
+    ("record", Some(ValueType::Record)),
+    ("symbol", Some(ValueType::Symbol)),
+    ("option", None),
+];
+
+/// The wire name for a `ValueType`.
+fn variant_name(value_type: ValueType) -> &'static str {
+    VARIANTS
+        .iter()
+        .find_map(|(name, vt)| (*vt == Some(value_type)).then_some(*name))
+        .expect("every ValueType has a wire name")
+}
+
+/// Why a constraint object could not be read.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WireError {
+    /// A `type` key that names no known variant.
+    UnknownVariant(String),
+    /// A constraint slot that is not one of the known ones.
+    UnknownSlot(String),
+    /// A slot's value had the wrong JSON shape.
+    Malformed(&'static str),
+    /// The constraint narrowed the admissible set to nothing — e.g. a
+    /// prefix on a boolean, or conformance on a non-entity.
+    Uninhabited(&'static str),
+}
+
+impl std::fmt::Display for WireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownVariant(name) => {
+                write!(f, "unknown type variant {name:?}")
+            }
+            Self::UnknownSlot(name) => write!(f, "unknown constraint {name:?}"),
+            Self::Malformed(what) => write!(f, "malformed {what}"),
+            Self::Uninhabited(what) => {
+                write!(f, "{what} leaves no admissible type")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WireError {}
+
+/// A [`Type`] in its wire form: `serialize` writes the named shape,
+/// `deserialize` accepts it and the legacy derived shape alike.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Wire(pub Type);
+
+impl Serialize for Wire {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        encode(&self.0).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Wire {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let json = Json::deserialize(deserializer)?;
+        decode(&json).map(Wire).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Write a [`Type`] as the named wire form.
+pub fn encode(kind: &Type) -> Json {
+    let mut out = Map::new();
+    out.insert("type".into(), encode_set(kind.primitive_part()));
+    if let Some(refinement) = kind.refinement() {
+        encode_refinement(refinement, &mut out);
+    }
+    Json::Object(out)
+}
+
+/// The `type` set: one key per admitted variant, each valued by an
+/// (empty, for now) parameter record.
+fn encode_set(primitive: Primitive) -> Json {
+    let mut set = Map::new();
+    for value_type in primitive.iter() {
+        set.insert(variant_name(value_type).into(), Json::Object(Map::new()));
+    }
+    if primitive.contains_nothing() {
+        set.insert("option".into(), Json::Object(Map::new()));
+    }
+    Json::Object(set)
+}
+
+/// The constraint slots, written beside `type`.
+fn encode_refinement(refinement: &Refinement, out: &mut Map<String, Json>) {
+    if let Some(prefix) = &refinement.prefix {
+        // A prefix that ends at the name boundary IS a domain, and
+        // saying so structurally is what keeps the trailing separator
+        // from being something a writer has to remember: omit it and
+        // the scan silently degrades from a range narrowing to a
+        // per-row filter.
+        match prefix.strip_suffix('/') {
+            Some(domain) if !domain.is_empty() && !domain.contains('/') => {
+                let mut slot = Map::new();
+                slot.insert("is".into(), Json::String(domain.into()));
+                out.insert("domain".into(), Json::Object(slot));
+            }
+            _ => {
+                out.insert("starts-with".into(), Json::String(prefix.clone()));
+            }
+        }
+    }
+    if let Some(shape) = refinement.name_shape {
+        let case = match shape {
+            NameShape::Position => "position",
+            NameShape::Symbol => "symbol",
+        };
+        let mut slot = Map::new();
+        slot.insert("case".into(), Json::String(case.into()));
+        out.insert("name".into(), Json::Object(slot));
+    }
+    if !refinement.conforms.is_empty() {
+        let targets = refinement
+            .conforms
+            .iter()
+            .map(|concept| {
+                let mut entry = Map::new();
+                entry.insert(concept.0.clone(), Json::Object(Map::new()));
+                Json::Object(entry)
+            })
+            .collect();
+        out.insert("as".into(), Json::Array(targets));
+    }
+    if let Some(interval) = &refinement.interval {
+        // Bounds are stored order-preservingly encoded under the
+        // literal's own type; decode back to the value that was
+        // written so the wire carries `>=: 5`, not a byte array.
+        let mut bound = |side: &Option<super::IntervalBound>, inclusive: &str, strict: &str| {
+            if let Some(bound) = side
+                && let Some((value, _)) = decode_value(interval.value_type, &bound.encoded)
+            {
+                let key = if bound.inclusive { inclusive } else { strict };
+                out.insert(key.into(), value_to_json(&value));
+            }
+        };
+        bound(&interval.lower, ">=", ">");
+        bound(&interval.upper, "<=", "<");
+    }
+}
+
+/// A bound literal as JSON. Only the comparable types can appear.
+fn value_to_json(value: &Value) -> Json {
+    match value {
+        Value::UnsignedInt(n) => Json::Number((*n as u64).into()),
+        Value::SignedInt(n) => Json::Number((*n as i64).into()),
+        Value::Float(n) => serde_json::Number::from_f64(*n)
+            .map(Json::Number)
+            .unwrap_or(Json::Null),
+        Value::String(text) => Json::String(text.clone()),
+        Value::Symbol(symbol) => Json::String(String::from(symbol)),
+        Value::Entity(entity) => Json::String(entity.as_str().to_string()),
+        Value::Boolean(flag) => Json::Bool(*flag),
+        other => Json::String(format!("{other:?}")),
+    }
+}
+
+/// Read a [`Type`] from either the named wire form or the legacy
+/// derived one.
+pub fn decode(json: &Json) -> Result<Type, WireError> {
+    let Json::Object(map) = json else {
+        return Err(WireError::Malformed("type: expected an object"));
+    };
+    // Legacy: the derived `Type` shape, kept readable so a rule
+    // written before this module still loads.
+    if map.contains_key("primitive") || map.contains_key("refined") {
+        return serde_json::from_value::<Type>(json.clone())
+            .map_err(|_| WireError::Malformed("legacy type"));
+    }
+
+    let mut kind = match map.get("type") {
+        Some(set) => Type::from(decode_set(set)?),
+        // No `type` slot: unconstrained, then narrowed by whatever
+        // constraints follow.
+        None => Type::from(Primitive::ANY),
+    };
+
+    for (slot, value) in map {
+        kind = match slot.as_str() {
+            "type" => continue,
+            "domain" => {
+                let domain = field(value, "is", "domain")?;
+                kind.with_prefix(format!("{domain}/"))
+                    .ok_or(WireError::Uninhabited("domain"))?
+            }
+            "name" => {
+                let case = field(value, "case", "name")?;
+                let shape = match case {
+                    "position" => NameShape::Position,
+                    "symbol" => NameShape::Symbol,
+                    _ => return Err(WireError::Malformed("name: case")),
+                };
+                kind.with_name_shape(shape)
+                    .ok_or(WireError::Uninhabited("name"))?
+            }
+            "starts-with" => {
+                let Json::String(prefix) = value else {
+                    return Err(WireError::Malformed("starts-with"));
+                };
+                kind.with_prefix(prefix.clone())
+                    .ok_or(WireError::Uninhabited("starts-with"))?
+            }
+            "as" => {
+                let Json::Array(targets) = value else {
+                    return Err(WireError::Malformed("as: expected an array"));
+                };
+                for target in targets {
+                    let Json::Object(entry) = target else {
+                        return Err(WireError::Malformed("as: entry"));
+                    };
+                    for concept in entry.keys() {
+                        kind = kind
+                            .with_conformance(ConceptRef(concept.clone()))
+                            .ok_or(WireError::Uninhabited("as"))?;
+                    }
+                }
+                kind
+            }
+            ">=" | ">" | "<=" | "<" => {
+                let bound = json_to_value(value)?;
+                let inclusive = slot == ">=" || slot == "<=";
+                let lower = slot.starts_with('>');
+                kind.with_interval(&bound, inclusive, lower)
+                    .ok_or(WireError::Uninhabited("bound"))?
+            }
+            other => return Err(WireError::UnknownSlot(other.into())),
+        };
+    }
+    Ok(kind)
+}
+
+/// Read one string field out of a constraint slot.
+fn field<'a>(value: &'a Json, key: &str, slot: &'static str) -> Result<&'a str, WireError> {
+    value
+        .get(key)
+        .and_then(Json::as_str)
+        .ok_or(WireError::Malformed(slot))
+}
+
+/// Read the `type` set: an object whose keys are variant names.
+fn decode_set(json: &Json) -> Result<Primitive, WireError> {
+    let Json::Object(entries) = json else {
+        return Err(WireError::Malformed("type: expected an object"));
+    };
+    let mut primitive = Primitive::EMPTY;
+    for name in entries.keys() {
+        let (_, value_type) = VARIANTS
+            .iter()
+            .find(|(variant, _)| variant == name)
+            .ok_or_else(|| WireError::UnknownVariant(name.clone()))?;
+        primitive = primitive.union(match value_type {
+            Some(value_type) => Primitive::from(*value_type),
+            None => Primitive::NOTHING,
+        });
+    }
+    Ok(primitive)
+}
+
+/// A bound literal from JSON.
+fn json_to_value(json: &Json) -> Result<Value, WireError> {
+    Ok(match json {
+        Json::Number(number) => {
+            if let Some(unsigned) = number.as_u64() {
+                Value::UnsignedInt(unsigned as u128)
+            } else if let Some(signed) = number.as_i64() {
+                Value::SignedInt(signed as i128)
+            } else if let Some(float) = number.as_f64() {
+                Value::Float(float)
+            } else {
+                return Err(WireError::Malformed("bound: number"));
+            }
+        }
+        Json::String(text) => Value::String(text.clone()),
+        Json::Bool(flag) => Value::Boolean(*flag),
+        _ => return Err(WireError::Malformed("bound")),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+
+    fn roundtrip(kind: &Type) -> Type {
+        let json = encode(kind);
+        decode(&json).unwrap_or_else(|error| panic!("{json} failed to decode: {error}"))
+    }
+
+    /// EVERY set of admissible types survives the round trip. The
+    /// bitset has ten members, so this walks all 1024 subsets: a
+    /// variant whose wire name were missing or duplicated would show
+    /// up here rather than the first time someone queried for it.
+    #[dialog_common::test]
+    async fn it_round_trips_every_type_set() {
+        for bits in 0u16..1024 {
+            let mut primitive = Primitive::EMPTY;
+            for (index, (_, value_type)) in VARIANTS.iter().enumerate() {
+                if bits & (1 << index) == 0 {
+                    continue;
+                }
+                primitive = primitive.union(match value_type {
+                    Some(value_type) => Primitive::from(*value_type),
+                    None => Primitive::NOTHING,
+                });
+            }
+            let kind = Type::from(primitive);
+            assert_eq!(
+                roundtrip(&kind),
+                kind,
+                "type set {bits:#012b} did not survive the round trip"
+            );
+        }
+    }
+
+    /// A whole-domain prefix is written as a `domain`, not as a raw
+    /// prefix — the trailing separator is an encoding detail, and a
+    /// writer who forgets it silently loses the range narrowing.
+    #[dialog_common::test]
+    async fn it_writes_a_whole_domain_as_a_domain() {
+        let kind = Type::from(ValueType::Symbol)
+            .with_prefix("todo.list/")
+            .expect("symbol is textual");
+        let json = encode(&kind);
+
+        assert_eq!(
+            json.get("domain").and_then(|slot| slot.get("is")),
+            Some(&Json::String("todo.list".into())),
+            "the domain is written without its separator"
+        );
+        assert!(
+            json.get("starts-with").is_none(),
+            "a domain is not also written as a prefix"
+        );
+        assert_eq!(roundtrip(&kind), kind);
+    }
+
+    /// A prefix that does NOT end at the name boundary has no domain
+    /// to name, so it stays a lexical prefix. Both forms round-trip.
+    #[dialog_common::test]
+    async fn it_keeps_a_partial_prefix_lexical() {
+        let kind = Type::from(ValueType::Symbol)
+            .with_prefix("todo.list/N")
+            .expect("symbol is textual");
+        let json = encode(&kind);
+
+        assert_eq!(
+            json.get("starts-with"),
+            Some(&Json::String("todo.list/N".into())),
+            "a prefix past the separator is not a domain"
+        );
+        assert!(json.get("domain").is_none());
+        assert_eq!(roundtrip(&kind), kind);
+    }
+
+    /// The collection case: a domain plus a name shape. Both halves
+    /// survive, and `name.case` says which half of a mixed domain the
+    /// scan wants.
+    #[dialog_common::test]
+    async fn it_round_trips_a_keyed_collection() {
+        for (shape, case) in [
+            (NameShape::Position, "position"),
+            (NameShape::Symbol, "symbol"),
+        ] {
+            let kind = Type::from(ValueType::Symbol)
+                .with_prefix("xyz.tonk.notebook/")
+                .expect("symbol is textual")
+                .with_name_shape(shape)
+                .expect("shapes compose with prefixes");
+            let json = encode(&kind);
+
+            assert_eq!(
+                json.get("name").and_then(|slot| slot.get("case")),
+                Some(&Json::String(case.into())),
+            );
+            assert_eq!(
+                json.get("domain").and_then(|slot| slot.get("is")),
+                Some(&Json::String("xyz.tonk.notebook".into())),
+            );
+            assert_eq!(roundtrip(&kind), kind);
+        }
+    }
+
+    /// An optional refined type — the shape EVERY `maybe:` field with
+    /// a constraint produces. The refinement belongs to the set, not
+    /// to a member of it, so `option` rides alongside without
+    /// disturbing it.
+    #[dialog_common::test]
+    async fn it_round_trips_an_optional_refined_type() {
+        let kind = Type::from(ValueType::String)
+            .optional()
+            .with_prefix("alice")
+            .expect("text is textual");
+
+        let json = encode(&kind);
+        let set = json.get("type").expect("a type set");
+        assert!(set.get("text").is_some(), "the present type survives");
+        assert!(set.get("option").is_some(), "so does admissible absence");
+        assert_eq!(roundtrip(&kind), kind);
+    }
+
+    /// Conformance is an ARRAY because it is an intersection: every
+    /// listed concept must hold. Two targets survive as two entries.
+    #[dialog_common::test]
+    async fn it_round_trips_conformance_as_an_intersection() {
+        let kind = Type::from(ValueType::Entity)
+            .with_conformance(ConceptRef("concept:abc".into()))
+            .expect("entity conforms")
+            .with_conformance(ConceptRef("concept:def".into()))
+            .expect("entity conforms");
+
+        let json = encode(&kind);
+        let targets = json.get("as").and_then(Json::as_array).expect("an array");
+        assert_eq!(targets.len(), 2, "both obligations are carried");
+        assert_eq!(roundtrip(&kind), kind);
+    }
+
+    /// Order bounds are written as the literals they came from, not
+    /// as the order-preserving bytes they are stored in.
+    #[dialog_common::test]
+    async fn it_round_trips_order_bounds() {
+        let kind = Type::from(ValueType::UnsignedInt)
+            .with_interval(&Value::UnsignedInt(5), true, true)
+            .expect("uint is comparable")
+            .with_interval(&Value::UnsignedInt(100), false, false)
+            .expect("uint is comparable");
+
+        let json = encode(&kind);
+        assert_eq!(json.get(">="), Some(&Json::Number(5u64.into())));
+        assert_eq!(json.get("<"), Some(&Json::Number(100u64.into())));
+        assert_eq!(roundtrip(&kind), kind);
+    }
+
+    /// Reading is looser than writing: the derived shape a rule was
+    /// stored under before this module still loads.
+    #[dialog_common::test]
+    async fn it_reads_the_legacy_derived_form() {
+        let kind = Type::from(ValueType::Symbol)
+            .with_prefix("todo.list/")
+            .expect("symbol is textual")
+            .with_name_shape(NameShape::Position)
+            .expect("shapes compose");
+        let legacy = serde_json::to_value(&kind).expect("the derived form");
+
+        assert_eq!(decode(&legacy), Ok(kind), "a stored type still loads");
+    }
+
+    /// A constraint that cannot narrow anything is refused rather
+    /// than silently yielding a variable that matches nothing.
+    #[dialog_common::test]
+    async fn it_rejects_constraints_that_admit_nothing() {
+        let prefixed_boolean = serde_json::json!({
+            "type": {"boolean": {}},
+            "starts-with": "alice"
+        });
+        assert_eq!(
+            decode(&prefixed_boolean),
+            Err(WireError::Uninhabited("starts-with")),
+            "a boolean has no lexical form to prefix"
+        );
+
+        let conforming_text = serde_json::json!({
+            "type": {"text": {}},
+            "as": [{"concept:abc": {}}]
+        });
+        assert_eq!(
+            decode(&conforming_text),
+            Err(WireError::Uninhabited("as")),
+            "conformance is a property of entities"
+        );
+    }
+
+    /// A misspelling is an error, not a silently dropped constraint.
+    #[dialog_common::test]
+    async fn it_rejects_names_it_does_not_know() {
+        assert_eq!(
+            decode(&serde_json::json!({"type": {"integer": {}}})),
+            Err(WireError::UnknownVariant("integer".into())),
+        );
+        assert_eq!(
+            decode(&serde_json::json!({"type": {"text": {}}, "named-by": "position"})),
+            Err(WireError::UnknownSlot("named-by".into())),
+        );
+        assert_eq!(
+            decode(&serde_json::json!({"type": {"symbol": {}}, "name": {"case": "sideways"}})),
+            Err(WireError::Malformed("name: case")),
+        );
+    }
+
+    /// The published shape, pinned. This is the contract a client
+    /// writes against, so a change here is a change to the wire.
+    #[dialog_common::test]
+    async fn it_writes_the_documented_shape() {
+        let kind = Type::from(ValueType::Symbol)
+            .with_prefix("xyz.tonk.notebook/")
+            .expect("symbol is textual")
+            .with_name_shape(NameShape::Position)
+            .expect("shapes compose");
+
+        assert_eq!(
+            encode(&kind),
+            serde_json::json!({
+                "type": {"symbol": {}},
+                "domain": {"is": "xyz.tonk.notebook"},
+                "name": {"case": "position"}
+            })
+        );
+    }
+}

--- a/rust/dialog-query/src/type_system/wire.rs
+++ b/rust/dialog-query/src/type_system/wire.rs
@@ -489,6 +489,69 @@ mod tests {
         assert_eq!(roundtrip(&kind), kind);
     }
 
+    /// The cliff the `domain` slot exists to remove: a name shape
+    /// narrows a scan to the shape's contiguous byte class ONLY when
+    /// the prefix ends at the name boundary. One byte short and the
+    /// shape falls back to a per-entry filter over the whole prefix
+    /// range — same rows, a wider scan, and nothing to notice.
+    ///
+    /// Writing the domain without its separator makes the bad state
+    /// unwritable: there is no way to spell a prefix that stops one
+    /// byte early.
+    #[dialog_common::test]
+    async fn it_cannot_write_a_prefix_that_misses_the_name_boundary() {
+        use crate::artifact::{ArtifactSelector, Constrained};
+        use dialog_artifacts::tree::selector_range;
+        use dialog_search_tree::Manifest;
+
+        // What the format produces: a domain, separator included.
+        let whole = decode(&serde_json::json!({
+            "type": {"symbol": {}},
+            "domain": {"is": "todo.list"},
+            "name": {"case": "position"}
+        }))
+        .expect("a domain and a name shape");
+        let refinement = whole.refinement().expect("refined");
+        assert_eq!(
+            refinement.prefix.as_deref(),
+            Some("todo.list/"),
+            "the separator is supplied on the way in, not by the writer"
+        );
+
+        // The degraded shape is still expressible through the raw
+        // `starts-with` escape hatch — this pins the DIFFERENCE, so a
+        // future change that routed domains through it would fail
+        // here rather than quietly widen every collection scan.
+        let partial = decode(&serde_json::json!({
+            "type": {"symbol": {}},
+            "starts-with": "todo.list/N",
+            "name": {"case": "position"}
+        }))
+        .expect("a partial prefix is a valid lexical constraint");
+
+        let range = |kind: &Type| {
+            let selector: ArtifactSelector<Constrained> = ArtifactSelector::new()
+                .the_starting_with(
+                    kind.refinement()
+                        .and_then(|r| r.prefix.clone())
+                        .expect("a prefix"),
+                )
+                .with_name_shape(
+                    kind.refinement()
+                        .and_then(|r| r.name_shape)
+                        .expect("a shape"),
+                );
+            selector_range(&selector, &Manifest::default())
+        };
+
+        assert_ne!(
+            range(&whole),
+            range(&partial),
+            "a boundary prefix narrows to the shape's byte class; a partial \
+             one cannot, and scans wider"
+        );
+    }
+
     /// Reading is looser than writing: the derived shape a rule was
     /// stored under before this module still loads.
     #[dialog_common::test]

--- a/rust/dialog-query/src/type_system/wire.rs
+++ b/rust/dialog-query/src/type_system/wire.rs
@@ -32,8 +32,11 @@
 //! stored before this module loads unchanged. Only the form above is
 //! ever written.
 
+use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as Json};
+use std::error::Error as StdError;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use crate::artifact::{Type as ValueType, Value, decode_value};
 
@@ -78,8 +81,8 @@ pub enum WireError {
     Uninhabited(&'static str),
 }
 
-impl std::fmt::Display for WireError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for WireError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::UnknownVariant(name) => {
                 write!(f, "unknown type variant {name:?}")
@@ -93,7 +96,7 @@ impl std::fmt::Display for WireError {
     }
 }
 
-impl std::error::Error for WireError {}
+impl StdError for WireError {}
 
 /// A [`Type`] in its wire form: `serialize` writes the named shape,
 /// `deserialize` accepts it and the legacy derived shape alike.
@@ -109,7 +112,7 @@ impl Serialize for Wire {
 impl<'de> Deserialize<'de> for Wire {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let json = Json::deserialize(deserializer)?;
-        decode(&json).map(Wire).map_err(serde::de::Error::custom)
+        decode(&json).map(Wire).map_err(DeError::custom)
     }
 }
 

--- a/rust/dialog-query/tests/formal_notation.rs
+++ b/rust/dialog-query/tests/formal_notation.rs
@@ -28,7 +28,7 @@ fn it_parses_attribute_formal_notation() {
         serde_json::from_value(json.clone()).expect("Should parse attribute");
 
     assert_eq!(attr.domain(), "io.gozala.person");
-    assert_eq!(attr.name(), "name");
+    assert_eq!(attr.name(), Some("name"));
     assert_eq!(attr.description(), "Name of the person");
     assert_eq!(
         attr.content_type(),
@@ -76,7 +76,7 @@ fn it_parses_minimal_attribute() {
     let attr: dialog_query::AttributeDescriptor =
         serde_json::from_value(json).expect("Minimal attribute should parse");
     assert_eq!(attr.domain(), "task");
-    assert_eq!(attr.name(), "status");
+    assert_eq!(attr.name(), Some("status"));
     assert_eq!(attr.cardinality(), dialog_query::Cardinality::One);
     assert_eq!(attr.content_type(), None);
 }
@@ -121,7 +121,7 @@ fn it_parses_concept_formal_notation() {
 
     let name_attr = concept.with().iter().find(|(k, _)| *k == "name").unwrap().1;
     assert_eq!(name_attr.domain(), "io.gozala.person");
-    assert_eq!(name_attr.name(), "name");
+    assert_eq!(name_attr.name(), Some("name"));
 
     let addr_attr = concept
         .with()
@@ -130,7 +130,7 @@ fn it_parses_concept_formal_notation() {
         .unwrap()
         .1;
     assert_eq!(addr_attr.domain(), "io.gozala.person");
-    assert_eq!(addr_attr.name(), "address");
+    assert_eq!(addr_attr.name(), Some("address"));
 }
 
 #[dialog_common::test]
@@ -572,7 +572,7 @@ fn it_parses_concept_premise() {
                 .unwrap()
                 .1;
             assert_eq!(attr.domain(), "diy.cook");
-            assert_eq!(attr.name(), "ingredient-name");
+            assert_eq!(attr.name(), Some("ingredient-name"));
         }
         other => panic!("Expected Concept, got {:?}", other),
     }

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -926,7 +926,7 @@ mod tests {
 
     use crate::RemoteSite;
     use crate::helpers::test_repo;
-    use dialog_artifacts::{Attribute as ArtifactsAttribute, NameShape};
+    use dialog_artifacts::{Attribute as ArtifactsAttribute, NameShape, Symbol};
     use dialog_artifacts::{Entity, Value};
     use dialog_capability::{Fork, Provider};
     use dialog_common::{ConditionalSend, ConditionalSync};
@@ -935,10 +935,14 @@ mod tests {
     use dialog_effects::memory::Resolve;
     use dialog_operator::helpers::test_operator_with_profile;
     use dialog_query::attribute::The;
+    use dialog_query::attribute::{AttributeDescriptor, Keyed, Relation};
+    use dialog_query::concept::descriptor::ConceptFieldDescriptor;
     use dialog_query::type_system::Type as Kind;
     use dialog_query::types::{Any, Type as ValueType};
     use dialog_query::{AttributeQuery, Claim, Term, the};
+    use dialog_query::{Cardinality, ConceptDescriptor, ConceptQuery, Output as _};
     use std::collections::BTreeMap;
+    use std::str::FromStr;
 
     /// The head flag flips only for scans that can actually read the
     /// overlay-injected metadata: a head attribute pinned by `the`,
@@ -1655,6 +1659,383 @@ mod tests {
             baseline,
             "and must not force a recompute"
         );
+        Ok(())
+    }
+
+    /// A concept whose field is a keyed collection: one field, many
+    /// facts, one per ordered member. This is the end-to-end shape —
+    /// the descriptor holds a `Relation::Collection`, its `term()`
+    /// lowers to a domain scan refined by name shape, and the query
+    /// comes back with one conclusion per member, each carrying the
+    /// entry as `(key, value)`: the wire form `member: {?key: ?member}`.
+    fn ordered_query() -> ConceptQuery {
+        serde_json::from_value(serde_json::json!({
+            "assert": ordered_members(),
+            "where": {
+                "this": {"?": {"name": "this"}},
+                "member": {"the": {"?": {"name": "key"}}, "is": {"?": {"name": "member"}}}
+            }
+        }))
+        .expect("the entry form parses")
+    }
+
+    /// The `(key, value)` entries a frame holds, in key order — which
+    /// for positions is list order.
+    fn entries(rows: &[dialog_query::ConceptConclusion]) -> Vec<(String, String)> {
+        let mut entries: Vec<(String, String)> = rows
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<String>("member/key").expect("the key is bound"),
+                    row.get::<String>("member").expect("the member is bound"),
+                )
+            })
+            .collect();
+        entries.sort();
+        entries
+    }
+
+    fn ordered_members() -> ConceptDescriptor {
+        ConceptDescriptor::try_from(vec![(
+            "member".to_owned(),
+            ConceptFieldDescriptor::required(AttributeDescriptor::over(
+                Relation::collection(
+                    Symbol::from_str("todo.list").expect("a valid domain"),
+                    Keyed::Sequence,
+                ),
+                "the list's members, in order",
+                Cardinality::Many,
+                Some(ValueType::String),
+            )),
+        )])
+        .expect("a collection field builds a concept")
+    }
+
+    /// Assert one member, and the concept query returns it — the
+    /// whole path from a stored fact under a position-named attribute
+    /// to a bound conclusion field.
+    #[dialog_common::test]
+    async fn it_queries_a_concept_over_a_collection() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        let second = The::from(ArtifactsAttribute::try_from("todo.list/N5".to_string())?);
+        branch
+            .transaction()
+            // A named field in the same domain: the dictionary half,
+            // which an ordered field must not pick up.
+            .assert(
+                the!("todo.list/title")
+                    .of(list.clone())
+                    .is("Groceries".to_string()),
+            )
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .assert(second.of(list.clone()).is("Bread".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let rows = branch
+            .query()
+            .select(ordered_query())
+            .perform(&operator)
+            .try_vec()
+            .await?;
+
+        assert_eq!(
+            entries(&rows),
+            vec![
+                ("N".to_string(), "Milk".to_string()),
+                ("N5".to_string(), "Bread".to_string()),
+            ],
+            "both ordered members bind with their keys, in list order, \
+             and the dictionary entry does not"
+        );
+        Ok(())
+    }
+
+    /// A subscription over a collection-field concept maintains
+    /// incrementally: appending a member emits it as a delta, and a
+    /// write to the domain's other half does not wake the
+    /// subscription at all.
+    #[dialog_common::test]
+    async fn it_maintains_a_collection_subscription() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        branch
+            .transaction()
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(ordered_query());
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(initial.asserted.len(), 1, "the one member");
+        let baseline = subscription.recomputes();
+
+        // Appending a member is inside the cover: it must arrive.
+        let second = The::from(ArtifactsAttribute::try_from("todo.list/N5".to_string())?);
+        branch
+            .transaction()
+            .assert(second.of(list.clone()).is("Bread".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("a new member");
+        assert_eq!(delta.asserted.len(), 1, "the appended member");
+        assert!(delta.retracted.is_empty(), "nothing was removed");
+        assert_eq!(subscription.results().len(), 2, "both members retained");
+
+        // The dictionary half of the same domain is outside the
+        // cover: an ordered subscription must not wake for it.
+        branch
+            .transaction()
+            .assert(
+                the!("todo.list/title")
+                    .of(list.clone())
+                    .is("Groceries".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        assert!(
+            subscription.poll(&operator).await?.is_none(),
+            "the other half of the domain is not this subscription's demand"
+        );
+        assert_eq!(
+            subscription.results().len(),
+            2,
+            "results retained across the gated poll"
+        );
+        let _ = baseline;
+        Ok(())
+    }
+
+    /// Retracting a member removes it from a live subscription: the
+    /// collection scan maintains in both directions, not just on
+    /// append.
+    #[dialog_common::test]
+    async fn it_retracts_a_member_from_a_collection_subscription() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        let second = The::from(ArtifactsAttribute::try_from("todo.list/N5".to_string())?);
+        branch
+            .transaction()
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .assert(second.clone().of(list.clone()).is("Bread".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(ordered_query());
+        assert_eq!(
+            subscription
+                .poll(&operator)
+                .await?
+                .expect("initial")
+                .asserted
+                .len(),
+            2
+        );
+
+        branch
+            .transaction()
+            .retract(second.of(list.clone()).is("Bread".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription.poll(&operator).await?.expect("a retraction");
+        assert_eq!(delta.retracted.len(), 1, "the removed member");
+        assert_eq!(subscription.results().len(), 1, "one member remains");
+        Ok(())
+    }
+
+    /// A literal key selects one entry: `member: {N5: ?member}` binds
+    /// only the member stored under `todo.list/N5`.
+    #[dialog_common::test]
+    async fn it_selects_one_entry_by_literal_key() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        let second = The::from(ArtifactsAttribute::try_from("todo.list/N5".to_string())?);
+        branch
+            .transaction()
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .assert(second.of(list.clone()).is("Bread".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let query: ConceptQuery = serde_json::from_value(serde_json::json!({
+            "assert": ordered_members(),
+            "where": {
+                "this": {"?": {"name": "this"}},
+                "member": {"the": "N5", "is": {"?": {"name": "member"}}}
+            }
+        }))?;
+        let rows = branch
+            .query()
+            .select(query)
+            .perform(&operator)
+            .try_vec()
+            .await?;
+        assert_eq!(
+            entries(&rows),
+            vec![("N5".to_string(), "Bread".to_string())],
+            "a literal key matches exactly one entry"
+        );
+        Ok(())
+    }
+
+    /// A dictionary field selects the symbol-named half of the same
+    /// domain, keyed by name, and leaves the ordered members alone.
+    #[dialog_common::test]
+    async fn it_queries_a_dictionary_field() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let member = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        branch
+            .transaction()
+            .assert(
+                the!("todo.list/title")
+                    .of(list.clone())
+                    .is("Groceries".to_string()),
+            )
+            .assert(
+                the!("todo.list/owner")
+                    .of(list.clone())
+                    .is("Alice".to_string()),
+            )
+            .assert(member.of(list.clone()).is("Milk".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let fields = ConceptDescriptor::try_from(vec![(
+            "field".to_owned(),
+            ConceptFieldDescriptor::required(AttributeDescriptor::over(
+                Relation::collection(
+                    Symbol::from_str("todo.list").expect("a valid domain"),
+                    Keyed::Dictionary,
+                ),
+                "the list's named fields",
+                Cardinality::Many,
+                Some(ValueType::String),
+            )),
+        )])?;
+        let query: ConceptQuery = serde_json::from_value(serde_json::json!({
+            "assert": fields,
+            "where": {
+                "this": {"?": {"name": "this"}},
+                "field": {"the": {"?": {"name": "name"}}, "is": {"?": {"name": "value"}}}
+            }
+        }))?;
+        let rows = branch
+            .query()
+            .select(query)
+            .perform(&operator)
+            .try_vec()
+            .await?;
+        let mut named: Vec<(String, String)> = rows
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<String>("field/key").expect("the name is bound"),
+                    row.get::<String>("field").expect("the value is bound"),
+                )
+            })
+            .collect();
+        named.sort();
+        assert_eq!(
+            named,
+            vec![
+                ("owner".to_string(), "Alice".to_string()),
+                ("title".to_string(), "Groceries".to_string()),
+            ],
+            "the dictionary half, by name, without the ordered member"
+        );
+        Ok(())
+    }
+
+    /// Two collection fields on one concept scan independently: each
+    /// has its own attribute variable, so their entries cross rather
+    /// than unify on a shared name.
+    #[dialog_common::test]
+    async fn it_scans_two_collection_fields_independently() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let member = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        branch
+            .transaction()
+            .assert(
+                the!("todo.list/title")
+                    .of(list.clone())
+                    .is("Groceries".to_string()),
+            )
+            .assert(member.of(list.clone()).is("Milk".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let collection = |keyed: Keyed, description: &str| {
+            ConceptFieldDescriptor::required(AttributeDescriptor::over(
+                Relation::collection(
+                    Symbol::from_str("todo.list").expect("a valid domain"),
+                    keyed,
+                ),
+                description,
+                Cardinality::Many,
+                Some(ValueType::String),
+            ))
+        };
+        let both = ConceptDescriptor::try_from(vec![
+            ("member".to_owned(), collection(Keyed::Sequence, "members")),
+            ("field".to_owned(), collection(Keyed::Dictionary, "fields")),
+        ])?;
+        let query: ConceptQuery = serde_json::from_value(serde_json::json!({
+            "assert": both,
+            "where": {
+                "this": {"?": {"name": "this"}},
+                "member": {"the": {"?": {"name": "position"}}, "is": {"?": {"name": "member"}}},
+                "field": {"the": {"?": {"name": "name"}}, "is": {"?": {"name": "value"}}}
+            }
+        }))?;
+        let rows = branch
+            .query()
+            .select(query)
+            .perform(&operator)
+            .try_vec()
+            .await?;
+        assert_eq!(rows.len(), 1, "one member crossed with one field");
+        let row = &rows[0];
+        assert_eq!(row.get::<String>("member/key")?, "N");
+        assert_eq!(row.get::<String>("member")?, "Milk");
+        assert_eq!(row.get::<String>("field/key")?, "title");
+        assert_eq!(row.get::<String>("field")?, "Groceries");
         Ok(())
     }
 

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -926,6 +926,7 @@ mod tests {
 
     use crate::RemoteSite;
     use crate::helpers::test_repo;
+    use dialog_artifacts::{Attribute as ArtifactsAttribute, NameShape};
     use dialog_artifacts::{Entity, Value};
     use dialog_capability::{Fork, Provider};
     use dialog_common::{ConditionalSend, ConditionalSync};
@@ -934,7 +935,8 @@ mod tests {
     use dialog_effects::memory::Resolve;
     use dialog_operator::helpers::test_operator_with_profile;
     use dialog_query::attribute::The;
-    use dialog_query::types::Any;
+    use dialog_query::type_system::Type as Kind;
+    use dialog_query::types::{Any, Type as ValueType};
     use dialog_query::{AttributeQuery, Claim, Term, the};
     use std::collections::BTreeMap;
 
@@ -1037,6 +1039,23 @@ mod tests {
     fn names_query() -> AttributeQuery {
         AttributeQuery::from(
             Term::<The>::from(the!("person/name"))
+                .of(Term::<Entity>::var("e"))
+                .is(Term::<String>::var("v")),
+        )
+    }
+
+    /// A scan of one half of the `todo.list` domain: the attribute is
+    /// a variable refined by the domain prefix and a name shape, which
+    /// is how an ordered collection (or a dictionary) is queried.
+    fn members_query(shape: NameShape) -> AttributeQuery {
+        let kind = Kind::from(ValueType::Symbol)
+            .with_prefix("todo.list/")
+            .expect("symbol is textual")
+            .with_name_shape(shape)
+            .expect("shapes compose with prefixes");
+        AttributeQuery::from(
+            Term::<The>::var("a")
+                .with_kind(kind)
                 .of(Term::<Entity>::var("e"))
                 .is(Term::<String>::var("v")),
         )
@@ -1485,6 +1504,157 @@ mod tests {
         // The pin advanced: polling again is a revision-equality
         // no-op, not another diff.
         assert!(subscription.poll(&operator).await?.is_none());
+        Ok(())
+    }
+
+    /// A subscription over one half of a mixed domain demands only
+    /// that half. Positions and symbols occupy disjoint first-byte
+    /// classes, so the demand cover is the shape's contiguous
+    /// sub-range: writing the OTHER half is as irrelevant as writing
+    /// an unrelated attribute, and must not re-evaluate.
+    ///
+    /// This is what makes an ordered collection cheap to watch. A
+    /// list's members and its named fields share one domain; without
+    /// the shape narrowing, renaming the list would wake every
+    /// subscription watching its contents.
+    #[dialog_common::test]
+    async fn it_ignores_the_other_half_of_a_mixed_domain() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        branch
+            .transaction()
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(members_query(NameShape::Position));
+        let initial = subscription.poll(&operator).await?.expect("initial");
+        assert_eq!(
+            initial.asserted.len(),
+            1,
+            "the one member is the initial result"
+        );
+
+        // A symbol-named fact in the SAME domain: the dictionary half.
+        branch
+            .transaction()
+            .assert(
+                the!("todo.list/title")
+                    .of(list.clone())
+                    .is("Groceries".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        assert!(
+            subscription.poll(&operator).await?.is_none(),
+            "the dictionary half is outside an ordered scan's cover"
+        );
+        assert_eq!(
+            subscription.results().len(),
+            1,
+            "results retained across the gated poll"
+        );
+        Ok(())
+    }
+
+    /// The complement: a write to the half the subscription DOES
+    /// demand re-evaluates and emits the new member. Without this the
+    /// test above would pass for a subscription that had simply
+    /// stopped working.
+    #[dialog_common::test]
+    async fn it_emits_a_new_member_of_the_demanded_half() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        branch
+            .transaction()
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(members_query(NameShape::Position));
+        subscription.poll(&operator).await?.expect("initial");
+
+        // A second ordered member, appended after the first.
+        let second = The::from(ArtifactsAttribute::try_from("todo.list/N5".to_string())?);
+        branch
+            .transaction()
+            .assert(second.of(list.clone()).is("Bread".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let delta = subscription
+            .poll(&operator)
+            .await?
+            .expect("a member landed in the demanded half");
+        assert_eq!(delta.asserted.len(), 1, "one new member");
+        assert!(delta.retracted.is_empty(), "nothing was removed");
+        assert_eq!(
+            subscription.results().len(),
+            2,
+            "both members are now in the result"
+        );
+        Ok(())
+    }
+
+    /// A domain scan must not flip the head flag. `selects_head`
+    /// treats an attribute-unconstrained scan conservatively, and a
+    /// scan that flipped it would recompute on EVERY commit —
+    /// silently turning incremental maintenance back into polling.
+    #[dialog_common::test]
+    async fn it_does_not_trip_the_head_gate_on_a_domain_scan() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let list = Entity::new()?;
+        let first = The::from(ArtifactsAttribute::try_from("todo.list/N".to_string())?);
+        branch
+            .transaction()
+            .assert(first.of(list.clone()).is("Milk".to_string()))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut subscription = branch.subscribe(members_query(NameShape::Position));
+        subscription.poll(&operator).await?.expect("initial");
+        let baseline = subscription.recomputes();
+
+        // A commit in an entirely unrelated domain. A head-gated
+        // subscription would recompute here; a properly covered one
+        // advances its pin and does nothing.
+        branch
+            .transaction()
+            .assert(
+                the!("misc/tag")
+                    .of(Entity::new()?)
+                    .is("unrelated".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        assert!(
+            subscription.poll(&operator).await?.is_none(),
+            "an unrelated commit must not re-evaluate a domain scan"
+        );
+        assert_eq!(
+            subscription.recomputes(),
+            baseline,
+            "and must not force a recompute"
+        );
         Ok(())
     }
 

--- a/rust/dialog-repository/src/repository/branch/transaction/induce.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/induce.rs
@@ -32,6 +32,11 @@
 
 use std::collections::{BTreeSet, HashMap};
 
+/// A rule's conclusion cannot be a keyed collection: the
+/// analyzer refuses one (`AnalysisError::CollectionHead`) precisely
+/// because the per-attribute tracking below could not represent it.
+const RULE_HEAD_ATTRIBUTE: &str = "a rule head names one attribute";
+
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::{
     Artifact, ArtifactSelector, Attribute, Change, Changes, Entity, Instruction, Select, Statement,
@@ -185,7 +190,13 @@ where
             for (_, field) in body.conclusion().with().iter() {
                 // Inserted after the `direct` snapshot, so these land
                 // in the expanded set and force full evaluation.
-                touched.insert(field.descriptor().the().clone().into());
+                touched.insert(
+                    field
+                        .descriptor()
+                        .the()
+                        .attribute()
+                        .expect(RULE_HEAD_ATTRIBUTE),
+                );
             }
         }
 
@@ -531,7 +542,11 @@ impl<'a> Dispatch<'a> {
                     continue;
                 };
                 for (_, field) in body.conclusion().with().iter() {
-                    let derived: Attribute = field.descriptor().the().clone().into();
+                    let derived = field
+                        .descriptor()
+                        .the()
+                        .attribute()
+                        .expect(RULE_HEAD_ATTRIBUTE);
                     if touched.insert(derived.clone()) {
                         frontier.push(derived);
                     }
@@ -908,7 +923,13 @@ fn premise_attrs(rule: &InductiveRule) -> (BTreeSet<Attribute>, BTreeSet<Attribu
             _ => continue,
         };
         for (_, field) in query.predicate.with().iter() {
-            target.insert(field.descriptor().the().clone().into());
+            // A premise may read a keyed collection even though a
+            // head may not derive one; a collection spans a domain,
+            // so it contributes no single attribute to this set.
+            let Some(attribute) = field.descriptor().the().attribute() else {
+                continue;
+            };
+            target.insert(attribute);
         }
     }
     (positive, unless)
@@ -954,7 +975,9 @@ where
             let mut seeded = false;
             let mut compatible = true;
             for (name, field) in query.predicate.with().iter() {
-                let attribute: Attribute = field.descriptor().the().clone().into();
+                let Some(attribute) = field.descriptor().the().attribute() else {
+                    continue;
+                };
                 if attribute != row.the {
                     continue;
                 }
@@ -1059,7 +1082,11 @@ where
                 // nothing.
                 continue;
             };
-            let attribute: Attribute = field.descriptor().the().clone().into();
+            let attribute = field
+                .descriptor()
+                .the()
+                .attribute()
+                .expect(RULE_HEAD_ATTRIBUTE);
             match rule.polarity() {
                 // A retracting head dissociates the exact bound
                 // triple, cardinality-independent.

--- a/rust/dialog-repository/src/repository/branch/transaction/induce.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/induce.rs
@@ -32,11 +32,6 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-/// A rule's conclusion cannot be a keyed collection: the
-/// analyzer refuses one (`AnalysisError::CollectionHead`) precisely
-/// because the per-attribute tracking below could not represent it.
-const RULE_HEAD_ATTRIBUTE: &str = "a rule head names one attribute";
-
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::{
     Artifact, ArtifactSelector, Attribute, Change, Changes, Entity, Instruction, Select, Statement,
@@ -47,7 +42,9 @@ use dialog_common::ConditionalSync;
 use dialog_effects::archive::{Get, Put};
 use dialog_effects::authority::Identify;
 use dialog_effects::memory::Resolve;
+use dialog_query::attribute::Relation;
 use dialog_query::rule::inductive::Polarity;
+use dialog_query::rule::statement::Reach;
 use dialog_query::{Any, Binding, Cardinality, Environment, InductiveRule, Match, Term};
 use futures_util::{StreamExt as _, TryStreamExt};
 use std::sync::Arc;
@@ -57,8 +54,7 @@ use crate::repository::branch::QueryLayer;
 use crate::repository::branch::session::QueryEnv;
 use crate::repository::source::SourceRef;
 use crate::rules::{
-    TriggerFootprint, hydrate, hydrate_inductive, on_attr, on_entity, reads_attr, source_attr,
-    transient_attr,
+    TriggerFootprint, hydrate, hydrate_inductive, on_attr, reads_attr, source_attr, transient_attr,
 };
 use crate::{CommitError, RemoteSite, Revision};
 
@@ -144,11 +140,15 @@ where
                 }
             }
         }
-        let mut touched: BTreeSet<Attribute> = stimulus
+        // Reach is tracked per attribute, or per keyed half of a
+        // domain for a collection: a stimulus row touches its own
+        // attribute, and a rule reading or writing a collection
+        // reaches every attribute of that half.
+        let mut touched: BTreeSet<Reach> = stimulus
             .iter()
             .map(|instruction| match instruction {
                 Instruction::Assert(a) | Instruction::Replace(a) | Instruction::Retract(a) => {
-                    a.the.clone()
+                    Reach::Attribute(a.the.clone())
                 }
             })
             .collect();
@@ -190,13 +190,7 @@ where
             for (_, field) in body.conclusion().with().iter() {
                 // Inserted after the `direct` snapshot, so these land
                 // in the expanded set and force full evaluation.
-                touched.insert(
-                    field
-                        .descriptor()
-                        .the()
-                        .attribute()
-                        .expect(RULE_HEAD_ATTRIBUTE),
-                );
+                touched.insert(Reach::of(field.descriptor().the()));
             }
         }
 
@@ -223,18 +217,17 @@ where
         // `dialog.rule/on` lookup (head-cached) per surviving attribute.
         // Nothing ever enumerates all rules.
         let mut candidates: BTreeSet<Entity> = BTreeSet::new();
-        for attribute in &touched {
-            let Some(on) = on_entity(attribute) else {
-                continue;
-            };
-            candidates.extend(dispatch.triggers(&on, &overlay, env).await?);
+        for reach in &touched {
+            for on in reach.probes() {
+                candidates.extend(dispatch.triggers(&on, &overlay, env).await?);
+            }
         }
         candidates.extend(installed.iter().cloned());
 
         // Attributes only reachable through the deductive closure: a
         // candidate premised on one changed *derivedly*, which a base
         // row cannot seed.
-        let expanded: BTreeSet<Attribute> = touched.difference(&direct).cloned().collect();
+        let expanded: BTreeSet<Reach> = touched.difference(&direct).cloned().collect();
 
         let mut novelty = Changes::new();
         let mut emitted_transients = Changes::new();
@@ -253,13 +246,17 @@ where
             // seed cannot express: enabling by removal (`unless` over
             // a retracted or superseded fact) and premises that
             // changed derivedly through the deductive closure.
-            let (positive_attrs, unless_attrs) = premise_attrs(&rule);
+            let (positive, unless) = premise_reach(&rule);
             let full = installed.contains(&entity)
                 || expanded
                     .iter()
-                    .any(|a| positive_attrs.contains(a) || unless_attrs.contains(a))
-                || retract_attrs.iter().any(|a| unless_attrs.contains(a))
-                || replace_attrs.iter().any(|a| unless_attrs.contains(a));
+                    .any(|a| positive.iter().chain(unless.iter()).any(|p| p.overlaps(a)))
+                || retract_attrs
+                    .iter()
+                    .any(|a| unless.iter().any(|u| u.covers(a)))
+                || replace_attrs
+                    .iter()
+                    .any(|a| unless.iter().any(|u| u.covers(a)));
             if full {
                 fire(
                     &rule,
@@ -491,7 +488,7 @@ impl<'a> Dispatch<'a> {
     /// negation, an assertion of a base fact can retract a derived one.
     async fn expand_through_deduction<Env>(
         &self,
-        touched: &mut BTreeSet<Attribute>,
+        touched: &mut BTreeSet<Reach>,
         overlay: &OverlayTriggers,
         env: &Env,
     ) -> Result<(), CommitError>
@@ -505,35 +502,33 @@ impl<'a> Dispatch<'a> {
             + 'static,
     {
         let cache = self.source.rule_cache();
-        let mut frontier: Vec<Attribute> = touched.iter().cloned().collect();
-        while let Some(attribute) = frontier.pop() {
-            let Some(on) = on_entity(&attribute) else {
-                continue;
-            };
-
+        let mut frontier: Vec<Reach> = touched.iter().cloned().collect();
+        while let Some(reach) = frontier.pop() {
             let mut readers: Vec<Entity> = Vec::new();
-            if let Some(head) = &self.head
-                && self.footprint.reads.contains(&on)
-            {
-                let committed_readers = match cache.reads(&on, head) {
-                    Some(entities) => entities,
-                    None => {
-                        let selector = ArtifactSelector::new()
-                            .the(reads_attr())
-                            .is(Value::Entity(on.clone()));
-                        let entities: Vec<Entity> = committed(self.source, selector, env)
-                            .await?
-                            .into_iter()
-                            .map(|claim| claim.of)
-                            .collect();
-                        cache.record_reads(on.clone(), head.clone(), entities.clone());
-                        entities
-                    }
-                };
-                readers.extend(committed_readers);
-            }
-            if let Some(staged) = overlay.reads.get(&on) {
-                readers.extend(staged.iter().cloned());
+            for on in reach.probes() {
+                if let Some(head) = &self.head
+                    && self.footprint.reads.contains(&on)
+                {
+                    let committed_readers = match cache.reads(&on, head) {
+                        Some(entities) => entities,
+                        None => {
+                            let selector = ArtifactSelector::new()
+                                .the(reads_attr())
+                                .is(Value::Entity(on.clone()));
+                            let entities: Vec<Entity> = committed(self.source, selector, env)
+                                .await?
+                                .into_iter()
+                                .map(|claim| claim.of)
+                                .collect();
+                            cache.record_reads(on.clone(), head.clone(), entities.clone());
+                            entities
+                        }
+                    };
+                    readers.extend(committed_readers);
+                }
+                if let Some(staged) = overlay.reads.get(&on) {
+                    readers.extend(staged.iter().cloned());
+                }
             }
             readers.retain(|entity| !overlay.removed.contains(entity));
 
@@ -542,11 +537,7 @@ impl<'a> Dispatch<'a> {
                     continue;
                 };
                 for (_, field) in body.conclusion().with().iter() {
-                    let derived = field
-                        .descriptor()
-                        .the()
-                        .attribute()
-                        .expect(RULE_HEAD_ATTRIBUTE);
+                    let derived = Reach::of(field.descriptor().the());
                     if touched.insert(derived.clone()) {
                         frontier.push(derived);
                     }
@@ -908,10 +899,10 @@ where
     emit_matches(rule, transient_head, matches, view, novelty, transients).await
 }
 
-/// The attributes a rule's concept premises name, split by polarity:
-/// positive premise attributes (seedable by an assert/replace row) and
-/// `unless` attributes (only enabled by removal — never seedable).
-fn premise_attrs(rule: &InductiveRule) -> (BTreeSet<Attribute>, BTreeSet<Attribute>) {
+/// The reach of a rule's concept premises, split by polarity:
+/// positive premises (seedable by an assert/replace row) and `unless`
+/// premises (only enabled by removal — never seedable).
+fn premise_reach(rule: &InductiveRule) -> (BTreeSet<Reach>, BTreeSet<Reach>) {
     use dialog_query::{Negation, Premise, Proposition};
 
     let mut positive = BTreeSet::new();
@@ -923,13 +914,7 @@ fn premise_attrs(rule: &InductiveRule) -> (BTreeSet<Attribute>, BTreeSet<Attribu
             _ => continue,
         };
         for (_, field) in query.predicate.with().iter() {
-            // A premise may read a keyed collection even though a
-            // head may not derive one; a collection spans a domain,
-            // so it contributes no single attribute to this set.
-            let Some(attribute) = field.descriptor().the().attribute() else {
-                continue;
-            };
-            target.insert(attribute);
+            target.insert(Reach::of(field.descriptor().the()));
         }
     }
     (positive, unless)
@@ -975,10 +960,8 @@ where
             let mut seeded = false;
             let mut compatible = true;
             for (name, field) in query.predicate.with().iter() {
-                let Some(attribute) = field.descriptor().the().attribute() else {
-                    continue;
-                };
-                if attribute != row.the {
+                let relation = field.descriptor().the();
+                if !Reach::of(relation).covers(&row.the) {
                     continue;
                 }
                 if !bind_seed(
@@ -987,6 +970,19 @@ where
                     query.terms.get(name),
                     row.is.clone(),
                 ) {
+                    compatible = false;
+                    break;
+                }
+                // A collection premise binds the entry's key too: the
+                // name half of the row's attribute.
+                if relation.attribute().is_none()
+                    && !bind_seed(
+                        &mut matched,
+                        &mut scope,
+                        query.terms.get(&Relation::key_operand(name)),
+                        Value::String(row.the.name().to_owned()),
+                    )
+                {
                     compatible = false;
                     break;
                 }
@@ -1082,11 +1078,21 @@ where
                 // nothing.
                 continue;
             };
-            let attribute = field
-                .descriptor()
-                .the()
-                .attribute()
-                .expect(RULE_HEAD_ATTRIBUTE);
+            // A collection head writes under `domain/key`, the key
+            // being what the body bound to the field's key operand.
+            let relation = field.descriptor().the();
+            let attribute = match relation.attribute() {
+                Some(attribute) => attribute,
+                None => {
+                    let key = Term::<Any>::var(Relation::key_operand(name));
+                    let Ok(Binding::Present(Value::String(key))) = matched.lookup(&key) else {
+                        continue;
+                    };
+                    relation.entry(&key).map_err(|error| {
+                        CommitError::Induction(format!("head field {name}: {error}"))
+                    })?
+                }
+            };
             match rule.polarity() {
                 // A retracting head dissociates the exact bound
                 // triple, cardinality-independent.
@@ -2626,6 +2632,246 @@ mod tests {
         assert!(
             branch.rule_cache().footprint(&head).is_none(),
             "a rule install invalidates the footprint; the next dispatch rescans"
+        );
+        Ok(())
+    }
+
+    /// The list concept: every position-named entry of `todo.list`,
+    /// valued by a member entity.
+    fn list_members() -> serde_json::Value {
+        json!({
+            "with": {
+                "member": {
+                    "the": { "domain": "todo.list", "keyed": "sequence" },
+                    "cardinality": "many",
+                    "as": "Entity"
+                }
+            }
+        })
+    }
+
+    /// The entries of `list`, in key order.
+    async fn members<Env>(branch: &Branch, env: &Env, list: &Entity) -> Result<Vec<(String, Value)>>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let selector = ArtifactSelector::new()
+            .the_starting_with("todo.list/".to_string())
+            .of(list.clone());
+        let stream = branch.claims().select(selector).perform(env).await?;
+        let artifacts: Vec<_> = stream.collect().await;
+        let mut entries: Vec<(String, Value)> = artifacts
+            .into_iter()
+            .map(|item| item.and_then(|view| view.to_owned()))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .map(|artifact| (artifact.the.name().to_owned(), artifact.is))
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(entries)
+    }
+
+    /// An inductive rule derives INTO a sequence: the head's entry is
+    /// written under `todo.list/<key>`, the key being what the body
+    /// bound — here `dialog/position` deriving a first position for
+    /// the member.
+    #[dialog_common::test]
+    async fn it_induces_an_entry_into_a_sequence() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let rule: InductiveRule = serde_json::from_value(json!({
+            "description": "An item joins its list",
+            "assert!": list_members(),
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "list": { "the": "todo.item/list", "as": "Entity" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "member" } },
+                        "list": { "?": { "name": "this" } }
+                    }
+                },
+                {
+                    "assert": "dialog/position",
+                    "where": {
+                        "member": { "?": { "name": "member" } },
+                        "after": "",
+                        "before": "",
+                        "is": { "?": { "name": "member/key" } }
+                    }
+                }
+            ]
+        }))?;
+        let list: Entity = "list:1".parse()?;
+        let item: Entity = "item:1".parse()?;
+        branch
+            .transaction()
+            .assert(rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+        branch.refresh(&operator).await?;
+
+        branch
+            .transaction()
+            .assert(
+                dialog_query::the!("todo.item/list")
+                    .of(item.clone())
+                    .is(list.clone()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+        branch.refresh(&operator).await?;
+
+        let entries = members(&branch, &operator, &list).await?;
+        assert_eq!(entries.len(), 1, "one entry for the one item");
+        let (key, value) = &entries[0];
+        assert!(
+            key.starts_with(|c: char| c.is_ascii_uppercase()),
+            "the key is a position: {key}"
+        );
+        assert_eq!(value, &Value::Entity(item));
+        Ok(())
+    }
+
+    /// An inductive rule READING a sequence wakes for a member write:
+    /// the write's attribute probes the domain half's cover key, the
+    /// rule seeds with both the value and the key bound, and its head
+    /// records the key it saw.
+    #[dialog_common::test]
+    async fn it_fires_a_rule_reading_a_collection() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let rule: InductiveRule = serde_json::from_value(json!({
+            "description": "Record where a member sits",
+            "assert!": {
+                "with": {
+                    "key": { "the": "seen/key", "as": "Text" }
+                }
+            },
+            "when": [
+                {
+                    "assert": list_members(),
+                    "where": {
+                        "this": { "?": { "name": "list" } },
+                        "member": {
+                            "the": { "?": { "name": "key" } },
+                            "is": { "?": { "name": "this" } }
+                        }
+                    }
+                }
+            ]
+        }))?;
+        let list: Entity = "list:1".parse()?;
+        let item: Entity = "item:1".parse()?;
+        branch
+            .transaction()
+            .assert(rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+        branch.refresh(&operator).await?;
+
+        let member: dialog_artifacts::Attribute = "todo.list/N5".parse()?;
+        branch
+            .transaction()
+            .assert(
+                dialog_query::The::from(member)
+                    .of(list.clone())
+                    .is(item.clone()),
+            )
+            .commit()
+            .perform(&operator)
+            .await?;
+        branch.refresh(&operator).await?;
+
+        assert_eq!(
+            values(&branch, &operator, "seen/key", &item).await?,
+            vec![Value::String("N5".to_string())],
+            "the rule fired on the member write with the key bound"
+        );
+        Ok(())
+    }
+
+    /// A head entry whose key has the wrong shape for its collection
+    /// fails the commit rather than landing in the other half of the
+    /// domain: a dictionary keyed by an uppercase name would be a
+    /// sequence member.
+    #[dialog_common::test]
+    async fn it_refuses_a_key_of_the_wrong_shape() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let rule: InductiveRule = serde_json::from_value(json!({
+            "description": "File an item under its name",
+            "assert!": {
+                "with": {
+                    "entry": {
+                        "the": { "domain": "todo.named", "keyed": "dictionary" },
+                        "cardinality": "many",
+                        "as": "Entity"
+                    }
+                }
+            },
+            "when": [
+                {
+                    "assert": {
+                        "with": {
+                            "list": { "the": "todo.item/list", "as": "Entity" },
+                            "name": { "the": "todo.item/name", "as": "Text" }
+                        }
+                    },
+                    "where": {
+                        "this": { "?": { "name": "entry" } },
+                        "list": { "?": { "name": "this" } },
+                        "name": { "?": { "name": "entry/key" } }
+                    }
+                }
+            ]
+        }))?;
+        let list: Entity = "list:1".parse()?;
+        let item: Entity = "item:1".parse()?;
+        branch
+            .transaction()
+            .assert(rule)
+            .commit()
+            .perform(&operator)
+            .await?;
+        branch.refresh(&operator).await?;
+
+        let result = branch
+            .transaction()
+            .assert(
+                dialog_query::the!("todo.item/list")
+                    .of(item.clone())
+                    .is(list.clone()),
+            )
+            .assert(
+                dialog_query::the!("todo.item/name")
+                    .of(item.clone())
+                    .is("Milk".to_string()),
+            )
+            .commit()
+            .perform(&operator)
+            .await;
+        assert!(
+            matches!(result, Err(CommitError::Induction(ref message)) if message.contains("Milk")),
+            "an uppercase key is not a dictionary key: {result:?}"
         );
         Ok(())
     }

--- a/rust/dialog-repository/src/rules.rs
+++ b/rust/dialog-repository/src/rules.rs
@@ -59,9 +59,7 @@ use crate::{Revision, schema};
 // install/uninstall a rule by plain assertion/retraction live with the
 // rule types themselves; this module re-uses them for its selectors,
 // caches, and dispatch probing.
-pub(crate) use dialog_query::rule::statement::{
-    conclusion_attr, on_attr, on_entity, reads_attr, source_attr,
-};
+pub(crate) use dialog_query::rule::statement::{conclusion_attr, on_attr, reads_attr, source_attr};
 
 /// The `dialog.concept/transient` marker attribute. A concept carrying it
 /// is a *command*: facts of it dispatched into a transaction (and heads


### PR DESCRIPTION
## Why

Dialog stores an ordered collection as facts sharing a domain whose *name* half carries the entry's key — `todo.list/N5` for a member, `todo.list/title` for a named field. Positions are uppercase and symbols lowercase, so the two halves are disjoint by first byte: one scan serves both, and either half is a contiguous key range.

The storage layer has had this for a while. Nothing above it could say it.

Two things were in the way, and this PR removes both.

## 1. The wire form published internals

`Type` reached the wire through its derive:

```json
{"refined":[{"bits":128},{"prefix":"todo.list/","name_shape":"position"}]}
```

`{"bits": 128}` is a bitfield whose meaning is an enum discriminant (`1 << 7` = Symbol), so adding a `ValueType` would silently change what stored documents mean. `name_shape` is snake_case alone in a kebab format. `[set, refinement]` is positional, carrying no hint of what either half is. This was not specific to collections — *every* typed variable serialized this way.

`type_system::wire` is the stable form: named variants, named constraints.

```json
{"type": {"symbol": {}},
 "domain": {"is": "todo.list"},
 "name": {"case": "position"}}
```

Two container conventions run through it, chosen to match how the values combine rather than as style:

- **object = union**, entries are alternatives of one kind. The `type` set is the case: intersecting two sets keeps the shared keys, which is exactly what `Primitive::intersect` does to the bits.
- **array = intersection**, entries are independent obligations. Conformance is the case: every listed concept must hold.
- **a record of fixed slots is neither** — each slot appears at most once and merges rather than accumulates.

Reading is looser than writing: the derived forms still parse, so a rule stored before this loads unchanged and no migration is needed.

Two decisions arrived at by trying the alternative first:

**Refinements attach to the type set, not per-variant.** Nesting constraints under each variant reads better and makes several nonsense combinations unwritable, but it cannot hold `Type::optional()`, which produces `Refined(Text|Nothing, {prefix})` — one refinement over a two-member union. That is not an edge case; it is what every optional refined field is.

**A whole-domain prefix is written as a `domain`, without its separator.** `apply_prefix_bounds` narrows a scan to a name shape's byte class only when the prefix ends at `/`; one byte short and it silently degrades to a per-row filter. Writing the domain structurally makes that unrepresentable.

## 2. A descriptor could not select a collection

`AttributeDescriptor` held a `The`, which validates as exactly one `/` — so a collection's domain-only relation had no representation, and a concept could not declare a collection field at all.

```rust
pub enum Relation {
    Attribute(The),
    Collection { domain: Symbol, keyed: Keyed },
}
pub enum Keyed { Dictionary, Sequence }
```

The key kind is the variant rather than a field beside one, so a collection described with a contradicting key kind is unrepresentable rather than merely rejected.

**`Relation::term()` is the seam.** An attribute lowers to a constant; a collection lowers to a variable refined by its domain and name shape — the query the scan machinery already plans, and the one the wire form above spells. Concept-to-premise lowering, the typed query path, and the `Concept` derive all route through it, so a collection field becomes an ordered scan wherever a concept becomes a query.

**`Relation::attribute()` returns an `Option`**, which forced every write path to say what it does when there is no single attribute. `resolve` refuses: a collection describes many facts, and the key belongs to the entry rather than the schema.

**Existing attributes are untouched.** They hash byte-identically, so every stored identity is preserved, and `"the": "person/name"` still deserializes as it did.

## A bug that Option surfaced

Induction tracks a rule's reach as a `BTreeSet<Attribute>` (the `touched` sets in `transaction::induce`). A rule concluding into a collection would write facts that nothing recorded it had touched — so its consumers would never re-evaluate. Stale derived data, silently.

`analyze_with` now refuses such a rule with `AnalysisError::CollectionHead`, and the induction sites assert rather than skip, pointing at that refusal for why they cannot be reached. Reading a collection in a premise stays fine — a collection simply contributes no single attribute to a set of attributes.

Letting a rule *derive* into a collection means widening those sets to hold domains alongside attributes. Nothing needs it yet, and refusing loudly beats skipping quietly meanwhile.

## Subscriptions

Ordered-collection subscriptions were correct by construction — `Demand::record` → `selector_range` → `apply_prefix_bounds` narrows the demand cover to the shape's byte class — and had **no coverage at all**: `grep name_shape` across `dialog-repository` returned nothing.

Three tests pin it: a symbol-named write in the same domain does not wake an ordered subscription, a position-named write does (so the first cannot pass by the subscription simply being broken), and a domain scan does not trip the head gate into recomputing on every commit.

## Spec drift

`notes/notation.md` and its schema had accumulated claims the implementation contradicts:

- **Optional attributes** were documented as unsupported and living under a `maybe` block. They are supported, carried per-attribute inside `with` as `"optional": true`. The schema had `maybe` and lacked `optional`.
- **Concept-typed fields** (`conforms`) were documented as a future extension. They are implemented.
- **Aggregation** was absent entirely — `reduce` is on `DeductiveRuleDescriptor` and serialized, with six aggregators. Added, including the derived grouping set and the identity/optionality algebra.
- **`Record`** was missing from the value types, in both the doc and `ScalarType`.
- **Position names** were undocumented; the spec described attribute names as lowercase-only.

Symbol enumerations remain the one genuinely unimplemented extension, still marked as such.

## Testing

2679 workspace tests pass; clippy clean. `it_round_trips_every_type_set` walks all 1024 subsets of the ten-member bitset, so a missing or duplicated wire name surfaces there rather than the first time someone queries for it.

## 3. Querying and inducing a collection

Two more commits make a collection field usable rather than merely describable.

Each entry is one row binding the field to the value and the field's key operand to the name half. On the wire and in notation the pair is a single entry under the field, `{the: ?key, is: ?value}`, the slots an attribute query already uses. A literal `the` selects one entry; a bare term binds every entry. Internally the concept's rule scans the domain with an attribute variable named for the field and projects the key with `dialog/attribute-parts`, so two collection fields on one concept scan independently and the key joins like any other term. The planner admits a prefix-ranged attribute slot as a constraint, which is what lets the scan plan with nothing bound.

Induction tracks reach as a `Reach`: one attribute, or one keyed half of a domain. A collection premise is filed under the half's cover key, which every write in that half probes alongside its own attribute's key, so a rule reading a collection wakes for any member write and seeds with the key bound. An inductive head over a collection writes the entry under `domain/key`; a key of the wrong shape fails the commit rather than landing in the other half of the domain. The earlier `CollectionHead` refusal is gone.

Conclusions now compare by entity and operand values rather than by term shape, so a subscription re-deriving one entity emits the delta instead of re-asserting unchanged rows.
