### PR TITLE
feat(artifacts): select history records by revision

### DIFF
--- a/rust/dialog-artifacts/src/history/query.rs
+++ b/rust/dialog-artifacts/src/history/query.rs
@@ -1,9 +1,11 @@
+use std::ops::Bound;
 use std::str::FromStr;
 
+use async_stream::try_stream;
 use dialog_common::{Blake3Hash as NodeHash, ConditionalSync};
 use dialog_search_tree::ContentAddressedStorage as NodeStorage;
 use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
-use futures_util::TryStreamExt;
+use futures_util::{Stream, TryStreamExt};
 
 use crate::Value;
 use crate::history::VersionExt as _;
@@ -11,10 +13,38 @@ use crate::tree::ArtifactTreeExt as _;
 use crate::tree::{ArtifactTree, SpillCache, TreeStorageBridge, fetch_spilled_cached, spill_cache};
 use crate::{
     Attribute, DialogArtifactsError, Entity, State, history_claim_range, history_key_version,
-    history_region_range,
+    history_region_range, history_version_range,
 };
 
 use super::{Claim, History, REVISION_ATTRIBUTE, Record, RevisionRecord, Version};
+
+/// Which history records a [`TreeHistory::select`] scan covers.
+///
+/// Each variant names a span of the history region that is contiguous in
+/// key order, so a scan is one range walk rather than a filtered sweep.
+/// The type is `non_exhaustive`: narrower spans (a version range, a causal
+/// span over the revision DAG) are additive here, and matching on it must
+/// stay open to them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HistorySelector {
+    /// Every record in the history region.
+    All,
+    /// Every claim recorded by the revision identified by this version.
+    At(Version),
+}
+
+impl From<Version> for HistorySelector {
+    fn from(version: Version) -> Self {
+        Self::At(version)
+    }
+}
+
+impl From<&Version> for HistorySelector {
+    fn from(version: &Version) -> Self {
+        Self::At(*version)
+    }
+}
 
 /// Read access to the history region of an artifact tree.
 ///
@@ -93,9 +123,63 @@ where
         )
     }
 
+    /// The history records the selector covers, in key order (ascending by
+    /// version; no record appears before one produced by an ancestor
+    /// revision), each paired with the version of the revision that wrote
+    /// it.
+    ///
+    /// Every selector names a contiguous span, so this is one range walk.
+    /// Records materialize as the stream is polled — a record is parsed out
+    /// of its key, and a spilled value's block fetched, only when its entry
+    /// is reached — so a caller that folds the stream never holds the whole
+    /// span at once. `try_collect()` for the eager `Vec`.
+    ///
+    /// A [`Version`] converts into a selector, so scanning one revision's
+    /// claims reads `select(version)`.
+    pub fn select(
+        &self,
+        selector: impl Into<HistorySelector>,
+    ) -> impl Stream<Item = Result<(Version, Record), DialogArtifactsError>> + '_ {
+        // Each selector's span, as bounds the tree walk takes directly. The
+        // region is inclusive on both ends (a bounded filler run tops it),
+        // while a version span is half-open (an unbounded entity encoding
+        // follows the prefix, so only the next prefix bounds it soundly) —
+        // see `history_version_range`.
+        let (min, max) = match selector.into() {
+            HistorySelector::All => {
+                let (min, max) = history_region_range();
+                (Bound::Included(min), Bound::Included(max))
+            }
+            HistorySelector::At(version) => {
+                let (min, max) = history_version_range(&version);
+                (Bound::Included(min), Bound::Excluded(max))
+            }
+        };
+
+        try_stream! {
+            let stream = self.tree.stream_range((min, max), &self.storage);
+            tokio::pin!(stream);
+
+            while let Some(entry) = stream.try_next().await? {
+                // A retracted history entry is not a retraction record: it
+                // is an entry erased from the region. Only live entries
+                // carry records.
+                if let State::Added(datum) = entry.value {
+                    let spilled =
+                        fetch_spilled_cached(&self.store, &self.spill, &entry.key).await?;
+                    yield (
+                        history_key_version(&entry.key)?,
+                        Record::try_from_key_datum_with_value(&entry.key, datum, spilled)?,
+                    );
+                }
+            }
+        }
+    }
+
     /// Every record in the history region, in key order (ascending by
     /// version; no record appears before one produced by an ancestor
     /// revision)
+    #[deprecated(note = "use `select(HistorySelector::All)`")]
     pub async fn records(&self) -> Result<Vec<(Version, Record)>, DialogArtifactsError> {
         let (min, max) = history_region_range();
         let stream = self.tree.stream_range(min..=max, &self.storage);

--- a/rust/dialog-artifacts/src/history/tests.rs
+++ b/rust/dialog-artifacts/src/history/tests.rs
@@ -6,14 +6,16 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use anyhow::Result;
 use dialog_storage::MemoryStorageBackend;
 use ed25519_dalek::SigningKey;
+use futures_util::TryStreamExt as _;
 
 use crate::key::default_manifest;
 use crate::tree::{ArtifactTree, ArtifactTreeExt as _};
 use crate::{Artifact, Attribute, DialogArtifactsError, Entity, Instruction, Value, encode_bytes};
 
 use super::{
-    Authority, Causality, CausalityCache, Cause, Claim, Edition, History, MemoryHistory, Origin,
-    Revision, RevisionRecord, TreeHistory, Version, causality, common_ancestor, extend_skips, log,
+    Authority, Causality, CausalityCache, Cause, Claim, Edition, History, HistorySelector,
+    MemoryHistory, Origin, Revision, RevisionRecord, TreeHistory, Version, causality,
+    common_ancestor, extend_skips, log,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -590,7 +592,10 @@ async fn it_records_history_in_the_artifact_tree() -> Result<()> {
     // The replacement's record supersedes the first claim, detectable via
     // the tiered conflict detection over the same tree
     let history = TreeHistory::new(tree.clone(), store.clone());
-    let records = history.records().await?;
+    let records = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(records.len(), 2);
     let (first_version, hej) = &records[0];
     let (second_version, hi) = &records[1];
@@ -613,7 +618,10 @@ async fn it_records_history_in_the_artifact_tree() -> Result<()> {
     )
     .await?;
     let history = TreeHistory::new(tree.clone(), store.clone());
-    let records = history.records().await?;
+    let records = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(records.len(), 3);
     let (_, retraction) = &records[2];
     assert!(!retraction.is_assertion());
@@ -623,6 +631,184 @@ async fn it_records_history_in_the_artifact_tree() -> Result<()> {
             .await?
             .is_empty()
     );
+
+    Ok(())
+}
+
+/// `select(version)` returns exactly the records one revision wrote, and
+/// `select(All)` the whole region — the same records `records()` collects.
+///
+/// The three versions here deliberately span TWO origins: the history key
+/// is origin-major, so a version scan must not spill into the neighbouring
+/// writer's span, and the two editions under origin 8 must not collapse
+/// into one another.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn it_selects_the_records_of_one_revision() -> Result<()> {
+    use dialog_search_tree::Delta;
+    use dialog_storage::{CborEncoder, Storage, StorageBackend as _};
+    use futures_util::stream;
+
+    let mut store = Storage {
+        encoder: CborEncoder,
+        backend: MemoryStorageBackend::default(),
+    };
+
+    let entity = Entity::new()?;
+    let the: Attribute = "post/title".parse()?;
+    let title = |value: &str| Artifact {
+        the: the.clone(),
+        of: entity.clone(),
+        is: Value::String(value.into()),
+        cause: None,
+    };
+
+    let first = Version::new(Origin::from([7u8; 32]), Edition::new(0));
+    let second = Version::new(Origin::from([8u8; 32]), Edition::new(1));
+    let third = Version::new(Origin::from([8u8; 32]), Edition::new(2));
+
+    let mut tree = ArtifactTree::empty();
+    let apply = async |tree: &mut ArtifactTree,
+                       store: &mut Storage<
+        CborEncoder,
+        MemoryStorageBackend<dialog_storage::Blake3Hash, Vec<u8>>,
+    >,
+                       version: Version,
+                       instructions: Vec<Instruction>|
+           -> Result<()> {
+        let mut delta = Delta::zero();
+        tree.apply_versioned(store, &mut delta, Some(version), stream::iter(instructions))
+            .await?;
+        for (digest, buffer) in delta.flush() {
+            store.set(*digest.as_bytes(), buffer.into_vec()).await?;
+        }
+        Ok(())
+    };
+
+    // The middle revision writes TWO claims, so the scan has to return a
+    // set rather than a single record.
+    let other: Attribute = "post/slug".parse()?;
+    apply(
+        &mut tree,
+        &mut store,
+        first,
+        vec![Instruction::Assert(title("Hej"))],
+    )
+    .await?;
+    apply(
+        &mut tree,
+        &mut store,
+        second,
+        vec![
+            Instruction::Replace(title("Hi")),
+            Instruction::Assert(Artifact {
+                the: other.clone(),
+                of: entity.clone(),
+                is: Value::String("hi".into()),
+                cause: None,
+            }),
+        ],
+    )
+    .await?;
+    apply(
+        &mut tree,
+        &mut store,
+        third,
+        vec![Instruction::Retract(title("Hi"))],
+    )
+    .await?;
+
+    let history = TreeHistory::new(tree.clone(), store.clone());
+
+    // The lone claim of the first revision, in the neighbouring origin.
+    let at_first: Vec<_> = history.select(first).try_collect().await?;
+    assert_eq!(at_first.len(), 1);
+    assert_eq!(at_first[0].0, first);
+    assert!(at_first[0].1.is_assertion());
+    assert_eq!(at_first[0].1.claim().is, Value::String("Hej".into()));
+
+    // Both claims of the second, and neither of its origin-mate's.
+    let at_second: Vec<_> = history.select(second).try_collect().await?;
+    assert_eq!(at_second.len(), 2);
+    assert!(at_second.iter().all(|(version, _)| *version == second));
+    let mut attributes: Vec<_> = at_second
+        .iter()
+        .map(|(_, record)| record.claim().the.as_str().to_string())
+        .collect();
+    attributes.sort();
+    assert_eq!(attributes, vec!["post/slug", "post/title"]);
+
+    // The retraction alone, adjacent in the same origin to the above.
+    let at_third: Vec<_> = history.select(third).try_collect().await?;
+    assert_eq!(at_third.len(), 1);
+    assert!(!at_third[0].1.is_assertion());
+    assert!(at_third[0].1.claim().cause.contains(&second));
+
+    // A revision that wrote nothing selects nothing, rather than
+    // spilling into an adjacent version's span.
+    let absent = Version::new(Origin::from([8u8; 32]), Edition::new(3));
+    let at_absent: Vec<_> = history.select(absent).try_collect().await?;
+    assert!(at_absent.is_empty());
+
+    // `All` is the whole region: every revision's records together.
+    let all: Vec<_> = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(all.len(), 4);
+    #[allow(deprecated)]
+    let collected = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(all, collected);
+
+    Ok(())
+}
+
+/// A value large enough to spill out of its key still reconstructs through
+/// a version scan: the record's value lives in an archive block, and
+/// `select` must fetch it rather than hand back a truncated claim.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn it_selects_records_whose_values_spilled() -> Result<()> {
+    use dialog_search_tree::Delta;
+    use dialog_storage::{CborEncoder, Storage, StorageBackend as _};
+    use futures_util::stream;
+
+    let mut store = Storage {
+        encoder: CborEncoder,
+        backend: MemoryStorageBackend::default(),
+    };
+
+    let entity = Entity::new()?;
+    let the: Attribute = "post/body".parse()?;
+    // Well above any inline threshold, so the value lands in its own block.
+    let body = "x".repeat(4096);
+    let version = Version::new(Origin::from([9u8; 32]), Edition::new(0));
+
+    let mut tree = ArtifactTree::empty();
+    let mut delta = Delta::zero();
+    tree.apply_versioned(
+        &mut store,
+        &mut delta,
+        Some(version),
+        stream::iter(vec![Instruction::Assert(Artifact {
+            the: the.clone(),
+            of: entity.clone(),
+            is: Value::String(body.clone()),
+            cause: None,
+        })]),
+    )
+    .await?;
+    for (digest, buffer) in delta.flush() {
+        store.set(*digest.as_bytes(), buffer.into_vec()).await?;
+    }
+
+    let history = TreeHistory::new(tree.clone(), store.clone());
+    let records: Vec<_> = history.select(version).try_collect().await?;
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].1.claim().is, Value::String(body));
 
     Ok(())
 }
@@ -829,7 +1015,10 @@ async fn it_collapses_a_same_batch_assert_and_retract() -> Result<()> {
     }
 
     let history = TreeHistory::new(tree.clone(), store.clone());
-    let records = history.records().await?;
+    let records = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(records.len(), 1, "the retraction overwrites the assertion");
     let (recorded_version, record) = &records[0];
     assert_eq!(*recorded_version, version);
@@ -903,7 +1092,10 @@ async fn it_reads_spilled_claim_values_back_through_history() -> Result<()> {
     assert_eq!(claims.len(), 1, "the spilled claim reads back");
     assert_eq!(claims[0].is, big, "with its full value resolved");
 
-    let records = history.records().await?;
+    let records = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(records.len(), 2, "the whole log lists, spilled or not");
     Ok(())
 }
@@ -952,7 +1144,11 @@ async fn it_ignores_a_retraction_of_a_nonexistent_fact() -> Result<()> {
 
     let history = TreeHistory::new(tree.clone(), store.clone());
     assert!(
-        history.records().await?.is_empty(),
+        history
+            .select(HistorySelector::All)
+            .try_collect::<Vec<_>>()
+            .await?
+            .is_empty(),
         "no record is minted for a withdrawal that never happened"
     );
     Ok(())
@@ -1026,7 +1222,10 @@ async fn it_folds_same_batch_records_at_one_history_key() -> Result<()> {
     // assertion citing the version it overrode — not a genesis assert
     // that forgot the retract's cause.
     let history = TreeHistory::new(tree.clone(), store.clone());
-    let records = history.records().await?;
+    let records = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
     let at_new: Vec<_> = records
         .iter()
         .filter(|(version, _)| *version == new)
@@ -1116,12 +1315,11 @@ async fn it_covers_every_observed_claim_of_a_retracted_value() -> Result<()> {
 
     let history = TreeHistory::new(tree.clone(), store.clone());
     let retract = history
-        .records()
+        .select(retractor)
+        .try_collect::<Vec<_>>()
         .await?
         .into_iter()
-        .find_map(|(version, record)| {
-            (version == retractor && !record.is_assertion()).then_some(record)
-        })
+        .find_map(|(_, record)| (!record.is_assertion()).then_some(record))
         .expect("the retraction is recorded");
     let mut covered = retract.claim().cause.versions().to_vec();
     covered.sort();
@@ -1345,7 +1543,10 @@ async fn it_supersedes_only_different_values_when_replacing_many() -> Result<()>
     );
 
     let history = TreeHistory::new(tree.clone(), store.clone());
-    let records = history.records().await?;
+    let records = history
+        .select(HistorySelector::All)
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(records.len(), 3);
     let (_, replacement) = &records[2];
     assert!(replacement.claim().cause.contains(&first));

--- a/rust/dialog-artifacts/src/key/history.rs
+++ b/rust/dialog-artifacts/src/key/history.rs
@@ -206,6 +206,46 @@ pub fn history_claim_range(version: &Version, of: &Entity, the: &Attribute) -> (
     (Key::from(min), Key::from(max))
 }
 
+/// The half-open bounds of the key range covering every history record
+/// produced by the revision identified by `version`.
+///
+/// The version prefix leads the key (after the tag), so one revision's
+/// records form a contiguous span and this is an exact prefix range.
+///
+/// Unlike [`history_claim_range`] the bounds are half-open, and that is
+/// load-bearing rather than a stylistic choice: what follows the version
+/// prefix here is the entity, whose encoding is UNBOUNDED in length. A
+/// filler-run upper bound (the trick [`history_claim_range`] and
+/// [`history_region_range`] use, where only a bounded value tail follows)
+/// would silently drop every record whose entity encodes longer than the
+/// run. Incrementing the prefix instead bounds the span exactly, whatever
+/// the entities in it.
+///
+/// The upper bound is the successor of the tagged version prefix. When the
+/// version is all `0xFF` the carry reaches the tag itself, and the bound
+/// becomes the next region's tag — correct, since that version's span runs
+/// to the end of this region.
+pub fn history_version_range(version: &Version) -> (Key, Key) {
+    let mut min = vec![HISTORY_KEY_TAG];
+    min.extend_from_slice(&version_prefix(version));
+
+    // Increment the prefix to the next distinct version span: strip the
+    // trailing `0xFF` run, then bump the last byte below it. Everything
+    // under `min` sorts below this and nothing at the next version does.
+    let mut max = min.clone();
+    while let Some(&last) = max.last() {
+        if last == u8::MAX {
+            max.pop();
+        } else {
+            let at = max.len() - 1;
+            max[at] += 1;
+            break;
+        }
+    }
+
+    (Key::from(min), Key::from(max))
+}
+
 /// The inclusive bounds of the key range covering the entire history region.
 ///
 /// The upper bound needs a full filler run, not a single `0xFF`: a history
@@ -324,6 +364,87 @@ mod tests {
         let (min, max) = history_region_range();
         assert!(key >= min, "high-origin key sorts above the region minimum");
         assert!(key <= max, "high-origin key sorts below the region maximum");
+        Ok(())
+    }
+
+    /// A version range brackets its own revision's keys and excludes the
+    /// neighbouring versions on either side — including the origin-mate at
+    /// the adjacent edition, which is the nearest key in the region.
+    #[test]
+    fn it_brackets_one_version() -> anyhow::Result<()> {
+        let of = Entity::from_str("test:entity")?;
+        let the = Attribute::from_str("test/attribute")?;
+        let key = |version: &Version| {
+            history_key(
+                version,
+                &of,
+                &the,
+                &crate::Value::String("value".into()),
+                &Manifest::default(),
+            )
+        };
+
+        let subject = version(4, 8);
+        let (min, max) = history_version_range(&subject);
+        let mine = key(&subject);
+        assert!(mine >= min && mine < max, "own key falls inside the range");
+
+        // The adjacent editions under the same origin, and another origin
+        // entirely, all fall outside.
+        for other in [version(3, 8), version(5, 8), version(4, 7), version(4, 9)] {
+            let key = key(&other);
+            assert!(
+                key < min || key >= max,
+                "{other} must fall outside the range of {subject}"
+            );
+        }
+        Ok(())
+    }
+
+    /// The upper bound must not be a fixed filler run: an entity long
+    /// enough to outrun one would sort above it and drop out of the scan.
+    /// Incrementing the version prefix bounds the span whatever follows it.
+    #[test]
+    fn it_brackets_keys_with_long_entities() -> anyhow::Result<()> {
+        let subject = version(4, 8);
+        let (min, max) = history_version_range(&subject);
+        let the = Attribute::from_str("test/attribute")?;
+        for length in [1usize, 64, 512, 4096] {
+            let of = Entity::from_str(&format!("test:{}", "e".repeat(length)))?;
+            let key = history_key(
+                &subject,
+                &of,
+                &the,
+                &crate::Value::String("value".into()),
+                &Manifest::default(),
+            );
+            assert!(
+                key >= min && key < max,
+                "a {length}-byte entity must stay inside its version's range"
+            );
+        }
+        Ok(())
+    }
+
+    /// An all-`0xFF` version carries the increment into the tag itself. The
+    /// bound must still sit above that version's keys — it marks the end of
+    /// the history region, which is exactly where its span ends.
+    #[test]
+    fn it_bounds_the_highest_version() -> anyhow::Result<()> {
+        let of = Entity::from_str("test:entity")?;
+        let the = Attribute::from_str("test/attribute")?;
+        use crate::history::{Edition, Origin};
+        let highest = Version::new(Origin::from([0xFF; 32]), Edition::from_key_bytes([0xFF; 8]));
+        let (min, max) = history_version_range(&highest);
+        let key = history_key(
+            &highest,
+            &of,
+            &the,
+            &crate::Value::String("value".into()),
+            &Manifest::default(),
+        );
+        assert!(key >= min, "highest-version key sorts above its minimum");
+        assert!(key < max, "highest-version key sorts below its bound");
         Ok(())
     }
 

--- a/rust/dialog-repository/src/repository/branch/commit.rs
+++ b/rust/dialog-repository/src/repository/branch/commit.rs
@@ -804,9 +804,11 @@ mod history_tests {
     use anyhow::Result;
     use dialog_operator::helpers::test_operator_with_profile;
 
-    use dialog_artifacts::history::{Causality, History as _, causality, common_ancestor};
+    use dialog_artifacts::history::{
+        Causality, History as _, HistorySelector, causality, common_ancestor,
+    };
     use dialog_artifacts::{Artifact, Instruction, Value};
-    use futures_util::stream;
+    use futures_util::{TryStreamExt as _, stream};
 
     fn title(of: &str, value: &str) -> Artifact {
         Artifact {
@@ -847,7 +849,10 @@ mod history_tests {
 
         // Both claims are recorded, and the replacement's cause lists the
         // version of the claim it superseded.
-        let records = history.records().await?;
+        let records = history
+            .select(HistorySelector::All)
+            .try_collect::<Vec<_>>()
+            .await?;
         let claims: Vec<_> = records
             .iter()
             .filter(|(_, record)| record.claim().the.to_string() == "post/title")

--- a/rust/dialog-repository/src/repository/branch/pull.rs
+++ b/rust/dialog-repository/src/repository/branch/pull.rs
@@ -1445,9 +1445,11 @@ mod history_tests {
     use anyhow::Result;
     use dialog_operator::helpers::{test_operator_with_profile, unique_name};
 
-    use dialog_artifacts::history::{Causality, History as _, causality, common_ancestor};
+    use dialog_artifacts::history::{
+        Causality, History as _, HistorySelector, causality, common_ancestor,
+    };
     use dialog_artifacts::{Artifact, Instruction, Value};
-    use futures_util::stream;
+    use futures_util::{TryStreamExt as _, stream};
 
     /// A scenario-2 pull ("upstream moved, but with things we already
     /// know") keeps the head and advances only the sync base — and it must
@@ -1901,7 +1903,8 @@ mod history_tests {
         // The supersession feature established over main's claim is
         // detectable from the merged history.
         let title_claims: Vec<_> = history
-            .records()
+            .select(HistorySelector::All)
+            .try_collect::<Vec<_>>()
             .await?
             .into_iter()
             .filter(|(_, record)| record.claim().the.to_string() == "post/title")


### PR DESCRIPTION
Reading the claims one revision recorded meant scanning the whole history region. `claims_at` is exact but needs an entity *and* an attribute; `records()` is the entire region, unbounded. Yet the version leads the history key (right after the tag), so a revision's records already occupy a contiguous span, and there was simply no range naming it.

## What this adds

- **`history_version_range(version)`**: the key range covering everything one revision wrote.
- **`HistorySelector`**: `non_exhaustive`, with `All` and `At(Version)`, plus `From<Version>` / `From<&Version>` so `select(version)` works bare.
- **`TreeHistory::select(selector)`**: streams `(Version, Record)` over the selected span. Records materialize as the stream is polled (a record is parsed from its key, and a spilled value's block fetched, only when its entry is reached), so a caller folding the stream never holds a whole span at once. `try_collect()` for the eager `Vec`.

Each record carries its `Assert`/`Retract` polarity, its full claim, and its `cause`, so a version scan is a real changelog rather than just metadata.

## The half-open bound

The version range is half-open, unlike `history_claim_range` and `history_region_range`. Those cap themselves with a fixed `0xFF` filler run, which is sound *there* because only a bounded value tail follows the prefix.

Here the **entity** follows the version prefix, and its encoding is unbounded in length. A filler-run upper bound would silently drop every record whose entity encoded longer than the run, the same class of bug the `history_region_range` doc warns about at a different offset. Incrementing the version prefix instead bounds the span exactly, whatever follows it. `it_brackets_keys_with_long_entities` pins this at 1/64/512/4096-byte entities; the 4096 case drops out of the scan under a filler bound.

An all-`0xFF` version carries the increment into the tag itself, which is correct: that version's span runs to the end of the region.

## Why an enum for one useful variant

`At` is the immediate need, but the region is **origin-major**: one writer's records cluster contiguously, ordered by edition within that cluster. So a version *range* across origins is not a single contiguous scan, and a causal span over the revision DAG is a walk plus per-version scans. Both are natural next variants and neither has `At`'s shape, hence `non_exhaustive` so adding them isn't a breaking change for downstream matchers.

## `records()`

Deprecated in favour of `select(HistorySelector::All)`, and its callers migrated (deprecating with live callers otherwise fails the `-D warnings` gate at every call site). All of them turned out to be in `#[cfg(test)]` modules. One was filtering the whole region down to a single version, which is now `select(version)` directly, the first real use of the new path.

## Tests

Version-scoped select across two origins (so a scan must neither bleed into an adjacent writer's span nor collapse two editions under one origin), a multi-claim revision, a revision that wrote nothing, a spilled value (exercising the archive-block fetch rather than only inline keys), `All` agreeing with `records()`, and the three key-range tests above.

`cargo fmt --all` and `cargo clippy --all --all-targets --all-features -- -D warnings` are clean.

**Not verified locally:** the wasm side. `nix develop --command test:native:debug` failed before running anything: `chmod ... google-chrome-144.0.7559.97 ... Operation not permitted` realizing the Chrome derivation, reproducing both inside and outside the sandbox. The change is target-agnostic (no new dependencies, since `async-stream` was already one, and no `cfg` branches), so I expect it to pass, but CI is the first thing actually checking it.
