### PR TITLE
fix(wbg-pool): harden pooled browser lifecycle

### DIFF
--- a/rust/wbg-pool/src/daemon/harness.rs
+++ b/rust/wbg-pool/src/daemon/harness.rs
@@ -125,3 +125,34 @@ pub fn generate(config: &RunConfig<'_>) -> Result<RunScripts> {
     };
     Ok(scripts)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn browser_reporting_keeps_fetch_from_before_test_code_runs() {
+        let scripts = generate(&RunConfig {
+            mode: TestMode::Browser,
+            module_js: "/module.js",
+            module_wasm: "/module.wasm",
+            exports: &["__wbgt_test"],
+            include_ignored: false,
+            filtered_count: 0,
+            nocapture: false,
+        })
+        .unwrap();
+
+        let capture = scripts
+            .run_js
+            .find("const daemonFetch = globalThis.fetch.bind(globalThis);")
+            .expect("the harness should capture fetch before running tests");
+        let test_run = scripts
+            .run_js
+            .find("const ok = await cx.run")
+            .expect("the harness should run the selected tests");
+        assert!(capture < test_run);
+        assert!(scripts.run_js.contains("await daemonFetch('report'"));
+        assert!(!scripts.run_js.contains("await fetch('report'"));
+    }
+}

--- a/rust/wbg-pool/src/daemon/js/run-browser.js
+++ b/rust/wbg-pool/src/daemon/js/run-browser.js
@@ -21,6 +21,10 @@ function grab(id) {
     return element ? element.textContent : '';
 }
 
+// Tests may replace window.fetch while exercising application networking.
+// Keep the daemon control channel independent from that test-owned global.
+const daemonFetch = globalThis.fetch.bind(globalThis);
+
 let reported = false;
 async function report(ok, error) {
     if (reported) {
@@ -32,7 +36,7 @@ async function report(ok, error) {
         const detail = error && error.stack ? error.stack : String(error);
         output += '\nharness error: ' + detail + '\n';
     }
-    await fetch('report', {
+    await daemonFetch('report', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({

--- a/rust/wbg-pool/src/daemon/server.rs
+++ b/rust/wbg-pool/src/daemon/server.rs
@@ -65,6 +65,11 @@ async fn isolate_origin_headers(mut response: Response) -> Response {
             HeaderValue::from_static("require-corp"),
         );
     }
+    // Closed tabs leave Chrome's HTTP/1 keep-alive sockets open, eventually
+    // exhausting the daemon's descriptors on macOS (soft limit 256).
+    response
+        .headers_mut()
+        .insert(header::CONNECTION, HeaderValue::from_static("close"));
     response
 }
 
@@ -380,4 +385,18 @@ async fn asset(
         bytes,
     )
         .into_response()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn it_closes_browser_connections_after_each_response() {
+        let response = isolate_origin_headers(StatusCode::OK.into_response()).await;
+        assert_eq!(
+            response.headers().get(header::CONNECTION),
+            Some(&HeaderValue::from_static("close"))
+        );
+    }
 }

--- a/rust/wbg-pool/src/shim.rs
+++ b/rust/wbg-pool/src/shim.rs
@@ -154,8 +154,16 @@ fn ensure_daemon() -> Result<String> {
         {
             Ok(mut lock) => {
                 let _ = write!(lock, "{}", std::process::id());
-                let result = spawn_daemon(&dir)
-                    .and_then(|_| wait_for_daemon(&state_path, Duration::from_secs(30)));
+                // A loaded daemon can miss the shim's 500 ms health probe
+                // while several test tabs start together. Do not orphan its
+                // browser by replacing a still-live process after one miss;
+                // give that process the normal readiness window instead.
+                let result = if daemon_process_alive(&state_path) {
+                    wait_for_daemon(&state_path, Duration::from_secs(30))
+                } else {
+                    spawn_daemon(&dir)
+                        .and_then(|_| wait_for_daemon(&state_path, Duration::from_secs(30)))
+                };
                 let _ = std::fs::remove_file(&lock_path);
                 return result;
             }
@@ -192,6 +200,25 @@ fn healthy_daemon(state_path: &Path) -> Option<String> {
     } else {
         None
     }
+}
+
+fn daemon_process_alive(state_path: &Path) -> bool {
+    let raw = match std::fs::read_to_string(state_path) {
+        Ok(raw) => raw,
+        Err(_) => return false,
+    };
+    let state: DaemonState = match serde_json::from_str(&raw) {
+        Ok(state) => state,
+        Err(_) => return false,
+    };
+    let Ok(pid) = libc::pid_t::try_from(state.pid) else {
+        return false;
+    };
+    if pid == 0 {
+        return false;
+    }
+    let result = unsafe { libc::kill(pid, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 fn wait_for_daemon(state_path: &Path, timeout: Duration) -> Result<String> {
@@ -235,4 +262,28 @@ fn spawn_daemon(state_dir: &PathBuf) -> Result<()> {
         .spawn()
         .context("failed to spawn the wbg-pool daemon")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_recognizes_a_recorded_live_daemon_process() {
+        let state_path = std::env::temp_dir().join(format!(
+            "wbg-pool-live-daemon-{}-{}.json",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let state = DaemonState {
+            url: "http://127.0.0.1:1".to_string(),
+            pid: std::process::id(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        std::fs::write(&state_path, serde_json::to_vec(&state).unwrap()).unwrap();
+
+        assert!(daemon_process_alive(&state_path));
+
+        std::fs::remove_file(state_path).unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

- Keep an existing daemon/browser alive when a loaded health probe briefly exceeds 500 ms instead of spawning a replacement and orphaning Chrome.
- Close daemon HTTP/1 responses so tabs do not leave keep-alive sockets behind until the process reaches its descriptor limit.
- Capture the browser harness's reporting `fetch` before test code can replace `window.fetch`.
- Add focused regressions for all three lifecycle contracts.

## Why

Tonk's 1,438-test nextest suite exposed three independent failures while adopting `wbg-pool` as its default Wasm runner:

1. Concurrent tab startup could delay `/api/health` beyond 500 ms. The shim acquired the spawn lock, replaced a daemon whose PID was still alive, and orphaned its browser.
2. Closing a test tab did not close its HTTP/1 keep-alive sockets. On macOS, an unchanged 164-test analyzer archive repeatedly failed after test 123 with the daemon at 254 descriptors against a 256-descriptor soft limit. Sending `Connection: close` reduced the post-run count to 18 and the same archive passed.
3. Application tests that replaced `window.fetch` also replaced the harness control channel, preventing the completed test result from reaching the daemon.

The daemon selection now treats an unhealthy live PID as an existing daemon and gives it the normal readiness window. The server closes browser connections after every response, and the browser harness reports through an early bound fetch reference.

## Verification

- `cargo test -p wbg-pool`: 9 passed
- `cargo clippy -p wbg-pool --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Each new regression was observed failing before its corresponding fix.
- Downstream Tonk pooled CI passed the same 1,438-test inventory in both debug and release with zero retries: [Actions run](https://github.com/tonk-labs/tonk/actions/runs/33366158099)
- Tonk's canonical, unsuffixed pooled commands also passed both complete web jobs after adoption: [Actions run](https://github.com/tonk-labs/tonk/actions/runs/33372091102)
