### PR TITLE
test(artifacts): pin retract-then-assert in one batch

### DIFF
--- a/rust/dialog-artifacts/src/history/tests.rs
+++ b/rust/dialog-artifacts/src/history/tests.rs
@@ -1036,6 +1036,95 @@ async fn it_collapses_a_same_batch_assert_and_retract() -> Result<()> {
     Ok(())
 }
 
+/// A batch that RETRACTS a standing fact and re-asserts it keeps the
+/// fact, and the record cites what it overrode.
+///
+/// The sibling above pins the other order, where the fact ends absent
+/// and the pair cancels. This order is what an update looks like —
+/// withdraw the old set, assert the new one, in a single atomic commit —
+/// and the overlap between the two sets lands here. If the erase won,
+/// an unchanged fact would vanish from an update that should have left
+/// it alone.
+#[dialog_common::test]
+async fn it_keeps_a_fact_retracted_and_re_asserted_in_one_batch() -> Result<()> {
+    use dialog_search_tree::Delta;
+    use dialog_storage::{CborEncoder, Storage, StorageBackend as _};
+    use futures_util::stream;
+
+    let mut store = Storage {
+        encoder: CborEncoder,
+        backend: MemoryStorageBackend::default(),
+    };
+
+    let entity = Entity::new()?;
+    let the: Attribute = "post/title".parse()?;
+    let title = Artifact {
+        the: the.clone(),
+        of: entity.clone(),
+        is: Value::String("Hej".into()),
+        cause: None,
+    };
+    let first = Version::new(Origin::from([7u8; 32]), Edition::new(0));
+    let second = Version::new(Origin::from([7u8; 32]), Edition::new(1));
+
+    let mut tree = ArtifactTree::empty();
+    let mut delta = Delta::zero();
+
+    // Establish the fact, so the retraction below has something standing
+    // to withdraw — a retract of an absent fact is a no-op and would
+    // prove nothing.
+    tree.apply_versioned(
+        &mut store,
+        &mut delta,
+        Some(first),
+        stream::iter(vec![Instruction::Assert(title.clone())]),
+    )
+    .await?;
+    for (digest, buffer) in delta.flush() {
+        store.set(*digest.as_bytes(), buffer.into_vec()).await?;
+    }
+
+    // The update: withdraw it, then assert it again, one batch.
+    let changed = tree
+        .apply_versioned(
+            &mut store,
+            &mut delta,
+            Some(second),
+            stream::iter(vec![
+                Instruction::Retract(title.clone()),
+                Instruction::Assert(title.clone()),
+            ]),
+        )
+        .await?;
+    assert!(changed);
+    for (digest, buffer) in delta.flush() {
+        store.set(*digest.as_bytes(), buffer.into_vec()).await?;
+    }
+
+    assert!(
+        !tree
+            .select_data(store.clone(), &entity, &the)
+            .await?
+            .is_empty(),
+        "the fact survives: the re-assert follows the erase"
+    );
+
+    let history = TreeHistory::new(tree.clone(), store.clone());
+    let records: Vec<_> = history.select(second).try_collect().await?;
+    let (_, folded) = records.first().expect("the update recorded a version");
+    assert!(
+        folded.is_assertion(),
+        "the later polarity wins, so the update reads as an assertion"
+    );
+    assert!(
+        folded.claim().cause.versions().contains(&first),
+        "the re-assert cites the version it overrode: {:?}",
+        folded.claim().cause
+    );
+
+    Ok(())
+}
+
 /// A claim on a value that spilled out of its key (larger than the inline
 /// threshold) must still read back through the history API: the raw bytes
 /// live in the archive under the key's 32-byte reference, and the reader


### PR DESCRIPTION
Closes #484.

Stacked on #482 (base `feat/revert`); review that one first.

`write_instructions` handles both same-batch orders of an assert and a retract on one fact, and they behave differently. Only one was tested:

- **assert then retract**: the erase follows the write, the fact ends absent, the pair cancels. Covered three times over.
- **retract then assert**: the re-assert follows the erase, the fact survives, and the record fold keeps the later polarity while unioning causes. Covered nowhere.

The second order is what an atomic update looks like: withdraw the old set, assert the new one. The overlap between the two sets lands exactly there. The comment at `tree.rs:1546` ("a same-batch assert+retract cancels to nothing") generalises easily to both orders, which would imply an update silently drops the facts it meant to leave alone. It does not, but nothing pinned that.

This adds `it_keeps_a_fact_retracted_and_re_asserted_in_one_batch`: establishes a fact under one version, retracts and re-asserts it under the next, then checks the fact survives and the folded record cites the version it overrode.

## Why this test earns its place

A passing test proves nothing on its own, so I mutation-tested it against the existing sibling:

- Breaking the record fold to keep the *earlier* polarity trips both this test and `it_collapses_a_same_batch_assert_and_retract`. Not evidence of new coverage.
- Dropping the retraction's cause union trips **only this test**; the sibling passes clean.

That second mutation is the demonstration that the retract-then-assert order was genuinely uncovered.

The test body uses `select(version)` rather than `records()`, which the base branch deprecates.
