### PR TITLE
feat(repository): stage transaction chains, publish with one CAS

### DIFF
--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -642,6 +642,7 @@ mod tests {
                 .transaction()
                 .integrate(moved)
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
         }

--- a/rust/dialog-query/src/attribute/expression/dynamic.rs
+++ b/rust/dialog-query/src/attribute/expression/dynamic.rs
@@ -434,6 +434,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -473,6 +474,7 @@ mod tests {
             .assert(the!("team/manager").of(alice.clone()).is(bob.clone()))
             .assert(the!("team/mentor").of(alice.clone()).is(bob.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/attribute/expression/typed.rs
+++ b/rust/dialog-query/src/attribute/expression/typed.rs
@@ -496,6 +496,7 @@ mod tests {
             .transaction()
             .assert(person::Name::of(alice.clone()).is("Alice"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -921,6 +921,7 @@ mod tests {
             .assert(the!("person/age").of(Entity::new()?).is(30u64))
             .assert(the!("person/age").of(Entity::new()?).is(50u64))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -968,6 +969,7 @@ mod tests {
             )
             .assert(the!("person/name").of(Entity::new()?).is("Zed".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1005,6 +1007,7 @@ mod tests {
             .assert(the!("score/value").of(Entity::new()?).is(2.5f64))
             .assert(the!("score/value").of(Entity::new()?).is(-3i64))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1059,6 +1062,7 @@ mod tests {
             )
             .assert(member.of(list.clone()).is("Milk".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1116,6 +1120,7 @@ mod tests {
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .assert(second.of(list.clone()).is("Bread".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1176,6 +1181,7 @@ mod tests {
             .transaction()
             .assert(the!("tag/kind").of(e.clone()).is(symbol))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1221,6 +1227,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1265,6 +1272,7 @@ mod tests {
                     .is("Bobby".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1311,6 +1319,7 @@ mod tests {
             )
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1347,6 +1356,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1358,6 +1368,7 @@ mod tests {
                     .is("Alicia".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1401,6 +1412,7 @@ mod tests {
                     .is("Alicia".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -309,6 +309,7 @@ mod tests {
                 .transaction()
                 .assert($the.clone().of($of.clone()).is($is))
                 .commit()
+                .publish()
                 .perform($operator)
                 .await
                 .unwrap();
@@ -328,6 +329,7 @@ mod tests {
             .transaction()
             .assert(name_attr.clone().of(alice.clone()).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -374,6 +376,7 @@ mod tests {
             .transaction()
             .assert(name_attr.clone().of(alice.clone()).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -381,6 +384,7 @@ mod tests {
             .transaction()
             .assert(name_attr.clone().of(alice.clone()).is("Alicia".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -642,6 +646,7 @@ mod tests {
             .transaction()
             .assert(name_attr.of(alice.clone()).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -678,6 +683,7 @@ mod tests {
             .transaction()
             .assert(name_attr.clone().of(alice.clone()).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -718,6 +724,7 @@ mod tests {
             .transaction()
             .assert(alice_name.clone())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -740,6 +747,7 @@ mod tests {
             .transaction()
             .retract(alice_name)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -771,6 +779,7 @@ mod tests {
             .transaction()
             .assert(the!("user/name").of(alice.clone()).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -808,6 +817,7 @@ mod tests {
             .assert(the!("user/name").of(alice.clone()).is("Alice".to_string()))
             .assert(the!("user/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -847,6 +857,7 @@ mod tests {
             .transaction()
             .assert(the!("user/name").of(alice.clone()).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -881,6 +892,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -923,6 +935,7 @@ mod tests {
             .transaction()
             .assert(person::Name::of(alice.clone()).is("Alice"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1024,6 +1037,7 @@ mod tests {
             .assert(the!("misc/tag").of(alice.clone()).is("blue".to_string()))
             .assert(the!("misc/tag").of(alice.clone()).is(7u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -362,6 +362,7 @@ mod tests {
                 .transaction()
                 .assert($the.clone().of($of.clone()).is($is))
                 .commit()
+                .publish()
                 .perform($operator)
                 .await
                 .unwrap();
@@ -507,6 +508,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await
             .unwrap();
@@ -518,6 +520,7 @@ mod tests {
                     .is("Alicia".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await
             .unwrap();
@@ -591,6 +594,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await
             .unwrap();
@@ -602,6 +606,7 @@ mod tests {
                     .is("Alicia".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await
             .unwrap();
@@ -677,6 +682,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await
             .unwrap();
@@ -688,6 +694,7 @@ mod tests {
                     .is("Alicia".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await
             .unwrap();

--- a/rust/dialog-query/src/attribute/query/typed.rs
+++ b/rust/dialog-query/src/attribute/query/typed.rs
@@ -218,6 +218,7 @@ mod tests {
             .transaction()
             .assert(person::Name::of(alice.clone()).is("Alice"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -251,6 +252,7 @@ mod tests {
             .transaction()
             .assert(person::Name::of(alice.clone()).is("Alice"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -258,6 +260,7 @@ mod tests {
             .transaction()
             .assert(person::Name::of(bob.clone()).is("Bob"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -306,6 +309,7 @@ mod tests {
             .transaction()
             .assert(person::Name::of(alice.clone()).is("Alice"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -313,6 +317,7 @@ mod tests {
             .transaction()
             .assert(person::Name::of(bob.clone()).is("Bob"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/concept.rs
+++ b/rust/dialog-query/src/concept.rs
@@ -659,6 +659,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -727,6 +728,7 @@ mod tests {
                     .is("Hacker".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -797,6 +799,7 @@ mod tests {
             .transaction()
             .assert(alice_person.clone())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -843,6 +846,7 @@ mod tests {
             .transaction()
             .retract(alice_person)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -905,6 +909,7 @@ mod tests {
             .transaction()
             .assert(name_relation.clone())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -928,6 +933,7 @@ mod tests {
             .transaction()
             .retract(name_relation)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -999,6 +1005,7 @@ mod tests {
             .transaction()
             .assert(alice.clone())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1063,6 +1070,7 @@ mod tests {
             .assert(alice)
             .assert(bob)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1115,6 +1123,7 @@ mod tests {
             .assert(alice)
             .assert(bob)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1152,6 +1161,7 @@ mod tests {
             .transaction()
             .assert(alice_with_email)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1165,6 +1175,7 @@ mod tests {
             .transaction()
             .assert(alice_with_birthday)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1232,6 +1243,7 @@ mod tests {
             .transaction()
             .assert(alice.clone())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1239,6 +1251,7 @@ mod tests {
             .transaction()
             .retract(alice)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1355,6 +1368,7 @@ mod tests {
             .assert(org::Badge::of(mallory.clone()).is("M-3"))
             .assert(org::Manager::of(mallory.clone()).is(carol.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1441,6 +1455,7 @@ mod tests {
                     .is("555-0199".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1508,6 +1523,7 @@ mod tests {
                 job: shortcut_employee::Job("Designer".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1559,6 +1575,7 @@ mod tests {
                 job: shortcut_employee::Job("Engineer".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1637,6 +1654,7 @@ mod tests {
             .assert(helper_person::Name::of(alice).is("Alice"))
             .assert(helper_person::Name::of(bob).is("Bob"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1677,6 +1695,7 @@ mod tests {
             .assert(helper_employee::Name::of(bob.clone()).is("Bob"))
             .assert(helper_employee::Department::of(bob).is("Sales"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1712,6 +1731,7 @@ mod tests {
             .assert(helper_employee::Name::of(bob.clone()).is("Bob"))
             .assert(helper_employee::Department::of(bob.clone()).is("Sales"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/concept/query.rs
+++ b/rust/dialog-query/src/concept/query.rs
@@ -630,6 +630,7 @@ mod tests {
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .assert(the!("person/age").of(bob.clone()).is(30u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -736,6 +737,7 @@ mod tests {
             )
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -852,6 +854,7 @@ mod tests {
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .assert(the!("person/bio").of(bob.clone()).is("Hi".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -985,6 +988,7 @@ mod tests {
             )
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1036,6 +1040,7 @@ mod tests {
             )
             .assert(the!("person/age").of(alice.clone()).is(25u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1351,6 +1356,7 @@ mod tests {
             )
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1414,6 +1420,7 @@ mod tests {
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .assert(the!("person/age").of(bob.clone()).is(30u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1486,6 +1493,7 @@ mod tests {
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .assert(the!("person/age").of(bob.clone()).is(30u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1737,6 +1745,7 @@ mod tests {
                 )
                 .assert(the!("org.employee/salary").of(carol.clone()).is(70u32))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1803,6 +1812,7 @@ mod tests {
                 .assert(the!("org.employee/dept").of(bob.clone()).is(dept_a.clone()))
                 .assert(the!("org.employee/salary").of(bob.clone()).is(50u32))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1904,6 +1914,7 @@ mod tests {
                 .assert(the!("org.employee/dept").of(carol.clone()).is(dept.clone()))
                 .assert(the!("org.employee/salary").of(carol.clone()).is(200u32))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1990,6 +2001,7 @@ mod tests {
                 .assert(the!("org.employee/bonus").of(alice.clone()).is(25u32))
                 .assert(the!("org.employee/dept").of(bob.clone()).is(dept_b.clone()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -2087,6 +2099,7 @@ mod tests {
                 .assert(the!("org.employee/dept").of(bob.clone()).is(dept_a.clone()))
                 .assert(the!("org.employee/salary").of(bob.clone()).is(50u32))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -2167,6 +2180,7 @@ mod tests {
                 )
                 .assert(the!("org.employee/salary").of(carol.clone()).is(7u32))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -2267,7 +2281,7 @@ mod tests {
                         )
                         .assert(the!("org.employee/salary").of(person.clone()).is(*salary));
                 }
-                tx.commit().perform(&operator).await?;
+                tx.commit().publish().perform(&operator).await?;
 
                 let rule = dept_total_rule();
                 let conclusion = rule.conclusion().clone();

--- a/rust/dialog-query/src/concept/query/fixpoint.rs
+++ b/rust/dialog-query/src/concept/query/fixpoint.rs
@@ -1413,6 +1413,7 @@ mod tests {
             .assert(the!("family/parent").of(carol.clone()).is(bob.clone()))
             .assert(the!("family/parent").of(bob.clone()).is(alice.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1454,6 +1455,7 @@ mod tests {
             .assert(the!("family/parent").of(b.clone()).is(a.clone()))
             .assert(the!("family/parent").of(c.clone()).is(a.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1504,6 +1506,7 @@ mod tests {
             .assert(the!("family/parent").of(b.clone()).is(a.clone()))
             .assert(the!("family/parent").of(c.clone()).is(a.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1608,6 +1611,7 @@ mod tests {
             .assert(the!("shop/item").of(x.clone()).is(item_b.clone()))
             .assert(the!("shop/franchise").of(y.clone()).is(x.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1732,6 +1736,7 @@ mod tests {
             .assert(the!("family/parent").of(carol.clone()).is(bob.clone()))
             .assert(the!("family/parent").of(bob.clone()).is(alice.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1790,7 +1795,7 @@ mod tests {
                     .is(pair[1].clone()),
             );
         }
-        transaction.commit().perform(&operator).await?;
+        transaction.commit().publish().perform(&operator).await?;
 
         let concept = ancestor_concept();
         let mut registry = RuleRegistry::new();
@@ -1862,7 +1867,7 @@ mod tests {
                     .is((*parent).clone()),
             );
         }
-        transaction.commit().perform(&operator).await?;
+        transaction.commit().publish().perform(&operator).await?;
 
         let concept = ancestor_concept();
         let mut registry = RuleRegistry::new();
@@ -1921,6 +1926,7 @@ mod tests {
             .assert(the!("meta/name").of(n2.clone()).is("b".to_string()))
             .assert(the!("meta/name").of(n3.clone()).is("c".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2098,6 +2104,7 @@ mod tests {
             .assert(the!("meta/name").of(y.clone()).is("b".to_string()))
             .assert(the!("meta/name").of(z.clone()).is("c".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2185,6 +2192,7 @@ mod tests {
             .transaction()
             .assert(the!("meta/name").of(x.clone()).is("a".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2265,6 +2273,7 @@ mod tests {
             .assert(the!("family/father").of(lisa.clone()).is(homer.clone()))
             .assert(the!("family/father").of(homer.clone()).is(abe.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2552,6 +2561,7 @@ mod derived_edge_tests {
             .assert(the!("family/parent").of(carol.clone()).is(bob.clone()))
             .assert(the!("family/parent").of(bob.clone()).is(alice.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/helpers.rs
+++ b/rust/dialog-query/src/helpers.rs
@@ -673,7 +673,11 @@ where
                 role: stuff::Role(format!("role-{}", index % 8)),
             });
         }
-        transaction.commit().perform(&self.operator).await?;
+        transaction
+            .commit()
+            .publish()
+            .perform(&self.operator)
+            .await?;
         Ok(entities)
     }
 
@@ -891,6 +895,7 @@ where
         transaction
             .commit()
             .canonicalize()
+            .publish()
             .perform(&self.operator)
             .await?;
         Ok(index)
@@ -1195,6 +1200,7 @@ where
                     .is(new.detail.to_string()),
             )
             .commit()
+            .publish()
             .perform(&self.operator)
             .await?;
         Ok(entity)
@@ -1251,6 +1257,7 @@ where
                     ordering: bug::Ordering(count as f64 * 1000.0),
                 })
                 .commit()
+                .publish()
                 .perform(&self.operator)
                 .await?;
         }
@@ -1305,7 +1312,11 @@ where
                 ordering: bug::Ordering(index as f64 * 1000.0),
             });
         }
-        transaction.commit().perform(&self.operator).await?;
+        transaction
+            .commit()
+            .publish()
+            .perform(&self.operator)
+            .await?;
         Ok(entities)
     }
 
@@ -1370,6 +1381,7 @@ where
                     .is(status.to_string()),
             )
             .commit()
+            .publish()
             .perform(&self.operator)
             .await?;
         Ok(())
@@ -1397,6 +1409,7 @@ where
                     .is(status.to_string()),
             )
             .commit()
+            .publish()
             .perform(&self.operator)
             .await?;
         Ok(())
@@ -1442,6 +1455,7 @@ where
                     ordering: bug::Ordering(index as f64 * 1000.0),
                 })
                 .commit()
+                .publish()
                 .perform(&self.operator)
                 .await?;
         }
@@ -1498,6 +1512,7 @@ where
                     ordering: bug::Ordering(index as f64),
                 })
                 .commit()
+                .publish()
                 .perform(&self.operator)
                 .await?;
 
@@ -1832,6 +1847,7 @@ mod test {
                     ordering: bug::Ordering(count as f64 * 1000.0),
                 })
                 .commit()
+                .publish()
                 .perform(&env.operator)
                 .await?;
         }

--- a/rust/dialog-query/src/optional.rs
+++ b/rust/dialog-query/src/optional.rs
@@ -310,6 +310,7 @@ mod tests {
                     .is("Ali".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -363,6 +364,7 @@ mod tests {
                     .is("Ali".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -399,6 +401,7 @@ mod tests {
                     .is("Ali".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -442,6 +445,7 @@ mod tests {
                     .is("Allie".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -485,6 +489,7 @@ mod tests {
             .transaction()
             .assert(the!("club/banned").of(club.clone()).is("Ali".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());

--- a/rust/dialog-query/src/planner.rs
+++ b/rust/dialog-query/src/planner.rs
@@ -276,6 +276,7 @@ mod tests {
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .assert(the!("person/age").of(bob.clone()).is(30u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -111,6 +111,7 @@ mod tests {
             )
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -201,6 +202,7 @@ mod tests {
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .assert(the!("club/banned").of(club.clone()).is("Ali".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -280,6 +282,7 @@ mod tests {
             )
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -365,6 +368,7 @@ mod tests {
             // scheme to one type.
             .assert(the!("game/bonus").of(bob.clone()).is(0.5f64))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -428,6 +432,7 @@ mod tests {
             .transaction()
             .assert(the!("game/score").of(alice.clone()).is(-5i64))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -484,6 +489,7 @@ mod tests {
             .assert(the!("misc/tag").of(alice.clone()).is("blue".to_string()))
             .assert(the!("misc/tag").of(alice.clone()).is(7u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -538,6 +544,7 @@ mod tests {
             .assert(the!("person/age").of(alice.clone()).is(25u32))
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let source = TestEnv::new(&branch, &operator, RuleRegistry::new());

--- a/rust/dialog-query/src/query.rs
+++ b/rust/dialog-query/src/query.rs
@@ -54,6 +54,7 @@ mod tests {
             )
             .assert(the!("user/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -126,6 +127,7 @@ mod tests {
             .transaction()
             .assert(the!("user/name").of(alice.clone()).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -160,6 +162,7 @@ mod tests {
             .assert(the!("user/name").of(bob.clone()).is("Bob".to_string()))
             .assert(the!("user/role").of(bob.clone()).is("user".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-query/src/session.rs
+++ b/rust/dialog-query/src/session.rs
@@ -87,6 +87,7 @@ mod tests {
                         .is("Mallory".to_string()),
                 )
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
         }
@@ -236,6 +237,7 @@ mod tests {
             .assert(alice)
             .assert(bob)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let session = TestEnv::new(&branch, &operator, RuleRegistry::new());
@@ -377,6 +379,7 @@ mod tests {
             .assert(alice)
             .assert(bob)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -503,6 +506,7 @@ mod tests {
             .assert(alice)
             .assert(bob)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -736,6 +740,7 @@ mod tests {
                 title: note_like_test::Title("Goodbye World".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -835,6 +840,7 @@ mod tests {
                 title: note_not_like_test::Title("Final Report".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -930,6 +936,7 @@ mod tests {
                 name: Name("Bob".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1217,6 +1224,7 @@ mod tests {
                 .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
                 .assert(the!("person/age").of(bob.clone()).is(25u32))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
         }
@@ -1284,6 +1292,7 @@ mod tests {
                 .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
                 .assert(the!("person/age").of(bob.clone()).is(25u32))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
         }

--- a/rust/dialog-repository/src/repository.rs
+++ b/rust/dialog-repository/src/repository.rs
@@ -815,6 +815,7 @@ mod tests {
                     role: employee::Role("Designer".into()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -879,6 +880,7 @@ mod tests {
                     entity: NamedEntity(page_v1.clone()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -906,6 +908,7 @@ mod tests {
                     entity: NamedEntity(page_v2.clone()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -963,6 +966,7 @@ mod tests {
                     tag: Tag("blue".into()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1024,6 +1028,7 @@ mod tests {
                     entity: NamedEntity(page_v1.clone()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1034,6 +1039,7 @@ mod tests {
                     entity: NamedEntity(page_v1.clone()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1133,6 +1139,7 @@ mod tests {
                     role: employee::Role("Engineer".into()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1144,6 +1151,7 @@ mod tests {
                     role: employee::Role("Designer".into()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1187,6 +1195,7 @@ mod tests {
                     role: employee::Role("Engineer".into()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             let main = repo.branch("main").load().perform(&operator).await?;
@@ -1232,6 +1241,7 @@ mod tests {
                         .is("Alice".to_string()),
                 )
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1332,6 +1342,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             // Reload so the revision cell reflects the commit.
@@ -1411,6 +1422,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1437,6 +1449,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is("Bob".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1481,6 +1494,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             let branch = repo.branch("main").load().perform(&operator).await?;
@@ -1540,6 +1554,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             let branch = repo.branch("main").load().perform(&operator).await?;
@@ -1549,6 +1564,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is("Bob".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             let branch = repo.branch("main").load().perform(&operator).await?;
@@ -1598,6 +1614,7 @@ mod tests {
                     .transaction()
                     .assert(the!("user/name").of(Entity::new()?).is(name.to_string()))
                     .commit()
+                    .publish()
                     .perform(&operator)
                     .await?;
                 revisions.push(branch.revision().expect("branch has a revision"));
@@ -1813,6 +1830,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is("Alice".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             let branch = repo.branch("main").load().perform(&operator).await?;
@@ -1916,6 +1934,7 @@ mod tests {
                     nickname: cardinality_one_attr::Nickname("Bobby".into()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -1930,6 +1949,7 @@ mod tests {
                     nickname: cardinality_one_attr::Nickname("Rob".into()),
                 })
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -2055,6 +2075,7 @@ mod tests {
                 .transaction()
                 .assert(changes.clone())
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             let branch = repo.branch("main").load().perform(&operator).await?;
@@ -2144,6 +2165,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(alice).is("Alice".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -2165,6 +2187,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(alice).is("Alice".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 
@@ -2217,6 +2240,7 @@ mod tests {
                 .transaction()
                 .assert(the!("item/tag").of(item).is("in-profile".to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
 

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -865,6 +865,7 @@ mod rule_tests {
             )
             .assert(employee_from_person())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         // refresh handle so the durable layer sees the new head
@@ -923,6 +924,7 @@ mod rule_tests {
             .assert(the!("org/salary").of(bob.clone()).is(4u32))
             .assert(&rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -962,6 +964,7 @@ mod rule_tests {
             .transaction()
             .assert(the!("org/person-name").of(alice).is("Alice".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -988,6 +991,7 @@ mod rule_tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1030,6 +1034,7 @@ mod rule_tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1075,6 +1080,7 @@ mod rule_tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1123,6 +1129,7 @@ mod rule_tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1135,6 +1142,7 @@ mod rule_tests {
             .transaction()
             .assert(employee_from_person())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1182,6 +1190,7 @@ mod rule_tests {
             .assert(&r1)
             .assert(&r2)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1225,6 +1234,7 @@ mod rule_tests {
             )
             .assert(&r1)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1275,6 +1285,7 @@ mod rule_tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1290,6 +1301,7 @@ mod rule_tests {
             .transaction()
             .assert(employee_from_person())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1333,6 +1345,7 @@ mod rule_tests {
             )
             .assert(&r_person)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1351,6 +1364,7 @@ mod rule_tests {
             )
             .assert(&r_contractor)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1402,6 +1416,7 @@ mod rule_tests {
             )
             .assert(&rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1413,6 +1428,7 @@ mod rule_tests {
             .transaction()
             .retract(&rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1448,6 +1464,7 @@ mod rule_tests {
             )
             .assert(&v1)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let branch = repo.branch("main").open().perform(&operator).await?;
@@ -1469,6 +1486,7 @@ mod rule_tests {
             )
             .assert(&v2)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1520,7 +1538,7 @@ mod resolver_tests {
                     .is(format!("entry-{at}")),
             );
         }
-        tx.commit().perform(operator).await?;
+        tx.commit().publish().perform(operator).await?;
         let revision = branch
             .revision()
             .expect("branch has a revision after commit");
@@ -1618,7 +1636,7 @@ mod resolver_tests {
                     .is(format!("entry-{at}-{pad}")),
             );
         }
-        tx.commit().perform(operator).await?;
+        tx.commit().publish().perform(operator).await?;
         let revision = branch
             .revision()
             .expect("branch has a revision after commit");
@@ -1758,6 +1776,7 @@ mod resolver_tests {
             .transaction()
             .assert(the!("probe/tree").of(probe.clone()).is(root.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1791,6 +1810,7 @@ mod resolver_tests {
             .transaction()
             .assert(&rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1934,6 +1954,7 @@ mod resolver_tests {
             .transaction()
             .assert(the!("test/name").of(Entity::new()?).is("later".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let revision = branch.revision().expect("second revision");
@@ -1988,6 +2009,7 @@ mod resolver_tests {
             .transaction()
             .assert(the!("test/big").of(Entity::new()?).is(big.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let revision = branch.revision().expect("committed");
@@ -2121,6 +2143,7 @@ mod ordered_relation_tests {
             .assert(membership(&list, &at_milk, &milk))
             .assert(membership(&list, &at_bread, &bread))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2139,6 +2162,7 @@ mod ordered_relation_tests {
                 cardinality: None,
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 

--- a/rust/dialog-repository/src/repository/branch/subscription.rs
+++ b/rust/dialog-repository/src/repository/branch/subscription.rs
@@ -1023,6 +1023,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1098,6 +1099,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1146,6 +1148,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1233,6 +1236,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1290,6 +1294,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1363,6 +1368,7 @@ mod tests {
             .transaction()
             .assert(the!("person/name").of(alice.clone()).is(spilled.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1435,6 +1441,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1477,6 +1484,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1492,6 +1500,7 @@ mod tests {
                     .is("unrelated".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1533,6 +1542,7 @@ mod tests {
             .transaction()
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1553,6 +1563,7 @@ mod tests {
                     .is("Groceries".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1584,6 +1595,7 @@ mod tests {
             .transaction()
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1596,6 +1608,7 @@ mod tests {
             .transaction()
             .assert(second.of(list.clone()).is("Bread".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1629,6 +1642,7 @@ mod tests {
             .transaction()
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1647,6 +1661,7 @@ mod tests {
                     .is("unrelated".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1735,6 +1750,7 @@ mod tests {
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .assert(second.of(list.clone()).is("Bread".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1773,6 +1789,7 @@ mod tests {
             .transaction()
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1787,6 +1804,7 @@ mod tests {
             .transaction()
             .assert(second.of(list.clone()).is("Bread".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1805,6 +1823,7 @@ mod tests {
                     .is("Groceries".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1838,6 +1857,7 @@ mod tests {
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .assert(second.clone().of(list.clone()).is("Bread".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1856,6 +1876,7 @@ mod tests {
             .transaction()
             .retract(second.of(list.clone()).is("Bread".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1881,6 +1902,7 @@ mod tests {
             .assert(first.of(list.clone()).is("Milk".to_string()))
             .assert(second.of(list.clone()).is("Bread".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1929,6 +1951,7 @@ mod tests {
             )
             .assert(member.of(list.clone()).is("Milk".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -1998,6 +2021,7 @@ mod tests {
             )
             .assert(member.of(list.clone()).is("Milk".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2056,6 +2080,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2067,6 +2092,7 @@ mod tests {
             .transaction()
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2088,6 +2114,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2121,6 +2148,7 @@ mod tests {
             .transaction()
             .assert(the!("misc/tag").of(Entity::new()?).is("seed".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2141,6 +2169,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2173,6 +2202,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2186,6 +2216,7 @@ mod tests {
             .transaction()
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2209,6 +2240,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2249,6 +2281,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2260,6 +2293,7 @@ mod tests {
             .transaction()
             .retract(the!("person/name").of(alice.clone()).is("Ali".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2301,6 +2335,7 @@ mod tests {
             )
             .assert(the!("person/name").of(bob.clone()).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2311,6 +2346,7 @@ mod tests {
             .transaction()
             .assert(the!("person/name").of(bob.clone()).is("Bobby".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2570,9 +2606,9 @@ mod tests {
     /// durably — a rule is a [`Statement`](dialog_artifacts::Statement),
     /// so installing it is asserting it.
     fn with_rule<'t>(
-        transaction: crate::Transaction<'t>,
+        transaction: crate::Transaction<&'t crate::Branch>,
         rule: &dialog_query::DeductiveRule,
-    ) -> crate::Transaction<'t> {
+    ) -> crate::Transaction<&'t crate::Branch> {
         transaction.assert(rule)
     }
 
@@ -2655,6 +2691,7 @@ mod tests {
             .transaction()
             .assert(Badge::of(alice.clone()).is("A-1"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2674,6 +2711,7 @@ mod tests {
             .transaction()
             .assert(Badge::of(bob.clone()).is("B-2"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2719,6 +2757,7 @@ mod tests {
             .assert(Name::of(mallory.clone()).is("Mallory"))
             .assert(Manager::of(mallory.clone()).is(carol.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2740,6 +2779,7 @@ mod tests {
             .transaction()
             .assert(Badge::of(carol.clone()).is("C-3"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2768,6 +2808,7 @@ mod tests {
             .transaction()
             .retract(Badge::of(carol.clone()).is("C-3"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2823,6 +2864,7 @@ mod tests {
             .assert(Phone::of(bob.clone()).is("555-0100"));
         with_rule(transaction, &email_rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2837,6 +2879,7 @@ mod tests {
         // range: recompute.
         with_rule(branch.transaction(), &phone_rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2857,6 +2900,7 @@ mod tests {
             .transaction()
             .assert(Email::of(bob.clone()).is("bob@mail"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2922,6 +2966,7 @@ mod tests {
             .assert(Parent::of(b.clone()).is(a.clone()));
         with_rule(with_rule(transaction, &base), &step)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -2940,6 +2985,7 @@ mod tests {
             .transaction()
             .assert(Parent::of(c.clone()).is(b.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         assert_eq!(subscription.recomputes(), 1);
@@ -2972,6 +3018,7 @@ mod tests {
             .transaction()
             .assert(Parent::of(d.clone()).is(c.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription
@@ -2991,6 +3038,7 @@ mod tests {
             .transaction()
             .retract(Parent::of(c.clone()).is(b.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("cone shrinks");
@@ -3014,6 +3062,7 @@ mod tests {
             .transaction()
             .assert(Parent::of(e.clone()).is(d.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("extends again");
@@ -3067,6 +3116,7 @@ mod tests {
             .assert(Title::of(frank.clone()).is("Frank"))
             .assert(Deputy::of(frank.clone()).is(mallory.clone()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3083,6 +3133,7 @@ mod tests {
             .transaction()
             .assert(Badge::of(carol.clone()).is("C-3"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3110,6 +3161,7 @@ mod tests {
             .transaction()
             .retract(Badge::of(carol.clone()).is("C-3"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("retraction");
@@ -3173,6 +3225,7 @@ mod tests {
                 salary: Salary(100),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3192,6 +3245,7 @@ mod tests {
                 salary: Salary(50),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("covered write");
@@ -3212,6 +3266,7 @@ mod tests {
                 salary: Salary(70),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("new group");
@@ -3266,6 +3321,7 @@ mod tests {
             .assert(bob_row.clone())
             .assert(carol_row.clone())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3281,6 +3337,7 @@ mod tests {
             .transaction()
             .retract(bob_row)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription
@@ -3296,6 +3353,7 @@ mod tests {
             .transaction()
             .retract(carol_row)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("group emptied");
@@ -3331,6 +3389,7 @@ mod tests {
                     .is("Alice".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3360,6 +3419,7 @@ mod tests {
             .transaction()
             .assert(the!("person/name").of(Entity::new()?).is("Bob".to_string()))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3410,6 +3470,7 @@ mod tests {
                 bonus: None,
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3430,6 +3491,7 @@ mod tests {
             .transaction()
             .assert(Bonus::of(alice.clone()).is(25u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("bonus arrived");
@@ -3455,6 +3517,7 @@ mod tests {
             .transaction()
             .retract(Bonus::of(alice.clone()).is(25u32))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription
@@ -3506,6 +3569,7 @@ mod tests {
                 salary: Salary(100),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3529,6 +3593,7 @@ mod tests {
                 salary: Salary(50),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("base change");
@@ -3598,6 +3663,7 @@ mod tests {
             .assert(Parent::of(dept_b.clone()).is(dept_a.clone()));
         with_rule(with_rule(transaction, &dept_total_rule()), &step)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -3620,6 +3686,7 @@ mod tests {
                 salary: Salary(50),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("growth");
@@ -3642,6 +3709,7 @@ mod tests {
                 salary: Salary(100),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         let delta = subscription.poll(&operator).await?.expect("shrinkage");

--- a/rust/dialog-repository/src/repository/branch/transaction.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction.rs
@@ -1,5 +1,7 @@
+mod batch;
 mod induce;
 mod query;
+pub use batch::*;
 pub use query::{TransactionQuery, TransactionSelectQuery};
 
 use crate::Commit;
@@ -13,24 +15,49 @@ use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::{Attest, Identify};
 use dialog_effects::memory::{Publish, Resolve};
 
-/// A transaction on a branch or a snapshot.
+/// A transaction on a line of the repository.
 ///
-/// Created by [`Branch::transaction`] or [`Snapshot::transaction`].
-/// Accumulates durable changes via `.assert()` / `.retract()` and
-/// *transient* facts (commands) via `.dispatch()`, then commits
-/// atomically via `.commit().perform(&env)`.
+/// `Line` is what the transaction runs on, and it decides what
+/// committing does:
+///
+/// - `&`[`Branch`]: `.commit().perform(&env)` STAGES the batch. It mints
+///   a revision on the branch's own origin — the successor edition of
+///   the head, exactly what a published commit would mint — but the
+///   branch head does not move and nothing becomes visible. The returned
+///   [`TransactionBatch`] chains further commits and finally
+///   [`publish`](TransactionBatch::publish)es the whole chain with one
+///   head CAS. A one-shot writer commits and publishes in one step with
+///   [`.commit().publish()`](TransactionCommit::publish).
+/// - [`TransactionBatch`]: the same, extending the staged chain by one
+///   more commit.
+/// - `&`[`Snapshot`]: commits advance the snapshot in place, minted on
+///   the snapshot's own lineage. Nothing publishes; a snapshot is a fork,
+///   not a stage.
+///
+/// Created by [`Branch::transaction`], [`Snapshot::transaction`], or
+/// [`TransactionBatch::transaction`]. Accumulates durable changes via
+/// `.assert()` / `.retract()` and *transient* facts (commands) via
+/// `.dispatch()`.
 ///
 /// Transients are visible to every read through [`query`](Self::query)
 /// and to inductive-rule bodies during commit-time induction, but they
 /// never enter the durable batch: they live for exactly one induction
 /// round and leave no trace in the committed tree.
-pub struct Transaction<'a> {
-    source: SourceRef<'a>,
+pub struct Transaction<Line> {
+    line: Line,
     changes: Changes,
     transients: Changes,
 }
 
-impl<'a> Transaction<'a> {
+impl<Line> Transaction<Line> {
+    pub(crate) fn on(line: Line) -> Self {
+        Transaction {
+            line,
+            changes: Changes::new(),
+            transients: Changes::new(),
+        }
+    }
+
     /// Assert a claim into this transaction.
     pub fn assert<C: Statement>(mut self, claim: C) -> Self {
         // Disambiguate from `Statement::assert` (which Changes now
@@ -79,32 +106,18 @@ impl<'a> Transaction<'a> {
         self
     }
 
-    /// Run queries against this transaction's "as-if committed" view of
-    /// the line it runs on.
-    ///
-    /// Pending asserts and retracts are surfaced through a
-    /// [`TransactionQuery`] handle — assertions show up alongside the
-    /// stored facts; retractions tombstone matching facts in the stored
-    /// stream before the merge. Dispatched transients are part of the
-    /// view too. The transaction itself stays open and committable.
-    pub fn query(&self) -> TransactionQuery<'_> {
-        let mut view = self.changes.clone();
-        self.transients.clone().assert(&mut view);
-        TransactionQuery::new(self.source, &view)
-    }
-
     /// Finalize the transaction into a commit command.
     ///
-    /// [`TransactionCommit::perform`] first runs commit-time induction:
-    /// the commit's delta (durable changes and dispatched transients
-    /// alike) probes the `dialog.rule/on` trigger index, matching inductive
-    /// rules fire against the transaction view, and their durable
-    /// novelty folds into the commit while transient heads seed further
-    /// rounds. Only then is the durable batch committed; transients are
-    /// dropped, never written.
-    pub fn commit(self) -> TransactionCommit<'a> {
+    /// `perform` first runs commit-time induction: the commit's delta
+    /// (durable changes and dispatched transients alike) probes the
+    /// `dialog.rule/on` trigger index, matching inductive rules fire
+    /// against the transaction view, and their durable novelty folds
+    /// into the commit while transient heads seed further rounds. Only
+    /// then is the durable batch committed; transients are dropped,
+    /// never written.
+    pub fn commit(self) -> TransactionCommit<Line> {
         TransactionCommit {
-            source: self.source,
+            line: self.line,
             changes: self.changes,
             transients: self.transients,
             allow_empty: false,
@@ -113,17 +126,52 @@ impl<'a> Transaction<'a> {
     }
 }
 
+/// The "as-if committed" view over `changes` + `transients` that
+/// [`Transaction::query`] serves on every line kind.
+fn transaction_view(changes: &Changes, transients: &Changes) -> Changes {
+    let mut view = changes.clone();
+    transients.clone().assert(&mut view);
+    view
+}
+
+impl<'a> Transaction<&'a Branch> {
+    /// Run queries against this transaction's "as-if committed" view of
+    /// the branch.
+    ///
+    /// Pending asserts and retracts are surfaced through a
+    /// [`TransactionQuery`] handle — assertions show up alongside the
+    /// stored facts; retractions tombstone matching facts in the stored
+    /// stream before the merge. Dispatched transients are part of the
+    /// view too. The transaction itself stays open and committable.
+    pub fn query(&self) -> TransactionQuery<'a> {
+        TransactionQuery::new(
+            SourceRef::Branch(self.line),
+            &transaction_view(&self.changes, &self.transients),
+        )
+    }
+}
+
+impl<'a> Transaction<&'a Snapshot> {
+    /// Run queries against this transaction's "as-if committed" view of
+    /// the snapshot. See [`Transaction::<&Branch>::query`].
+    pub fn query(&self) -> TransactionQuery<'a> {
+        TransactionQuery::new(
+            SourceRef::Snapshot(self.line),
+            &transaction_view(&self.changes, &self.transients),
+        )
+    }
+}
+
 impl Branch {
     /// Start a transaction on this branch.
     ///
-    /// Use `.assert()` and `.retract()` to accumulate changes,
-    /// then `.commit().perform(&env)` to apply them.
-    pub fn transaction(&self) -> Transaction<'_> {
-        Transaction {
-            source: SourceRef::from(self),
-            changes: Changes::new(),
-            transients: Changes::new(),
-        }
+    /// Use `.assert()` and `.retract()` to accumulate changes, then
+    /// either `.commit().publish().perform(&env)` to commit and publish
+    /// in one step, or `.commit().perform(&env)` to stage a
+    /// [`TransactionBatch`] that chains further commits before one
+    /// atomic publish.
+    pub fn transaction(&self) -> Transaction<&Branch> {
+        Transaction::on(self)
     }
 }
 
@@ -135,33 +183,30 @@ impl Snapshot {
     /// `.commit().perform(&env)` to apply them; the snapshot advances to
     /// the revision `perform` returns. Clone first to keep the view you
     /// have.
-    pub fn transaction(&self) -> Transaction<'_> {
-        Transaction {
-            source: SourceRef::from(self),
-            changes: Changes::new(),
-            transients: Changes::new(),
-        }
+    pub fn transaction(&self) -> Transaction<&Snapshot> {
+        Transaction::on(self)
     }
 }
 
 /// Command committing a [`Transaction`]: runs commit-time induction
-/// over the transaction's delta, then delegates the settled durable
-/// batch to [`Branch::commit`] / [`Snapshot::commit`].
+/// over the transaction's delta, then mints the settled durable batch
+/// on the line.
 ///
-/// Mirrors [`Commit`](crate::Commit)'s builder surface
+/// What `perform` returns follows the line — see [`Transaction`]. The
+/// builder mirrors [`Commit`](crate::Commit)'s surface
 /// ([`allow_empty`](Self::allow_empty) /
 /// [`canonicalize`](Self::canonicalize)); the difference is the
 /// induction step in front and that transients never reach the
 /// durable batch.
-pub struct TransactionCommit<'a> {
-    source: SourceRef<'a>,
-    changes: Changes,
-    transients: Changes,
-    allow_empty: bool,
-    canonicalize: bool,
+pub struct TransactionCommit<Line> {
+    pub(super) line: Line,
+    pub(super) changes: Changes,
+    pub(super) transients: Changes,
+    pub(super) allow_empty: bool,
+    pub(super) canonicalize: bool,
 }
 
-impl<'a> TransactionCommit<'a> {
+impl<Line> TransactionCommit<Line> {
     /// Mint a revision even when the settled change batch leaves the
     /// indexes untouched. See [`Commit::allow_empty`](crate::Commit::allow_empty).
     pub fn allow_empty(mut self) -> Self {
@@ -175,10 +220,12 @@ impl<'a> TransactionCommit<'a> {
         self.canonicalize = true;
         self
     }
+}
 
-    /// Run induction, then execute the commit, returning the
-    /// newly-published [`Revision`] (or the unchanged head when the
-    /// settled batch is a no-op).
+impl TransactionCommit<&Snapshot> {
+    /// Run induction, then execute the commit, advancing the snapshot to
+    /// the returned [`Revision`] (or returning the unchanged head when
+    /// the settled batch is a no-op).
     pub async fn perform<Env>(self, env: &Env) -> Result<Revision, CommitError>
     where
         Env: Provider<Get>
@@ -193,13 +240,20 @@ impl<'a> TransactionCommit<'a> {
             + ConditionalSync
             + 'static,
     {
+        let snapshot = self.line;
         let mut changes = self.changes;
-        induce::induce(self.source, &mut changes, self.transients, env).await?;
+        induce::induce(
+            SourceRef::Snapshot(snapshot),
+            &mut changes,
+            self.transients,
+            env,
+        )
+        .await?;
 
-        let previous = self.source.revision();
+        let previous = snapshot.revision();
         let touches_rules = touches_rules(&changes);
 
-        let mut commit = Commit::new(self.source, changes.into_stream());
+        let mut commit = Commit::new(snapshot, changes.into_stream());
         if self.allow_empty {
             commit = commit.allow_empty();
         }
@@ -208,23 +262,12 @@ impl<'a> TransactionCommit<'a> {
         }
         let revision = Box::pin(commit.perform(env)).await?;
 
-        // Advance the induction watermark: rules have now evaluated
-        // through this revision (induction ran over the commit's delta
-        // plus any lag, and the settled batch is what `revision`
-        // holds). A raced publish here at worst regresses the
-        // watermark, which re-induces a covered span — idempotent
-        // under the novelty check. A snapshot keeps no watermark: its
-        // head moves only through commits like this one, every one of
-        // which induces, so it is always at the head.
-        if let SourceRef::Branch(branch) = self.source {
-            let cell = branch.induction_cell();
-            if cell.content().as_ref() != Some(&revision) {
-                cell.publish(revision.clone()).perform(env).await?;
-            }
-        }
-
         if !touches_rules {
-            carry_footprint(&self.source.rule_cache(), previous.as_ref(), &revision);
+            carry_footprint(
+                &SourceRef::Snapshot(snapshot).rule_cache(),
+                Some(&previous),
+                &revision,
+            );
         }
         Ok(revision)
     }
@@ -291,6 +334,6 @@ impl Branch {
             + ConditionalSync
             + 'static,
     {
-        self.transaction().commit().perform(env).await
+        Box::pin(self.transaction().commit().publish().perform(env)).await
     }
 }

--- a/rust/dialog-repository/src/repository/branch/transaction/batch.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/batch.rs
@@ -1,0 +1,809 @@
+//! Staged transaction chains: commit without publishing, publish once.
+//!
+//! A commit on a branch transaction does NOT move the branch head.
+//! It mints the revision — on the branch's own origin, at the successor
+//! edition, byte-identical to what a published commit would mint — and
+//! hands back a [`TransactionBatch`] holding the staged chain. Further
+//! transactions extend the chain; [`TransactionBatch::publish`] moves
+//! the branch head to the chain tip with one CAS, making every staged
+//! commit visible atomically, at exactly the versions minted.
+//!
+//! This is what lets a writer record a fact naming its own commit
+//! without prediction or a second published commit: commit once, read
+//! the minted [`Version`] off the batch, assert it in the next commit
+//! on the same chain, publish. Either both commits become visible or
+//! neither does.
+//!
+//! A batch that loses the publish CAS (the head moved: a pull, another
+//! writer) is stale wholesale — its editions are taken. Recovery is to
+//! re-run the transaction against the fresh head, minting fresh
+//! versions; nothing staged is ever rewritten.
+
+use super::induce::induce;
+use super::{Transaction, TransactionCommit, carry_footprint, touches_rules, transaction_view};
+use crate::repository::branch::commit::{Mint, Minted, Outcome};
+use crate::repository::source::{Caches, SourceRef};
+use crate::{
+    Branch, Cell, Checkpoint, CommitError, PublishError, QueryLayer, RemoteSite, Revision,
+    SelectQuery, Snapshot, SnapshotClaims, TransactionQuery, origin_of,
+};
+use dialog_artifacts::history::{CausalityCache, Context, ContextCache, RevisionRecord, Version};
+use dialog_artifacts::tree::WriteScope;
+use dialog_artifacts::{Changes, Entity, Statement};
+use dialog_capability::history::Origin;
+use dialog_capability::{Did, Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Import, Put};
+use dialog_effects::authority::{Attest, Identify, OperatorExt as _};
+use dialog_effects::memory::{Publish, Resolve, Version as MemoryVersion};
+use dialog_query::query::Application;
+use dialog_search_tree::Cache;
+
+/// A staged chain of commits on a branch: minted, persisted, invisible.
+///
+/// Produced by committing a branch [`Transaction`] (or another link on
+/// the same batch). Every staged commit is a real revision on the
+/// branch's OWN origin — the successor edition of the head the chain
+/// builds on — so [`version`](Self::version) reports exactly what
+/// [`publish`](Self::publish) makes visible, synchronously and without
+/// prediction. Until publish, the branch head does not move: staged
+/// blocks persist to the shared archive (unreachable garbage if the
+/// batch is dropped), but no head cell, watermark, or shared memo
+/// changes.
+///
+/// Reads through [`claims`](Self::claims) / [`select`](Self::select) /
+/// [`query`](Self::query) serve the staged state.
+///
+/// Publish CAS's the branch head from the head the chain was staged
+/// from to the chain tip. If the head moved in between, publish fails
+/// with [`PublishError::VersionMismatch`] and the whole batch is stale:
+/// its editions now belong to whatever advanced the head. Recovery is
+/// to re-run the transaction on the fresh head — versions come out
+/// fresh, which is why a fact citing a staged version must ride the
+/// same batch as the commit it cites.
+#[must_use = "staged commits are invisible until .publish().perform(&env) moves the branch head"]
+pub struct TransactionBatch {
+    /// The staged view: reads serve the chain tip, and commits mint on
+    /// the branch's own line (see `Snapshot::staged`). Carries the
+    /// version-keyed memos (records, contexts, causality) batch-locally:
+    /// a dropped batch's versions can be re-minted with different
+    /// content by the retry, so nothing keyed by them may leak into the
+    /// branch's shared memos before the publish CAS settles who owns
+    /// them. Content-keyed caches (nodes, spills, rules, plans, spine)
+    /// are shared with the branch.
+    snapshot: Snapshot,
+    /// The branch head cell as checkpointed when staging began; publish
+    /// CAS's the chain tip against it.
+    head: Checkpoint<Revision>,
+    /// The same cell, for the empty-chain staleness re-check.
+    cell: Cell<Revision>,
+    /// The cell version staging began at, compared on an empty-chain
+    /// publish.
+    base_version: Option<MemoryVersion>,
+    /// The branch's induction watermark cell, advanced at publish (every
+    /// staged commit induced, so the published head is fully induced).
+    induction: Cell<Revision>,
+    /// The staged links in chain order, for seeding the branch's
+    /// verified-record memo once the head has actually advanced.
+    chain: Vec<(Version, RevisionRecord)>,
+    /// The chain tip's causal context, for the branch's context memo.
+    context: Option<Context>,
+    /// The branch's shared memos, seeded at publish.
+    records: Cache<Version, RevisionRecord>,
+    contexts: ContextCache,
+}
+
+impl TransactionBatch {
+    /// The [`Version`] of the chain tip — for a batch with staged
+    /// commits, the version the latest one minted, which is exactly the
+    /// version [`publish`](Self::publish) makes visible. A batch whose
+    /// commits were all no-ops reports the version of the head it was
+    /// staged from.
+    ///
+    /// This is authoritative, not predicted: the commit that minted it
+    /// has already happened. A writer that wants a fact naming its own
+    /// commit stages the commit, reads this, and asserts it in the next
+    /// link of the same batch.
+    pub fn version(&self) -> Version {
+        self.snapshot.revision().version()
+    }
+
+    /// The chain tip: the [`Revision`] publish will move the branch
+    /// head to.
+    pub fn revision(&self) -> Revision {
+        self.snapshot.revision()
+    }
+
+    /// Start the next transaction on this chain. Its commit extends the
+    /// batch by one more staged revision.
+    pub fn transaction(self) -> Transaction<TransactionBatch> {
+        Transaction::on(self)
+    }
+
+    /// Assert a claim into the next transaction on this chain.
+    /// Shorthand for `.transaction().assert(claim)`.
+    pub fn assert<C: Statement>(self, claim: C) -> Transaction<TransactionBatch> {
+        self.transaction().assert(claim)
+    }
+
+    /// Retract a claim in the next transaction on this chain.
+    /// Shorthand for `.transaction().retract(claim)`.
+    pub fn retract<C: Statement>(self, claim: C) -> Transaction<TransactionBatch> {
+        self.transaction().retract(claim)
+    }
+
+    /// Dispatch a transient into the next transaction on this chain.
+    /// Shorthand for `.transaction().dispatch(claim)`.
+    pub fn dispatch<C: Statement>(self, claim: C) -> Transaction<TransactionBatch> {
+        self.transaction().dispatch(claim)
+    }
+
+    /// The staged artifact index, serving the chain tip.
+    pub fn claims(&self) -> SnapshotClaims<'_> {
+        self.snapshot.claims()
+    }
+
+    /// Query the staged state with an application.
+    pub fn select<Q: Application>(&self, query: Q) -> SelectQuery<'_, Q> {
+        self.snapshot.select(query)
+    }
+
+    /// Open a query over the staged state.
+    pub fn query(&self) -> QueryLayer<'_> {
+        self.snapshot.query()
+    }
+
+    /// Publish the staged chain: one CAS moving the branch head to the
+    /// chain tip. See [`BatchPublish::perform`].
+    pub fn publish(self) -> BatchPublish {
+        BatchPublish { batch: self }
+    }
+}
+
+/// Command publishing a [`TransactionBatch`] — created by
+/// [`TransactionBatch::publish`], executed with `.perform(&env)`.
+pub struct BatchPublish {
+    batch: TransactionBatch,
+}
+
+impl BatchPublish {
+    /// Move the branch head to the staged chain tip, CAS'd against the
+    /// head the chain was staged from. On success every staged commit
+    /// becomes visible atomically — at exactly the versions minted — the
+    /// branch's shared memos are seeded with the staged records, and the
+    /// induction watermark advances to the tip. On a lost CAS nothing is
+    /// adopted and the batch is consumed: re-run the transaction against
+    /// the fresh head.
+    ///
+    /// A batch whose commits were all no-ops publishes nothing, but does
+    /// not silently succeed from a stale view either: the head is
+    /// re-read and compared, so "nothing to do" judged against a
+    /// superseded head fails with the same
+    /// [`VersionMismatch`](PublishError::VersionMismatch) any other
+    /// stale write gets.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Revision, CommitError>
+    where
+        Env: Provider<Publish> + Provider<Resolve> + ConditionalSync,
+    {
+        let TransactionBatch {
+            snapshot,
+            head,
+            cell,
+            base_version,
+            induction,
+            chain,
+            context,
+            records,
+            contexts,
+        } = self.batch;
+        let tip = snapshot.revision();
+
+        if chain.is_empty() {
+            // Nothing staged. A same-value publish would bump the cell
+            // version and fail concurrent writers spuriously, so re-read
+            // and compare instead — mirroring the no-op handling in
+            // `Commit::perform`. The induction watermark still advances
+            // below: a no-op transaction was still an inducing instant
+            // (this is what lets `Branch::induce` adopt a head).
+            cell.resolve().perform(env).await?;
+            let actual = cell.edition().map(|edition| edition.version);
+            if actual != base_version {
+                return Err(PublishError::VersionMismatch {
+                    expected: base_version,
+                    actual,
+                }
+                .into());
+            }
+            if induction.content().as_ref() != Some(&tip) {
+                induction.publish(tip.clone()).perform(env).await?;
+            }
+            return Ok(tip);
+        }
+
+        head.publish(tip.clone(), env).await?;
+
+        // Only now that the head has actually advanced do the staged
+        // records and context enter the branch's shared memos: they are
+        // keyed by version, and until the CAS settled, a competing
+        // writer could have owned these editions.
+        for (version, record) in chain {
+            records.insert(version, record);
+        }
+        if let Some(context) = context {
+            contexts.insert(tip.version(), context);
+        }
+
+        // Advance the induction watermark: every staged commit ran
+        // commit-time induction, so the published head is fully induced.
+        if induction.content().as_ref() != Some(&tip) {
+            induction.publish(tip.clone()).perform(env).await?;
+        }
+
+        Ok(tip)
+    }
+}
+
+/// Command committing a branch transaction (or a chain link) and
+/// publishing in one step — created by [`TransactionCommit::publish`],
+/// executed with `.perform(&env)`. The one-shot form: equivalent to
+/// staging the batch and immediately publishing it.
+pub struct TransactionPublish<Line> {
+    commit: TransactionCommit<Line>,
+}
+
+impl<'a> TransactionCommit<&'a Branch> {
+    /// Commit and publish in one step: stage the batch, then move the
+    /// branch head to it. The one-shot write path.
+    pub fn publish(self) -> TransactionPublish<&'a Branch> {
+        TransactionPublish { commit: self }
+    }
+}
+
+impl TransactionCommit<TransactionBatch> {
+    /// Commit this link and publish the whole staged chain in one step.
+    pub fn publish(self) -> TransactionPublish<TransactionBatch> {
+        TransactionPublish { commit: self }
+    }
+}
+
+impl TransactionPublish<&Branch> {
+    /// Run induction, mint the commit, and publish it — returning the
+    /// newly-published [`Revision`] (or the unchanged head when the
+    /// settled batch is a no-op).
+    pub async fn perform<Env>(self, env: &Env) -> Result<Revision, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let batch = Box::pin(self.commit.perform(env)).await?;
+        batch.publish().perform(env).await
+    }
+}
+
+impl TransactionPublish<TransactionBatch> {
+    /// Commit the link, then publish the whole staged chain — returning
+    /// the newly-published [`Revision`].
+    pub async fn perform<Env>(self, env: &Env) -> Result<Revision, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Publish>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let batch = Box::pin(self.commit.perform(env)).await?;
+        batch.publish().perform(env).await
+    }
+}
+
+impl Transaction<TransactionBatch> {
+    /// Run queries against this transaction's "as-if committed" view of
+    /// the staged chain. See [`Transaction::<&Branch>::query`].
+    pub fn query(&self) -> TransactionQuery<'_> {
+        TransactionQuery::new(
+            SourceRef::Snapshot(&self.line.snapshot),
+            &transaction_view(&self.changes, &self.transients),
+        )
+    }
+}
+
+impl TransactionCommit<&Branch> {
+    /// Run induction, then STAGE the commit: mint it on the branch's
+    /// own origin — the successor edition of the head, exactly what a
+    /// published commit would mint — without moving the branch head.
+    /// The returned [`TransactionBatch`] chains further commits and
+    /// publishes the lot with one CAS.
+    ///
+    /// Staging needs no publish capability; only
+    /// [`TransactionBatch::publish`] does.
+    pub async fn perform<Env>(self, env: &Env) -> Result<TransactionBatch, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let branch = self.line;
+
+        // The publish CAS target, captured before the mint reads the
+        // head it builds on: if anything advances the cell from here,
+        // publish fails rather than silently adopting a chain built on
+        // a superseded head.
+        let head = branch.revision.checkpoint();
+        let cell = branch.revision.clone();
+        let base_version = branch.revision.edition().map(|edition| edition.version);
+        let base = branch.revision();
+
+        // The line staged commits mint on: the branch's own identity,
+        // derived once here (memoized) so the batch's snapshot can carry
+        // it for the links that follow.
+        let authority = Identify.perform(env).await?;
+        let (line, _) = branch.commit_identity(authority.profile(), &authority.did());
+
+        let outcome = Box::pin(mint_link(
+            SourceRef::Branch(branch),
+            base,
+            |profile, issuer| branch.commit_identity(profile, issuer),
+            self.changes,
+            self.transients,
+            self.allow_empty,
+            self.canonicalize,
+            env,
+        ))
+        .await?;
+
+        // Version-keyed memos are batch-local (see the field docs on
+        // `TransactionBatch::snapshot`); content-keyed caches stay
+        // shared with the branch.
+        let caches = Caches {
+            causality: CausalityCache::new(),
+            contexts: ContextCache::new(),
+            records: Cache::new(),
+            ..branch.caches()
+        };
+
+        Ok(match outcome {
+            Outcome::Unchanged(tip) => TransactionBatch {
+                snapshot: Snapshot::staged(branch.subject(), tip, caches, line),
+                head,
+                cell,
+                base_version,
+                induction: branch.induction_cell().clone(),
+                chain: Vec::new(),
+                context: None,
+                records: branch.records(),
+                contexts: branch.contexts(),
+            },
+            Outcome::Minted(minted) => {
+                let Minted {
+                    revision,
+                    record,
+                    context,
+                } = *minted;
+                let snapshot = Snapshot::staged(branch.subject(), revision.clone(), caches, line);
+                let version = revision.version();
+                snapshot.caches().records.insert(version, record.clone());
+                snapshot.caches().contexts.insert(version, context.clone());
+                TransactionBatch {
+                    snapshot,
+                    head,
+                    cell,
+                    base_version,
+                    induction: branch.induction_cell().clone(),
+                    chain: vec![(version, record)],
+                    context: Some(context),
+                    records: branch.records(),
+                    contexts: branch.contexts(),
+                }
+            }
+        })
+    }
+}
+
+impl TransactionCommit<TransactionBatch> {
+    /// Run induction, then extend the staged chain by one more commit,
+    /// minted on the same line at the next edition. See
+    /// [`TransactionCommit::<&Branch>::perform`].
+    pub async fn perform<Env>(self, env: &Env) -> Result<TransactionBatch, CommitError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Import>
+            + Provider<Resolve>
+            + Provider<Identify>
+            + Provider<Attest>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let mut batch = self.line;
+        let (base, lineage) = batch.snapshot.head();
+        let line = lineage.expect("a transaction batch's line is seeded at construction");
+
+        let outcome = Box::pin(mint_link(
+            SourceRef::Snapshot(&batch.snapshot),
+            Some(base.clone()),
+            |_, issuer| (line.clone(), origin_of(&line, issuer)),
+            self.changes,
+            self.transients,
+            self.allow_empty,
+            self.canonicalize,
+            env,
+        ))
+        .await?;
+
+        if let Outcome::Minted(minted) = outcome {
+            let Minted {
+                revision,
+                record,
+                context,
+            } = *minted;
+            batch.snapshot.advance(&base, revision.clone(), line)?;
+            let version = revision.version();
+            batch
+                .snapshot
+                .caches()
+                .records
+                .insert(version, record.clone());
+            batch
+                .snapshot
+                .caches()
+                .contexts
+                .insert(version, context.clone());
+            batch.chain.push((version, record));
+            batch.context = Some(context);
+        }
+        Ok(batch)
+    }
+}
+
+/// Mint one staged link: run commit-time induction over the batch, then
+/// [`Mint`] the settled changes on the line `line` names, carrying the
+/// trigger footprint forward. Nothing is published or adopted — the
+/// caller owns what happens to the [`Outcome`].
+#[allow(clippy::too_many_arguments)]
+async fn mint_link<Env>(
+    source: SourceRef<'_>,
+    base: Option<Revision>,
+    line: impl FnOnce(&Did, &Did) -> (Entity, Origin),
+    mut changes: Changes,
+    transients: Changes,
+    allow_empty: bool,
+    canonicalize: bool,
+    env: &Env,
+) -> Result<Outcome, CommitError>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Import>
+        + Provider<Resolve>
+        + Provider<Identify>
+        + Provider<Attest>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    induce(source, &mut changes, transients, env).await?;
+    let touches = touches_rules(&changes);
+    let previous = base.clone();
+    let outcome = Mint {
+        source,
+        base,
+        changes: changes.into_stream(),
+        entries: Vec::new(),
+        scope: WriteScope::Application,
+        allow_empty,
+        canonicalize,
+    }
+    .perform(env, line)
+    .await?;
+    if let Outcome::Minted(minted) = &outcome
+        && !touches
+    {
+        carry_footprint(&source.rule_cache(), previous.as_ref(), &minted.revision);
+    }
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use crate::helpers::test_repo;
+    use crate::{Branch, CommitError, PublishError};
+    use anyhow::Result;
+    use dialog_artifacts::history::Edition;
+    use dialog_operator::Operator;
+    use dialog_operator::helpers::test_operator_with_profile;
+    use dialog_query::query::Output;
+    use dialog_query::{Concept, Entity, Query, Term};
+    use dialog_storage::provider::storage::VolatileSpace;
+
+    pub mod note {
+        #[derive(dialog_query::Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct Body(pub String);
+    }
+
+    #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Note {
+        pub this: Entity,
+        pub body: note::Body,
+    }
+
+    fn note(body: &str) -> Result<Note> {
+        Ok(Note {
+            this: Entity::new()?,
+            body: note::Body(body.into()),
+        })
+    }
+
+    async fn bodies(branch: &Branch, operator: &Operator<VolatileSpace>) -> Result<Vec<String>> {
+        let mut bodies: Vec<String> = branch
+            .query()
+            .select(Query::<Note> {
+                this: Term::var("this"),
+                body: Term::var("body"),
+            })
+            .perform(operator)
+            .try_vec()
+            .await?
+            .into_iter()
+            .map(|note| note.body.0)
+            .collect();
+        bodies.sort();
+        Ok(bodies)
+    }
+
+    /// A staged chain is invisible on the branch until publish, then
+    /// every link lands atomically at exactly the versions minted.
+    #[dialog_common::test]
+    async fn it_stages_privately_and_publishes_atomically() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let seed = branch
+            .transaction()
+            .assert(note("seed")?)
+            .commit()
+            .publish()
+            .perform(&operator)
+            .await?;
+
+        let batch = branch
+            .transaction()
+            .assert(note("first")?)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // The staged commit minted on the branch's own line, at the
+        // head's successor edition — yet the branch head did not move.
+        assert_eq!(
+            batch.version().origin,
+            seed.version().origin,
+            "staged commits mint on the branch's own origin"
+        );
+        assert_eq!(batch.version().edition, seed.version().edition.successor());
+        assert_eq!(branch.revision(), Some(seed.clone()));
+        assert_eq!(bodies(&branch, &operator).await?, vec!["seed"]);
+
+        // Chain a second link; the batch reads its own staged state.
+        let batch = batch
+            .assert(note("second")?)
+            .commit()
+            .perform(&operator)
+            .await?;
+        assert_eq!(
+            batch.version().edition,
+            seed.version().edition.successor().successor()
+        );
+
+        let tip = batch.revision();
+        let head = batch.publish().perform(&operator).await?;
+        assert_eq!(head, tip, "publish moves the head to the chain tip");
+        assert_eq!(branch.revision(), Some(head));
+        assert_eq!(
+            bodies(&branch, &operator).await?,
+            vec!["first", "second", "seed"]
+        );
+
+        Ok(())
+    }
+
+    /// The tonk flow: commit claims, read the minted version off the
+    /// batch, assert a fact naming it in the next link, publish both
+    /// atomically. The recorded version is exactly the one the branch
+    /// history reports for the commit carrying the claims.
+    #[dialog_common::test]
+    async fn it_captures_the_version_a_commit_minted() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let batch = branch
+            .transaction()
+            .assert(note("claim")?)
+            .commit()
+            .perform(&operator)
+            .await?;
+        let version = batch.version();
+
+        batch
+            .assert(note(&format!("committed-at:{version}"))?)
+            .commit()
+            .publish()
+            .perform(&operator)
+            .await?;
+
+        // The capture fact is on the branch, naming the version the
+        // history actually holds for the claim commit.
+        let recorded = bodies(&branch, &operator).await?;
+        assert!(
+            recorded.contains(&format!("committed-at:{version}")),
+            "the capture fact names the minted version: {recorded:?}"
+        );
+        let log = branch.log(&operator, 4).await?;
+        assert!(
+            log.iter().any(|(recorded, _)| *recorded == version),
+            "the branch history holds the captured version"
+        );
+
+        Ok(())
+    }
+
+    /// A batch whose base head moved loses the publish CAS loudly; a
+    /// re-run against the fresh head reconciles.
+    #[dialog_common::test]
+    async fn it_fails_publish_after_the_head_moved_then_recovers() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        branch
+            .transaction()
+            .assert(note("seed")?)
+            .commit()
+            .publish()
+            .perform(&operator)
+            .await?;
+
+        let batch = branch
+            .transaction()
+            .assert(note("staged")?)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // Another writer publishes while the batch is staged.
+        branch
+            .transaction()
+            .assert(note("interloper")?)
+            .commit()
+            .publish()
+            .perform(&operator)
+            .await?;
+
+        let raced = batch.publish().perform(&operator).await;
+        assert!(
+            matches!(
+                raced,
+                Err(CommitError::Publish(PublishError::VersionMismatch { .. }))
+            ),
+            "a batch staged on a superseded head must lose the CAS; got {raced:?}"
+        );
+
+        // Recovery: re-run against the fresh head.
+        branch
+            .transaction()
+            .assert(note("staged")?)
+            .commit()
+            .publish()
+            .perform(&operator)
+            .await?;
+        assert_eq!(
+            bodies(&branch, &operator).await?,
+            vec!["interloper", "seed", "staged"]
+        );
+
+        Ok(())
+    }
+
+    /// A virgin branch stages a genesis chain: nothing exists on the
+    /// branch until the batch publishes its first-ever head.
+    #[dialog_common::test]
+    async fn it_stages_a_genesis_chain() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+        assert_eq!(branch.revision(), None);
+
+        let batch = branch
+            .transaction()
+            .assert(note("genesis")?)
+            .commit()
+            .perform(&operator)
+            .await?;
+        assert_eq!(batch.version().edition, Edition::GENESIS);
+        assert_eq!(
+            branch.revision(),
+            None,
+            "staging establishes no head on a virgin branch"
+        );
+
+        let head = batch.publish().perform(&operator).await?;
+        assert_eq!(branch.revision(), Some(head));
+        assert_eq!(bodies(&branch, &operator).await?, vec!["genesis"]);
+
+        Ok(())
+    }
+
+    /// An all-no-op batch publishes nothing — but does not report
+    /// success from a stale view either.
+    #[dialog_common::test]
+    async fn it_treats_an_empty_batch_as_a_noop_only_at_the_current_head() -> Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let seed = branch
+            .transaction()
+            .assert(note("seed")?)
+            .commit()
+            .publish()
+            .perform(&operator)
+            .await?;
+
+        // No changes staged: the batch sits at the head it was staged
+        // from and publish is a no-op returning it.
+        let batch = branch.transaction().commit().perform(&operator).await?;
+        assert_eq!(batch.version(), seed.version());
+        assert_eq!(batch.publish().perform(&operator).await?, seed);
+        assert_eq!(branch.revision(), Some(seed.clone()));
+
+        // The same no-op judged against a superseded head fails loudly.
+        let stale = branch.transaction().commit().perform(&operator).await?;
+        branch
+            .transaction()
+            .assert(note("interloper")?)
+            .commit()
+            .publish()
+            .perform(&operator)
+            .await?;
+        let raced = stale.publish().perform(&operator).await;
+        assert!(
+            matches!(
+                raced,
+                Err(CommitError::Publish(PublishError::VersionMismatch { .. }))
+            ),
+            "an empty batch from a stale view must not silently succeed; got {raced:?}"
+        );
+
+        Ok(())
+    }
+}

--- a/rust/dialog-repository/src/repository/branch/transaction/induce.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/induce.rs
@@ -1304,6 +1304,7 @@ mod tests {
                     .is(1u64),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1317,6 +1318,7 @@ mod tests {
                     .is(counter.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1385,6 +1387,7 @@ mod tests {
             .transaction()
             .assert(rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1401,6 +1404,7 @@ mod tests {
             )
             .assert(dialog_query::the!("task/done").of(task.clone()).is(true))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1418,6 +1422,7 @@ mod tests {
             .transaction()
             .retract(dialog_query::the!("task/done").of(task.clone()).is(true))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1493,6 +1498,7 @@ mod tests {
             .assert(stage)
             .assert(finish)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1507,6 +1513,7 @@ mod tests {
                     .is(target.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1582,6 +1589,7 @@ mod tests {
             .assert(ping_to_pong)
             .assert(pong_to_ping)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1594,6 +1602,7 @@ mod tests {
                     .is(1u64),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await;
         assert!(
@@ -1635,6 +1644,7 @@ mod tests {
             .assert(stamp("cmd.x/target", "result.x/target"))
             .assert(stamp("cmd.y/target", "result.y/target"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1649,6 +1659,7 @@ mod tests {
                     .is(target.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1725,6 +1736,7 @@ mod tests {
                     .is("second".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1737,6 +1749,7 @@ mod tests {
                     .is(message.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1824,6 +1837,7 @@ mod tests {
             .assert(status)
             .assert(notify)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1845,6 +1859,7 @@ mod tests {
                     .is("hello".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1866,6 +1881,7 @@ mod tests {
                     .is("on-duty".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1911,6 +1927,7 @@ mod tests {
             .transaction()
             .assert(stamp("result.first/target"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1923,6 +1940,7 @@ mod tests {
                     .is(target.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1933,6 +1951,7 @@ mod tests {
             .transaction()
             .assert(stamp("result.second/target"))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1946,6 +1965,7 @@ mod tests {
                     .is(target.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1977,6 +1997,7 @@ mod tests {
             .transaction()
             .assert(tagger())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -1990,6 +2011,7 @@ mod tests {
                     .is("before".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2003,6 +2025,7 @@ mod tests {
             .transaction()
             .retract(tagger())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2016,6 +2039,7 @@ mod tests {
                     .is("after".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2046,6 +2070,7 @@ mod tests {
             .transaction()
             .assert(tagger())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2060,6 +2085,7 @@ mod tests {
                     .is("hello".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2097,6 +2123,7 @@ mod tests {
             )
             .assert(dialog_query::the!("dialog.rule/on").of(forged).is(on))
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2110,6 +2137,7 @@ mod tests {
                     .is("hello".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2141,6 +2169,7 @@ mod tests {
                     .is("hello".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2150,6 +2179,7 @@ mod tests {
             .transaction()
             .assert(tagger())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2193,6 +2223,7 @@ mod tests {
                     .is("pending".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2201,6 +2232,7 @@ mod tests {
             .transaction()
             .assert(drain)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2251,6 +2283,7 @@ mod tests {
                     .is("on-duty".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2281,6 +2314,7 @@ mod tests {
             .transaction()
             .assert(status)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2330,6 +2364,7 @@ mod tests {
             .transaction()
             .assert(tagger())
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2412,6 +2447,7 @@ mod tests {
             .transaction()
             .assert(pair)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2439,6 +2475,7 @@ mod tests {
                     .is("q".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2541,6 +2578,7 @@ mod tests {
                     .is("hello".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2553,6 +2591,7 @@ mod tests {
                     .is("doc:1".parse::<Entity>()?),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         assert_eq!(
@@ -2580,6 +2619,7 @@ mod tests {
                     .is("n".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2597,6 +2637,7 @@ mod tests {
                     .is("n".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2625,6 +2666,7 @@ mod tests {
             .transaction()
             .assert(stamp)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2719,6 +2761,7 @@ mod tests {
             .transaction()
             .assert(rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2731,6 +2774,7 @@ mod tests {
                     .is(list.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2782,6 +2826,7 @@ mod tests {
             .transaction()
             .assert(rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2795,6 +2840,7 @@ mod tests {
                     .is(item.clone()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2850,6 +2896,7 @@ mod tests {
             .transaction()
             .assert(rule)
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
         branch.refresh(&operator).await?;
@@ -2867,6 +2914,7 @@ mod tests {
                     .is("Milk".to_string()),
             )
             .commit()
+            .publish()
             .perform(&operator)
             .await;
         assert!(

--- a/rust/dialog-repository/src/repository/branch/transaction/query.rs
+++ b/rust/dialog-repository/src/repository/branch/transaction/query.rs
@@ -223,6 +223,7 @@ mod tests {
                 name: people::Name("Alice".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -329,6 +330,7 @@ mod tests {
                 name: people::Name("Bob".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -366,6 +368,7 @@ mod tests {
                 name: people::Name("Alice".into()),
             })
             .commit()
+            .publish()
             .perform(&operator)
             .await?;
 
@@ -457,7 +460,7 @@ mod tests {
             .try_vec()
             .await?;
         assert_eq!(seen.len(), 1, "txn-query must see Session");
-        tx.commit().perform(&operator).await?;
+        tx.commit().publish().perform(&operator).await?;
 
         // After commit, the branch tree must not contain any
         // `dialog.session/*` facts — those are auto-materialized at
@@ -540,6 +543,7 @@ mod tests {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is(name.to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?;
             revisions.push(branch.revision().expect("branch has a revision"));

--- a/rust/dialog-repository/src/repository/snapshot.rs
+++ b/rust/dialog-repository/src/repository/snapshot.rs
@@ -250,6 +250,30 @@ impl Snapshot {
         }
     }
 
+    /// The staged view inside a [`TransactionBatch`](crate::TransactionBatch):
+    /// reads like any snapshot of `revision`, but its line is pre-seeded
+    /// with the branch entity, so commits through it mint on the branch's
+    /// OWN origin — successor editions of the head the batch was staged
+    /// from — instead of allocating a random lineage of their own. That
+    /// is what lets [`BatchPublish`](crate::BatchPublish) move the branch
+    /// head to the staged tip with the versions exactly as minted.
+    pub(crate) fn staged(
+        subject: Subject,
+        revision: Revision,
+        caches: Caches,
+        line: Entity,
+    ) -> Self {
+        Snapshot {
+            subject,
+            head: RwLock::new(Head {
+                revision,
+                lineage: Some(line),
+            }),
+            caches,
+            overlay: Overlay::default(),
+        }
+    }
+
     /// The revision this snapshot names.
     pub fn revision(&self) -> Revision {
         self.head.read().revision.clone()

--- a/rust/dialog-repository/src/repository/snapshot/read_tests.rs
+++ b/rust/dialog-repository/src/repository/snapshot/read_tests.rs
@@ -146,6 +146,7 @@ async fn it_reads_what_the_branch_reads() -> Result<()> {
         .assert(person("id:alice", "Alice"))
         .assert(person("id:bob", "Bob"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
 
@@ -180,6 +181,7 @@ async fn it_stays_pinned_while_the_branch_advances() -> Result<()> {
         .transaction()
         .assert(person("id:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     let snapshot = branch.snapshot().expect("snapshot");
@@ -189,6 +191,7 @@ async fn it_stays_pinned_while_the_branch_advances() -> Result<()> {
         .transaction()
         .assert(person("id:bob", "Bob"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
 
@@ -231,6 +234,7 @@ async fn it_reads_through_a_cold_handle() -> Result<()> {
         .transaction()
         .assert(person("id:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
 
@@ -254,6 +258,7 @@ async fn it_fails_when_the_root_is_absent() -> Result<()> {
         .transaction()
         .assert(person("id:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     revision.tree = TreeReference::from([7u8; 32]);
@@ -282,6 +287,7 @@ async fn it_joins_a_snapshot_into_a_branch_query() -> Result<()> {
     main.transaction()
         .assert(person("id:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     let snapshot = main.snapshot().expect("snapshot");
@@ -291,6 +297,7 @@ async fn it_joins_a_snapshot_into_a_branch_query() -> Result<()> {
         .transaction()
         .assert(person("id:bob", "Bob"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
 
@@ -322,6 +329,7 @@ async fn it_injects_session_metadata() -> Result<()> {
         .transaction()
         .assert(person("id:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     let snapshot = branch.snapshot().expect("snapshot");
@@ -376,6 +384,7 @@ async fn it_folds_the_overlay_into_reads() -> Result<()> {
         .transaction()
         .assert(person("id:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     let snapshot = branch.snapshot().expect("snapshot");
@@ -453,6 +462,7 @@ async fn it_resolves_committed_rules() -> Result<()> {
                 .is("Alice".to_string()),
         )
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
 
@@ -490,6 +500,7 @@ async fn it_resolves_derived_revision_concepts() -> Result<()> {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is(name.to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?,
         );
@@ -542,6 +553,7 @@ async fn it_logs_history() -> Result<()> {
                 .transaction()
                 .assert(the!("user/name").of(Entity::new()?).is(name.to_string()))
                 .commit()
+                .publish()
                 .perform(&operator)
                 .await?,
         );
@@ -648,6 +660,7 @@ async fn it_reports_an_unreferenced_blob_as_absent() -> Result<()> {
         .transaction()
         .assert(person("id:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     let snapshot = branch.snapshot().expect("snapshot");

--- a/rust/dialog-repository/src/repository/snapshot/transaction_tests.rs
+++ b/rust/dialog-repository/src/repository/snapshot/transaction_tests.rs
@@ -144,6 +144,7 @@ async fn staged() -> Result<(
         .transaction()
         .assert(name("user:alice", "Alice"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     let snapshot = branch.snapshot().expect("a committed branch snapshots");
@@ -244,6 +245,7 @@ async fn it_mints_on_its_own_line() -> Result<()> {
         .transaction()
         .assert(name("user:carol", "Carol"))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
 
@@ -636,6 +638,7 @@ async fn it_induces_on_commit() -> Result<()> {
         .assert(increment)
         .assert(the!("counter/count").of(counter.clone()).is(1u64))
         .commit()
+        .publish()
         .perform(&operator)
         .await?;
     let snapshot = branch.snapshot().expect("snapshot");


### PR DESCRIPTION
A branch transaction's commit no longer publishes. It stages: the revision is minted on the branch's own origin, at the successor edition of the head, byte identical to what a published commit would mint, and comes back as a `TransactionBatch`. Further transactions chain onto the batch, and `.publish()` moves the branch head to the chain tip with one CAS, making every staged commit visible atomically at exactly the versions minted. One shot writers spell it `.commit().publish().perform(env)`.

```rust
// One shot (previous behavior, now explicit):
branch.transaction().assert(a).commit().publish().perform(&env).await?; // -> Revision

// Staged chain:
let batch = branch.transaction().assert(a).commit().perform(&env).await?; // -> TransactionBatch
let version = batch.version(); // authoritative and sync: the commit already minted it
batch.assert(capture(version)).commit().publish().perform(&env).await?;  // both links, one CAS
```

## Why

A writer that wants a fact naming its own commit could previously only predict the version before committing (racy, and unsound the moment the head moves) or commit twice (not atomic). Staging makes the version a fact about a commit that has already happened, and moves the atomicity boundary to publish: either every link of the chain becomes visible or none does. This supersedes #487, whose async `version()` accessor reported an unenforced prediction.

## Semantics

- `Transaction` and `TransactionCommit` are generic over the line they run on. Branch and batch commits stage; snapshot transactions are unchanged (a snapshot is a fork, not a stage: its commits keep advancing it in place on its own lineage and nothing publishes).
- A batch that loses the publish CAS is stale wholesale, since its editions now belong to whatever advanced the head. Recovery is re running the transaction against the fresh head; staged versions are never rewritten.
- An all no-op batch publishes nothing but re reads the head first, so a no-op verdict from a superseded view still fails with `VersionMismatch`. It still advances the induction watermark, because a no-op transaction was still an inducing instant; `Branch::induce` relies on this to adopt a head.
- Version keyed memos (records, contexts, causality) stay batch local until publish: a dropped batch's versions can be re minted with different content, so nothing keyed by them may reach the branch's shared memos before the CAS settles who owns them. Content keyed caches (nodes, spills, rules, plans, spine) stay shared.
- Staging needs no publish capability; only publish does.
- A virgin branch stages a genesis chain with no special casing.
- `TransactionBatch` is `#[must_use]`, which is what surfaced every call site of the old commit and publish behavior during the migration; they now publish explicitly.

## Known sharp edge

An abandoned batch leaves signed revision records at `(origin, edition)` pairs a retry re mints with different content. They are unreachable garbage and push only ships reachable blocks, so they should never travel; if one ever leaked, the equivocation defense would read it as a fork. The eventual fix is deferring record signing to publish time.

## Tests

New coverage in `transaction/batch.rs`: staging is invisible until publish and lands atomically on the branch origin at successor editions; the capture the minted version flow end to end against the branch history; a lost CAS fails loudly and re running reconciles; a genesis chain on a virgin branch; an empty batch is a no-op only at the current head. Full native suite passes (2666), `cargo fmt --all` and workspace `clippy --all-targets --all-features -D warnings` are clean. The wasm leg is target agnostic (no new deps, no cfg branches); CI is the first thing checking it.
