### PR TITLE
feat(remote): single-flight identical concurrent reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "hyper-util",
  "ipld-core",
  "md5",
+ "parking_lot",
  "rand 0.8.5",
  "reqwest",
  "s3s",

--- a/rust/dialog-remote-s3/Cargo.toml
+++ b/rust/dialog-remote-s3/Cargo.toml
@@ -56,6 +56,7 @@ rand = { workspace = true, optional = true }
 # reads the whole body with `bytes()`, and enabling `stream` there would pull in
 # `wasm-streams` (see the note on the workspace `reqwest`).
 reqwest = { workspace = true, features = ["stream"] }
+parking_lot = { workspace = true }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync", "fs", "macros", "rt", "net"], optional = true }
 s3s = { workspace = true, optional = true }
@@ -76,7 +77,7 @@ dialog-common = { workspace = true, features = ["helpers"] }
 ipld-core = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 wasm-bindgen-test = { workspace = true }
 
 

--- a/rust/dialog-remote-s3/src/error.rs
+++ b/rust/dialog-remote-s3/src/error.rs
@@ -8,7 +8,11 @@ use dialog_effects::memory::MemoryError;
 use thiserror::Error;
 
 /// Error type for S3 operations.
-#[derive(Debug, Error)]
+///
+/// `Clone` so a single-flight outcome (see [`crate::flight`]) can be
+/// shared with every joined caller; each variant already carries only
+/// clonable data.
+#[derive(Debug, Error, Clone)]
 pub enum S3Error {
     /// The request was not authorized.
     ///

--- a/rust/dialog-remote-s3/src/flight.rs
+++ b/rust/dialog-remote-s3/src/flight.rs
@@ -1,0 +1,299 @@
+//! Single-flight join for identical concurrent requests.
+//!
+//! Two callers asking the remote for the same immutable thing at the
+//! same moment each paid a full round trip: nothing here waited on a
+//! fetch another caller had in flight, because nothing could DRIVE that
+//! fetch — a future advances only while its owner polls it, and an
+//! owner parked between two yields left every waiter parked with it.
+//! That rule was load-bearing (an earlier claim-based dedup deadlocked
+//! a proof walk against its own in-flight fetch) but its price was real:
+//! a cold boot's concurrent tree walks fetched the same root block up
+//! to sixteen times.
+//!
+//! [`Flight`] removes the price without touching the rule, by removing
+//! the OWNER. The in-flight work is a [`Shared`] future: every caller
+//! that joins it polls the same underlying future, so whoever is
+//! actually awaiting makes progress for everyone, and a joiner never
+//! depends on the liveness of whoever arrived first. The re-entrant
+//! shape that sank the claim design — a walk needing a block whose
+//! fetch it is itself waiting on — now drives that fetch forward
+//! instead of parking behind it.
+//!
+//! The map holds only in-flight work. Whoever observes completion
+//! removes the entry (scoped by pointer identity, so a fresh flight
+//! started under the same key is left alone), which means outcomes are
+//! never cached here — a failure is shared with everyone already
+//! joined, and the next caller starts clean. Callers therefore keep
+//! their existing retry semantics.
+//!
+//! Only requests whose answer is identical for every caller belong in a
+//! flight: content-addressed block reads and permit redeems for one
+//! object. Mutable reads (a branch head cell) must not join one.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::Hash;
+
+use dialog_common::ConditionalSend;
+use futures_util::FutureExt;
+use futures_util::future::Shared;
+
+#[cfg(not(target_arch = "wasm32"))]
+use futures_util::future::BoxFuture;
+#[cfg(target_arch = "wasm32")]
+use futures_util::future::LocalBoxFuture;
+
+#[cfg(not(target_arch = "wasm32"))]
+type Stored<V> = Shared<BoxFuture<'static, V>>;
+#[cfg(target_arch = "wasm32")]
+type Stored<V> = Shared<LocalBoxFuture<'static, V>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type Map<K, V> = parking_lot::Mutex<HashMap<K, Stored<V>>>;
+// A worker context is single-threaded; RefCell is enough, and the
+// borrow never crosses an await (see `join`).
+#[cfg(target_arch = "wasm32")]
+type Map<K, V> = std::cell::RefCell<HashMap<K, Stored<V>>>;
+
+/// A map of in-flight computations, joined by key.
+///
+/// See the module docs for the semantics; [`join`](Flight::join) is the
+/// whole API.
+pub struct Flight<K, V> {
+    inflight: Map<K, V>,
+}
+
+impl<K, V> Default for Flight<K, V> {
+    fn default() -> Self {
+        Self {
+            inflight: Map::default(),
+        }
+    }
+}
+
+impl<K, V> std::fmt::Debug for Flight<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Flight")
+            .field("inflight", &self.lock().len())
+            .finish()
+    }
+}
+
+impl<K, V> Flight<K, V> {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn lock(&self) -> parking_lot::MutexGuard<'_, HashMap<K, Stored<V>>> {
+        self.inflight.lock()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn lock(&self) -> std::cell::RefMut<'_, HashMap<K, Stored<V>>> {
+        self.inflight.borrow_mut()
+    }
+}
+
+impl<K, V> Flight<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    /// Join the in-flight computation for `key`, or start `make()` as
+    /// the shared one.
+    ///
+    /// Every joiner polls the shared future itself, so completion never
+    /// depends on the caller that started it. The entry is removed once
+    /// any joiner observes completion; outcomes — failures included —
+    /// are shared only with callers already in flight, never cached.
+    pub async fn join<F, Make>(&self, key: K, make: Make) -> V
+    where
+        Make: FnOnce() -> F,
+        F: Future<Output = V> + ConditionalSend + 'static,
+    {
+        let shared = {
+            let mut inflight = self.lock();
+            match inflight.get(&key) {
+                Some(shared) => shared.clone(),
+                None => {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let shared = make().boxed().shared();
+                    #[cfg(target_arch = "wasm32")]
+                    let shared = make().boxed_local().shared();
+                    inflight.insert(key.clone(), shared.clone());
+                    shared
+                }
+            }
+            // The guard drops here: the map is never held across an await.
+        };
+
+        let value = shared.clone().await;
+
+        let mut inflight = self.lock();
+        if inflight
+            .get(&key)
+            .is_some_and(|current| current.ptr_eq(&shared))
+        {
+            inflight.remove(&key);
+        }
+        drop(inflight);
+
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::Flight;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    async fn yield_once() {
+        let mut yielded = false;
+        std::future::poll_fn(move |context| {
+            if yielded {
+                std::task::Poll::Ready(())
+            } else {
+                yielded = true;
+                context.waker().wake_by_ref();
+                std::task::Poll::Pending
+            }
+        })
+        .await
+    }
+
+    /// Concurrent joins of one key run the computation once and all see
+    /// its value.
+    #[dialog_common::test]
+    async fn it_runs_one_computation_for_concurrent_joins() {
+        let flight = Flight::<u8, u8>::default();
+        let runs = Arc::new(AtomicUsize::new(0));
+
+        let make = || {
+            let runs = runs.clone();
+            || async move {
+                runs.fetch_add(1, Ordering::SeqCst);
+                yield_once().await;
+                7u8
+            }
+        };
+
+        let (first, second) =
+            futures_util::future::join(flight.join(1, make()), flight.join(1, make())).await;
+
+        assert_eq!((first, second), (7, 7));
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+    }
+
+    /// The joiner drives the shared computation itself: an initiator
+    /// polled once and then parked forever must not park the joiner
+    /// with it. This is the invariant whose violation sank the old
+    /// claim-based dedup.
+    // Native only: the bound is tokio's timer, which has no wasm runtime.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_lets_a_joiner_drive_a_flight_the_initiator_parked() {
+        use std::task::{Context, Poll};
+
+        let flight = Arc::new(Flight::<u8, u8>::default());
+        let runs = Arc::new(AtomicUsize::new(0));
+
+        let make = || {
+            let runs = runs.clone();
+            || async move {
+                runs.fetch_add(1, Ordering::SeqCst);
+                yield_once().await;
+                9u8
+            }
+        };
+
+        // The initiator starts the flight and is never polled again.
+        let mut parked = Box::pin(flight.join(1, make()));
+        let waker = std::task::Waker::noop();
+        let mut context = Context::from_waker(waker);
+        assert!(matches!(parked.as_mut().poll(&mut context), Poll::Pending));
+        assert_eq!(runs.load(Ordering::SeqCst), 1, "the flight is in flight");
+
+        let joined = flight.join(1, make());
+        let value = tokio::time::timeout(std::time::Duration::from_secs(2), joined)
+            .await
+            .expect("a joiner must be able to drive a parked flight");
+        assert_eq!(value, 9);
+        assert_eq!(
+            runs.load(Ordering::SeqCst),
+            1,
+            "the joiner joined, not re-ran"
+        );
+
+        drop(parked);
+    }
+
+    /// A failure is shared with the callers already joined and cached
+    /// for nobody: the next join starts a fresh computation.
+    #[dialog_common::test]
+    async fn it_shares_a_failure_without_caching_it() {
+        let flight = Flight::<u8, Result<u8, &'static str>>::default();
+        let runs = Arc::new(AtomicUsize::new(0));
+
+        let failing = {
+            let runs = runs.clone();
+            || async move {
+                runs.fetch_add(1, Ordering::SeqCst);
+                yield_once().await;
+                Err("no")
+            }
+        };
+        let (first, second) = futures_util::future::join(
+            flight.join(1, failing),
+            flight.join(1, {
+                let runs = runs.clone();
+                || async move {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    yield_once().await;
+                    Err("no")
+                }
+            }),
+        )
+        .await;
+        assert_eq!(first, Err("no"));
+        assert_eq!(second, Err("no"));
+        assert_eq!(runs.load(Ordering::SeqCst), 1, "the failure was shared");
+
+        let retried = flight
+            .join(1, {
+                let runs = runs.clone();
+                || async move {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    Ok(3)
+                }
+            })
+            .await;
+        assert_eq!(retried, Ok(3));
+        assert_eq!(runs.load(Ordering::SeqCst), 2, "nothing was cached");
+    }
+
+    /// Sequential joins each run their own computation: the map holds
+    /// in-flight work only.
+    #[dialog_common::test]
+    async fn it_removes_the_entry_once_the_flight_lands() {
+        let flight = Flight::<u8, u8>::default();
+        let runs = Arc::new(AtomicUsize::new(0));
+
+        for expected in 1..=2 {
+            let value = flight
+                .join(1, {
+                    let runs = runs.clone();
+                    || async move {
+                        runs.fetch_add(1, Ordering::SeqCst);
+                        5u8
+                    }
+                })
+                .await;
+            assert_eq!(value, 5);
+            assert_eq!(runs.load(Ordering::SeqCst), expected);
+        }
+    }
+}

--- a/rust/dialog-remote-s3/src/lib.rs
+++ b/rust/dialog-remote-s3/src/lib.rs
@@ -45,6 +45,7 @@
 
 mod client;
 mod error;
+pub mod flight;
 pub mod request;
 pub mod s3;
 

--- a/rust/dialog-remote-s3/src/s3/provider/archive.rs
+++ b/rust/dialog-remote-s3/src/s3/provider/archive.rs
@@ -1,5 +1,7 @@
 //! Archive providers for S3.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use dialog_capability::ForkInvocation;
 use dialog_capability::Provider;
@@ -7,7 +9,37 @@ use dialog_capability::access::AuthorizeError;
 use dialog_effects::archive::*;
 use reqwest::StatusCode;
 
+use crate::S3Error;
+use crate::flight::Flight;
 use crate::s3::{S3, S3Invocation};
+
+/// In-flight block GETs, joined by presigned URL.
+///
+/// A block is immutable content, so every caller holding the same
+/// presigned URL gets the same bytes — the one read that is always safe
+/// to share. The URL's signature binds it to the permit (and through it
+/// the operator) that redeemed it, so a process-wide registry shares
+/// nothing across operators: a different operator's request for the
+/// same object carries a different signature and never joins.
+///
+/// Mutable reads (memory cells) deliberately do not come through here.
+type BlockGets = Flight<String, Result<(u16, Arc<Vec<u8>>), S3Error>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn block_gets() -> &'static BlockGets {
+    static BLOCK_GETS: std::sync::LazyLock<BlockGets> = std::sync::LazyLock::new(Flight::default);
+    &BLOCK_GETS
+}
+
+/// See the native arm; a worker context is single-threaded, so the
+/// registry lives in a thread-local and is handed out by `Rc`.
+#[cfg(target_arch = "wasm32")]
+fn block_gets() -> std::rc::Rc<BlockGets> {
+    thread_local! {
+        static BLOCK_GETS: std::rc::Rc<BlockGets> = Default::default();
+    }
+    BLOCK_GETS.with(std::rc::Rc::clone)
+}
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -30,26 +62,35 @@ impl Provider<ForkInvocation<S3, Get>> for S3 {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider<S3Invocation<Get>> for S3 {
     async fn execute(&self, input: S3Invocation<Get>) -> Result<Option<Vec<u8>>, ArchiveError> {
-        let response = input.permit.send().await?;
+        // Concurrent readers of one block join a single request; see
+        // `block_gets`. The future owns its permit, so it outlives any
+        // one caller and whoever still cares drives it.
+        let key = input.permit.url.to_string();
+        let permit = input.permit;
+        let (status, bytes) = block_gets()
+            .join(key, move || async move {
+                let response = permit.send().await?;
+                let status = response.status().as_u16();
+                let bytes = response.bytes().await.map_err(S3Error::from)?;
+                Ok((status, Arc::new(bytes.to_vec())))
+            })
+            .await?;
 
-        if response.status().is_success() {
-            let bytes = response.bytes().await.map_err(crate::S3Error::from)?;
-            Ok(Some(bytes.to_vec()))
-        } else if response.status() == StatusCode::NOT_FOUND {
+        let status = StatusCode::from_u16(status)
+            .map_err(|error| ArchiveError::Storage(format!("invalid status: {error}")))?;
+        if status.is_success() {
+            Ok(Some(bytes.as_ref().clone()))
+        } else if status == StatusCode::NOT_FOUND {
             Ok(None)
-        } else if matches!(
-            response.status(),
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
-        ) {
+        } else if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
             Err(ArchiveError::Authorization(
                 AuthorizeError::UnavailableProof {
-                    link: format!("Failed to get value: {}", response.status()),
+                    link: format!("Failed to get value: {status}"),
                 },
             ))
         } else {
             Err(ArchiveError::Storage(format!(
-                "Failed to get value: {}",
-                response.status()
+                "Failed to get value: {status}"
             )))
         }
     }
@@ -66,6 +107,95 @@ impl Provider<ForkInvocation<S3, Put>> for S3 {
             .invoke(input.capability)
             .perform(self)
             .await
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use dialog_capability::{Provider, Subject, did};
+    use dialog_effects::Use;
+    use dialog_effects::archive::{Archive, Catalog, Get};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use crate::s3::{Permit, S3, S3Invocation};
+
+    /// A one-shot object server: answers every GET with the same bytes,
+    /// counting how many requests arrived.
+    async fn counting_server(body: &'static [u8]) -> (String, Arc<AtomicUsize>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let count = Arc::new(AtomicUsize::new(0));
+        let counted = count.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                counted.fetch_add(1, Ordering::SeqCst);
+                let mut buffer = [0u8; 4096];
+                let _ = stream.read(&mut buffer).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.write_all(body).await;
+            }
+        });
+        (endpoint, count)
+    }
+
+    /// Concurrent readers holding one presigned URL share one request:
+    /// a block is immutable, so the second read joins the first's
+    /// in-flight fetch instead of paying its own round trip.
+    #[dialog_common::test]
+    async fn it_shares_one_fetch_between_concurrent_block_reads() {
+        let (endpoint, hits) = counting_server(b"block bytes").await;
+
+        let permit = Permit {
+            url: format!("{endpoint}/bucket/subject/index/shared-block")
+                .parse()
+                .unwrap(),
+            method: "GET".to_string(),
+            headers: vec![],
+        };
+        let capability = || {
+            Subject::from(did!("key:zSharedBlockReadTest"))
+                .attenuate(Use)
+                .attenuate(Archive)
+                .attenuate(Catalog::new("index"))
+                .invoke(Get::new([4u8; 32]))
+        };
+
+        let first = Provider::<S3Invocation<Get>>::execute(
+            &S3,
+            S3Invocation::new(permit.clone(), capability()),
+        );
+        let second = Provider::<S3Invocation<Get>>::execute(
+            &S3,
+            S3Invocation::new(permit.clone(), capability()),
+        );
+        let (first, second) = tokio::join!(first, second);
+
+        assert_eq!(first.unwrap(), Some(b"block bytes".to_vec()));
+        assert_eq!(second.unwrap(), Some(b"block bytes".to_vec()));
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "concurrent reads of one presigned URL must share one fetch"
+        );
+
+        // The flight holds in-flight work only: a later read fetches
+        // afresh rather than being served yesterday's response.
+        let third =
+            Provider::<S3Invocation<Get>>::execute(&S3, S3Invocation::new(permit, capability()))
+                .await
+                .unwrap();
+        assert_eq!(third, Some(b"block bytes".to_vec()));
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
     }
 }
 

--- a/rust/dialog-remote-ucan-s3/src/provider.rs
+++ b/rust/dialog-remote-ucan-s3/src/provider.rs
@@ -50,15 +50,29 @@ where
 
         let cached = key.as_ref().and_then(|key| cache.lookup(key, now));
         let from_cache = cached.is_some();
-        let permit = match cached {
-            Some(permit) => permit,
-            None => {
-                let permit = invocation.authorization.redeem(&invocation.address).await?;
-                if let Some(key) = key.clone() {
-                    cache.store(key, &permit, now);
-                }
-                permit
+        let permit = match (cached, &key) {
+            (Some(permit), _) => permit,
+            // A cacheable miss joins the site's in-flight redeems:
+            // concurrent requests for one object share a single redeem
+            // round-trip, and whoever completes it stores the permit —
+            // exactly once — for the TTL window that follows. The shared
+            // future owns clones of everything it touches, so any joiner
+            // can drive it; a shared failure is returned to everyone in
+            // flight and cached for nobody.
+            (None, Some(key)) => {
+                let authorization = invocation.authorization.clone();
+                let address = invocation.address.clone();
+                let permits = self.permits_shared();
+                let key = key.clone();
+                self.redeems()
+                    .join(key.clone(), move || async move {
+                        let permit = authorization.redeem(&address).await?;
+                        permits.store(key, &permit, time::now());
+                        Ok(permit)
+                    })
+                    .await?
             }
+            (None, None) => invocation.authorization.redeem(&invocation.address).await?,
         };
 
         // A retry presents the capability a second time, so it is
@@ -213,6 +227,90 @@ mod tests {
         use dialog_effects::blob::BlobError;
         use dialog_effects::blob::prelude::{ArchiveBlobExt, BlobExt};
         use dialog_remote_s3::helpers::LocalS3;
+
+        /// A one-shot access service: answers every POST with the given
+        /// permit, counting how many redeems arrived.
+        async fn counting_redeemer(
+            permit: Permit,
+        ) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+            use std::sync::Arc;
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let endpoint = format!("http://{}", listener.local_addr().unwrap());
+            let count = Arc::new(AtomicUsize::new(0));
+            let counted = count.clone();
+            let body = serde_ipld_dagcbor::to_vec(&permit).unwrap();
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut stream, _)) = listener.accept().await else {
+                        break;
+                    };
+                    counted.fetch_add(1, Ordering::SeqCst);
+                    let mut buffer = [0u8; 8192];
+                    let _ = stream.read(&mut buffer).await;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/cbor\r\n\
+                         Content-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.write_all(&body).await;
+                }
+            });
+            (endpoint, count)
+        }
+
+        /// Concurrent requests for one cacheable object share a single
+        /// redeem round-trip: the second joins the first's in-flight
+        /// redeem instead of POSTing its own invocation.
+        #[dialog_common::test]
+        async fn it_shares_one_redeem_between_concurrent_requests() {
+            let (endpoint, redeems) = counting_redeemer(unreachable_permit()).await;
+
+            let signer = Ed25519Signer::import(&[11u8; 32]).await.unwrap();
+            let capability = || {
+                Subject::from(did!("key:zSharedRedeemTest"))
+                    .attenuate(Use)
+                    .attenuate(Archive)
+                    .attenuate(Catalog::new("blocks"))
+                    .invoke(Get::new([3u8; 32]))
+            };
+
+            let site = UcanSite::default();
+            let address = UcanAddress::new(endpoint);
+            let authorization = self_authorization(&signer).await;
+
+            type Read = Result<Option<Vec<u8>>, ArchiveError>;
+            let first = site.execute(ForkInvocation::new(
+                capability(),
+                address.clone(),
+                authorization.clone(),
+            ));
+            let second = site.execute(ForkInvocation::new(
+                capability(),
+                address.clone(),
+                authorization,
+            ));
+            let (first, second): (Read, Read) = tokio::join!(first, second);
+
+            // The permit points nowhere, so the S3 leg fails for both —
+            // past the redeem, which is the leg under test.
+            assert!(first.is_err() && second.is_err());
+            assert_eq!(
+                redeems.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "concurrent requests for one object must share one redeem"
+            );
+
+            let key = PermitKey::cacheable(&address, capability().to_request())
+                .expect("a GET request is cacheable");
+            assert!(
+                site.permits().lookup(&key, time::now()).is_some(),
+                "the shared redeem stores the permit once for the TTL window"
+            );
+        }
 
         /// The pin for the presence-probe finding: a GET that comes
         /// back 404 is a semantic outcome, not a permit failure. The

--- a/rust/dialog-remote-ucan-s3/src/site.rs
+++ b/rust/dialog-remote-ucan-s3/src/site.rs
@@ -45,7 +45,8 @@ fn read_rejection(status: u16, body: &[u8]) -> S3Error {
     })
 }
 
-use crate::permit_cache::PermitCache;
+use crate::permit_cache::{PermitCache, PermitKey};
+use dialog_remote_s3::flight::Flight;
 
 // Re-export UCAN types for convenience.
 pub use dialog_ucan::{Ucan, UcanInvocation};
@@ -214,15 +215,33 @@ fn now_s() -> u64 {
 /// this site (one `Network`, hence one `Operator`) and are dropped with
 /// it; another operator in the same process has its own site and can
 /// never be served a permit this one redeemed. Clones share the cache.
+///
+/// The site also owns the in-flight redeem [`Flight`]: concurrent
+/// requests for one cacheable object share a single redeem round-trip
+/// instead of each POSTing an invocation for the same permit. Scoped to
+/// the site for the same reason the cache is — a redeem carries this
+/// operator's authorization, and nobody else may ride it.
 #[derive(Debug, Clone, Default)]
 pub struct UcanSite {
     permits: Arc<PermitCache>,
+    redeems: Arc<Flight<PermitKey, Result<Permit, S3Error>>>,
 }
 
 impl UcanSite {
     /// The cache of redeemed GET permits shared by clones of this site.
     pub(crate) fn permits(&self) -> &PermitCache {
         &self.permits
+    }
+
+    /// The permit cache as an owned handle, for futures that outlive
+    /// any one borrow of the site.
+    pub(crate) fn permits_shared(&self) -> Arc<PermitCache> {
+        self.permits.clone()
+    }
+
+    /// The in-flight redeems shared by clones of this site.
+    pub(crate) fn redeems(&self) -> &Flight<PermitKey, Result<Permit, S3Error>> {
+        &self.redeems
     }
 }
 


### PR DESCRIPTION
A cold boot's concurrent tree walks each paid a full round trip for the same block: measured in tonk's browser harness, 26-37% of a cold join's block fetches were duplicates, with the tree root fetched 10x in the same second. The cache layer does this deliberately — nothing waits on a fetch another caller owns, because only the owner can drive it, and an earlier claim-based dedup deadlocked a proof walk against its own in-flight fetch. A previous attempt to fix this at the cache layer also spread `'static` bounds through the env-borrowing provider chain and was rejected.

This takes a different route on both counts. `Flight<K, V>` stores in-flight work as a `Shared` future with no owner: every joiner polls it itself, so completion never depends on whoever arrived first, and the re-entrant shape that sank the claim design now drives the fetch forward instead of parking behind it (pinned by a test that polls the initiator once, parks it forever, and requires a joiner to complete anyway). And it lives only in the concrete remote crates, where futures own everything they touch and are `'static` for free — the generic cache, the accessor, and every env-borrowing signature are untouched.

Two joins, both scoped to reads whose answer is identical for every caller:

- `UcanSite` shares concurrent redeems per `PermitKey`. One invocation chain still buys exactly one permit — this dedups the concurrent window the permit cache's TTL cannot see — and the winner stores the permit exactly once.
- Archive block GETs share by presigned URL. Blocks are immutable, and the URL's signature scopes sharing to the operator that redeemed it, so a process-wide registry crosses no authorization boundary. Memory cells stay unshared: they are mutable heads and must answer fresh.

The map holds in-flight work only. Whoever observes completion removes the entry (by pointer identity, so a fresh flight under the same key is left alone), failures reach only callers already joined, and nothing is ever cached — callers keep their retry semantics.

Re-measured on the same harness scenario: 48 block GET permits, 48 distinct objects, 0 repeat fetches.

Full `dialog-repository` integration suite passes (351), both crates' unit suites pass (67), `cargo fmt` and `clippy --all-targets -D warnings` clean, wasm targets compile.