### PR TITLE
Expose the blob index to the wasm bindings

### DIFF
--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -77,7 +77,7 @@ use crate::tree::{
     spill_cache,
 };
 use crate::{
-    DialogArtifactsError, HASH_SIZE, Key, State,
+    BlobChange, BlobIndexExt as _, BlobRecord, DialogArtifactsError, HASH_SIZE, Key, State,
     artifacts::selector::Constrained,
     buffered::{BufferedBatch, SpineSlot, apply_buffered_reusing},
     make_reference,
@@ -517,6 +517,99 @@ where
         }
     }
 
+    /// Record a blob reference in the blob index, publishing the resulting
+    /// revision the way a commit does.
+    ///
+    /// Only the reference and its intrinsic [`BlobRecord`] enter the tree; the
+    /// blob's bytes live in a blob store, which this triple store does not
+    /// keep. Recording the reference is what makes the blob visible to
+    /// [`blob_changes`](Artifacts::blob_changes), so a replica knows the blob
+    /// is owed.
+    pub async fn put_blob(
+        &mut self,
+        reference: &Blake3Hash,
+        record: BlobRecord,
+    ) -> Result<Blake3Hash, DialogArtifactsError> {
+        let base_revision = self.revision().await?;
+
+        let transaction_result = async {
+            let mut index = self.index.write().await;
+            let mut delta: Delta<NodeHash, TreeBuffer> = Delta::zero();
+
+            index
+                .put_blob(&mut self.storage, &mut delta, reference, record)
+                .await?;
+
+            Self::publish_root(&mut self.storage, &self.identifier, index.root(), delta).await
+        }
+        .await;
+
+        match transaction_result {
+            Ok(revision) => Ok(revision),
+            Err(error) => {
+                self.reset(Some(base_revision)).await?;
+                Err(error)
+            }
+        }
+    }
+
+    /// The [`BlobRecord`] the blob index holds for `reference`, or `None` if
+    /// the current revision does not reference that blob. Answered from the
+    /// index alone, so it costs no blob fetch.
+    pub async fn get_blob(
+        &self,
+        reference: &Blake3Hash,
+    ) -> Result<Option<BlobRecord>, DialogArtifactsError> {
+        let index = self.index.read().await;
+        index.get_blob(&self.storage, reference).await
+    }
+
+    /// Stream the blob references added and removed between two revisions, in
+    /// reference order.
+    ///
+    /// Runs the tree differential over the blob index, so the cost is
+    /// proportional to what changed rather than to the number of facts. This
+    /// is what a replication or backup pass reads to learn which blobs it owes
+    /// since its checkpoint.
+    pub fn blob_changes(
+        &self,
+        checkpoint: Blake3Hash,
+        current: Blake3Hash,
+    ) -> impl Stream<Item = Result<BlobChange, DialogArtifactsError>> + 'static + ConditionalSend
+    {
+        let storage = self.storage.clone();
+
+        try_stream! {
+            let checkpoint = Self::index_at(&storage, &checkpoint).await?;
+            let current = Self::index_at(&storage, &current).await?;
+            let changes = crate::blob_changes(checkpoint, current, storage);
+            tokio::pin!(changes);
+            for await change in changes {
+                yield change?;
+            }
+        }
+    }
+
+    /// The index tree as of `revision`, for reads that need a version other
+    /// than the live one.
+    async fn index_at(
+        storage: &Storage<CborEncoder, Backend>,
+        revision: &Blake3Hash,
+    ) -> Result<ArtifactTree, DialogArtifactsError> {
+        if revision == &NULL_REVISION_HASH {
+            return Ok(ArtifactTree::empty());
+        }
+
+        let root = storage.read::<IndexRoot>(revision).await?.ok_or_else(|| {
+            DialogArtifactsError::InvalidRevision(format!(
+                "Block ({}) not found in storage",
+                revision.to_base58()
+            ))
+        })?;
+
+        Ok(ArtifactTree::from_hash(NodeHash::from(*root.index())))
+    }
+
     /// Persists `delta`'s pending nodes, mints a revision for `root`, and
     /// advances the store's head pointer to it. The flush completes before the
     /// revision is written: a revision must only reference durable blocks.
@@ -630,12 +723,45 @@ mod tests {
     use crate::tree::distribution;
     use crate::{
         Artifact, ArtifactSelector, ArtifactStoreMutExt, ArtifactViewStream, Artifacts, Attribute,
-        DialogArtifactsError, Entity, Instruction, NULL_REVISION_HASH, NameShape, Symbol, Value,
-        make_reference,
+        BlobChange, BlobRecord, DialogArtifactsError, Entity, Instruction, NULL_REVISION_HASH,
+        NameShape, Symbol, Value, make_reference,
     };
 
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    /// The blob index is reachable through [`Artifacts`] itself: a recorded
+    /// reference reads back with its record, and the differential between the
+    /// revisions before and after the write names exactly that blob — without
+    /// any fact having been committed.
+    #[dialog_common::test]
+    async fn it_records_a_blob_reference_and_reports_it_as_added() -> Result<()> {
+        let mut artifacts =
+            Artifacts::open("blob-index".into(), MemoryStorageBackend::default()).await?;
+
+        let bytes = b"the bytes of a blob";
+        let reference = make_reference(bytes);
+        let record = BlobRecord::new(bytes.len() as u64);
+
+        let checkpoint = artifacts.revision().await?;
+        let current = artifacts.put_blob(&reference, record).await?;
+
+        assert_eq!(artifacts.get_blob(&reference).await?, Some(record));
+        assert_eq!(
+            artifacts
+                .get_blob(&make_reference(b"some other blob"))
+                .await?,
+            None
+        );
+
+        let changes: Vec<_> = artifacts
+            .blob_changes(checkpoint, current)
+            .try_collect()
+            .await?;
+        assert_eq!(changes, vec![BlobChange::Added(reference)]);
+
+        Ok(())
+    }
 
     /// A store that keeps its live spine across commits must publish exactly
     /// the revisions a store that re-opens its root from bytes before every

--- a/rust/dialog-artifacts/src/web.rs
+++ b/rust/dialog-artifacts/src/web.rs
@@ -42,8 +42,8 @@ use wasm_bindgen_futures::js_sys::{self, Object, Reflect, Symbol, Uint8Array};
 
 use crate::{
     Artifact, ArtifactSelector, ArtifactStore, ArtifactStoreMutExt, ArtifactViewStream as _,
-    Artifacts, Attribute, Cause, DialogArtifactsError, Entity, HASH_SIZE, Instruction, Value,
-    ValueDataType, artifacts::selector::Constrained,
+    Artifacts, Attribute, BlobChange, BlobRecord, Cause, DialogArtifactsError, Entity, HASH_SIZE,
+    Instruction, Value, ValueDataType, artifacts::selector::Constrained,
 };
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -115,6 +115,36 @@ interface ArtifactSelector {
  * The shape of the "async iterable" that is returned by `Artifacts.select`
  */
 type ArtifactIterable = AsyncIterable<Artifact & ArtifactApi>;
+
+/**
+ * A reference to a blob: the BLAKE3 hash of the blob's complete bytes. It
+ * must be exactly 32-bytes long, and may be produced with `makeReference`.
+ */
+type BlobReference = Uint8Array;
+
+/**
+ * The intrinsic, content-derived metadata that the blob index keeps for a
+ * referenced blob. The `version` is the encoding version of the record, so
+ * that new fields may be added to it over time.
+ */
+interface BlobRecord {
+  version: number,
+  size: number
+}
+
+/**
+ * A blob reference that was added or removed between two revisions.
+ */
+interface BlobChange {
+  type: BlobChangeType,
+  reference: BlobReference
+}
+
+/**
+ * The shape of the "async iterable" that is returned by
+ * `Artifacts.blobChanges`
+ */
+type BlobChangeIterable = AsyncIterable<BlobChange>;
 "#;
 
 #[wasm_bindgen]
@@ -177,6 +207,17 @@ pub enum InstructionTypeBinding {
     Assert = 0,
     /// The `Instruction` is a retraction
     Retract = 1,
+}
+
+/// Used to specify if a `BlobChange` newly references a blob or drops a
+/// reference to one
+#[repr(u8)]
+#[wasm_bindgen(js_name = "BlobChangeType")]
+pub enum BlobChangeTypeBinding {
+    /// The blob is referenced by the later revision, but not the earlier one
+    Added = 0,
+    /// The blob is referenced by the earlier revision, but not the later one
+    Removed = 1,
 }
 
 type WebStorageBackend = Arc<Mutex<dyn ObjectSafeStorageBackend>>;
@@ -311,6 +352,66 @@ impl ArtifactsBinding {
 
         Ok(iterable)
     }
+
+    /// Record a blob of `size` bytes in the blob index, under the
+    /// `BlobReference` that identifies it. The returned promise resolves to
+    /// the new revision, as `Artifacts.commit` does.
+    ///
+    /// The blob's bytes are the caller's to keep: the index carries only the
+    /// reference and the size, which is what a replication or backup pass
+    /// reads. Recording the reference is what makes the blob visible to
+    /// `Artifacts.blobChanges`.
+    #[wasm_bindgen(js_name = "putBlob")]
+    pub async fn put_blob(&self, reference: Vec<u8>, size: f64) -> Result<Vec<u8>, JsError> {
+        let reference = blob_reference(reference)?;
+
+        Ok(self
+            .artifacts
+            .write()
+            .await
+            .put_blob(&reference, BlobRecord::new(size as u64))
+            .await?
+            .to_vec())
+    }
+
+    /// Get the `BlobRecord` that the blob index holds for a `BlobReference`,
+    /// or `undefined` if the current revision does not reference that blob.
+    /// The record is read from the index alone, so no blob bytes are fetched.
+    #[wasm_bindgen(js_name = "getBlob", unchecked_return_type = "BlobRecord|undefined")]
+    pub async fn get_blob(&self, reference: Vec<u8>) -> Result<JsValue, JsError> {
+        let reference = blob_reference(reference)?;
+
+        match self.artifacts.read().await.get_blob(&reference).await? {
+            Some(record) => JsValue::try_from(record),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    /// Query for the blob references that were added or removed between two
+    /// revisions. Matching results are provided via an async iterator, in
+    /// reference order.
+    ///
+    /// The work is proportional to what changed between the revisions, not to
+    /// the number of facts in the store, so a sync or backup layer can learn
+    /// which blobs it owes without walking every artifact.
+    #[wasm_bindgen(js_name = "blobChanges", unchecked_return_type = "BlobChangeIterable")]
+    pub fn blob_changes(&self, checkpoint: Vec<u8>, current: Vec<u8>) -> Result<JsValue, JsError> {
+        let checkpoint = revision_hash(checkpoint)?;
+        let current = revision_hash(current)?;
+        let artifacts = self.artifacts.clone();
+
+        let iterable = JsValue::from(Object::new());
+        let async_iterator: Closure<dyn FnMut() -> BlobChangeIteratorBinding> =
+            Closure::new(move || {
+                BlobChangeIteratorBinding::new(checkpoint, current, artifacts.clone())
+            });
+        let async_iterator = async_iterator.into_js_value();
+
+        Reflect::set(&iterable, &Symbol::async_iterator(), &async_iterator)
+            .map_err(js_value_to_error)?;
+
+        Ok(iterable)
+    }
 }
 
 /// An async iterator that lazily yields `Artifact`s
@@ -363,11 +464,83 @@ impl ArtifactIteratorBinding {
     }
 }
 
+/// An async iterator that lazily yields the `BlobChange`s between two
+/// revisions
+#[wasm_bindgen(js_name = "BlobChangeIterator")]
+pub struct BlobChangeIteratorBinding {
+    checkpoint: Blake3Hash,
+    current: Blake3Hash,
+    artifacts: Arc<RwLock<Artifacts<WebStorageBackend>>>,
+    stream: Option<Pin<Box<dyn Stream<Item = Result<BlobChange, DialogArtifactsError>>>>>,
+}
+
+#[wasm_bindgen(js_class = "BlobChangeIterator")]
+impl BlobChangeIteratorBinding {
+    fn new(
+        checkpoint: Blake3Hash,
+        current: Blake3Hash,
+        artifacts: Arc<RwLock<Artifacts<WebStorageBackend>>>,
+    ) -> Self {
+        Self {
+            checkpoint,
+            current,
+            artifacts,
+            stream: None,
+        }
+    }
+
+    /// Get the next `BlobChange` yielded by this iterator
+    #[wasm_bindgen(unchecked_return_type = "IteratorResult<BlobChange>")]
+    pub async fn next(&mut self) -> Result<JsValue, JsError> {
+        if self.stream.is_none() {
+            self.stream = Some(Box::pin(
+                self.artifacts
+                    .read()
+                    .await
+                    .blob_changes(self.checkpoint, self.current),
+            ));
+        }
+
+        let Some(stream) = &mut self.stream else {
+            return iterable_result(None);
+        };
+
+        let Some(next_element) = stream.next().await else {
+            return iterable_result(None);
+        };
+
+        let next_element = JsValue::try_from(next_element?)?;
+
+        iterable_result(Some(next_element))
+    }
+}
+
 // NOTE: Everything below this line is a conversion to support duck typing on the
 // JavaScript side of the API boundary
 
 fn js_value_to_error(value: JsValue) -> JsError {
     JsError::new(&format!("{:?}", value))
+}
+
+/// Interpret bytes handed across the boundary as a `BlobReference`
+fn blob_reference(bytes: Vec<u8>) -> Result<Blake3Hash, JsError> {
+    Ok(Blake3Hash::try_from(bytes).map_err(|bytes: Vec<u8>| {
+        DialogArtifactsError::InvalidReference(format!(
+            "Incorrect byte length (expected {HASH_SIZE}, received {})",
+            bytes.len()
+        ))
+    })?)
+}
+
+/// Interpret bytes handed across the boundary as a revision, of the kind that
+/// `Artifacts.revision` returns
+fn revision_hash(bytes: Vec<u8>) -> Result<Blake3Hash, JsError> {
+    Ok(Blake3Hash::try_from(bytes).map_err(|bytes: Vec<u8>| {
+        DialogArtifactsError::InvalidRevision(format!(
+            "Incorrect byte length (expected {HASH_SIZE}, received {})",
+            bytes.len()
+        ))
+    })?)
 }
 
 fn iterable_result(value: Option<JsValue>) -> Result<JsValue, JsError> {
@@ -426,6 +599,53 @@ impl TryFrom<Value> for JsValue {
 
         Reflect::set(&object, &"type".into(), &data_type).map_err(js_value_to_error)?;
         Reflect::set(&object, &"value".into(), &value).map_err(js_value_to_error)?;
+
+        Ok(object)
+    }
+}
+
+impl TryFrom<BlobRecord> for JsValue {
+    type Error = JsError;
+
+    fn try_from(record: BlobRecord) -> Result<Self, Self::Error> {
+        let object = JsValue::from(Object::new());
+
+        Reflect::set(
+            &object,
+            &"version".into(),
+            &JsValue::from_f64(record.version as f64),
+        )
+        .map_err(js_value_to_error)?;
+        // TODO: BigNum support
+        Reflect::set(
+            &object,
+            &"size".into(),
+            &JsValue::from_f64(record.size as f64),
+        )
+        .map_err(js_value_to_error)?;
+
+        Ok(object)
+    }
+}
+
+impl TryFrom<BlobChange> for JsValue {
+    type Error = JsError;
+
+    fn try_from(change: BlobChange) -> Result<Self, Self::Error> {
+        let change_type = match change {
+            BlobChange::Added(_) => BlobChangeTypeBinding::Added,
+            BlobChange::Removed(_) => BlobChangeTypeBinding::Removed,
+        };
+
+        let reference = Uint8Array::new_with_length(HASH_SIZE as u32);
+        reference.copy_from(change.hash().as_ref());
+
+        let object = JsValue::from(Object::new());
+
+        Reflect::set(&object, &"type".into(), &JsValue::from(change_type))
+            .map_err(js_value_to_error)?;
+        Reflect::set(&object, &"reference".into(), &JsValue::from(reference))
+            .map_err(js_value_to_error)?;
 
         Ok(object)
     }

--- a/typescript/dialog-artifacts-web-tests/bindings.test.ts
+++ b/typescript/dialog-artifacts-web-tests/bindings.test.ts
@@ -1,4 +1,4 @@
-import init, { Artifacts, generateEntity, encode, Entity, InstructionType, ValueDataType, Artifact, ArtifactApi } from "./dialog-artifacts";
+import init, { Artifacts, generateEntity, encode, makeReference, BlobChangeType, Entity, InstructionType, ValueDataType, Artifact, ArtifactApi } from "./dialog-artifacts";
 import { assert, expect } from "@open-wc/testing";
 
 await init();
@@ -289,6 +289,32 @@ describe('artifacts', () => {
         }
 
         expect(count).to.be.eql(5);
+    });
+
+    it('reports the blob references added between two revisions', async () => {
+        let artifacts = await Artifacts.anonymous();
+
+        let bytes = new TextEncoder().encode("the bytes of a blob");
+        let reference = makeReference(bytes);
+
+        let checkpoint = await artifacts.revision();
+        let current = await artifacts.putBlob(reference, bytes.length);
+
+        let record = await artifacts.getBlob(reference);
+
+        expect(record).to.be.ok;
+        expect(record!.size).to.be.eql(bytes.length);
+        expect(await artifacts.getBlob(makeReference(new Uint8Array()))).to.be.undefined;
+
+        let changes = [];
+
+        for await (const change of artifacts.blobChanges(checkpoint, current)) {
+            changes.push(change);
+        }
+
+        expect(changes.length).to.be.eql(1);
+        expect(changes[0].type).to.be.eql(BlobChangeType.Added);
+        expect(encode(changes[0].reference)).to.be.eql(encode(reference));
     });
 
 });


### PR DESCRIPTION
The `Artifacts` wasm class had no way to reach the blob index, so a JavaScript caller could see facts but not the blobs a tree references. This adds `putBlob` (record a reference and its size, returns the new revision), `getBlob` (read the record for a reference), and `blobChanges` (iterate the references added and removed between two revisions). They wrap three same-named methods added to `Artifacts` in Rust, and follow the existing `commit`, `select`, and `revision` bindings in how bytes, revisions, and errors cross the boundary.

Why: a backup tool running in a browser can take the revision it last archived, ask which blob references were added since, and upload only those, rather than scanning every fact. Blob bytes are outside this surface: the index carries a reference and a size, and the bytes stay wherever the caller keeps them.

Verified with `cargo test -p dialog-artifacts` (205 tests, including a new one that records a reference, reads it back, and checks the differential names that blob), `cargo check --target wasm32-unknown-unknown`, and a test in `dialog-artifacts-web-tests` that passes in headless Chrome against the built package.