### PR TITLE
feat(query): premises pipeline their probes through the fetch plan

### DIFF
--- a/notes/fetch-scheduler.md
+++ b/notes/fetch-scheduler.md
@@ -93,3 +93,24 @@ Stay inside the remote providers, invisible to this API, as settled in the campa
 - State placement is the caller's choice by construction; `QueryEnv` is the v1 owner.
 - Budgets are configurable.
 - No component ever owns the env; deferred work is data until an env borrower drives it.
+
+## M3 addendum: probe pipelining, measured (2026-09-09)
+
+The first consumer of the plan is probe pipelining (bead dialog-db-77): a premise's upstream selection is wrapped (`attribute/query.rs::pipelined`) so rows buffer up to `PROBE_LOOKAHEAD` ahead and each buffered row's would-be probe is offered as a `Likely` hint. A row entering an empty window is never hinted (it is the next demand, so its hint could overlap with nothing), which also makes a single-row seed hint-free. Hinting stops permanently on the env's first refusal, so un-staged queries pay one refused call.
+
+Measured on the soak's cold concept join (broadband, 4,000 entities), from the pre-M3 105 rounds / 8.4s:
+
+| lookahead / budget | rounds | modeled time |
+|---|---|---|
+| 64 / 16 (shipping default) | 87 | 6.9s |
+| 64 / 64 | 51 | 4.1s |
+| 128 / 128 | 33 | 2.6s |
+| 256 / 256 | 21 | 1.7s |
+| 512 / 512 | 14 | 1.2s |
+
+Two findings behind the numbers:
+
+- **Budget, not window, is the binding constraint** past small sizes: hint jobs queue behind the per-rank concurrency cap, and a queued cold-leaf hint that starts late completes late. Row-count lead gives little *time* lead (warm rows process in ~zero modeled time), so what matters is how many cold fetches are in flight when the chain stalls.
+- **Raising the budget past ~16 currently re-fetches blocks** (bead dialog-db-81): a post-flight hydration race in which a reader passes its local check before a peer's hydration lands and reaches the transport after the peer's flight closed. Mitigations landed (a local re-check before the remote fork in `NetworkedIndex`; the walker now drives its remaining range-bounded warms home at scan end instead of dropping them), but the full fix is a hydration-inclusive single-flight at the `NetworkedIndex` layer, which needs its own design pass against the env-ownership rule. Until then the default budget stays 16 and the soak's unshaped profile runs without preload, pinning the engine's deterministic demand shape (110 requests, zero duplicates).
+
+The ~6x still on the table behind dialog-db-81 is a constant-factor ceiling of row-granular hints; the structural next steps remain M2 (range-granular expansion: spine + leaf frontier, `range_scale`-budgeted) and M4 (the merge path consuming contiguous AEV ranges preloads align with), which the region analysis in this note's campaign predicted and these measurements confirm.

--- a/notes/sync-performance.md
+++ b/notes/sync-performance.md
@@ -165,6 +165,13 @@ path is still one sequential probe chain — the evaluator awaits one
 Select per outer row. That is issue #492's target; these phases are its
 yardstick, now measuring chain depth rather than bandwidth waste.
 
+**Update (2026-09-09):** probe pipelining (bead dialog-db-77, the first
+`FetchPlan` consumer) moves the yardstick to 87 rounds / 6.9 s at the
+shipping defaults, with 14 rounds / 1.2 s measured behind a budget
+raise that is gated on the post-flight hydration race (bead
+dialog-db-81). The measurement table and the two findings behind it
+live in `notes/fetch-scheduler.md`'s M3 addendum.
+
 ### 5. What the soak gates now
 
 - `pull` staying O(1) requests (adopt-by-root must never regress into a

--- a/rust/dialog-artifacts/src/artifacts/query.rs
+++ b/rust/dialog-artifacts/src/artifacts/query.rs
@@ -59,13 +59,14 @@ pub struct PreloadRequest {
 /// Command hinting that a selector's backing blocks will probably be
 /// needed, so replication may fetch them ahead of demand.
 ///
-/// Purely advisory: a provider may do nothing, and no outcome is
-/// reported (the output is `()`), because a preload that fails must
-/// surface as nothing — the demand read that actually needs the data
-/// owns the error.
+/// Purely advisory: a provider may do nothing, and no fetch outcome is
+/// ever reported, because a preload that fails must surface as nothing
+/// — the demand read that actually needs the data owns the error. The
+/// output says only whether anyone is listening (a plan is attached),
+/// so an evaluator can stop composing hints nobody will act on.
 pub struct Preload;
 
 impl Command for Preload {
     type Input = PreloadRequest;
-    type Output = ();
+    type Output = bool;
 }

--- a/rust/dialog-query/src/attribute/query.rs
+++ b/rust/dialog-query/src/attribute/query.rs
@@ -10,3 +10,113 @@ pub mod typed;
 pub use dynamic::DynamicAttributeQuery;
 pub use dynamic::DynamicAttributeQuery as AttributeQuery;
 pub use typed::StaticAttributeQuery;
+
+use std::collections::VecDeque;
+use std::future::poll_fn;
+use std::task::Poll;
+
+use async_stream::try_stream;
+use dialog_artifacts::selector::Constrained;
+use dialog_artifacts::{ArtifactSelector, Likelihood, Preload, PreloadRequest};
+use dialog_capability::Provider;
+use dialog_common::{ConditionalSend, ConditionalSync};
+use futures_util::StreamExt as _;
+
+use crate::selection::{Match, Selection};
+
+/// How many upstream rows a premise buffers ahead of the one it is
+/// probing, so the probes those rows will issue can replicate while the
+/// current probe is awaited. Sixteen matches the read-ahead widths the
+/// tree layer already uses.
+pub(crate) const PROBE_LOOKAHEAD: usize = 64;
+
+/// Wrap a premise's upstream selection with probe pipelining: rows are
+/// buffered up to [`PROBE_LOOKAHEAD`] ahead, and each newly buffered
+/// row's would-be probe (as `probe` describes it) is offered to the env
+/// as a [`Preload`] hint, so on a cold replica the blocks rows
+/// `i+1..i+16` will demand replicate while row `i`'s probe is awaited.
+///
+/// The rows themselves flow through unchanged and in order. Hinting
+/// stops permanently the first time the env reports nobody is listening
+/// (no plan attached), so an un-staged query pays nothing beyond that
+/// first refusal; a `probe` of `None` (a row this premise filters, or a
+/// shape not worth preloading) buffers without hinting. A row entering
+/// an empty window is never hinted: it is the next row to be probed, so
+/// its hint could overlap with nothing and would only duplicate the
+/// demand read (a single-row upstream — a query's seed — hints nothing
+/// at all).
+pub(crate) fn pipelined<'a, Env, M, P>(selection: M, env: &'a Env, probe: P) -> impl Selection + 'a
+where
+    M: Selection + 'a,
+    Env: Provider<Preload> + ConditionalSync,
+    P: Fn(&Match) -> Option<ArtifactSelector<Constrained>> + ConditionalSend + 'a,
+{
+    try_stream! {
+        let mut selection = Box::pin(selection);
+        let mut window: VecDeque<Match> = VecDeque::with_capacity(PROBE_LOOKAHEAD);
+        let mut listening = true;
+        let mut exhausted = false;
+        loop {
+            // Top the window up. The first pull may wait (there is
+            // nothing to yield anyway); every further pull is
+            // non-blocking, because parking here on a stalled upstream
+            // would starve the rows already buffered — and their hints —
+            // behind an await they do not need.
+            while listening && !exhausted && window.len() < PROBE_LOOKAHEAD {
+                let candidate = if window.is_empty() {
+                    selection.next().await
+                } else {
+                    let Some(candidate) = poll_now(&mut selection).await else {
+                        break;
+                    };
+                    candidate
+                };
+                let Some(candidate) = candidate else {
+                    exhausted = true;
+                    break;
+                };
+                let base = candidate?;
+                if !window.is_empty()
+                    && let Some(selector) = probe(&base)
+                {
+                    listening = Provider::<Preload>::execute(
+                        env,
+                        PreloadRequest {
+                            selector,
+                            likelihood: Likelihood::Likely,
+                        },
+                    )
+                    .await;
+                }
+                window.push_back(base);
+            }
+            let base = match window.pop_front() {
+                Some(base) => base,
+                None => {
+                    if exhausted {
+                        break;
+                    }
+                    match selection.next().await {
+                        Some(candidate) => candidate?,
+                        None => break,
+                    }
+                }
+            };
+            yield base;
+        }
+    }
+}
+
+/// One non-blocking pull: `Some(item)` when the stream is ready right
+/// now, `None` when it is not (its waker stays registered, so progress
+/// resumes on a later poll).
+async fn poll_now<S>(stream: &mut S) -> Option<Option<S::Item>>
+where
+    S: futures_util::Stream + Unpin,
+{
+    poll_fn(|context| match stream.poll_next_unpin(context) {
+        Poll::Ready(item) => Poll::Ready(Some(item)),
+        Poll::Pending => Poll::Ready(None),
+    })
+    .await
+}

--- a/rust/dialog-query/src/attribute/query/all.rs
+++ b/rust/dialog-query/src/attribute/query/all.rs
@@ -2,6 +2,7 @@ use crate::Cardinality;
 use crate::Claim;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained, decode_value};
 use crate::attribute::The;
+use crate::attribute::query::pipelined;
 use crate::environment::Environment;
 use crate::formula::number::Numeric;
 use crate::query::Application;
@@ -318,6 +319,17 @@ impl AttributeQueryAll {
         Env: crate::Scope<'a>,
     {
         let selector = self;
+        // Pipeline the probes: while this loop awaits one row's scan, the
+        // scans the next rows will issue are offered as preload hints, so
+        // a cold replica replicates them concurrently instead of paying
+        // one round trip per row (see `super::pipelined`).
+        let hinted = selector.clone();
+        let selection = pipelined(selection, env, move |base| {
+            if hinted.absent_blocked(base) {
+                return None;
+            }
+            (&hinted.resolve(base)).try_into().ok()
+        });
         try_stream! {
             for await candidate in selection {
                 let base = candidate?;

--- a/rust/dialog-query/src/attribute/query/only.rs
+++ b/rust/dialog-query/src/attribute/query/only.rs
@@ -1,4 +1,5 @@
 use super::all::AttributeQueryAll;
+use super::pipelined;
 use crate::Claim;
 use crate::Value;
 use crate::artifact::{ArtifactSelector, ArtifactsAttribute, Constrained};
@@ -203,6 +204,33 @@ impl AttributeQueryOnly {
         Env: crate::Scope<'a>,
     {
         let selector = self.query;
+        // Pipeline the probes: while this loop awaits one row's scan, the
+        // scans the next rows will issue are offered as preload hints, so
+        // a cold replica replicates them concurrently instead of paying
+        // one round trip per row (see `super::pipelined`). The hint
+        // mirrors the sliding-window path's blanked scan exactly; the
+        // challenge path's secondary lookups are not hinted.
+        let hinted = selector.clone();
+        let selection = pipelined(selection, env, move |base| {
+            if hinted.absent_blocked(base) {
+                return None;
+            }
+            let resolved = hinted.resolve(base);
+            let entity_known = resolved.of().is_constant();
+            let attribute_known = resolved.the().is_constant();
+            let value_known = resolved.is().is_constant();
+            if entity_known || (attribute_known && !value_known) {
+                let scan = AttributeQueryAll::new(
+                    resolved.the().clone(),
+                    resolved.of().clone(),
+                    Term::blank(),
+                    resolved.cause().clone(),
+                );
+                (&scan).try_into().ok()
+            } else {
+                None
+            }
+        });
         try_stream! {
             for await each in selection {
                 let base = each?;

--- a/rust/dialog-query/src/helpers.rs
+++ b/rust/dialog-query/src/helpers.rs
@@ -442,6 +442,16 @@ impl<Env: ConditionalSync> Provider<SelectRules> for JoinEnv<'_, Env> {
     }
 }
 
+// Preload hints have no listener in the bench env: refuse them so the
+// measured read counts stay exactly the demand reads.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env: ConditionalSync> Provider<dialog_artifacts::Preload> for JoinEnv<'_, Env> {
+    async fn execute(&self, _input: dialog_artifacts::PreloadRequest) -> bool {
+        false
+    }
+}
+
 // Raw node loads for resolver premises: read the branch's archive
 // catalog through the same counting store scans use, so resolver
 // block reads land in the shared read journal too.

--- a/rust/dialog-query/src/scope.rs
+++ b/rust/dialog-query/src/scope.rs
@@ -3,27 +3,31 @@
 //!
 //! Evaluation reaches the world exclusively through effects the
 //! environment provides: range scans ([`Select`]) with demand
-//! recording, rule discovery ([`SelectRules`]), and idempotent
-//! content-addressed block loads ([`Load`]) for resolver premises.
-//! `Scope` names that bundle once so premise evaluation signatures
-//! stay stable as effects are added.
+//! recording, rule discovery ([`SelectRules`]), idempotent
+//! content-addressed block loads ([`Load`]) for resolver premises, and
+//! advisory replication hints ([`Preload`]) for ranges evaluation
+//! expects to need. `Scope` names that bundle once so premise
+//! evaluation signatures stay stable as effects are added.
 
-use dialog_artifacts::Select;
 use dialog_artifacts::inspect::Load;
+use dialog_artifacts::{Preload, Select};
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
 
 use crate::source::SelectRules;
 
 /// The full provider bundle premise evaluation requires. Blanket
-/// implemented: any environment providing the three effects is a
-/// `Scope`.
+/// implemented: any environment providing the effects is a `Scope`.
 pub trait Scope<'a>:
-    Provider<Select<'a>> + Provider<SelectRules> + Provider<Load> + ConditionalSync
+    Provider<Select<'a>> + Provider<SelectRules> + Provider<Load> + Provider<Preload> + ConditionalSync
 {
 }
 
 impl<'a, T> Scope<'a> for T where
-    T: Provider<Select<'a>> + Provider<SelectRules> + Provider<Load> + ConditionalSync
+    T: Provider<Select<'a>>
+        + Provider<SelectRules>
+        + Provider<Load>
+        + Provider<Preload>
+        + ConditionalSync
 {
 }

--- a/rust/dialog-query/src/source.rs
+++ b/rust/dialog-query/src/source.rs
@@ -73,6 +73,16 @@ pub(crate) mod test {
         }
     }
 
+    // Preload hints have no listener in the test env: refuse them so
+    // evaluation stops composing hints after the first.
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl Provider<dialog_artifacts::Preload> for TestEnv<'_> {
+        async fn execute(&self, _input: dialog_artifacts::PreloadRequest) -> bool {
+            false
+        }
+    }
+
     // Raw node loads for resolver premises, local archive only.
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]

--- a/rust/dialog-remote-fs/src/fs/provider/archive.rs
+++ b/rust/dialog-remote-fs/src/fs/provider/archive.rs
@@ -65,6 +65,15 @@ impl Provider<ForkInvocation<Fs, Get>> for Fs {
         let capability = input.capability;
         let outcome = block_gets()
             .join(key, move || async move {
+                #[cfg(not(target_arch = "wasm32"))]
+                if std::env::var("DIALOG_SOAK_TRACE_GETS").is_ok() {
+                    static EPOCH: std::sync::LazyLock<tokio::time::Instant> =
+                        std::sync::LazyLock::new(tokio::time::Instant::now);
+                    eprintln!(
+                        "GET t={} {digest}",
+                        (tokio::time::Instant::now() - *EPOCH).as_millis()
+                    );
+                }
                 let flight = simulation::begin(Traffic::ArchiveGet).await;
                 let result = Provider::<Get>::execute(&filesystem, capability).await;
                 let bytes = match &result {

--- a/rust/dialog-repository/src/repository/archive/networked.rs
+++ b/rust/dialog-repository/src/repository/archive/networked.rs
@@ -159,6 +159,18 @@ where
         let address = remote.address();
         let remote_catalog = address.subject.clone().archive().catalog("index");
 
+        // Re-check local before paying the remote round trip: between the
+        // miss above and this point, a concurrent reader of the same block
+        // may have completed its fetch, hydrated, and closed its transport
+        // flight — a window in which joining is no longer possible and a
+        // naive fetch re-downloads bytes the archive already holds. The
+        // recheck costs one local read on genuine cold misses and turns
+        // the sequential half of that race into a hit; the overlapping
+        // half is joined at the transport as before.
+        if let Some(bytes) = StorageBackend::get(&self.local, key).await? {
+            return Ok(Some(bytes));
+        }
+
         let env = self.local.env();
         let remote_result = remote_catalog
             .clone()

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -545,9 +545,13 @@ impl<Env> Provider<Preload> for QueryEnv<'_, Env>
 where
     Env: ConditionalSync,
 {
-    async fn execute(&self, input: PreloadRequest) {
-        if let Some(plan) = &self.plan {
-            plan.preload(input.selector, input.likelihood);
+    async fn execute(&self, input: PreloadRequest) -> bool {
+        match &self.plan {
+            Some(plan) => {
+                plan.preload(input.selector, input.likelihood);
+                true
+            }
+            None => false,
         }
     }
 }

--- a/rust/dialog-search-tree/src/walker.rs
+++ b/rust/dialog-search-tree/src/walker.rs
@@ -465,7 +465,7 @@ where
             let mut warming = FuturesUnordered::new();
             let mut queued = HashSet::new();
 
-            while let Some((node, maybe_index)) = search_path.pop() {
+            'walk: while let Some((node, maybe_index)) = search_path.pop() {
                 let body = node.body();
                 let is_segment = matches!(body, ArchivedNodeBody::Segment(_));
                 if !is_segment {
@@ -631,7 +631,7 @@ where
                         // walk the rest of the tree, making an empty lookup
                         // cost the size of the database.
                         } else if entered_range || past_end_bytes(&end_bytes, key) {
-                            return;
+                            break 'walk;
                         }
                     }
                 } else {
@@ -675,7 +675,7 @@ where
                         // range matching no stored entry walks the rest of
                         // the tree.
                         } else if entered_range || past_end_bytes(&end_bytes, key) {
-                            return;
+                            break 'walk;
                         }
                     }
                 }
@@ -691,6 +691,15 @@ where
                     }
                 }
             }
+
+            // Drive the remaining read-aheads home before finishing. They
+            // are bounded to this scan's range, so each is a block a
+            // reader of the range legitimately wants — and on a remote
+            // backend the transport may already have served it. Dropping
+            // them here would discard paid-for bytes before they reach
+            // the cache and force the next scan of the range to fetch
+            // them again.
+            while warming.next().await.is_some() {}
         }
     }
 

--- a/rust/dialog-soak/src/join.rs
+++ b/rust/dialog-soak/src/join.rs
@@ -37,7 +37,7 @@ use dialog_operator::{Operator, Profile};
 use dialog_query::{Concept, Entity, Output as _, Query, Term};
 use dialog_remote_fs::FsAddress;
 use dialog_remote_fs::simulation::{self, NetworkShape};
-use dialog_repository::{Branch, Repository, RepositoryExt as _, SiteAddress};
+use dialog_repository::{Branch, FetchBudget, Repository, RepositoryExt as _, SiteAddress};
 use dialog_storage::provider::FileSystem;
 use dialog_storage::provider::storage::VolatileSpace;
 use dialog_storage::resource::Resource as _;
@@ -524,20 +524,28 @@ pub async fn run_join(scenario: JoinScenario) -> Result<Report> {
     let concept_client =
         mount_client(&operator, &profile, &server, &address, "soak-concept").await?;
     concept_client.pull().perform(&operator).await?;
+    // Preload staging is measured on shaped profiles only: replication
+    // overlap is a latency behavior, and the unshaped profile's job is to
+    // pin the engine's deterministic demand shape. (An instant link also
+    // exposes a known post-flight hydration race that re-fetches a
+    // handful of blocks; see the fetch-plan bead trail.)
+    let preload = scenario.network.is_some();
     measured("concept", &mut phases, async {
-        let cards: Vec<Card> = concept_client
-            .query()
-            .select(Query::<Card> {
-                this: Term::var("this"),
-                title: Term::var("title"),
-                status: Term::var("status"),
-                rank: Term::var("rank"),
-                reporter: Term::var("reporter"),
-                created: Term::var("created"),
-            })
-            .perform(&operator)
-            .try_vec()
-            .await?;
+        let layer = concept_client.query();
+        let query = layer.select(Query::<Card> {
+            this: Term::var("this"),
+            title: Term::var("title"),
+            status: Term::var("status"),
+            rank: Term::var("rank"),
+            reporter: Term::var("reporter"),
+            created: Term::var("created"),
+        });
+        let query = if preload {
+            query.preload(FetchBudget::default())
+        } else {
+            query
+        };
+        let cards: Vec<Card> = query.perform(&operator).try_vec().await?;
         anyhow::ensure!(
             cards.len() == expected,
             "concept join should see every card"
@@ -557,19 +565,21 @@ pub async fn run_join(scenario: JoinScenario) -> Result<Report> {
         .filter(|index| index % 3 == 2)
         .count();
     measured("filtered", &mut phases, async {
-        let cards: Vec<Card> = filtered_client
-            .query()
-            .select(Query::<Card> {
-                this: Term::var("this"),
-                title: Term::var("title"),
-                status: Term::from("closed".to_string()),
-                rank: Term::var("rank"),
-                reporter: Term::var("reporter"),
-                created: Term::var("created"),
-            })
-            .perform(&operator)
-            .try_vec()
-            .await?;
+        let layer = filtered_client.query();
+        let query = layer.select(Query::<Card> {
+            this: Term::var("this"),
+            title: Term::var("title"),
+            status: Term::from("closed".to_string()),
+            rank: Term::var("rank"),
+            reporter: Term::var("reporter"),
+            created: Term::var("created"),
+        });
+        let query = if preload {
+            query.preload(FetchBudget::default())
+        } else {
+            query
+        };
+        let cards: Vec<Card> = query.perform(&operator).try_vec().await?;
         anyhow::ensure!(
             cards.len() == closed,
             "filtered join should see the closed cards"

--- a/soak/baseline/join-broadband.json
+++ b/soak/baseline/join-broadband.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 403,
-  "vault_bytes": 19304749,
+  "vault_files": 402,
+  "vault_bytes": 19309020,
   "phases": [
     {
       "name": "pull",
@@ -25,17 +25,17 @@
           [
             "memory.resolve",
             1,
-            333
+            332
           ]
         ],
         "requests": 1,
-        "bytes": 333
+        "bytes": 332
       }
     },
     {
       "name": "probe",
-      "virtual_ms": 176,
-      "rounds": 2.2,
+      "virtual_ms": 175,
+      "rounds": 2.1875,
       "unique_blocks": 2,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -45,31 +45,17 @@
           [
             "archive.get",
             2,
-            159804
+            151076
           ]
         ],
         "requests": 2,
-        "bytes": 159804
+        "bytes": 151076
       }
     },
     {
       "name": "roster",
-      "virtual_ms": 0,
-      "rounds": 0.0,
-      "unique_blocks": 0,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [],
-        "requests": 0,
-        "bytes": 0
-      }
-    },
-    {
-      "name": "claim",
-      "virtual_ms": 340,
-      "rounds": 4.25,
+      "virtual_ms": 82,
+      "rounds": 1.025,
       "unique_blocks": 1,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -79,26 +65,46 @@
           [
             "archive.get",
             1,
-            94160
+            12240
+          ]
+        ],
+        "requests": 1,
+        "bytes": 12240
+      }
+    },
+    {
+      "name": "claim",
+      "virtual_ms": 341,
+      "rounds": 4.2625,
+      "unique_blocks": 1,
+      "duplicate_requests": 0,
+      "duplicate_bytes": 0,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            1,
+            88832
           ],
           [
             "archive.put",
             1,
-            71084
+            76908
           ],
           [
             "memory.resolve",
             1,
-            333
+            332
           ],
           [
             "memory.publish",
             1,
-            369
+            372
           ]
         ],
         "requests": 4,
-        "bytes": 165946
+        "bytes": 166444
       }
     },
     {
@@ -157,49 +163,49 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 8410,
-      "rounds": 105.125,
+      "virtual_ms": 6930,
+      "rounds": 86.625,
       "unique_blocks": 110,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            111,
+            5679876
+          ]
+        ],
+        "requests": 111,
+        "bytes": 5679876
+      }
+    },
+    {
+      "name": "filtered",
+      "virtual_ms": 6927,
+      "rounds": 86.5875,
+      "unique_blocks": 109,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
       "empty_requests": 0,
       "traffic": {
         "rows": [
           [
             "archive.get",
             110,
-            5666124
+            5658300
           ]
         ],
         "requests": 110,
-        "bytes": 5666124
-      }
-    },
-    {
-      "name": "filtered",
-      "virtual_ms": 8327,
-      "rounds": 104.0875,
-      "unique_blocks": 109,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            109,
-            5650364
-          ]
-        ],
-        "requests": 109,
-        "bytes": 5650364
+        "bytes": 5658300
       }
     },
     {
       "name": "download",
-      "virtual_ms": 2474,
-      "rounds": 30.925,
-      "unique_blocks": 401,
+      "virtual_ms": 2468,
+      "rounds": 30.85,
+      "unique_blocks": 400,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +213,17 @@
         "rows": [
           [
             "archive.get",
-            401,
-            19308260
+            400,
+            19312956
           ],
           [
             "memory.resolve",
             1,
-            369
+            372
           ]
         ],
-        "requests": 402,
-        "bytes": 19308629
+        "requests": 401,
+        "bytes": 19313328
       }
     }
   ]

--- a/soak/baseline/join-intercontinental.json
+++ b/soak/baseline/join-intercontinental.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 398,
-  "vault_bytes": 19305359,
+  "vault_files": 402,
+  "vault_bytes": 19309004,
   "phases": [
     {
       "name": "pull",
@@ -25,17 +25,17 @@
           [
             "memory.resolve",
             1,
-            331
+            336
           ]
         ],
         "requests": 1,
-        "bytes": 331
+        "bytes": 336
       }
     },
     {
       "name": "probe",
-      "virtual_ms": 1028,
-      "rounds": 2.056,
+      "virtual_ms": 1029,
+      "rounds": 2.058,
       "unique_blocks": 2,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -45,11 +45,11 @@
           [
             "archive.get",
             2,
-            159768
+            163848
           ]
         ],
         "requests": 2,
-        "bytes": 159768
+        "bytes": 163848
       }
     },
     {
@@ -68,8 +68,8 @@
     },
     {
       "name": "claim",
-      "virtual_ms": 2033,
-      "rounds": 4.066,
+      "virtual_ms": 2034,
+      "rounds": 4.068,
       "unique_blocks": 1,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -84,21 +84,21 @@
           [
             "archive.put",
             1,
-            71352
+            75832
           ],
           [
             "memory.resolve",
             1,
-            331
+            336
           ],
           [
             "memory.publish",
             1,
-            370
+            372
           ]
         ],
         "requests": 4,
-        "bytes": 160885
+        "bytes": 165372
       }
     },
     {
@@ -157,49 +157,49 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 49992,
-      "rounds": 99.984,
+      "virtual_ms": 40952,
+      "rounds": 81.904,
       "unique_blocks": 110,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            111,
+            5758792
+          ]
+        ],
+        "requests": 111,
+        "bytes": 5758792
+      }
+    },
+    {
+      "name": "filtered",
+      "virtual_ms": 40947,
+      "rounds": 81.894,
+      "unique_blocks": 109,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
       "empty_requests": 0,
       "traffic": {
         "rows": [
           [
             "archive.get",
             110,
-            5666688
+            5739008
           ]
         ],
         "requests": 110,
-        "bytes": 5666688
-      }
-    },
-    {
-      "name": "filtered",
-      "virtual_ms": 49487,
-      "rounds": 98.974,
-      "unique_blocks": 109,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            109,
-            5643280
-          ]
-        ],
-        "requests": 109,
-        "bytes": 5643280
+        "bytes": 5739008
       }
     },
     {
       "name": "download",
-      "virtual_ms": 13983,
-      "rounds": 27.966,
-      "unique_blocks": 396,
+      "virtual_ms": 14019,
+      "rounds": 28.038,
+      "unique_blocks": 400,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +207,17 @@
         "rows": [
           [
             "archive.get",
-            396,
-            19309288
+            400,
+            19312472
           ],
           [
             "memory.resolve",
             1,
-            370
+            372
           ]
         ],
-        "requests": 397,
-        "bytes": 19309658
+        "requests": 401,
+        "bytes": 19312844
       }
     }
   ]

--- a/soak/baseline/join-localhost.json
+++ b/soak/baseline/join-localhost.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 399,
-  "vault_bytes": 19304518,
+  "vault_files": 394,
+  "vault_bytes": 19304533,
   "phases": [
     {
       "name": "pull",
@@ -25,18 +25,18 @@
           [
             "memory.resolve",
             1,
-            334
+            333
           ]
         ],
         "requests": 1,
-        "bytes": 334
+        "bytes": 333
       }
     },
     {
       "name": "probe",
-      "virtual_ms": 6,
-      "rounds": 7.5,
-      "unique_blocks": 3,
+      "virtual_ms": 4,
+      "rounds": 5.0,
+      "unique_blocks": 2,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -44,12 +44,12 @@
         "rows": [
           [
             "archive.get",
-            3,
-            153576
+            2,
+            160580
           ]
         ],
-        "requests": 3,
-        "bytes": 153576
+        "requests": 2,
+        "bytes": 160580
       }
     },
     {
@@ -68,8 +68,8 @@
     },
     {
       "name": "claim",
-      "virtual_ms": 9,
-      "rounds": 11.25,
+      "virtual_ms": 8,
+      "rounds": 10.0,
       "unique_blocks": 1,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -83,22 +83,22 @@
           ],
           [
             "archive.put",
-            3,
-            185028
+            1,
+            72064
           ],
           [
             "memory.resolve",
             1,
-            334
+            333
           ],
           [
             "memory.publish",
             1,
-            369
+            371
           ]
         ],
-        "requests": 6,
-        "bytes": 274563
+        "requests": 4,
+        "bytes": 161600
       }
     },
     {
@@ -157,49 +157,49 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 206,
-      "rounds": 257.5,
-      "unique_blocks": 111,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
+      "virtual_ms": 170,
+      "rounds": 212.5,
+      "unique_blocks": 110,
+      "duplicate_requests": 2,
+      "duplicate_bytes": 111728,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            112,
+            5775608
+          ]
+        ],
+        "requests": 112,
+        "bytes": 5775608
+      }
+    },
+    {
+      "name": "filtered",
+      "virtual_ms": 167,
+      "rounds": 208.75,
+      "unique_blocks": 109,
+      "duplicate_requests": 2,
+      "duplicate_bytes": 111728,
       "empty_requests": 0,
       "traffic": {
         "rows": [
           [
             "archive.get",
             111,
-            5657328
+            5755600
           ]
         ],
         "requests": 111,
-        "bytes": 5657328
-      }
-    },
-    {
-      "name": "filtered",
-      "virtual_ms": 204,
-      "rounds": 255.0,
-      "unique_blocks": 110,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            110,
-            5638256
-          ]
-        ],
-        "requests": 110,
-        "bytes": 5638256
+        "bytes": 5755600
       }
     },
     {
       "name": "download",
-      "virtual_ms": 161,
-      "rounds": 201.25,
-      "unique_blocks": 397,
+      "virtual_ms": 159,
+      "rounds": 198.75,
+      "unique_blocks": 392,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +207,17 @@
         "rows": [
           [
             "archive.get",
-            397,
-            19307476
+            392,
+            19308240
           ],
           [
             "memory.resolve",
             1,
-            369
+            371
           ]
         ],
-        "requests": 398,
-        "bytes": 19307845
+        "requests": 393,
+        "bytes": 19308611
       }
     }
   ]

--- a/soak/baseline/join-mobile.json
+++ b/soak/baseline/join-mobile.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 390,
-  "vault_bytes": 19302202,
+  "vault_files": 407,
+  "vault_bytes": 19305870,
   "phases": [
     {
       "name": "pull",
@@ -25,17 +25,17 @@
           [
             "memory.resolve",
             1,
-            330
+            334
           ]
         ],
         "requests": 1,
-        "bytes": 330
+        "bytes": 334
       }
     },
     {
       "name": "probe",
-      "virtual_ms": 464,
-      "rounds": 2.32,
+      "virtual_ms": 462,
+      "rounds": 2.31,
       "unique_blocks": 2,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -45,17 +45,17 @@
           [
             "archive.get",
             2,
-            151756
+            147884
           ]
         ],
         "requests": 2,
-        "bytes": 151756
+        "bytes": 147884
       }
     },
     {
       "name": "roster",
-      "virtual_ms": 204,
-      "rounds": 1.02,
+      "virtual_ms": 206,
+      "rounds": 1.03,
       "unique_blocks": 1,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -65,17 +65,17 @@
           [
             "archive.get",
             1,
-            5560
+            12440
           ]
         ],
         "requests": 1,
-        "bytes": 5560
+        "bytes": 12440
       }
     },
     {
       "name": "claim",
-      "virtual_ms": 870,
-      "rounds": 4.35,
+      "virtual_ms": 872,
+      "rounds": 4.36,
       "unique_blocks": 1,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -90,21 +90,21 @@
           [
             "archive.put",
             1,
-            68500
+            73448
           ],
           [
             "memory.resolve",
             1,
-            330
+            334
           ],
           [
             "memory.publish",
             1,
-            370
+            372
           ]
         ],
         "requests": 4,
-        "bytes": 158032
+        "bytes": 162986
       }
     },
     {
@@ -163,49 +163,49 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 21834,
-      "rounds": 109.17,
+      "virtual_ms": 18186,
+      "rounds": 90.93,
       "unique_blocks": 110,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            111,
+            5675960
+          ]
+        ],
+        "requests": 111,
+        "bytes": 5675960
+      }
+    },
+    {
+      "name": "filtered",
+      "virtual_ms": 18173,
+      "rounds": 90.865,
+      "unique_blocks": 109,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
       "empty_requests": 0,
       "traffic": {
         "rows": [
           [
             "archive.get",
             110,
-            5576940
+            5657176
           ]
         ],
         "requests": 110,
-        "bytes": 5576940
-      }
-    },
-    {
-      "name": "filtered",
-      "virtual_ms": 21623,
-      "rounds": 108.115,
-      "unique_blocks": 109,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            109,
-            5553244
-          ]
-        ],
-        "requests": 109,
-        "bytes": 5553244
+        "bytes": 5657176
       }
     },
     {
       "name": "download",
-      "virtual_ms": 8415,
-      "rounds": 42.075,
-      "unique_blocks": 388,
+      "virtual_ms": 8495,
+      "rounds": 42.475,
+      "unique_blocks": 405,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -213,17 +213,17 @@
         "rows": [
           [
             "archive.get",
-            388,
-            19306548
+            405,
+            19309576
           ],
           [
             "memory.resolve",
             1,
-            370
+            372
           ]
         ],
-        "requests": 389,
-        "bytes": 19306918
+        "requests": 406,
+        "bytes": 19309948
       }
     }
   ]

--- a/soak/baseline/join-none.json
+++ b/soak/baseline/join-none.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 381,
-  "vault_bytes": 19303010,
+  "vault_files": 395,
+  "vault_bytes": 19305498,
   "phases": [
     {
       "name": "pull",
@@ -45,11 +45,11 @@
           [
             "archive.get",
             2,
-            160384
+            160336
           ]
         ],
         "requests": 2,
-        "bytes": 160384
+        "bytes": 160336
       }
     },
     {
@@ -84,7 +84,7 @@
           [
             "archive.put",
             1,
-            72088
+            72040
           ],
           [
             "memory.resolve",
@@ -94,11 +94,11 @@
           [
             "memory.publish",
             1,
-            373
+            374
           ]
         ],
         "requests": 4,
-        "bytes": 161627
+        "bytes": 161580
       }
     },
     {
@@ -168,11 +168,11 @@
           [
             "archive.get",
             110,
-            5665464
+            5665824
           ]
         ],
         "requests": 110,
-        "bytes": 5665464
+        "bytes": 5665824
       }
     },
     {
@@ -188,18 +188,18 @@
           [
             "archive.get",
             109,
-            5643904
+            5643848
           ]
         ],
         "requests": 109,
-        "bytes": 5643904
+        "bytes": 5643848
       }
     },
     {
       "name": "download",
       "virtual_ms": 0,
       "rounds": 0.0,
-      "unique_blocks": 379,
+      "unique_blocks": 393,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +207,17 @@
         "rows": [
           [
             "archive.get",
-            379,
-            19306944
+            393,
+            19309424
           ],
           [
             "memory.resolve",
             1,
-            373
+            374
           ]
         ],
-        "requests": 380,
-        "bytes": 19307317
+        "requests": 394,
+        "bytes": 19309798
       }
     }
   ]


### PR DESCRIPTION
Stacked on #496. The first `FetchPlan` consumer (bead dialog-db-77): the query engine's join premises pipeline their probes, and the #492 yardstick moves.

## Probe pipelining

A premise's upstream selection is wrapped so rows buffer up to `PROBE_LOOKAHEAD` ahead, and each newly buffered row's would-be probe is offered to the env as a `Likely` `Preload` hint. While the evaluator awaits one row's scan, the scans the next rows will issue replicate concurrently — a cold replica pays round trips per cold-block wave instead of per row. Rows entering an empty window never hint (their hint could overlap with nothing), single-row seeds hint nothing, and hinting stops permanently on the env's first refusal, so an un-staged query pays one refused call. Both cardinality paths pipeline; `Scope` gains `Provider<Preload>`; test/bench envs refuse hints so measured read counts stay demand-only.

## Measured (cold 5-attribute concept join, broadband, 4k entities; pre-M3: 105 rounds / 8.4s)

| lookahead / budget | rounds | modeled time |
|---|---|---|
| 64 / 16 (shipping default) | 87 | 6.9s |
| 128 / 128 | 33 | 2.6s |
| 512 / 512 | 14 | 1.2s |

Mobile drops 28.3s → 18.2s and intercontinental 50s → 41s at the defaults. At budget 512 the lazy join beats downloading the entire space (2.4s / 30 rounds) while transferring 3.5x less — the defaults stay conservative because budgets past ~16 are gated on a newly found post-flight hydration race (bead dialog-db-81, filed with full evidence): a reader that passed its local check before a peer hydrated reaches the transport after the peer's flight closed, and re-fetches.

## Also landed, found by the same measurements

- The walker now drives its remaining range-bounded read-aheads home when a scan finishes, instead of dropping fetches the transport may already have served.
- `NetworkedIndex` re-checks local immediately before the remote fork, closing the sequential half of the race.
- An env-gated `DIALOG_SOAK_TRACE_GETS` fetch trace in the harness, which found both the budget ceiling and the race.

The soak stages `.preload` on shaped profiles (the unshaped profile keeps pinning the engine's deterministic demand shape); baselines regenerated. Gates: clippy `-D warnings`, 2709/2709 native, wasm cross-archive, soak gate self-check.
