### PR TITLE
feat(repository): report the version a transaction will commit at

### DIFF
--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -1861,6 +1861,79 @@ mod tests {
             Ok(())
         }
 
+        /// The version a transaction reports is the one its commit mints.
+        ///
+        /// This is what lets a writer record a fact NAMING its own commit
+        /// — storing the version alongside the claims it tags, in the same
+        /// batch, rather than committing twice. If the two ever drifted,
+        /// that fact would point at a revision that never existed.
+        #[dialog_common::test]
+        async fn it_reports_the_version_its_commit_will_mint() -> anyhow::Result<()> {
+            let (operator, profile) = test_operator_with_profile().await;
+            let repo = test_repo(&operator, &profile).await;
+            let branch = repo.branch("main").open().perform(&operator).await?;
+
+            let txn = branch.transaction().assert(Employee {
+                this: Entity::new()?,
+                name: employee::Name("Alice".into()),
+                role: employee::Role("Engineer".into()),
+            });
+            let predicted = txn
+                .version(&operator)
+                .await?
+                .expect("a branch transaction knows its version");
+
+            let revision = txn.commit().perform(&operator).await?;
+            assert_eq!(
+                revision.version(),
+                predicted,
+                "the reported version is the one the commit minted"
+            );
+
+            // And it advances: the next transaction reports the successor,
+            // not the version just used.
+            let next = branch
+                .transaction()
+                .assert(Employee {
+                    this: Entity::new()?,
+                    name: employee::Name("Bob".into()),
+                    role: employee::Role("Engineer".into()),
+                })
+                .version(&operator)
+                .await?
+                .expect("a branch transaction knows its version");
+            assert_ne!(next, predicted, "a second commit mints a new version");
+
+            // A snapshot allocates its lineage at its first commit, so it
+            // has no version to report until then — and reports one after.
+            let snapshot = branch.snapshot().expect("a committed branch snapshots");
+            assert!(
+                snapshot.transaction().version(&operator).await?.is_none(),
+                "a snapshot that has not committed has no lineage yet"
+            );
+            let committed = snapshot
+                .transaction()
+                .assert(Employee {
+                    this: Entity::new()?,
+                    name: employee::Name("Carol".into()),
+                    role: employee::Role("Engineer".into()),
+                })
+                .commit()
+                .perform(&operator)
+                .await?;
+            assert_eq!(
+                snapshot
+                    .transaction()
+                    .version(&operator)
+                    .await?
+                    .map(|version| version.origin),
+                Some(committed.version().origin),
+                "once it has committed, a snapshot reports the line it minted on"
+            );
+
+            Ok(())
+        }
+
         #[dialog_common::test]
         async fn it_starts_with_only_its_branch_and_empty_overlay() -> anyhow::Result<()> {
             let (operator, profile) = test_operator_with_profile().await;

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -6,11 +6,12 @@ use crate::Commit;
 use crate::repository::source::SourceRef;
 use crate::rules::{SharedRuleCache, TriggerFootprint, on_attr, reads_attr};
 use crate::{Branch, CommitError, RemoteSite, Revision, Snapshot};
+use dialog_artifacts::history::{Edition, Version};
 use dialog_artifacts::{Changes, Instruction, Statement, Update};
 use dialog_capability::{Fork, Provider};
 use dialog_common::ConditionalSync;
 use dialog_effects::archive::{Get, Import, Put};
-use dialog_effects::authority::{Attest, Identify};
+use dialog_effects::authority::{Attest, Identify, OperatorExt as _};
 use dialog_effects::memory::{Publish, Resolve};
 
 /// A transaction on a branch or a snapshot.
@@ -44,6 +45,48 @@ impl<'a> Transaction<'a> {
     pub fn retract<C: Statement>(mut self, claim: C) -> Self {
         claim.retract(&mut self.changes);
         self
+    }
+
+    /// The [`Version`] this transaction's commit will mint.
+    ///
+    /// A version is `(origin, edition)`: the issuer's line and a counter.
+    /// Neither depends on what the commit contains — the edition is the
+    /// head's successor, the origin derives from the branch and the
+    /// issuer — so it is knowable before the batch is written, which is
+    /// why [`Commit`] computes it up front and tags every datum and
+    /// history record with it.
+    ///
+    /// Exposing it lets a writer record a fact that NAMES its own commit:
+    /// a caller that wants to find its claims again later (through
+    /// [`TreeHistory::select`](dialog_artifacts::history::TreeHistory::select))
+    /// can store this alongside them, in the same batch, rather than
+    /// committing twice.
+    ///
+    /// A [`Revision`] cannot be self-named this way — it includes the
+    /// tree the commit produces — which is the distinction this accessor
+    /// exists to make usable.
+    ///
+    /// `None` only for a snapshot that has never committed: its lineage
+    /// is allocated at that first commit, so there is nothing to report
+    /// beforehand. A snapshot that has committed reuses that lineage and
+    /// reports a version like a branch does.
+    ///
+    /// Resolves the issuer through the environment, so it takes the same
+    /// `env` the commit will.
+    pub async fn version<Env>(&self, env: &Env) -> Result<Option<Version>, CommitError>
+    where
+        Env: Provider<Identify> + ConditionalSync + 'static,
+    {
+        let authority = Identify.perform(env).await?;
+        let edition = self
+            .source
+            .revision()
+            .map(|base| base.edition.successor())
+            .unwrap_or(Edition::GENESIS);
+        Ok(self
+            .source
+            .commit_identity(authority.profile(), &authority.did())
+            .map(|(_, origin)| Version::new(origin, edition)))
     }
 
     /// Dispatch a claim as a *transient* fact (a command): visible to

--- a/rust/dialog-repository/src/repository/source.rs
+++ b/rust/dialog-repository/src/repository/source.rs
@@ -13,7 +13,8 @@ use dialog_artifacts::history::{
 };
 use dialog_artifacts::tree::{SpillCache, spill_cache};
 use dialog_artifacts::{Changes, DialogArtifactsError, Entity, SpineSlot, Statement as _};
-use dialog_capability::{Capability, Fork, Provider, Subject};
+use dialog_capability::history::Origin;
+use dialog_capability::{Capability, Did, Fork, Provider, Subject};
 use dialog_common::{Blake3Hash as NodeHash, ConditionalSync};
 use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
 use dialog_effects::archive::{Archive, Get as ArchiveGet, Put as ArchivePut};
@@ -106,6 +107,25 @@ impl<'a> SourceRef<'a> {
         match self {
             SourceRef::Branch(branch) => branch.subject(),
             SourceRef::Snapshot(snapshot) => snapshot.subject(),
+        }
+    }
+
+    /// The line entity and [`Origin`] this line's next commit mints on.
+    ///
+    /// A branch derives both from its identity, so it always has one. A
+    /// snapshot's lineage is allocated at its FIRST commit — random
+    /// rather than derived, so two clones of one base do not share it —
+    /// and reused after, so it reports one only once it has committed.
+    pub(crate) fn commit_identity(self, profile: &Did, issuer: &Did) -> Option<(Entity, Origin)> {
+        match self {
+            SourceRef::Branch(branch) => Some(branch.commit_identity(profile, issuer)),
+            SourceRef::Snapshot(snapshot) => {
+                let (_, lineage) = snapshot.head();
+                lineage.map(|lineage| {
+                    let origin = crate::origin_of(&lineage, issuer);
+                    (lineage, origin)
+                })
+            }
         }
     }
 


### PR DESCRIPTION
A version is `(origin, edition)`: the issuer's line and a counter. Neither depends on what the commit contains — which is why `Commit` computes it up front (`let version = Version::new(origin, edition)`, then `debug_assert_eq!(revision.version(), version)`) and tags every datum and history record with it. Nothing outside could ask for it.

## Why

Now that `TreeHistory::select` takes a version (#482), a writer can find the claims one commit made. But to use that it has to know which version its own claims landed at, and the only ways were:

- **Commit twice** — once for the claims, once to record where they landed. Not atomic, and a failure between them leaves a record pointing at the wrong place.
- **Reimplement the derivation** — `origin_of(branch_of(subject, profile, name), issuer)` plus the head's successor edition. Correct today, drifts the moment the derivation changes.

With this, a fact can name the commit that carries it, in that same commit.

## A revision cannot do this

`Revision` includes the tree the commit produces, so a fact inside it can never name it. That asymmetry is the reason the accessor is worth having, and the doc says so — it is easy to reach for the revision and conclude self-naming is impossible.

## The `None`

Only for a snapshot that has never committed. Its lineage is allocated at that first commit — random rather than derived, so two clones of one base do not share a line — and reused after, so a snapshot that has committed reports a version like a branch does.

`SourceRef::commit_identity` gained a snapshot arm for this; the branch arm routes through `Branch::commit_identity`, the same memoized path `Commit` uses, so the two cannot disagree.

## Tests

`it_reports_the_version_its_commit_will_mint` covers the whole claim: the reported version equals the one the commit mints, a second transaction reports a successor rather than the version just used, an uncommitted snapshot reports `None`, and a committed one reports the line it minted on.

Full native suite passes (2680), `cargo fmt --all` and the nix clippy check are clean. The wasm leg is untested locally — the change is target-agnostic, no new dependencies and no cfg branches, so CI is the first thing checking it.
