### PR TITLE
fix(storage): recover IndexedDB lifecycle failures

### DIFF
--- a/rust/dialog-identity/src/profile.rs
+++ b/rust/dialog-identity/src/profile.rs
@@ -250,7 +250,31 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use dialog_effects::storage::{Create, Load, StorageError};
     use dialog_storage::provider::storage::Storage;
+
+    struct FailingLoad {
+        create_called: AtomicBool,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl Provider<Load> for FailingLoad {
+        async fn execute(&self, _input: Capability<Load>) -> Result<Credential, StorageError> {
+            Err(StorageError::Storage("database unavailable".into()))
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl Provider<Create> for FailingLoad {
+        async fn execute(&self, _input: Capability<Create>) -> Result<Credential, StorageError> {
+            self.create_called.store(true, Ordering::SeqCst);
+            Err(StorageError::AlreadyExists("Profile/tonk".into()))
+        }
+    }
 
     #[dialog_common::test]
     async fn it_opens_profile() {
@@ -268,6 +292,24 @@ mod tests {
         let second = Profile::open("bob").perform(&storage).await.unwrap();
 
         assert_eq!(first.did(), second.did());
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_create_after_a_storage_load_failure() {
+        let storage = FailingLoad {
+            create_called: AtomicBool::new(false),
+        };
+
+        let result = Profile::open("tonk").perform(&storage).await;
+
+        assert!(matches!(
+            result,
+            Err(ProfileError::Storage(message)) if message.contains("database unavailable")
+        ));
+        assert!(
+            !storage.create_called.load(Ordering::SeqCst),
+            "a backend failure must not fall through to profile creation"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/dialog-identity/src/profile/open.rs
+++ b/rust/dialog-identity/src/profile/open.rs
@@ -93,7 +93,7 @@ impl OpenProfile {
 
                 match load_result {
                     Ok(cred) => cred,
-                    Err(_) => {
+                    Err(storage_fx::StorageError::NotFound(_)) => {
                         let signer = Ed25519Signer::generate()
                             .await
                             .map_err(|e| ProfileError::Key(e.to_string()))?;
@@ -106,6 +106,7 @@ impl OpenProfile {
                             .await
                             .map_err(|e| ProfileError::Storage(e.to_string()))?
                     }
+                    Err(error) => return Err(ProfileError::Storage(error.to_string())),
                 }
             }
         };

--- a/rust/dialog-storage/src/resource.rs
+++ b/rust/dialog-storage/src/resource.rs
@@ -23,6 +23,17 @@ pub trait Resource<Address>: Sized {
     /// if absent. This is the open-or-create path.
     async fn open(address: &Address) -> Result<Self, Self::Error>;
 
+    /// Whether an error from [`load`](Resource::load) means that the
+    /// resource is absent, rather than that its backing store failed.
+    ///
+    /// Callers that implement open-or-create behavior must only create
+    /// after this returns `true`; treating every load error as absence can
+    /// overwrite or collide with a store that is present but temporarily
+    /// unusable.
+    fn is_not_found(_error: &Self::Error) -> bool {
+        false
+    }
+
     /// Open an *existing* resource at the given address, failing if it
     /// does not already exist. Unlike [`open`](Resource::open) this must
     /// never bring the backing store into being.

--- a/rust/dialog-storage/src/storage/provider/indexeddb.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb.rs
@@ -55,6 +55,7 @@ mod certificate;
 mod credential;
 mod memory;
 
+use futures_util::lock::Mutex;
 use js_sys::{Array, Function, Promise, Reflect, Uint8Array, global};
 use rexie::{ObjectStore, Rexie, RexieBuilder, TransactionMode};
 use std::cell::RefCell;
@@ -72,12 +73,21 @@ fn to_uint8array(bytes: &[u8]) -> Uint8Array {
 
 /// Shared database state.
 struct Connection {
-    name: String,
     version: u32,
     stores: HashSet<String>,
-    /// Shared via Rc so StoreSession can hold a clone across .await
-    /// points without borrowing the Connection.
+    /// Shared via `Rc` so a transaction can outlive the brief connection
+    /// state borrow used to start it.
     db: Rc<Rexie>,
+}
+
+/// Connection state shared by every provider for one database.
+///
+/// Object-store creation is a database version upgrade, so only one may be
+/// planned at a time. The async mutex spans the version read, open, and swap;
+/// waiters re-check the current schema after acquiring it.
+struct SharedConnection {
+    current: RefCell<Connection>,
+    schema: Mutex<()>,
 }
 
 impl Connection {
@@ -93,7 +103,6 @@ impl Connection {
         let stores = db.store_names().into_iter().collect();
 
         Ok(Self {
-            name: name.to_string(),
             version,
             stores,
             db: Rc::new(db),
@@ -106,10 +115,14 @@ impl Connection {
     }
 }
 
-/// A handle to a named object store. Holds a shared `Rc<Rexie>` so it
-/// can be used freely across .await points.
+/// A handle to a named object store.
+///
+/// It keeps an [`IndexedDb`] clone rather than a snapshot of the current
+/// `Rexie` handle. A version change may close that handle between `store()`
+/// and the first request; resolving the transaction through the provider lets
+/// it refresh the pooled connection before retrying.
 struct StoreSession {
-    db: Rc<Rexie>,
+    provider: IndexedDb,
     store_name: String,
 }
 
@@ -120,25 +133,16 @@ impl StoreSession {
         Fut: std::future::Future<Output = Result<Output, E>>,
         E: From<IndexedDbError>,
     {
-        let tx = self
-            .db
-            .transaction(&[&self.store_name], TransactionMode::ReadOnly)
-            .map_err(|e| IndexedDbError::Transaction(e.to_string()))?;
+        let (object_store, _armed) = self
+            .provider
+            .begin_transaction(&self.store_name, TransactionMode::ReadOnly)
+            .await?;
 
-        let object_store = tx
-            .store(&self.store_name)
-            .map_err(|e| IndexedDbError::Store(e.to_string()))?;
-
-        // Armed before the first request: see `crate::storage::settle`.
-        let armed = crate::storage::settle::arm(tx);
-        let result = select(object_store).await?;
-
-        armed
-            .settle()
-            .await
-            .map_err(|e| IndexedDbError::Transaction(e.to_string()))?;
-
-        Ok(result)
+        // A read is complete once its request resolves. Keeping the armed
+        // terminal handlers alive until then (and briefly after drop) closes
+        // the callback race without making a successful read wait on a
+        // terminal event that some browsers may never deliver.
+        select(object_store).await
     }
 
     async fn transact<F, Fut, Output, E>(&self, mutate: F) -> Result<Output, E>
@@ -147,17 +151,10 @@ impl StoreSession {
         Fut: std::future::Future<Output = Result<Output, E>>,
         E: From<IndexedDbError>,
     {
-        let tx = self
-            .db
-            .transaction(&[&self.store_name], TransactionMode::ReadWrite)
-            .map_err(|e| IndexedDbError::Transaction(e.to_string()))?;
-
-        let object_store = tx
-            .store(&self.store_name)
-            .map_err(|e| IndexedDbError::Store(e.to_string()))?;
-
-        // Armed before the first request: see `crate::storage::settle`.
-        let armed = crate::storage::settle::arm(tx);
+        let (object_store, armed) = self
+            .provider
+            .begin_transaction(&self.store_name, TransactionMode::ReadWrite)
+            .await?;
         let result = mutate(object_store).await?;
 
         armed
@@ -173,7 +170,7 @@ impl StoreSession {
 // for the same database, they all share one Connection via this pool.
 // The entry is removed when the last IndexedDb clone for that database drops.
 thread_local! {
-    static CONNECTIONS: RefCell<HashMap<String, Rc<RefCell<Connection>>>> =
+    static CONNECTIONS: RefCell<HashMap<String, Rc<SharedConnection>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -185,7 +182,7 @@ thread_local! {
 #[derive(Clone)]
 pub struct IndexedDb {
     name: String,
-    connection: Rc<RefCell<Connection>>,
+    connection: Rc<SharedConnection>,
 }
 
 impl IndexedDb {
@@ -201,7 +198,10 @@ impl IndexedDb {
             Some(rc) => rc,
             None => {
                 let conn = Connection::open(&name).await?;
-                let rc = Rc::new(RefCell::new(conn));
+                let rc = Rc::new(SharedConnection {
+                    current: RefCell::new(conn),
+                    schema: Mutex::new(()),
+                });
                 CONNECTIONS.with(|pool| {
                     pool.borrow_mut().insert(name.clone(), rc.clone());
                 });
@@ -212,53 +212,92 @@ impl IndexedDb {
         Ok(Self { name, connection })
     }
 
+    /// Add a store while the caller holds the schema lock.
+    async fn ensure_store_locked(&self, name: &str) -> Result<(), IndexedDbError> {
+        if self.connection.current.borrow().stores.contains(name) {
+            return Ok(());
+        }
+
+        let (version, mut new_stores) = {
+            let conn = self.connection.current.borrow();
+            (conn.version, conn.stores.clone())
+        };
+        new_stores.insert(name.to_string());
+
+        let mut builder = RexieBuilder::new(&self.name).version(version + 1);
+        for store in &new_stores {
+            builder = builder.add_object_store(ObjectStore::new(store).auto_increment(false));
+        }
+        let db = builder
+            .build()
+            .await
+            .map_err(|error| IndexedDbError::Database(format!("{error:?}")))?;
+
+        let mut conn = self.connection.current.borrow_mut();
+        conn.version = db
+            .version()
+            .map_err(|error| IndexedDbError::Database(error.to_string()))?;
+        conn.stores = db.store_names().into_iter().collect();
+        conn.db = Rc::new(db);
+        Ok(())
+    }
+
+    fn current_transaction(
+        &self,
+        store_name: &str,
+        mode: TransactionMode,
+    ) -> Result<(rexie::Store, crate::storage::settle::Armed), IndexedDbError> {
+        let db = self.connection.current.borrow().db();
+        let tx = db
+            .transaction(&[store_name], mode)
+            .map_err(|error| IndexedDbError::Transaction(error.to_string()))?;
+        let store = tx
+            .store(store_name)
+            .map_err(|error| IndexedDbError::Store(error.to_string()))?;
+        let armed = crate::storage::settle::arm(tx);
+        Ok((store, armed))
+    }
+
+    /// Start a transaction against the current pooled connection.
+    ///
+    /// A browser closes a database connection when another context upgrades
+    /// its version. If opening the transaction fails, refresh the connection
+    /// and schema under the per-database lock, then retry once.
+    async fn begin_transaction(
+        &self,
+        store_name: &str,
+        mode: TransactionMode,
+    ) -> Result<(rexie::Store, crate::storage::settle::Armed), IndexedDbError> {
+        let _schema = self.connection.schema.lock().await;
+        match self.current_transaction(store_name, mode) {
+            Ok(transaction) => Ok(transaction),
+            Err(first_error) => {
+                let refreshed = Connection::open(&self.name).await.map_err(|error| {
+                    IndexedDbError::Database(format!(
+                        "failed to reopen after {first_error}: {error}"
+                    ))
+                })?;
+                *self.connection.current.borrow_mut() = refreshed;
+                self.ensure_store_locked(store_name).await?;
+                self.current_transaction(store_name, mode)
+            }
+        }
+    }
+
     /// Gets a handle to the named object store. Upgrades the database
     /// schema if the store doesn't exist yet.
     ///
-    /// The returned StoreSession holds a shared `Rc<Rexie>` so it can
-    /// be used across .await points without holding a borrow on Connection.
-    ///
-    /// During an upgrade, the old database connection remains valid for
-    /// any active StoreSession. The new connection is opened alongside it
-    /// and swapped in once ready. IndexedDB's `versionchange` mechanism
-    /// coordinates the transition.
+    /// The returned session resolves the current pooled connection when a
+    /// transaction starts, so it does not retain a handle closed by a later
+    /// version change.
     async fn store(&self, name: &str) -> Result<StoreSession, IndexedDbError> {
-        // Check if upgrade is needed (brief borrow, dropped before .await).
-        let needs_upgrade = !self.connection.borrow().stores.contains(name);
-
-        if needs_upgrade {
-            // Gather what we need from the connection (brief borrow).
-            let (version, mut new_stores) = {
-                let conn = self.connection.borrow();
-                (conn.version, conn.stores.clone())
-            };
-            new_stores.insert(name.to_string());
-
-            // Build the upgraded database. No RefCell borrow held here,
-            // so the old Rc<Rexie> remains valid for concurrent readers.
-            let new_version = version + 1;
-            let mut builder = RexieBuilder::new(&self.name).version(new_version);
-            for store in &new_stores {
-                builder = builder.add_object_store(ObjectStore::new(store).auto_increment(false));
-            }
-            let db = builder
-                .build()
-                .await
-                .map_err(|e| IndexedDbError::Database(format!("{:?}", e)))?;
-
-            // Swap in the new connection (brief borrow). Any StoreSession
-            // holding the old Rc<Rexie> keeps it alive until they drop.
-            let mut conn = self.connection.borrow_mut();
-            conn.version = db
-                .version()
-                .map_err(|e| IndexedDbError::Database(e.to_string()))?;
-            conn.stores = db.store_names().into_iter().collect();
-            conn.db = Rc::new(db);
-        }
-
-        let db = self.connection.borrow().db();
+        // The lock spans schema inspection and any upgrade. A waiter must
+        // inspect after acquiring it so concurrent additions compose instead
+        // of both attempting the same database version from stale snapshots.
+        let _schema = self.connection.schema.lock().await;
+        self.ensure_store_locked(name).await?;
         Ok(StoreSession {
-            db,
+            provider: self.clone(),
             store_name: name.to_string(),
         })
     }
@@ -331,6 +370,10 @@ impl Resource<Location> for IndexedDb {
         Self::connect(database_name(location)).await
     }
 
+    fn is_not_found(error: &Self::Error) -> bool {
+        matches!(error, IndexedDbError::NotFound(_))
+    }
+
     /// Open an existing database, failing if it was never created.
     ///
     /// IndexedDB's `open` brings a database into being, so the base
@@ -400,7 +443,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_opens_new_database_with_no_stores() -> anyhow::Result<()> {
         let db = IndexedDb::connect(unique_name("new-db")).await?;
-        assert!(db.connection.borrow().stores.is_empty());
+        assert!(db.connection.current.borrow().stores.is_empty());
         Ok(())
     }
 
@@ -440,14 +483,81 @@ mod tests {
     #[dialog_common::test]
     async fn it_creates_store_via_upgrade() -> anyhow::Result<()> {
         let db = IndexedDb::connect(unique_name("upgrade")).await?;
-        let initial_version = db.connection.borrow().version;
+        let initial_version = db.connection.current.borrow().version;
 
         let _store = db.store("new-store").await?;
 
-        let conn = db.connection.borrow();
+        let conn = db.connection.current.borrow();
         assert!(conn.stores.contains("new-store"));
         assert_eq!(conn.version, initial_version + 1);
 
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_serializes_concurrent_store_upgrades() -> anyhow::Result<()> {
+        let db = IndexedDb::connect(unique_name("concurrent-upgrades")).await?;
+
+        let (left, right) = futures_util::future::join(db.store("left"), db.store("right")).await;
+        left?;
+        right?;
+
+        let conn = db.connection.current.borrow();
+        assert!(
+            conn.stores.contains("left"),
+            "concurrent upgrade lost the left store: {:?}",
+            conn.stores
+        );
+        assert!(
+            conn.stores.contains("right"),
+            "concurrent upgrade lost the right store: {:?}",
+            conn.stores
+        );
+
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reopens_after_an_external_version_change() -> anyhow::Result<()> {
+        let db = IndexedDb::connect(unique_name("external-upgrade")).await?;
+        let store = db.store("memory").await?;
+        store
+            .transact(|object_store| async move {
+                object_store
+                    .put(
+                        &JsValue::from_str("test-value"),
+                        Some(&JsValue::from_str("test-key")),
+                    )
+                    .await
+                    .map_err(|error| IndexedDbError::Store(error.to_string()))
+            })
+            .await?;
+
+        let (version, stores) = {
+            let current = db.connection.current.borrow();
+            (current.version, current.stores.clone())
+        };
+        let mut builder = RexieBuilder::new(&db.name).version(version + 1);
+        for store_name in stores.into_iter().chain(["external".to_string()]) {
+            builder = builder.add_object_store(ObjectStore::new(&store_name).auto_increment(false));
+        }
+        let external = builder.build().await.expect("external upgrade succeeds");
+        external.close();
+
+        let store = db.store("memory").await?;
+        let result: Option<JsValue> = store
+            .query(|object_store| async move {
+                object_store
+                    .get(JsValue::from_str("test-key"))
+                    .await
+                    .map_err(|error| IndexedDbError::Store(error.to_string()))
+            })
+            .await?;
+
+        assert_eq!(
+            result.and_then(|value| value.as_string()).as_deref(),
+            Some("test-value")
+        );
         Ok(())
     }
 
@@ -566,7 +676,7 @@ mod tests {
         did.credential().key("self").save(cred).perform(&db).await?;
 
         // Verify the store names match our expectations
-        let conn = db.connection.borrow();
+        let conn = db.connection.current.borrow();
         assert!(
             conn.stores.contains("archive/index"),
             "expected archive/index store, got: {:?}",

--- a/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
+++ b/rust/dialog-storage/src/storage/provider/indexeddb/certificate.rs
@@ -31,7 +31,12 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
             None => format!("{}/_/", audience),
         };
 
-        let has_store = self.connection.borrow().stores.contains(CERTIFICATE);
+        let has_store = self
+            .connection
+            .current
+            .borrow()
+            .stores
+            .contains(CERTIFICATE);
         if !has_store {
             return Ok(Vec::new());
         }
@@ -67,7 +72,12 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
     }
 
     async fn export(&self) -> Result<Vec<P::Certificate>, AuthorizeError> {
-        let has_store = self.connection.borrow().stores.contains(CERTIFICATE);
+        let has_store = self
+            .connection
+            .current
+            .borrow()
+            .stores
+            .contains(CERTIFICATE);
         if !has_store {
             return Ok(Vec::new());
         }
@@ -95,7 +105,12 @@ impl<P: Protocol> CertificateStore<P> for IndexedDb {
     }
 
     async fn forget(&self, certificates: &[P::Certificate]) -> Result<(), AuthorizeError> {
-        let has_store = self.connection.borrow().stores.contains(CERTIFICATE);
+        let has_store = self
+            .connection
+            .current
+            .borrow()
+            .stores
+            .contains(CERTIFICATE);
         if has_store {
             let store = self.store(CERTIFICATE).await?;
             for cert in certificates {

--- a/rust/dialog-storage/src/storage/provider/space.rs
+++ b/rust/dialog-storage/src/storage/provider/space.rs
@@ -226,6 +226,10 @@ where
 {
     type Error = StorageError;
 
+    fn is_not_found(error: &Self::Error) -> bool {
+        matches!(error, StorageError::NotFound(_))
+    }
+
     async fn open(location: &Location) -> Result<Self, StorageError> {
         Ok(Space {
             archive: A::open(location)
@@ -250,19 +254,31 @@ where
         Ok(Space {
             archive: A::load(location)
                 .await
-                .map_err(|e| StorageError::Storage(e.to_string()))?,
+                .map_err(|e| resource_load_error::<A>(e))?,
             memory: M::load(location)
                 .await
-                .map_err(|e| StorageError::Storage(e.to_string()))?,
+                .map_err(|e| resource_load_error::<M>(e))?,
             credential: C::load(location)
                 .await
-                .map_err(|e| StorageError::Storage(e.to_string()))?,
+                .map_err(|e| resource_load_error::<C>(e))?,
             certificate: P::load(location)
                 .await
-                .map_err(|e| StorageError::Storage(e.to_string()))?,
+                .map_err(|e| resource_load_error::<P>(e))?,
             blob: B::load(location)
                 .await
-                .map_err(|e| StorageError::Storage(e.to_string()))?,
+                .map_err(|e| resource_load_error::<B>(e))?,
         })
+    }
+}
+
+fn resource_load_error<R>(error: R::Error) -> StorageError
+where
+    R: Resource<Location>,
+    R::Error: Display,
+{
+    if R::is_not_found(&error) {
+        StorageError::NotFound(error.to_string())
+    } else {
+        StorageError::Storage(error.to_string())
     }
 }

--- a/rust/dialog-storage/src/storage/provider/storage/loader.rs
+++ b/rust/dialog-storage/src/storage/provider/storage/loader.rs
@@ -64,6 +64,13 @@ fn location_key(location: &Location) -> String {
     format!("{:?}/{}", location.directory, location.name)
 }
 
+fn credential_load_error(error: credential::CredentialError) -> StorageError {
+    match error {
+        credential::CredentialError::NotFound(detail) => StorageError::NotFound(detail),
+        error => StorageError::Storage(error.to_string()),
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S> Provider<storage::Load> for Loader<S>
@@ -86,15 +93,19 @@ where
                 .load()
                 .perform(&store)
                 .await
-                .map_err(|e| StorageError::NotFound(e.to_string()));
+                .map_err(credential_load_error);
         }
 
         // `load`, not `open`: a `storage::Load` of a space that was never
         // created must fail without materializing its backing store (an
         // `open` here would, on IndexedDB, create the database into being).
-        let store = S::load(location)
-            .await
-            .map_err(|e| StorageError::NotFound(e.to_string()))?;
+        let store = S::load(location).await.map_err(|error| {
+            if S::is_not_found(&error) {
+                StorageError::NotFound(error.to_string())
+            } else {
+                StorageError::Storage(error.to_string())
+            }
+        })?;
 
         let cred: Credential = did!("local:storage")
             .credential()
@@ -102,7 +113,7 @@ where
             .load()
             .perform(&store)
             .await
-            .map_err(|e| StorageError::NotFound(e.to_string()))?;
+            .map_err(credential_load_error)?;
 
         let did = cred.did();
         self.register(did, key, store);


### PR DESCRIPTION
## Summary

- serialize per-database object-store upgrades so concurrent additions compose
- reopen pooled IndexedDB handles after external version changes and avoid waiting for readonly terminal events
- distinguish missing resources from storage failures so profile open-or-create does not create over an unusable existing profile

## Why

A Tonk service worker could successfully bootstrap a profile but later fail to open the registry profile with Space already exists: Profile/tonk.

The underlying IndexedDB load failure was being converted to NotFound, causing profile opening to fall through to creation and mask the original failure as AlreadyExists. The same runtime logs showed concurrent schema/version changes and a stranded readonly transaction settle.

## Regression coverage

- concurrent store upgrades preserve both stores
- a pooled connection reopens after an external version change
- a storage load failure never invokes profile creation

## Verification

- cargo fmt --all -- --check
- cargo test -p dialog-storage --lib (153 passed)
- cargo test -p dialog-identity --lib (11 passed)
- cargo test -p dialog-storage --target wasm32-unknown-unknown (141 passed)
- cargo test -p dialog-identity --target wasm32-unknown-unknown (11 passed)