### PR TITLE
fix(credentials): archive the X25519 key wrapped where the browser cannot clone it

### DIFF
--- a/rust/dialog-credentials/src/ed25519/web.rs
+++ b/rust/dialog-credentials/src/ed25519/web.rs
@@ -11,14 +11,16 @@
 //! provides defense-in-depth: even if an attacker gains code execution in your
 //! service worker, they cannot exfiltrate the private key material.
 
+use std::cell::Cell;
+
 use crate::key::KeyExport;
 use dialog_varsig::eddsa::Ed25519Signature;
-use js_sys::{Object, Reflect, Uint8Array};
+use js_sys::{Function, Object, Reflect, Uint8Array};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{CryptoKey, SubtleCrypto};
 
-use crate::key::AgreementKeyPair;
+use crate::key::{AgreementArchive, AgreementKeyPair, WrappedAgreementKey};
 
 // Re-export for backwards compatibility
 pub use crate::key::{ExtractableAgreementKey, ExtractableKey, WebCryptoError};
@@ -180,10 +182,8 @@ impl SigningKey {
                 // from the archive. Without one the signing key still works;
                 // only key agreement is unavailable.
                 match agreement {
-                    Some(pair) => {
-                        let agreement =
-                            AgreementSecretKey::from_crypto_keys(pair.private_key, pair.public_key)
-                                .await?;
+                    Some(archive) => {
+                        let agreement = AgreementSecretKey::from_archive(archive).await?;
                         Ok(key.with_agreement(agreement))
                     }
                     None => Ok(key),
@@ -226,10 +226,7 @@ impl SigningKey {
             Ok(KeyExport::NonExtractable {
                 private_key: self.private_key.clone(),
                 public_key: self.public_key.clone(),
-                agreement: self.agreement.as_ref().map(|key| AgreementKeyPair {
-                    private_key: key.private_key().clone(),
-                    public_key: key.public_key().clone(),
-                }),
+                agreement: self.agreement.as_ref().map(AgreementSecretKey::archive),
             })
         }
     }
@@ -656,10 +653,8 @@ impl ExtractableKey for SigningKey {
                 let public_key_bytes = export_public_key_raw(&subtle, &public_key).await?;
                 let key = SigningKey::new(private_key, public_key, public_key_bytes);
                 match agreement {
-                    Some(pair) => {
-                        let agreement =
-                            AgreementSecretKey::from_crypto_keys(pair.private_key, pair.public_key)
-                                .await?;
+                    Some(archive) => {
+                        let agreement = AgreementSecretKey::from_archive(archive).await?;
                         Ok(key.with_agreement(agreement))
                     }
                     None => Ok(key),
@@ -689,6 +684,23 @@ pub struct AgreementSecretKey {
     public_key: CryptoKey,
     /// Cached raw public key bytes.
     public_key_bytes: [u8; 32],
+    /// How this key is archived next to its signing key.
+    archive: Archive,
+}
+
+/// The archival form of an [`AgreementSecretKey`], decided when the key is
+/// derived and kept so every export of the same key writes the same shape.
+#[derive(Debug, Clone)]
+enum Archive {
+    /// The `CryptoKey`s themselves; the browser can clone them.
+    Keys,
+    /// The private key wrapped under `wrapping_key`, for a browser that
+    /// cannot deserialize an X25519 `CryptoKey` (see
+    /// [`AgreementArchive::Wrapped`]).
+    Wrapped {
+        wrapping_key: CryptoKey,
+        wrapped_key: Vec<u8>,
+    },
 }
 
 impl AgreementSecretKey {
@@ -698,6 +710,7 @@ impl AgreementSecretKey {
             private_key,
             public_key,
             public_key_bytes,
+            archive: Archive::Keys,
         }
     }
 
@@ -707,13 +720,95 @@ impl AgreementSecretKey {
     /// The derivation matches the native path exactly, so the same Ed25519 seed
     /// yields the same X25519 public key on both platforms.
     ///
+    /// This is the one place the X25519 secret is in hand, so it is also
+    /// where the archival form is decided: the `CryptoKey`s themselves when
+    /// the browser can clone them, otherwise the private key wrapped under
+    /// an AES-KW key (see [`AgreementArchive::Wrapped`]).
+    ///
     /// # Errors
     ///
     /// Returns an error if the WebCrypto import fails or the browser does not
     /// support X25519.
     pub async fn from_ed25519_seed(seed: &[u8; 32]) -> Result<Self, WebCryptoError> {
         let secret = super::agreement_secret_bytes(seed);
-        Self::import_secret(&secret, false).await
+        let key = Self::import_secret(&secret, false).await?;
+        if x25519_keys_are_cloneable(&key.public_key) {
+            Ok(key)
+        } else {
+            key.wrapped(&secret).await
+        }
+    }
+
+    /// Switch this key's archival form to wrapped.
+    ///
+    /// `wrapKey` needs an extractable key to read, and the working key is
+    /// not, so the secret is imported once more as extractable for the wrap
+    /// alone and dropped here. The wrapping key is non-extractable, so
+    /// nothing readable is archived.
+    async fn wrapped(mut self, secret: &[u8; 32]) -> Result<Self, WebCryptoError> {
+        let subtle = get_subtle_crypto()?;
+        let wrapping_key = generate_wrapping_key(&subtle).await?;
+        let extractable = import_agreement_private_key(&subtle, secret, true).await?;
+        let wrapped_key = wrap_agreement_private_key(&subtle, &extractable, &wrapping_key).await?;
+        self.archive = Archive::Wrapped {
+            wrapping_key,
+            wrapped_key,
+        };
+        Ok(self)
+    }
+
+    /// Restore from an archive written by [`archive`](Self::archive).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the public key's raw bytes cannot be exported, or
+    /// a wrapped private key cannot be unwrapped.
+    pub async fn from_archive(archive: AgreementArchive) -> Result<Self, WebCryptoError> {
+        match archive {
+            AgreementArchive::Keys(pair) => {
+                Self::from_crypto_keys(pair.private_key, pair.public_key).await
+            }
+            AgreementArchive::Wrapped(wrapped) => Self::from_wrapped(wrapped).await,
+        }
+    }
+
+    /// Reconstruct from a wrapped archive: unwrap the private key (back to a
+    /// non-extractable `CryptoKey`) and import the public bytes. The wrapping
+    /// material is kept so a later export writes the same archive.
+    async fn from_wrapped(wrapped: WrappedAgreementKey) -> Result<Self, WebCryptoError> {
+        let subtle = get_subtle_crypto()?;
+        let private_key =
+            unwrap_agreement_private_key(&subtle, &wrapped.wrapped_key, &wrapped.wrapping_key)
+                .await?;
+        let public_key = import_agreement_public_key_raw(&subtle, &wrapped.public_key).await?;
+        Ok(Self {
+            private_key,
+            public_key,
+            public_key_bytes: wrapped.public_key,
+            archive: Archive::Wrapped {
+                wrapping_key: wrapped.wrapping_key,
+                wrapped_key: wrapped.wrapped_key,
+            },
+        })
+    }
+
+    /// The archival form of this key, for a [`KeyExport`].
+    #[must_use]
+    pub fn archive(&self) -> AgreementArchive {
+        match &self.archive {
+            Archive::Keys => AgreementArchive::Keys(AgreementKeyPair {
+                private_key: self.private_key.clone(),
+                public_key: self.public_key.clone(),
+            }),
+            Archive::Wrapped {
+                wrapping_key,
+                wrapped_key,
+            } => AgreementArchive::Wrapped(WrappedAgreementKey {
+                wrapping_key: wrapping_key.clone(),
+                wrapped_key: wrapped_key.clone(),
+                public_key: self.public_key_bytes,
+            }),
+        }
     }
 
     /// Import a raw X25519 secret as a non-extractable key.
@@ -727,32 +822,7 @@ impl AgreementSecretKey {
     /// Import a raw X25519 secret with the given extractability.
     async fn import_secret(secret: &[u8; 32], extractable: bool) -> Result<Self, WebCryptoError> {
         let subtle = get_subtle_crypto()?;
-
-        let pkcs8 = X25519Pkcs8::from(secret);
-
-        let algorithm = Object::new();
-        Reflect::set(&algorithm, &"name".into(), &"X25519".into())
-            .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
-
-        let key_usages = js_sys::Array::new();
-        key_usages.push(&"deriveBits".into());
-
-        let pkcs8_array = Uint8Array::from(pkcs8.as_bytes());
-
-        let promise = subtle
-            .import_key_with_object(
-                "pkcs8",
-                &pkcs8_array.buffer(),
-                &algorithm,
-                extractable,
-                &key_usages,
-            )
-            .map_err(|e| WebCryptoError::KeyImport(format!("{e:?}")))?;
-
-        let private_key: CryptoKey = JsFuture::from(promise)
-            .await
-            .map_err(|e| WebCryptoError::KeyImport(format!("X25519 import failed: {e:?}")))?
-            .unchecked_into();
+        let private_key = import_agreement_private_key(&subtle, secret, extractable).await?;
 
         // The public key is the Montgomery point for this secret. Derive it in
         // Rust (WebCrypto cannot export it from a non-extractable private key)
@@ -908,6 +978,155 @@ async fn import_agreement_public_key_raw(
     Ok(key.unchecked_into())
 }
 
+/// Import a raw X25519 secret as a WebCrypto private key with `deriveBits`.
+async fn import_agreement_private_key(
+    subtle: &SubtleCrypto,
+    secret: &[u8; 32],
+    extractable: bool,
+) -> Result<CryptoKey, WebCryptoError> {
+    let pkcs8 = X25519Pkcs8::from(secret);
+    let pkcs8_array = Uint8Array::from(pkcs8.as_bytes());
+
+    let promise = subtle
+        .import_key_with_object(
+            "pkcs8",
+            &pkcs8_array.buffer(),
+            &x25519_algorithm()?,
+            extractable,
+            &derive_bits_usage(),
+        )
+        .map_err(|e| WebCryptoError::KeyImport(format!("{e:?}")))?;
+
+    Ok(JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyImport(format!("X25519 import failed: {e:?}")))?
+        .unchecked_into())
+}
+
+/// `{ name: "X25519" }`.
+fn x25519_algorithm() -> Result<Object, WebCryptoError> {
+    let algorithm = Object::new();
+    Reflect::set(&algorithm, &"name".into(), &"X25519".into())
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+    Ok(algorithm)
+}
+
+/// `["deriveBits"]`.
+fn derive_bits_usage() -> js_sys::Array {
+    let key_usages = js_sys::Array::new();
+    key_usages.push(&"deriveBits".into());
+    key_usages
+}
+
+// ============================================================================
+// Wrapped archival
+// ============================================================================
+
+/// Whether this browser can clone an X25519 `CryptoKey`, decided once per
+/// thread from `sample` and remembered.
+///
+/// `structuredClone` is the serializer IndexedDB and `postMessage` use, so a
+/// clone that throws (WebKit: `TypeError: Unable to deserialize data`) means
+/// an archive holding the key would come back `null`. A browser without
+/// `structuredClone` at all is treated the same way; wrapping works
+/// everywhere AES-KW does.
+fn x25519_keys_are_cloneable(sample: &CryptoKey) -> bool {
+    X25519_KEYS_ARE_CLONEABLE.with(|known| {
+        if let Some(cloneable) = known.get() {
+            return cloneable;
+        }
+        let cloneable =
+            structured_clone(sample).is_some_and(|clone| clone.is_instance_of::<CryptoKey>());
+        known.set(Some(cloneable));
+        cloneable
+    })
+}
+
+thread_local! {
+    /// The remembered answer of [`x25519_keys_are_cloneable`]; `None` until
+    /// the first key is derived on this thread.
+    static X25519_KEYS_ARE_CLONEABLE: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+/// Override what [`x25519_keys_are_cloneable`] answers on this thread, or
+/// `None` to probe again. Lets a browser that clones X25519 keys exercise the
+/// path taken by one that cannot.
+#[cfg(test)]
+pub(crate) fn assume_x25519_keys_are_cloneable(cloneable: Option<bool>) {
+    X25519_KEYS_ARE_CLONEABLE.with(|known| known.set(cloneable));
+}
+
+/// `structuredClone(value)`, or `None` if it throws or does not exist.
+fn structured_clone(value: &JsValue) -> Option<JsValue> {
+    let global = js_sys::global();
+    let clone = Reflect::get(&global, &"structuredClone".into()).ok()?;
+    let clone = clone.dyn_ref::<Function>()?;
+    clone.call1(&global, value).ok()
+}
+
+/// Generate the non-extractable AES-KW key an agreement key is wrapped under.
+async fn generate_wrapping_key(subtle: &SubtleCrypto) -> Result<CryptoKey, WebCryptoError> {
+    let algorithm = Object::new();
+    Reflect::set(&algorithm, &"name".into(), &"AES-KW".into())
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+    Reflect::set(&algorithm, &"length".into(), &256.into())
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+
+    let key_usages = js_sys::Array::new();
+    key_usages.push(&"wrapKey".into());
+    key_usages.push(&"unwrapKey".into());
+
+    let promise = subtle
+        .generate_key_with_object(&algorithm, false, &key_usages)
+        .map_err(|e| WebCryptoError::JsError(format!("{e:?}")))?;
+
+    Ok(JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyGeneration(format!("AES-KW generate failed: {e:?}")))?
+        .unchecked_into())
+}
+
+/// Wrap an extractable X25519 private key's PKCS#8 form under `wrapping_key`.
+///
+/// PKCS#8 is 48 bytes, a multiple of the 8 AES-KW needs; the JWK form is not.
+async fn wrap_agreement_private_key(
+    subtle: &SubtleCrypto,
+    private_key: &CryptoKey,
+    wrapping_key: &CryptoKey,
+) -> Result<Vec<u8>, WebCryptoError> {
+    let promise = subtle
+        .wrap_key_with_str("pkcs8", private_key, wrapping_key, "AES-KW")
+        .map_err(|e| WebCryptoError::KeyExport(format!("wrapKey: {e:?}")))?;
+    let wrapped = JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyExport(format!("wrapKey failed: {e:?}")))?;
+    Ok(Uint8Array::new(&wrapped).to_vec())
+}
+
+/// Unwrap a private key wrapped by [`wrap_agreement_private_key`] back into
+/// a non-extractable X25519 `CryptoKey`.
+async fn unwrap_agreement_private_key(
+    subtle: &SubtleCrypto,
+    wrapped_key: &[u8],
+    wrapping_key: &CryptoKey,
+) -> Result<CryptoKey, WebCryptoError> {
+    let promise = subtle
+        .unwrap_key_with_u8_array_and_str_and_object(
+            "pkcs8",
+            wrapped_key,
+            wrapping_key,
+            "AES-KW",
+            &x25519_algorithm()?,
+            false,
+            &derive_bits_usage(),
+        )
+        .map_err(|e| WebCryptoError::KeyImport(format!("unwrapKey: {e:?}")))?;
+    Ok(JsFuture::from(promise)
+        .await
+        .map_err(|e| WebCryptoError::KeyImport(format!("unwrapKey failed: {e:?}")))?
+        .unchecked_into())
+}
+
 /// PKCS#8 wrapper for an X25519 private key.
 ///
 /// Same DER shape as the Ed25519 wrapper, with OID 1.3.101.110 (X25519).
@@ -940,5 +1159,208 @@ impl ExtractableAgreementKey for AgreementSecretKey {
     async fn from_ed25519_seed(seed: &[u8; 32]) -> Result<Self, WebCryptoError> {
         let secret = super::agreement_secret_bytes(seed);
         Self::import_secret(&secret, true).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_service_worker);
+
+    /// A guard that makes this thread behave like a browser that cannot
+    /// clone X25519 keys, and probes again once dropped.
+    struct UncloneableX25519;
+
+    impl UncloneableX25519 {
+        fn assume() -> Self {
+            assume_x25519_keys_are_cloneable(Some(false));
+            Self
+        }
+    }
+
+    impl Drop for UncloneableX25519 {
+        fn drop(&mut self) {
+            assume_x25519_keys_are_cloneable(None);
+        }
+    }
+
+    async fn shared_secret(key: &SigningKey, peer: &AgreementSecretKey) -> [u8; 32] {
+        key.agreement_key()
+            .expect("key should carry an agreement key")
+            .diffie_hellman(&peer.agreement_public_key())
+            .await
+            .unwrap()
+    }
+
+    fn archived_wrapped(export: &KeyExport) -> bool {
+        matches!(
+            export,
+            KeyExport::NonExtractable {
+                agreement: Some(AgreementArchive::Wrapped(_)),
+                ..
+            }
+        )
+    }
+
+    #[dialog_common::test]
+    async fn it_remembers_whether_x25519_keys_clone() {
+        assume_x25519_keys_are_cloneable(None);
+        let sample = AgreementSecretKey::from_secret_bytes(&[7u8; 32])
+            .await
+            .unwrap();
+
+        let probed = x25519_keys_are_cloneable(sample.public_key());
+        let direct = structured_clone(sample.public_key())
+            .is_some_and(|clone| clone.is_instance_of::<CryptoKey>());
+        assert_eq!(
+            probed, direct,
+            "the probe should report what structuredClone does"
+        );
+
+        // Remembered: a sample that could never clone does not change the answer.
+        assert_eq!(
+            x25519_keys_are_cloneable(sample.private_key()),
+            probed,
+            "the answer should be remembered, not re-probed"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn the_same_seed_derives_the_same_agreement_key_either_way() {
+        let seed = [42u8; 32];
+        let peer = AgreementSecretKey::from_secret_bytes(&[9u8; 32])
+            .await
+            .unwrap();
+
+        assume_x25519_keys_are_cloneable(None);
+        let native = SigningKey::import(&seed).await.unwrap();
+        let native_secret = shared_secret(&native, &peer).await;
+
+        let _uncloneable = UncloneableX25519::assume();
+        let wrapped = SigningKey::import(&seed).await.unwrap();
+        let wrapped_secret = shared_secret(&wrapped, &peer).await;
+
+        assert_eq!(
+            native
+                .agreement_key()
+                .unwrap()
+                .agreement_public_key()
+                .to_bytes(),
+            wrapped
+                .agreement_key()
+                .unwrap()
+                .agreement_public_key()
+                .to_bytes(),
+            "the archival form should not change the derived public key"
+        );
+        assert_eq!(
+            native_secret, wrapped_secret,
+            "the archival form should not change the derived secret"
+        );
+        assert!(
+            archived_wrapped(&wrapped.export().await.unwrap()),
+            "a browser that cannot clone X25519 keys should archive wrapped"
+        );
+        assert!(
+            !wrapped.agreement_key().unwrap().private_key().extractable(),
+            "the working key should stay non-extractable"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn a_wrapped_archive_survives_a_js_value_roundtrip() {
+        let _uncloneable = UncloneableX25519::assume();
+        let seed = [43u8; 32];
+        let peer = AgreementSecretKey::from_secret_bytes(&[10u8; 32])
+            .await
+            .unwrap();
+
+        let original = SigningKey::import(&seed).await.unwrap();
+        let before = shared_secret(&original, &peer).await;
+
+        // Through the shape storage sees, as IndexedDB would hand it back.
+        let archived: JsValue = original.export().await.unwrap().into();
+        let restored = SigningKey::import(KeyExport::try_from(archived).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shared_secret(&restored, &peer).await,
+            before,
+            "the unwrapped key should agree on the same secret"
+        );
+        assert!(
+            !restored
+                .agreement_key()
+                .unwrap()
+                .private_key()
+                .extractable(),
+            "the unwrapped key should be non-extractable"
+        );
+        assert_eq!(
+            restored.verifying_key().to_bytes(),
+            original.verifying_key().to_bytes(),
+            "the signing key should be untouched"
+        );
+
+        // A restored key archives the way it was archived, under the same
+        // wrapping key, so a re-save writes the same record.
+        let (first, second) = match (
+            original.export().await.unwrap(),
+            restored.export().await.unwrap(),
+        ) {
+            (
+                KeyExport::NonExtractable {
+                    agreement: Some(AgreementArchive::Wrapped(first)),
+                    ..
+                },
+                KeyExport::NonExtractable {
+                    agreement: Some(AgreementArchive::Wrapped(second)),
+                    ..
+                },
+            ) => (first, second),
+            _ => panic!("both exports should archive wrapped"),
+        };
+        assert_eq!(first.wrapped_key, second.wrapped_key);
+        assert_eq!(first.public_key, second.public_key);
+    }
+
+    #[dialog_common::test]
+    async fn a_generated_key_archives_wrapped_when_keys_do_not_clone() {
+        let _uncloneable = UncloneableX25519::assume();
+        let peer = AgreementSecretKey::from_secret_bytes(&[11u8; 32])
+            .await
+            .unwrap();
+
+        let generated = SigningKey::generate().await.unwrap();
+        let export = generated.export().await.unwrap();
+        assert!(
+            archived_wrapped(&export),
+            "generate should archive wrapped too"
+        );
+
+        let restored = SigningKey::import(export).await.unwrap();
+        assert_eq!(
+            shared_secret(&restored, &peer).await,
+            shared_secret(&generated, &peer).await,
+        );
+    }
+
+    #[dialog_common::test]
+    async fn a_keys_archive_is_still_written_where_keys_clone() {
+        assume_x25519_keys_are_cloneable(Some(true));
+        let key = SigningKey::import(&[44u8; 32]).await.unwrap();
+        assert!(
+            matches!(
+                key.export().await.unwrap(),
+                KeyExport::NonExtractable {
+                    agreement: Some(AgreementArchive::Keys(_)),
+                    ..
+                }
+            ),
+            "a browser that clones X25519 keys should archive the keys themselves"
+        );
+        assume_x25519_keys_are_cloneable(None);
     }
 }

--- a/rust/dialog-credentials/src/key.rs
+++ b/rust/dialog-credentials/src/key.rs
@@ -1,7 +1,7 @@
 //! Algorithm-agnostic key export types and credential storage formats.
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-use js_sys::{Reflect, Uint8Array};
+use js_sys::{Object, Reflect, Uint8Array};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use thiserror::Error;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -26,15 +26,42 @@ pub enum KeyExport {
         private_key: CryptoKey,
         /// The WebCrypto public key.
         public_key: CryptoKey,
-        /// The derived X25519 agreement key pair, when one was archived.
+        /// The derived X25519 agreement key, when one was archived.
         ///
         /// A non-extractable signing key never yields its seed, so the X25519
         /// key it was derived from cannot be recovered later. Archiving it here
         /// as a third component is what makes the agreement key restorable.
         /// `None` for exports written before the agreement key existed, or for
         /// keys that never had one.
-        agreement: Option<AgreementKeyPair>,
+        agreement: Option<AgreementArchive>,
     },
+}
+
+/// How an X25519 agreement key is archived next to its signing key.
+///
+/// The key is opaque WebCrypto material either way; the two forms differ only
+/// in how it crosses the structured-clone boundary into storage.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[derive(Debug, Clone)]
+pub enum AgreementArchive {
+    /// The X25519 `CryptoKey`s themselves, serialized as
+    /// `{ privateKey, publicKey }`. The form used wherever the browser can
+    /// clone them.
+    Keys(AgreementKeyPair),
+
+    /// The private key wrapped under an AES-KW key, serialized as
+    /// `{ wrappingKey, wrappedKey, publicKey }`.
+    ///
+    /// WebKit (Safari 27) serializes an X25519 `CryptoKey` but cannot
+    /// deserialize one: `structuredClone` throws and IndexedDB hands back
+    /// `null` for any value that contains one, so a `Keys` archive written
+    /// there is lost on the next read. AES-KW keys do round-trip, so the
+    /// private key is archived as the AES-KW ciphertext of its PKCS#8 form
+    /// under a non-extractable `CryptoKey`, and the public key as raw bytes.
+    /// The wrap adds no secrecy, since whoever can use the wrapping key can
+    /// unwrap; it is a serialization the browser can read back, and the key
+    /// it unwraps to is non-extractable again.
+    Wrapped(WrappedAgreementKey),
 }
 
 /// An opaque WebCrypto X25519 key pair, archived alongside a signing key.
@@ -45,6 +72,18 @@ pub struct AgreementKeyPair {
     pub private_key: CryptoKey,
     /// The WebCrypto X25519 public key.
     pub public_key: CryptoKey,
+}
+
+/// An X25519 private key wrapped for archival, with its public half.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[derive(Debug, Clone)]
+pub struct WrappedAgreementKey {
+    /// The non-extractable AES-KW key the private key is wrapped under.
+    pub wrapping_key: CryptoKey,
+    /// The private key's PKCS#8 form, wrapped: `wrapKey("pkcs8", …, "AES-KW")`.
+    pub wrapped_key: Vec<u8>,
+    /// The raw 32-byte X25519 public key.
+    pub public_key: [u8; 32],
 }
 
 impl From<&[u8; 32]> for KeyExport {
@@ -75,11 +114,11 @@ impl From<KeyExport> for JsValue {
                 agreement,
             } => {
                 let pair = CryptoKeyPair::new(&private_key, &public_key);
-                // The X25519 pair rides along as an extra property so the
+                // The X25519 key rides along as an extra property so the
                 // archived value stays a plain `{ privateKey, publicKey }`
                 // object for readers that predate the agreement key.
                 if let Some(agreement) = agreement {
-                    let value = CryptoKeyPair::new(&agreement.private_key, &agreement.public_key);
+                    let value = JsValue::from(agreement);
                     // Set failures here would silently drop the agreement key,
                     // so surface them as a dropped property rather than a
                     // half-written object: `Reflect::set` on a fresh object
@@ -92,9 +131,82 @@ impl From<KeyExport> for JsValue {
     }
 }
 
-/// Property name carrying the archived X25519 pair on a serialized key export.
+/// Property name carrying the archived X25519 key on a serialized key export.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const AGREEMENT_KEY: &str = "agreementKey";
+/// Property names of the wrapped archive shape.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+const WRAPPING_KEY: &str = "wrappingKey";
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+const WRAPPED_KEY: &str = "wrappedKey";
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+const PUBLIC_KEY: &str = "publicKey";
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+const PRIVATE_KEY: &str = "privateKey";
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl From<AgreementArchive> for JsValue {
+    fn from(archive: AgreementArchive) -> Self {
+        match archive {
+            AgreementArchive::Keys(pair) => {
+                CryptoKeyPair::new(&pair.private_key, &pair.public_key).into()
+            }
+            AgreementArchive::Wrapped(wrapped) => {
+                let value = Object::new();
+                // As above: a fresh object is never frozen, so these cannot fail.
+                let _ = Reflect::set(&value, &WRAPPING_KEY.into(), &wrapped.wrapping_key);
+                let _ = Reflect::set(
+                    &value,
+                    &WRAPPED_KEY.into(),
+                    &Uint8Array::from(wrapped.wrapped_key.as_slice()),
+                );
+                let _ = Reflect::set(
+                    &value,
+                    &PUBLIC_KEY.into(),
+                    &Uint8Array::from(wrapped.public_key.as_slice()),
+                );
+                value.into()
+            }
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl AgreementArchive {
+    /// Read either archive shape back; `None` when the value is neither.
+    fn from_js(value: &JsValue) -> Option<Self> {
+        if let (Some(private_key), Some(public_key)) = (
+            crypto_key_property(value, PRIVATE_KEY),
+            crypto_key_property(value, PUBLIC_KEY),
+        ) {
+            return Some(Self::Keys(AgreementKeyPair {
+                private_key,
+                public_key,
+            }));
+        }
+        let wrapping_key = crypto_key_property(value, WRAPPING_KEY)?;
+        let wrapped_key = bytes_property(value, WRAPPED_KEY)?;
+        let public_key = bytes_property(value, PUBLIC_KEY)?.try_into().ok()?;
+        Some(Self::Wrapped(WrappedAgreementKey {
+            wrapping_key,
+            wrapped_key,
+            public_key,
+        }))
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn crypto_key_property(value: &JsValue, name: &str) -> Option<CryptoKey> {
+    Reflect::get(value, &name.into()).ok()?.dyn_into().ok()
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn bytes_property(value: &JsValue, name: &str) -> Option<Vec<u8>> {
+    Reflect::get(value, &name.into())
+        .ok()?
+        .dyn_ref::<Uint8Array>()
+        .map(Uint8Array::to_vec)
+}
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl TryFrom<JsValue> for KeyExport {
@@ -122,20 +234,7 @@ impl TryFrom<JsValue> for KeyExport {
         let agreement = Reflect::get(&value, &AGREEMENT_KEY.into())
             .ok()
             .filter(|v| !v.is_undefined() && !v.is_null())
-            .and_then(|v| {
-                let private_key: CryptoKey = Reflect::get(&v, &"privateKey".into())
-                    .ok()?
-                    .dyn_into()
-                    .ok()?;
-                let public_key: CryptoKey = Reflect::get(&v, &"publicKey".into())
-                    .ok()?
-                    .dyn_into()
-                    .ok()?;
-                Some(AgreementKeyPair {
-                    private_key,
-                    public_key,
-                })
-            });
+            .and_then(|v| AgreementArchive::from_js(&v));
 
         Ok(KeyExport::NonExtractable {
             private_key,
@@ -312,5 +411,65 @@ mod web_tests {
     fn it_fails_to_convert_invalid_jsvalue() {
         let result = KeyExport::try_from(JsValue::from_str("not a key"));
         assert!(result.is_err());
+    }
+
+    /// Both archive shapes read back as their variant; anything else reads
+    /// as no archive, like an export written before agreement keys existed.
+    #[dialog_common::test]
+    async fn it_reads_both_agreement_archive_shapes() {
+        let signer = Ed25519Signer::generate().await.unwrap();
+        let export: JsValue = signer.export().await.unwrap().into();
+        let pair = Reflect::get(&export, &"privateKey".into()).unwrap();
+        let public = Reflect::get(&export, &"publicKey".into()).unwrap();
+
+        let keys = Object::new();
+        Reflect::set(&keys, &"privateKey".into(), &pair).unwrap();
+        Reflect::set(&keys, &"publicKey".into(), &public).unwrap();
+        assert!(matches!(
+            AgreementArchive::from_js(&keys),
+            Some(AgreementArchive::Keys(_))
+        ));
+
+        let wrapped = Object::new();
+        Reflect::set(&wrapped, &"wrappingKey".into(), &pair).unwrap();
+        Reflect::set(
+            &wrapped,
+            &"wrappedKey".into(),
+            &Uint8Array::from([1u8; 56].as_slice()),
+        )
+        .unwrap();
+        Reflect::set(
+            &wrapped,
+            &"publicKey".into(),
+            &Uint8Array::from([2u8; 32].as_slice()),
+        )
+        .unwrap();
+        match AgreementArchive::from_js(&wrapped) {
+            Some(AgreementArchive::Wrapped(archive)) => {
+                assert_eq!(archive.wrapped_key, vec![1u8; 56]);
+                assert_eq!(archive.public_key, [2u8; 32]);
+            }
+            other => panic!("expected a wrapped archive, got {other:?}"),
+        }
+
+        let short = Object::new();
+        Reflect::set(&short, &"wrappingKey".into(), &pair).unwrap();
+        Reflect::set(
+            &short,
+            &"wrappedKey".into(),
+            &Uint8Array::from([1u8; 56].as_slice()),
+        )
+        .unwrap();
+        Reflect::set(
+            &short,
+            &"publicKey".into(),
+            &Uint8Array::from([2u8; 31].as_slice()),
+        )
+        .unwrap();
+        assert!(
+            AgreementArchive::from_js(&short).is_none(),
+            "a public key of the wrong length is not an archive"
+        );
+        assert!(AgreementArchive::from_js(&JsValue::from_str("nope")).is_none());
     }
 }


### PR DESCRIPTION
Safari 27 can serialize an X25519 `CryptoKey` but cannot deserialize one: `structuredClone` throws `TypeError: Unable to deserialize data`, `postMessage` delivers `messageerror`, and IndexedDB, on the same serializer, swallows the failure. A `put` reports success and the row exists, but `get`, `getAll` and cursors hand back `null` for the whole value. Since #463 a browser signer's export carries its derived X25519 agreement pair next to the Ed25519 pair, so on Safari the stored credential (Ed25519 keys included) reads back as missing on the very next load. In tonk that turned into "Space already exists" on every profile open after boot, and a fresh identity on every service worker restart. Ed25519, ECDSA, ECDH and AES keys all round-trip; only X25519 is affected.

The archive shape is now decided where the X25519 key is derived, the one moment the secret is in hand. The public key just imported is passed through `structuredClone` once per thread; where that succeeds the archive is the `{ privateKey, publicKey }` pair it always was. Where it throws, the private key is imported once more as extractable purely to be wrapped under a fresh non-extractable AES-KW key (`wrapKey("pkcs8")`, since PKCS#8 is 48 bytes and satisfies AES-KW's 8-byte rule where JWK does not), and the archive becomes `{ wrappingKey, wrappedKey, publicKey }` with the public half as raw bytes. Readers accept both shapes, `unwrapKey` yields a non-extractable X25519 key again, and a restored key keeps its wrapping material so a re-save writes the same record. The wrap adds no secrecy, since whoever can use the wrapping key can unwrap; it is a serialization the browser can read back.

The probe is overridable under `cfg(test)`, so Chrome runs the wrapped path: the same seed derives the same public key and shared secret either way, a wrapped archive survives a `JsValue` round trip and stays non-extractable, `generate()` archives wrapped when keys do not clone, and both shapes parse. Verified end to end in Safari against tonk: the profile credential reads back with the wrapped shape and profile opens succeed.

Minimal repro of the WebKit bug, any origin:

```js
const k = await crypto.subtle.generateKey({ name: "X25519" }, false, ["deriveBits"]);
structuredClone(k.publicKey); // TypeError: Unable to deserialize data
```
