### PR TITLE
feat(query): balanced concept joins evaluate as a preloaded N-way merge

### DIFF
--- a/notes/fetch-scheduler.md
+++ b/notes/fetch-scheduler.md
@@ -125,3 +125,29 @@ Two designs died on the way, both worth remembering:
 - **`QueryEnv` cannot hold the flight.** Interior mutability over `'env`-borrowing futures makes the holder invariant, and `QueryEnv`'s covariance in its lifetime is load-bearing for the `Provider<Select>` lifetime unification (the strict-impl dance its comments document). The flight therefore hangs off `Driven`, whose lifetime nothing shrinks. Demand reads stay outside it, protected by the local re-check and the transport flight; the measured residual is ~2 duplicate fetches per cold join, versus 449 at budget 512 before.
 
 Post-fix sweep (broadband, 4k entities): budget 512 gives 1.18s / 14.8 rounds / zero duplicates; the shipping default moves to 256/16 (1.65s / 20.6 rounds), at which the cold lazy join beats eagerly downloading the entire space (2.4s / 30 rounds) while transferring 3.5x less — the campaign's thesis, landed: from 8.4s / 105 rounds pre-M3, a 5x cut at defaults and 7x at full throttle, with M2 (range-granular preload) and M4 (merge over AEV ranges) still ahead.
+
+## M2 landed: range-granular job executor (2026-09-10)
+
+Preload jobs now execute as scoped level-parallel traversals (`warm_source` in `repository/fetch.rs`): the selector's exact key range (`selector_range` under the tree's manifest) scopes `traverse_available_within`, so each depth's whole frontier fetches concurrently and a cold range costs tree-depth round trips, not block-count round trips. Reads run through the line's shared node cache in front of the hydrating networked index (`CacheThrough`), so jobs share spines with one another and with the demand reads that follow, and every fetched block still hydrates the local archive under the hydration flight. Compared to the select-and-drain executor this drops per-row parsing and spilled-value fetches for rows nobody reads.
+
+One deliberate scope trim against the original sketch: no spine-versus-leaf rank split and no `range_scale` block budget inside the job. Point probes (today's only hints) make both moot, and M4's merge-path ranges are wanted in full once promoted; the budget returns with M6's speculative unbounded ranges if measurements ask for it.
+
+Measured: rounds unchanged at the defaults (20.6), as predicted — the executor is substrate; moving rounds further belongs to range-shaped hints, which arrive with M4's merge over AEV ranges.
+
+## M4 landed: concept joins evaluate as an N-way merge (2026-09-10)
+
+The merge-join stack from `notes/set-at-a-time-joins.md` (branches `feat/merge-join-operator` + `spike/merge-join-planner`), ported onto current main and the preload substrate. Four pieces:
+
+- **The operator** (`merge_join`, `multi_merge_join` in `dialog-query/src/merge_join.rs`): sorted-cursor intersection generic over an `Ord` key with a caller-supplied extractor (index encoding stays in the scan layer), plus `Match::combine`/`value_of`. Ported near-verbatim; the oracle suite (nested-loop equivalence over 350 random shapes, N-way included) passes unchanged on current `Match` internals.
+- **The `Estimate` capability**: one root read summing per-child `Scale`s over a selector's range (`PersistentTree::range_estimate` → `ArtifactTreeExt::estimate` → `Select::estimate` → `Provider<Estimate>` on `QueryEnv`, lines summed). The spike's wide bound-threading collapsed to one addition on `Scope` — the alias absorbed the whole motion, macros included.
+- **The planner**: a conjunction whose every step is a positive attribute scan sorted on one shared variable (`sort_order_of`, now cardinality-independent) is structurally merge-eligible; `scans_balanced_for` resolves each scan against the first row and takes the merge only when the widest range estimate is within 3x of the narrowest, so a pinned selective value keeps the nested-loop fold (pinned by a test against real tree estimates). Optional (left-join) fields are excluded structurally — an `OptionalScan` step disqualifies the merge, so set-widening semantics never route through the inner intersection; only the lockstep N-way was ported (the spike's cascade variant measured identical and was dropped).
+- **The preload wiring**: on the merge path every input range is committed work, so each scan's resolved selector is hinted `Likely` before the streams open; the driven plan warms the ranges level-parallel (M2's executor) while the merge consumes them.
+
+Measured (cold 5-attribute concept join, 4k entities; campaign start 8.4s / 105 rounds / 5.5MB):
+
+| profile | rounds | modeled time | blocks |
+|---|---|---|---|
+| broadband | **6.2** | **498ms** | 69 / 3.0MB |
+| mobile | 9.3 | 1.86s | 69 |
+
+**17x faster than the campaign start on broadband, 15x on mobile, 5x faster than downloading the entire space — and strictly fewer blocks than the fold (69 vs 110), because the merge consumes the three AEV ranges and never touches the EAV probe region.** The original rejection (merge reads more blocks) is fully dissolved for the balanced case: fewer rounds AND fewer blocks. `filtered` (status pinned) correctly folds at the 3x balance threshold and keeps the pipelined-fold profile (~20 rounds); tuning that guard against latency-weighted cost rather than block estimates is future work, as is bead 79 (locality) and 80 (rule-join speculation).

--- a/rust/dialog-artifacts/src/artifacts.rs
+++ b/rust/dialog-artifacts/src/artifacts.rs
@@ -13,6 +13,9 @@ pub use instruction::*;
 pub mod selector;
 pub use selector::{ArtifactSelector, ValueBound};
 
+mod estimate;
+pub use estimate::Estimate;
+
 mod query;
 pub use query::{ArtifactStream, Likelihood, Preload, PreloadRequest, Select};
 

--- a/rust/dialog-artifacts/src/artifacts/estimate.rs
+++ b/rust/dialog-artifacts/src/artifacts/estimate.rs
@@ -1,0 +1,27 @@
+use dialog_capability::Command;
+
+use crate::selector::Constrained;
+use crate::{ArtifactSelector, DialogArtifactsError};
+
+/// Command for estimating how many artifacts a selector's key range spans,
+/// without scanning them.
+///
+/// Answered by reading a single shallow index node (the tree root) and summing
+/// the [`Scale`](dialog_search_tree::Scale)s of the children the selector's
+/// range touches, so the cost is one block read rather than a full scan. The
+/// result is an advisory upper bound on the entry count, suitable for a
+/// planner choosing between join strategies, not an exact count.
+///
+/// A planner uses it to compare the range sizes of independent scans: a merge
+/// that reads every range in full only wins over a nested loop when the ranges
+/// are comparably broad, which this lets the evaluator check with real
+/// tree-derived numbers instead of the cost model's fixed constants.
+pub struct Estimate;
+
+impl Command for Estimate {
+    type Input = ArtifactSelector<Constrained>;
+    /// An advisory upper-bound entry count for the selector's range. `None`
+    /// when the tree is empty or the estimate is unavailable, in which case a
+    /// caller should treat the range as unknown (maximally broad).
+    type Output = Result<Option<u64>, DialogArtifactsError>;
+}

--- a/rust/dialog-artifacts/src/tree.rs
+++ b/rust/dialog-artifacts/src/tree.rs
@@ -762,6 +762,23 @@ pub trait ArtifactTreeExt {
             + Clone
             + ConditionalSync
             + 's;
+
+    /// An advisory upper-bound estimate of how many artifacts the `selector`'s
+    /// key range spans, read from the tree root alone (see
+    /// `PersistentTree::range_estimate`).
+    ///
+    /// Reads one block instead of scanning, so a planner can compare the range
+    /// sizes of independent scans cheaply. Returns `None` for an empty tree.
+    async fn estimate<S>(
+        self,
+        store: S,
+        selector: ArtifactSelector<Constrained>,
+    ) -> Result<Option<u64>, DialogArtifactsError>
+    where
+        Self: Sized,
+        S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync;
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -962,6 +979,32 @@ impl ArtifactTreeExt for ArtifactTree {
         };
         *self = transient.persist(delta)?;
         Ok(())
+    }
+
+    async fn estimate<S>(
+        self,
+        store: S,
+        selector: ArtifactSelector<Constrained>,
+    ) -> Result<Option<u64>, DialogArtifactsError>
+    where
+        S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync,
+    {
+        let tree = self;
+        let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
+        // The range must be built under the manifest the facts were written
+        // with, the same requirement `scan` has.
+        let manifest = tree.manifest(&storage).await?;
+        let range = selector_range(&selector, &manifest);
+        // `range_scale` intersects half-open `[lower, upper)`; the selector's
+        // range is inclusive, so the upper bound is the successor of the last
+        // key. A single extra trailing byte is below any real successor key
+        // and keeps the estimate an upper bound.
+        let lower = range.start().as_ref();
+        let mut upper = range.end().as_ref().to_vec();
+        upper.push(0);
+        Ok(tree.range_estimate(lower, &upper, &storage).await?)
     }
 
     fn scan<'s, S>(

--- a/rust/dialog-query/src/attribute/query/dynamic.rs
+++ b/rust/dialog-query/src/attribute/query/dynamic.rs
@@ -114,6 +114,28 @@ impl DynamicAttributeQuery {
         }
     }
 
+    /// The [`ArtifactSelector`] this scan would issue against a store *given*
+    /// the bindings in `source`, resolving each term to a constant where the
+    /// row binds it. This is the same selector the scan's own evaluation
+    /// builds per row; exposed so a planner can estimate the scan's range
+    /// size without evaluating it. Returns an error only when nothing
+    /// constrains the selector (which cannot happen for a well-formed
+    /// attribute scan).
+    pub fn resolved_selector(
+        &self,
+        source: &Match,
+    ) -> Result<ArtifactSelector<Constrained>, EvaluationError> {
+        let the = self.the().resolve(source);
+        let of = self.of().resolve(source);
+        let is = match source.lookup(self.is()).and_then(|b| b.content()) {
+            Ok(value) => Term::Constant(value),
+            Err(_) => self.is().clone(),
+        };
+        let cause = self.cause().resolve(source);
+        let resolved = AttributeQueryAll::new(the, of, is, cause);
+        ArtifactSelector::try_from(&resolved)
+    }
+
     /// Get the source term (internal claim handle).
     pub fn source(&self) -> &Term<Record> {
         match self {

--- a/rust/dialog-query/src/helpers.rs
+++ b/rust/dialog-query/src/helpers.rs
@@ -442,6 +442,31 @@ impl<Env: ConditionalSync> Provider<SelectRules> for JoinEnv<'_, Env> {
     }
 }
 
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> Provider<dialog_artifacts::Estimate> for JoinEnv<'_, Env>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    async fn execute(
+        &self,
+        input: ArtifactSelector<Constrained>,
+    ) -> Result<Option<u64>, DialogArtifactsError> {
+        // Route the estimate's root read through the same counting store as
+        // the scans, so a bench sees the block it costs.
+        let select = self.branch.claims().select(input);
+        let store = NetworkedIndex::new(self.operator, select.catalog(), None);
+        let counting = CountingStore::new(store, self.journal.clone());
+        select.estimate(counting).await
+    }
+}
+
 // Preload hints have no listener in the bench env: refuse them so the
 // measured read counts stay exactly the demand reads.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/rust/dialog-query/src/lib.rs
+++ b/rust/dialog-query/src/lib.rs
@@ -87,6 +87,9 @@ pub mod term;
 
 mod sort_order;
 pub use sort_order::*;
+
+mod merge_join;
+pub use merge_join::*;
 /// Unified schema-layer type system (`Type`, `Primitive`,
 /// `Refinement`, set-operations).
 pub mod type_system;

--- a/rust/dialog-query/src/merge_join.rs
+++ b/rust/dialog-query/src/merge_join.rs
@@ -1,0 +1,739 @@
+//! A merge join over two streams sorted on a shared variable.
+//!
+//! The nested-loop join this codebase uses today feeds one scan's rows into
+//! the other, issuing a fresh index probe per row (see
+//! [`AttributeQueryAll::evaluate`](crate::attribute::query::all::AttributeQueryAll)).
+//! A merge join instead evaluates both sides *independently* and correlates
+//! their outputs by walking two sorted cursors in lockstep, so neither side is
+//! re-scanned per row of the other.
+//!
+//! It applies only when both inputs are already sorted on the join variable
+//! (see [`SortOrder`](crate::SortOrder)). This module is the operator alone;
+//! nothing plans it yet. It exists to be proven correct against the nested-loop
+//! join as an oracle before the planner learns to emit it.
+//!
+//! # The join key is the caller's, not the operator's
+//!
+//! Rows arrive already ordered because the scans read an ordered index, and
+//! that order is the index's *key encoding*, which is not the same as any
+//! `Ord` on the bound value. So the operator does not derive the ordering
+//! itself: the caller supplies a `key` function mapping each row to a
+//! comparable key in the *same* order both scans produced. The operator then
+//! only assumes the two streams agree on that ordering and compares keys with
+//! their `Ord`. This keeps the index-encoding concern in the scan layer, where
+//! it belongs, and out of the join.
+
+use std::cmp::Ordering;
+use std::pin::Pin;
+
+use futures_util::StreamExt;
+use futures_util::stream::Peekable;
+
+use dialog_common::ConditionalSync;
+
+use crate::error::EvaluationError;
+use crate::selection::{Match, Selection};
+use crate::try_stream;
+
+/// Joins two selections sorted on a shared variable by merging their sorted
+/// runs.
+///
+/// `key` maps a row to the value it is ordered by; both `left` and `right` must
+/// already yield rows in ascending `key` order (the caller establishes this
+/// from the scans' [`SortOrder`](crate::SortOrder)). A row for which `key`
+/// returns `None` does not participate and is dropped, which is how a row that
+/// fails to bind the join variable is handled.
+///
+/// For each key present on both sides, every left row with that key is combined
+/// (via [`Match::combine`]) with every right row with that key. Combinations
+/// that disagree on some other shared variable are filtered out. A key on only
+/// one side contributes nothing, exactly as an inner join.
+///
+/// The result carries no ordering guarantee: within an equal-key group the
+/// cross product is emitted in an unspecified order, so a join that must feed a
+/// further merge would need its output order re-established.
+pub fn merge_join<'a, L, R, K, Key>(left: L, right: R, key: K) -> impl Selection + 'a
+where
+    L: Selection + 'a,
+    R: Selection + 'a,
+    K: Fn(&Match) -> Option<Key> + ConditionalSync + 'a,
+    Key: Ord + Clone + ConditionalSync + 'a,
+{
+    try_stream! {
+        let mut left = Box::pin(left.peekable());
+        let mut right = Box::pin(right.peekable());
+
+        // The current equal-key run buffered from the right side, reused across
+        // every left row sharing its key so the right side is read once even in
+        // the many-to-many case.
+        let mut right_run: Vec<Match> = Vec::new();
+        let mut right_run_key: Option<Key> = None;
+
+        while let Some((left_row, left_key)) = next_keyed(&mut left, &key).await? {
+            // Advance the right cursor until its buffered run covers left_key,
+            // or has moved past it. When the run already holds left_key, reuse
+            // it untouched.
+            if right_run_key.as_ref() != Some(&left_key) {
+                advance_right_to(&mut right, &key, &left_key, &mut right_run, &mut right_run_key)
+                    .await?;
+            }
+
+            if right_run_key.as_ref() == Some(&left_key) {
+                for right_row in &right_run {
+                    if let Some(joined) = left_row.clone().combine(right_row) {
+                        yield joined;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Pull the next row with a key, returning it paired with that key. Rows whose
+/// `key` is `None` are skipped.
+async fn next_keyed<S, K, Key>(
+    stream: &mut Pin<Box<Peekable<S>>>,
+    key: &K,
+) -> Result<Option<(Match, Key)>, EvaluationError>
+where
+    S: Selection,
+    K: Fn(&Match) -> Option<Key>,
+{
+    while let Some(item) = stream.next().await {
+        let row = item?;
+        if let Some(k) = key(&row) {
+            return Ok(Some((row, k)));
+        }
+    }
+    Ok(None)
+}
+
+/// Advance the right cursor until the buffered run holds the rows whose key is
+/// `target`, or the right side has moved to a key past `target` (which leaves
+/// the run holding that later group, so a subsequent larger left key can reuse
+/// it, or an empty run if the right side is exhausted).
+///
+/// Both sides are sorted ascending, so once a right key reaches or exceeds
+/// `target` no earlier right row can match it; keys strictly below `target` are
+/// discarded as they pass.
+async fn advance_right_to<S, K, Key>(
+    right: &mut Pin<Box<Peekable<S>>>,
+    key: &K,
+    target: &Key,
+    run: &mut Vec<Match>,
+    run_key: &mut Option<Key>,
+) -> Result<(), EvaluationError>
+where
+    S: Selection,
+    K: Fn(&Match) -> Option<Key>,
+    Key: Ord + Clone,
+{
+    // A buffered run at or past target is already the answer: either it is
+    // target's group, or target has no group and this is the next one.
+    if let Some(current) = run_key.as_ref()
+        && *current >= *target
+    {
+        return Ok(());
+    }
+
+    loop {
+        let Some((row, k)) = next_keyed(right, key).await? else {
+            run.clear();
+            *run_key = None;
+            return Ok(());
+        };
+
+        match k.cmp(target) {
+            Ordering::Less => continue,
+            // At target, or overshot it: buffer this key's whole group. The
+            // overshoot case leaves a run the next larger left key may reuse.
+            Ordering::Equal | Ordering::Greater => {
+                run.clear();
+                run.push(row);
+                *run_key = Some(k.clone());
+                buffer_equal_run(right, key, &k, run).await?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Extend `run` with every subsequent right row whose key equals `key_value`,
+/// leaving the first differing row buffered in the peekable stream for the next
+/// call.
+async fn buffer_equal_run<S, K, Key>(
+    right: &mut Pin<Box<Peekable<S>>>,
+    key: &K,
+    key_value: &Key,
+    run: &mut Vec<Match>,
+) -> Result<(), EvaluationError>
+where
+    S: Selection,
+    K: Fn(&Match) -> Option<Key>,
+    Key: Ord,
+{
+    loop {
+        match right.as_mut().peek().await {
+            Some(Ok(row)) => match key(row) {
+                Some(next_key) if next_key == *key_value => {
+                    let row = right.next().await.expect("peek observed a row")?;
+                    run.push(row);
+                }
+                _ => return Ok(()),
+            },
+            // A pending error is surfaced when `next_keyed` next polls the
+            // stream; leave it in place.
+            Some(Err(_)) => return Ok(()),
+            None => return Ok(()),
+        }
+    }
+}
+
+/// One input to [`multi_merge_join`]: a sorted selection advanced as an
+/// equal-key group buffer.
+struct Cursor<S: Selection, Key> {
+    stream: Pin<Box<Peekable<S>>>,
+    /// The buffered group for the cursor's current key.
+    run: Vec<Match>,
+    /// The current key, or `None` once the stream is exhausted.
+    key: Option<Key>,
+}
+
+impl<S, Key> Cursor<S, Key>
+where
+    S: Selection,
+    Key: Ord + Clone,
+{
+    async fn new<K>(stream: S, key_of: &K) -> Result<Self, EvaluationError>
+    where
+        K: Fn(&Match) -> Option<Key>,
+    {
+        let mut cursor = Self {
+            stream: Box::pin(stream.peekable()),
+            run: Vec::new(),
+            key: None,
+        };
+        cursor.load_next_group(key_of).await?;
+        Ok(cursor)
+    }
+
+    /// Replace the buffered group with the next key's group (the smallest key
+    /// strictly greater than the current one), leaving the cursor exhausted if
+    /// the stream ends.
+    async fn load_next_group<K>(&mut self, key_of: &K) -> Result<(), EvaluationError>
+    where
+        K: Fn(&Match) -> Option<Key>,
+    {
+        self.run.clear();
+        let Some((row, key)) = next_keyed(&mut self.stream, key_of).await? else {
+            self.key = None;
+            return Ok(());
+        };
+        self.run.push(row);
+        buffer_equal_run(&mut self.stream, key_of, &key, &mut self.run).await?;
+        self.key = Some(key);
+        Ok(())
+    }
+
+    /// Advance until the cursor's key is at least `target`, skipping groups
+    /// below it. Returns after loading the first group whose key `>= target`,
+    /// or on exhaustion.
+    async fn advance_to<K>(&mut self, key_of: &K, target: &Key) -> Result<(), EvaluationError>
+    where
+        K: Fn(&Match) -> Option<Key>,
+    {
+        while let Some(current) = self.key.as_ref() {
+            if current >= target {
+                return Ok(());
+            }
+            self.load_next_group(key_of).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Intersects N selections all sorted on the same shared variable, joining
+/// every N-way group whose key is present on *every* input.
+///
+/// This is the single-variable case of a worst-case-optimal join: all N
+/// cursors advance in lockstep on one key, so an entity absent from any one
+/// input is skipped in a single pass across all inputs, and no intermediate
+/// join is ever materialized. A concept's implicit rule (one `(this, attr, v)`
+/// premise per field, all sharing `this`) is exactly this shape.
+///
+/// Every input must yield rows in ascending `key` order under the same
+/// encoding (the caller establishes this from each scan's
+/// [`SortOrder`](crate::SortOrder)). An empty input list yields nothing. A
+/// single input passes its rows through, keyed. Rows within an equal-key group
+/// are combined as a cross product across all inputs, and any combination that
+/// disagrees on a non-key variable is dropped, exactly as the binary
+/// [`merge_join`].
+///
+/// This is an *inner* intersection: an input that lacks the key contributes
+/// nothing, so an entity missing any required attribute is excluded. Optional
+/// (left-join) attributes are therefore NOT handled here; a concept with
+/// optional fields cannot use this directly without widening the missing side.
+pub fn multi_merge_join<'a, S, K, Key>(inputs: Vec<S>, key: K) -> impl Selection + 'a
+where
+    S: Selection + 'a,
+    K: Fn(&Match) -> Option<Key> + ConditionalSync + 'a,
+    Key: Ord + Clone + ConditionalSync + 'a,
+{
+    try_stream! {
+        if inputs.is_empty() {
+            return;
+        }
+
+        let mut cursors = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            cursors.push(Cursor::new(input, &key).await?);
+        }
+
+        // Lockstep intersection: repeatedly bring every cursor up to the
+        // current maximum key. When they all agree, that key is in every
+        // input; emit its N-way cross product and step all cursors past it.
+        loop {
+            // The largest current key across all cursors, or stop if any
+            // cursor is exhausted (no further key can be in every input).
+            let mut max: Option<Key> = None;
+            let mut exhausted = false;
+            for cursor in &cursors {
+                match cursor.key.as_ref() {
+                    None => {
+                        exhausted = true;
+                        break;
+                    }
+                    Some(k) => {
+                        if max.as_ref().is_none_or(|m| k > m) {
+                            max = Some(k.clone());
+                        }
+                    }
+                }
+            }
+            if exhausted {
+                break;
+            }
+            let max = max.expect("non-empty, non-exhausted cursors have a max");
+
+            // Pull every cursor up to max.
+            for cursor in &mut cursors {
+                cursor.advance_to(&key, &max).await?;
+            }
+
+            // All at max means the key is in every input. If any overshot,
+            // restart the round with the new maximum.
+            if cursors.iter().all(|c| c.key.as_ref() == Some(&max)) {
+                for combined in cross_combine(&cursors) {
+                    yield combined;
+                }
+                // Step every cursor to its next group so the next round makes
+                // progress.
+                for cursor in &mut cursors {
+                    cursor.load_next_group(&key).await?;
+                }
+            }
+        }
+    }
+}
+
+/// The cross product of every cursor's buffered group, folded left to right via
+/// [`Match::combine`]; combinations that disagree on a non-key variable are
+/// dropped.
+fn cross_combine<S, Key>(cursors: &[Cursor<S, Key>]) -> Vec<Match>
+where
+    S: Selection,
+    Key: Ord + Clone,
+{
+    let mut acc: Vec<Match> = vec![Match::new()];
+    for cursor in cursors {
+        let mut next = Vec::new();
+        for partial in &acc {
+            for row in &cursor.run {
+                if let Some(combined) = partial.clone().combine(row) {
+                    next.push(combined);
+                }
+            }
+        }
+        acc = next;
+        if acc.is_empty() {
+            break;
+        }
+    }
+    acc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{merge_join, multi_merge_join};
+    use crate::selection::{Match, Selection};
+    use crate::{Term, Value};
+    use futures_util::TryStreamExt;
+    use futures_util::stream;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    /// A row binding `join` to `key` and `tag` to a per-row marker, so the
+    /// oracle can tell which side each binding came from.
+    fn row(join: i64, tag_var: &str, tag: i64) -> Match {
+        let mut m = Match::new();
+        m.bind(&Term::var("j"), Value::from(join)).unwrap();
+        m.bind(&Term::var(tag_var), Value::from(tag)).unwrap();
+        m
+    }
+
+    /// The join key: the `Present` value of `j`, compared as i64 so the test's
+    /// ordering is unambiguous (the real caller supplies encoded-order bytes).
+    fn key(m: &Match) -> Option<i64> {
+        m.value_of("j").and_then(|v| match v {
+            Value::SignedInt(n) => Some(*n as i64),
+            _ => None,
+        })
+    }
+
+    fn seed(rows: Vec<Match>) -> impl Selection {
+        stream::iter(rows.into_iter().map(Ok))
+    }
+
+    /// Reference inner join: the O(n*m) nested-loop combine, the oracle the
+    /// merge must match. Independent of sort order.
+    fn nested_loop(left: &[Match], right: &[Match]) -> Vec<Match> {
+        let mut out = Vec::new();
+        for l in left {
+            for r in right {
+                // Only correlate rows that agree on the join key, mirroring
+                // what an equi-join on `j` does.
+                if key(l).is_some()
+                    && key(l) == key(r)
+                    && let Some(joined) = l.clone().combine(r)
+                {
+                    out.push(joined);
+                }
+            }
+        }
+        out
+    }
+
+    /// Compare two result sets ignoring order: sort each by (j, l, r) markers.
+    fn normalize(mut rows: Vec<Match>) -> Vec<(i64, Option<i64>, Option<i64>)> {
+        let mut keyed: Vec<_> = rows
+            .drain(..)
+            .map(|m| {
+                let j = key(&m).unwrap_or(i64::MIN);
+                let l = m.value_of("l").and_then(as_int);
+                let r = m.value_of("r").and_then(as_int);
+                (j, l, r)
+            })
+            .collect();
+        keyed.sort();
+        keyed
+    }
+
+    fn as_int(v: &Value) -> Option<i64> {
+        match v {
+            Value::SignedInt(n) => Some(*n as i64),
+            _ => None,
+        }
+    }
+
+    async fn run_merge(left: Vec<Match>, right: Vec<Match>) -> Vec<Match> {
+        merge_join(seed(left), seed(right), key)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+    }
+
+    /// A row binding `j` (the join key) and one tag var; used for N-way tests
+    /// where each input tags with a distinct variable so the oracle can see
+    /// every side contributed.
+    fn nrow(join: i64, tag_var: &str, tag: i64) -> Match {
+        row(join, tag_var, tag)
+    }
+
+    /// Reference N-way inner intersection: the O(product) nested combine over
+    /// all inputs, keeping only entities present in every input.
+    fn nested_intersect(inputs: &[Vec<Match>]) -> Vec<Match> {
+        let mut acc: Vec<Match> = vec![Match::new()];
+        for input in inputs {
+            let mut next = Vec::new();
+            for partial in &acc {
+                for row in input {
+                    if key(row).is_some()
+                        && let Some(combined) = partial.clone().combine(row)
+                    {
+                        next.push(combined);
+                    }
+                }
+            }
+            acc = next;
+        }
+        // Keep only combinations that bound the join key from some input (an
+        // all-empty-input product would otherwise leak the empty seed).
+        acc.into_iter().filter(|m| key(m).is_some()).collect()
+    }
+
+    fn normalize_keys(mut rows: Vec<Match>) -> Vec<i64> {
+        let mut keys: Vec<i64> = rows.drain(..).filter_map(|m| key(&m)).collect();
+        keys.sort();
+        keys
+    }
+
+    async fn run_multi(inputs: Vec<Vec<Match>>) -> Vec<Match> {
+        let streams: Vec<_> = inputs.into_iter().map(seed).collect();
+        multi_merge_join(streams, key)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_intersects_three_inputs_on_the_shared_key() {
+        // Only keys present in ALL THREE survive: 2 and 5.
+        let a = vec![
+            nrow(1, "a", 1),
+            nrow(2, "a", 2),
+            nrow(5, "a", 5),
+            nrow(7, "a", 7),
+        ];
+        let b = vec![nrow(2, "b", 2), nrow(3, "b", 3), nrow(5, "b", 5)];
+        let c = vec![
+            nrow(0, "c", 0),
+            nrow(2, "c", 2),
+            nrow(5, "c", 5),
+            nrow(9, "c", 9),
+        ];
+
+        let got = run_multi(vec![a.clone(), b.clone(), c.clone()]).await;
+        assert_eq!(normalize_keys(got.clone()), vec![2, 5]);
+        // And it agrees with the nested oracle exactly.
+        let oracle = nested_intersect(&[a, b, c]);
+        assert_eq!(normalize_keys(got), normalize_keys(oracle));
+    }
+
+    #[dialog_common::test]
+    async fn it_matches_the_nested_intersect_over_five_inputs() {
+        // Five inputs (the Bug concept's arity), small key domain so the
+        // intersection is non-trivial and many-to-one collisions occur.
+        let mk = |tag: &str, keys: &[i64]| -> Vec<Match> {
+            keys.iter()
+                .enumerate()
+                .map(|(i, k)| nrow(*k, tag, i as i64))
+                .collect()
+        };
+        let inputs = vec![
+            mk("a", &[1, 2, 3, 4, 5, 6]),
+            mk("b", &[2, 3, 4, 5, 6]),
+            mk("c", &[3, 4, 5, 6, 7]),
+            mk("d", &[3, 4, 5]),
+            mk("e", &[4, 5, 8]),
+        ];
+        // Present in all five: 4 and 5.
+        let got = run_multi(inputs.clone()).await;
+        assert_eq!(normalize_keys(got.clone()), vec![4, 5]);
+        assert_eq!(
+            normalize_keys(got),
+            normalize_keys(nested_intersect(&inputs))
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_yields_nothing_when_one_input_is_empty() {
+        let a = vec![nrow(1, "a", 1), nrow(2, "a", 2)];
+        let empty: Vec<Match> = vec![];
+        let c = vec![nrow(1, "c", 1), nrow(2, "c", 2)];
+        assert!(run_multi(vec![a, empty, c]).await.is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_passes_a_single_input_through() {
+        let a = vec![nrow(1, "a", 1), nrow(3, "a", 3)];
+        let got = run_multi(vec![a]).await;
+        assert_eq!(normalize_keys(got), vec![1, 3]);
+    }
+
+    #[dialog_common::test]
+    async fn it_combines_many_to_many_across_inputs() {
+        // Key 5 has two rows in input a and two in input b: the intersection
+        // must produce the 2x2 cross product for that key.
+        let a = vec![nrow(5, "a", 1), nrow(5, "a", 2)];
+        let b = vec![nrow(5, "b", 1), nrow(5, "b", 2)];
+        let got = run_multi(vec![a.clone(), b.clone()]).await;
+        assert_eq!(got.len(), 4);
+        assert_eq!(normalize_keys(got), vec![5, 5, 5, 5]);
+    }
+
+    #[dialog_common::test]
+    async fn it_matches_the_nested_intersect_over_random_shapes() {
+        let mut state: u64 = 0xD1B54A32D192ED03;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as i64
+        };
+        for _ in 0..150 {
+            let arity = 2 + (next().unsigned_abs() % 4) as usize; // 2..5 inputs
+            let inputs: Vec<Vec<Match>> = (0..arity)
+                .map(|t| {
+                    let len = (next().unsigned_abs() % 7) as usize;
+                    let mut keys: Vec<i64> =
+                        (0..len).map(|_| next().unsigned_abs() as i64 % 6).collect();
+                    keys.sort();
+                    keys.iter()
+                        .enumerate()
+                        .map(|(i, k)| nrow(*k, &format!("t{t}"), i as i64))
+                        .collect()
+                })
+                .collect();
+            let got = run_multi(inputs.clone()).await;
+            assert_eq!(
+                normalize_keys(got),
+                normalize_keys(nested_intersect(&inputs)),
+                "diverged on inputs {inputs:?}"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_matches_the_nested_loop_on_a_one_to_one_join() {
+        let left = vec![row(1, "l", 10), row(2, "l", 20), row(3, "l", 30)];
+        let right = vec![row(2, "r", 200), row(3, "r", 300), row(4, "r", 400)];
+
+        let merged = run_merge(left.clone(), right.clone()).await;
+        assert_eq!(normalize(merged), normalize(nested_loop(&left, &right)));
+    }
+
+    #[dialog_common::test]
+    async fn it_matches_the_nested_loop_on_a_many_to_many_join() {
+        // Two left rows and three right rows all share key 5: the equal-key
+        // group must produce the full 2x3 cross product.
+        let left = vec![row(5, "l", 1), row(5, "l", 2), row(7, "l", 3)];
+        let right = vec![
+            row(5, "r", 100),
+            row(5, "r", 200),
+            row(5, "r", 300),
+            row(7, "r", 400),
+        ];
+
+        let merged = run_merge(left.clone(), right.clone()).await;
+        let oracle = nested_loop(&left, &right);
+        assert_eq!(merged.len(), oracle.len());
+        assert_eq!(normalize(merged), normalize(oracle));
+    }
+
+    #[dialog_common::test]
+    async fn it_matches_the_nested_loop_with_disjoint_and_gapped_keys() {
+        // Interleaved keys with gaps on both sides, so the cursor has to skip
+        // right keys below a left key and left keys with no right match.
+        let left = vec![
+            row(1, "l", 1),
+            row(4, "l", 4),
+            row(6, "l", 6),
+            row(9, "l", 9),
+        ];
+        let right = vec![
+            row(2, "r", 2),
+            row(4, "r", 4),
+            row(5, "r", 5),
+            row(9, "r", 9),
+        ];
+
+        let merged = run_merge(left.clone(), right.clone()).await;
+        assert_eq!(normalize(merged), normalize(nested_loop(&left, &right)));
+    }
+
+    #[dialog_common::test]
+    async fn it_yields_nothing_when_no_keys_overlap() {
+        let left = vec![row(1, "l", 1), row(3, "l", 3)];
+        let right = vec![row(2, "r", 2), row(4, "r", 4)];
+
+        let merged = run_merge(left, right).await;
+        assert!(merged.is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_an_empty_side() {
+        let left = vec![row(1, "l", 1), row(2, "l", 2)];
+        let merged = run_merge(left.clone(), vec![]).await;
+        assert!(merged.is_empty());
+
+        let right = vec![row(1, "r", 1)];
+        let merged = run_merge(vec![], right).await;
+        assert!(merged.is_empty());
+    }
+
+    /// A deterministic pseudo-random sweep: many left/right key multisets built
+    /// from a linear-congruential generator, each joined both ways and checked
+    /// against the oracle. This exercises the cursor's reuse path (consecutive
+    /// left keys falling in right-side gaps, then hitting a buffered group) far
+    /// more thoroughly than the hand-picked cases.
+    #[dialog_common::test]
+    async fn it_matches_the_nested_loop_over_many_random_shapes() {
+        // No Math.random in this environment; a fixed LCG keeps it reproducible.
+        let mut state: u64 = 0x9E3779B97F4A7C15;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as i64
+        };
+
+        for _ in 0..200 {
+            let left_len = (next().unsigned_abs() % 8) as usize;
+            let right_len = (next().unsigned_abs() % 8) as usize;
+            // Keys drawn from a small domain so collisions (many-to-many) are
+            // common; sorted ascending to satisfy the merge precondition.
+            let mut left_keys: Vec<i64> = (0..left_len)
+                .map(|_| next().unsigned_abs() as i64 % 5)
+                .collect();
+            let mut right_keys: Vec<i64> = (0..right_len)
+                .map(|_| next().unsigned_abs() as i64 % 5)
+                .collect();
+            left_keys.sort();
+            right_keys.sort();
+
+            let left: Vec<Match> = left_keys
+                .iter()
+                .enumerate()
+                .map(|(i, k)| row(*k, "l", i as i64))
+                .collect();
+            let right: Vec<Match> = right_keys
+                .iter()
+                .enumerate()
+                .map(|(i, k)| row(*k, "r", i as i64))
+                .collect();
+
+            let merged = run_merge(left.clone(), right.clone()).await;
+            assert_eq!(
+                normalize(merged),
+                normalize(nested_loop(&left, &right)),
+                "diverged on left={left_keys:?} right={right_keys:?}"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_filters_rows_that_disagree_on_a_non_join_variable() {
+        // Both sides bind a shared variable `x`; only rows agreeing on it
+        // survive the combine, even when the join key matches.
+        let mut l1 = Match::new();
+        l1.bind(&Term::var("j"), Value::from(1i64)).unwrap();
+        l1.bind(&Term::var("x"), Value::from(100i64)).unwrap();
+        let mut l2 = Match::new();
+        l2.bind(&Term::var("j"), Value::from(1i64)).unwrap();
+        l2.bind(&Term::var("x"), Value::from(999i64)).unwrap();
+
+        let mut r = Match::new();
+        r.bind(&Term::var("j"), Value::from(1i64)).unwrap();
+        r.bind(&Term::var("x"), Value::from(100i64)).unwrap();
+
+        let merged = merge_join(seed(vec![l1, l2]), seed(vec![r]), key)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        // Only l1 (x=100) unifies with r (x=100); l2 (x=999) is filtered.
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].value_of("x").and_then(as_int), Some(100));
+    }
+}

--- a/rust/dialog-query/src/planner/conjunction.rs
+++ b/rust/dialog-query/src/planner/conjunction.rs
@@ -1,7 +1,24 @@
 use super::Plan;
-use crate::Environment;
-use crate::selection::Selection;
+use crate::attribute::query::DynamicAttributeQuery;
+use crate::selection::{Match, Selection};
+use crate::{Environment, SortOrder, multi_merge_join};
 use core::pin::Pin;
+use dialog_artifacts::{Estimate, Likelihood, Preload, PreloadRequest, encode_value_owned};
+use dialog_capability::Provider;
+use dialog_common::ConditionalSync;
+use futures_util::StreamExt;
+
+/// Largest ratio of the widest to narrowest scan range estimate that still
+/// takes the merge path. Above it, one scan is selective enough that a nested
+/// loop driving from it reads fewer blocks than a merge scanning every range
+/// in full.
+///
+/// The estimates come from the tree (per-child
+/// [`Scale`](dialog_search_tree::Scale) sums, one root read per scan), so an
+/// all-broad concept join — every attribute a full entity range — has a ratio
+/// near 1, while pinning one attribute to a value collapses that scan's range
+/// to a narrow band and pushes the ratio well past this threshold.
+const MERGE_COST_BALANCE: usize = 3;
 
 /// An ordered sequence of [`Plan`] steps produced by the query planner.
 ///
@@ -44,10 +61,233 @@ impl Conjunction {
     where
         Env: crate::Scope<'a>,
     {
+        // A conjunction whose every step is an attribute scan sorted on the
+        // same free variable is an equi-join on that variable (the shape a
+        // concept's implicit rule always has). Such a run *can* be evaluated
+        // as an N-way merge: each scan runs once and the sorted outputs are
+        // intersected, rather than probing the later scans once per row of
+        // the earlier ones. Whether the merge actually wins depends on the
+        // incoming row's bindings (a pinned selective attribute favors the
+        // nested loop), so that choice is made per query inside
+        // `evaluate_maybe_merge`. Any structurally ineligible conjunction
+        // keeps the fold unchanged.
+        if let Some(variable) = self.merge_variable() {
+            return self.evaluate_maybe_merge(selection, env, variable);
+        }
+
+        self.into_fold(selection, env)
+    }
+
+    /// The nested-loop fold: each step feeds its output to the next.
+    fn into_fold<'a, Env, M: Selection + 'a>(
+        self,
+        selection: M,
+        env: &'a Env,
+    ) -> Pin<Box<dyn Selection + 'a>>
+    where
+        Env: crate::Scope<'a>,
+    {
         self.steps.into_iter().fold(
             Box::pin(selection) as Pin<Box<dyn Selection + 'a>>,
             |selection, plan| Box::pin(plan.evaluate(selection, env)),
         )
+    }
+
+    /// The single variable every step is sorted on, if this conjunction is
+    /// *structurally* a merge-eligible equi-join, else `None`.
+    ///
+    /// Eligible when there are at least two steps, every one is a positive
+    /// attribute [`Scan`](Plan::Scan) (not optional, not a formula, concept,
+    /// or constraint), and every scan reports the *same* [`SortOrder::On`]
+    /// variable. Because the scans all sort on that shared variable and none
+    /// is a chained probe, they are independent inputs to an intersection.
+    ///
+    /// This is only the structural test. Whether a merge actually reads fewer
+    /// blocks than the nested loop depends on the incoming row's bindings (a
+    /// pinned selective attribute favors the loop), which are not known until
+    /// evaluation; that decision is made per query in
+    /// [`evaluate_maybe_merge`](Self::evaluate_maybe_merge).
+    fn merge_variable(&self) -> Option<String> {
+        if self.steps.len() < 2 {
+            return None;
+        }
+
+        let mut shared: Option<String> = None;
+        for step in &self.steps {
+            let query = match step {
+                Plan::Scan(_, query) => query,
+                _ => return None,
+            };
+            let variable = match query.sort_order() {
+                SortOrder::On(name) => name,
+                SortOrder::None => return None,
+            };
+            match &shared {
+                None => shared = Some(variable),
+                Some(existing) if *existing == variable => {}
+                Some(_) => return None,
+            }
+        }
+        shared
+    }
+
+    /// Whether the scans are balanced enough to merge, given a row's
+    /// bindings, measured from the tree rather than the cost model's fixed
+    /// constants.
+    ///
+    /// A merge reads every input range in full, in parallel; the nested loop
+    /// reads one range and probes the others only at surviving entities. So
+    /// when one scan is far more selective than the rest, the loop touches
+    /// far fewer blocks. Each scan is resolved against `base` (binding any
+    /// value the caller pinned) and its range size estimated via
+    /// [`Estimate`] — one root-node read per scan, an advisory upper bound
+    /// from the tree's per-child [`Scale`](dialog_search_tree::Scale)s. The
+    /// merge is taken only when the widest scan's estimate is within a small
+    /// multiple of the narrowest; a scan a caller pinned to a value estimates
+    /// far narrower and pushes the ratio past the threshold, so the query
+    /// keeps the fold.
+    ///
+    /// A scan that cannot be turned into a selector (no bound field) or that
+    /// the store cannot estimate is treated as maximally broad, which keeps
+    /// the balanced (all-broad) case eligible and only ever errs toward the
+    /// fold.
+    async fn scans_balanced_for<Env>(&self, base: &Match, env: &Env) -> bool
+    where
+        Env: Provider<Estimate> + ConditionalSync,
+    {
+        let mut min_size = u64::MAX;
+        let mut max_size = 0u64;
+        for step in &self.steps {
+            let Plan::Scan(_, query) = step else { continue };
+            // A selector build failure or an unavailable estimate means
+            // "range size unknown"; treat as maximally broad so an all-broad
+            // join stays eligible and a genuinely selective one is never
+            // wrongly merged on a missing estimate.
+            let size = match query.resolved_selector(base) {
+                Ok(selector) => Provider::<Estimate>::execute(env, selector)
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or(u64::MAX),
+                Err(_) => u64::MAX,
+            };
+            min_size = min_size.min(size);
+            max_size = max_size.max(size);
+        }
+        min_size != 0 && max_size <= min_size.saturating_mul(MERGE_COST_BALANCE as u64)
+    }
+
+    /// Evaluate a structurally merge-eligible conjunction, choosing per query
+    /// between the N-way merge and the nested-loop fold by the incoming
+    /// rows' selectivity.
+    ///
+    /// Every match in a selection shares one binding pattern (only the
+    /// values differ), so the merge-versus-fold choice is uniform across the
+    /// stream. This peeks the first row, decides once via
+    /// [`scans_balanced_for`](Self::scans_balanced_for), and runs the chosen
+    /// strategy over the whole selection (the peeked row put back at the
+    /// head). An empty selection yields nothing either way. On the merge
+    /// path, each scan is resolved against the incoming row (binding any
+    /// variables the caller already supplied), evaluated independently, and
+    /// the sorted outputs are intersected on `variable`'s encoded value via
+    /// [`multi_merge_join`]; the incoming row's own bindings are folded back
+    /// in, preserving the caller's context exactly as the fold would.
+    fn evaluate_maybe_merge<'a, Env, M: Selection + 'a>(
+        self,
+        selection: M,
+        env: &'a Env,
+        variable: String,
+    ) -> Pin<Box<dyn Selection + 'a>>
+    where
+        Env: crate::Scope<'a>,
+    {
+        Box::pin(crate::try_stream! {
+            let mut selection = Box::pin(selection.peekable());
+
+            // Decide from the first row's bindings; nothing to do if empty.
+            let balanced = match selection.as_mut().peek().await {
+                Some(Ok(first)) => {
+                    let first = first.clone();
+                    self.scans_balanced_for(&first, env).await
+                }
+                // Empty, or a pending error surfaced on the next poll below.
+                _ => true,
+            };
+
+            if !balanced {
+                // A selective attribute is pinned: the nested-loop fold reads
+                // fewer blocks by driving from the narrow scan.
+                for await row in self.into_fold(selection, env) {
+                    yield row?;
+                }
+                return;
+            }
+
+            let scans: Vec<DynamicAttributeQuery> = self
+                .steps
+                .into_iter()
+                .map(|step| match step {
+                    Plan::Scan(_, query) => *query,
+                    // merge_variable already proved every step is a Scan.
+                    _ => unreachable!("merge eligibility guarantees every step is a Scan"),
+                })
+                .collect();
+
+            let mut listening = true;
+            for await incoming in selection {
+                let base = incoming?;
+
+                // The merge will read every input range in full, so each
+                // range is committed work: hint it Likely, and a driven
+                // plan replicates it level-parallel while the merge's own
+                // streams consume — the demand reads join the in-flight
+                // hydrations or find the blocks local. Hinting stops on
+                // the env's first refusal, exactly as probe pipelining
+                // does.
+                if listening {
+                    for scan in &scans {
+                        let Ok(selector) = scan.resolved_selector(&base) else {
+                            continue;
+                        };
+                        listening = Provider::<Preload>::execute(
+                            env,
+                            PreloadRequest {
+                                selector,
+                                likelihood: Likelihood::Likely,
+                            },
+                        )
+                        .await;
+                        if !listening {
+                            break;
+                        }
+                    }
+                }
+
+                // Each scan seeded from the incoming row so any
+                // caller-supplied bindings resolve into the scan's constants;
+                // the shared join variable stays free and drives the merge.
+                let mut inputs: Vec<Pin<Box<dyn Selection + 'a>>> =
+                    Vec::with_capacity(scans.len());
+                for scan in &scans {
+                    let seeded = base.clone().seed();
+                    inputs.push(Box::pin(scan.clone().evaluate(env, seeded)));
+                }
+
+                let variable = variable.clone();
+                let key = move |m: &Match| -> Option<Vec<u8>> {
+                    m.value_of(&variable).map(encode_value_owned)
+                };
+
+                for await row in multi_merge_join(inputs, key) {
+                    let row = row?;
+                    // Fold the joined bindings back onto the incoming row so
+                    // the caller's context (and provenance) is preserved.
+                    if let Some(merged) = base.clone().combine(&row) {
+                        yield merged;
+                    }
+                }
+            }
+        })
     }
 }
 
@@ -84,6 +324,88 @@ mod tests {
     use dialog_artifacts::Entity;
     use dialog_operator::helpers::{test_operator_with_profile, test_repo};
     use futures_util::TryStreamExt;
+
+    /// A two-attribute conjunction over a shared entity is structurally merge
+    /// eligible, and the tree-derived balance check picks merge only when
+    /// neither scan is selective. This pins the regression the merge
+    /// introduced: with a value pinned on one scan, `scans_balanced_for` must
+    /// report imbalance (from the real range estimates) so the query falls
+    /// back to the nested-loop fold instead of scanning every range in full.
+    #[dialog_common::test]
+    async fn it_prefers_the_fold_when_one_scan_is_selective() -> anyhow::Result<()> {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        // Seed a spread of entities, each with a name and a role, so the two
+        // attribute ranges are broad and comparably sized, while any single
+        // value ("name-7") is selective.
+        let mut tx = branch.transaction();
+        for i in 0..2000 {
+            let entity = Entity::new()?;
+            tx = tx
+                .assert(
+                    the!("thing/name")
+                        .of(entity.clone())
+                        .is(format!("name-{i}")),
+                )
+                .assert(the!("thing/role").of(entity).is(format!("role-{}", i % 4)));
+        }
+        tx.commit().publish().perform(&operator).await?;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let env = TestEnv::new(&branch, &operator, RuleRegistry::new());
+
+        let name_scan = AttributeQuery::new(
+            Term::from(the!("thing/name")),
+            Term::<Entity>::var("this"),
+            Term::<Any>::var("name"),
+            Term::var("c1"),
+            Some(Cardinality::One),
+        );
+        let role_scan = AttributeQuery::new(
+            Term::from(the!("thing/role")),
+            Term::<Entity>::var("this"),
+            Term::<Any>::var("role"),
+            Term::var("c2"),
+            Some(Cardinality::One),
+        );
+
+        let plan = Planner::from(vec![
+            Premise::Assert(Proposition::Attribute(Box::new(name_scan))),
+            Premise::Assert(Proposition::Attribute(Box::new(role_scan))),
+        ])
+        .plan(&Environment::new())?;
+
+        // Both scans sort on the shared entity, so the conjunction is
+        // structurally eligible.
+        assert_eq!(plan.merge_variable().as_deref(), Some("this"));
+
+        // Nothing pinned: both ranges are the full attribute range,
+        // comparably sized, so the estimates are balanced and the merge is
+        // taken.
+        assert!(
+            plan.scans_balanced_for(&Match::new(), &env).await,
+            "with no value pinned the ranges are comparable and should merge"
+        );
+
+        // Pin the name value, which is unique per entity: the name scan
+        // collapses to a single-entity band while the role scan stays a full
+        // range, so the tree estimates are decisively imbalanced and the
+        // fold is preferred. (A near-unique value makes the ratio
+        // unambiguous, unlike a low-cardinality one near the threshold.)
+        let mut pinned = Match::new();
+        pinned.bind(
+            &Term::<Any>::var("name"),
+            Value::String("name-7".to_string()),
+        )?;
+        assert!(
+            !plan.scans_balanced_for(&pinned, &env).await,
+            "with the name value pinned the name scan is selective and should fold"
+        );
+
+        Ok(())
+    }
 
     /// Coalesce must take the *source* when the lookup finds a value
     /// and the fallback only when it does not. The coalesce's source

--- a/rust/dialog-query/src/scope.rs
+++ b/rust/dialog-query/src/scope.rs
@@ -10,7 +10,7 @@
 //! evaluation signatures stay stable as effects are added.
 
 use dialog_artifacts::inspect::Load;
-use dialog_artifacts::{Preload, Select};
+use dialog_artifacts::{Estimate, Preload, Select};
 use dialog_capability::Provider;
 use dialog_common::ConditionalSync;
 
@@ -19,7 +19,12 @@ use crate::source::SelectRules;
 /// The full provider bundle premise evaluation requires. Blanket
 /// implemented: any environment providing the effects is a `Scope`.
 pub trait Scope<'a>:
-    Provider<Select<'a>> + Provider<SelectRules> + Provider<Load> + Provider<Preload> + ConditionalSync
+    Provider<Select<'a>>
+    + Provider<SelectRules>
+    + Provider<Load>
+    + Provider<Preload>
+    + Provider<Estimate>
+    + ConditionalSync
 {
 }
 
@@ -28,6 +33,7 @@ impl<'a, T> Scope<'a> for T where
         + Provider<SelectRules>
         + Provider<Load>
         + Provider<Preload>
+        + Provider<Estimate>
         + ConditionalSync
 {
 }

--- a/rust/dialog-query/src/selection/match.rs
+++ b/rust/dialog-query/src/selection/match.rs
@@ -210,6 +210,64 @@ impl Match {
         Ok(())
     }
 
+    /// Merge every binding and claim from `other` into this match,
+    /// returning `None` if the two disagree on any shared variable.
+    ///
+    /// This is the row-combining step of a set-at-a-time join: two rows
+    /// produced independently (rather than one fed into the other) are
+    /// joined by unifying their bindings. A shared variable bound to the
+    /// same `Present` value in both, or `Absent` in both, unifies; a
+    /// `Present`/`Absent` clash or two different `Present` values is a
+    /// non-match, which yields `None` rather than an error, since a
+    /// failed unification is ordinary data-dependent filtering, not a
+    /// contract violation.
+    ///
+    /// Bindings only in `other` are added; bindings only in `self` are
+    /// kept. Claims from `other` fill in only where `self` has none, so a
+    /// row's own provenance is never overwritten by the row it joins with.
+    pub fn combine(mut self, other: &Match) -> Option<Match> {
+        for (name, binding) in &other.bindings {
+            match probe(&self.bindings, name) {
+                None => self.bindings.push((name.clone(), binding.clone())),
+                Some(existing) if existing == binding => {}
+                Some(_) => return None,
+            }
+        }
+        for (name, claim) in &other.claims {
+            if probe(&self.claims, name).is_none() {
+                self.claims.push((name.clone(), claim.clone()));
+            }
+        }
+        Some(self)
+    }
+
+    /// The `Present` value bound to `name`, if any. Used by the merge
+    /// join to read the join key out of a row without going through a
+    /// [`Term`].
+    pub fn value_of(&self, name: &str) -> Option<&Value> {
+        match probe(&self.bindings, name) {
+            Some(Binding::Present(value)) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// The environment of variables this match binds to a `Present`
+    /// value.
+    ///
+    /// Used to estimate a scan's cost against the bindings a row
+    /// actually carries: a scan whose value variable is present here
+    /// scans a narrow band rather than a full range, which is what the
+    /// merge-versus-nested-loop choice turns on.
+    pub fn environment(&self) -> crate::Environment {
+        let mut env = crate::Environment::new();
+        for (name, binding) in &self.bindings {
+            if matches!(binding, Binding::Present(_)) {
+                env.add(name.as_ref());
+            }
+        }
+        env
+    }
+
     /// Bind a term to a [`Binding::Present`] value. For named
     /// variables, stores the value in the bindings map; checks
     /// consistency if already bound:

--- a/rust/dialog-query/src/sort_order.rs
+++ b/rust/dialog-query/src/sort_order.rs
@@ -14,9 +14,11 @@
 //! output sorted on it. Nothing consumes it yet; it is surfaced so the planner
 //! can, without changing how any scan runs today.
 
-use crate::Term;
+use crate::attribute::The;
 use crate::attribute::query::all::AttributeQueryAll;
-use crate::types::Typed;
+use crate::attribute::query::dynamic::DynamicAttributeQuery;
+use crate::types::{Any, Typed};
+use crate::{Entity, Term};
 
 /// The variable a scan's output is sorted on, or that it carries no useful
 /// order (a fully-constrained point lookup, or an ordering led by a variable
@@ -91,44 +93,54 @@ impl AttributeQueryAll {
     /// Returns [`SortOrder::None`] when the leading dimensions are all bound to
     /// constants (a point lookup carries no join-useful order).
     pub fn sort_order(&self) -> SortOrder {
-        let entity_bound = matches!(self.of(), Term::Constant(_));
-        let value_bound = matches!(self.is(), Term::Constant(_));
-        let attribute_bound = matches!(self.the(), Term::Constant(_));
+        sort_order_of(self.the(), self.of(), self.is())
+    }
+}
 
-        // The component sequence of the ordering the storage layer will pick,
-        // most significant first. This is the exact priority `selector_range`
-        // applies: entity index unless entity is free and something else is
-        // bound, then value, then attribute.
-        let sequence: [Option<String>; 3] = if entity_bound || (!value_bound && !attribute_bound) {
-            // EAV: entity, attribute, value.
-            [
-                free_variable(self.of()),
-                free_variable(self.the()),
-                free_variable(self.is()),
-            ]
-        } else if value_bound {
-            // VAE: value, attribute, entity.
-            [
-                free_variable(self.is()),
-                free_variable(self.the()),
-                free_variable(self.of()),
-            ]
-        } else {
-            // AEV: attribute, entity, value.
-            [
-                free_variable(self.the()),
-                free_variable(self.of()),
-                free_variable(self.is()),
-            ]
-        };
+/// The sort order of an attribute scan with the given `(the, of, is)` terms,
+/// independent of cardinality: cardinality-one winner selection reads the same
+/// index in the same order as the cardinality-many scan, so both sort on the
+/// same variable. Shared by [`AttributeQueryAll::sort_order`] and
+/// [`DynamicAttributeQuery::sort_order`].
+pub(crate) fn sort_order_of(the: &Term<The>, of: &Term<Entity>, is: &Term<Any>) -> SortOrder {
+    let entity_bound = matches!(of, Term::Constant(_));
+    let value_bound = matches!(is, Term::Constant(_));
+    let attribute_bound = matches!(the, Term::Constant(_));
 
-        // The leading free dimension is the first sequence entry that is a
-        // variable. Bound leading components are fixed across the scan, so the
-        // order is decided by the first free one.
-        match sequence.into_iter().flatten().next() {
-            Some(name) => SortOrder::On(name),
-            None => SortOrder::None,
-        }
+    // The component sequence of the ordering the storage layer will pick, most
+    // significant first. This is the exact priority `selector_range` applies:
+    // entity index unless entity is free and something else is bound, then
+    // value, then attribute.
+    let sequence: [Option<String>; 3] = if entity_bound || (!value_bound && !attribute_bound) {
+        // EAV: entity, attribute, value.
+        [free_variable(of), free_variable(the), free_variable(is)]
+    } else if value_bound {
+        // VAE: value, attribute, entity.
+        [free_variable(is), free_variable(the), free_variable(of)]
+    } else {
+        // AEV: attribute, entity, value.
+        [free_variable(the), free_variable(of), free_variable(is)]
+    };
+
+    // The leading free dimension is the first sequence entry that is a
+    // variable. Bound leading components are fixed across the scan, so the
+    // order is decided by the first free one.
+    match sequence.into_iter().flatten().next() {
+        Some(name) => SortOrder::On(name),
+        None => SortOrder::None,
+    }
+}
+
+impl DynamicAttributeQuery {
+    /// The variable this scan's output is sorted on, for either cardinality.
+    ///
+    /// A cardinality-one (`Only`) scan reads the same index in the same order
+    /// as a cardinality-many (`All`) scan and merely selects a winner per
+    /// group, so its output is sorted on the same variable. This lets a merge
+    /// join over a concept's attribute premises apply regardless of their
+    /// cardinality.
+    pub fn sort_order(&self) -> SortOrder {
+        sort_order_of(self.the(), self.of(), self.is())
     }
 }
 

--- a/rust/dialog-query/src/source.rs
+++ b/rust/dialog-query/src/source.rs
@@ -73,6 +73,21 @@ pub(crate) mod test {
         }
     }
 
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl Provider<dialog_artifacts::Estimate> for TestEnv<'_> {
+        async fn execute(
+            &self,
+            input: ArtifactSelector<Constrained>,
+        ) -> Result<Option<u64>, DialogArtifactsError> {
+            self.branch
+                .claims()
+                .select(input)
+                .estimate_perform(self.operator)
+                .await
+        }
+    }
+
     // Preload hints have no listener in the test env: refuse them so
     // evaluation stops composing hints after the first.
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]

--- a/rust/dialog-repository/src/repository/branch/select.rs
+++ b/rust/dialog-repository/src/repository/branch/select.rs
@@ -158,6 +158,46 @@ impl Select<'_> {
         Ok(tree.scan(store, self.source.spill_cache(), self.selector))
     }
 
+    /// Estimate this selector's range size, picking a store the same way
+    /// [`perform`](Self::perform) does. See [`estimate`](Self::estimate).
+    pub async fn estimate_perform<Env>(self, env: &Env) -> Result<Option<u64>, DialogArtifactsError>
+    where
+        Env: Provider<Get>
+            + Provider<Put>
+            + Provider<Resolve>
+            + Provider<Fork<RemoteSite, Get>>
+            + Provider<Fork<RemoteSite, Resolve>>
+            + ConditionalSync
+            + 'static,
+    {
+        let remote = self.source.fallback(env).await;
+        let store = NetworkedIndex::new(env, self.catalog(), remote);
+        self.estimate(store).await
+    }
+
+    /// An advisory upper-bound estimate of how many artifacts this selector's
+    /// range spans, read from the tree root alone (see
+    /// [`ArtifactTreeExt::estimate`](dialog_artifacts::tree::ArtifactTreeExt::estimate)).
+    ///
+    /// One block read rather than a scan, for a planner comparing scan sizes.
+    /// This estimates against the line's tree only; it ignores any pending
+    /// `Changes` overlay, whose in-memory edits are small relative to the tree
+    /// and do not change the order-of-magnitude answer a strategy choice
+    /// needs. Returns `None` for an empty tree.
+    pub async fn estimate<S>(self, store: S) -> Result<Option<u64>, DialogArtifactsError>
+    where
+        S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + Clone
+            + ConditionalSync,
+    {
+        let tree_hash = self.tree_hash();
+        if tree_hash == EMPTY_TREE_HASH {
+            return Ok(None);
+        }
+        let tree = Index::from_hash_with_cache(NodeHash::from(tree_hash), self.source.node_cache());
+        tree.estimate(store, self.selector).await
+    }
+
     /// [`execute`](Self::execute) materializing every row from the scan's
     /// own key parse — the fast path behind [`SelectOwned`], which by
     /// definition materializes everything and would otherwise pay a second

--- a/rust/dialog-repository/src/repository/branch/session.rs
+++ b/rust/dialog-repository/src/repository/branch/session.rs
@@ -4,7 +4,7 @@ use dialog_artifacts::inspect::Load;
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::{
     Artifact, ArtifactSelector, ArtifactStream, ArtifactViewStream as _, Changes,
-    DialogArtifactsError, Entity, Preload, PreloadRequest, Select, SortKey, Statement,
+    DialogArtifactsError, Entity, Estimate, Preload, PreloadRequest, Select, SortKey, Statement,
 };
 use dialog_capability::{Capability, Fork, Provider};
 use dialog_common::Blake3Hash as NodeHash;
@@ -539,6 +539,42 @@ where
         }
 
         Ok(merge_grouped(streams))
+    }
+}
+
+// A range-size estimate for the planner's merge-versus-fold choice:
+// one root read per line, summed. The `Changes` overlay is not
+// consulted (small, and irrelevant to the order-of-magnitude answer a
+// strategy heuristic needs). Summing lines is an upper bound — a fact
+// on two lines counts twice — which is the safe direction for a "how
+// broad is this range" question. `None` from every line (all empty)
+// yields `None`.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<Env> Provider<Estimate> for QueryEnv<'_, Env>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    async fn execute(
+        &self,
+        input: ArtifactSelector<Constrained>,
+    ) -> Result<Option<u64>, DialogArtifactsError> {
+        let mut total: Option<u64> = None;
+        for source in &self.sources {
+            let select = crate::Select::from_source(source.as_ref(), input.clone());
+            let remote = source.as_ref().fallback(self.env).await;
+            let store = NetworkedIndex::new(self.env, select.catalog(), remote);
+            if let Some(estimate) = select.estimate(store).await? {
+                total = Some(total.unwrap_or(0).saturating_add(estimate));
+            }
+        }
+        Ok(total)
     }
 }
 

--- a/rust/dialog-repository/src/repository/fetch.rs
+++ b/rust/dialog-repository/src/repository/fetch.rs
@@ -34,10 +34,18 @@ use dialog_effects::memory::Resolve;
 use futures_util::stream::FuturesUnordered;
 use futures_util::{Stream, StreamExt as _};
 
-use crate::RemoteSite;
+use async_trait::async_trait;
+use dialog_artifacts::tree::{TreeStorageBridge, selector_range};
+use dialog_common::Blake3Hash as NodeHash;
+use dialog_effects::archive::prelude::ArchiveSubjectExt as _;
+use dialog_search_tree::{
+    Buffer, Cache, ContentAddressedStorage, DialogSearchTreeError, Traversable as _,
+};
+use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
+
 use crate::repository::archive::networked::HydrationFlight;
-use crate::repository::branch::select_from_source;
 use crate::repository::source::Source;
+use crate::{EMPTY_TREE_HASH, Index, NetworkedIndex, RemoteSite, RepositoryArchiveExt as _};
 
 #[cfg(not(target_arch = "wasm32"))]
 type FetchFuture<'a> = Pin<Box<dyn Future<Output = Likelihood> + Send + 'a>>;
@@ -294,19 +302,10 @@ where
             let hydration = self.hydration.clone();
             let future = async move {
                 for source in sources {
-                    let mut scan = select_from_source(
-                        source,
-                        env,
-                        job.selector.clone(),
-                        Some(hydration.clone()),
-                    );
-                    // Drain: rows are discarded, blocks land in the
-                    // caches. An error ends this source's scan silently.
-                    while let Some(row) = scan.next().await {
-                        if row.is_err() {
-                            break;
-                        }
-                    }
+                    // Warming is advisory: an error ends this source's
+                    // walk silently, and the demand read that actually
+                    // needs the data owns the failure.
+                    let _ = warm_source(source, env, &job.selector, hydration.clone()).await;
                 }
                 likelihood
             };
@@ -355,6 +354,114 @@ where
             this.reap(context);
         }
         polled
+    }
+}
+
+/// Replicate every block `selector`'s range can touch on `source`, level
+/// by level: each depth's whole frontier fetches concurrently, so a cold
+/// range costs tree-depth round trips instead of block-count round trips
+/// (the level-parallel walk `traverse_available_within` already gives
+/// downloads). This is the range-granular job executor of bead
+/// dialog-db-76, replacing the select-and-drain executor, which paid row
+/// parsing and spilled-value fetches for rows nobody read and fetched
+/// leaf by leaf.
+///
+/// Reads go through the line's shared node cache (so a later demand read
+/// is free) and the networked index (so every fetched block hydrates the
+/// local archive), sharing in-flight hydrations through `flight`. The
+/// scope is the selector's exact key range; a subtree the range cannot
+/// touch is never fetched, and warming a conservative superset at the
+/// edges is harmless.
+async fn warm_source<'a, Env>(
+    source: Source,
+    env: &'a Env,
+    selector: &ArtifactSelector<Constrained>,
+    flight: Arc<HydrationFlight<'a>>,
+) -> Result<(), DialogSearchTreeError>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let root = source.as_ref().root();
+    if root == EMPTY_TREE_HASH {
+        return Ok(());
+    }
+    let remote = source.as_ref().fallback(env).await;
+    let catalog = source.as_ref().subject().archive().index();
+    let store = NetworkedIndex::new(env, catalog, remote).with_flight(flight);
+    let store = CacheThrough {
+        cache: source.as_ref().node_cache(),
+        store,
+    };
+    let storage = ContentAddressedStorage::new(TreeStorageBridge(store));
+    let tree = Index::from_hash(NodeHash::from(root));
+
+    let manifest = tree.manifest(&storage).await?;
+    let range = selector_range(selector, &manifest);
+    let scope = [range.start().as_ref().to_vec()..=range.end().as_ref().to_vec()];
+
+    let visits = tree.traverse_available_within(&storage, &scope);
+    futures_util::pin_mut!(visits);
+    while let Some(visit) = visits.next().await {
+        // A present node has landed in the caches, which is the whole
+        // point; an absent block is a partial region (nothing to warm);
+        // an error ends the walk, owned by whichever demand read hits it.
+        if visit.is_err() {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// The node cache in front of a hydrating store, as a raw block backend:
+/// the traversal's reads hit the line's shared cache first (a job whose
+/// spine a peer already warmed re-reads nothing), and every miss lands
+/// in it, so the demand read that follows a warm is served from memory.
+struct CacheThrough<'a, Env> {
+    cache: Cache<NodeHash, Buffer>,
+    store: NetworkedIndex<'a, Env>,
+}
+
+impl<Env> Clone for CacheThrough<'_, Env> {
+    fn clone(&self) -> Self {
+        Self {
+            cache: self.cache.clone(),
+            store: self.store.clone(),
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Env> StorageBackend for CacheThrough<'_, Env>
+where
+    Env:
+        Provider<Get> + Provider<Put> + Provider<Fork<RemoteSite, Get>> + ConditionalSync + 'static,
+{
+    type Key = Blake3Hash;
+    type Value = Vec<u8>;
+    type Error = DialogStorageError;
+
+    async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
+        StorageBackend::set(&mut self.store, key, value).await
+    }
+
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
+        let buffer = self
+            .cache
+            .get_or_fetch(&NodeHash::from(*key), async |hash| {
+                self.store
+                    .get(hash.as_bytes())
+                    .await
+                    .map(|bytes| bytes.map(Buffer::from))
+            })
+            .await?;
+        Ok(buffer.map(|buffer| buffer.as_ref().to_vec()))
     }
 }
 

--- a/rust/dialog-search-tree/src/tree.rs
+++ b/rust/dialog-search-tree/src/tree.rs
@@ -225,6 +225,42 @@ where
         self.stream_range(.., storage)
     }
 
+    /// An advisory upper-bound estimate of how many entries fall in the key
+    /// range `[lower, upper)`, read from the root node alone.
+    ///
+    /// Reads one block (the root, already the hottest and usually cached) and,
+    /// if it is an index, sums the [`Scale`](crate::Scale)s of the children the
+    /// range touches via [`range_scale`](crate::node::archive::ArchivedIndex::range_scale). A
+    /// root that is itself a leaf reports its own entry count. Returns `None`
+    /// for an empty tree.
+    ///
+    /// The estimate is a [`Scale`](crate::Scale) upper bound and is
+    /// edge-inflated: a range narrower than one child counts that whole
+    /// child's subtree. It answers "is this range large or small" cheaply, not
+    /// "exactly how many", which is what a planner comparing scan sizes needs.
+    pub async fn range_estimate<Backend>(
+        &self,
+        lower: &[u8],
+        upper: &[u8],
+        storage: &ContentAddressedStorage<Backend>,
+    ) -> Result<Option<u64>, DialogSearchTreeError>
+    where
+        Backend: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+            + ConditionalSync,
+    {
+        if &self.root == NULL_BLAKE3_HASH {
+            return Ok(None);
+        }
+        let accessor = Accessor::new(self.node_cache.clone(), storage.clone());
+        let node: PersistentNode<Key, Value> = accessor.get_node(&self.root).await?;
+        let estimate = match node.as_index() {
+            Ok(index) => index.range_scale(lower, upper)?.estimate(),
+            // A root leaf holds every entry; the whole-node scale is its count.
+            Err(_) => node.scale().estimate(),
+        };
+        Ok(Some(estimate))
+    }
+
     /// Returns an async stream over entries with keys within the provided
     /// range.
     ///

--- a/soak/baseline/join-broadband.json
+++ b/soak/baseline/join-broadband.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 396,
-  "vault_bytes": 19303711,
+  "vault_files": 388,
+  "vault_bytes": 19305457,
   "phases": [
     {
       "name": "pull",
@@ -25,17 +25,17 @@
           [
             "memory.resolve",
             1,
-            335
+            333
           ]
         ],
         "requests": 1,
-        "bytes": 335
+        "bytes": 333
       }
     },
     {
       "name": "probe",
-      "virtual_ms": 174,
-      "rounds": 2.175,
+      "virtual_ms": 176,
+      "rounds": 2.2,
       "unique_blocks": 2,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -45,31 +45,25 @@
           [
             "archive.get",
             2,
-            140348
+            161536
           ]
         ],
         "requests": 2,
-        "bytes": 140348
+        "bytes": 161536
       }
     },
     {
       "name": "roster",
-      "virtual_ms": 82,
-      "rounds": 1.025,
-      "unique_blocks": 1,
+      "virtual_ms": 0,
+      "rounds": 0.0,
+      "unique_blocks": 0,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
       "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            1,
-            10440
-          ]
-        ],
-        "requests": 1,
-        "bytes": 10440
+        "rows": [],
+        "requests": 0,
+        "bytes": 0
       }
     },
     {
@@ -90,21 +84,21 @@
           [
             "archive.put",
             1,
-            74312
+            73756
           ],
           [
             "memory.resolve",
             1,
-            335
+            333
           ],
           [
             "memory.publish",
             1,
-            372
+            370
           ]
         ],
         "requests": 4,
-        "bytes": 163851
+        "bytes": 163291
       }
     },
     {
@@ -163,49 +157,49 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 1647,
-      "rounds": 20.5875,
-      "unique_blocks": 110,
+      "virtual_ms": 496,
+      "rounds": 6.2,
+      "unique_blocks": 69,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            69,
+            3148460
+          ]
+        ],
+        "requests": 69,
+        "bytes": 3148460
+      }
+    },
+    {
+      "name": "filtered",
+      "virtual_ms": 1652,
+      "rounds": 20.65,
+      "unique_blocks": 109,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
       "empty_requests": 0,
       "traffic": {
         "rows": [
           [
             "archive.get",
             110,
-            5584696
+            5736932
           ]
         ],
         "requests": 110,
-        "bytes": 5584696
-      }
-    },
-    {
-      "name": "filtered",
-      "virtual_ms": 1572,
-      "rounds": 19.65,
-      "unique_blocks": 109,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            109,
-            5566072
-          ]
-        ],
-        "requests": 109,
-        "bytes": 5566072
+        "bytes": 5736932
       }
     },
     {
       "name": "download",
-      "virtual_ms": 2432,
-      "rounds": 30.4,
-      "unique_blocks": 394,
+      "virtual_ms": 2390,
+      "rounds": 29.875,
+      "unique_blocks": 386,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -213,17 +207,17 @@
         "rows": [
           [
             "archive.get",
-            394,
-            19307408
+            386,
+            19309164
           ],
           [
             "memory.resolve",
             1,
-            372
+            370
           ]
         ],
-        "requests": 395,
-        "bytes": 19307780
+        "requests": 387,
+        "bytes": 19309534
       }
     }
   ]

--- a/soak/baseline/join-intercontinental.json
+++ b/soak/baseline/join-intercontinental.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 401,
-  "vault_bytes": 19308746,
+  "vault_files": 400,
+  "vault_bytes": 19307080,
   "phases": [
     {
       "name": "pull",
@@ -25,17 +25,17 @@
           [
             "memory.resolve",
             1,
-            334
+            332
           ]
         ],
         "requests": 1,
-        "bytes": 334
+        "bytes": 332
       }
     },
     {
       "name": "probe",
-      "virtual_ms": 1029,
-      "rounds": 2.058,
+      "virtual_ms": 1028,
+      "rounds": 2.056,
       "unique_blocks": 2,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -45,11 +45,11 @@
           [
             "archive.get",
             2,
-            162328
+            160736
           ]
         ],
         "requests": 2,
-        "bytes": 162328
+        "bytes": 160736
       }
     },
     {
@@ -84,21 +84,21 @@
           [
             "archive.put",
             1,
-            74512
+            72440
           ],
           [
             "memory.resolve",
             1,
-            334
+            332
           ],
           [
             "memory.publish",
             1,
-            369
+            371
           ]
         ],
         "requests": 4,
-        "bytes": 164047
+        "bytes": 161975
       }
     },
     {
@@ -157,49 +157,49 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 9450,
-      "rounds": 18.9,
-      "unique_blocks": 110,
+      "virtual_ms": 2051,
+      "rounds": 4.102,
+      "unique_blocks": 69,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            69,
+            3145752
+          ]
+        ],
+        "requests": 69,
+        "bytes": 3145752
+      }
+    },
+    {
+      "name": "filtered",
+      "virtual_ms": 9397,
+      "rounds": 18.794,
+      "unique_blocks": 109,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
       "empty_requests": 0,
       "traffic": {
         "rows": [
           [
             "archive.get",
             110,
-            5667872
+            5734224
           ]
         ],
         "requests": 110,
-        "bytes": 5667872
-      }
-    },
-    {
-      "name": "filtered",
-      "virtual_ms": 8924,
-      "rounds": 17.848,
-      "unique_blocks": 109,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            109,
-            5646296
-          ]
-        ],
-        "requests": 109,
-        "bytes": 5646296
+        "bytes": 5734224
       }
     },
     {
       "name": "download",
-      "virtual_ms": 14022,
-      "rounds": 28.044,
-      "unique_blocks": 399,
+      "virtual_ms": 13975,
+      "rounds": 27.95,
+      "unique_blocks": 398,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +207,17 @@
         "rows": [
           [
             "archive.get",
-            399,
-            19313128
+            398,
+            19311016
           ],
           [
             "memory.resolve",
             1,
-            369
+            371
           ]
         ],
-        "requests": 400,
-        "bytes": 19313497
+        "requests": 399,
+        "bytes": 19311387
       }
     }
   ]

--- a/soak/baseline/join-localhost.json
+++ b/soak/baseline/join-localhost.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 396,
-  "vault_bytes": 19308418,
+  "vault_files": 395,
+  "vault_bytes": 19306597,
   "phases": [
     {
       "name": "pull",
@@ -25,11 +25,11 @@
           [
             "memory.resolve",
             1,
-            334
+            333
           ]
         ],
         "requests": 1,
-        "bytes": 334
+        "bytes": 333
       }
     },
     {
@@ -45,25 +45,31 @@
           [
             "archive.get",
             2,
-            163224
+            143900
           ]
         ],
         "requests": 2,
-        "bytes": 163224
+        "bytes": 143900
       }
     },
     {
       "name": "roster",
-      "virtual_ms": 0,
-      "rounds": 0.0,
-      "unique_blocks": 0,
+      "virtual_ms": 2,
+      "rounds": 2.5,
+      "unique_blocks": 1,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
       "traffic": {
-        "rows": [],
-        "requests": 0,
-        "bytes": 0
+        "rows": [
+          [
+            "archive.get",
+            1,
+            16248
+          ]
+        ],
+        "requests": 1,
+        "bytes": 16248
       }
     },
     {
@@ -79,26 +85,26 @@
           [
             "archive.get",
             1,
-            88832
+            97568
           ],
           [
             "archive.put",
             1,
-            74936
+            72024
           ],
           [
             "memory.resolve",
             1,
-            334
+            333
           ],
           [
             "memory.publish",
             1,
-            373
+            369
           ]
         ],
         "requests": 4,
-        "bytes": 164475
+        "bytes": 170294
       }
     },
     {
@@ -157,9 +163,9 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 54,
-      "rounds": 67.5,
-      "unique_blocks": 110,
+      "virtual_ms": 30,
+      "rounds": 37.5,
+      "unique_blocks": 70,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -167,18 +173,18 @@
         "rows": [
           [
             "archive.get",
-            110,
-            5668416
+            70,
+            3155376
           ]
         ],
-        "requests": 110,
-        "bytes": 5668416
+        "requests": 70,
+        "bytes": 3155376
       }
     },
     {
       "name": "filtered",
-      "virtual_ms": 53,
-      "rounds": 66.25,
+      "virtual_ms": 52,
+      "rounds": 65.0,
       "unique_blocks": 109,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -188,18 +194,18 @@
           [
             "archive.get",
             109,
-            5646752
+            5579104
           ]
         ],
         "requests": 109,
-        "bytes": 5646752
+        "bytes": 5579104
       }
     },
     {
       "name": "download",
       "virtual_ms": 159,
       "rounds": 198.75,
-      "unique_blocks": 394,
+      "unique_blocks": 393,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +213,17 @@
         "rows": [
           [
             "archive.get",
-            394,
-            19312360
+            393,
+            19309872
           ],
           [
             "memory.resolve",
             1,
-            373
+            369
           ]
         ],
-        "requests": 395,
-        "bytes": 19312733
+        "requests": 394,
+        "bytes": 19310241
       }
     }
   ]

--- a/soak/baseline/join-mobile.json
+++ b/soak/baseline/join-mobile.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 398,
-  "vault_bytes": 19307470,
+  "vault_files": 387,
+  "vault_bytes": 19301414,
   "phases": [
     {
       "name": "pull",
@@ -34,8 +34,8 @@
     },
     {
       "name": "probe",
-      "virtual_ms": 468,
-      "rounds": 2.34,
+      "virtual_ms": 466,
+      "rounds": 2.33,
       "unique_blocks": 2,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -45,11 +45,11 @@
           [
             "archive.get",
             2,
-            162160
+            157392
           ]
         ],
         "requests": 2,
-        "bytes": 162160
+        "bytes": 157392
       }
     },
     {
@@ -68,8 +68,8 @@
     },
     {
       "name": "claim",
-      "virtual_ms": 872,
-      "rounds": 4.36,
+      "virtual_ms": 870,
+      "rounds": 4.35,
       "unique_blocks": 1,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
@@ -84,7 +84,7 @@
           [
             "archive.put",
             1,
-            74844
+            68984
           ],
           [
             "memory.resolve",
@@ -94,11 +94,11 @@
           [
             "memory.publish",
             1,
-            371
+            373
           ]
         ],
         "requests": 4,
-        "bytes": 164377
+        "bytes": 158519
       }
     },
     {
@@ -157,49 +157,49 @@
     },
     {
       "name": "concept",
-      "virtual_ms": 4681,
-      "rounds": 23.405,
-      "unique_blocks": 110,
+      "virtual_ms": 1862,
+      "rounds": 9.31,
+      "unique_blocks": 69,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
+      "empty_requests": 0,
+      "traffic": {
+        "rows": [
+          [
+            "archive.get",
+            69,
+            3142408
+          ]
+        ],
+        "requests": 69,
+        "bytes": 3142408
+      }
+    },
+    {
+      "name": "filtered",
+      "virtual_ms": 4553,
+      "rounds": 22.765,
+      "unique_blocks": 109,
+      "duplicate_requests": 1,
+      "duplicate_bytes": 89968,
       "empty_requests": 0,
       "traffic": {
         "rows": [
           [
             "archive.get",
             110,
-            5666876
+            5730880
           ]
         ],
         "requests": 110,
-        "bytes": 5666876
-      }
-    },
-    {
-      "name": "filtered",
-      "virtual_ms": 4459,
-      "rounds": 22.295,
-      "unique_blocks": 109,
-      "duplicate_requests": 0,
-      "duplicate_bytes": 0,
-      "empty_requests": 0,
-      "traffic": {
-        "rows": [
-          [
-            "archive.get",
-            109,
-            5648052
-          ]
-        ],
-        "requests": 109,
-        "bytes": 5648052
+        "bytes": 5730880
       }
     },
     {
       "name": "download",
-      "virtual_ms": 8437,
-      "rounds": 42.185,
-      "unique_blocks": 396,
+      "virtual_ms": 8418,
+      "rounds": 42.09,
+      "unique_blocks": 385,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +207,17 @@
         "rows": [
           [
             "archive.get",
-            396,
-            19311644
+            385,
+            19305352
           ],
           [
             "memory.resolve",
             1,
-            371
+            373
           ]
         ],
-        "requests": 397,
-        "bytes": 19312015
+        "requests": 386,
+        "bytes": 19305725
       }
     }
   ]

--- a/soak/baseline/join-none.json
+++ b/soak/baseline/join-none.json
@@ -9,8 +9,8 @@
   "entities": 4000,
   "facts": 24011,
   "commits": 33,
-  "vault_files": 393,
-  "vault_bytes": 19306440,
+  "vault_files": 387,
+  "vault_bytes": 19308963,
   "phases": [
     {
       "name": "pull",
@@ -25,11 +25,11 @@
           [
             "memory.resolve",
             1,
-            332
+            335
           ]
         ],
         "requests": 1,
-        "bytes": 332
+        "bytes": 335
       }
     },
     {
@@ -45,11 +45,11 @@
           [
             "archive.get",
             2,
-            161536
+            163192
           ]
         ],
         "requests": 2,
-        "bytes": 161536
+        "bytes": 163192
       }
     },
     {
@@ -79,26 +79,26 @@
           [
             "archive.get",
             1,
-            88832
+            109520
           ],
           [
             "archive.put",
             1,
-            73248
+            74896
           ],
           [
             "memory.resolve",
             1,
-            332
+            335
           ],
           [
             "memory.publish",
             1,
-            373
+            374
           ]
         ],
         "requests": 4,
-        "bytes": 162785
+        "bytes": 185125
       }
     },
     {
@@ -159,7 +159,7 @@
       "name": "concept",
       "virtual_ms": 0,
       "rounds": 0.0,
-      "unique_blocks": 110,
+      "unique_blocks": 69,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -167,12 +167,12 @@
         "rows": [
           [
             "archive.get",
-            110,
-            5666912
+            69,
+            3168896
           ]
         ],
-        "requests": 110,
-        "bytes": 5666912
+        "requests": 69,
+        "bytes": 3168896
       }
     },
     {
@@ -188,18 +188,18 @@
           [
             "archive.get",
             109,
-            5645056
+            5672104
           ]
         ],
         "requests": 109,
-        "bytes": 5645056
+        "bytes": 5672104
       }
     },
     {
       "name": "download",
       "virtual_ms": 0,
       "rounds": 0.0,
-      "unique_blocks": 391,
+      "unique_blocks": 385,
       "duplicate_requests": 0,
       "duplicate_bytes": 0,
       "empty_requests": 0,
@@ -207,17 +207,17 @@
         "rows": [
           [
             "archive.get",
-            391,
-            19310376
+            385,
+            19312896
           ],
           [
             "memory.resolve",
             1,
-            373
+            374
           ]
         ],
-        "requests": 392,
-        "bytes": 19310749
+        "requests": 386,
+        "bytes": 19313270
       }
     }
   ]


### PR DESCRIPTION
Stacked on #498. Lands M2 (range-granular preload, bead dialog-db-76) and M4 (the merge-join revival, bead dialog-db-78) — the campaign's headline result:

## The #492 yardstick (cold 5-attribute concept join, 4k entities)

| profile | campaign start | this PR | speedup |
|---|---|---|---|
| broadband | 8.4s / 105 rounds / 110 blocks | **498ms / 6.2 rounds / 69 blocks** | **17x** |
| mobile | 28.3s | **1.86s** | 15x |
| intercontinental | 50s | **2.05s** | 24x |

The lazy join is now **5x faster than eagerly downloading the entire space, on 6x less transfer** — and the balanced merge reads *strictly fewer blocks* than the nested loop, because it consumes the attribute (AEV) ranges and never touches the entity-region probes. The original merge-join rejection ("reads more blocks") is dissolved for the balanced case: fewer rounds AND fewer blocks. The selective shape correctly folds at the balance guard and keeps the pipelined-fold profile.

## The four commits

1. **Range-granular preload jobs**: the job executor becomes a scoped level-parallel traversal (`traverse_available_within` bounded by `selector_range`) through the line's shared node cache in front of the hydrating index — a cold range costs depth round trips, not block-count round trips, with no row parsing or spill fetches.
2. **The merge-join operators**, ported from the paused stack (`feat/merge-join-operator` + spike): two-way lockstep with read-once right groups, and `multi_merge_join`, the single-variable worst-case-optimal intersection — a concept's exact shape. Generic over an `Ord` key with a caller-supplied extractor so index encoding stays in the scan layer. The 350-shape nested-loop oracle suite passes unchanged.
3. **The `Estimate` capability**: one root read summing per-child `Scale`s over a selector's range — `Scale` (#400) and `range_scale` (#401) finally get their planner consumer. The spike threaded the bound through every evaluator signature and both derive macros by hand; `Scope` absorbs the entire motion in one line.
4. **The planner**: a conjunction of positive attribute scans all sorted on one shared variable (cardinality-independent `sort_order`) is structurally merge-eligible; `scans_balanced_for` takes the merge only when the widest tree-estimated range is within 3x of the narrowest, pinned by a test against real estimates — a pinned selective value keeps the nested-loop fold. Optional (left-join) fields disqualify the merge structurally, so set-widening semantics never route through the inner intersection. On the merge path every input range is committed work: each scan's selector is hinted `Likely` before the streams open, and the driven plan replicates the ranges level-parallel while the merge consumes them.

Baselines regenerated; notes carry the measurement table and the ported stack's history. Beads dialog-db-76 and dialog-db-78 closed; remaining campaign beads are 79 (locality) and 80 (rule-join speculation).

Gates: clippy `-D warnings`, 2723/2723 native, wasm cross-archive, soak gate self-check. Merge order: #496 → #497 → #498 → this.
