### PR TITLE
chore(ucan-s3): drop the pre-/use command spellings

### DIFF
--- a/rust/dialog-remote-ucan-s3/src/authorizer.rs
+++ b/rust/dialog-remote-ucan-s3/src/authorizer.rs
@@ -514,17 +514,6 @@ where
             ["use", "put", "archive", "block"]   => dialog_effects::archive::Put,
             ["use", "get", "archive", "blob"]    => dialog_effects::blob::Read,
             ["use", "put", "archive", "blob"]    => dialog_effects::blob::Import,
-            // The spellings before the `use` prefix. Clients minted
-            // against an earlier release still invoke these; their chains
-            // are `/`, which covers both. Dropped once no such client is
-            // deployed.
-            ["memory", "resolve"]  => dialog_effects::memory::Resolve,
-            ["memory", "publish"]  => dialog_effects::memory::Publish,
-            ["memory", "retract"]  => dialog_effects::memory::Retract,
-            ["archive", "get"]     => dialog_effects::archive::Get,
-            ["archive", "put"]     => dialog_effects::archive::Put,
-            ["archive", "blob", "read"]   => dialog_effects::blob::Read,
-            ["archive", "blob", "import"] => dialog_effects::blob::Import,
         })
     }
 }
@@ -603,7 +592,12 @@ mod tests {
         let attacker_signer = Ed25519Signer::import(&[7u8; 32]).await.unwrap();
         let attacker_did = attacker_signer.did();
 
-        let command = vec!["memory".to_string(), "resolve".to_string()];
+        let command = vec![
+            "use".to_string(),
+            "get".to_string(),
+            "memory".to_string(),
+            "cell".to_string(),
+        ];
 
         // Forge: iss = subject, aud = attacker, sub = subject, signed by
         // the attacker (who cannot sign as the subject).
@@ -694,7 +688,12 @@ mod tests {
         let container = build_test_container(
             &subject_signer,
             &operator_signer,
-            vec!["memory".to_string(), "resolve".to_string()],
+            vec![
+                "use".to_string(),
+                "get".to_string(),
+                "memory".to_string(),
+                "cell".to_string(),
+            ],
             args,
         )
         .await;
@@ -727,7 +726,12 @@ mod tests {
         let container = build_test_container(
             &subject_signer,
             &operator_signer,
-            vec!["archive".to_string(), "get".to_string()],
+            vec![
+                "use".to_string(),
+                "get".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ],
             args,
         )
         .await;
@@ -766,7 +770,12 @@ mod tests {
         let container = build_test_container(
             &subject_signer,
             &operator_signer,
-            vec!["archive".to_string(), "put".to_string()],
+            vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ],
             args,
         )
         .await;
@@ -802,7 +811,7 @@ mod tests {
         let payload = build_test_container(
             &operator,
             &operator,
-            vec!["archive".into(), "get".into()],
+            vec!["use".into(), "get".into(), "archive".into(), "block".into()],
             args,
         )
         .await;
@@ -868,7 +877,12 @@ mod tests {
         // Build self-invocation (issuer == subject, no delegation)
         let container = build_self_invocation_container(
             &signer,
-            vec!["archive".to_string(), "get".to_string()],
+            vec![
+                "use".to_string(),
+                "get".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ],
             args,
         )
         .await;
@@ -909,7 +923,12 @@ mod tests {
 
         let container = build_self_invocation_container(
             &signer,
-            vec!["archive".to_string(), "put".to_string()],
+            vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ],
             args,
         )
         .await;
@@ -947,7 +966,12 @@ mod tests {
 
         let container = build_self_invocation_container(
             &signer,
-            vec!["memory".to_string(), "resolve".to_string()],
+            vec![
+                "use".to_string(),
+                "get".to_string(),
+                "memory".to_string(),
+                "cell".to_string(),
+            ],
             args,
         )
         .await;
@@ -1005,7 +1029,7 @@ mod tests {
             .issuer(subject.clone())
             .audience(&operator.did())
             .subject(DelegatedSubject::Specific(subject.did()))
-            .command(vec!["archive".to_string()])
+            .command(vec!["use".to_string()])
             .try_build()
             .await
             .expect("delegation");
@@ -1022,7 +1046,12 @@ mod tests {
             .issuer(operator.clone())
             .audience(&subject.did())
             .subject(&subject.did())
-            .command(vec!["archive".to_string(), "get".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "get".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .arguments(args)
             .proofs(vec![cid])
             .try_build()
@@ -1070,7 +1099,7 @@ mod tests {
 
     /// Asking beyond what a delegation grants is named as escalation.
     ///
-    /// The grant covers `archive`, the invocation asks for `blob/put`.
+    /// The grant covers `/use/get`, the invocation asks to put a blob.
     /// That is a decision about authority, and it must be tellable from
     /// unreadable input: the fix is a wider delegation, not a re-encoded
     /// request.
@@ -1083,7 +1112,7 @@ mod tests {
             .issuer(subject.clone())
             .audience(&operator.did())
             .subject(DelegatedSubject::Specific(subject.did()))
-            .command(vec!["archive".to_string()])
+            .command(vec!["use".to_string(), "get".to_string()])
             .try_build()
             .await
             .expect("delegation");
@@ -1099,7 +1128,12 @@ mod tests {
             .issuer(operator.clone())
             .audience(&subject.did())
             .subject(&subject.did())
-            .command(vec!["blob".to_string(), "put".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "blob".to_string(),
+            ])
             .arguments(args)
             .proofs(vec![cid])
             .try_build()
@@ -1134,7 +1168,7 @@ mod tests {
                     "the refusal must name what was asked for, got: {claimed}"
                 );
                 assert!(
-                    authorized.contains("archive"),
+                    authorized.contains("use/get"),
                     "and what was actually granted, got: {authorized}"
                 );
             }
@@ -1159,7 +1193,7 @@ mod tests {
             .issuer(subject.clone())
             .audience(&stranger.did())
             .subject(DelegatedSubject::Specific(subject.did()))
-            .command(vec!["archive".to_string()])
+            .command(vec!["use".to_string()])
             .try_build()
             .await
             .expect("delegation");
@@ -1176,7 +1210,12 @@ mod tests {
             .issuer(operator.clone())
             .audience(&subject.did())
             .subject(&subject.did())
-            .command(vec!["archive".to_string(), "get".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "get".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .arguments(args)
             .proofs(vec![cid])
             .try_build()
@@ -1237,7 +1276,7 @@ mod tests {
             .issuer(subject.clone())
             .audience(&operator.did())
             .subject(DelegatedSubject::Specific(subject.did()))
-            .command(vec!["archive".to_string()])
+            .command(vec!["use".to_string()])
             .expiration(expired_at)
             .try_build()
             .await
@@ -1255,7 +1294,12 @@ mod tests {
             .issuer(operator.clone())
             .audience(&subject.did())
             .subject(&subject.did())
-            .command(vec!["archive".to_string(), "get".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "get".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .arguments(args)
             .proofs(vec![cid])
             .try_build()
@@ -1331,7 +1375,12 @@ mod tests {
 
         let container = build_self_invocation_container(
             &signer,
-            vec!["archive".to_string(), "get".to_string()],
+            vec![
+                "use".to_string(),
+                "get".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ],
             args,
         )
         .await;

--- a/rust/dialog-remote-ucan-s3/src/provider.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider.rs
@@ -116,7 +116,12 @@ mod tests {
             .issuer(dialog_credentials::Signer::from(signer.clone()))
             .audience(&did)
             .subject(&did)
-            .command(vec!["archive".to_string(), "get".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "get".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .proofs(vec![])
             .try_build()
             .await
@@ -125,7 +130,7 @@ mod tests {
         UcanInvocation {
             chain: Box::new(chain),
             subject: did,
-            ability: "/archive/get".to_string(),
+            ability: "/use/get/archive/block".to_string(),
         }
         .into()
     }

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -425,7 +425,12 @@ mod tests {
         let operator = Ed25519Signer::import(&[42; 32])
             .await
             .expect("operator key");
-        let command = vec!["memory".to_string(), "resolve".to_string()];
+        let command = vec![
+            "use".to_string(),
+            "get".to_string(),
+            "memory".to_string(),
+            "cell".to_string(),
+        ];
         let delegation = DelegationBuilder::new()
             .issuer(dialog_credentials::Signer::from(subject.clone()))
             .audience(&operator)
@@ -450,7 +455,7 @@ mod tests {
         let authorization = UcanAuthorization::from(UcanInvocation {
             chain: Box::new(InvocationChain::new(invocation, delegations)),
             subject: subject.did(),
-            ability: "/memory/resolve".to_string(),
+            ability: "/use/get/memory/cell".to_string(),
         });
 
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");

--- a/rust/dialog-repository/src/repository/branch/delegation/prove.rs
+++ b/rust/dialog-repository/src/repository/branch/delegation/prove.rs
@@ -669,7 +669,7 @@ mod tests {
         let proof = harness
             .parity(
                 &holder.did(),
-                scope(&space, &["archive"]),
+                scope(&space, &["use"]),
                 TimeRange::unbounded(),
             )
             .await;

--- a/rust/dialog-ucan-core/src/container/delegation.rs
+++ b/rust/dialog-ucan-core/src/container/delegation.rs
@@ -612,19 +612,19 @@ mod tests {
     }
 
     /// Test that a delegation for archive capability roundtrips correctly.
-    /// This tests creating a delegation that grants /archive access.
+    /// This tests creating a delegation that grants /use access.
     #[dialog_common::test]
     async fn it_roundtrips_archive_delegation() {
         let subject_signer = generate_signer().await;
         let subject_did = subject_signer.did();
         let operator_signer = generate_signer().await;
 
-        // Create delegation granting /archive capability
+        // Create delegation granting /use capability
         let delegation = DelegationBuilder::new()
             .issuer(subject_signer.clone())
             .audience(&operator_signer)
             .subject(Subject::Specific(subject_did.clone()))
-            .command(vec!["archive".to_string()])
+            .command(vec!["use".to_string()])
             .try_build()
             .await
             .unwrap();
@@ -632,14 +632,14 @@ mod tests {
         let chain = DelegationChain::new(delegation);
 
         // Verify ability path
-        assert_eq!(chain.ability(), "/archive");
+        assert_eq!(chain.ability(), "/use");
 
         // Serialize and deserialize
         let bytes = chain.to_bytes().unwrap();
         let restored = DelegationChain::try_from(bytes.as_slice()).unwrap();
 
         assert_eq!(chain, restored);
-        assert_eq!(restored.ability(), "/archive");
+        assert_eq!(restored.ability(), "/use");
     }
 
     #[dialog_common::test]
@@ -737,7 +737,12 @@ mod tests {
             .issuer(subject_signer.clone())
             .audience(&operator_signer)
             .subject(Subject::Specific(subject_did.clone()))
-            .command(vec!["archive".to_string(), "put".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .try_build()
             .await
             .unwrap();
@@ -745,13 +750,13 @@ mod tests {
         let chain = DelegationChain::new(delegation);
 
         // Verify ability path
-        assert_eq!(chain.ability(), "/archive/put");
+        assert_eq!(chain.ability(), "/use/put/archive/block");
 
         // Serialize via serde to DAG-CBOR
         let cbor_bytes = serde_ipld_dagcbor::to_vec(&chain).unwrap();
         let restored: DelegationChain = serde_ipld_dagcbor::from_slice(&cbor_bytes).unwrap();
 
         assert_eq!(chain, restored);
-        assert_eq!(restored.ability(), "/archive/put");
+        assert_eq!(restored.ability(), "/use/put/archive/block");
     }
 }

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -1110,14 +1110,10 @@ mod tests {
         let subject_did = subject_signer.did();
         let operator_signer = generate_signer().await;
 
-        let delegation = create_delegation(
-            &subject_signer,
-            &operator_signer,
-            &subject_signer,
-            &["archive"],
-        )
-        .await
-        .expect("Failed to create delegation");
+        let delegation =
+            create_delegation(&subject_signer, &operator_signer, &subject_signer, &["use"])
+                .await
+                .expect("Failed to create delegation");
 
         let delegation_cid = delegation.to_cid();
 
@@ -1125,7 +1121,12 @@ mod tests {
             .issuer(operator_signer.clone())
             .audience(&subject_did)
             .subject(&subject_did)
-            .command(vec!["archive".to_string(), "put".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .proofs(vec![delegation_cid])
             .try_build()
             .await
@@ -1136,12 +1137,12 @@ mod tests {
 
         let chain = InvocationChain::new(invocation, delegations);
 
-        assert_eq!(chain.command().to_string(), "/archive/put");
+        assert_eq!(chain.command().to_string(), "/use/put/archive/block");
 
         let bytes = chain.to_bytes().expect("Failed to serialize");
         let restored = InvocationChain::try_from(bytes.as_slice()).expect("Failed to deserialize");
 
-        assert_eq!(restored.command().to_string(), "/archive/put");
+        assert_eq!(restored.command().to_string(), "/use/put/archive/block");
         assert_eq!(restored.subject(), &subject_did);
     }
 
@@ -1152,14 +1153,10 @@ mod tests {
         let subject_did = subject_signer.did();
         let operator_signer = generate_signer().await;
 
-        let delegation = create_delegation(
-            &subject_signer,
-            &operator_signer,
-            &subject_signer,
-            &["archive"],
-        )
-        .await
-        .expect("Failed to create delegation");
+        let delegation =
+            create_delegation(&subject_signer, &operator_signer, &subject_signer, &["use"])
+                .await
+                .expect("Failed to create delegation");
 
         let delegation_cid = delegation.to_cid();
 
@@ -1167,7 +1164,12 @@ mod tests {
             .issuer(operator_signer.clone())
             .audience(&subject_did)
             .subject(&subject_did)
-            .command(vec!["archive".to_string(), "put".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .proofs(vec![delegation_cid])
             .try_build()
             .await
@@ -1183,7 +1185,7 @@ mod tests {
         let restored: InvocationChain<AnySignature> =
             serde_ipld_dagcbor::from_slice(&cbor_bytes).expect("Failed to deserialize");
 
-        assert_eq!(restored.command().to_string(), "/archive/put");
+        assert_eq!(restored.command().to_string(), "/use/put/archive/block");
         assert_eq!(restored.subject(), &subject_did);
     }
 
@@ -1194,14 +1196,10 @@ mod tests {
         let subject_did = subject_signer.did();
         let operator_signer = generate_signer().await;
 
-        let delegation = create_delegation(
-            &subject_signer,
-            &operator_signer,
-            &subject_signer,
-            &["archive"],
-        )
-        .await
-        .expect("Failed to create delegation");
+        let delegation =
+            create_delegation(&subject_signer, &operator_signer, &subject_signer, &["use"])
+                .await
+                .expect("Failed to create delegation");
 
         let delegation_cid = delegation.to_cid();
 
@@ -1209,7 +1207,12 @@ mod tests {
             .issuer(operator_signer.clone())
             .audience(&subject_did)
             .subject(&subject_did)
-            .command(vec!["archive".to_string(), "put".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .proofs(vec![delegation_cid])
             .try_build()
             .await
@@ -1236,14 +1239,10 @@ mod tests {
         let subject_did = subject_signer.did();
         let operator_signer = generate_signer().await;
 
-        let delegation = create_delegation(
-            &subject_signer,
-            &operator_signer,
-            &subject_signer,
-            &["archive"],
-        )
-        .await
-        .expect("Failed to create delegation");
+        let delegation =
+            create_delegation(&subject_signer, &operator_signer, &subject_signer, &["use"])
+                .await
+                .expect("Failed to create delegation");
 
         let delegation_cid = delegation.to_cid();
 
@@ -1251,7 +1250,12 @@ mod tests {
             .issuer(operator_signer.clone())
             .audience(&subject_did)
             .subject(&subject_did)
-            .command(vec!["archive".to_string(), "put".to_string()])
+            .command(vec![
+                "use".to_string(),
+                "put".to_string(),
+                "archive".to_string(),
+                "block".to_string(),
+            ])
             .proofs(vec![delegation_cid])
             .try_build()
             .await

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -426,21 +426,21 @@ mod tests {
                 issuer,
                 &audience,
                 &subject,
-                vec!["archive".into(), "get".into()],
+                vec!["use".into(), "get".into(), "archive".into(), "block".into()],
             )
             .await;
             let certificate = UcanCertificate(delegation);
 
             // Ask for a sibling ability the delegation does not cover.
-            let scope = scope_for(&subject, "/archive/put");
+            let scope = scope_for(&subject, "/use/put/archive/block");
 
             match certificate.verify(&scope) {
                 Err(AuthorizeError::CommandEscalation {
                     claimed,
                     authorized,
                 }) => {
-                    assert_eq!(claimed, "/archive/put");
-                    assert_eq!(authorized, "/archive/get");
+                    assert_eq!(claimed, "/use/put/archive/block");
+                    assert_eq!(authorized, "/use/get/archive/block");
                 }
                 other => panic!("expected CommandEscalation, got {other:?}"),
             }
@@ -455,10 +455,10 @@ mod tests {
             let subject = signer(9).await.did();
 
             let delegation =
-                build_delegation_for(issuer, &audience, &subject, vec!["archive".into()]).await;
+                build_delegation_for(issuer, &audience, &subject, vec!["use".into()]).await;
             let certificate = UcanCertificate(delegation);
 
-            let scope = scope_for(&subject, "/archive/get");
+            let scope = scope_for(&subject, "/use/get/archive/block");
 
             certificate
                 .verify(&scope)


### PR DESCRIPTION
## Why

The authorizer dispatched `/memory/publish`, `/archive/get` and their
siblings beside the `/use` forms #469 introduced, kept for clients
minted against an earlier release.

The problem is that those spellings are not merely old, they are
**undelegatable**. A delegation's command must be a prefix of the
invocation's, so `/use/put/memory` covers `/use/put/memory/cell` and
never `/memory/publish`. An invocation spelled the legacy way therefore
authorizes only while it is self-signed and proofless; the moment it
needs a delegated grant it fails, and it fails as an authorization
error rather than as the spelling mistake it is.

That is a trap rather than a compatibility shim: it accepts invocations
that can never be granted to anyone. tonk's custody cell writes were
sitting in it, working only because a custody key is its own space's
root.

## What

Removed the legacy `dispatch!` arms. Nothing in dialog or tonk mints
these outside tests -- the production path composes its command from
`Attenuation` impls, which have always produced `/use`.

Tests move to the `/use` spelling. Two needed more than a rename, since
a blanket substitution would have changed what they assert:

- `it_names_a_command_escalation_as_escalation` grants a deliberately
  narrow prefix so the invocation escalates past it. `/archive` became
  `/use/get` rather than `/use`, which is the umbrella and would no
  longer escalate.
- `it_roundtrips_archive_delegation` asserts its ability path, so the
  assertions moved with the command.

## Note

Pre-signed invocations do not update the way a reloaded client does.
tonk's deferred custody publish carries a 30-day TTL, so an entry minted
before tonk-labs/tonk#820 will fail after this lands. Confirmed with the
author that this is the intended time to make the change.