### PR TITLE
feat(ucan): let a delegation carry signed meta, and read it back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,7 @@ dependencies = [
  "dialog-ucan",
  "dialog-ucan-core",
  "dialog-varsig",
+ "ipld-core",
  "serde",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/dialog-identity/Cargo.toml
+++ b/rust/dialog-identity/Cargo.toml
@@ -15,6 +15,7 @@ dialog-ucan = { workspace = true }
 dialog-ucan-core = { workspace = true }
 dialog-varsig = { workspace = true }
 async-trait = { workspace = true }
+ipld-core = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/rust/dialog-identity/src/profile/access.rs
+++ b/rust/dialog-identity/src/profile/access.rs
@@ -11,6 +11,8 @@ use dialog_ucan::Scope;
 use dialog_ucan::{Ucan, UcanDelegation, UcanProof};
 use dialog_ucan_core::time::Timestamp;
 use dialog_varsig::{Did, Principal};
+use ipld_core::ipld::Ipld;
+use std::collections::BTreeMap;
 
 /// Access handle scoped to a profile's credential.
 ///
@@ -95,6 +97,7 @@ impl<'a, C: Constraint> Claim<'a, C> {
         Delegate {
             claim: self,
             audience: audience.into(),
+            meta: None,
         }
     }
 
@@ -174,6 +177,20 @@ fn signer_of(credential: &SignerCredential) -> dialog_credentials::Signer {
 pub struct Delegate<'a, C: Constraint> {
     claim: Claim<'a, C>,
     audience: Did,
+    meta: Option<BTreeMap<String, Ipld>>,
+}
+
+impl<C: Constraint> Delegate<'_, C> {
+    /// Entries for the minted delegation's signed `meta`.
+    ///
+    /// Meta travels inside the signed envelope, so whatever the grant
+    /// carries here cannot be swapped independently of the grant.
+    /// Verification ignores it.
+    #[must_use]
+    pub fn meta(mut self, meta: BTreeMap<String, Ipld>) -> Self {
+        self.meta = Some(meta);
+        self
+    }
 }
 
 impl<C: Constraint> Delegate<'_, C>
@@ -194,6 +211,9 @@ where
         }
         if let Some(exp) = duration.expiration {
             authorization = authorization.expires(exp)?;
+        }
+        if let Some(meta) = self.meta {
+            authorization = authorization.meta(meta);
         }
         authorization.delegate(self.audience).await
     }

--- a/rust/dialog-ucan-core/src/container/delegation.rs
+++ b/rust/dialog-ucan-core/src/container/delegation.rs
@@ -16,6 +16,7 @@ use crate::time::Timestamp;
 use dialog_varsig::AnySignature;
 use dialog_varsig::Did;
 use ipld_core::cid::Cid;
+use ipld_core::ipld::Ipld;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -101,6 +102,21 @@ impl DelegationChain {
     /// Get the CIDs for use in invocation proofs field.
     pub fn proof_cids(&self) -> &[Cid] {
         &self.proof_cids
+    }
+
+    /// The value the chain carries for `key` in its delegations' signed
+    /// meta, scanned leaf-to-root: the delegation minted closest to the
+    /// recipient is the one minted at handoff time, so its entry wins.
+    ///
+    /// Meta is informational — verification ignores it — so nothing
+    /// authority-bearing belongs behind this.
+    #[must_use]
+    pub fn meta(&self, key: &str) -> Option<&Ipld> {
+        self.proof_cids
+            .iter()
+            .rev()
+            .filter_map(|cid| self.delegations.get(cid))
+            .find_map(|delegation| delegation.meta().get(key))
     }
 
     /// Iterate the chain's delegations in root-to-leaf order.

--- a/rust/dialog-ucan-core/src/container/invocation.rs
+++ b/rust/dialog-ucan-core/src/container/invocation.rs
@@ -31,6 +31,7 @@ use dialog_varsig::Did;
 use dialog_varsig::Resolver;
 use dialog_varsig::Signature;
 use ipld_core::cid::Cid;
+use ipld_core::ipld::Ipld;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -142,6 +143,25 @@ impl<S: Signature> InvocationChain<S> {
                     ),
                 },
             })
+    }
+
+    /// The value this container carries for `key` in signed meta: the
+    /// invocation's own entry first — it is the artifact minted last, at
+    /// invoke time — then its `prf` delegations leaf-to-root, so the hop
+    /// minted closest to the invoker wins among the proofs.
+    ///
+    /// Meta is informational — verification ignores it — so nothing
+    /// authority-bearing belongs behind this.
+    #[must_use]
+    pub fn meta(&self, key: &str) -> Option<&Ipld> {
+        if let Some(value) = self.invocation.meta().get(key) {
+            return Some(value);
+        }
+        self.proofs()
+            .iter()
+            .rev()
+            .filter_map(|cid| self.delegations.get(cid))
+            .find_map(|delegation| delegation.meta().get(key))
     }
 
     /// Look up a delegation the container carries as a block.
@@ -359,6 +379,63 @@ pub(crate) mod tests {
         delegations.insert(delegation_cid, Arc::new(delegation));
 
         (InvocationChain::new(invocation, delegations), subject_did)
+    }
+
+    /// The invocation's own meta entry wins over a proof delegation's;
+    /// a key only a proof carries still resolves through the container.
+    #[dialog_common::test]
+    async fn it_reads_meta_from_the_invocation_before_its_proofs() {
+        use ipld_core::ipld::Ipld;
+        use std::collections::BTreeMap;
+
+        let subject_signer = generate_signer().await;
+        let subject_did = subject_signer.did();
+        let operator_signer = generate_signer().await;
+
+        let delegation = DelegationBuilder::new()
+            .issuer(subject_signer.clone())
+            .audience(&operator_signer.did())
+            .subject(Subject::Specific(subject_did.clone()))
+            .command(vec![])
+            .meta(BTreeMap::from([
+                (
+                    "home.address".to_owned(),
+                    Ipld::String("https://proof.example/ucan/".to_owned()),
+                ),
+                ("origin".to_owned(), Ipld::String("proof".to_owned())),
+            ]))
+            .try_build()
+            .await
+            .unwrap();
+        let delegation_cid = delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(operator_signer)
+            .audience(&subject_did)
+            .subject(&subject_did)
+            .command(vec!["storage".to_string(), "get".to_string()])
+            .proofs(vec![delegation_cid])
+            .meta(BTreeMap::from([(
+                "home.address".to_owned(),
+                Ipld::String("https://invocation.example/ucan/".to_owned()),
+            )]))
+            .try_build()
+            .await
+            .unwrap();
+
+        let mut delegations = HashMap::new();
+        delegations.insert(delegation_cid, Arc::new(delegation));
+        let chain = InvocationChain::new(invocation, delegations);
+
+        assert_eq!(
+            chain.meta("home.address"),
+            Some(&Ipld::String("https://invocation.example/ucan/".to_owned())),
+        );
+        assert_eq!(
+            chain.meta("origin"),
+            Some(&Ipld::String("proof".to_owned())),
+        );
+        assert_eq!(chain.meta("absent"), None);
     }
 
     #[dialog_common::test]

--- a/rust/dialog-ucan/src/access.rs
+++ b/rust/dialog-ucan/src/access.rs
@@ -15,6 +15,8 @@ use dialog_ucan_core::time::Timestamp;
 use dialog_ucan_core::time::timestamp::{Duration, UNIX_EPOCH};
 use dialog_ucan_core::{Delegation, DelegationChain, InvocationBuilder, InvocationChain};
 use dialog_varsig::AnySignature;
+use ipld_core::ipld::Ipld;
+use std::collections::BTreeMap;
 
 use super::scope::Scope;
 use super::{Ucan, UcanInvocation};
@@ -169,6 +171,7 @@ impl Proof<Ucan> for UcanProof {
             signer,
             scope: self.scope,
             duration: self.duration,
+            meta: None,
         })
     }
 }
@@ -186,6 +189,26 @@ pub struct UcanAuthorization {
     pub scope: Scope,
     /// The time range this authorization is valid for.
     pub duration: TimeRange,
+    /// Entries for the next minted delegation's signed `meta`. Set with
+    /// [`UcanAuthorization::meta`]; [`Authorization::delegate`] signs
+    /// them into the leaf.
+    pub meta: Option<BTreeMap<String, Ipld>>,
+}
+
+impl UcanAuthorization {
+    /// Entries for the minted delegation's signed `meta`.
+    ///
+    /// Meta is how a grant carries information that must travel with it
+    /// and cannot be swapped independently — a client naming the sync
+    /// endpoint the granted subject is served from, for example. It is
+    /// informational: verification ignores it. Consuming, like
+    /// [`Authorization::not_before`] and [`Authorization::expires`], so
+    /// it chains ahead of [`Authorization::delegate`].
+    #[must_use]
+    pub fn meta(mut self, meta: BTreeMap<String, Ipld>) -> Self {
+        self.meta = Some(meta);
+        self
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -228,6 +251,9 @@ impl Authorization<Ucan> for UcanAuthorization {
             .subject(self.scope.subject.clone())
             .command(self.scope.command.segments().clone())
             .policy(self.scope.policy());
+        if let Some(meta) = &self.meta {
+            builder = builder.meta(meta.clone());
+        }
 
         if let Some(exp) = self.duration.expiration
             && let Ok(ts) = Timestamp::new(UNIX_EPOCH + Duration::from_secs(exp))
@@ -394,6 +420,102 @@ mod tests {
             .try_build()
             .await
             .unwrap()
+    }
+
+    mod delegate_meta {
+        use super::*;
+        use dialog_ucan_core::command::Command;
+
+        /// A self-authorized claim over `subject`, root command, no policy.
+        fn authorization(issuer: Signer, subject: &Did) -> UcanAuthorization {
+            let scope = crate::Scope {
+                subject: UcanSubject::Specific(subject.clone()),
+                command: Command::parse("/").unwrap(),
+                parameters: Default::default(),
+            };
+            UcanProof::new(scope).claim(issuer).unwrap()
+        }
+
+        #[dialog_common::test]
+        async fn it_stamps_the_requested_meta_into_the_signed_leaf() {
+            let issuer = signer(1).await;
+            let subject = issuer.did();
+            let audience = signer(2).await.did();
+            let meta = BTreeMap::from([(
+                "home.address".to_owned(),
+                Ipld::String("https://sync.example/ucan/".to_owned()),
+            )]);
+
+            let delegation = authorization(issuer, &subject)
+                .meta(meta)
+                .delegate(audience.clone())
+                .await
+                .unwrap();
+
+            let chain = delegation.into_chain();
+            assert_eq!(*chain.audience(), audience);
+            assert_eq!(
+                chain.meta("home.address"),
+                Some(&Ipld::String("https://sync.example/ucan/".to_owned())),
+            );
+        }
+
+        /// Two hops carrying the same key: the leaf — the delegation
+        /// minted closest to the recipient — wins.
+        #[dialog_common::test]
+        async fn it_prefers_the_leaf_entry_when_hops_disagree() {
+            let root = signer(1).await;
+            let subject = root.did();
+            let middle = signer(2).await;
+            let leaf_audience = signer(3).await.did();
+
+            let first = DelegationBuilder::new()
+                .issuer(root)
+                .audience(&middle.did())
+                .subject(UcanSubject::Specific(subject.clone()))
+                .command(vec![])
+                .meta(BTreeMap::from([(
+                    "home.address".to_owned(),
+                    Ipld::String("https://root.example/ucan/".to_owned()),
+                )]))
+                .try_build()
+                .await
+                .unwrap();
+            let second = DelegationBuilder::new()
+                .issuer(middle)
+                .audience(&leaf_audience)
+                .subject(UcanSubject::Specific(subject.clone()))
+                .command(vec![])
+                .meta(BTreeMap::from([(
+                    "home.address".to_owned(),
+                    Ipld::String("https://leaf.example/ucan/".to_owned()),
+                )]))
+                .try_build()
+                .await
+                .unwrap();
+            let chain = DelegationChain::new(first).push(second).unwrap();
+
+            assert_eq!(
+                chain.meta("home.address"),
+                Some(&Ipld::String("https://leaf.example/ucan/".to_owned())),
+            );
+        }
+
+        #[dialog_common::test]
+        async fn it_leaves_meta_absent_when_none_was_requested() {
+            let issuer = signer(1).await;
+            let subject = issuer.did();
+            let audience = signer(2).await.did();
+
+            let delegation = authorization(issuer, &subject)
+                .delegate(audience)
+                .await
+                .unwrap();
+
+            let chain = delegation.into_chain();
+            assert!(chain.proofs().last().unwrap().meta().is_empty());
+            assert_eq!(chain.meta("home.address"), None);
+        }
     }
 
     // These drive a real `Certificate::verify` against a real delegation


### PR DESCRIPTION
Tonk is moving the sync endpoint into the grant itself: an invite or account delegation carries a `home.address` entry in its signed meta, so the grant and the address travel together and cannot be swapped independently (tonk currently rebuilds the leaf by hand from `UcanAuthorization`'s public fields to get this — this PR is what lets it delete that).

**Writing.** `DelegationBuilder` already supports meta; what was missing is a way to reach it through the authorize path. `UcanAuthorization::meta(...)` stages entries the way `not_before`/`expires` stage bounds, and `delegate()` signs them into the leaf. The profile access `Delegate` builder threads them through:

~~~rust
profile.access()
    .claim(Subject::from(space).attenuate(Use))
    .delegate(audience)
    .meta(meta)
    .perform(&operator)
~~~

**Reading.** The accessor is chain-level, so the precedence rule lives in one place instead of per consumer: `DelegationChain::meta(key)` scans leaf-to-root — the delegation minted closest to the recipient is the one minted at handoff time, so its entry wins — and `InvocationChain::meta(key)` answers from the invocation's own meta first, then its proofs leaf-to-root.

Verification is untouched: meta is informational and rides inside the signed envelope, so nothing authority-bearing should be read through these.