### PR TITLE
dialog-artifacts: gate the wasm-bindgen surface behind a default-on `web` feature

### DIFF
--- a/rust/dialog-artifacts/Cargo.toml
+++ b/rust/dialog-artifacts/Cargo.toml
@@ -9,7 +9,10 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["csv"]
+default = ["csv", "web"]
+# The wasm-bindgen surface in `web.rs`. Off, the crate compiles for wasm32
+# without exporting anything, so a dependant can bind its own surface.
+web = []
 debug = []
 helpers = ["dep:anyhow"]
 csv = ["dep:csv-async"]

--- a/rust/dialog-artifacts/src/artifacts/value.rs
+++ b/rust/dialog-artifacts/src/artifacts/value.rs
@@ -826,7 +826,7 @@ impl From<Value> for ValueDataType {
 /// [`ValueDataType`] embodies all types that are able to be represented
 /// as a [`Value`].
 #[cfg_attr(
-    all(target_arch = "wasm32", target_os = "unknown"),
+    all(feature = "web", target_arch = "wasm32", target_os = "unknown"),
     wasm_bindgen::prelude::wasm_bindgen
 )]
 #[repr(u8)]

--- a/rust/dialog-artifacts/src/lib.rs
+++ b/rust/dialog-artifacts/src/lib.rs
@@ -47,7 +47,7 @@
 //! # }
 //! ```
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(feature = "web", target_arch = "wasm32", target_os = "unknown"))]
 pub mod web;
 
 mod artifacts;


### PR DESCRIPTION
A crate that depends on `dialog-artifacts` and targets wasm32 gets every `#[wasm_bindgen]` export in `web.rs`, and the binding on `ValueDataType`, compiled in. If that crate defines its own wasm-bindgen exports, the names collide and the generated `.d.ts` includes both sets.

This PR adds a `web` feature, on by default, and gates `pub mod web` and the `wasm_bindgen` attribute on `ValueDataType` behind it. Default builds, the nix packaging, and the web tests are unchanged. With the feature off, the crate compiles for wasm32 with no exports.

This replaces the `openWith` change this PR carried before. Since the JavaScript bindings may be dropped, a downstream crate can bind its own surface over `Artifacts::open` in Rust instead; the feature gate is the one change that needs. Start at `rust/dialog-artifacts/src/lib.rs`.