### PR TITLE
feat(operator): support bounded in-memory session grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ dependencies = [
  "dialog-varsig",
  "dirs",
  "ed25519-dalek",
+ "futures-util",
  "getrandom 0.2.16",
  "ipld-core",
  "parking_lot",

--- a/rust/dialog-operator/Cargo.toml
+++ b/rust/dialog-operator/Cargo.toml
@@ -45,6 +45,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "io-util"] }
 tracing = { workspace = true }
 [dev-dependencies]
+futures-util = { workspace = true }
 dialog-storage = { workspace = true, features = ["helpers"] }
 dialog-remote-s3 = { workspace = true, features = ["helpers"] }
 dialog-remote-ucan-s3 = { workspace = true, features = ["helpers"] }

--- a/rust/dialog-operator/src/operator/access.rs
+++ b/rust/dialog-operator/src/operator/access.rs
@@ -297,9 +297,11 @@ impl<S: Clone> Operator<S> {
 
     /// The session grant covering `claim`, if the operator holds one.
     fn session_grant(&self, claim: &Prove<Ucan>) -> Option<&UcanCertificate> {
-        self.session
-            .iter()
-            .find(|grant| grant.verify(&claim.access).is_ok())
+        self.session.iter().find(|grant| {
+            grant
+                .verify(&claim.access)
+                .is_ok_and(|range| range.covers(&claim.duration))
+        })
     }
 
     /// Re-resolve the access branch handle's head and upstream from
@@ -983,6 +985,124 @@ mod tests {
             .resolve(Prove::<Ucan>::new(operator.did(), storage_scope(&space)))
             .await?;
         assert_eq!(proof.proofs().len(), 2);
+        Ok(())
+    }
+    async fn retained_count(operator: &Operator<VolatileSpace>) -> Result<usize> {
+        use futures_util::TryStreamExt as _;
+        let rows: Vec<_> = operator
+            .delegations()?
+            .claims()
+            .select(dialog_artifacts::ArtifactSelector::new().the("dialog.ucan/audience".parse()?))
+            .perform(operator)
+            .await?
+            .try_collect()
+            .await?;
+        Ok(rows.len())
+    }
+
+    #[dialog_common::test]
+    async fn it_bounds_in_memory_sessions_without_retaining_them() -> Result<()> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique("bounded-session"))
+            .perform(&storage)
+            .await?;
+        let setup = profile.derive(b"setup").build(storage.clone()).await?;
+        let space = Ed25519Signer::generate().await?;
+        let now = now_s();
+        let upstream_end = now + 7200;
+        let delegation = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(space.clone()))
+            .audience(&profile.did())
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec!["storage".into()])
+            .expiration(Timestamp::try_from(upstream_end as i128)?)
+            .try_build()
+            .await?;
+        profile
+            .access()
+            .save(UcanDelegation::new(DelegationChain::new(delegation)))
+            .perform(&setup)
+            .await?;
+        let revision = setup.delegations()?.revision();
+        assert_eq!(retained_count(&setup).await?, 1);
+        let exported = Subject::from(profile.did())
+            .attenuate(Access)
+            .invoke(Export::<Ucan>::new())
+            .perform(&setup)
+            .await?;
+        for session_end in [now + 3600, now + 10800, now - 60] {
+            let operator = profile
+                .derive(session_end.to_le_bytes())
+                .allow_until(Subject::any(), Timestamp::try_from(session_end as i128)?)
+                .build(storage.clone())
+                .await?;
+            assert_eq!(operator.delegations()?.revision(), revision);
+            let end = session_end.min(upstream_end);
+            let mut claim = Prove::<Ucan>::new(operator.did(), storage_scope(&space));
+            claim.duration = TimeRange {
+                not_before: Some(end - 10),
+                expiration: Some(end - 1),
+            };
+            for _ in 0..2 {
+                let proof = operator.resolve(claim.clone()).await?;
+                assert_eq!(proof.duration().expiration, Some(end));
+                assert_eq!(proof.proofs().len(), 2);
+                assert_eq!(proof.proofs()[0].0.audience(), proof.proofs()[1].0.issuer());
+                assert_eq!(proof.proofs()[1].0.audience(), &operator.did());
+            }
+            let key = Operator::<VolatileSpace>::cache_key(&claim).unwrap();
+            assert_eq!(operator.cached(&key, &claim).is_some(), session_end > now);
+            claim.duration = TimeRange {
+                not_before: Some(now),
+                expiration: Some(now),
+            };
+            assert_eq!(
+                operator.resolve(claim.clone()).await.is_ok(),
+                session_end > now
+            );
+            claim.duration = TimeRange {
+                not_before: Some(end),
+                expiration: Some(end + 1),
+            };
+            assert!(operator.resolve(claim).await.is_err());
+            assert_eq!(operator.delegations()?.revision(), revision);
+            let after = Subject::from(profile.did())
+                .attenuate(Access)
+                .invoke(Export::<Ucan>::new())
+                .perform(&operator)
+                .await?;
+            assert_eq!(after.len(), exported.len());
+            assert_eq!(retained_count(&operator).await?, 1);
+        }
+        Ok(())
+    }
+    #[dialog_common::test]
+    async fn it_selects_a_session_grant_covering_the_requested_window() -> Result<()> {
+        let storage = Storage::volatile();
+        let profile = Profile::open(unique("session-windows"))
+            .perform(&storage)
+            .await?;
+        let now = now_s();
+        let operator = profile
+            .derive(b"test")
+            .allow_until(Subject::any(), Timestamp::try_from((now - 60) as i128)?)
+            .allow_until(Subject::any(), Timestamp::try_from((now + 3600) as i128)?)
+            .build(storage)
+            .await?;
+        let mut claim = Prove::<Ucan>::new(
+            operator.did(),
+            Scope {
+                subject: UcanSubject::Specific(profile.did()),
+                command: UcanCommand(vec!["storage".into()]),
+                parameters: Parameters::default(),
+            },
+        );
+        claim.duration = TimeRange {
+            not_before: Some(now),
+            expiration: Some(now),
+        };
+        let proof = operator.resolve(claim).await?;
+        assert_eq!(proof.duration.expiration, Some(now + 3600));
         Ok(())
     }
 }

--- a/rust/dialog-operator/src/operator/builder.rs
+++ b/rust/dialog-operator/src/operator/builder.rs
@@ -16,7 +16,7 @@ use dialog_repository::{ACCESS_BRANCH, RemoteSite};
 use dialog_storage::provider::space::SpaceProvider;
 use dialog_storage::provider::storage::Storage;
 use dialog_ucan::{Scope, UcanCertificate};
-use dialog_ucan_core::DelegationBuilder;
+use dialog_ucan_core::{DelegationBuilder, time::Timestamp};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use dialog_varsig::Signer;
 
@@ -42,7 +42,7 @@ impl DeriveOperator for Profile {
 pub struct OperatorBuilder {
     credential: SignerCredential,
     context: Vec<u8>,
-    allowed: Vec<Scope>,
+    allowed: Vec<(Scope, Option<Timestamp>)>,
     directory: Directory,
     network: Network,
 }
@@ -74,7 +74,19 @@ impl OperatorBuilder {
         Capability<T>: Ability,
     {
         let cap = capability.into();
-        self.allowed.push(Scope::from(&cap));
+        self.allowed.push((Scope::from(&cap), None));
+        self
+    }
+
+    /// Allow a capability until `expiration`, held only in memory.
+    pub fn allow_until<T, C>(mut self, capability: C, expiration: Timestamp) -> Self
+    where
+        T: Constraint,
+        C: Into<Capability<T>>,
+        Capability<T>: Ability,
+    {
+        let cap = capability.into();
+        self.allowed.push((Scope::from(&cap), Some(expiration)));
         self
     }
 
@@ -111,13 +123,17 @@ impl OperatorBuilder {
 
         // Mint the session: one in-memory grant per allowed scope.
         let mut session = Vec::with_capacity(self.allowed.len());
-        for scope in &self.allowed {
-            let delegation = DelegationBuilder::new()
+        for (scope, expiration) in &self.allowed {
+            let mut builder = DelegationBuilder::new()
                 .issuer(dialog_credentials::Signer::from(profile_signer.clone()))
                 .audience(&operator_signer)
                 .subject(scope.subject.clone())
                 .command(scope.command.segments().clone())
-                .policy(scope.policy())
+                .policy(scope.policy());
+            if let Some(expiration) = expiration {
+                builder = builder.expiration(*expiration);
+            }
+            let delegation = builder
                 .try_build()
                 .await
                 .map_err(|e| OperatorError::Delegation(format!("{e:?}")))?;


### PR DESCRIPTION
## What changed

Allow callers to create expiring profile-to-operator grants held only in memory with `OperatorBuilder::allow_until`. Existing `allow` callers retain unbounded behavior. Session selection now considers the requested time window so a lapsed overlapping grant cannot mask a valid grant.

This is the prerequisite for https://github.com/tonk-labs/tonk/pull/918: each worker can authorize its actual operator without retaining a session delegation on every boot. Tests verify chain continuity and audience, the earlier upstream/session expiry, fresh and cached proofs, historical/current windows, and unchanged access-branch revision and delegation count.

## Verification

- `cargo test -p dialog-operator --locked`: 33 passed.
- `cargo test -p dialog-operator --locked --target wasm32-unknown-unknown session`: four Chromium tests passed using `wbg-pool`.
- Rust formatting and diff whitespace checks passed.
- Downstream Tonk: 121 native tests, 40 focused Chromium tests, and its Nix dependency/build check passed against commit `314e49926eb5bca58bacdcf9f2123ccb4422ea35`.

Safari/iOS worker replacement, remote pull/push recovery, and signing latency measurements remain unverified.
